### PR TITLE
compact: handle partially written blocks

### DIFF
--- a/pkg/compact/compact_e2e_test.go
+++ b/pkg/compact/compact_e2e_test.go
@@ -248,6 +248,7 @@ func TestGroup_Compact_e2e(t *testing.T) {
 			metrics.compactions.WithLabelValues(""),
 			metrics.compactionFailures.WithLabelValues(""),
 			metrics.garbageCollectedBlocks,
+			metrics.partiallyWrittenBlocks.WithLabelValues(""),
 		)
 		testutil.Ok(t, err)
 


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

originates from https://github.com/thanos-io/thanos/issues/1331

* [Changed] skip compacting of partially written blocks

## Changes

<!-- Enumerate changes you made -->

* Determine whether a block is only partially written (e.g. meta.json is present, but index file is missing)
* Expose a metric that counts found and therefore skipped partially written blocks (`thanos_compact_group_partially_written_blocks_detected_total`)
* Remove partially written blocks from the compaction plan before running prometheus/tsdb compaction on the final compaction plan.

## Verification

<!-- How you tested it? How do you know it works? -->

We encountered partially written blocks in our own thanos system. Adding this fix let the compactor skip the partially written block (instead of crashing/exiting). It was then later garbage collected.

I would like to provide an automated test for this but i am having trouble creating a minimal artificial error scenario in which to reproduce the crash. 