### PR TITLE
keep same logic with prometheus about alert end time

### DIFF
--- a/cmd/thanos/rule.go
+++ b/cmd/thanos/rule.go
@@ -68,7 +68,8 @@ func registerRule(m map[string]setupFunc, app *kingpin.Application) {
 
 	ruleFiles := cmd.Flag("rule-file", "Rule files that should be used by rule manager. Can be in glob format (repeated).").
 		Default("rules/").Strings()
-
+	resendDelay := modelDuration(cmd.Flag("resend-delay", "Minimum amount of time to wait before resending an alert to Alertmanager.").
+		Default("1m"))
 	evalInterval := modelDuration(cmd.Flag("eval-interval", "The default evaluation interval to use.").
 		Default("30s"))
 	tsdbBlockDuration := modelDuration(cmd.Flag("tsdb.block-duration", "Block duration for TSDB block.").
@@ -160,6 +161,7 @@ func registerRule(m map[string]setupFunc, app *kingpin.Application) {
 			*webRoutePrefix,
 			*webExternalPrefix,
 			*webPrefixHeaderName,
+			time.Duration(*resendDelay),
 			time.Duration(*evalInterval),
 			*dataDir,
 			*ruleFiles,
@@ -194,6 +196,7 @@ func runRule(
 	webRoutePrefix string,
 	webExternalPrefix string,
 	webPrefixHeaderName string,
+	resendDelay time.Duration,
 	evalInterval time.Duration,
 	dataDir string,
 	ruleFiles []string,
@@ -297,6 +300,8 @@ func runRule(
 				}
 				if !alrt.ResolvedAt.IsZero() {
 					a.EndsAt = alrt.ResolvedAt
+				} else {
+					a.EndsAt = alrt.ValidUntil
 				}
 				res = append(res, a)
 			}
@@ -310,6 +315,7 @@ func runRule(
 			Appendable:  st,
 			ExternalURL: nil,
 			TSDB:        st,
+			ResendDelay: resendDelay,
 		}
 
 		for _, strategy := range storepb.PartialResponseStrategy_value {


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

* [] CHANGELOG entry if change is relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->