### PR TITLE
query: Add replica priorities for deduplication

### DIFF
--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -273,13 +273,13 @@ func runQuery(
 	fileSDCache := cache.New()
 	dnsProvider := dns.NewProvider(logger, extprom.NewSubsystem(reg, "query_store_api"))
 
-	replicaPriorities := map[string]int{}
+	replicaPriorities := map[string]int64{}
 	for _, priority := range replicaPriority {
 		parts := strings.Split(priority, ",")
 		if len(parts) != 2 {
 			return fmt.Errorf("malformed query.replica-priority parameter: %s", priority)
 		}
-		intPriority, err := strconv.Atoi(parts[1])
+		intPriority, err := strconv.ParseInt(parts[1], 10, 64)
 		if err != nil {
 			return errors.Wrap(err, fmt.Sprintf("malformed query.replica-priority parameter: %s", priority))
 		}

--- a/pkg/query/querier_test.go
+++ b/pkg/query/querier_test.go
@@ -369,7 +369,7 @@ func TestDedupSeriesIterator(t *testing.T) {
 	// ahead this far at least once.
 	cases := []struct {
 		a, b, exp            []sample
-		aPriority, bPriority int
+		aPriority, bPriority int64
 	}{
 		{ // Generally prefer the first series.
 			a:   []sample{{10000, 10}, {20000, 11}, {30000, 12}, {40000, 13}},
@@ -430,7 +430,7 @@ func BenchmarkDedupSeriesIterator(b *testing.B) {
 		it := newDedupSeriesIterator(
 			&SampleIterator{l: s1, i: -1},
 			&SampleIterator{l: s2, i: -1},
-			MinInt, MinInt,
+			math.MinInt64, math.MinInt64,
 		)
 		b.ResetTimer()
 		var total int64


### PR DESCRIPTION
Implements #707.

This turned out to be reasonably straight forward once I had some time to look at it. This is my first pass at an implementation and I'm happy to get feedback or improvement suggestions.

The tl;dr is that the priorities adjust the series set sort order, which causes the existing dedup iterators to work with minimal modification. Omitting priorities falls back to the existing behaviour by setting all priorities to be equal so the sort does nothing.

## Changes

Added support for replica priorities for query deduplication. Priorities are provided as cli args in `<pattern>,<priority>` pairs. These are applied in alphabetical order (aside: unsure if this is the best way to prioritise these args. Should we apply them in the order they are provided on the cli instead?) and for any given query with replica results, points from the highest priority replica are preferred. If the highest priority replica has no data points the next highest priority replica is preferred, continuing until no replicas remain.

The main use case for this is clusters running different granularity replicas (eg: short-term retention with high granularity, and long-term retention with low granularity), where the user querying would prefer to see data from the high granularity replica where possible, falling back to the low granularity data only when the high granularity replicas have no data.

## Verification

I added tests to cover both the base case and the new cases with configured replica priorities for both the sorting func and the deduplication iterator. On top of this, I also did some adhoc testing by running the binary in front of prom and performing the queries that prompted the desire for this change.

### Old binary
<img width="1914" alt="screen shot 2019-01-03 at 10 20 41 am" src="https://user-images.githubusercontent.com/1133705/50844903-514f7d80-1331-11e9-8252-7dc06cb0cf87.png">
<img width="1914" alt="screen shot 2019-01-03 at 10 20 58 am" src="https://user-images.githubusercontent.com/1133705/50844928-60363000-1331-11e9-974c-4fac18eff52f.png">

### New binary with no priorities configured
<img width="1913" alt="screen shot 2019-01-08 at 11 39 05 am" src="https://user-images.githubusercontent.com/1133705/50845072-adb29d00-1331-11e9-9bc8-b334fe004930.png">
<img width="1918" alt="screen shot 2019-01-08 at 11 39 36 am" src="https://user-images.githubusercontent.com/1133705/50845091-ba36f580-1331-11e9-8941-5c1ab6dfa58d.png">

### New binary with short-term-retention node priority 100 and long-term-retention node priority 50
<img width="1920" alt="screen shot 2019-01-08 at 11 40 42 am" src="https://user-images.githubusercontent.com/1133705/50845178-e18dc280-1331-11e9-88d6-f743da8e9cf2.png">
<img width="1920" alt="screen shot 2019-01-08 at 11 41 03 am" src="https://user-images.githubusercontent.com/1133705/50845197-ec485780-1331-11e9-80a7-250662b3b6d8.png">

## Known problems

The resolution of series to use isn't perfect. As you can see in the above new binary with priorities configured image, there's a gap in the deduplicated graph before it falls-forward to the short-term-retention node data again when data returns there. I think this is a result of the long-term node having a higher penalty (because it has a much longer scrape interval) causing the priority-based fallback to drop more data than desired. I couldn't figure out a good solution to this, open to suggestions (but I also think a small gap in that case is probably ok as long as it's documented).