### PR TITLE
compact: clarify retention wording

### DIFF
--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -80,9 +80,9 @@ func registerCompact(m map[string]setupFunc, app *kingpin.Application, name stri
 	syncDelay := modelDuration(cmd.Flag("sync-delay", "Minimum age of fresh (non-compacted) blocks before they are being processed.").
 		Default("30m"))
 
-	retentionRaw := modelDuration(cmd.Flag("retention.resolution-raw", "How long to retain raw samples in bucket. 0d - disables this retention").Default("0d"))
-	retention5m := modelDuration(cmd.Flag("retention.resolution-5m", "How long to retain samples of resolution 1 (5 minutes) in bucket. 0d - disables this retention").Default("0d"))
-	retention1h := modelDuration(cmd.Flag("retention.resolution-1h", "How long to retain samples of resolution 2 (1 hour) in bucket. 0d - disables this retention").Default("0d"))
+	retentionRaw := modelDuration(cmd.Flag("retention.resolution-raw", "How long to retain raw samples in bucket. 0d - disables this retention limit").Default("0d"))
+	retention5m := modelDuration(cmd.Flag("retention.resolution-5m", "How long to retain samples of resolution 1 (5 minutes) in bucket. 0d - disables this retention limit").Default("0d"))
+	retention1h := modelDuration(cmd.Flag("retention.resolution-1h", "How long to retain samples of resolution 2 (1 hour) in bucket. 0d - disables this retention limit").Default("0d"))
 
 	wait := cmd.Flag("wait", "Do not exit after all compactions have been processed and wait for new work.").
 		Short('w').Bool()

--- a/docs/components/compact.md
+++ b/docs/components/compact.md
@@ -58,13 +58,14 @@ Flags:
                            they are being processed.
       --retention.resolution-raw=0d
                            How long to retain raw samples in bucket. 0d -
-                           disables this retention
+                           disables this retention limit
       --retention.resolution-5m=0d
                            How long to retain samples of resolution 1 (5
                            minutes) in bucket. 0d - disables this retention
+                           limit
       --retention.resolution-1h=0d
                            How long to retain samples of resolution 2 (1 hour)
-                           in bucket. 0d - disables this retention
+                           in bucket. 0d - disables this retention limit
   -w, --wait               Do not exit after all compactions have been processed
                            and wait for new work.
       --block-sync-concurrency=20


### PR DESCRIPTION
## Changes

As discussed on Slack, the default 0d means unlimited.

## Verification

n/a

Are the docs autogenerated or should I update them? https://github.com/improbable-eng/thanos/blob/master/docs/components/compact.md