### PR TITLE
docs: fix typo of katacoda 1-globalview

### DIFF
--- a/tutorials/katacoda/thanos/1-globalview/index.json
+++ b/tutorials/katacoda/thanos/1-globalview/index.json
@@ -1,5 +1,5 @@
 {
-  "title": "Intro: Global View and seemless HA for Prometheus",
+  "title": "Intro: Global View and seamless HA for Prometheus",
   "description": "Learn how to easily transform Prometheus into centralized, highly available monitoring using Thanos.",
   "difficulty": "Beginner",
   "time": "10-15 Minutes",

--- a/tutorials/katacoda/thanos/1-globalview/step3.md
+++ b/tutorials/katacoda/thanos/1-globalview/step3.md
@@ -65,7 +65,7 @@ prometheus_tsdb_head_series{cluster="us1",instance="127.0.0.1:9092",job="prometh
 
 ## Handling of Highly Availabile Prometheus
 
-Now, as you rememmber we configured Prometheus 0 US1 and Prometheus 1 US1 to scrape the same things. We also connect Querier
+Now, as you remember we configured Prometheus 0 US1 and Prometheus 1 US1 to scrape the same things. We also connect Querier
 to both, so how Querier knows what is an HA group?
 
 Try to query the same query as before: <a href="https://[[HOST_SUBDOMAIN]]-29090-[[KATACODA_HOST]].environments.katacoda.com/graph?g0.range_input=1h&g0.expr=sum(prometheus_tsdb_head_series)&g0.tab=1&g1.range_input=5m&g1.expr=prometheus_tsdb_head_series&g1.tab=0">`sum(prometheus_tsdb_head_series)`</a>

--- a/tutorials/katacoda/thanos/1-globalview/step3.md
+++ b/tutorials/katacoda/thanos/1-globalview/step3.md
@@ -82,7 +82,7 @@ prometheus_tsdb_head_series{cluster="us1",instance="127.0.0.1:9092",job="prometh
 
 So how Thanos Querier knows how to deduplicate correctly?
 
-If we would look again into Querier configuration we can see that we also set `quey.replica-label` flag. 
+If we would look again into Querier configuration we can see that we also set `query.replica-label` flag. 
 This is exactly the label Querier will try to deduplicate by for HA groups. This means that any metric with exactly
 the same labels *except replica label* will be assumed as the metric from the same HA group, and deduplicated accordingly.
 


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

## Changes

<!-- Enumerate changes you made -->
fix typo of step 3 of  `Intro: Global View and seamless HA for Prometheus`  in katacoda

