### PR TITLE
query: Add readiness probe to query

### DIFF
--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -169,8 +169,8 @@ func runCompact(
 
 	statusProber := prober.NewProber(component, logger, prometheus.WrapRegistererWithPrefix("thanos_", reg))
 	// Initiate default HTTP listener providing metrics endpoint and readiness/liveness probes.
-	if err := defaultHTTPListener(g, logger, reg, httpBindAddr, statusProber); err != nil {
-		return errors.Wrap(err, "create readiness prober")
+	if err := defaultHTTPListener(component, g, logger, reg, nil, httpBindAddr, statusProber); err != nil {
+		return errors.Wrap(err, "create default HTTP server with readiness prober")
 	}
 
 	confContentYaml, err := objStoreConfig.Content()

--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -169,7 +169,7 @@ func runCompact(
 
 	statusProber := prober.NewProber(component, logger, prometheus.WrapRegistererWithPrefix("thanos_", reg))
 	// Initiate default HTTP listener providing metrics endpoint and readiness/liveness probes.
-	if err := defaultHTTPListener(component, g, logger, reg, nil, httpBindAddr, statusProber); err != nil {
+	if err := scheduleHTTPServer(g, logger, reg, statusProber, httpBindAddr, nil, component); err != nil {
 		return errors.Wrap(err, "create default HTTP server with readiness prober")
 	}
 

--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -415,7 +415,7 @@ func runQuery(
 		api.Register(router.WithPrefix(path.Join(webRoutePrefix, "/api/v1")), tracer, logger, ins)
 
 		// Initiate default HTTP listener providing metrics endpoint and readiness/liveness probes.
-		if err := defaultHTTPListener(comp, g, logger, reg, router, httpBindAddr, statusProber); err != nil {
+		if err := scheduleHTTPServer(g, logger, reg, statusProber, httpBindAddr, router, comp); err != nil {
 			return errors.Wrap(err, "create default HTTP server with readiness prober")
 		}
 	}
@@ -423,13 +423,13 @@ func runQuery(
 	{
 		l, err := net.Listen("tcp", grpcBindAddr)
 		if err != nil {
-			return errors.Wrapf(err, "listen gRPC on address")
+			return errors.Wrap(err, "listen gRPC on address")
 		}
 		logger := log.With(logger, "component", component.Query.String())
 
 		opts, err := defaultGRPCServerOpts(logger, srvCert, srvKey, srvClientCA)
 		if err != nil {
-			return errors.Wrapf(err, "build gRPC server")
+			return errors.Wrap(err, "build gRPC server")
 		}
 		s := newStoreGRPCServer(logger, reg, tracer, proxy, opts)
 

--- a/cmd/thanos/sidecar.go
+++ b/cmd/thanos/sidecar.go
@@ -121,7 +121,7 @@ func runSidecar(
 
 	statusProber := prober.NewProber(comp, logger, prometheus.WrapRegistererWithPrefix("thanos_", reg))
 	// Initiate default HTTP listener providing metrics endpoint and readiness/liveness probes.
-	if err := defaultHTTPListener(comp, g, logger, reg, nil, httpBindAddr, statusProber); err != nil {
+	if err := scheduleHTTPServer(g, logger, reg, statusProber, httpBindAddr, nil, comp); err != nil {
 		return errors.Wrap(err, "create default HTTP server with readiness prober")
 	}
 

--- a/cmd/thanos/sidecar.go
+++ b/cmd/thanos/sidecar.go
@@ -121,8 +121,8 @@ func runSidecar(
 
 	statusProber := prober.NewProber(comp, logger, prometheus.WrapRegistererWithPrefix("thanos_", reg))
 	// Initiate default HTTP listener providing metrics endpoint and readiness/liveness probes.
-	if err := defaultHTTPListener(g, logger, reg, httpBindAddr, statusProber); err != nil {
-		return errors.Wrap(err, "create readiness prober")
+	if err := defaultHTTPListener(comp, g, logger, reg, nil, httpBindAddr, statusProber); err != nil {
+		return errors.Wrap(err, "create default HTTP server with readiness prober")
 	}
 
 	// Setup all the concurrent groups.

--- a/tutorials/kubernetes-demo/manifests/thanos-querier.yaml
+++ b/tutorials/kubernetes-demo/manifests/thanos-querier.yaml
@@ -50,8 +50,12 @@ spec:
           containerPort: 10901
         livenessProbe:
           httpGet:
-            path: /-/healthy
             port: http
+            path: /-/healthy
+        readinessProbe:
+          httpGet:
+            port: http
+            path: /-/ready
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
This PR,

* Adds `/-/ready` endpoint for readiness checks.

## Changes

* Adds `/-/ready` endpoint for readiness checks.
* Uses `prober.Prober` for readiness and liveness endpoints.
* Changes ~`defaultHTTPListener`~ `scheduleHTTPServer` to consume an existing `http.Handler`

## Verification

1. `make test`

2. Started `thanos query` and made a request to related endpoints.

```console
➜ curl http://0.0.0.0:10902/-/healthy
thanos query is healthy
```

```console
➜ curl http://0.0.0.0:10902/-/ready
thanos query is not ready. Reason: thanos query is initializing
```

```console
➜ curl http://0.0.0.0:10902/-/ready
thanos query is ready
```