### PR TITLE
fix store: handle invalid cache block dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 
 ## Unreleased
 
+### Fixed
+
+-[1505](https://github.com/thanos-io/thanos/pull/1505) Thanos store now removes invalid local cache blocks.
+
 ## v0.7.0 - 2019.09.02
 
 Accepted into CNCF:

--- a/pkg/block/block.go
+++ b/pkg/block/block.go
@@ -153,3 +153,10 @@ func IsBlockDir(path string) (id ulid.ULID, ok bool) {
 	id, err := ulid.Parse(filepath.Base(path))
 	return id, err == nil
 }
+
+func HasMetaFile(blockPath string) bool {
+	if _, err := os.Stat(path.Join(blockPath, MetaFilename)); os.IsNotExist(err) {
+		return false
+	}
+	return true
+}

--- a/pkg/block/block.go
+++ b/pkg/block/block.go
@@ -153,10 +153,3 @@ func IsBlockDir(path string) (id ulid.ULID, ok bool) {
 	id, err := ulid.Parse(filepath.Base(path))
 	return id, err == nil
 }
-
-func HasMetaFile(blockPath string) bool {
-	if _, err := os.Stat(path.Join(blockPath, MetaFilename)); os.IsNotExist(err) {
-		return false
-	}
-	return true
-}

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -1189,7 +1189,7 @@ func (b *bucketBlock) indexCacheFilename() string {
 
 func loadMeta(ctx context.Context, logger log.Logger, bucket objstore.BucketReader, dir string, id ulid.ULID) (error, *metadata.Meta) {
 	// If we haven't seen the block before or it is missing the meta.json, download it.
-	if _, err := os.Stat(dir); os.IsNotExist(err) || (err == nil && !block.HasMetaFile(dir)) {
+	if _, err := os.Stat(path.Join(dir, block.MetaFilename)); os.IsNotExist(err) {
 		if err := os.MkdirAll(dir, 0777); err != nil {
 			return errors.Wrap(err, "create dir"), nil
 		}

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -1188,8 +1188,8 @@ func (b *bucketBlock) indexCacheFilename() string {
 }
 
 func loadMeta(ctx context.Context, logger log.Logger, bucket objstore.BucketReader, dir string, id ulid.ULID) (error, *metadata.Meta) {
-	// If we haven't seen the block before download the meta.json file.
-	if _, err := os.Stat(dir); os.IsNotExist(err) {
+	// If we haven't seen the block before or it is missing the meta.json, download it.
+	if _, err := os.Stat(dir); os.IsNotExist(err) || (err == nil && !block.HasMetaFile(dir)) {
 		if err := os.MkdirAll(dir, 0777); err != nil {
 			return errors.Wrap(err, "create dir"), nil
 		}


### PR DESCRIPTION
fixes #1504

* [x] CHANGELOG entry if change is relevant to the end user.

## Changes
- store: delete block dir with missing `meta.json` on startup
