### PR TITLE
*: Use exponential buckets for histogram metrics

### DIFF
--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -168,9 +168,7 @@ func registerQuery(m map[string]setupFunc, app *kingpin.Application) {
 func storeClientGRPCOpts(logger log.Logger, reg *prometheus.Registry, tracer opentracing.Tracer, secure bool, cert, key, caCert, serverName string) ([]grpc.DialOption, error) {
 	grpcMets := grpc_prometheus.NewClientMetrics()
 	grpcMets.EnableClientHandlingTimeHistogram(
-		grpc_prometheus.WithHistogramBuckets([]float64{
-			0.001, 0.01, 0.05, 0.1, 0.2, 0.4, 0.8, 1.6, 3.2, 6.4,
-		}),
+		grpc_prometheus.WithHistogramBuckets(prometheus.ExponentialBuckets(0.001, 2, 15)),
 	)
 	dialOpts := []grpc.DialOption{
 		// We want to make sure that we can receive huge gRPC messages from storeAPI.

--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -83,7 +83,7 @@ func newSyncerMetrics(reg prometheus.Registerer) *syncerMetrics {
 	m.syncMetaDuration = prometheus.NewHistogram(prometheus.HistogramOpts{
 		Name:    "thanos_compact_sync_meta_duration_seconds",
 		Help:    "Time it took to sync meta files.",
-		Buckets: prometheus.ExponentialBuckets(0.1, 2.5, 12),
+		Buckets: prometheus.ExponentialBuckets(0.01, 2.5, 12),
 	})
 
 	m.garbageCollectedBlocks = prometheus.NewCounter(prometheus.CounterOpts{
@@ -101,7 +101,7 @@ func newSyncerMetrics(reg prometheus.Registerer) *syncerMetrics {
 	m.garbageCollectionDuration = prometheus.NewHistogram(prometheus.HistogramOpts{
 		Name:    "thanos_compact_garbage_collection_duration_seconds",
 		Help:    "Time it took to perform garbage collection iteration.",
-		Buckets: prometheus.ExponentialBuckets(0.1, 2.5, 12),
+		Buckets: prometheus.ExponentialBuckets(0.05, 2.5, 12),
 	})
 
 	m.compactions = prometheus.NewCounterVec(prometheus.CounterOpts{

--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -83,7 +83,7 @@ func newSyncerMetrics(reg prometheus.Registerer) *syncerMetrics {
 	m.syncMetaDuration = prometheus.NewHistogram(prometheus.HistogramOpts{
 		Name:    "thanos_compact_sync_meta_duration_seconds",
 		Help:    "Time it took to sync meta files.",
-		Buckets: prometheus.ExponentialBuckets(0.01, 2.5, 12),
+		Buckets: prometheus.ExponentialBuckets(0.001, 2, 15),
 	})
 
 	m.garbageCollectedBlocks = prometheus.NewCounter(prometheus.CounterOpts{

--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -101,7 +101,7 @@ func newSyncerMetrics(reg prometheus.Registerer) *syncerMetrics {
 	m.garbageCollectionDuration = prometheus.NewHistogram(prometheus.HistogramOpts{
 		Name:    "thanos_compact_garbage_collection_duration_seconds",
 		Help:    "Time it took to perform garbage collection iteration.",
-		Buckets: prometheus.ExponentialBuckets(0.05, 2.5, 12),
+		Buckets: prometheus.ExponentialBuckets(0.001, 2, 15),
 	})
 
 	m.compactions = prometheus.NewCounterVec(prometheus.CounterOpts{

--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -81,11 +81,9 @@ func newSyncerMetrics(reg prometheus.Registerer) *syncerMetrics {
 		Help: "Total number of failed sync meta operations.",
 	})
 	m.syncMetaDuration = prometheus.NewHistogram(prometheus.HistogramOpts{
-		Name: "thanos_compact_sync_meta_duration_seconds",
-		Help: "Time it took to sync meta files.",
-		Buckets: []float64{
-			0.25, 0.6, 1, 2, 3.5, 5, 7.5, 10, 15, 30, 60, 100, 200, 500,
-		},
+		Name:    "thanos_compact_sync_meta_duration_seconds",
+		Help:    "Time it took to sync meta files.",
+		Buckets: prometheus.ExponentialBuckets(0.1, 2.5, 12),
 	})
 
 	m.garbageCollectedBlocks = prometheus.NewCounter(prometheus.CounterOpts{
@@ -101,11 +99,9 @@ func newSyncerMetrics(reg prometheus.Registerer) *syncerMetrics {
 		Help: "Total number of failed garbage collection operations.",
 	})
 	m.garbageCollectionDuration = prometheus.NewHistogram(prometheus.HistogramOpts{
-		Name: "thanos_compact_garbage_collection_duration_seconds",
-		Help: "Time it took to perform garbage collection iteration.",
-		Buckets: []float64{
-			0.25, 0.6, 1, 2, 3.5, 5, 7.5, 10, 15, 30, 60, 100, 200, 500,
-		},
+		Name:    "thanos_compact_garbage_collection_duration_seconds",
+		Help:    "Time it took to perform garbage collection iteration.",
+		Buckets: prometheus.ExponentialBuckets(0.1, 2.5, 12),
 	})
 
 	m.compactions = prometheus.NewCounterVec(prometheus.CounterOpts{

--- a/pkg/extprom/http/instrument_server.go
+++ b/pkg/extprom/http/instrument_server.go
@@ -39,8 +39,9 @@ func NewInstrumentationMiddleware(reg prometheus.Registerer) InstrumentationMidd
 	ins := defaultInstrumentationMiddleware{
 		requestDuration: prometheus.NewHistogramVec(
 			prometheus.HistogramOpts{
-				Name: "http_request_duration_seconds",
-				Help: "Tracks the latencies for HTTP requests.",
+				Name:    "http_request_duration_seconds",
+				Help:    "Tracks the latencies for HTTP requests.",
+				Buckets: prometheus.ExponentialBuckets(0.001, 2, 15),
 			},
 			[]string{"code", "handler", "method"},
 		),

--- a/pkg/extprom/http/instrument_server.go
+++ b/pkg/extprom/http/instrument_server.go
@@ -41,7 +41,7 @@ func NewInstrumentationMiddleware(reg prometheus.Registerer) InstrumentationMidd
 			prometheus.HistogramOpts{
 				Name:    "http_request_duration_seconds",
 				Help:    "Tracks the latencies for HTTP requests.",
-				Buckets: prometheus.ExponentialBuckets(0.001, 2, 15),
+				Buckets: prometheus.ExponentialBuckets(0.001, 2, 17),
 			},
 			[]string{"code", "handler", "method"},
 		),

--- a/pkg/objstore/objstore.go
+++ b/pkg/objstore/objstore.go
@@ -204,7 +204,7 @@ func BucketWithMetrics(name string, b Bucket, r prometheus.Registerer) Bucket {
 			Name:        "thanos_objstore_bucket_operation_duration_seconds",
 			Help:        "Duration of operations against the bucket",
 			ConstLabels: prometheus.Labels{"bucket": name},
-			Buckets:     []float64{0.005, 0.01, 0.02, 0.04, 0.08, 0.15, 0.3, 0.6, 1, 1.5, 2.5, 5, 10, 20, 30},
+			Buckets:     prometheus.ExponentialBuckets(0.001, 2, 17),
 		}, []string{"operation"}),
 		lastSuccessfullUploadTime: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Name: "thanos_objstore_bucket_last_successful_upload_time",

--- a/pkg/server/grpc/grpc.go
+++ b/pkg/server/grpc/grpc.go
@@ -43,9 +43,7 @@ func New(logger log.Logger, reg prometheus.Registerer, tracer opentracing.Tracer
 
 	met := grpc_prometheus.NewServerMetrics()
 	met.EnableHandlingTimeHistogram(
-		grpc_prometheus.WithHistogramBuckets([]float64{
-			0.001, 0.01, 0.05, 0.1, 0.2, 0.4, 0.8, 1.6, 3.2, 6.4,
-		}),
+		grpc_prometheus.WithHistogramBuckets(prometheus.ExponentialBuckets(0.001, 2, 15)),
 	)
 	panicsTotal := prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "thanos_grpc_req_panics_recovered_total",

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -135,18 +135,14 @@ func newBucketStoreMetrics(reg prometheus.Registerer) *bucketStoreMetrics {
 		Help: "Number of blocks in a bucket store that were touched to satisfy a query.",
 	})
 	m.seriesGetAllDuration = prometheus.NewHistogram(prometheus.HistogramOpts{
-		Name: "thanos_bucket_store_series_get_all_duration_seconds",
-		Help: "Time it takes until all per-block prepares and preloads for a query are finished.",
-		Buckets: []float64{
-			0.01, 0.05, 0.1, 0.25, 0.6, 1, 2, 3.5, 5, 7.5, 10, 15, 30, 60,
-		},
+		Name:    "thanos_bucket_store_series_get_all_duration_seconds",
+		Help:    "Time it takes until all per-block prepares and preloads for a query are finished.",
+		Buckets: prometheus.ExponentialBuckets(0.01, 2, 15),
 	})
 	m.seriesMergeDuration = prometheus.NewHistogram(prometheus.HistogramOpts{
-		Name: "thanos_bucket_store_series_merge_duration_seconds",
-		Help: "Time it takes to merge sub-results from all queried blocks into a single result.",
-		Buckets: []float64{
-			0.01, 0.05, 0.1, 0.25, 0.6, 1, 2, 3.5, 5, 7.5, 10, 15, 30, 60,
-		},
+		Name:    "thanos_bucket_store_series_merge_duration_seconds",
+		Help:    "Time it takes to merge sub-results from all queried blocks into a single result.",
+		Buckets: prometheus.ExponentialBuckets(0.01, 2, 15),
 	})
 	m.resultSeriesCount = prometheus.NewSummary(prometheus.SummaryOpts{
 		Name: "thanos_bucket_store_series_result_series",

--- a/pkg/store/gate.go
+++ b/pkg/store/gate.go
@@ -24,11 +24,9 @@ func NewGate(maxConcurrent int, reg prometheus.Registerer) *Gate {
 			Help: "Number of queries that are currently in flight.",
 		}),
 		gateTiming: prometheus.NewHistogram(prometheus.HistogramOpts{
-			Name: "gate_duration_seconds",
-			Help: "How many seconds it took for queries to wait at the gate.",
-			Buckets: []float64{
-				0.01, 0.05, 0.1, 0.25, 0.6, 1, 2, 3.5, 5, 10,
-			},
+			Name:    "gate_duration_seconds",
+			Help:    "How many seconds it took for queries to wait at the gate.",
+			Buckets: prometheus.ExponentialBuckets(0.001, 2, 15),
 		}),
 	}
 

--- a/pkg/store/gate.go
+++ b/pkg/store/gate.go
@@ -26,7 +26,7 @@ func NewGate(maxConcurrent int, reg prometheus.Registerer) *Gate {
 		gateTiming: prometheus.NewHistogram(prometheus.HistogramOpts{
 			Name:    "gate_duration_seconds",
 			Help:    "How many seconds it took for queries to wait at the gate.",
-			Buckets: prometheus.ExponentialBuckets(0.001, 2, 15),
+			Buckets: prometheus.ExponentialBuckets(0.1, 2, 15),
 		}),
 	}
 


### PR DESCRIPTION
This PR changes existing bucket configurations to fix issues that observed with latency graphs.

For example, as you can observe there are large differences between mean and P50 latencies. 

* `thanos_compact_garbage_collection_duration_seconds_bucket`

![Screenshot 2019-09-25 16 55 49](https://user-images.githubusercontent.com/536449/65612918-6b131c80-dfb5-11e9-9433-af578c06b4ca.png)

* `thanos_compact_sync_meta_duration_seconds_bucket`

![Screenshot 2019-09-25 16 57 43](https://user-images.githubusercontent.com/536449/65613044-9ac22480-dfb5-11e9-8eeb-528484814d3c.png)

**This increases the number of buckets for most of the histograms. For certain metrics, it significantly affects cardinality. However, it's needed to properly instrument the components.**

## Changes

Uses exponential buckets to provide more even distribution. (number of buckets, before and after)

* `grpc_server_handling_seconds_bucket` : 10 -> 15 (+exposes multiple labels)
* `http_request_duration_seconds_bucket` : 11 -> 17 (+exposes 3 labels, code, method, handler)
* `thanos_compact_sync_meta_duration_seconds_bucket` : 14 -> 15
* `thanos_compact_garbage_collection_duration_seconds_bucket` : 14 -> 15
* `thanos_objstore_bucket_operation_duration_seconds_bucket` : 15 -> 17
* `thanos_bucket_store_series_get_all_duration_seconds_bucket` :  14 -> 15
* `thanos_bucket_store_series_gate_duration_seconds_bucket` : 14 -> 15
* `thanos_bucket_store_series_merge_duration_seconds_bucket` : 10 -> 15

## Verification

1. `make test`
2. Run `MINIO_ENABLED=1 ./scripts/quickstart.sh` and `curl` to `/metrics`.