### PR TITLE
Make tests buildable on non-linux systems

### DIFF
--- a/pkg/testutil/prometheus.go
+++ b/pkg/testutil/prometheus.go
@@ -179,10 +179,8 @@ func (p *Prometheus) start() error {
 	}, extra...)
 
 	p.cmd = exec.Command(prometheusBin(p.version), args...)
-	p.cmd.SysProcAttr = &syscall.SysProcAttr{
-		// For linux only, kill this if the go test process dies before the cleanup.
-		Pdeathsig: syscall.SIGKILL,
-	}
+	p.cmd.SysProcAttr = sysProcAttr()
+
 	go func() {
 		if b, err := p.cmd.CombinedOutput(); err != nil {
 			fmt.Fprintln(os.Stderr, "running Prometheus failed", err)

--- a/pkg/testutil/prometheus.go
+++ b/pkg/testutil/prometheus.go
@@ -179,7 +179,7 @@ func (p *Prometheus) start() error {
 	}, extra...)
 
 	p.cmd = exec.Command(prometheusBin(p.version), args...)
-	p.cmd.SysProcAttr = sysProcAttr()
+	p.cmd.SysProcAttr = SysProcAttr()
 
 	go func() {
 		if b, err := p.cmd.CombinedOutput(); err != nil {

--- a/pkg/testutil/sysprocattr.go
+++ b/pkg/testutil/sysprocattr.go
@@ -1,0 +1,9 @@
+// +build !linux
+
+package testutil
+
+import "syscall"
+
+func sysProcAttr() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{}
+}

--- a/pkg/testutil/sysprocattr.go
+++ b/pkg/testutil/sysprocattr.go
@@ -4,6 +4,6 @@ package testutil
 
 import "syscall"
 
-func sysProcAttr() *syscall.SysProcAttr {
+func SysProcAttr() *syscall.SysProcAttr {
 	return &syscall.SysProcAttr{}
 }

--- a/pkg/testutil/sysprocattr_linux.go
+++ b/pkg/testutil/sysprocattr_linux.go
@@ -1,0 +1,10 @@
+package testutil
+
+import "syscall"
+
+func sysProcAttr() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{
+		// For linux only, kill this if the go test process dies before the cleanup.
+		Pdeathsig: syscall.SIGKILL,
+	}
+}

--- a/pkg/testutil/sysprocattr_linux.go
+++ b/pkg/testutil/sysprocattr_linux.go
@@ -2,7 +2,7 @@ package testutil
 
 import "syscall"
 
-func sysProcAttr() *syscall.SysProcAttr {
+func SysProcAttr() *syscall.SysProcAttr {
 	return &syscall.SysProcAttr{
 		// For linux only, kill this if the go test process dies before the cleanup.
 		Pdeathsig: syscall.SIGKILL,

--- a/test/e2e/spinup_test.go
+++ b/test/e2e/spinup_test.go
@@ -91,10 +91,7 @@ func newCmdExec(cmd *exec.Cmd) *cmdExec {
 func (c *cmdExec) Start(stdout io.Writer, stderr io.Writer) error {
 	c.Stderr = stderr
 	c.Stdout = stdout
-	c.SysProcAttr = &syscall.SysProcAttr{
-		// For linux only, kill this if the go test process dies before the cleanup.
-		Pdeathsig: syscall.SIGKILL,
-	}
+	c.SysProcAttr = testutil.SysProcAttr()
 	return c.Cmd.Start()
 }
 


### PR DESCRIPTION
The unguarded use of Linux-specific fields in `syscall.SysProcAttr` makes developing a little awkward on non-Linux systems. This change makes tests build and run on systems other than linux.

* [x] CHANGELOG entry if change is relevant to the end user.

## Changes

Extract configuration of `syscall.SysProcAttr` for prometheus and spinup_test to separate files with build flags (!linux/linux) so test code compiles on all platforms.

## Verification

I was able to run tests on OSX