### PR TITLE
prometheus.go: fix typos in error message

### DIFF
--- a/pkg/store/prometheus.go
+++ b/pkg/store/prometheus.go
@@ -287,7 +287,7 @@ func (p *PrometheusStore) promSeries(ctx context.Context, q prompb.Query) (*prom
 	}
 	spanUnmarshal.Finish()
 	if len(data.Results) != 1 {
-		return nil, errors.Errorf("unexepected result size %d", len(data.Results))
+		return nil, errors.Errorf("unexpected result size %d", len(data.Results))
 	}
 	return &data, nil
 }


### PR DESCRIPTION
Signed-off-by: Guangming Wang <guangming.wang@daocloud.io>

just correct misspelled words in error message
* [] CHANGELOG entry if change is relevant to the end user.

## Changes

just correct misspelled words in error message

## Verification

<!-- How you tested it? How do you know it works? -->