### PR TITLE
Unified fetching/syncing block metadata everywhere 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 We use *breaking* word for marking changes that are not backward compatible (relates only to v0.y.z releases.)
 
 ## Unreleased
+- [#1394](https://github.com/thanos-io/thanos/pull/1394) Fix a bug where partially uploaded blocks cause issues when retrieved. 
 
 ## Added
 - [#1540](https://github.com/thanos-io/thanos/pull/1540) Added `/-/ready` and `/-/healthy` endpoints to Thanos Downsample.

--- a/pkg/block/block.go
+++ b/pkg/block/block.go
@@ -163,7 +163,7 @@ func deleteDir(ctx context.Context, logger log.Logger, bkt objstore.Bucket, dir 
 
 // DownloadMeta downloads only meta file from bucket by block ID.
 // TODO(bwplotka): Differentiate between network error & partial upload.
-func DownloadMeta(ctx context.Context, logger log.Logger, bkt objstore.Bucket, id ulid.ULID) (metadata.Meta, error) {
+func DownloadMeta(ctx context.Context, logger log.Logger, bkt objstore.BucketReader, id ulid.ULID) (metadata.Meta, error) {
 	rc, err := bkt.Get(ctx, path.Join(id.String(), MetaFilename))
 	if err != nil {
 		return metadata.Meta{}, errors.Wrapf(err, "meta.json bkt get for %s", id.String())

--- a/pkg/block/mdfetcher.go
+++ b/pkg/block/mdfetcher.go
@@ -1,0 +1,103 @@
+package block
+
+import (
+	"context"
+	"sync"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/oklog/ulid"
+	"github.com/thanos-io/thanos/pkg/block/metadata"
+	"github.com/thanos-io/thanos/pkg/objstore"
+)
+
+type MetadataFetcher struct {
+	cachedBlockMDs map[ulid.ULID]*metadata.Meta
+	mu             *sync.RWMutex
+
+	concurrencyLimit int
+	logger           log.Logger
+	bkt              objstore.BucketReader
+}
+
+func NewMetadataFetcher(logger log.Logger, concurrencyLimit int, bkt objstore.BucketReader) *MetadataFetcher {
+	return &MetadataFetcher{
+		logger:           logger,
+		concurrencyLimit: concurrencyLimit,
+		mu:               &sync.RWMutex{},
+		cachedBlockMDs:   make(map[ulid.ULID]*metadata.Meta),
+		bkt:              bkt,
+	}
+}
+
+// Fetch wil return the mapping from block ID to its metadata that are currently stored in the bucket passed in.
+// If the corresponding value for a block ID key is nil, no valid metadata is retrieved successfully.
+func (f *MetadataFetcher) Fetch(ctx context.Context) (map[ulid.ULID]*metadata.Meta, error) {
+	blockIDs := make(chan ulid.ULID, f.concurrencyLimit)
+	defer close(blockIDs)
+	remoteBlockMDs := make(map[ulid.ULID]*metadata.Meta, len(f.cachedBlockMDs))
+	wg := &sync.WaitGroup{}
+
+	for i := 0; i < f.concurrencyLimit; i++ {
+		go func() {
+			for blockID := range blockIDs {
+				md, err := f.fetchBlockMDIfNotCached(ctx, wg, blockID)
+				if err != nil {
+					level.Debug(f.logger).Log("msg", "failed to fetch block metadata", "block", blockID, "error", err)
+				}
+
+				f.mu.Lock()
+				remoteBlockMDs[blockID] = md
+				f.mu.Unlock()
+			}
+		}()
+	}
+
+	if err := f.bkt.Iter(ctx, "", func(name string) error {
+		wg.Add(1)
+
+		id, isBlock := IsBlockDir(name)
+		if !isBlock {
+			return nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case blockIDs <- id:
+		}
+
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+	wg.Wait()
+
+	f.mu.Lock()
+	f.cachedBlockMDs = make(map[ulid.ULID]*metadata.Meta, len(remoteBlockMDs))
+	for k, v := range remoteBlockMDs {
+		f.cachedBlockMDs[k] = v
+	}
+	f.mu.Unlock()
+
+	return remoteBlockMDs, nil
+}
+
+func (f *MetadataFetcher) fetchBlockMDIfNotCached(ctx context.Context, wg *sync.WaitGroup, blockID ulid.ULID) (*metadata.Meta, error) {
+	defer wg.Done()
+
+	f.mu.RLock()
+	existingMD, exist := f.cachedBlockMDs[blockID]
+	f.mu.RUnlock()
+
+	if exist {
+		return existingMD, nil
+	}
+
+	md, err := DownloadMeta(ctx, f.logger, f.bkt, blockID)
+	if err != nil {
+		return nil, err
+	}
+
+	return &md, nil
+}

--- a/pkg/block/mdfetcher_test.go
+++ b/pkg/block/mdfetcher_test.go
@@ -1,0 +1,73 @@
+package block
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"path"
+	"testing"
+	"time"
+
+	"github.com/go-kit/kit/log"
+	"github.com/oklog/ulid"
+	"github.com/thanos-io/thanos/pkg/block/metadata"
+	"github.com/thanos-io/thanos/pkg/objstore/inmem"
+	"github.com/thanos-io/thanos/pkg/testutil"
+)
+
+const (
+	testConcurrencyLimit = 5
+)
+
+type metadataFetcherTestHarness struct {
+	fetcher *MetadataFetcher
+
+	bkt *inmem.Bucket
+}
+
+func newMetadataFetcherTestHarness() *metadataFetcherTestHarness {
+	bkt := inmem.NewBucket()
+
+	return &metadataFetcherTestHarness{
+		bkt:     bkt,
+		fetcher: NewMetadataFetcher(log.NewNopLogger(), testConcurrencyLimit, bkt),
+	}
+}
+
+func TestRemoteBlockMetadataFetcher_Fetch(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	h := newMetadataFetcherTestHarness()
+
+	blockIDWithoutMD, err := ulid.New(uint64(time.Now().Unix()*1000), nil)
+	testutil.Ok(t, err)
+	blockIDWithMD, err := ulid.New(uint64(time.Now().Add(time.Minute).Unix()*1000), nil)
+	testutil.Ok(t, err)
+
+	var fakeChunk1 bytes.Buffer
+	fakeChunk1.Write([]byte{0, 1, 2, 3})
+	testutil.Ok(t, h.bkt.Upload(ctx, blockIDWithoutMD.String(), &fakeChunk1))
+	var fakeChunk2 bytes.Buffer
+	fakeChunk2.Write([]byte{0, 1, 2, 3, 4})
+	testutil.Ok(t, h.bkt.Upload(ctx, blockIDWithMD.String(), &fakeChunk2))
+	fakeChunk2.Write([]byte{0, 1, 2, 3, 4})
+
+	md := metadata.Meta{}
+	mdBytes, err := json.Marshal(md)
+	testutil.Ok(t, err)
+	var fakeChunk3 bytes.Buffer
+	fakeChunk3.Write(mdBytes)
+	testutil.Ok(t, h.bkt.Upload(ctx, path.Join(blockIDWithMD.String(), MetaFilename), &fakeChunk3))
+
+	res, err := h.fetcher.Fetch(ctx)
+
+	testutil.Ok(t, err)
+	testutil.Equals(t, 2, len(res))
+	md1, exist := res[blockIDWithoutMD]
+	testutil.Equals(t, true, md1 == nil)
+	testutil.Equals(t, true, exist)
+	md2, exist := res[blockIDWithMD]
+	testutil.Equals(t, true, md2 != nil)
+	testutil.Equals(t, true, exist)
+}

--- a/pkg/compact/retention_test.go
+++ b/pkg/compact/retention_test.go
@@ -246,7 +246,7 @@ func TestApplyRetentionPolicyByResolution(t *testing.T) {
 				return nil
 			}))
 
-			testutil.Equals(t, got, tt.want)
+			testutil.Equals(t, tt.want, got)
 		})
 	}
 }


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

* [] CHANGELOG entry if change is relevant to the end user.

## Changes

<!-- Enumerate changes you made -->
* add a new block meta fetcher that fetches block metadata stored in a bucket
* replace some of the existing block md fetching code with the new fetcher
* change the signature of `DownloadMeta` to use the more restrictive `BucketReader`

## Verification

<!-- How you tested it? How do you know it works? -->
Unit test