### PR TITLE
pkg/receive: replication should succeed if length errs < threshold

### DIFF
--- a/pkg/receive/handler.go
+++ b/pkg/receive/handler.go
@@ -409,6 +409,7 @@ func (h *Handler) replicate(ctx context.Context, tenant string, wreq *prompb.Wri
 		if uint64(len(errs)) >= (h.options.ReplicationFactor+1)/2 {
 			return errors.New("did not meet replication threshold")
 		}
+		return nil
 	}
 	return errors.Wrap(err, "could not replicate write request")
 }


### PR DESCRIPTION
When the number of replication errors are below the error threshold,
the replication func should not return an error.

Fixes: #1508
Signed-off-by: Lucas Servén Marín <lserven@gmail.com>

## Verification
e2e tests

cc @brancz @R4scal