### PR TITLE
Add bucket inspect timeout flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 
 ## Unreleased
 
+## Added
+-[1533](https://github.com/thanos-io/thanos/pull/1533) Thanos inspect now supports the timeout flag.
+
 ### Fixed
 
 -[#1525](https://github.com/thanos-io/thanos/pull/1525) Thanos now deletes block's file in correct order allowing to detect partial blocks without problems. 

--- a/cmd/thanos/bucket.go
+++ b/cmd/thanos/bucket.go
@@ -247,6 +247,7 @@ func registerBucketInspect(m map[string]setupFunc, root *kingpin.CmdClause, name
 		PlaceHolder("<name>=\\\"<value>\\\"").Strings()
 	sortBy := cmd.Flag("sort-by", "Sort by columns. It's also possible to sort by multiple columns, e.g. '--sort-by FROM --sort-by UNTIL'. I.e., if the 'FROM' value is equal the rows are then further sorted by the 'UNTIL' value.").
 		Default("FROM", "UNTIL").Enums(inspectColumns...)
+	timeout := cmd.Flag("timeout", "Timeout to download metadata from remote storage").Default("5m").Duration()
 
 	m[name+" inspect"] = func(g *run.Group, logger log.Logger, reg *prometheus.Registry, _ opentracing.Tracer, _ bool) error {
 
@@ -271,7 +272,7 @@ func registerBucketInspect(m map[string]setupFunc, root *kingpin.CmdClause, name
 
 		defer runutil.CloseWithLogOnErr(logger, bkt, "bucket client")
 
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+		ctx, cancel := context.WithTimeout(context.Background(), *timeout)
 		defer cancel()
 
 		// Getting Metas.

--- a/docs/components/bucket.md
+++ b/docs/components/bucket.md
@@ -278,5 +278,6 @@ Flags:
                              multiple columns, e.g. '--sort-by FROM --sort-by
                              UNTIL'. I.e., if the 'FROM' value is equal the rows
                              are then further sorted by the 'UNTIL' value.
+      --timeout=5m           Timeout to download metadata from remote storage
 
 ```


### PR DESCRIPTION
Signed-off-by: Johnathan Falk <johnathan.falk@gmail.com>

Fixes #1532 

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

* [X] CHANGELOG entry if change is relevant to the end user.

## Changes

Added timeout flag to bucket inspect

## Verification

Built and run