### PR TITLE
Enable sharding compact instances by prometheus shard

### DIFF
--- a/pkg/compact/compact_e2e_test.go
+++ b/pkg/compact/compact_e2e_test.go
@@ -32,7 +32,7 @@ func TestSyncer_SyncMetas_e2e(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 		defer cancel()
 
-		sy, err := NewSyncer(nil, nil, bkt, 0, 1, false)
+		sy, err := NewSyncer(nil, nil, bkt, 0, 1, false, []string{}, []string{})
 		testutil.Ok(t, err)
 
 		// Generate 15 blocks. Initially the first 10 are synced into memory and only the last
@@ -134,7 +134,7 @@ func TestSyncer_GarbageCollect_e2e(t *testing.T) {
 		}
 
 		// Do one initial synchronization with the bucket.
-		sy, err := NewSyncer(nil, nil, bkt, 0, 1, false)
+		sy, err := NewSyncer(nil, nil, bkt, 0, 1, false, []string{}, []string{})
 		testutil.Ok(t, err)
 		testutil.Ok(t, sy.SyncMetas(ctx))
 


### PR DESCRIPTION
We have some very large prometheus shards which take a long time to compact and downsample (especially if there's catching up to do).

This PR adds two new flags, `shard.include` and `shard.exclude` which specify prometheus shards to filter blocks by. Filtering is done when the syncer builds a slice of metadata about blocks in the bucket.

Each flag can be specified multiple times (but including both at once is not valid, I thought this would over-complicate things and increase the chance of mistakes in config).

@bwplotka I think we chatted about this briefly last week :)

I'm currently testing this on a production-like workload.