### PR TITLE
Rule: Fixed wrong query url in rules and alerts pages

### DIFF
--- a/pkg/ui/templates/alerts.html
+++ b/pkg/ui/templates/alerts.html
@@ -21,7 +21,7 @@
       <tr class="alert_details">
         <td>
           <div>
-            <pre style="display:block; padding:9.5px; font-size:13px; color:#333; word-break:break-all; background-color:#f5f5f5; border:1px solid #ccc; border-radius:4px;" ><code>{{.HTMLSnippet pathPrefix}}</code></pre>
+            <pre style="display:block; padding:9.5px; font-size:13px; color:#333; word-break:break-all; background-color:#f5f5f5; border:1px solid #ccc; border-radius:4px;" ><code>{{.HTMLSnippet queryURL}}</code></pre>
           </div>
           {{if $activeAlerts}}
           <table class="table table-bordered table-hover table-sm alert_elements_table">

--- a/pkg/ui/templates/rules.html
+++ b/pkg/ui/templates/rules.html
@@ -24,7 +24,7 @@
           </tr>
           {{range .Rules}}
           <tr>
-            <td class="rule_cell">{{.HTMLSnippet pathPrefix}}</td>
+            <td class="rule_cell">{{.HTMLSnippet queryURL}}</td>
             <td class="state">
               <span class="alert alert-{{ .Health | ruleHealthToClass }} state_indicator text-uppercase">
                 {{.Health}}


### PR DESCRIPTION
Signed-off-by: jojohappy <sarahdj0917@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

* [] CHANGELOG entry if change is relevant to the end user.

## Changes

<!-- Enumerate changes you made -->
[Bugfix]: User can not click the link of `expr` or `alert` to jump to Query ui in rule pages.

## Verification

Visit the rule or alert page, and try to click the link of `expr` or `alert`.
<!-- How you tested it? How do you know it works? -->