### PR TITLE
cmd/thanos/receive: fix close chan panic

### DIFF
--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -263,9 +263,9 @@ func runReceive(
 				cancel()
 			})
 		} else {
-			defer close(updates)
 			cancel := make(chan struct{})
 			g.Add(func() error {
+				defer close(updates)
 				updates <- receive.SingleNodeHashring(endpoint)
 				<-cancel
 				return nil
@@ -410,7 +410,7 @@ func runReceive(
 			// Upload on demand.
 			ctx, cancel := context.WithCancel(context.Background())
 			g.Add(func() error {
-				defer close(uploadC)
+				defer close(uploadDone)
 				for {
 					select {
 					case <-ctx.Done():


### PR DESCRIPTION
This commit fixes a panic caused by sending on the chan which is closed
too early. This chan was closed when the setup func returned, rather
than when the group's goroutine returned.

Fixes: #1594
Signed-off-by: Lucas Servén Marín <lserven@gmail.com>