### PR TITLE
Fix typos, including 'fomrat' -> 'format' in tracing.config-file help text

### DIFF
--- a/cmd/thanos/flags.go
+++ b/cmd/thanos/flags.go
@@ -118,7 +118,7 @@ func regCommonTracingFlags(app *kingpin.Application) *pathOrContent {
 	fileFlagName := fmt.Sprintf("tracing.config-file")
 	contentFlagName := fmt.Sprintf("tracing.config")
 
-	help := fmt.Sprintf("Path to YAML file that contains tracing configuration. See fomrat details: https://thanos.io/tracing.md/#configuration ")
+	help := fmt.Sprintf("Path to YAML file that contains tracing configuration. See format details: https://thanos.io/tracing.md/#configuration ")
 	tracingConfFile := app.Flag(fileFlagName, help).PlaceHolder("<tracing.config-yaml-path>").String()
 
 	help = fmt.Sprintf("Alternative to '%s' flag. Tracing configuration in YAML. See format details: https://thanos.io/tracing.md/#configuration", fileFlagName)

--- a/docs/components/bucket.md
+++ b/docs/components/bucket.md
@@ -24,7 +24,7 @@ config:
 ```
 
 Bucket can be extended to add more subcommands that will be helpful when working with object storage buckets
-by adding a new command within `/cmd/thanos/bucket.go`
+by adding a new command within `/cmd/thanos/bucket.go`.
 
 
 ## Deployment
@@ -44,7 +44,7 @@ Flags:
       --log.format=logfmt  Log format to use.
       --tracing.config-file=<tracing.config-yaml-path>
                            Path to YAML file that contains tracing
-                           configuration. See fomrat details:
+                           configuration. See format details:
                            https://thanos.io/tracing.md/#configuration
       --tracing.config=<tracing.config-yaml>
                            Alternative to 'tracing.config-file' flag. Tracing
@@ -103,7 +103,7 @@ Flags:
       --log.format=logfmt      Log format to use.
       --tracing.config-file=<tracing.config-yaml-path>
                                Path to YAML file that contains tracing
-                               configuration. See fomrat details:
+                               configuration. See format details:
                                https://thanos.io/tracing.md/#configuration
       --tracing.config=<tracing.config-yaml>
                                Alternative to 'tracing.config-file' flag.
@@ -151,7 +151,7 @@ Flags:
       --log.format=logfmt  Log format to use.
       --tracing.config-file=<tracing.config-yaml-path>
                            Path to YAML file that contains tracing
-                           configuration. See fomrat details:
+                           configuration. See format details:
                            https://thanos.io/tracing.md/#configuration
       --tracing.config=<tracing.config-yaml>
                            Alternative to 'tracing.config-file' flag. Tracing
@@ -213,7 +213,7 @@ Flags:
       --log.format=logfmt  Log format to use.
       --tracing.config-file=<tracing.config-yaml-path>
                            Path to YAML file that contains tracing
-                           configuration. See fomrat details:
+                           configuration. See format details:
                            https://thanos.io/tracing.md/#configuration
       --tracing.config=<tracing.config-yaml>
                            Alternative to 'tracing.config-file' flag. Tracing
@@ -256,7 +256,7 @@ Flags:
       --log.format=logfmt    Log format to use.
       --tracing.config-file=<tracing.config-yaml-path>
                              Path to YAML file that contains tracing
-                             configuration. See fomrat details:
+                             configuration. See format details:
                              https://thanos.io/tracing.md/#configuration
       --tracing.config=<tracing.config-yaml>
                              Alternative to 'tracing.config-file' flag. Tracing

--- a/docs/components/check.md
+++ b/docs/components/check.md
@@ -25,7 +25,7 @@ Flags:
       --log.format=logfmt  Log format to use.
       --tracing.config-file=<tracing.config-yaml-path>
                            Path to YAML file that contains tracing
-                           configuration. See fomrat details:
+                           configuration. See format details:
                            https://thanos.io/tracing.md/#configuration
       --tracing.config=<tracing.config-yaml>
                            Alternative to 'tracing.config-file' flag. Tracing
@@ -69,7 +69,7 @@ Flags:
       --log.format=logfmt  Log format to use.
       --tracing.config-file=<tracing.config-yaml-path>
                            Path to YAML file that contains tracing
-                           configuration. See fomrat details:
+                           configuration. See format details:
                            https://thanos.io/tracing.md/#configuration
       --tracing.config=<tracing.config-yaml>
                            Alternative to 'tracing.config-file' flag. Tracing

--- a/docs/components/compact.md
+++ b/docs/components/compact.md
@@ -44,7 +44,7 @@ Flags:
       --log.format=logfmt      Log format to use.
       --tracing.config-file=<tracing.config-yaml-path>
                                Path to YAML file that contains tracing
-                               configuration. See fomrat details:
+                               configuration. See format details:
                                https://thanos.io/tracing.md/#configuration
       --tracing.config=<tracing.config-yaml>
                                Alternative to 'tracing.config-file' flag.

--- a/docs/components/query.md
+++ b/docs/components/query.md
@@ -206,7 +206,7 @@ Flags:
       --log.format=logfmt        Log format to use.
       --tracing.config-file=<tracing.config-yaml-path>
                                  Path to YAML file that contains tracing
-                                 configuration. See fomrat details:
+                                 configuration. See format details:
                                  https://thanos.io/tracing.md/#configuration
       --tracing.config=<tracing.config-yaml>
                                  Alternative to 'tracing.config-file' flag.

--- a/docs/components/rule.md
+++ b/docs/components/rule.md
@@ -159,7 +159,7 @@ Flags:
       --log.format=logfmt        Log format to use.
       --tracing.config-file=<tracing.config-yaml-path>
                                  Path to YAML file that contains tracing
-                                 configuration. See fomrat details:
+                                 configuration. See format details:
                                  https://thanos.io/tracing.md/#configuration
       --tracing.config=<tracing.config-yaml>
                                  Alternative to 'tracing.config-file' flag.

--- a/docs/components/sidecar.md
+++ b/docs/components/sidecar.md
@@ -21,7 +21,7 @@ In details:
 Prometheus servers connected to the Thanos cluster via the sidecar are subject to a few limitations and recommendations for safe operations:
 
 * The recommended Prometheus version is 2.2.1 or greater (including newest releases). This is due to Prometheus instability in previous versions as well as lack of `flags` endpoint.
-* (!) The Prometheus `external_labels` section of the Prometheus configuration file has unique labels in the overall Thanos system. Those external labels will be used by sidecar and then Thanos in many places:
+* (!) The Prometheus `external_labels` section of the Prometheus configuration file has unique labels in the overall Thanos system. Those external labels will be used by the sidecar and then Thanos in many places:
   
   * [Querier](./query.md) to filter out store APIs to touch during query requests.
   * Many object storage readers like [compactor](./compact.md) and [store gateway](./store.md) which groups the blocks by Prometheus source. Each produced TSDB block by Prometheus is labelled with external label by sidecar before upload to object storage.
@@ -31,7 +31,7 @@ Prometheus servers connected to the Thanos cluster via the sidecar are subject t
 If you choose to use the sidecar to also upload to object storage:
 
 * The `--storage.tsdb.min-block-duration` and `--storage.tsdb.max-block-duration` must be set to equal values to disable local compaction on order to use Thanos sidecar upload, otherwise leave local compaction on if sidecar just exposes StoreAPI and your retention is normal. The default of `2h` is recommended. 
-  Mentioned parameters set to equal values disable the internal Prometheus compaction, which is needed to avoid the uploaded data corruption when Thanos compactor does its job, this is critical for data consistency and should not be ignored if you plan to use Thanos compactor. Even though you set mentioned parameters equal, you might observe Prometheus internal metric `prometheus_tsdb_compactions_total` being incremented, don't be confused by that: Prometheus writes initial head block to filesytem via internal compaction mechanism, but if you have followed recommendations - data won't be modified by Prometheus before sidecar uploads it. Thanos sidecar will also check sanity of the flags set to Prometheus on the startup and log errors or warning if they have been configured improperly (#838).
+  Mentioned parameters set to equal values disable the internal Prometheus compaction, which is needed to avoid the uploaded data corruption when Thanos compactor does its job, this is critical for data consistency and should not be ignored if you plan to use Thanos compactor. Even though you set mentioned parameters equal, you might observe Prometheus internal metric `prometheus_tsdb_compactions_total` being incremented, don't be confused by that: Prometheus writes initial head block to filesytem via its internal compaction mechanism, but if you have followed recommendations - data won't be modified by Prometheus before the sidecar uploads it. Thanos sidecar will also check sanity of the flags set to Prometheus on the startup and log errors or warning if they have been configured improperly (#838).
 * The retention is recommended to not be lower than three times the min block duration, so 6 hours. This achieves resilience in the face of connectivity issues to the object storage since all local data will remain available within the Thanos cluster. If connectivity gets restored the backlog of blocks gets uploaded to the object storage.
 
 ## Reloader Configuration
@@ -40,7 +40,7 @@ Thanos can watch changes in Prometheus configuration and refresh Prometheus conf
 
 You can configure watching for changes in directory via `--reloader.rule-dir=DIR_NAME` flag.
 
-Thanos sidecar can watch `--reloader.config-file=CONFIG_FILE` configuration file, evaluate environment variables found in there and produce generated config in `--reloader.config-envsubst-file=OUT_CONFIG_FILE` file.
+Thanos sidecar can watch `--reloader.config-file=CONFIG_FILE` configuration file, evaluate environment variables found in there, and produce generated config in `--reloader.config-envsubst-file=OUT_CONFIG_FILE` file.
 
 
 ## Example basic deployment
@@ -83,7 +83,7 @@ Flags:
       --log.format=logfmt        Log format to use.
       --tracing.config-file=<tracing.config-yaml-path>
                                  Path to YAML file that contains tracing
-                                 configuration. See fomrat details:
+                                 configuration. See format details:
                                  https://thanos.io/tracing.md/#configuration
       --tracing.config=<tracing.config-yaml>
                                  Alternative to 'tracing.config-file' flag.

--- a/docs/components/store.md
+++ b/docs/components/store.md
@@ -42,7 +42,7 @@ Flags:
       --log.format=logfmt        Log format to use.
       --tracing.config-file=<tracing.config-yaml-path>
                                  Path to YAML file that contains tracing
-                                 configuration. See fomrat details:
+                                 configuration. See format details:
                                  https://thanos.io/tracing.md/#configuration
       --tracing.config=<tracing.config-yaml>
                                  Alternative to 'tracing.config-file' flag.

--- a/pkg/shipper/shipper.go
+++ b/pkg/shipper/shipper.go
@@ -247,7 +247,7 @@ func (c *lazyOverlapChecker) IsOverlapping(ctx context.Context, newMeta tsdb.Blo
 // Sync performs a single synchronization, which ensures all non-compacted local blocks have been uploaded
 // to the object bucket once.
 //
-// If updload
+// If uploaded.
 //
 // It is not concurrency-safe, however it is compactor-safe (running concurrently with compactor is ok)
 func (s *Shipper) Sync(ctx context.Context) (uploaded int, err error) {


### PR DESCRIPTION
Mostly minor type/grammar/punctuation fixes in components markdown files.

Signed-off-by: Callum Styan <callumstyan@gmail.com>