### PR TITLE
feat sicedar: added readiness prober

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 
 - [#1358](https://github.com/thanos-io/thanos/pull/1358) Added `part_size` configuration option for HTTP multipart requests minimum part size for S3 storage type
 - [#1363](https://github.com/thanos-io/thanos/pull/1363) Thanos Receive now exposes `thanos_receive_hashring_nodes` and `thanos_receive_hashring_tenants` metrics to monitor status of hash-rings
+- [#1395](https://github.com/thanos-io/thanos/pull/1395) Added `/-/ready` and `/-/healthy` endpoints to Thanos sidecar.
 
 ### Changed
 

--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -70,8 +70,7 @@ func (cs compactionSet) maxLevel() int {
 }
 
 func registerCompact(m map[string]setupFunc, app *kingpin.Application) {
-	comp := component.Compact
-	cmd := app.Command(comp.String(), "continuously compacts blocks in an object store bucket")
+	cmd := app.Command(component.Compact.String(), "continuously compacts blocks in an object store bucket")
 
 	haltOnError := cmd.Flag("debug.halt-on-error", "Halt the process if a critical compaction error is detected.").
 		Hidden().Default("true").Bool()
@@ -112,7 +111,7 @@ func registerCompact(m map[string]setupFunc, app *kingpin.Application) {
 	compactionConcurrency := cmd.Flag("compact.concurrency", "Number of goroutines to use when compacting groups.").
 		Default("1").Int()
 
-	m[comp.String()] = func(g *run.Group, logger log.Logger, reg *prometheus.Registry, tracer opentracing.Tracer, _ bool) error {
+	m[component.Compact.String()] = func(g *run.Group, logger log.Logger, reg *prometheus.Registry, tracer opentracing.Tracer, _ bool) error {
 		return runCompact(g, logger, reg,
 			*httpAddr,
 			*dataDir,
@@ -127,7 +126,7 @@ func registerCompact(m map[string]setupFunc, app *kingpin.Application) {
 				compact.ResolutionLevel5m:  time.Duration(*retention5m),
 				compact.ResolutionLevel1h:  time.Duration(*retention1h),
 			},
-			comp,
+			component.Compact,
 			*disableDownsampling,
 			*maxCompactionLevel,
 			*blockSyncConcurrency,

--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -169,9 +169,9 @@ func runCompact(
 
 	downsampleMetrics := newDownsampleMetrics(reg)
 
-	readinessProber := prober.NewProber(component, logger, prometheus.WrapRegistererWithPrefix("thanos_", reg))
+	statusProber := prober.NewProber(component, logger, prometheus.WrapRegistererWithPrefix("thanos_", reg))
 	// Initiate default HTTP listener providing metrics endpoint and readiness/liveness probes.
-	if err := defaultHTTPListener(g, logger, reg, httpBindAddr, readinessProber); err != nil {
+	if err := defaultHTTPListener(g, logger, reg, httpBindAddr, statusProber); err != nil {
 		return errors.Wrap(err, "create readiness prober")
 	}
 
@@ -326,7 +326,7 @@ func runCompact(
 	})
 
 	level.Info(logger).Log("msg", "starting compact node")
-	readinessProber.SetReady()
+	statusProber.SetReady()
 	return nil
 }
 

--- a/cmd/thanos/main.go
+++ b/cmd/thanos/main.go
@@ -70,7 +70,7 @@ func main() {
 	tracingConfig := regCommonTracingFlags(app)
 
 	cmds := map[string]setupFunc{}
-	registerSidecar(cmds, app, "sidecar")
+	registerSidecar(cmds, app)
 	registerStore(cmds, app, "store")
 	registerQuery(cmds, app, "query")
 	registerRule(cmds, app, "rule")

--- a/cmd/thanos/sidecar.go
+++ b/cmd/thanos/sidecar.go
@@ -8,8 +8,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/thanos-io/thanos/pkg/prober"
-
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/oklog/run"
@@ -21,6 +19,7 @@ import (
 	"github.com/thanos-io/thanos/pkg/block/metadata"
 	"github.com/thanos-io/thanos/pkg/component"
 	"github.com/thanos-io/thanos/pkg/objstore/client"
+	"github.com/thanos-io/thanos/pkg/prober"
 	"github.com/thanos-io/thanos/pkg/promclient"
 	"github.com/thanos-io/thanos/pkg/reloader"
 	"github.com/thanos-io/thanos/pkg/runutil"
@@ -34,8 +33,7 @@ import (
 const waitForExternalLabelsTimeout = 10 * time.Minute
 
 func registerSidecar(m map[string]setupFunc, app *kingpin.Application) {
-	comp := component.Sidecar
-	cmd := app.Command(comp.String(), "sidecar for Prometheus server")
+	cmd := app.Command(component.Sidecar.String(), "sidecar for Prometheus server")
 
 	grpcBindAddr, httpBindAddr, cert, key, clientCA := regCommonServerFlags(cmd)
 
@@ -57,7 +55,7 @@ func registerSidecar(m map[string]setupFunc, app *kingpin.Application) {
 
 	uploadCompacted := cmd.Flag("shipper.upload-compacted", "[Experimental] If true sidecar will try to upload compacted blocks as well. Useful for migration purposes. Works only if compaction is disabled on Prometheus.").Default("false").Hidden().Bool()
 
-	m[comp.String()] = func(g *run.Group, logger log.Logger, reg *prometheus.Registry, tracer opentracing.Tracer, _ bool) error {
+	m[component.Sidecar.String()] = func(g *run.Group, logger log.Logger, reg *prometheus.Registry, tracer opentracing.Tracer, _ bool) error {
 		rl := reloader.New(
 			log.With(logger, "component", "reloader"),
 			reloader.ReloadURLFromBase(*promURL),
@@ -80,7 +78,7 @@ func registerSidecar(m map[string]setupFunc, app *kingpin.Application) {
 			objStoreConfig,
 			rl,
 			*uploadCompacted,
-			comp,
+			component.Sidecar,
 		)
 	}
 }

--- a/cmd/thanos/sidecar.go
+++ b/cmd/thanos/sidecar.go
@@ -187,10 +187,8 @@ func runSidecar(
 				if err := m.UpdateLabels(iterCtx, logger); err != nil {
 					level.Warn(logger).Log("msg", "heartbeat failed", "err", err)
 					promUp.Set(0)
-					statusProber.SetNotReady(err)
 				} else {
 					promUp.Set(1)
-					statusProber.SetReady()
 					lastHeartbeat.Set(float64(time.Now().UnixNano()) / 1e9)
 				}
 

--- a/pkg/prober/prober.go
+++ b/pkg/prober/prober.go
@@ -89,7 +89,7 @@ func (p *Prober) writeResponse(w http.ResponseWriter, probeFn func() error, prob
 		http.Error(w, fmt.Sprintf("thanos %v is not %v. Reason: %v", p.component, probeType, err), probeErrorHTTPStatus)
 		return
 	}
-	if _, err := io.WriteString(w, fmt.Sprintf("thanos %v is %v", p.component, probeType)); err == nil {
+	if _, err := io.WriteString(w, fmt.Sprintf("thanos %v is %v", p.component, probeType)); err != nil {
 		level.Error(p.logger).Log("msg", "failed to write probe response", "probe type", probeType, "err", err)
 	}
 }

--- a/pkg/prober/prober.go
+++ b/pkg/prober/prober.go
@@ -22,6 +22,19 @@ const (
 )
 
 // Prober represents health and readiness status of given component.
+//
+// From Kubernetes documentation https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/ :
+//
+//   liveness: Many applications running for long periods of time eventually transition to broken states,
+//   (healthy) and cannot recover except by being restarted.
+//             Kubernetes provides liveness probes to detect and remedy such situations.
+//
+//   readiness: Sometimes, applications are temporarily unable to serve traffic.
+//   (ready)    For example, an application might need to load large data or configuration files during startup,
+//              or depend on external services after startup. In such cases, you don’t want to kill the application,
+//              but you don’t want to send it requests either. Kubernetes provides readiness probes to detect
+//              and mitigate these situations. A pod with containers reporting that they are not ready
+//              does not receive traffic through Kubernetes Services.
 type Prober struct {
 	logger             log.Logger
 	component          component.Component
@@ -36,20 +49,6 @@ type Prober struct {
 // NewProber returns Prober representing readiness and healthiness of given component.
 func NewProber(component component.Component, logger log.Logger, reg prometheus.Registerer) *Prober {
 	initialErr := fmt.Errorf(initialErrorFmt, component)
-
-	// From Kubernetes documentation https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/ :
-	//
-	//   liveness: Many applications running for long periods of time eventually transition to broken states,
-	//   (healthy) and cannot recover except by being restarted.
-	//             Kubernetes provides liveness probes to detect and remedy such situations.
-	//
-	//   readiness: Sometimes, applications are temporarily unable to serve traffic.
-	//   (ready)    For example, an application might need to load large data or configuration files during startup,
-	//              or depend on external services after startup. In such cases, you don’t want to kill the application,
-	//              but you don’t want to send it requests either. Kubernetes provides readiness probes to detect
-	//              and mitigate these situations. A pod with containers reporting that they are not ready
-	//              does not receive traffic through Kubernetes Services.
-
 	p := &Prober{
 		component:   component,
 		logger:      logger,

--- a/pkg/prober/prober.go
+++ b/pkg/prober/prober.go
@@ -37,6 +37,19 @@ type Prober struct {
 func NewProber(component component.Component, logger log.Logger, reg prometheus.Registerer) *Prober {
 	initialErr := fmt.Errorf(initialErrorFmt, component)
 
+	// From Kubernetes documentation https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/ :
+	//
+	//   liveness: Many applications running for long periods of time eventually transition to broken states,
+	//   (healthy) and cannot recover except by being restarted.
+	//             Kubernetes provides liveness probes to detect and remedy such situations.
+	//
+	//   readiness: Sometimes, applications are temporarily unable to serve traffic.
+	//   (ready)    For example, an application might need to load large data or configuration files during startup,
+	//              or depend on external services after startup. In such cases, you don’t want to kill the application,
+	//              but you don’t want to send it requests either. Kubernetes provides readiness probes to detect
+	//              and mitigate these situations. A pod with containers reporting that they are not ready
+	//              does not receive traffic through Kubernetes Services.
+
 	p := &Prober{
 		component:   component,
 		logger:      logger,

--- a/tutorials/kubernetes-demo/manifests/prometheus-ha-sidecar-lts.yaml
+++ b/tutorials/kubernetes-demo/manifests/prometheus-ha-sidecar-lts.yaml
@@ -145,6 +145,14 @@ spec:
             containerPort: 10902
           - name: grpc
             containerPort: 10901
+        livenessProbe:
+            httpGet:
+              port: 10902
+              path: /-/healthy
+        readinessProbe:
+          httpGet:
+            port: 10902
+            path: /-/ready
         volumeMounts:
           - name: prometheus
             mountPath: /var/prometheus

--- a/tutorials/kubernetes-demo/manifests/prometheus-ha-sidecar.yaml
+++ b/tutorials/kubernetes-demo/manifests/prometheus-ha-sidecar.yaml
@@ -129,6 +129,14 @@ spec:
             containerPort: 10902
           - name: grpc
             containerPort: 10901
+        livenessProbe:
+            httpGet:
+              port: 10902
+              path: /-/healthy
+        readinessProbe:
+          httpGet:
+            port: 10902
+            path: /-/ready
         volumeMounts:
           - name: prometheus
             mountPath: /var/prometheus


### PR DESCRIPTION
Signed-off-by: Martin Chodur <m.chodur@seznam.cz>

* [x] CHANGELOG entry if change is relevant to the end user.

## Changes

_Next PR in the from the series of adding readiness and liveness probes._

Added readiness and liveness prober to the thanos sidecar.
It follows the logic of setting the `promUp` metric so when it successfully fetches config of the Prometheus it becomes ready.

The question is should it take into account status of the GRPC interface also?

## Verification

1.  started sidecar without running the Prometheus instance results in 
```
$ curl http://0.0.0.0:10902/-/ready
thanos sidecar is not ready. Reason: request flags against http://localhost:9090/api/v1/status/config: Get http://localhost:9090/api/v1/status/config: dial tcp 127.0.0.1:9090: connect: connection refused
``` 
2.  started the prometheus sidecar becomes ready
```
$ curl http://0.0.0.0:10902/-/ready
thanos sidecar is ready
```

3. stopped the prometheus instance again sidecar goes again to not ready state after max 30s which is the sidecar check interval
```
$ curl http://0.0.0.0:10902/-/ready
thanos sidecar is not ready. Reason: request flags against http://localhost:9090/api/v1/status/config: Get http://localhost:9090/api/v1/status/config: dial tcp 127.0.0.1:9090: connect: connection refused
``` 