### PR TITLE
fix docs: fixed getting started link to release process

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -31,7 +31,7 @@ We also perform minor releases every 6 weeks.
 
 During that, we build tarballs for major platforms and release docker images.
 
-See [release process docs](docs/release-process.md) for details.
+See [release process docs](release-process.md) for details.
 
 ## Running Thanos 
 


### PR DESCRIPTION
@bwplotka 

Fixes invalid link causing CI to fail 
https://circleci.com/gh/thanos-io/thanos/4811?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link 