### PR TITLE
Remove deprecated option from example

### DIFF
--- a/docs/components/store.md
+++ b/docs/components/store.md
@@ -12,7 +12,6 @@ It keeps a small amount of information about all remote blocks on local disk and
 ```bash
 $ thanos store \
     --data-dir        "/local/state/data/dir" \
-    --cluster.peers    "thanos-cluster.example.org" \
     --objstore.config-file "bucket.yml"
 ```
 


### PR DESCRIPTION
Removing this after gossip removal, also, is there anything that needs to be added?

* [] CHANGELOG entry if change is relevant to the end user.

## Changes

Updated doc removing cluster argument for Store.

## Verification

Just a doc change