### PR TITLE
feat compact: added readiness Prober

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 ### Changed
 
 - [#1338](https://github.com/thanos-io/thanos/pull/1338) Querier still warns on store API duplicate, but allows a single one from duplicated set. This is gracefully warn about the problematic logic and not disrupt immediately.
+- [#1297](https://github.com/improbable-eng/thanos/pull/1297) Added `/-/ready` and `/-/healthy` endpoints to Thanos compact.
 
 ### Fixed
 

--- a/tutorials/kubernetes-demo/manifests/thanos-compactor.yaml
+++ b/tutorials/kubernetes-demo/manifests/thanos-compactor.yaml
@@ -35,6 +35,14 @@ spec:
           ports:
             - name: http
               containerPort: 10902
+          livenessProbe:
+            httpGet:
+              port: 10902
+              path: /-/healthy
+          readinessProbe:
+            httpGet:
+              port: 10902
+              path: /-/ready
           resources:
             limits:
               cpu: "1"


### PR DESCRIPTION
## Changes
Used new Prober package in the Thanos compact to provide `/-/healthy` and `/-/ready` endpoints

I also added new `defatltHTTPListener` which registers the prober. I'm leaving the old `metricHTTPListenGroup` with `TODO` to remove it once all components are migrated to the new one to avoid touching different components in this PR.

Also I switched to using `component.Component` instead of passing the string from the main. 
It felt weird to have somewhere string and somewhere the component interface.

## Verification
Tested it and works as expected, also exposes metrics about Prober status 
```
# HELP thanos_prober_healthy Represents health status of the component Prober.
# TYPE thanos_prober_healthy gauge
thanos_prober_healthy{component="compact"} 1
# HELP thanos_prober_ready Represents readiness status of the component Prober.
# TYPE thanos_prober_ready gauge
thanos_prober_ready{component="compact"} 1
```