### PR TITLE
feat store: added readiness and livenes prober

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,11 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 ## Unreleased
 
 ## Added
-- [#1540](https://github.com/thanos-io/thanos/pull/1540) Added `/-/ready` and `/-/healthy` endpoints to Thanos Downsample.
-- [#1538](https://github.com/thanos-io/thanos/pull/1538) Added `/-/ready` and `/-/healthy` endpoints to Thanos Rule.
-- [#1537](https://github.com/thanos-io/thanos/pull/1537) Added `/-/ready` and `/-/healthy` endpoints to Thanos Receive.
-- [#1534](https://github.com/thanos-io/thanos/pull/1534) Added `/-/ready` endpoint to Thanos Query.
+- [#1540](https://github.com/thanos-io/thanos/pull/1540) Thanos Downsample added `/-/ready` and `/-/healthy` endpoints.
+- [#1538](https://github.com/thanos-io/thanos/pull/1538) Thanos Rule added `/-/ready` and `/-/healthy` endpoints.
+- [#1537](https://github.com/thanos-io/thanos/pull/1537) Thanos Receive added `/-/ready` and `/-/healthy` endpoints.
+- [#1460](https://github.com/thanos-io/thanos/pull/1460) Thanos Store Added `/-/ready` and `/-/healthy` endpoints.
+- [#1534](https://github.com/thanos-io/thanos/pull/1534) Thanos Query Added `/-/ready` and `/-/healthy` endpoints.
 - [#1533](https://github.com/thanos-io/thanos/pull/1533) Thanos inspect now supports the timeout flag.
 
 ### Fixed

--- a/cmd/thanos/main.go
+++ b/cmd/thanos/main.go
@@ -74,7 +74,7 @@ func main() {
 
 	cmds := map[string]setupFunc{}
 	registerSidecar(cmds, app)
-	registerStore(cmds, app, "store")
+	registerStore(cmds, app)
 	registerQuery(cmds, app)
 	registerRule(cmds, app)
 	registerCompact(cmds, app)
@@ -331,27 +331,6 @@ func newStoreGRPCServer(logger log.Logger, reg *prometheus.Registry, tracer open
 	met.InitializeMetrics(s)
 
 	return s
-}
-
-// TODO Remove once all components are migrated to the new scheduleHTTPServer.
-// metricHTTPListenGroup is a run.Group that servers HTTP endpoint with only Prometheus metrics.
-func metricHTTPListenGroup(g *run.Group, logger log.Logger, reg *prometheus.Registry, httpBindAddr string) error {
-	mux := http.NewServeMux()
-	registerMetrics(mux, reg)
-	registerProfile(mux)
-
-	l, err := net.Listen("tcp", httpBindAddr)
-	if err != nil {
-		return errors.Wrap(err, "listen metrics address")
-	}
-
-	g.Add(func() error {
-		level.Info(logger).Log("msg", "Listening for metrics", "address", httpBindAddr)
-		return errors.Wrap(http.Serve(l, mux), "serve metrics")
-	}, func(error) {
-		runutil.CloseWithLogOnErr(logger, l, "metric listener")
-	})
-	return nil
 }
 
 // scheduleHTTPServer starts a run.Group that servers HTTP endpoint with default endpoints providing Prometheus metrics,

--- a/tutorials/kubernetes-demo/manifests/thanos-store-gateway.yaml
+++ b/tutorials/kubernetes-demo/manifests/thanos-store-gateway.yaml
@@ -40,6 +40,14 @@ spec:
           containerPort: 10902
         - name: grpc
           containerPort: 10901
+        livenessProbe:
+          httpGet:
+            port: 10902
+            path: /-/healthy
+        readinessProbe:
+          httpGet:
+            port: 10902
+            path: /-/ready
         resources:
           limits:
             cpu: "1"


### PR DESCRIPTION
Added the prober to yet another component. Store this time.

The store does the bucket initialization and sync synchronously, so the default http server will start up only once it is finished. Then it gets healthy(live) and once the gRPC server starts up the store gets also ready.

Personally I'd much rather see the liveness probe to answer right from the start during the bucket init since this way we leave the bucket sync duration to some initial back-off of an orchestrator. 

* [x] CHANGELOG entry if change is relevant to the end user.

## Changes

- added prober to the thanos store

## Verification

Started it and verified it gets ready end healthy as expected.