### PR TITLE
query: Experimental federate endpoint.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	github.com/opentracing/opentracing-go v1.1.0
 	github.com/pkg/errors v0.8.1
 	github.com/prometheus/client_golang v1.1.0
+	github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4
 	github.com/prometheus/common v0.6.0
 	github.com/prometheus/prometheus v1.8.2-0.20190819201610-48b2c9c8eae2 // v1.8.2 is misleading as Prometheus does not have v2 module. This is pointing to one commit after 2.12.0.
 	github.com/uber-go/atomic v1.4.0 // indirect

--- a/pkg/query/adapter/adapter.go
+++ b/pkg/query/adapter/adapter.go
@@ -1,0 +1,223 @@
+package adapter
+
+import (
+	"fmt"
+	"net/http"
+	"sort"
+	"time"
+
+	"github.com/gogo/protobuf/proto"
+	"github.com/thanos-io/thanos/pkg/runutil"
+
+	"github.com/go-kit/kit/log/level"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/expfmt"
+	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/prometheus/pkg/timestamp"
+	"github.com/prometheus/prometheus/pkg/value"
+	"github.com/prometheus/prometheus/promql"
+
+	"github.com/NYTimes/gziphandler"
+	"github.com/go-kit/kit/log"
+	"github.com/opentracing/opentracing-go"
+	"github.com/prometheus/common/route"
+	"github.com/prometheus/prometheus/storage"
+	extpromhttp "github.com/thanos-io/thanos/pkg/extprom/http"
+	"github.com/thanos-io/thanos/pkg/tracing"
+)
+
+// PrometheusAdapter is a sneaky component that is able to export Thanos data directly via Prometheus native federate API.
+// Experimental and not recommended: Done only for compatibility and migration purposes.
+// Why not recommended?
+// * Federate endpoint is not recommended as it tries to replicate metric database with requirement of highly available network (double scrape).
+// Also all warnings (e.g related to partial responses) are only logged, as federate API has no way of handling those.
+type PrometheusAdapter struct {
+	logger log.Logger
+	// TODO(bwplotka): Move to storepb.StoreClient, once Querier will allow deduplication on StoreAPI.
+	// Operating on StoreAPI would allow to extract this into separate service.
+	queryable storage.Queryable
+
+	now func() time.Time
+}
+
+// NewAPI returns an initialized API type.
+func NewPrometheus(
+	logger log.Logger,
+	queryable storage.Queryable,
+) *PrometheusAdapter {
+	return &PrometheusAdapter{
+		logger:    logger,
+		queryable: queryable,
+
+		now: time.Now,
+	}
+}
+
+// Register the API's endpoints in the given router.
+func (a *PrometheusAdapter) Register(r *route.Router, tracer opentracing.Tracer, ins extpromhttp.InstrumentationMiddleware) {
+	r.Get("/federate", ins.NewHandler("federate", tracing.HTTPMiddleware(tracer, "federate", a.logger, gziphandler.GzipHandler(http.HandlerFunc(a.federation)))))
+}
+
+func (a *PrometheusAdapter) federation(w http.ResponseWriter, req *http.Request) {
+	if err := req.ParseForm(); err != nil {
+		http.Error(w, fmt.Sprintf("error parsing form values: %v", err), http.StatusBadRequest)
+		return
+	}
+
+	var matcherSets [][]*labels.Matcher
+	for _, s := range req.Form["match[]"] {
+		matchers, err := promql.ParseMetricSelector(s)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		matcherSets = append(matcherSets, matchers)
+	}
+
+	var (
+		mint   = timestamp.FromTime(a.now().Add(-promql.LookbackDelta))
+		maxt   = timestamp.FromTime(a.now())
+		format = expfmt.Negotiate(req.Header)
+		enc    = expfmt.NewEncoder(w, format)
+	)
+	w.Header().Set("Content-Type", string(format))
+
+	q, err := a.queryable.Querier(req.Context(), mint, maxt)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	defer runutil.CloseWithLogOnErr(a.logger, q, "close federate querier")
+
+	vec := make(promql.Vector, 0, 8000)
+
+	params := &storage.SelectParams{
+		Start: mint,
+		End:   maxt,
+	}
+
+	var sets []storage.SeriesSet
+	for _, mset := range matcherSets {
+		s, wrns, err := q.Select(params, mset...)
+		if wrns != nil {
+			level.Warn(a.logger).Log("msg", "federation select returned warnings", "warnings", wrns)
+		}
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		sets = append(sets, s)
+	}
+
+	set := storage.NewMergeSeriesSet(sets, nil)
+	it := storage.NewBuffer(int64(promql.LookbackDelta / 1e6))
+	for set.Next() {
+		s := set.At()
+
+		it.Reset(s.Iterator())
+
+		var t int64
+		var v float64
+
+		ok := it.Seek(maxt)
+		if ok {
+			t, v = it.Values()
+		} else {
+			t, v, ok = it.PeekBack(1)
+			if !ok {
+				continue
+			}
+		}
+
+		// The exposition formats do not support stale markers, so drop them. This
+		// is good enough for staleness handling of federated data, as the
+		// interval-based limits on staleness will do the right thing for supported
+		// use cases (which is to say federating aggregated time series).
+		if value.IsStaleNaN(v) {
+			continue
+		}
+
+		vec = append(vec, promql.Sample{
+			Metric: s.Labels(),
+			Point:  promql.Point{T: t, V: v},
+		})
+	}
+	if set.Err() != nil {
+		http.Error(w, set.Err().Error(), http.StatusInternalServerError)
+		return
+	}
+
+	sort.Sort(byName(vec))
+
+	var (
+		lastMetricName string
+		protMetricFam  *dto.MetricFamily
+	)
+	for _, s := range vec {
+		nameSeen := false
+		protMetric := &dto.Metric{
+			Untyped: &dto.Untyped{},
+		}
+
+		for _, l := range s.Metric {
+			if l.Value == "" {
+				// No value means unset. Never consider those labels.
+				// This is also important to protect against nameless metrics.
+				continue
+			}
+			if l.Name == labels.MetricName {
+				nameSeen = true
+				if l.Value == lastMetricName {
+					// We already have the name in the current MetricFamily,
+					// and we ignore nameless metrics.
+					continue
+				}
+				// Need to start a new MetricFamily. Ship off the old one (if any) before
+				// creating the new one.
+				if protMetricFam != nil {
+					if err := enc.Encode(protMetricFam); err != nil {
+						level.Error(a.logger).Log("msg", "federation failed", "err", err)
+						return
+					}
+				}
+				protMetricFam = &dto.MetricFamily{
+					Type: dto.MetricType_UNTYPED.Enum(),
+					Name: proto.String(l.Value),
+				}
+				lastMetricName = l.Value
+				continue
+			}
+			protMetric.Label = append(protMetric.Label, &dto.LabelPair{
+				Name:  proto.String(l.Name),
+				Value: proto.String(l.Value),
+			})
+		}
+		if !nameSeen {
+			level.Warn(a.logger).Log("msg", "ignoring nameless metric during federation", "metric", s.Metric)
+			continue
+		}
+
+		protMetric.TimestampMs = proto.Int64(s.T)
+		protMetric.Untyped.Value = proto.Float64(s.V)
+
+		protMetricFam.Metric = append(protMetricFam.Metric, protMetric)
+	}
+	// Still have to ship off the last MetricFamily, if any.
+	if protMetricFam != nil {
+		if err := enc.Encode(protMetricFam); err != nil {
+			level.Error(a.logger).Log("msg", "federation failed", "err", err)
+		}
+	}
+}
+
+// byName makes a model.Vector sortable by metric name.
+type byName promql.Vector
+
+func (vec byName) Len() int      { return len(vec) }
+func (vec byName) Swap(i, j int) { vec[i], vec[j] = vec[j], vec[i] }
+
+func (vec byName) Less(i, j int) bool {
+	ni := vec[i].Metric.Get(labels.MetricName)
+	nj := vec[j].Metric.Get(labels.MetricName)
+	return ni < nj
+}

--- a/pkg/query/adapter/adapter_test.go
+++ b/pkg/query/adapter/adapter_test.go
@@ -1,0 +1,190 @@
+package adapter
+
+import (
+	"bytes"
+	"net/http/httptest"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/prometheus/promql"
+)
+
+var scenarios = map[string]struct {
+	params string
+	code   int
+	body   string
+}{
+	"empty": {
+		params: "",
+		code:   200,
+		body:   ``,
+	},
+	"match nothing": {
+		params: "match[]=does_not_match_anything",
+		code:   200,
+		body:   ``,
+	},
+	"invalid params from the beginning": {
+		params: "match[]=-not-a-valid-metric-name",
+		code:   400,
+		body: `parse error at char 1: vector selector must contain label matchers or metric name
+`,
+	},
+	"invalid params somewhere in the middle": {
+		params: "match[]=not-a-valid-metric-name",
+		code:   400,
+		body: `parse error at char 4: could not parse remaining input "-a-valid-metric"...
+`,
+	},
+	"test_metric1": {
+		params: "match[]=test_metric1",
+		code:   200,
+		body: `# TYPE test_metric1 untyped
+test_metric1{foo="bar",instance="i"} 10000 6000000
+test_metric1{foo="boo",instance="i"} 1 6000000
+`,
+	},
+	"test_metric2": {
+		params: "match[]=test_metric2",
+		code:   200,
+		body: `# TYPE test_metric2 untyped
+test_metric2{foo="boo",instance="i"} 1 6000000
+`,
+	},
+	"test_metric_without_labels": {
+		params: "match[]=test_metric_without_labels",
+		code:   200,
+		body: `# TYPE test_metric_without_labels untyped
+test_metric_without_labels 1001 6000000
+`,
+	},
+	"test_stale_metric": {
+		params: "match[]=test_metric_stale",
+		code:   200,
+		body:   ``,
+	},
+	"test_old_metric": {
+		params: "match[]=test_metric_old",
+		code:   200,
+		body: `# TYPE test_metric_old untyped
+test_metric_old 981 5880000
+`,
+	},
+	"{foo='boo'}": {
+		params: "match[]={foo='boo'}",
+		code:   200,
+		body: `# TYPE test_metric1 untyped
+test_metric1{foo="boo",instance="i"} 1 6000000
+# TYPE test_metric2 untyped
+test_metric2{foo="boo",instance="i"} 1 6000000
+`,
+	},
+	"two matchers": {
+		params: "match[]=test_metric1&match[]=test_metric2",
+		code:   200,
+		body: `# TYPE test_metric1 untyped
+test_metric1{foo="bar",instance="i"} 10000 6000000
+test_metric1{foo="boo",instance="i"} 1 6000000
+# TYPE test_metric2 untyped
+test_metric2{foo="boo",instance="i"} 1 6000000
+`,
+	},
+	"everything": {
+		params: "match[]={__name__=~'.%2b'}", // '%2b' is an URL-encoded '+'.
+		code:   200,
+		body: `# TYPE test_metric1 untyped
+test_metric1{foo="bar",instance="i"} 10000 6000000
+test_metric1{foo="boo",instance="i"} 1 6000000
+# TYPE test_metric2 untyped
+test_metric2{foo="boo",instance="i"} 1 6000000
+# TYPE test_metric_old untyped
+test_metric_old 981 5880000
+# TYPE test_metric_without_labels untyped
+test_metric_without_labels 1001 6000000
+`,
+	},
+	"empty label value matches everything that doesn't have that label": {
+		params: "match[]={foo='',__name__=~'.%2b'}",
+		code:   200,
+		body: `# TYPE test_metric_old untyped
+test_metric_old 981 5880000
+# TYPE test_metric_without_labels untyped
+test_metric_without_labels 1001 6000000
+`,
+	},
+	"empty label value for a label that doesn't exist at all, matches everything": {
+		params: "match[]={bar='',__name__=~'.%2b'}",
+		code:   200,
+		body: `# TYPE test_metric1 untyped
+test_metric1{foo="bar",instance="i"} 10000 6000000
+test_metric1{foo="boo",instance="i"} 1 6000000
+# TYPE test_metric2 untyped
+test_metric2{foo="boo",instance="i"} 1 6000000
+# TYPE test_metric_old untyped
+test_metric_old 981 5880000
+# TYPE test_metric_without_labels untyped
+test_metric_without_labels 1001 6000000
+`,
+	},
+}
+
+func TestAdapterFederation(t *testing.T) {
+	suite, err := promql.NewTest(t, `
+		load 1m
+			test_metric1{foo="bar",instance="i"}    0+100x100
+			test_metric1{foo="boo",instance="i"}    1+0x100
+			test_metric2{foo="boo",instance="i"}    1+0x100
+			test_metric_without_labels 1+10x100
+			test_metric_stale                       1+10x99 stale
+			test_metric_old                         1+10x98
+	`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer suite.Close()
+
+	if err := suite.Run(); err != nil {
+		t.Fatal(err)
+	}
+
+	a := &PrometheusAdapter{
+		queryable: suite.Storage(),
+		now:       func() time.Time { return time.Unix(0, 0).Add(101 * time.Minute) },
+	}
+
+	for name, scenario := range scenarios {
+		t.Run(name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", "http://example.org/federate?"+scenario.params, nil)
+			res := httptest.NewRecorder()
+			a.federation(res, req)
+			if got, want := res.Code, scenario.code; got != want {
+				t.Errorf("Scenario %q: got code %d, want %d", name, got, want)
+			}
+			if got, want := normalizeBody(res.Body), scenario.body; got != want {
+				t.Errorf("Scenario %q: got body\n%s\n, want\n%s\n", name, got, want)
+			}
+		})
+	}
+}
+
+// normalizeBody sorts the lines within a metric to make it easy to verify the body.
+// (Federation is not taking care of sorting within a metric family.)
+func normalizeBody(body *bytes.Buffer) string {
+	var (
+		lines    []string
+		lastHash int
+	)
+	for line, err := body.ReadString('\n'); err == nil; line, err = body.ReadString('\n') {
+		if line[0] == '#' && len(lines) > 0 {
+			sort.Strings(lines[lastHash+1:])
+			lastHash = len(lines)
+		}
+		lines = append(lines, line)
+	}
+	if len(lines) > 0 {
+		sort.Strings(lines[lastHash+1:])
+	}
+	return strings.Join(lines, "")
+}

--- a/pkg/query/api/v1.go
+++ b/pkg/query/api/v1.go
@@ -135,7 +135,7 @@ func NewAPI(
 }
 
 // Register the API's endpoints in the given router.
-func (api *API) Register(r *route.Router, tracer opentracing.Tracer, logger log.Logger, ins extpromhttp.InstrumentationMiddleware) {
+func (api *API) Register(r *route.Router, tracer opentracing.Tracer, ins extpromhttp.InstrumentationMiddleware) {
 	instr := func(name string, f ApiFunc) http.HandlerFunc {
 		hf := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			SetCORS(w)
@@ -147,7 +147,7 @@ func (api *API) Register(r *route.Router, tracer opentracing.Tracer, logger log.
 				w.WriteHeader(http.StatusNoContent)
 			}
 		})
-		return ins.NewHandler(name, tracing.HTTPMiddleware(tracer, name, logger, gziphandler.GzipHandler(hf)))
+		return ins.NewHandler(name, tracing.HTTPMiddleware(tracer, name, api.logger, gziphandler.GzipHandler(hf)))
 	}
 
 	r.Options("/*path", instr("options", api.options))

--- a/pkg/query/api/v1_test.go
+++ b/pkg/query/api/v1_test.go
@@ -30,8 +30,7 @@ import (
 	"time"
 
 	"github.com/fortytw2/leaktest"
-	"github.com/go-kit/kit/log"
-	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go"
 	"github.com/prometheus/common/route"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/pkg/timestamp"
@@ -1021,7 +1020,7 @@ func TestParseDuration(t *testing.T) {
 func TestOptionsMethod(t *testing.T) {
 	r := route.New()
 	api := &API{}
-	api.Register(r, &opentracing.NoopTracer{}, log.NewNopLogger(), extpromhttp.NewNopInstrumentationMiddleware())
+	api.Register(r, &opentracing.NoopTracer{}, extpromhttp.NewNopInstrumentationMiddleware())
 
 	s := httptest.NewServer(r)
 	defer s.Close()


### PR DESCRIPTION
This adds `/federate` endpoint directly to Querier.

**NOTE**: This PR is not intended to be merged for now. It's just exploring capabilities of integrating Thanos with older Prometheus APIs like federate.

:warning:  **Federate endpoint is not recommended as it tries to replicate a metric database (TSDB) with the requirement of the highly available network (double scrape).**

cc @brancz  @metalmatze @aditya-konarde

There are available docker images with those commits:

* `quay.io/thanos/thanos:v0.7.0-with-federate-b7177f666c`

### Why not separate service on top of StoreAPI?

Querier StoreAPI implementation does not do deduplication which might be handy, so, for now, we implemented that in querier itself. If separate service is needed, separate querier might be deployed.

Signed-off-by: Bartek Plotka <bwplotka@gmail.com>
