### PR TITLE
[WIP] Add HDFS storage backend

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,15 +1,36 @@
 # NOTE: Current plan gives 1500 build minutes per month.
 version: 2
 jobs:
+  package-hdfs:
+    docker:
+      - image: circleci/golang:1.11
+    working_directory: /go/src/github.com/improbable-eng/thanos
+    steps:
+      - checkout
+      - run: make package-hdfs
+      - persist_to_workspace:
+          root: .
+          paths:
+          - .hdfs.*.tar.gz
+
   test:
     docker:
       # Available from https://hub.docker.com/r/circleci/golang/
       - image: circleci/golang:1.10
+      - image: uhopper/hadoop-namenode:2.8.1
+        environment:
+          CLUSTER_NAME: thanos
+          CORE_CONF_fs_defaultFS: hdfs://localhost:8020
+      - image: uhopper/hadoop-datanode:2.8.1
+        environment:
+          CORE_CONF_fs_defaultFS: hdfs://localhost:8020
     working_directory: /go/src/github.com/improbable-eng/thanos
     steps:
       - checkout
       - setup_remote_docker:
             version: 17.07.0-ce
+      - attach_workspace:
+          at: .
       - run:
           name: Create Secret if PR is not forked
           # GCS integration tests are run only for author's PR that have write access, because these tests
@@ -46,6 +67,8 @@ jobs:
     working_directory: /home/circleci/.go_workspace/src/github.com/improbable-eng/thanos
     steps:
     - checkout
+    - attach_workspace:
+        at: .
     - run: make crossbuild
     - persist_to_workspace:
         root: .
@@ -97,7 +120,13 @@ workflows:
   version: 2
   thanos:
     jobs:
+    - package-hdfs:
+        filters:
+          tags:
+            only: /.*/
     - test:
+        requires:
+        - package-hdfs
         filters:
           tags:
             only: /.*/

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ data/
 
 /.idea
 /*.iml
+
+/.hdfs.*.tar.gz

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -104,6 +104,13 @@
   revision = "9f541cc9db5d55bce703bd99987c9d5cb8eea45e"
 
 [[projects]]
+  digest = "1:dfce66afa58b8dca3c176c2ff132a1d2ecb8008ee43b7bdb969513441a8f37e1"
+  name = "github.com/fharding1/limit"
+  packages = ["."]
+  pruneopts = ""
+  revision = "25d8d1dc2d1f95a37b6c0eb4378a7e0717f6f4e1"
+
+[[projects]]
   digest = "1:e5c807ac3b60699ccec9263f6eec756251b17e78582eb149f90ac345d9e58327"
   name = "github.com/fortytw2/leaktest"
   packages = ["."]
@@ -755,6 +762,7 @@
     "github.com/NYTimes/gziphandler",
     "github.com/armon/go-metrics",
     "github.com/armon/go-metrics/prometheus",
+    "github.com/fharding1/limit",
     "github.com/fortytw2/leaktest",
     "github.com/fsnotify/fsnotify",
     "github.com/go-kit/kit/log",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,4 +1,4 @@
-ignored = ["github.com/improbable-eng/thanos/benchmark/*"]
+ignored = ["github.com/improbable-eng/thanos/benchmark/*", "github.com/colinmarc/hdfs/*"]
 
 [[constraint]]
   name = "cloud.google.com/go"
@@ -83,3 +83,7 @@ ignored = ["github.com/improbable-eng/thanos/benchmark/*"]
 [[constraint]]
   name = "github.com/gophercloud/gophercloud"
   revision = "0719c6b22f30132b0ae6c90b038e0d50992107b0"
+
+[[constraint]]
+  name = "github.com/fharding1/limit"
+  revision = "25d8d1dc2d1f95a37b6c0eb4378a7e0717f6f4e1"

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -4,16 +4,17 @@ Thanos supports any object stores that can be implemented against Thanos [objsto
 
 Current object storage client implementations:
 
-| Provider             | Maturity | Auto-tested on CI | Maintainers |
-|----------------------|-------------------|-----------|---------------|
-| Google Cloud Storage | Stable  (production usage)             | yes       | @bplotka   |
-| AWS S3               | Beta  (working PoCs, testing usage)               | no        | ?          |
-| Azure Storage Account | Alpha   | yes       | @vglafirov   |
-| OpenStack Swift      | Beta  (working PoCs, testing usage)               | no        | @sudhi-vm   |
+| Provider              | Maturity                            | Auto-tested on CI | Maintainers |
+|-----------------------|-------------------------------------|-------------------|-------------|
+| Google Cloud Storage  | Stable  (production usage)          | yes               | @bplotka    |
+| AWS S3                | Beta  (working PoCs, testing usage) | no                | ?           |
+| Azure Storage Account | Alpha                               | yes               | @vglafirov  |
+| OpenStack Swift       | Beta  (working PoCs, testing usage) | no                | @sudhi-vm   |
+| Apache Hadoop HDFS    | Alpha                               | yes               | @twz123     |
 
 NOTE: Currently Thanos requires strong consistency (write-read) for object store implementation.
 
-## How to add a new client?
+## How to add a new client
 
 1. Create new directory under `pkg/objstore/<provider>`
 2. Implement [objstore.Bucket inteface](/pkg/objstore/objstore.go)
@@ -51,6 +52,7 @@ Make sure you use a correct signature version to set `signature-version2: true`,
 For debug purposes you can set `insecure: true` to switch to plain insecure HTTP instead of HTTPS
 
 ### Credentials
+
 By default Thanos will try to retrieve credentials from the following sources:
 
 1. IAM credentials retrieved from an instance profile
@@ -159,7 +161,7 @@ You can read more on how to get application credential json file in [https://clo
 
 For deployment:
 
-`Storage Object Creator` and ` Storage Object Viewer`
+`Storage Object Creator` and `Storage Object Viewer`
 
 For testing:
 
@@ -188,9 +190,10 @@ config:
 ```
 
 ### OpenStack Swift Configuration
+
 Thanos uses [gophercloud](http://gophercloud.io/) client to upload Prometheus data into [OpenStack Swift](https://docs.openstack.org/swift/latest/).
 
-Below is an example configuration file for thanos to use OpenStack swift container as an object store. 
+Below is an example configuration file for Thanos to use OpenStack swift container as an object store.
 
 ```yaml
 type: SWIFT
@@ -202,5 +205,25 @@ config:
     region_name: <region>
     container_name: <container>
 ```
+
+### Apache Hadoop HDFS
+
+Thanos uses the [colinmarc/hdfs][go-hdfs] client to upload Prometheus data into
+[HDFS][hdfs]. Below is an example configuration file for Thanos to use HDFS as
+an object store.
+
+```yaml
+type: HDFS
+config:
+    namenode_addresses:                   # specify the namenode(s) to connect to.
+    - primary-namenode.example.com:8020
+    - secondary-namenode.example.com:8020
+    username: thanos                      # specifies which HDFS user the client will act as
+    use_datanode_hostnames: false         # whether to connect to the datanodes via hostname or IP address
+    bucket_path: /path/to/bucket/on/hdfs  # absolute path of this bucket within HDFS
+```
+
+[go-hdfs]: https://github.com/colinmarc/hdfs
+[hdfs]: https://hadoop.apache.org/docs/stable/hadoop-project-dist/hadoop-hdfs/HdfsDesign.html
 
 Set the flags `--objstore.config-file` to reference to the configuration file.

--- a/hack/package-hdfs.sh
+++ b/hack/package-hdfs.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env sh
+
+set -e
+
+[ $# -eq 2 ] || {
+  echo expected exactly two arguments, got "$#" 1>&2
+  exit 1
+}
+
+case "$(go version)" in
+*" go1.11 "*) ;;
+*" go1.11."*) ;;
+*)
+  echo unsupported go version, needs 1.11 1>&2
+  exit 1
+  ;;
+esac
+
+FETCH_DIR="$(mktemp -d)" || {
+  echo failed to create temporary directory 1>&2
+  exit 1
+}
+
+# shellcheck disable=SC2064
+trap "rm -rf -- \"$FETCH_DIR\"" INT EXIT
+
+curl -sSL "https://codeload.github.com/colinmarc/hdfs/tar.gz/$1" |
+  tar xz --strip-components=1 -C"$FETCH_DIR"
+
+(
+  CDPATH='' cd -- "$FETCH_DIR"
+  go mod vendor
+)
+
+tar cz -C"$FETCH_DIR" -f"$2" .

--- a/pkg/objstore/client/factory.go
+++ b/pkg/objstore/client/factory.go
@@ -10,6 +10,7 @@ import (
 	"github.com/improbable-eng/thanos/pkg/objstore"
 	"github.com/improbable-eng/thanos/pkg/objstore/azure"
 	"github.com/improbable-eng/thanos/pkg/objstore/gcs"
+	"github.com/improbable-eng/thanos/pkg/objstore/hdfs"
 	"github.com/improbable-eng/thanos/pkg/objstore/s3"
 	"github.com/improbable-eng/thanos/pkg/objstore/swift"
 	"github.com/pkg/errors"
@@ -20,9 +21,10 @@ import (
 type objProvider string
 
 const (
-	GCS   objProvider = "GCS"
-	S3    objProvider = "S3"
 	AZURE objProvider = "AZURE"
+	GCS   objProvider = "GCS"
+	HDFS  objProvider = "HDFS"
+	S3    objProvider = "S3"
 	SWIFT objProvider = "SWIFT"
 )
 
@@ -53,12 +55,14 @@ func NewBucket(logger log.Logger, confContentYaml []byte, reg *prometheus.Regist
 
 	var bucket objstore.Bucket
 	switch strings.ToUpper(string(bucketConf.Type)) {
-	case string(GCS):
-		bucket, err = gcs.NewBucket(context.Background(), logger, config, component)
-	case string(S3):
-		bucket, err = s3.NewBucket(logger, config, component)
 	case string(AZURE):
 		bucket, err = azure.NewBucket(logger, config, component)
+	case string(GCS):
+		bucket, err = gcs.NewBucket(context.Background(), logger, config, component)
+	case string(HDFS):
+		bucket, err = hdfs.NewBucket(logger, config)
+	case string(S3):
+		bucket, err = s3.NewBucket(logger, config, component)
 	case string(SWIFT):
 		bucket, err = swift.NewContainer(logger, config)
 	default:

--- a/pkg/objstore/hdfs/bucket.go
+++ b/pkg/objstore/hdfs/bucket.go
@@ -1,0 +1,477 @@
+package hdfs
+
+import (
+	"context"
+	"encoding/base64"
+	"io"
+	"net"
+	"os"
+	"sort"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	hdfs "github.com/colinmarc/hdfs/v2"
+	"github.com/fharding1/limit"
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/improbable-eng/thanos/pkg/objstore"
+	"github.com/pkg/errors"
+)
+
+// FIXME: Pass on context to HDFS lib somehow (https://medium.com/@zombiezen/canceling-i-o-in-go-capn-proto-5ae8c09c5b29)
+// FIXME: Metrics
+
+const (
+	partialsDir       = ".partials"
+	partialsDirPrefix = partialsDir + "/"
+)
+
+var (
+	errPartials = errors.Errorf("the %q directory is reserved for internal use", partialsDir)
+)
+
+type hdfsBucket struct {
+	logger     log.Logger
+	bucketPath hdfsPath
+	client     *hdfs.Client
+}
+
+func NewBucket(logger log.Logger, config *Config) (objstore.Bucket, error) {
+	return newBucket(logger, config)
+}
+
+func NewTestBucket(t *testing.T, config *Config) (objstore.Bucket, func(), error) {
+	bucket, err := newBucket(log.NewLogfmtLogger(os.Stdout), config)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	closeFn := func() {
+		if err := bucket.client.RemoveAll(string(bucket.bucketPath)); err != nil {
+			t.Errorf("failed to delete bucket: %v", err)
+		}
+		if err := bucket.Close(); err != nil {
+			t.Errorf("failed to close HDFS client: %v", err)
+		}
+	}
+
+	return bucket, closeFn, nil
+}
+
+func newBucket(logger log.Logger, config *Config) (*hdfsBucket, error) {
+	bucketPath, err := buildPath(config.BucketPath)
+	if err != nil {
+		return nil, errors.Wrapf(err, "invalid HDFS bucket path: %q", config.BucketPath)
+	}
+
+	dialFunc := (&net.Dialer{
+		Timeout:   5 * time.Second,
+		KeepAlive: 5 * time.Second,
+		DualStack: true,
+	}).DialContext
+
+	ctxDialFunc := func(ctx context.Context, network, address string) (net.Conn, error) {
+		level.Debug(logger).Log("msg", "Dialing HDFS", "ctx", ctx, "network", network, "address", address)
+		return dialFunc(ctx, network, address)
+	}
+
+	opts := hdfs.ClientOptions{
+		Addresses:           config.NameNodeAddresses,
+		User:                config.UserName,
+		UseDatanodeHostname: config.UseDataNodeHostnames,
+		NamenodeDialFunc:    ctxDialFunc,
+		DatanodeDialFunc:    ctxDialFunc,
+	}
+
+	client, err := hdfs.NewClient(opts)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to connect to %v", opts.Addresses)
+	}
+
+	partialsPath, err := bucketPath.join(partialsDir)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := mkdirAll(client, partialsPath); err != nil {
+		if closeErr := client.Close(); closeErr != nil {
+			return nil, moreErrors([]error{err, closeErr})
+		}
+		return nil, err
+	}
+
+	return &hdfsBucket{
+		logger:     logger,
+		bucketPath: bucketPath,
+		client:     client,
+	}, nil
+}
+
+// Name returns the bucket name for the provider.
+func (h *hdfsBucket) Name() string {
+	return string(h.bucketPath)
+}
+
+func (h *hdfsBucket) Close() error {
+	return h.client.Close()
+}
+
+// Iter calls f for each entry in the given directory (not recursive.). The argument to f is the full
+// object name including the prefix of the inspected directory.
+func (h *hdfsBucket) Iter(ctx context.Context, dir string, callback func(string) error) error {
+	if strings.HasSuffix(dir, "/") {
+		dir = dir[:len(dir)-1]
+	}
+
+	reader, _, err := h.open(ctx, dir)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	prefix := dir
+	if prefix != "" {
+		prefix += "/"
+	}
+
+	return allErrors(
+		iter(reader, prefix, callback),
+		reader.Close(),
+	)
+}
+
+// Get returns a reader for the given object name.
+func (h *hdfsBucket) Get(ctx context.Context, name string) (io.ReadCloser, error) {
+	return h.openFile(ctx, name)
+}
+
+// GetRange returns a new range reader for the given object name and range.
+func (h *hdfsBucket) GetRange(ctx context.Context, name string, off, length int64) (io.ReadCloser, error) {
+	reader, err := h.openFile(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+
+	if _, err := reader.Seek(off, io.SeekStart); err != nil {
+		if closeErr := reader.Close(); closeErr != nil {
+			return nil, moreErrors([]error{err, closeErr})
+		}
+		return nil, err
+	}
+
+	return limit.ReadCloser(reader, length), nil
+}
+
+// Exists checks if the given object exists in the bucket.
+func (h *hdfsBucket) Exists(ctx context.Context, name string) (bool, error) {
+	path, err := h.fromExternalName(name)
+	if err != nil {
+		return false, &os.PathError{Op: "stat", Path: name, Err: err}
+	}
+
+	info, err := h.client.Stat(string(path))
+	if err != nil {
+		if h.IsObjNotFoundErr(err) {
+			return false, nil
+		}
+
+		return false, err
+	}
+
+	return !info.IsDir(), nil
+}
+
+// IsObjNotFoundErr returns true if error means that object is not found. Relevant to Get operations.
+func (h *hdfsBucket) IsObjNotFoundErr(err error) bool {
+	return os.IsNotExist(err)
+}
+
+// Upload the contents of the reader as an object into the bucket.
+func (h *hdfsBucket) Upload(ctx context.Context, name string, r io.Reader) error {
+	path, err := h.fromExternalName(name)
+	if err != nil {
+		return &os.PathError{Op: "create", Path: name, Err: err}
+	}
+
+	partialsPath, err := h.bucketPath.join(partialsDir, base64.URLEncoding.EncodeToString([]byte(name)))
+	if err != nil {
+		return &os.PathError{Op: "create", Path: name, Err: err}
+	}
+
+	if err := h.upload(partialsPath, r); err != nil {
+		return err
+	}
+
+	if err := h.rename(partialsPath, path); err != nil {
+		if delErr := h.delete(partialsPath); delErr != nil {
+			return moreErrors([]error{err, delErr})
+		}
+
+		return err
+	}
+
+	return nil
+}
+
+// Delete removes the object with the given name.
+func (h *hdfsBucket) Delete(ctx context.Context, name string) error {
+	path, err := h.fromExternalName(name)
+	if err != nil {
+		return &os.PathError{Op: "remove", Path: name, Err: err}
+	}
+
+	return h.delete(path)
+}
+
+func isPartials(name string) bool {
+	return name == partialsDir || strings.HasPrefix(name, partialsDirPrefix)
+}
+
+func (h *hdfsBucket) fromExternalName(name string) (hdfsPath, error) {
+	if isPartials(name) {
+		return invalidHdfsPath, errPartials
+	}
+
+	if name == "" {
+		return h.bucketPath, nil
+	}
+
+	return h.bucketPath.join(name)
+}
+
+func (h *hdfsBucket) open(ctx context.Context, name string) (*hdfs.FileReader, hdfsPath, error) {
+	path, err := h.fromExternalName(name)
+	if err != nil {
+		return nil, path, &os.PathError{Op: "open", Path: name, Err: err}
+	}
+
+	reader, err := h.client.Open(string(path))
+	return reader, path, err
+}
+
+func (h *hdfsBucket) openFile(ctx context.Context, name string) (*hdfs.FileReader, error) {
+	reader, path, err := h.open(ctx, name)
+	if err == nil && reader.Stat().IsDir() {
+		if err := reader.Close(); err != nil {
+			return nil, err
+		}
+		return nil, pathError("open", path, syscall.EISDIR)
+	}
+
+	return reader, err
+}
+
+func iter(reader *hdfs.FileReader, prefix string, callback func(string) error) error {
+	// TODO: Clarify if ordering is important, or if it's just an implementation
+	// detail of the acceptance tests. If ordering is not important, remove the
+	// client-side sorting code here and don't fetch the whole directory
+	// contents in memory, but use a fetch size > 0.
+	readDirFetchSize := 0
+	content, err := reader.Readdir(readDirFetchSize)
+	if err != nil {
+		return err
+	}
+
+	sort.Slice(content, func(i, j int) bool {
+		if content[i].IsDir() != content[j].IsDir() {
+			return content[j].IsDir()
+		}
+		return content[i].Name() < content[j].Name()
+	})
+
+	for _, info := range content {
+		name := prefix + info.Name()
+		if isPartials(name) {
+			continue
+		}
+
+		if info.IsDir() {
+			name += "/"
+		}
+
+		if err := callback(name); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (h *hdfsBucket) upload(path hdfsPath, r io.Reader) error {
+	writer, pruneFn, err := h.create(path)
+	if err != nil {
+		return err
+	}
+
+	level.Debug(h.logger).Log("msg", "starting upload", "path", path)
+
+	written, err := io.Copy(writer, r)
+	err = allErrors(err, writer.Close())
+	if err != nil {
+		return allErrors(err, pruneFn())
+	}
+
+	level.Debug(h.logger).Log("msg", "upload complete", "path", path, "written", written)
+	return nil
+}
+
+func mkdirAll(c *hdfs.Client, path hdfsPath) error {
+	if err := c.MkdirAll(string(path), os.FileMode(0755)); err != nil {
+		return errors.Wrapf(err, "failed to create directory %q", path)
+	}
+
+	return nil
+}
+
+var noop = func() error { return nil }
+
+func (h *hdfsBucket) create(path hdfsPath) (*hdfs.FileWriter, func() error, error) {
+	writer, pruneFn, err := h.doOnPath(path, func() (io.Closer, error) {
+		return h.client.Create(string(path))
+	})
+
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if writer, ok := writer.(*hdfs.FileWriter); ok {
+		return writer, pruneFn, nil
+	}
+
+	return nil, nil, allErrors(
+		errors.New("internal error"),
+		writer.Close(),
+		pruneFn(),
+	)
+}
+
+func (h *hdfsBucket) rename(from, to hdfsPath) error {
+	_, _, err := h.doOnPath(to, func() (io.Closer, error) {
+		err := h.client.Rename(string(from), string(to))
+		return nil, err
+	})
+
+	if err == nil {
+		level.Debug(h.logger).Log("msg", "renamed file", "from", from, "to", to)
+	}
+	return err
+}
+
+func (h *hdfsBucket) delete(path hdfsPath) error {
+	err := h.client.Remove(string(path))
+	if err != nil {
+		return err
+	}
+
+	if parent, ok := path.parent(); ok {
+		if err := h.prune(parent); err != nil {
+			return pathError("remove", path, err)
+		}
+	} else {
+		return pathError("remove", path, errors.New("failed to determine parent directory"))
+	}
+
+	return nil
+}
+
+func (h *hdfsBucket) doOnPath(path hdfsPath, fn func() (io.Closer, error)) (io.Closer, func() error, error) {
+	writer, err := fn()
+	if err == nil {
+		return writer, noop, nil
+	}
+
+	if !h.IsObjNotFoundErr(err) {
+		return nil, nil, err
+	}
+
+	// try to create parent dir
+	parent, ok := path.parent()
+	if !ok || !h.bucketPath.isParentOf(parent) {
+		return nil, nil, errors.Errorf("refusing to create parent directory for %q", path)
+	}
+
+	if err := mkdirAll(h.client, parent); err != nil {
+		return nil, nil, err
+	}
+
+	pruneFn := func() error {
+		return h.prune(path)
+	}
+
+	writer, err = fn()
+	if err != nil {
+		return nil, nil, allErrors(err, pruneFn())
+	}
+
+	return writer, pruneFn, nil
+}
+
+func (h *hdfsBucket) prune(path hdfsPath) error {
+	for h.bucketPath.isParentOf(path) {
+		if err := h.client.Remove(string(path)); err != nil {
+			if h.IsObjNotFoundErr(err) {
+				return nil
+			}
+
+			if pathErr, ok := err.(*os.PathError); ok && pathErr.Err == syscall.ENOTEMPTY {
+				return nil // ok, found a non-empty parent, all good!
+			}
+
+			return err
+		}
+
+		parent, ok := path.parent()
+		if !ok {
+			return errors.Errorf("failed to determine parent directory of %q", path)
+		}
+
+		path = parent
+	}
+
+	if path == h.bucketPath {
+		return nil // reached the bucket's root
+	}
+
+	return errors.Errorf("refusing to prune %q", path)
+}
+
+func pathError(op string, path hdfsPath, err error) error {
+	return &os.PathError{Op: op, Path: string(path), Err: err}
+}
+
+type moreErrors []error
+
+func (errs moreErrors) Error() string {
+	var errStrings []string
+	for _, err := range errs {
+		errStrings = append(errStrings, err.Error())
+	}
+
+	return strings.Join(errStrings, "; ")
+}
+
+func allErrors(allErrors ...error) error {
+	var errs []error
+	for _, err := range allErrors {
+		if err != nil {
+			if moreErrs, ok := err.(moreErrors); ok {
+				errs = append(errs, moreErrs...)
+			} else {
+				errs = append(errs, err)
+			}
+		}
+	}
+
+	switch len(errs) {
+	case 0:
+		return nil
+	case 1:
+		return errs[0]
+	}
+
+	return moreErrors(errs)
+}

--- a/pkg/objstore/hdfs/config.go
+++ b/pkg/objstore/hdfs/config.go
@@ -1,18 +1,42 @@
 package hdfs
 
+import (
+	"regexp"
+
+	"github.com/pkg/errors"
+)
+
 // Config stores the configuration for an HDFS Bucket.
 type Config struct {
-	// NameNodeAddresses specifies the namenode(s) to connect to.
-	NameNodeAddresses []string
+	// NamenodeAddresses specifies the namenode(s) to connect to.
+	NamenodeAddresses []string `yaml:"namenode_addresses"`
 
-	// UserName specifies which HDFS user the client will act as.
-	UserName string
+	// Username specifies which HDFS user the client will act as.
+	Username string `yaml:"username"`
 
-	// UseDataNodeHostnames specifies whether to connect to the DataNodes via
+	// UseDatanodeHostnames specifies whether to connect to the DataNodes via
 	// hostname (which is useful in multi-homed setups) or IP address, which may
 	// be required if DNS isn't available.
-	UseDataNodeHostnames bool
+	UseDatanodeHostnames bool `yaml:"use_datanode_hostnames"`
 
 	// BucketPath is the path of this bucket within HDFS.
-	BucketPath string
+	BucketPath string `yaml:"bucket_path"`
+}
+
+// HDFS usernames must comply to this pattern. Taken from the "CAVEATS" section
+// of `man 8 useradd`.
+var usernamePattern = regexp.MustCompilePOSIX("^[a-z_][a-z0-9_-]*[$]?$")
+
+func (c *Config) validate() (hdfsPath, error) {
+	if len(c.NamenodeAddresses) < 1 {
+		return invalidHdfsPath, errors.New("no HDFS namenode addresses specified")
+	}
+	if !usernamePattern.MatchString(c.Username) {
+		return invalidHdfsPath, errors.Errorf("HDFS username invalid: %q", c.Username)
+	}
+	bucketPath, err := buildPath(c.BucketPath)
+	if err != nil {
+		return invalidHdfsPath, errors.Wrapf(err, "HDFS bucket path is invalid")
+	}
+	return bucketPath, nil
 }

--- a/pkg/objstore/hdfs/config.go
+++ b/pkg/objstore/hdfs/config.go
@@ -1,0 +1,18 @@
+package hdfs
+
+// Config stores the configuration for an HDFS Bucket.
+type Config struct {
+	// NameNodeAddresses specifies the namenode(s) to connect to.
+	NameNodeAddresses []string
+
+	// UserName specifies which HDFS user the client will act as.
+	UserName string
+
+	// UseDataNodeHostnames specifies whether to connect to the DataNodes via
+	// hostname (which is useful in multi-homed setups) or IP address, which may
+	// be required if DNS isn't available.
+	UseDataNodeHostnames bool
+
+	// BucketPath is the path of this bucket within HDFS.
+	BucketPath string
+}

--- a/pkg/objstore/hdfs/path.go
+++ b/pkg/objstore/hdfs/path.go
@@ -1,0 +1,154 @@
+package hdfs
+
+import (
+	"strings"
+	"unicode"
+
+	"github.com/pkg/errors"
+)
+
+// hdfsPath is a rooted path in HDFS. It is guaranteed to start with a slash and
+// not to end with a slash, except for the root path "/". Create an hdfsPath
+// using the buildPath method.
+// https://hadoop.apache.org/docs/current/hadoop-project-dist/hadoop-common/filesystem/model.html
+type hdfsPath string
+
+const (
+	invalidHdfsPath = hdfsPath("")
+	hdfsRootPath    = hdfsPath("/")
+)
+
+func buildPath(elem ...string) (hdfsPath, error) {
+	// Path elements MUST NOT be in {"", ".", "..", "/"}.
+	// Path elements MUST NOT contain the characters {'/', ':'}.
+
+	switch len(elem) {
+	case 0:
+		return "", errors.New("empty path")
+
+	case 1:
+		if _, err := checkRootPath(elem[0]); err != nil {
+			return "", err
+		}
+		return hdfsPath(elem[0]), nil
+	}
+
+	return buildRootedPath(elem[0], elem[1:])
+}
+
+func buildRootedPath(root string, elem []string) (hdfsPath, error) {
+	isRoot, err := checkRootPath(root)
+	if err != nil {
+		return invalidHdfsPath, err
+	}
+
+	for _, el := range elem {
+		if err := checkPath(el); err != nil {
+			return invalidHdfsPath, err
+		}
+	}
+
+	if isRoot {
+		return hdfsPath("/" + strings.Join(elem, "/")), nil
+	}
+
+	return hdfsPath(root + "/" + strings.Join(elem, "/")), nil
+}
+
+func checkRootPath(path string) (root bool, err error) {
+	if path == "/" {
+		return true, nil
+	}
+
+	if !strings.HasPrefix(path, "/") {
+		return false, errors.Errorf("root paths must start with a slash: %q", path)
+	}
+
+	return false, checkPath(path[1:])
+}
+
+func checkPath(path string) error {
+	type state int
+	const (
+		slashSeen state = iota
+		dotSeen
+		dotDotSeen
+		inElem
+	)
+	s := slashSeen
+
+	for _, ch := range path {
+		switch {
+		case ch == '/':
+			switch s {
+			case slashSeen:
+				return errors.Errorf("empty path element: %q", path)
+			case dotSeen, dotDotSeen:
+				return errors.Errorf("invalid path element: %q", path)
+			}
+			s = slashSeen
+
+		case ch == '.':
+			switch s {
+			case slashSeen:
+				s = dotSeen
+			case dotSeen:
+				s = dotDotSeen
+			case dotDotSeen:
+				s = inElem
+			}
+
+		case unicode.IsControl(ch), ch == ':', ch == unicode.ReplacementChar:
+			return errors.Errorf("illegal character in path: %q", path)
+
+		default:
+			s = inElem
+		}
+	}
+
+	switch s {
+	case slashSeen:
+		return errors.Errorf("empty path element: %q", path)
+	case dotSeen, dotDotSeen:
+		return errors.Errorf("invalid path element: %q", path)
+	}
+
+	return nil
+}
+
+func (p hdfsPath) join(elem ...string) (hdfsPath, error) {
+	return buildRootedPath(string(p), elem)
+}
+
+func (p hdfsPath) parent() (hdfsPath, bool) {
+	splitPoint := strings.LastIndex(string(p), "/")
+	if splitPoint < 0 {
+		return invalidHdfsPath, false
+	}
+	if splitPoint == 0 {
+		return hdfsRootPath, len(p) > 1
+	}
+
+	path := p[:splitPoint]
+	if _, err := checkRootPath(string(path)); err != nil {
+		return invalidHdfsPath, false
+	}
+
+	return path, true
+}
+
+func (p hdfsPath) isParentOf(other hdfsPath) bool {
+	if p == invalidHdfsPath {
+		return false
+	}
+	if p == hdfsRootPath && other != hdfsRootPath {
+		return true
+	}
+
+	if len(other) >= len(p)+1 && other[len(p)] == '/' && other[0:len(p)] == p {
+		_, err := checkRootPath(string(p))
+		return err == nil
+	}
+
+	return false
+}

--- a/pkg/objstore/hdfs/path_test.go
+++ b/pkg/objstore/hdfs/path_test.go
@@ -16,11 +16,6 @@ var validParts = []string{
 	"a..", "a..b",
 }
 
-func TestDoo(t *testing.T) {
-	var foo []string
-	testutil.Equals(t, true, foo == nil)
-}
-
 func TestBuildHdfsPath(t *testing.T) {
 	test := func(expected string, parts ...string) {
 		t.Run(fmt.Sprintf("buildPath(%q)", parts), func(t *testing.T) {

--- a/pkg/objstore/hdfs/path_test.go
+++ b/pkg/objstore/hdfs/path_test.go
@@ -1,0 +1,140 @@
+package hdfs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/improbable-eng/thanos/pkg/testutil"
+)
+
+var validParts = []string{
+	"...",
+	"a", "ab",
+	".a", ".ab",
+	"a.", "a.b",
+	"..a", "..ab",
+	"a..", "a..b",
+}
+
+func TestDoo(t *testing.T) {
+	var foo []string
+	testutil.Equals(t, true, foo == nil)
+}
+
+func TestBuildHdfsPath(t *testing.T) {
+	test := func(expected string, parts ...string) {
+		t.Run(fmt.Sprintf("buildPath(%q)", parts), func(t *testing.T) {
+			path, err := buildPath(parts...)
+			testutil.Ok(t, err)
+			testutil.Equals(t, expected, string(path))
+		})
+	}
+
+	var buildSpec = [][]string{
+		[]string{"/"}, []string{"/"},
+		[]string{"/foo"}, []string{"/foo"},
+		[]string{"/foo", "bar"}, []string{"/foo/bar"},
+	}
+
+	for _, part := range validParts {
+		test("/"+part, "/", part)
+		test("/"+part, "/"+part)
+	}
+
+	for i := 0; i < len(buildSpec); i += 2 {
+		test(buildSpec[i+1][0], buildSpec[i]...)
+	}
+}
+
+func TestBuildBadHdfsPath(t *testing.T) {
+	test := func(parts ...string) {
+		t.Run(fmt.Sprintf("buildPath(%q)", parts), func(t *testing.T) {
+			path, err := buildPath(parts...)
+			testutil.NotOk(t, err)
+			testutil.Equals(t, "", string(path))
+		})
+	}
+
+	test([]string(nil)...)
+	test([]string{}...)
+	test("/", "/")
+	test("//")
+
+	for _, invalidPart := range []string{
+		".", "..", ":", "x:", ":x", "x:y",
+	} {
+		test(invalidPart)
+		test("/" + invalidPart)
+		test("/", invalidPart)
+		test(invalidPart, "/")
+		test(invalidPart + "/")
+		for _, validPart := range validParts {
+			for _, parts := range [][]string{{invalidPart, validPart}, {validPart, invalidPart}} {
+				test(parts[0], parts[1])
+				test("/", parts[0], parts[1])
+				test("/"+parts[0], parts[1])
+				test(parts[0] + "/" + parts[1])
+				test("/" + parts[0] + "/" + parts[1])
+			}
+		}
+	}
+
+	for _, validPart := range validParts {
+		test(validPart)
+		test(validPart + "/")
+		test(validPart, "/")
+	}
+}
+
+var pathsWithParents = map[string]string{
+	"/foo":        "/",
+	"/foo/":       "/foo",
+	"/foo/\\":     "/foo",
+	"/foo\\/":     "/foo\\",
+	"/foo/bar":    "/foo",
+	"/foo/\\bar":  "/foo",
+	"/foo\\/bar":  "/foo\\",
+	"/foo/bar/":   "/foo/bar",
+	"/foo/\\bar/": "/foo/\\bar",
+	"/foo\\/bar/": "/foo\\/bar",
+}
+
+func TestHdfsParentPath(t *testing.T) {
+	test := func(path, parent hdfsPath, ok bool) {
+		t.Run(fmt.Sprintf("%q.parent()", path), func(t *testing.T) {
+			actParent, actOk := path.parent()
+			testutil.Equals(t, parent, actParent)
+			testutil.Equals(t, ok, actOk)
+		})
+	}
+
+	for path, parent := range map[hdfsPath]hdfsPath{
+		invalidHdfsPath: invalidHdfsPath,
+		hdfsRootPath:    hdfsRootPath,
+		hdfsPath("foo"): invalidHdfsPath,
+	} {
+		test(path, parent, false)
+	}
+
+	for path, parent := range pathsWithParents {
+		test(hdfsPath(path), hdfsPath(parent), true)
+		test(hdfsPath(path[1:]), invalidHdfsPath, false)
+	}
+}
+
+func TestHdfsIsParentOfPath(t *testing.T) {
+	test := func(parent, other hdfsPath, isParent bool) {
+		t.Run(fmt.Sprintf("%q.isParentOf(%q)", parent, other), func(t *testing.T) {
+			actIsParent := parent.isParentOf(other)
+			testutil.Equals(t, isParent, actIsParent)
+		})
+	}
+
+	for path, parent := range pathsWithParents {
+		test(hdfsPath(parent), hdfsPath(path), true)
+		test(hdfsPath(parent[1:]), hdfsPath(path[1:]), false)
+		test(hdfsPath(path), hdfsPath(parent), false)
+		test(hdfsPath(path), hdfsPath(path), false)
+		test(hdfsPath(parent), hdfsPath(parent), false)
+	}
+}

--- a/pkg/objstore/objtesting/foreach.go
+++ b/pkg/objstore/objtesting/foreach.go
@@ -105,9 +105,9 @@ func ForeachStore(t *testing.T, testFn func(t testing.TB, bkt objstore.Bucket)) 
 	// Optional HDFS.
 	if _, ok := os.LookupEnv("THANOS_SKIP_HDFS_TESTS"); !ok {
 		config := &hdfs.Config{
-			NameNodeAddresses:    []string{"localhost:8020"},
-			UseDataNodeHostnames: false,
-			UserName:             "root",
+			NamenodeAddresses:    []string{"localhost:8020"},
+			UseDatanodeHostnames: false,
+			Username:             "root",
 			BucketPath:           "/tmp/thanos-e2e-tests/test-buckets/" + t.Name(),
 		}
 


### PR DESCRIPTION
## Changes

Add an HDFS storage backend. This is a PoC that needs further testing and improvements and lots of inputs of folks who are familiar with the Thanos code base.

Here are the blockers that I'm currently aware of:
* The HDFS library in use is not compatible to dep, but uses go modules. This PR currently uses a cruel hack to patch the vendor folder and make it work on the CI. There's a PR open for the switch to go modules (#602). Probably this needs to wait until it has landed.
* Concurrency safety needs to be verified. Not entirely sure about the requirements that Thanos has, nor about the guarantees which are provided by the HDFS library. In the most pessimistic case, one could either create one-shot HDFS clients for each call to the bucket, or add some sort of object pooling so that HDFS clients are never used concurrently. I'm not yet sure about how heavy-weight the client instances are. They definitely hold a TCP connection to the HDFS namenode.
* Contexts are not honored. Maybe one could add some support for those based on the techniques described in [this blog post](https://medium.com/@zombiezen/5ae8c09c5b29).

Some other things to double-check:
* Currently, the e2e tests impose a strict sort order on the callbacks invoked by the `Iter` function. AFAIK, here's no way of telling HDFS to get an ordered directory listing. This means that the whole directory listing needs to be fetched into memory, so that it can be sorted on the client side, instead of allowing callbacks for partial results. I've already heard that ordering is not a requirement. This has to be reworked then.

## Verification

Added e2e test capabilities to CI. Running a sample deployment for one Prometheus using sidecar / store / compact / querier against a Cloudera HDFS backend since 2018-11-06.