### PR TITLE
receive: Add liveness and readiness probe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 
 ## Added
 - [#1538](https://github.com/thanos-io/thanos/pull/1538) Added `/-/ready` and `/-/healthy` endpoints to Thanos Rule.
+- [#XXX](https://github.com/thanos-io/thanos/pull/XXX) Added `/-/ready` and `/-/healthy` endpoints to Thanos Receive.
+- [#1534](https://github.com/thanos-io/thanos/pull/1534) Added `/-/ready` endpoint to Thanos Query.
 -[1533](https://github.com/thanos-io/thanos/pull/1533) Thanos inspect now supports the timeout flag.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,14 +13,14 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 
 ## Added
 - [#1538](https://github.com/thanos-io/thanos/pull/1538) Added `/-/ready` and `/-/healthy` endpoints to Thanos Rule.
-- [#XXX](https://github.com/thanos-io/thanos/pull/XXX) Added `/-/ready` and `/-/healthy` endpoints to Thanos Receive.
+- [#1537](https://github.com/thanos-io/thanos/pull/1537) Added `/-/ready` and `/-/healthy` endpoints to Thanos Receive.
 - [#1534](https://github.com/thanos-io/thanos/pull/1534) Added `/-/ready` endpoint to Thanos Query.
--[1533](https://github.com/thanos-io/thanos/pull/1533) Thanos inspect now supports the timeout flag.
+- [#1533](https://github.com/thanos-io/thanos/pull/1533) Thanos inspect now supports the timeout flag.
 
 ### Fixed
 
--[#1525](https://github.com/thanos-io/thanos/pull/1525) Thanos now deletes block's file in correct order allowing to detect partial blocks without problems.
--[#1505](https://github.com/thanos-io/thanos/pull/1505) Thanos store now removes invalid local cache blocks.
+- [#1525](https://github.com/thanos-io/thanos/pull/1525) Thanos now deletes block's file in correct order allowing to detect partial blocks without problems.
+- [#1505](https://github.com/thanos-io/thanos/pull/1505) Thanos store now removes invalid local cache blocks.
 
 ## v0.7.0 - 2019.09.02
 

--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -170,7 +170,7 @@ func runCompact(
 	statusProber := prober.NewProber(component, logger, prometheus.WrapRegistererWithPrefix("thanos_", reg))
 	// Initiate default HTTP listener providing metrics endpoint and readiness/liveness probes.
 	if err := scheduleHTTPServer(g, logger, reg, statusProber, httpBindAddr, nil, component); err != nil {
-		return errors.Wrap(err, "create default HTTP server with readiness prober")
+		return errors.Wrap(err, "schedule default HTTP server with probes")
 	}
 
 	confContentYaml, err := objStoreConfig.Content()

--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -168,9 +168,9 @@ func runCompact(
 	downsampleMetrics := newDownsampleMetrics(reg)
 
 	statusProber := prober.NewProber(component, logger, prometheus.WrapRegistererWithPrefix("thanos_", reg))
-	// Initiate default HTTP listener providing metrics endpoint and readiness/liveness probes.
+	// Initiate HTTP listener providing metrics endpoint and readiness/liveness probes.
 	if err := scheduleHTTPServer(g, logger, reg, statusProber, httpBindAddr, nil, component); err != nil {
-		return errors.Wrap(err, "schedule default HTTP server with probes")
+		return errors.Wrap(err, "schedule HTTP server with probes")
 	}
 
 	confContentYaml, err := objStoreConfig.Content()

--- a/cmd/thanos/main.go
+++ b/cmd/thanos/main.go
@@ -80,7 +80,7 @@ func main() {
 	registerCompact(cmds, app)
 	registerBucket(cmds, app, "bucket")
 	registerDownsample(cmds, app, "downsample")
-	registerReceive(cmds, app, "receive")
+	registerReceive(cmds, app)
 	registerChecks(cmds, app, "check")
 
 	cmd, err := app.Parse(os.Args[1:])

--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -416,7 +416,7 @@ func runQuery(
 
 		// Initiate default HTTP listener providing metrics endpoint and readiness/liveness probes.
 		if err := scheduleHTTPServer(g, logger, reg, statusProber, httpBindAddr, router, comp); err != nil {
-			return errors.Wrap(err, "create default HTTP server with readiness prober")
+			return errors.Wrap(err, "schedule default HTTP server with probes")
 		}
 	}
 	// Start query (proxy) gRPC StoreAPI.

--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -414,9 +414,9 @@ func runQuery(
 
 		api.Register(router.WithPrefix(path.Join(webRoutePrefix, "/api/v1")), tracer, logger, ins)
 
-		// Initiate default HTTP listener providing metrics endpoint and readiness/liveness probes.
+		// Initiate HTTP listener providing metrics endpoint and readiness/liveness probes.
 		if err := scheduleHTTPServer(g, logger, reg, statusProber, httpBindAddr, router, comp); err != nil {
-			return errors.Wrap(err, "schedule default HTTP server with probes")
+			return errors.Wrap(err, "schedule HTTP server with probes")
 		}
 	}
 	// Start query (proxy) gRPC StoreAPI.

--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -252,11 +252,11 @@ func runReceive(
 		)
 	}
 
-	level.Debug(logger).Log("msg", "setting up default http server")
+	level.Debug(logger).Log("msg", "setting up http server")
 	statusProber := prober.NewProber(comp, logger, prometheus.WrapRegistererWithPrefix("thanos_", reg))
-	// Initiate default HTTP listener providing metrics endpoint and readiness/liveness probes.
+	// Initiate HTTP listener providing metrics endpoint and readiness/liveness probes.
 	if err := scheduleHTTPServer(g, logger, reg, statusProber, httpBindAddr, nil, comp); err != nil {
-		return errors.Wrap(err, "schedule default HTTP server with probes")
+		return errors.Wrap(err, "schedule HTTP server with probes")
 	}
 
 	level.Debug(logger).Log("msg", "setting up grpc server")

--- a/cmd/thanos/sidecar.go
+++ b/cmd/thanos/sidecar.go
@@ -122,7 +122,7 @@ func runSidecar(
 	statusProber := prober.NewProber(comp, logger, prometheus.WrapRegistererWithPrefix("thanos_", reg))
 	// Initiate default HTTP listener providing metrics endpoint and readiness/liveness probes.
 	if err := scheduleHTTPServer(g, logger, reg, statusProber, httpBindAddr, nil, comp); err != nil {
-		return errors.Wrap(err, "create default HTTP server with readiness prober")
+		return errors.Wrap(err, "schedule default HTTP server with probes")
 	}
 
 	// Setup all the concurrent groups.

--- a/cmd/thanos/sidecar.go
+++ b/cmd/thanos/sidecar.go
@@ -120,9 +120,9 @@ func runSidecar(
 	}
 
 	statusProber := prober.NewProber(comp, logger, prometheus.WrapRegistererWithPrefix("thanos_", reg))
-	// Initiate default HTTP listener providing metrics endpoint and readiness/liveness probes.
+	// Initiate HTTP listener providing metrics endpoint and readiness/liveness probes.
 	if err := scheduleHTTPServer(g, logger, reg, statusProber, httpBindAddr, nil, comp); err != nil {
-		return errors.Wrap(err, "schedule default HTTP server with probes")
+		return errors.Wrap(err, "schedule HTTP server with probes")
 	}
 
 	// Setup all the concurrent groups.

--- a/go.mod
+++ b/go.mod
@@ -65,3 +65,5 @@ replace (
 	k8s.io/klog => k8s.io/klog v0.3.1
 	k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20190228160746-b3a7cee44a30
 )
+
+go 1.13

--- a/go.mod
+++ b/go.mod
@@ -65,5 +65,3 @@ replace (
 	k8s.io/klog => k8s.io/klog v0.3.1
 	k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20190228160746-b3a7cee44a30
 )
-
-go 1.13


### PR DESCRIPTION
This PR,

* Adds `/-/healthy` endpoint for liveness checks.
* Adds `/-/ready` endpoint for readiness checks.

## Changes

* Adds `/-/healthy` endpoint for liveness checks.
* Adds `/-/ready` endpoint for readiness checks.
* Uses `prober.Prober` for readiness and liveness endpoints.

## Verification

1. `make test`

2. Started `thanos receive` and made a request to related endpoints.

```console
➜ curl http://0.0.0.0:10902/-/healthy
thanos receive is healthy%
```

```console
➜ curl http://0.0.0.0:10902/-/ready
thanos receive is not ready. Reason: thanos receive is initializing
```

```console
➜ curl http://0.0.0.0:10902/-/ready
thanos receive is ready%
```