### PR TITLE
pkg/receive: surface conflict error

### DIFF
--- a/pkg/receive/handler.go
+++ b/pkg/receive/handler.go
@@ -22,6 +22,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/route"
 	"github.com/prometheus/prometheus/prompb"
+	"github.com/prometheus/prometheus/storage"
 	terrors "github.com/prometheus/prometheus/tsdb/errors"
 	extpromhttp "github.com/thanos-io/thanos/pkg/extprom/http"
 	"github.com/thanos-io/thanos/pkg/runutil"
@@ -219,6 +220,10 @@ func (h *Handler) receive(w http.ResponseWriter, r *http.Request) {
 	// destined for the local node will be written to the receiver.
 	// Time series will be replicated as necessary.
 	if err := h.forward(r.Context(), tenant, rep, &wreq); err != nil {
+		if hasCause(err, isConflict) {
+			http.Error(w, err.Error(), http.StatusConflict)
+			return
+		}
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -352,7 +357,7 @@ func (h *Handler) parallelizeRequests(ctx context.Context, tenant string, replic
 				return
 			}
 			if res.StatusCode != http.StatusOK {
-				err = errors.New(res.Status)
+				err = errors.New(strconv.Itoa(res.StatusCode))
 				level.Error(h.logger).Log("msg", "forwarding returned non-200 status", "err", err, "endpoint", endpoint)
 				ec <- err
 				return
@@ -407,8 +412,32 @@ func (h *Handler) replicate(ctx context.Context, tenant string, wreq *prompb.Wri
 	err := h.parallelizeRequests(ctx, tenant, replicas, wreqs)
 	if errs, ok := err.(terrors.MultiError); ok {
 		if uint64(len(errs)) >= (h.options.ReplicationFactor+1)/2 {
-			return errors.New("did not meet replication threshold")
+			return errors.Wrap(err, "did not meet replication threshold")
 		}
 	}
 	return errors.Wrap(err, "could not replicate write request")
+}
+
+// hasCause performs a depth-first search of the causes of a nested MultiError
+// to determine if it contains an error that satisfies the given cause.
+func hasCause(err error, f func(error) bool) bool {
+	if err == nil {
+		return false
+	}
+	err = errors.Cause(err)
+	errs, ok := err.(terrors.MultiError)
+	if !ok {
+		return f(err)
+	}
+	for i := range errs {
+		if hasCause(errs[i], f) {
+			return true
+		}
+	}
+	return false
+}
+
+// isConflict returns whether or not the given error represents a conflict.
+func isConflict(err error) bool {
+	return err == storage.ErrOutOfOrderSample || err == storage.ErrOutOfBounds || err.Error() == strconv.Itoa(http.StatusConflict)
 }

--- a/pkg/receive/handler_test.go
+++ b/pkg/receive/handler_test.go
@@ -1,0 +1,99 @@
+package receive
+
+import (
+	"net/http"
+	"strconv"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/prometheus/prometheus/storage"
+	terrors "github.com/prometheus/prometheus/tsdb/errors"
+)
+
+func TestHasCause(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  error
+		f    func(error) bool
+		out  bool
+	}{
+		{
+			name: "nil",
+			f:    isConflict,
+			out:  false,
+		},
+		{
+			name: "nil multierror",
+			err:  terrors.MultiError([]error{}),
+			f:    isConflict,
+			out:  false,
+		},
+		{
+			name: "non-matching multierror",
+			err: terrors.MultiError([]error{
+				errors.New("foo"),
+				errors.New("bar"),
+			}),
+			f:   isConflict,
+			out: false,
+		},
+		{
+			name: "nested non-matching multierror",
+			err: errors.Wrap(terrors.MultiError([]error{
+				errors.New("foo"),
+				errors.New("bar"),
+			}), "baz"),
+			f:   isConflict,
+			out: false,
+		},
+		{
+			name: "deep nested non-matching multierror",
+			err: errors.Wrap(terrors.MultiError([]error{
+				errors.New("foo"),
+				terrors.MultiError([]error{
+					errors.New("bar"),
+					errors.New("qux"),
+				}),
+			}), "baz"),
+			f:   isConflict,
+			out: false,
+		},
+		{
+			name: "matching multierror",
+			err: terrors.MultiError([]error{
+				storage.ErrOutOfOrderSample,
+				errors.New("foo"),
+				errors.New("bar"),
+			}),
+			f:   isConflict,
+			out: true,
+		},
+		{
+			name: "nested matching multierror",
+			err: errors.Wrap(terrors.MultiError([]error{
+				storage.ErrOutOfOrderSample,
+				errors.New("foo"),
+				errors.New("bar"),
+			}), "baz"),
+			f:   isConflict,
+			out: true,
+		},
+		{
+			name: "deep nested matching multierror",
+			err: errors.Wrap(terrors.MultiError([]error{
+				terrors.MultiError([]error{
+					errors.New("qux"),
+					errors.New(strconv.Itoa(http.StatusConflict)),
+				}),
+				errors.New("foo"),
+				errors.New("bar"),
+			}), "baz"),
+			f:   isConflict,
+			out: true,
+		},
+	} {
+		if hasCause(tc.err, tc.f) != tc.out {
+			t.Errorf("test case %s: expected %t, got %t", tc.name, tc.out, !tc.out)
+		}
+	}
+}


### PR DESCRIPTION
This commit adds support to the receive component to identify if a
failed request is due to an ErrOutOfOrderSample error. If a request is
determined to have failed due to this reason, the handler responds with
a 409 Conflict status.

Fixes: #1509

cc @brancz @krasi-georgiev 