### PR TITLE
tests: only adjust SysProcAttr on linux

### DIFF
--- a/pkg/testutil/prometheus.go
+++ b/pkg/testutil/prometheus.go
@@ -179,10 +179,8 @@ func (p *Prometheus) start() error {
 	}, extra...)
 
 	p.cmd = exec.Command(prometheusBin(p.version), args...)
-	p.cmd.SysProcAttr = &syscall.SysProcAttr{
-		// For linux only, kill this if the go test process dies before the cleanup.
-		Pdeathsig: syscall.SIGKILL,
-	}
+	SetSysProcAttr(p.cmd)
+
 	go func() {
 		if b, err := p.cmd.CombinedOutput(); err != nil {
 			fmt.Fprintln(os.Stderr, "running Prometheus failed", err)

--- a/pkg/testutil/syscmd.go
+++ b/pkg/testutil/syscmd.go
@@ -1,0 +1,10 @@
+// +build !linux
+
+package testutil
+
+import (
+	"os/exec"
+)
+
+// SetSysProcAttr changes cmd.SysProcAttr as needed to run and cleanup test commands.
+func SetSysProcAttr(cmd *exec.Cmd) {}

--- a/pkg/testutil/syscmd_linux.go
+++ b/pkg/testutil/syscmd_linux.go
@@ -1,0 +1,14 @@
+package testutil
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// SetSysProcAttr changes cmd.SysProcAttr as needed to run and cleanup test commands.
+func SetSysProcAttr(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		// For linux only, kill this if the go test process dies before the cleanup.
+		Pdeathsig: syscall.SIGKILL,
+	}
+}

--- a/test/e2e/spinup_test.go
+++ b/test/e2e/spinup_test.go
@@ -91,10 +91,7 @@ func newCmdExec(cmd *exec.Cmd) *cmdExec {
 func (c *cmdExec) Start(stdout io.Writer, stderr io.Writer) error {
 	c.Stderr = stderr
 	c.Stdout = stdout
-	c.SysProcAttr = &syscall.SysProcAttr{
-		// For linux only, kill this if the go test process dies before the cleanup.
-		Pdeathsig: syscall.SIGKILL,
-	}
+	testutil.SetSysProcAttr(c.Cmd)
 	return c.Cmd.Start()
 }
 


### PR DESCRIPTION
Fixes compilation and local test runs on darwin.

Signed-off-by: Alfred Landrum <alfred@leakybucket.org>
