### PR TITLE
Ruler: Add status tab to UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 - [#2030](https://github.com/thanos-io/thanos/pull/2030) Query: Add `thanos_proxy_store_empty_stream_responses_total` metric for number of empty responses from stores.
 - [#2049](https://github.com/thanos-io/thanos/pull/2049) Tracing: Support sampling on Elastic APM with new sample_rate setting.
 - [#2008](https://github.com/thanos-io/thanos/pull/2008) Querier, Receiver, Sidecar, Store: Add gRPC [health check](https://github.com/grpc/grpc/blob/master/doc/health-checking.md) endpoints.
+- [#1427](https://github.com/thanos-io/thanos/pull/1427) Thanos Rule added "Status" tab to Ruler UI
 
 ### Changed
 

--- a/pkg/ui/templates/rule_menu.html
+++ b/pkg/ui/templates/rule_menu.html
@@ -9,6 +9,12 @@
           <ul class="navbar-nav">
             <li class="nav-item"><a class="nav-link" href="{{ pathPrefix }}/alerts">Alerts</a></li>
             <li class="nav-item"><a class="nav-link" href="{{ pathPrefix }}/rules">Rules</a></li>
+            <li class="nav-item dropdown">
+              <a href="#" class="nav-link dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Status<span class="caret"></span></a>
+              <div class="dropdown-menu">
+                <a class="dropdown-item" href="{{ pathPrefix }}/status">Runtime &amp; Build Information</a>
+              </div>
+            </li>
             <li class="nav-item">
               <a class="nav-link" href="https://thanos.io/getting-started.md/" target="_blank">Help</a>
             </li>


### PR DESCRIPTION
## Changes

Added status tab to Ruler UI as per https://github.com/thanos-io/thanos/issues/1282.  Just copy-pasted the same for the Query UI.

## Verification
![Screen Shot 2019-08-16 at 11 20 04](https://user-images.githubusercontent.com/5380389/63161376-e4633b00-c017-11e9-9348-5b39b6da33cf.png)

