### PR TITLE
Refactor compactor constants, fix bucket column

### DIFF
--- a/cmd/thanos/bucket.go
+++ b/cmd/thanos/bucket.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/thanos-io/thanos/pkg/block"
 	"github.com/thanos-io/thanos/pkg/block/metadata"
+	"github.com/thanos-io/thanos/pkg/compact/downsample"
 	extpromhttp "github.com/thanos-io/thanos/pkg/extprom/http"
 	"github.com/thanos-io/thanos/pkg/objstore"
 	"github.com/thanos-io/thanos/pkg/objstore/client"
@@ -422,11 +423,11 @@ func printTable(blockMetas []*metadata.Meta, selectorLabels labels.Labels, sortB
 		timeRange := time.Duration((blockMeta.MaxTime - blockMeta.MinTime) * int64(time.Millisecond))
 		// Calculate how long it takes until the next compaction.
 		untilComp := "-"
-		if blockMeta.Thanos.Downsample.Resolution == 0 { // data currently raw, downsample if range >= 40 hours
-			untilComp = (time.Duration(40*60*60*1000*time.Millisecond) - timeRange).String()
+		if blockMeta.Thanos.Downsample.Resolution == downsample.ResLevel0 { // data currently raw, downsample if range >= 40 hours
+			untilComp = (time.Duration(downsample.DownsampleRange0*time.Millisecond) - timeRange).String()
 		}
-		if blockMeta.Thanos.Downsample.Resolution == 5*60*1000 { // data currently 5m resolution, downsample if range >= 10 days
-			untilComp = (time.Duration(10*24*60*60*1000*time.Millisecond) - timeRange).String()
+		if blockMeta.Thanos.Downsample.Resolution == downsample.ResLevel1 { // data currently 5m resolution, downsample if range >= 10 days
+			untilComp = (time.Duration(downsample.DownsampleRange1*time.Millisecond) - timeRange).String()
 		}
 		var labels []string
 		for _, key := range getKeysAlphabetically(blockMeta.Thanos.Labels) {

--- a/cmd/thanos/bucket.go
+++ b/cmd/thanos/bucket.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/thanos-io/thanos/pkg/block"
 	"github.com/thanos-io/thanos/pkg/block/metadata"
-	"github.com/thanos-io/thanos/pkg/compact/downsample"
+	"github.com/thanos-io/thanos/pkg/compact"
 	extpromhttp "github.com/thanos-io/thanos/pkg/extprom/http"
 	"github.com/thanos-io/thanos/pkg/objstore"
 	"github.com/thanos-io/thanos/pkg/objstore/client"
@@ -51,7 +51,7 @@ var (
 		sort.Strings(s)
 		return s
 	}
-	inspectColumns = []string{"ULID", "FROM", "UNTIL", "RANGE", "UNTIL-COMP", "#SERIES", "#SAMPLES", "#CHUNKS", "COMP-LEVEL", "COMP-FAILED", "LABELS", "RESOLUTION", "SOURCE"}
+	inspectColumns = []string{"ULID", "FROM", "UNTIL", "RANGE", "UNTIL-DOWN", "#SERIES", "#SAMPLES", "#CHUNKS", "COMP-LEVEL", "COMP-FAILED", "LABELS", "RESOLUTION", "SOURCE"}
 )
 
 func registerBucket(m map[string]setupFunc, app *kingpin.Application, name string) {
@@ -421,13 +421,10 @@ func printTable(blockMetas []*metadata.Meta, selectorLabels labels.Labels, sortB
 		}
 
 		timeRange := time.Duration((blockMeta.MaxTime - blockMeta.MinTime) * int64(time.Millisecond))
-		// Calculate how long it takes until the next compaction.
-		untilComp := "-"
-		if blockMeta.Thanos.Downsample.Resolution == downsample.ResLevel0 { // data currently raw, downsample if range >= 40 hours
-			untilComp = (time.Duration(downsample.DownsampleRange0*time.Millisecond) - timeRange).String()
-		}
-		if blockMeta.Thanos.Downsample.Resolution == downsample.ResLevel1 { // data currently 5m resolution, downsample if range >= 10 days
-			untilComp = (time.Duration(downsample.DownsampleRange1*time.Millisecond) - timeRange).String()
+
+		untilDown := "-"
+		if until, err := compact.UntilNextDownsampling(blockMeta); err == nil {
+			untilDown = until.String()
 		}
 		var labels []string
 		for _, key := range getKeysAlphabetically(blockMeta.Thanos.Labels) {
@@ -439,7 +436,7 @@ func printTable(blockMetas []*metadata.Meta, selectorLabels labels.Labels, sortB
 		line = append(line, time.Unix(blockMeta.MinTime/1000, 0).Format("02-01-2006 15:04:05"))
 		line = append(line, time.Unix(blockMeta.MaxTime/1000, 0).Format("02-01-2006 15:04:05"))
 		line = append(line, timeRange.String())
-		line = append(line, untilComp)
+		line = append(line, untilDown)
 		line = append(line, p.Sprintf("%d", blockMeta.Stats.NumSeries))
 		line = append(line, p.Sprintf("%d", blockMeta.Stats.NumSamples))
 		line = append(line, p.Sprintf("%d", blockMeta.Stats.NumChunks))

--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -166,16 +166,16 @@ func (c *Syncer) SyncMetas(ctx context.Context) error {
 }
 
 // UntilNextDownsampling calculates how long it will take until the next downsampling operation.
-// Returns an error if there will be no downsampling. Does not take retention policies into consideration.
+// Returns an error if there will be no downsampling.
 func UntilNextDownsampling(m *metadata.Meta) (time.Duration, error) {
 	timeRange := time.Duration((m.MaxTime - m.MinTime) * int64(time.Millisecond))
 	switch m.Thanos.Downsample.Resolution {
 	case downsample.ResLevel2:
 		return time.Duration(0), errors.New("no downsampling")
 	case downsample.ResLevel1:
-		return time.Duration(downsample.DownsampleRange0*time.Millisecond) - timeRange, nil
-	case downsample.ResLevel0:
 		return time.Duration(downsample.DownsampleRange1*time.Millisecond) - timeRange, nil
+	case downsample.ResLevel0:
+		return time.Duration(downsample.DownsampleRange0*time.Millisecond) - timeRange, nil
 	default:
 		panic(fmt.Errorf("invalid resolution %v", m.Thanos.Downsample.Resolution))
 	}

--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -162,8 +162,23 @@ func (c *Syncer) SyncMetas(ctx context.Context) error {
 	}
 	c.metrics.syncMetas.Inc()
 	c.metrics.syncMetaDuration.Observe(time.Since(begin).Seconds())
-
 	return err
+}
+
+// UntilNextDownsampling calculates how long it will take until the next downsampling operation.
+// Returns an error if there will be no downsampling. Does not take retention policies into consideration.
+func UntilNextDownsampling(m *metadata.Meta) (time.Duration, error) {
+	timeRange := time.Duration((m.MaxTime - m.MinTime) * int64(time.Millisecond))
+	switch m.Thanos.Downsample.Resolution {
+	case downsample.ResLevel2:
+		return time.Duration(0), errors.New("no downsampling")
+	case downsample.ResLevel1:
+		return time.Duration(downsample.DownsampleRange0*time.Millisecond) - timeRange, nil
+	case downsample.ResLevel0:
+		return time.Duration(downsample.DownsampleRange1*time.Millisecond) - timeRange, nil
+	default:
+		panic(fmt.Errorf("invalid resolution %v", m.Thanos.Downsample.Resolution))
+	}
 }
 
 func (c *Syncer) syncMetas(ctx context.Context) error {

--- a/pkg/compact/downsample/downsample.go
+++ b/pkg/compact/downsample/downsample.go
@@ -28,6 +28,12 @@ const (
 	ResLevel2 = int64(60 * 60 * 1000) // 1 hour in milliseconds
 )
 
+// Downsampling ranges i.e. after what time we start to downsample blocks (in seconds).
+const (
+	DownsampleRange0 = 10 * 24 * 60 * 60 * 1000 // 10 days
+	DownsampleRange1 = 40 * 60 * 60 * 1000      // 40 hours
+)
+
 // Downsample downsamples the given block. It writes a new block into dir and returns its ID.
 func Downsample(
 	logger log.Logger,

--- a/pkg/compact/downsample/downsample.go
+++ b/pkg/compact/downsample/downsample.go
@@ -30,8 +30,8 @@ const (
 
 // Downsampling ranges i.e. after what time we start to downsample blocks (in seconds).
 const (
-	DownsampleRange0 = 10 * 24 * 60 * 60 * 1000 // 10 days
-	DownsampleRange1 = 40 * 60 * 60 * 1000      // 40 hours
+	DownsampleRange0 = 40 * 60 * 60 * 1000      // 40 hours
+	DownsampleRange1 = 10 * 24 * 60 * 60 * 1000 // 10 days
 )
 
 // Downsample downsamples the given block. It writes a new block into dir and returns its ID.


### PR DESCRIPTION
I wanted to add some metrics but actually I have realized that I don't need them in the middle. However, this has turned out into a nice refactoring PR. The following things were done:

* `UNTIL-COMP` column in `bucket inspect` has been renamed into `UNTIL-DOWN` because that is what it actually shows - time until the downsampling
* Some constants that were sprinkled all over the code were moved into one package