### PR TITLE
Added katacoda.yaml file to determine the location of the katacoda scenarios in the git repo.

### DIFF
--- a/katacoda.yaml
+++ b/katacoda.yaml
@@ -1,0 +1,1 @@
+scenario_root : tutorials/katacoda


### PR DESCRIPTION
Katacoda added the possibility to define an attribute in katacoda.yaml to determine the location of the katacoda scenarios in the git repo.
We have tested with your repo, and worked fine. 
We will be happy to help if you have questions building the scenarios.

Signed-off-by: Gabriela S. Soria <soria.gaby@gmail.com>

## Changes

Added `katacoda.yaml ` file setting the property 
`scenario_root : tutorials/katacoda
`
## Verification

We have tested cloning using the forked repository inside https://katacoda.com
