### PR TITLE
Support max source resolution for instant queries

### DIFF
--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -67,7 +67,7 @@ func registerQuery(m map[string]setupFunc, app *kingpin.Application, name string
 	replicaLabel := cmd.Flag("query.replica-label", "Label to treat as a replica indicator along which data is deduplicated. Still you will be able to query without deduplication using 'dedup=false' parameter.").
 		String()
 
-	defaultMaxSourceResolution := modelDuration(cmd.Flag("query.instant.default.max_source_resolution", "default value for max_source_resolution for instant queries. If not set, defaults to 0s only taking raw resolution into account. 1h can be a good value if you use instant queries over time ranges that incorporate times outside of your raw-retention.").Default("0s"))
+	instantDefaultMaxSourceResolution := modelDuration(cmd.Flag("query.instant.default.max_source_resolution", "default value for max_source_resolution for instant queries. If not set, defaults to 0s only taking raw resolution into account. 1h can be a good value if you use instant queries over time ranges that incorporate times outside of your raw-retention.").Default("0s"))
 
 	selectorLabels := cmd.Flag("selector-label", "Query selector labels that will be exposed in info endpoint (repeated).").
 		PlaceHolder("<name>=\"<value>\"").Strings()
@@ -156,7 +156,7 @@ func registerQuery(m map[string]setupFunc, app *kingpin.Application, name string
 			time.Duration(*dnsSDInterval),
 			*dnsSDResolver,
 			time.Duration(*unhealthyStoreTimeout),
-			time.Duration(*defaultMaxSourceResolution),
+			time.Duration(*instantDefaultMaxSourceResolution),
 		)
 	}
 }
@@ -274,7 +274,7 @@ func runQuery(
 	dnsSDInterval time.Duration,
 	dnsSDResolver string,
 	unhealthyStoreTimeout time.Duration,
-	defaultMaxSourceResolution time.Duration,
+	instantDefaultMaxSourceResolution time.Duration,
 ) error {
 	// TODO(bplotka in PR #513 review): Move arguments into struct.
 	duplicatedStores := prometheus.NewCounter(prometheus.CounterOpts{
@@ -405,7 +405,7 @@ func runQuery(
 		ins := extpromhttp.NewInstrumentationMiddleware(reg)
 		ui.NewQueryUI(logger, reg, stores, flagsMap).Register(router.WithPrefix(webRoutePrefix), ins)
 
-		api := v1.NewAPI(logger, reg, engine, queryableCreator, enableAutodownsampling, enablePartialResponse, defaultMaxSourceResolution)
+		api := v1.NewAPI(logger, reg, engine, queryableCreator, enableAutodownsampling, enablePartialResponse, instantDefaultMaxSourceResolution)
 
 		api.Register(router.WithPrefix(path.Join(webRoutePrefix, "/api/v1")), tracer, logger, ins)
 

--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -67,7 +67,7 @@ func registerQuery(m map[string]setupFunc, app *kingpin.Application, name string
 	replicaLabel := cmd.Flag("query.replica-label", "Label to treat as a replica indicator along which data is deduplicated. Still you will be able to query without deduplication using 'dedup=false' parameter.").
 		String()
 
-	defaultMaxSourceResolution := modelDuration(cmd.Flag("query.instant.default.max_source_resolution", "default value for max_source_resolution for instant queries. If not set, defaults to 0s only taking raw resolution into account.").Default("0s"))
+	defaultMaxSourceResolution := modelDuration(cmd.Flag("query.instant.default.max_source_resolution", "default value for max_source_resolution for instant queries. If not set, defaults to 0s only taking raw resolution into account. 1h can be a good value if you use instant queries over time ranges that incorporate times outside of your raw-retention.").Default("0s"))
 
 	selectorLabels := cmd.Flag("selector-label", "Query selector labels that will be exposed in info endpoint (repeated).").
 		PlaceHolder("<name>=\"<value>\"").Strings()

--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -67,7 +67,7 @@ func registerQuery(m map[string]setupFunc, app *kingpin.Application, name string
 	replicaLabel := cmd.Flag("query.replica-label", "Label to treat as a replica indicator along which data is deduplicated. Still you will be able to query without deduplication using 'dedup=false' parameter.").
 		String()
 
-	instantDefaultMaxSourceResolution := modelDuration(cmd.Flag("query.instant.default.max_source_resolution", "default value for max_source_resolution for instant queries. If not set, defaults to 0s only taking raw resolution into account. 1h can be a good value if you use instant queries over time ranges that incorporate times outside of your raw-retention.").Default("0s"))
+	instantDefaultMaxSourceResolution := modelDuration(cmd.Flag("query.instant.default.max_source_resolution", "default value for max_source_resolution for instant queries. If not set, defaults to 0s only taking raw resolution into account. 1h can be a good value if you use instant queries over time ranges that incorporate times outside of your raw-retention.").Default("0s").Hidden())
 
 	selectorLabels := cmd.Flag("selector-label", "Query selector labels that will be exposed in info endpoint (repeated).").
 		PlaceHolder("<name>=\"<value>\"").Strings()

--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -67,6 +67,8 @@ func registerQuery(m map[string]setupFunc, app *kingpin.Application, name string
 	replicaLabel := cmd.Flag("query.replica-label", "Label to treat as a replica indicator along which data is deduplicated. Still you will be able to query without deduplication using 'dedup=false' parameter.").
 		String()
 
+	defaultMaxSourceResolution := modelDuration(cmd.Flag("query.instant.default.max_source_resolution", "default value for max_source_resolution for instant queries. If not set, defaults to 0s only taking raw resolution into account.").Default("0s"))
+
 	selectorLabels := cmd.Flag("selector-label", "Query selector labels that will be exposed in info endpoint (repeated).").
 		PlaceHolder("<name>=\"<value>\"").Strings()
 
@@ -154,6 +156,7 @@ func registerQuery(m map[string]setupFunc, app *kingpin.Application, name string
 			time.Duration(*dnsSDInterval),
 			*dnsSDResolver,
 			time.Duration(*unhealthyStoreTimeout),
+			time.Duration(*defaultMaxSourceResolution),
 		)
 	}
 }
@@ -271,6 +274,7 @@ func runQuery(
 	dnsSDInterval time.Duration,
 	dnsSDResolver string,
 	unhealthyStoreTimeout time.Duration,
+	defaultMaxSourceResolution time.Duration,
 ) error {
 	// TODO(bplotka in PR #513 review): Move arguments into struct.
 	duplicatedStores := prometheus.NewCounter(prometheus.CounterOpts{
@@ -401,7 +405,7 @@ func runQuery(
 		ins := extpromhttp.NewInstrumentationMiddleware(reg)
 		ui.NewQueryUI(logger, reg, stores, flagsMap).Register(router.WithPrefix(webRoutePrefix), ins)
 
-		api := v1.NewAPI(logger, reg, engine, queryableCreator, enableAutodownsampling, enablePartialResponse)
+		api := v1.NewAPI(logger, reg, engine, queryableCreator, enableAutodownsampling, enablePartialResponse, defaultMaxSourceResolution)
 
 		api.Register(router.WithPrefix(path.Join(webRoutePrefix, "/api/v1")), tracer, logger, ins)
 

--- a/docs/components/query.md
+++ b/docs/components/query.md
@@ -238,13 +238,6 @@ Flags:
                                  which data is deduplicated. Still you will be
                                  able to query without deduplication using
                                  'dedup=false' parameter.
-      --query.instant.default.max_source_resolution=0s
-                                 default value for max_source_resolution for
-                                 instant queries. If not set, defaults to 0s
-                                 only taking raw resolution into account. 1h can
-                                 be a good value if you use instant queries over
-                                 time ranges that incorporate times outside of
-                                 your raw-retention.
       --selector-label=<name>="<value>" ...
                                  Query selector labels that will be exposed in
                                  info endpoint (repeated).

--- a/docs/components/query.md
+++ b/docs/components/query.md
@@ -238,6 +238,10 @@ Flags:
                                  which data is deduplicated. Still you will be
                                  able to query without deduplication using
                                  'dedup=false' parameter.
+      --query.instant.default.max_source_resolution=0s
+                                 default value for max_source_resolution for
+                                 instant queries. If not set, defaults to 0s
+                                 only taking raw resolution into account.
       --selector-label=<name>="<value>" ...
                                  Query selector labels that will be exposed in
                                  info endpoint (repeated).

--- a/docs/components/query.md
+++ b/docs/components/query.md
@@ -241,7 +241,10 @@ Flags:
       --query.instant.default.max_source_resolution=0s
                                  default value for max_source_resolution for
                                  instant queries. If not set, defaults to 0s
-                                 only taking raw resolution into account.
+                                 only taking raw resolution into account. 1h can
+                                 be a good value if you use instant queries over
+                                 time ranges that incorporate times outside of
+                                 your raw-retention.
       --selector-label=<name>="<value>" ...
                                  Query selector labels that will be exposed in
                                  info endpoint (repeated).

--- a/pkg/query/api/v1.go
+++ b/pkg/query/api/v1.go
@@ -185,11 +185,6 @@ func (api *API) parseEnableDedupParam(r *http.Request) (enableDeduplication bool
 	return enableDeduplication, nil
 }
 
-func (api *API) parseDownsamplingParamMillis(r *http.Request, step time.Duration) (maxResolutionMillis int64, _ *ApiError) {
-	// If no max_source_resolution is specified fit at least 5 samples between steps.
-	return api.parseDownsamplingParamMillisWithDefault(r, step/5)
-}
-
 func (api *API) parseDownsamplingParamMillisWithDefault(r *http.Request, defaultVal time.Duration) (maxResolutionMillis int64, _ *ApiError) {
 	const maxSourceResolutionParam = "max_source_resolution"
 	maxSourceResolution := 0 * time.Second
@@ -346,7 +341,8 @@ func (api *API) queryRange(r *http.Request) (interface{}, []error, *ApiError) {
 		return nil, nil, apiErr
 	}
 
-	maxSourceResolution, apiErr := api.parseDownsamplingParamMillis(r, step)
+	// If no max_source_resolution is specified fit at least 5 samples between steps.
+	maxSourceResolution, apiErr := api.parseDownsamplingParamMillisWithDefault(r, step/5)
 	if apiErr != nil {
 		return nil, nil, apiErr
 	}

--- a/pkg/query/api/v1.go
+++ b/pkg/query/api/v1.go
@@ -185,7 +185,7 @@ func (api *API) parseEnableDedupParam(r *http.Request) (enableDeduplication bool
 	return enableDeduplication, nil
 }
 
-func (api *API) parseDownsamplingParamMillisWithDefault(r *http.Request, defaultVal time.Duration) (maxResolutionMillis int64, _ *ApiError) {
+func (api *API) parseDownsamplingParamMillis(r *http.Request, defaultVal time.Duration) (maxResolutionMillis int64, _ *ApiError) {
 	const maxSourceResolutionParam = "max_source_resolution"
 	maxSourceResolution := 0 * time.Second
 
@@ -260,7 +260,7 @@ func (api *API) query(r *http.Request) (interface{}, []error, *ApiError) {
 		return nil, nil, apiErr
 	}
 
-	maxSourceResolution, apiErr := api.parseDownsamplingParamMillisWithDefault(r, api.defaultInstantQueryMaxSourceResolution)
+	maxSourceResolution, apiErr := api.parseDownsamplingParamMillis(r, api.defaultInstantQueryMaxSourceResolution)
 	if apiErr != nil {
 		return nil, nil, apiErr
 	}
@@ -342,7 +342,7 @@ func (api *API) queryRange(r *http.Request) (interface{}, []error, *ApiError) {
 	}
 
 	// If no max_source_resolution is specified fit at least 5 samples between steps.
-	maxSourceResolution, apiErr := api.parseDownsamplingParamMillisWithDefault(r, step/5)
+	maxSourceResolution, apiErr := api.parseDownsamplingParamMillis(r, step/5)
 	if apiErr != nil {
 		return nil, nil, apiErr
 	}

--- a/pkg/query/api/v1_test.go
+++ b/pkg/query/api/v1_test.go
@@ -898,7 +898,7 @@ func TestParseDownsamplingParamMillis(t *testing.T) {
 		v.Set("max_source_resolution", test.maxSourceResolutionParam)
 		r := http.Request{PostForm: v}
 
-		maxResMillis, _ := api.parseDownsamplingParamMillis(&r, test.step)
+		maxResMillis, _ := api.parseDownsamplingParamMillisWithDefault(&r, test.step/5)
 		if test.fail == false {
 			testutil.Assert(t, maxResMillis == test.result, "case %v: expected %v to be equal to %v", i, maxResMillis, test.result)
 		} else {

--- a/pkg/query/api/v1_test.go
+++ b/pkg/query/api/v1_test.go
@@ -898,7 +898,8 @@ func TestParseDownsamplingParamMillis(t *testing.T) {
 		v.Set("max_source_resolution", test.maxSourceResolutionParam)
 		r := http.Request{PostForm: v}
 
-		maxResMillis, _ := api.parseDownsamplingParamMillisWithDefault(&r, test.step/5)
+		// If no max_source_resolution is specified fit at least 5 samples between steps.
+		maxResMillis, _ := api.parseDownsamplingParamMillis(&r, test.step/5)
 		if test.fail == false {
 			testutil.Assert(t, maxResMillis == test.result, "case %v: expected %v to be equal to %v", i, maxResMillis, test.result)
 		} else {


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

* [] Added `thanos query --query.instant.default.max_source_resolution` flag to set a default value for maxSourceResolution on instant queries (as are for example used by the `thanos rule` component)
* [] Added support for the max_source_resolution query parameter for `/api/v1/query`

## Reasoning

We have configured our compactor with different retentions for different resolution levels:

```
thanos
  compact
  --log.level=debug
  --data-dir=/var/thanos/store
  --objstore.config-file=/s3/thanos.yaml
  --retention.resolution-raw=7d
  --retention.resolution-5m=30d
  --retention.resolution-1h=180d
  --wait
```

This causes a situation where the result of a `thanos rule` recording rule was
only taking the last 7-8 days of data into account, because instant queries were
always using a maxSourceResolution of 0 and therefore only using raw resolution
data.

In our case the query looked like this and was executed on a thanos ruler
because our prometheuses only have a relatively short retention of a few days:

```
(100 -
  sum_over_time (
    some_metric:errors_count:increase1d[30d]
  ) /
  sum_over_time (
    some_metric:total_count:increase1d[30d]
  ) * 100
)
```

The `thanos rule` component runs an instant query in order to retrieve a single
datapoint to set for the recording rule metric. Our query requires that data
from at least 30 days is taken into account. But by default it would only select
raw data and therefore only provide data from the last 7 days.

## Changes

This allows for `/api/v1/query` to accept the `?max_source_resolution` query parameter
(the documentation did not clearly state that it was only accepted for
`/api/v1/query_range` prior to this).
We also added a command line argument to set a default should the query parameter not be set.

We also propose the following (for later PRs):

* Amend the UI to allow setting the `max_source_resolution` for "Console"
queries (which are executing instant queries).
* Add a new field to the rule-yaml for thanos ruler to set the
  `max_source_resolution` on a per-recording-rule basis.

## Verification

* We've used a fork to fire individual instant queries with the `max_source_resolution`
  parameter set and compared it with the last result we got from a range query.
* We also deployed a version with the default value changed and observed that the recording
  rule was now producing the expected value.
