### PR TITLE
store: fix chunk pool memory leak

### DIFF
--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -1275,11 +1275,13 @@ func (b *bucketBlock) readChunkRange(ctx context.Context, seq int, off, length i
 
 	r, err := b.bucket.GetRange(ctx, b.chunkObjs[seq], off, length)
 	if err != nil {
+		b.chunkPool.Put(c)
 		return nil, errors.Wrap(err, "get range reader")
 	}
 	defer runutil.CloseWithLogOnErr(b.logger, r, "readChunkRange close range reader")
 
 	if _, err = io.Copy(buf, r); err != nil {
+		b.chunkPool.Put(c)
 		return nil, errors.Wrap(err, "read range")
 	}
 	internalBuf := buf.Bytes()


### PR DESCRIPTION
I experienced a slow drip of "key does not exist" errors, presumably due to compactions, then nearly all get_range requests began to fail with "pool exhausted" errors.

caller | err
-- | --
bucket.go:871 | rpc error: code = Aborted desc = fetch series for block 01DM8ACH11QQQESTY0VET5PXKS: preload chunks: read range for 1: get range reader: The specified key does not exist.
bucket.go:871 | rpc error: code = Aborted desc = fetch series for block 01DMA1C7D151KM6H1DGY498WWQ: preload chunks: read range for 6: allocate chunk bytes: pool exhausted

![Screen Shot 2019-09-12 at 3 41 44 PM](https://user-images.githubusercontent.com/1512418/64826317-275ff200-d575-11e9-9358-b14dc889eb30.png)

## Changes

Return the byte slice to the pool on error paths.

## Verification

N/A