### PR TITLE
downsample: Add liveness and readiness probe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,12 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 ## Unreleased
 
 ## Added
+- [#XXX](https://github.com/thanos-io/thanos/pull/XXX) Added `/-/ready` and `/-/healthy` endpoints to Thanos Downsample.
 - [#1538](https://github.com/thanos-io/thanos/pull/1538) Added `/-/ready` and `/-/healthy` endpoints to Thanos Rule.
 - [#1537](https://github.com/thanos-io/thanos/pull/1537) Added `/-/ready` and `/-/healthy` endpoints to Thanos Receive.
 - [#1534](https://github.com/thanos-io/thanos/pull/1534) Added `/-/ready` endpoint to Thanos Query.
 - [#1533](https://github.com/thanos-io/thanos/pull/1533) Thanos inspect now supports the timeout flag.
+-[1533](https://github.com/thanos-io/thanos/pull/1533) Thanos inspect now supports the timeout flag.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 ## Unreleased
 
 ## Added
-- [#XXX](https://github.com/thanos-io/thanos/pull/XXX) Added `/-/ready` and `/-/healthy` endpoints to Thanos Downsample.
+- [#1540](https://github.com/thanos-io/thanos/pull/1540) Added `/-/ready` and `/-/healthy` endpoints to Thanos Downsample.
 - [#1538](https://github.com/thanos-io/thanos/pull/1538) Added `/-/ready` and `/-/healthy` endpoints to Thanos Rule.
 - [#1537](https://github.com/thanos-io/thanos/pull/1537) Added `/-/ready` and `/-/healthy` endpoints to Thanos Receive.
 - [#1534](https://github.com/thanos-io/thanos/pull/1534) Added `/-/ready` endpoint to Thanos Query.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,6 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 - [#1537](https://github.com/thanos-io/thanos/pull/1537) Added `/-/ready` and `/-/healthy` endpoints to Thanos Receive.
 - [#1534](https://github.com/thanos-io/thanos/pull/1534) Added `/-/ready` endpoint to Thanos Query.
 - [#1533](https://github.com/thanos-io/thanos/pull/1533) Thanos inspect now supports the timeout flag.
--[1533](https://github.com/thanos-io/thanos/pull/1533) Thanos inspect now supports the timeout flag.
 
 ### Fixed
 

--- a/cmd/thanos/downsample.go
+++ b/cmd/thanos/downsample.go
@@ -120,9 +120,9 @@ func runDownsample(
 	}
 
 	statusProber := prober.NewProber(comp, logger, prometheus.WrapRegistererWithPrefix("thanos_", reg))
-	// Initiate default HTTP listener providing metrics endpoint and readiness/liveness probes.
+	// Initiate HTTP listener providing metrics endpoint and readiness/liveness probes.
 	if err := scheduleHTTPServer(g, logger, reg, statusProber, httpBindAddr, nil, comp); err != nil {
-		return errors.Wrap(err, "schedule default HTTP server with probe")
+		return errors.Wrap(err, "schedule HTTP server with probe")
 	}
 
 	level.Info(logger).Log("msg", "starting downsample node")

--- a/cmd/thanos/downsample.go
+++ b/cmd/thanos/downsample.go
@@ -93,13 +93,14 @@ func runDownsample(
 	}()
 
 	metrics := newDownsampleMetrics(reg)
-
+	statusProber := prober.NewProber(comp, logger, prometheus.WrapRegistererWithPrefix("thanos_", reg))
 	// Start cycle of syncing blocks from the bucket and garbage collecting the bucket.
 	{
 		ctx, cancel := context.WithCancel(context.Background())
 
 		g.Add(func() error {
 			defer runutil.CloseWithLogOnErr(logger, bkt, "bucket client")
+			statusProber.SetReady()
 
 			level.Info(logger).Log("msg", "start first pass of downsampling")
 
@@ -119,7 +120,6 @@ func runDownsample(
 		})
 	}
 
-	statusProber := prober.NewProber(comp, logger, prometheus.WrapRegistererWithPrefix("thanos_", reg))
 	// Initiate HTTP listener providing metrics endpoint and readiness/liveness probes.
 	if err := scheduleHTTPServer(g, logger, reg, statusProber, httpBindAddr, nil, comp); err != nil {
 		return errors.Wrap(err, "schedule HTTP server with probe")

--- a/cmd/thanos/main.go
+++ b/cmd/thanos/main.go
@@ -79,7 +79,7 @@ func main() {
 	registerRule(cmds, app)
 	registerCompact(cmds, app)
 	registerBucket(cmds, app, "bucket")
-	registerDownsample(cmds, app, "downsample")
+	registerDownsample(cmds, app)
 	registerReceive(cmds, app)
 	registerChecks(cmds, app, "check")
 


### PR DESCRIPTION
This PR,

* Adds `/-/healthy` endpoint for liveness checks.
* Adds `/-/ready` endpoint for readiness checks.

## Changes

* Adds `/-/healthy` endpoint for liveness checks.
* Adds `/-/ready` endpoint for readiness checks.
* Uses `prober.Prober` for readiness and liveness endpoints.

## Verification

1. `make test`

2. Started `thanos downsample` and made a request to related endpoints.

```console
➜ curl http://0.0.0.0:10902/-/healthy
thanos downsample is healthy%
```

```console
➜ curl http://0.0.0.0:10902/-/ready
thanos downsample is not ready. Reason: thanos downsample is initializing
```

```console
➜ curl http://0.0.0.0:10902/-/ready
thanos downsample is ready%
```