### PR TITLE
Adding doc explaining the importance of groups for compactor

### DIFF
--- a/docs/components/compact.md
+++ b/docs/components/compact.md
@@ -28,6 +28,17 @@ config:
 The compactor needs local disk space to store intermediate data for its processing. Generally, about 100GB are recommended for it to keep working as the compacted time ranges grow over time.
 On-disk data is safe to delete between restarts and should be the first attempt to get crash-looping compactors unstuck.
 
+## Groups
+
+The compactor groups blocks using the [external_labels](https://thanos.io/getting-started.md/#external-labels) added by the 
+Prometheus who produced the block. The labels must be both _unique_ and _persistent_ across different Prometheus instances. 
+
+By _unique_, we mean that the set of labels in a Prometheus instance must be different from all other sets of labels of 
+your Prometheus instances, so that the compactor will be able to group blocks by Prometheus instance. 
+
+By _persistent_, we mean that one Prometheus instance must keep the same labels if it restarts, so that the compactor will keep
+compacting blocks from an instance even when a Prometheus instance goes down for some time.
+
 ## Flags
 
 [embedmd]:# (flags/compact.txt $)


### PR DESCRIPTION
## Changes

Added a `Groups` section in `compact.md` explaining the importance for the `external_labels` to be both unique and persistent across different Prometheis.

## Motivation

I have recently had to deal with quite a large data loss incident. 

I believe that it happened because we had a compactor running while the `external_labels` of the Prometheis that produced blocks for it had as `replica` a value that had a hash appended to it. 

That hash changed when a Prometheus version restarted for some reason, since it was a hash generated on startup. No more blocks from the group generated by the now-dead replica arrived, and so the old blocks never became big enough for them to be downsampled, and eventually they were deleted because of the retention policy we had.

So I think it's quite important to explain how groups are used by the compactor. I apologize if my explanation is incorrect in some way, I tried to read the code for the compactor, but I am not very familiar with Go.