### PR TITLE
Store,Compactor: Thanos sharding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 - [#1534](https://github.com/thanos-io/thanos/pull/1534) Thanos Query Added `/-/ready` and `/-/healthy` endpoints.
 - [#1533](https://github.com/thanos-io/thanos/pull/1533) Thanos inspect now supports the timeout flag.
 - [#1362](https://github.com/thanos-io/thanos/pull/1362) Optional `replicaLabels` param for `/query` and `/query_range` querier endpoints. When provided overwrite the `query.replica-label` cli flags.
+- [#1583](https://github.com/thanos-io/thanos/pull/1583) Thanos sharding:
+  - Add relabel config (`--selector.relabel-config-file` and `selector.relabel-config`) into Thanos
+  - Selecting blocks to serve depends on the result of block labels relabeling.
+  - For store gateway, expose advertise labels after relabeling.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,9 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 - [#1533](https://github.com/thanos-io/thanos/pull/1533) Thanos inspect now supports the timeout flag.
 - [#1362](https://github.com/thanos-io/thanos/pull/1362) Optional `replicaLabels` param for `/query` and `/query_range` querier endpoints. When provided overwrite the `query.replica-label` cli flags.
 - [#1583](https://github.com/thanos-io/thanos/pull/1583) Thanos sharding:
-  - Add relabel config (`--selector.relabel-config-file` and `selector.relabel-config`) into Thanos
+  - Add relabel config (`--selector.relabel-config-file` and `selector.relabel-config`) into Thanos Store and Compact components.
+  - For store gateway, advertise labels from "approved" blocks.
   - Selecting blocks to serve depends on the result of block labels relabeling.
-  - For store gateway, expose advertise labels after relabeling.
 
 ### Changed
 

--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -156,7 +156,7 @@ func runCompact(
 	maxCompactionLevel int,
 	blockSyncConcurrency int,
 	concurrency int,
-	selectorRelabelConf *pathOrContent,
+	selectorRelabelConf *extflag.PathOrContent,
 ) error {
 	halted := prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "thanos_compactor_halted",

--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -111,6 +111,8 @@ func registerCompact(m map[string]setupFunc, app *kingpin.Application) {
 	compactionConcurrency := cmd.Flag("compact.concurrency", "Number of goroutines to use when compacting groups.").
 		Default("1").Int()
 
+	selectorRelabelConf := regSelectorRelabelFlags(cmd)
+
 	m[component.Compact.String()] = func(g *run.Group, logger log.Logger, reg *prometheus.Registry, tracer opentracing.Tracer, _ bool) error {
 		return runCompact(g, logger, reg,
 			*httpAddr,
@@ -131,6 +133,7 @@ func registerCompact(m map[string]setupFunc, app *kingpin.Application) {
 			*maxCompactionLevel,
 			*blockSyncConcurrency,
 			*compactionConcurrency,
+			selectorRelabelConf,
 		)
 	}
 }
@@ -153,6 +156,7 @@ func runCompact(
 	maxCompactionLevel int,
 	blockSyncConcurrency int,
 	concurrency int,
+	selectorRelabelConf *pathOrContent,
 ) error {
 	halted := prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "thanos_compactor_halted",
@@ -185,6 +189,16 @@ func runCompact(
 		return err
 	}
 
+	relabelContentYaml, err := selectorRelabelConf.Content()
+	if err != nil {
+		return errors.Wrap(err, "get content of relabel configuration")
+	}
+
+	relabelConfig, err := parseRelabelConfig(relabelContentYaml)
+	if err != nil {
+		return err
+	}
+
 	// Ensure we close up everything properly.
 	defer func() {
 		if err != nil {
@@ -193,7 +207,7 @@ func runCompact(
 	}()
 
 	sy, err := compact.NewSyncer(logger, reg, bkt, consistencyDelay,
-		blockSyncConcurrency, acceptMalformedIndex)
+		blockSyncConcurrency, acceptMalformedIndex, relabelConfig)
 	if err != nil {
 		return errors.Wrap(err, "create syncer")
 	}

--- a/cmd/thanos/flags.go
+++ b/cmd/thanos/flags.go
@@ -77,7 +77,7 @@ func regSelectorRelabelFlags(cmd *kingpin.CmdClause) *extflag.PathOrContent {
 	return extflag.RegisterPathOrContent(
 		cmd,
 		"selector.relabel-config",
-		"YAML file that contains seletor relabeling configuration. It follows native Prometheus relabel-config syntax. See format details: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config ",
+		"YAML file that contains relabeling configuration that allows selecting blocks. It follows native Prometheus relabel-config syntax. See format details: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config ",
 		false,
 	)
 }

--- a/cmd/thanos/flags.go
+++ b/cmd/thanos/flags.go
@@ -72,3 +72,24 @@ func regCommonTracingFlags(app *kingpin.Application) *extflag.PathOrContent {
 		false,
 	)
 }
+
+func regSelectorRelabelFlags(cmd *kingpin.CmdClause) *pathOrContent {
+	fileFlagName := "selector.relabel-config-file"
+	contentFlagName := "selector.relabel-config"
+	help := "Path to YAML file that contains seletor relabeling configuration. It follows native Prometheus relabel-config syntax. See format details: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config "
+
+	selectorRelabelConfFile := cmd.Flag(fileFlagName, help).PlaceHolder("<seletor.relabel-config-yaml-path>").String()
+
+	help = fmt.Sprintf("Alternative to '%s' flag. Relabeling configuration in YAML. See format details: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config", fileFlagName)
+
+	selectorRelabelConf := cmd.Flag(contentFlagName, help).PlaceHolder("<selector.relabel-config-yaml>").String()
+
+	return &pathOrContent{
+		fileFlagName:    fileFlagName,
+		contentFlagName: contentFlagName,
+		required:        false,
+
+		path:    selectorRelabelConfFile,
+		content: selectorRelabelConf,
+	}
+}

--- a/cmd/thanos/flags.go
+++ b/cmd/thanos/flags.go
@@ -73,23 +73,11 @@ func regCommonTracingFlags(app *kingpin.Application) *extflag.PathOrContent {
 	)
 }
 
-func regSelectorRelabelFlags(cmd *kingpin.CmdClause) *pathOrContent {
-	fileFlagName := "selector.relabel-config-file"
-	contentFlagName := "selector.relabel-config"
-	help := "Path to YAML file that contains seletor relabeling configuration. It follows native Prometheus relabel-config syntax. See format details: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config "
-
-	selectorRelabelConfFile := cmd.Flag(fileFlagName, help).PlaceHolder("<seletor.relabel-config-yaml-path>").String()
-
-	help = fmt.Sprintf("Alternative to '%s' flag. Relabeling configuration in YAML. See format details: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config", fileFlagName)
-
-	selectorRelabelConf := cmd.Flag(contentFlagName, help).PlaceHolder("<selector.relabel-config-yaml>").String()
-
-	return &pathOrContent{
-		fileFlagName:    fileFlagName,
-		contentFlagName: contentFlagName,
-		required:        false,
-
-		path:    selectorRelabelConfFile,
-		content: selectorRelabelConf,
-	}
+func regSelectorRelabelFlags(cmd *kingpin.CmdClause) *extflag.PathOrContent {
+	return extflag.RegisterPathOrContent(
+		cmd,
+		"selector.relabel-config",
+		"YAML file that contains seletor relabeling configuration. It follows native Prometheus relabel-config syntax. See format details: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config ",
+		false,
+	)
 }

--- a/cmd/thanos/store.go
+++ b/cmd/thanos/store.go
@@ -13,6 +13,7 @@ import (
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/prometheus/pkg/relabel"
 	"github.com/thanos-io/thanos/pkg/component"
 	"github.com/thanos-io/thanos/pkg/model"
 	"github.com/thanos-io/thanos/pkg/objstore/client"
@@ -21,6 +22,7 @@ import (
 	"github.com/thanos-io/thanos/pkg/store"
 	storecache "github.com/thanos-io/thanos/pkg/store/cache"
 	"gopkg.in/alecthomas/kingpin.v2"
+	yaml "gopkg.in/yaml.v2"
 )
 
 // registerStore registers a store command.
@@ -116,7 +118,7 @@ func runStore(
 	syncInterval time.Duration,
 	blockSyncConcurrency int,
 	filterConf *store.FilterConfig,
-	selectorRelabelConf *pathOrContent,
+	selectorRelabelConf *extflag.PathOrContent,
 ) error {
 	statusProber := prober.NewProber(component, logger, prometheus.WrapRegistererWithPrefix("thanos_", reg))
 

--- a/docs/components/compact.md
+++ b/docs/components/compact.md
@@ -120,16 +120,18 @@ Flags:
                                metadata from object storage.
       --compact.concurrency=1  Number of goroutines to use when compacting
                                groups.
-      --selector.relabel-config-file=<seletor.relabel-config-yaml-path>
+      --selector.relabel-config-file=<file-path>
                                Path to YAML file that contains seletor
                                relabeling configuration. It follows native
                                Prometheus relabel-config syntax. See format
                                details:
                                https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
-      --selector.relabel-config=<selector.relabel-config-yaml>
+      --selector.relabel-config=<content>
                                Alternative to 'selector.relabel-config-file'
-                               flag. Relabeling configuration in YAML. See
-                               format details:
+                               flag (lower priority). Content of YAML file that
+                               contains seletor relabeling configuration. It
+                               follows native Prometheus relabel-config syntax.
+                               See format details:
                                https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
 
 ```

--- a/docs/components/compact.md
+++ b/docs/components/compact.md
@@ -121,17 +121,17 @@ Flags:
       --compact.concurrency=1  Number of goroutines to use when compacting
                                groups.
       --selector.relabel-config-file=<file-path>
-                               Path to YAML file that contains seletor
-                               relabeling configuration. It follows native
-                               Prometheus relabel-config syntax. See format
-                               details:
+                               Path to YAML file that contains relabeling
+                               configuration that allows selecting blocks. It
+                               follows native Prometheus relabel-config syntax.
+                               See format details:
                                https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
       --selector.relabel-config=<content>
                                Alternative to 'selector.relabel-config-file'
                                flag (lower priority). Content of YAML file that
-                               contains seletor relabeling configuration. It
-                               follows native Prometheus relabel-config syntax.
-                               See format details:
+                               contains relabeling configuration that allows
+                               selecting blocks. It follows native Prometheus
+                               relabel-config syntax. See format details:
                                https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
 
 ```

--- a/docs/components/compact.md
+++ b/docs/components/compact.md
@@ -120,5 +120,16 @@ Flags:
                                metadata from object storage.
       --compact.concurrency=1  Number of goroutines to use when compacting
                                groups.
+      --selector.relabel-config-file=<seletor.relabel-config-yaml-path>
+                               Path to YAML file that contains seletor
+                               relabeling configuration. It follows native
+                               Prometheus relabel-config syntax. See format
+                               details:
+                               https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
+      --selector.relabel-config=<selector.relabel-config-yaml>
+                               Alternative to 'selector.relabel-config-file'
+                               flag. Relabeling configuration in YAML. See
+                               format details:
+                               https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
 
 ```

--- a/docs/components/store.md
+++ b/docs/components/store.md
@@ -105,6 +105,17 @@ Flags:
                                  RFC3339 format or time duration relative to
                                  current time, such as -1d or 2h45m. Valid
                                  duration units are ms, s, m, h, d, w, y.
+      --selector.relabel-config-file=<seletor.relabel-config-yaml-path>
+                                 Path to YAML file that contains seletor
+                                 relabeling configuration. It follows native
+                                 Prometheus relabel-config syntax. See format
+                                 details:
+                                 https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
+      --selector.relabel-config=<selector.relabel-config-yaml>
+                                 Alternative to 'selector.relabel-config-file'
+                                 flag. Relabeling configuration in YAML. See
+                                 format details:
+                                 https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
 
 ```
 

--- a/docs/components/store.md
+++ b/docs/components/store.md
@@ -105,16 +105,18 @@ Flags:
                                  RFC3339 format or time duration relative to
                                  current time, such as -1d or 2h45m. Valid
                                  duration units are ms, s, m, h, d, w, y.
-      --selector.relabel-config-file=<seletor.relabel-config-yaml-path>
+      --selector.relabel-config-file=<file-path>
                                  Path to YAML file that contains seletor
                                  relabeling configuration. It follows native
                                  Prometheus relabel-config syntax. See format
                                  details:
                                  https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
-      --selector.relabel-config=<selector.relabel-config-yaml>
+      --selector.relabel-config=<content>
                                  Alternative to 'selector.relabel-config-file'
-                                 flag. Relabeling configuration in YAML. See
-                                 format details:
+                                 flag (lower priority). Content of YAML file
+                                 that contains seletor relabeling configuration.
+                                 It follows native Prometheus relabel-config
+                                 syntax. See format details:
                                  https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
 
 ```

--- a/docs/components/store.md
+++ b/docs/components/store.md
@@ -106,17 +106,18 @@ Flags:
                                  current time, such as -1d or 2h45m. Valid
                                  duration units are ms, s, m, h, d, w, y.
       --selector.relabel-config-file=<file-path>
-                                 Path to YAML file that contains seletor
-                                 relabeling configuration. It follows native
-                                 Prometheus relabel-config syntax. See format
-                                 details:
+                                 Path to YAML file that contains relabeling
+                                 configuration that allows selecting blocks. It
+                                 follows native Prometheus relabel-config
+                                 syntax. See format details:
                                  https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
       --selector.relabel-config=<content>
                                  Alternative to 'selector.relabel-config-file'
                                  flag (lower priority). Content of YAML file
-                                 that contains seletor relabeling configuration.
-                                 It follows native Prometheus relabel-config
-                                 syntax. See format details:
+                                 that contains relabeling configuration that
+                                 allows selecting blocks. It follows native
+                                 Prometheus relabel-config syntax. See format
+                                 details:
                                  https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
 
 ```

--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -226,8 +226,8 @@ func (c *Syncer) syncMetas(ctx context.Context) error {
 				lset := promlables.FromMap(meta.Thanos.Labels)
 				processedLabels := relabel.Process(lset, c.relabelConfig...)
 				if processedLabels == nil {
-					level.Warn(c.logger).Log("msg", "dropping block(drop in relabeling)", "block", id)
-					return
+					level.Debug(c.logger).Log("msg", "dropping block(drop in relabeling)", "block", id)
+					continue
 				}
 
 				c.blocksMtx.Lock()

--- a/pkg/compact/compact_e2e_test.go
+++ b/pkg/compact/compact_e2e_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/go-kit/kit/log"
 	"github.com/oklog/ulid"
 	"github.com/pkg/errors"
+	"github.com/prometheus/prometheus/pkg/relabel"
 	"github.com/prometheus/prometheus/tsdb"
 	"github.com/prometheus/prometheus/tsdb/index"
 	"github.com/prometheus/prometheus/tsdb/labels"
@@ -32,7 +33,8 @@ func TestSyncer_SyncMetas_e2e(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 		defer cancel()
 
-		sy, err := NewSyncer(nil, nil, bkt, 0, 1, false)
+		relabelConfig := make([]*relabel.Config, 0)
+		sy, err := NewSyncer(nil, nil, bkt, 0, 1, false, relabelConfig)
 		testutil.Ok(t, err)
 
 		// Generate 15 blocks. Initially the first 10 are synced into memory and only the last
@@ -85,6 +87,8 @@ func TestSyncer_GarbageCollect_e2e(t *testing.T) {
 		var metas []*metadata.Meta
 		var ids []ulid.ULID
 
+		relabelConfig := make([]*relabel.Config, 0)
+
 		for i := 0; i < 10; i++ {
 			var m metadata.Meta
 
@@ -134,7 +138,7 @@ func TestSyncer_GarbageCollect_e2e(t *testing.T) {
 		}
 
 		// Do one initial synchronization with the bucket.
-		sy, err := NewSyncer(nil, nil, bkt, 0, 1, false)
+		sy, err := NewSyncer(nil, nil, bkt, 0, 1, false, relabelConfig)
 		testutil.Ok(t, err)
 		testutil.Ok(t, sy.SyncMetas(ctx))
 

--- a/pkg/compact/compact_test.go
+++ b/pkg/compact/compact_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/oklog/ulid"
 	"github.com/pkg/errors"
+	"github.com/prometheus/prometheus/pkg/relabel"
 	terrors "github.com/prometheus/prometheus/tsdb/errors"
 	"github.com/thanos-io/thanos/pkg/objstore/inmem"
 	"github.com/thanos-io/thanos/pkg/testutil"
@@ -75,7 +76,8 @@ func TestSyncer_SyncMetas_HandlesMalformedBlocks(t *testing.T) {
 	defer cancel()
 
 	bkt := inmem.NewBucket()
-	sy, err := NewSyncer(nil, nil, bkt, 10*time.Second, 1, false)
+	relabelConfig := make([]*relabel.Config, 0)
+	sy, err := NewSyncer(nil, nil, bkt, 10*time.Second, 1, false, relabelConfig)
 	testutil.Ok(t, err)
 
 	// Generate 1 block which is older than MinimumAgeForRemoval which has chunk data but no meta.  Compactor should delete it.

--- a/pkg/query/storeset.go
+++ b/pkg/query/storeset.go
@@ -362,7 +362,9 @@ func externalLabelsFromStore(store *storeRef) string {
 
 	// Append the storeType to the end of list, because the store gateway will be exposed external labels,
 	// we allow the duplicate external labels with different components.
-	tsdbLabelSetStrings = append(tsdbLabelSetStrings, store.storeType.String())
+	if store.storeType != nil {
+		tsdbLabelSetStrings = append(tsdbLabelSetStrings, store.storeType.String())
+	}
 
 	return strings.Join(tsdbLabelSetStrings, ",")
 }

--- a/pkg/query/storeset.go
+++ b/pkg/query/storeset.go
@@ -218,10 +218,7 @@ func (s *StoreSet) Update(ctx context.Context) {
 	// Record the number of occurrences of external label combinations for current store slice.
 	externalLabelOccurrencesInStores := map[string]int{}
 	for _, st := range healthyStores {
-		if st.storeType != nil && (st.storeType.ToProto() == storepb.StoreType_QUERY ||
-			st.storeType.ToProto() == storepb.StoreType_SIDECAR) {
-			externalLabelOccurrencesInStores[externalLabelsFromStore(st)]++
-		}
+		externalLabelOccurrencesInStores[externalLabelsFromStore(st)]++
 	}
 	level.Debug(s.logger).Log("msg", "updating healthy stores", "externalLabelOccurrencesInStores", fmt.Sprintf("%#+v", externalLabelOccurrencesInStores))
 
@@ -257,8 +254,7 @@ func (s *StoreSet) Update(ctx context.Context) {
 		externalLabels := externalLabelsFromStore(store)
 		if len(store.LabelSets()) > 0 &&
 			store.storeType != nil &&
-			(store.storeType.ToProto() == storepb.StoreType_QUERY ||
-				store.storeType.ToProto() == storepb.StoreType_SIDECAR) &&
+			store.storeType.ToProto() != storepb.StoreType_STORE &&
 			externalLabelOccurrencesInStores[externalLabels] != 1 {
 			store.close()
 			s.updateStoreStatus(store, errors.New(droppingStoreMessage))

--- a/pkg/query/storeset.go
+++ b/pkg/query/storeset.go
@@ -360,6 +360,10 @@ func externalLabelsFromStore(store *storeRef) string {
 	}
 	sort.Strings(tsdbLabelSetStrings)
 
+	// Append the storeType to the end of list, because the store gateway will be exposed external labels,
+	// we allow the duplicate external labels with different components.
+	tsdbLabelSetStrings = append(tsdbLabelSetStrings, store.storeType.String())
+
 	return strings.Join(tsdbLabelSetStrings, ",")
 }
 

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -22,7 +22,7 @@ import (
 	"github.com/oklog/ulid"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
-	prom_labels "github.com/prometheus/prometheus/pkg/labels"
+	promlabels "github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/pkg/relabel"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
 	"github.com/prometheus/prometheus/tsdb/chunks"
@@ -463,11 +463,11 @@ func (s *BucketStore) addBlock(ctx context.Context, id ulid.ULID) (err error) {
 	lset := labels.FromMap(b.meta.Thanos.Labels)
 	h := lset.Hash()
 
-	// Check tsdb labels by relabel configuration.
+	// Check for block labels by relabeling.
 	// If output is empty, the block will be dropped.
-	processedLabels := relabel.Process(prom_labels.FromMap(lset.Map()), s.relabelConfig...)
+	processedLabels := relabel.Process(promlabels.FromMap(lset.Map()), s.relabelConfig...)
 	if processedLabels == nil {
-		level.Debug(s.logger).Log("msg", "dropping block(drop in relabeling)", "id", id)
+		level.Debug(s.logger).Log("msg", "dropping block(drop in relabeling)", "block", id)
 		return os.RemoveAll(dir)
 	}
 	b.labels = labels.FromMap(processedLabels.Map())

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -468,7 +468,7 @@ func (s *BucketStore) addBlock(ctx context.Context, id ulid.ULID) (err error) {
 	processedLabels := relabel.Process(prom_labels.FromMap(lset.Map()), s.relabelConfig...)
 	if processedLabels == nil {
 		level.Debug(s.logger).Log("msg", "dropping block(drop in relabeling)", "id", id)
-		return nil
+		return os.RemoveAll(dir)
 	}
 	b.labels = labels.FromMap(processedLabels.Map())
 	sort.Sort(b.labels)

--- a/pkg/store/bucket_e2e_test.go
+++ b/pkg/store/bucket_e2e_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-kit/kit/log"
 	"github.com/oklog/ulid"
 	"github.com/pkg/errors"
+	"github.com/prometheus/prometheus/pkg/relabel"
 	"github.com/prometheus/prometheus/pkg/timestamp"
 	"github.com/prometheus/prometheus/tsdb/labels"
 	"github.com/thanos-io/thanos/pkg/block"
@@ -137,6 +138,7 @@ func prepareStoreWithTestBlocks(t testing.TB, dir string, bkt objstore.Bucket, m
 		labels.FromStrings("a", "2", "c", "2"),
 	}
 	extLset := labels.FromStrings("ext1", "value1")
+	relabelConfig := make([]*relabel.Config, 0)
 
 	blocks, minTime, maxTime := prepareTestBlocks(t, time.Now(), 3, dir, bkt,
 		series, extLset)
@@ -150,7 +152,7 @@ func prepareStoreWithTestBlocks(t testing.TB, dir string, bkt objstore.Bucket, m
 		maxTime: maxTime,
 	}
 
-	store, err := NewBucketStore(s.logger, nil, bkt, dir, s.cache, 0, maxSampleCount, 20, false, 20, filterConf)
+	store, err := NewBucketStore(s.logger, nil, bkt, dir, s.cache, 0, maxSampleCount, 20, false, 20, filterConf, relabelConfig)
 	testutil.Ok(t, err)
 	s.store = store
 
@@ -474,6 +476,7 @@ func TestBucketStore_TimePartitioning_e2e(t *testing.T) {
 		labels.FromStrings("a", "1", "b", "2"),
 	}
 	extLset := labels.FromStrings("ext1", "value1")
+	relabelConfig := make([]*relabel.Config, 0)
 
 	_, minTime, _ := prepareTestBlocks(t, time.Now(), 3, dir, bkt, series, extLset)
 
@@ -484,7 +487,7 @@ func TestBucketStore_TimePartitioning_e2e(t *testing.T) {
 		&FilterConfig{
 			MinTime: minTimeDuration,
 			MaxTime: filterMaxTime,
-		})
+		}, relabelConfig)
 	testutil.Ok(t, err)
 
 	err = store.SyncBlocks(ctx)

--- a/pkg/store/bucket_e2e_test.go
+++ b/pkg/store/bucket_e2e_test.go
@@ -126,7 +126,7 @@ func prepareTestBlocks(t testing.TB, now time.Time, count int, dir string, bkt o
 	return
 }
 
-func prepareStoreWithTestBlocks(t testing.TB, dir string, bkt objstore.Bucket, manyParts bool, maxSampleCount uint64) *storeSuite {
+func prepareStoreWithTestBlocks(t testing.TB, dir string, bkt objstore.Bucket, manyParts bool, maxSampleCount uint64, relabelConfig []*relabel.Config) *storeSuite {
 	series := []labels.Labels{
 		labels.FromStrings("a", "1", "b", "1"),
 		labels.FromStrings("a", "1", "b", "2"),
@@ -138,7 +138,6 @@ func prepareStoreWithTestBlocks(t testing.TB, dir string, bkt objstore.Bucket, m
 		labels.FromStrings("a", "2", "c", "2"),
 	}
 	extLset := labels.FromStrings("ext1", "value1")
-	relabelConfig := make([]*relabel.Config, 0)
 
 	blocks, minTime, maxTime := prepareTestBlocks(t, time.Now(), 3, dir, bkt,
 		series, extLset)
@@ -393,7 +392,7 @@ func TestBucketStore_e2e(t *testing.T) {
 		testutil.Ok(t, err)
 		defer func() { testutil.Ok(t, os.RemoveAll(dir)) }()
 
-		s := prepareStoreWithTestBlocks(t, dir, bkt, false, 0)
+		s := prepareStoreWithTestBlocks(t, dir, bkt, false, 0, emptyRelabelConfig)
 		defer s.Close()
 
 		t.Log("Test with no index cache")
@@ -442,7 +441,7 @@ func TestBucketStore_ManyParts_e2e(t *testing.T) {
 		testutil.Ok(t, err)
 		defer func() { testutil.Ok(t, os.RemoveAll(dir)) }()
 
-		s := prepareStoreWithTestBlocks(t, dir, bkt, true, 0)
+		s := prepareStoreWithTestBlocks(t, dir, bkt, true, 0, emptyRelabelConfig)
 		defer s.Close()
 
 		indexCache, err := storecache.NewIndexCache(s.logger, nil, storecache.Opts{
@@ -476,7 +475,6 @@ func TestBucketStore_TimePartitioning_e2e(t *testing.T) {
 		labels.FromStrings("a", "1", "b", "2"),
 	}
 	extLset := labels.FromStrings("ext1", "value1")
-	relabelConfig := make([]*relabel.Config, 0)
 
 	_, minTime, _ := prepareTestBlocks(t, time.Now(), 3, dir, bkt, series, extLset)
 
@@ -487,7 +485,7 @@ func TestBucketStore_TimePartitioning_e2e(t *testing.T) {
 		&FilterConfig{
 			MinTime: minTimeDuration,
 			MaxTime: filterMaxTime,
-		}, relabelConfig)
+		}, emptyRelabelConfig)
 	testutil.Ok(t, err)
 
 	err = store.SyncBlocks(ctx)

--- a/pkg/store/bucket_test.go
+++ b/pkg/store/bucket_test.go
@@ -566,7 +566,7 @@ func TestBucketStore_selectorBlocks(t *testing.T) {
 		testutil.Equals(t, sc.exceptedLength, len(bucketStore.blocks))
 
 		ids := make([]ulid.ULID, 0, len(bucketStore.blocks))
-		for id, _ := range bucketStore.blocks {
+		for id := range bucketStore.blocks {
 			ids = append(ids, id)
 		}
 		testutil.Equals(t, sc.exceptedIds, ids)

--- a/pkg/store/bucket_test.go
+++ b/pkg/store/bucket_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/leanovate/gopter/prop"
 	"github.com/oklog/ulid"
 	prommodel "github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/pkg/relabel"
 	"github.com/prometheus/prometheus/pkg/timestamp"
 	"github.com/prometheus/prometheus/tsdb/labels"
 	"github.com/thanos-io/thanos/pkg/block/metadata"
@@ -422,7 +423,8 @@ func TestBucketStore_Info(t *testing.T) {
 	dir, err := ioutil.TempDir("", "bucketstore-test")
 	testutil.Ok(t, err)
 
-	bucketStore, err := NewBucketStore(nil, nil, nil, dir, noopCache{}, 2e5, 0, 0, false, 20, filterConf)
+	relabelConfig := make([]*relabel.Config, 0)
+	bucketStore, err := NewBucketStore(nil, nil, nil, dir, noopCache{}, 2e5, 0, 0, false, 20, filterConf, relabelConfig)
 	testutil.Ok(t, err)
 
 	resp, err := bucketStore.Info(ctx, &storepb.InfoRequest{})
@@ -440,6 +442,7 @@ func TestBucketStore_isBlockInMinMaxRange(t *testing.T) {
 
 	series := []labels.Labels{labels.FromStrings("a", "1", "b", "1")}
 	extLset := labels.FromStrings("ext1", "value1")
+	relabelConfig := make([]*relabel.Config, 0)
 
 	// Create a block in range [-2w, -1w].
 	id1, err := testutil.CreateBlock(ctx, dir, series, 10,
@@ -480,7 +483,7 @@ func TestBucketStore_isBlockInMinMaxRange(t *testing.T) {
 		&FilterConfig{
 			MinTime: minTimeDuration,
 			MaxTime: hourBefore,
-		})
+		}, relabelConfig)
 	testutil.Ok(t, err)
 
 	inRange, err := bucketStore.isBlockInMinMaxRange(context.TODO(), id1)

--- a/pkg/store/bucket_test.go
+++ b/pkg/store/bucket_test.go
@@ -6,6 +6,7 @@ import (
 	"math"
 	"path"
 	"path/filepath"
+	"sort"
 	"testing"
 	"time"
 
@@ -569,6 +570,12 @@ func TestBucketStore_selectorBlocks(t *testing.T) {
 		for id := range bucketStore.blocks {
 			ids = append(ids, id)
 		}
+		sort.Slice(sc.exceptedIds, func(i, j int) bool {
+			return sc.exceptedIds[i].Compare(sc.exceptedIds[j]) > 0
+		})
+		sort.Slice(ids, func(i, j int) bool {
+			return ids[i].Compare(ids[j]) > 0
+		})
 		testutil.Equals(t, sc.exceptedIds, ids)
 	}
 }

--- a/test/e2e/spinup_test.go
+++ b/test/e2e/spinup_test.go
@@ -243,7 +243,7 @@ func querier(http, grpc address, storeAddresses []address, fileSDStoreAddresses 
 	}
 }
 
-func storeGateway(http, grpc address, bucketConfig []byte) *serverScheduler {
+func storeGateway(http, grpc address, bucketConfig []byte, relabelConfig []byte) *serverScheduler {
 	return &serverScheduler{
 		HTTP: http,
 		GRPC: grpc,
@@ -264,6 +264,7 @@ func storeGateway(http, grpc address, bucketConfig []byte) *serverScheduler {
 				"--objstore.config", string(bucketConfig),
 				// Accelerated sync time for quicker test (3m by default).
 				"--sync-block-duration", "5s",
+				"--selector.relabel-config", string(relabelConfig),
 			)), nil
 		},
 	}


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

* [x] CHANGELOG entry if change is relevant to the end user.

## Changes

<!-- Enumerate changes you made -->
Implement partial parts of proposal #1501 :
* Add relabel config into Thanos, store gateway and compactor are supported now.
* Selecting blocks to serve depends on the result of block labels relabeling.
* For store gateway, expose advertise labels after relabeling.
* Allow the duplicate external labels for store gateway components.

Note: pre-filter has been implemented before this PR.

TODO:
- [x] Add unit test.
- [ ] Add documents for relabeling.

@bwplotka @brancz @povilasv @GiedriusS PTAL, thanks!