### PR TITLE
[Docs] - Compact: Add line clarifying that its also responsib…

### DIFF
--- a/docs/components/compact.md
+++ b/docs/components/compact.md
@@ -9,6 +9,8 @@ menu: components
 The compactor component of Thanos applies the compaction procedure of the Prometheus 2.0 storage engine to block data stored in object storage.
 It is generally not semantically concurrency safe and must be deployed as a singleton against a bucket.
 
+It is also responsible for downsampling of data - performing 5m downsampling after **40 hours** and 1h downsampling after **10 days**.
+
 Example:
 
 ```bash


### PR DESCRIPTION
…le for downsampling

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

* [] CHANGELOG entry if change is relevant to the end user.

## Changes

Added line clarifying that the compact component is also responsible for downsampling and documenting the magic numbers use to determine when to start. 

Partly addresses #813 which appears to be the only place the times downsampling begins are currently documented - have now seen a number of queries about whether or not the `compact` component is responsible for downsampling as well, and this should at leats make that info easier to find.

Was unsure whether to link back to #813 as the central place for discussion of this.

## Verification

N/A