### PR TITLE
store: use a slice instead of a map for storing the symbols in an index

### DIFF
--- a/pkg/block/index.go
+++ b/pkg/block/index.go
@@ -175,7 +175,7 @@ func WriteIndexCache(logger log.Logger, indexFn string, fn string) error {
 // ReadIndexCache reads an index cache file.
 func ReadIndexCache(logger log.Logger, fn string) (
 	version int,
-	symbols map[uint32]string,
+	symbols []string,
 	lvals map[string][]string,
 	postings map[labels.Label]index.Range,
 	err error,
@@ -201,6 +201,14 @@ func ReadIndexCache(logger log.Logger, fn string) (
 	lvals = make(map[string][]string, len(v.LabelValues))
 	postings = make(map[labels.Label]index.Range, len(v.Postings))
 
+	maxSymbolID := 0
+	for o := range v.Symbols {
+		if int(o) > maxSymbolID {
+			maxSymbolID = int(o)
+		}
+	}
+	symbols = make([]string, maxSymbolID+1)
+
 	// Most strings we encounter are duplicates. Dedup string objects that we keep
 	// around after the function returns to reduce total memory usage.
 	// NOTE(fabxc): it could even make sense to deduplicate globally.
@@ -213,7 +221,7 @@ func ReadIndexCache(logger log.Logger, fn string) (
 	}
 
 	for o, s := range v.Symbols {
-		v.Symbols[o] = getStr(s)
+		symbols[o] = getStr(s)
 	}
 	for ln, vals := range v.LabelValues {
 		for i := range vals {
@@ -228,7 +236,7 @@ func ReadIndexCache(logger log.Logger, fn string) (
 		}
 		postings[l] = index.Range{Start: e.Start, End: e.End}
 	}
-	return v.Version, v.Symbols, lvals, postings, nil
+	return v.Version, symbols, lvals, postings, nil
 }
 
 // VerifyIndex does a full run over a block index and verifies that it fulfills the order invariants.

--- a/pkg/block/index.go
+++ b/pkg/block/index.go
@@ -201,10 +201,10 @@ func ReadIndexCache(logger log.Logger, fn string) (
 	lvals = make(map[string][]string, len(v.LabelValues))
 	postings = make(map[labels.Label]index.Range, len(v.Postings))
 
-	maxSymbolID := 0
+	var maxSymbolID uint32
 	for o := range v.Symbols {
-		if int(o) > maxSymbolID {
-			maxSymbolID = int(o)
+		if o > maxSymbolID {
+			maxSymbolID = o
 		}
 	}
 	symbols = make([]string, maxSymbolID+1)

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -1261,11 +1261,11 @@ func newBucketIndexReader(ctx context.Context, logger log.Logger, block *bucketB
 
 func (r *bucketIndexReader) lookupSymbol(o uint32) (string, error) {
 	idx := int(o)
-	if idx < len(r.block.symbols) {
-		return r.block.symbols[idx], nil
+	if idx >= len(r.block.symbols) {
+		return "", errors.Errorf("bucketIndexReader: unknown symbol offset %d", o)
 	}
 
-	return "", errors.Errorf("bucketIndexReader: unknown symbol offset %d", o)
+	return r.block.symbols[idx], nil
 }
 
 // ExpandedPostings returns postings in expanded list instead of index.Postings.

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -1060,7 +1060,7 @@ type bucketBlock struct {
 	chunkPool  *pool.BytesPool
 
 	indexVersion int
-	symbols      map[uint32]string
+	symbols      []string
 	lvals        map[string][]string
 	postings     map[labels.Label]index.Range
 
@@ -1260,11 +1260,12 @@ func newBucketIndexReader(ctx context.Context, logger log.Logger, block *bucketB
 }
 
 func (r *bucketIndexReader) lookupSymbol(o uint32) (string, error) {
-	s, ok := r.block.symbols[o]
-	if !ok {
-		return "", errors.Errorf("bucketIndexReader: unknown symbol offset %d", o)
+	idx := int(o)
+	if idx < len(r.block.symbols) {
+		return r.block.symbols[idx], nil
 	}
-	return s, nil
+
+	return "", errors.Errorf("bucketIndexReader: unknown symbol offset %d", o)
 }
 
 // ExpandedPostings returns postings in expanded list instead of index.Postings.


### PR DESCRIPTION
This PR attempts to reduce the memory used by the store component when initializing the local cache during startup. It transforms the `map[uint32]string` into a `[]string`, accepting that there might be many, many empty elements in the slice. This also makes it so that there is no difference between a non-existing label and an empty label.

Testing showed a reduction from 4.0 GiB to 3.6 GiB when loading 3 GiB data from S3 (on an XPS 13 running Ubuntu 18.04).

## Verification

I let the unit tests run, both with the original, my patched and and intentionally broken implementation to check if there are tests for the `lookupSymbol()` function at all.