### PR TITLE
Add link for Docker images to homepage

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ The philosophy of Thanos and our community is borrowing much from UNIX philosoph
 
 Master should be stable and usable. Every commit to master builds docker image named `master-<data>-<sha>`.
 
-We also perform minor releases every 6 weeks. 
-During that, we build tarballs for major platforms and docker image.
+We also perform minor releases every 6 weeks.
+During that, we build tarballs for major platforms and docker image ([available from Quay](https://quay.io/repository/thanos/thanos)).
 
 See [release process docs](docs/release-process.md) for details.
 

--- a/website/hugo.yaml
+++ b/website/hugo.yaml
@@ -31,5 +31,7 @@ params:
   SlackInvite: "https://slack.cncf.io"
   GithubUser: "thanos-io"
   GithubProject: "thanos"
+  QuayIoUser: "thanos"
+  QuayIoRepository: "thanos"
   TwitterHandle: "ThanosMetrics"
   Description: "Highly available Prometheus setup with long term storage capabilities."

--- a/website/layouts/index.html
+++ b/website/layouts/index.html
@@ -20,6 +20,11 @@
                     </a>
                 </li>
                 <li class="list-inline-item my-3">
+                    <a href="https://quay.io/repository/{{ .Site.Params.QuayIoUser }}/{{ .Site.Params.QuayIoRepository }}" class="btn btn-outline-secondary">
+                        <i class="fab fa-fw fa-docker"></i> Docker Images
+                    </a>
+                </li>
+                <li class="list-inline-item my-3">
                     <a href="https://github.com/{{ .Site.Params.GithubUser }}/{{ .Site.Params.GithubProject }}" class="btn btn-outline-secondary">
                         <i class="fab fa-fw fa-github"></i> Github
                     </a>


### PR DESCRIPTION
## Changes

* Added a link to the quay.io Docker images to the homepage.

## Verification

* Built website locally and confirmed it looks as expected.

<img width="1349" alt="Screen Shot 2019-08-22 at 13 43 19" src="https://user-images.githubusercontent.com/52065239/63515656-3fe36c00-c4e3-11e9-85da-41ac315650e5.png">