### PR TITLE
sidecar: time limit requests to Prometheus remote read api

### DIFF
--- a/docs/components/sidecar.md
+++ b/docs/components/sidecar.md
@@ -104,6 +104,9 @@ Flags:
       --prometheus.url=http://localhost:9090
                                  URL at which to reach Prometheus's API. For
                                  better performance use local network.
+      --prometheus.retention=0d  A limit on how much retention to query from
+                                 Prometheus. 0d means query all TSDB data found
+                                 on disk
       --tsdb.path="./data"       Data directory of TSDB.
       --reloader.config-file=""  Config file watched by the reloader.
       --reloader.config-envsubst-file=""

--- a/pkg/store/prometheus.go
+++ b/pkg/store/prometheus.go
@@ -125,6 +125,14 @@ func (p *PrometheusStore) Series(r *storepb.SeriesRequest, s storepb.Store_Serie
 		return nil
 	}
 	q := prompb.Query{StartTimestampMs: r.MinTime, EndTimestampMs: r.MaxTime}
+	// Check to see if we can limit the mint/maxt for a more efficient query.
+	mint, maxt := p.timestamps()
+	if mint > q.StartTimestampMs {
+		q.StartTimestampMs = mint
+	}
+	if maxt < q.EndTimestampMs {
+		q.EndTimestampMs = maxt
+	}
 
 	// TODO(fabxc): import common definitions from prompb once we have a stable gRPC
 	// query API there.

--- a/pkg/store/prometheus_test.go
+++ b/pkg/store/prometheus_test.go
@@ -58,7 +58,11 @@ func testPrometheusStoreSeriesE2e(t *testing.T, prefix string) {
 	proxy, err := NewPrometheusStore(nil, nil, u, component.Sidecar,
 		func() labels.Labels {
 			return labels.FromStrings("region", "eu-west")
-		}, nil)
+		},
+		func() (int64, int64) {
+			return baseT, math.MaxInt64
+		},
+	)
 	testutil.Ok(t, err)
 
 	// Query all three samples except for the first one. Since we round up queried data
@@ -136,7 +140,11 @@ func TestPrometheusStore_LabelValues_e2e(t *testing.T) {
 	u, err := url.Parse(fmt.Sprintf("http://%s", p.Addr()))
 	testutil.Ok(t, err)
 
-	proxy, err := NewPrometheusStore(nil, nil, u, component.Sidecar, getExternalLabels, nil)
+	proxy, err := NewPrometheusStore(nil, nil, u, component.Sidecar, getExternalLabels,
+		func() (int64, int64) {
+			return 0, math.MaxInt64
+		},
+	)
 	testutil.Ok(t, err)
 
 	resp, err := proxy.LabelValues(ctx, &storepb.LabelValuesRequest{
@@ -170,7 +178,11 @@ func TestPrometheusStore_ExternalLabelValues_e2e(t *testing.T) {
 	u, err := url.Parse(fmt.Sprintf("http://%s", p.Addr()))
 	testutil.Ok(t, err)
 
-	proxy, err := NewPrometheusStore(nil, nil, u, component.Sidecar, getExternalLabels, nil)
+	proxy, err := NewPrometheusStore(nil, nil, u, component.Sidecar, getExternalLabels,
+		func() (int64, int64) {
+			return 0, math.MaxInt64
+		},
+	)
 	testutil.Ok(t, err)
 
 	resp, err := proxy.LabelValues(ctx, &storepb.LabelValuesRequest{
@@ -217,7 +229,11 @@ func TestPrometheusStore_Series_MatchExternalLabel_e2e(t *testing.T) {
 	proxy, err := NewPrometheusStore(nil, nil, u, component.Sidecar,
 		func() labels.Labels {
 			return labels.FromStrings("region", "eu-west")
-		}, nil)
+		},
+		func() (int64, int64) {
+			return baseT, math.MaxInt64
+		},
+	)
 	testutil.Ok(t, err)
 	srv := newStoreSeriesServer(ctx)
 
@@ -345,7 +361,12 @@ func TestPrometheusStore_Series_SplitSamplesIntoChunksWithMaxSizeOfUint16_e2e(t 
 		proxy, err := NewPrometheusStore(nil, nil, u, component.Sidecar,
 			func() labels.Labels {
 				return labels.FromStrings("region", "eu-west")
-			}, nil)
+			},
+			func() (int64, int64) {
+				return 0, math.MaxInt64
+			},
+		)
+
 		testutil.Ok(t, err)
 
 		return proxy


### PR DESCRIPTION
* [ENHANCEMENT] Add --prometheus.retention=0d flag to sidecar to limit the TSDB data made available from Prometheus to the last given duration.  The default is 0 or no limit.

## Changes

Implement #1191

The Sidecar keeps track of the mint/maxt of the TSDB data that's it makes available via the Prometheus Remote Read API.  This limits the mint to the given duration, such as 1d or 3d, and makes available only the last 1d or 3d worth of data from the local Prometheus.  

This can vastly improve query response times if Prometheus has more data than this on disk and long term storage is also uploaded into object storage.  Querying the Store component is more efficient than large queries via the Remote Read API.  This can also fix 400 errors returned by the Remote Read API when `storage.remote.read-sample-limit` is hit.

## Verification

* Monitored remote read queries hitting Prometheus that they were for the correct time period.  
* Tested the Query component for errors and speed of query execution.
