### PR TITLE
chore: added makefile target to check Go code comments trailing periods

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -158,9 +158,19 @@ check-docs: $(EMBEDMD) $(LICHE) build
 	@$(LICHE) --recursive docs --exclude "cloud.tencent.com" --document-root .
 	@$(LICHE) --exclude "cloud.tencent.com|goreportcard.com" --document-root . *.md
 
+# checks Go code comments if they have trailing period (excludes protobuffers and vendor files).
+.PHONY: check-comments
+check-comments:
+	@printf ">> checking Go comments trailing periods\n\n\n"
+	@if grep -Przo --color --include \*.go --exclude \*.pb.go --exclude bindata.go --exclude-dir vendor '\n.*\s+//\s{0,3}[^\s][^\n]+[^.?!:]{2}\n[ \t]*[^/\s].*\n' ./; \
+	 then \
+	 	printf "\n\n\n Error: Found comments without trailing period. Please make sure to add them.\n\n\n." \
+	 	&& false; \
+	 fi;
+
 # format formats the code (including imports format).
 .PHONY: format
-format: $(GOIMPORTS)
+format: $(GOIMPORTS) check-comments
 	@echo ">> formatting code"
 	@$(GOIMPORTS) -w $(FILES_TO_FMT)
 

--- a/Makefile
+++ b/Makefile
@@ -159,7 +159,7 @@ check-docs: $(EMBEDMD) $(LICHE) build
 	@$(LICHE) --exclude "cloud.tencent.com|goreportcard.com" --document-root . *.md
 
 # checks Go code comments if they have trailing period (excludes protobuffers and vendor files).
-# Comments with more than 3 spaces at begining are ommited from the check, example: '//    - foo'.
+# Comments with more than 3 spaces at beginning are omitted from the check, example: '//    - foo'.
 .PHONY: check-comments
 check-comments:
 	@printf ">> checking Go comments trailing periods\n\n\n"

--- a/Makefile
+++ b/Makefile
@@ -159,6 +159,7 @@ check-docs: $(EMBEDMD) $(LICHE) build
 	@$(LICHE) --exclude "cloud.tencent.com|goreportcard.com" --document-root . *.md
 
 # checks Go code comments if they have trailing period (excludes protobuffers and vendor files).
+# Comments with more than 3 spaces at begining are ommited from the check, example: '//    - foo'.
 .PHONY: check-comments
 check-comments:
 	@printf ">> checking Go comments trailing periods\n\n\n"

--- a/Makefile
+++ b/Makefile
@@ -162,7 +162,7 @@ check-docs: $(EMBEDMD) $(LICHE) build
 .PHONY: check-comments
 check-comments:
 	@printf ">> checking Go comments trailing periods\n\n\n"
-	@if grep -Przo --color --include \*.go --exclude \*.pb.go --exclude bindata.go --exclude-dir vendor '\n.*\s+//\s{0,3}[^\s][^\n]+[^.?!:]{2}\n[ \t]*[^/\s].*\n' ./; \
+	@if grep -Przo --color --include \*.go --exclude \*.pb.go --exclude bindata.go --exclude-dir vendor '\n.*\s+//(\s{0,3}[^\s][^\n]+[^.?!:]{2}|[^\s].*)\n[ \t]*[^/\s].*\n' ./; \
 	 then \
 	 	printf "\n\n\n Error: Found comments without trailing period. Comments has to be full sentences.\n\n\n." \
 	 	&& false; \

--- a/Makefile
+++ b/Makefile
@@ -164,7 +164,7 @@ check-comments:
 	@printf ">> checking Go comments trailing periods\n\n\n"
 	@if grep -Przo --color --include \*.go --exclude \*.pb.go --exclude bindata.go --exclude-dir vendor '\n.*\s+//\s{0,3}[^\s][^\n]+[^.?!:]{2}\n[ \t]*[^/\s].*\n' ./; \
 	 then \
-	 	printf "\n\n\n Error: Found comments without trailing period. Please make sure to add them.\n\n\n." \
+	 	printf "\n\n\n Error: Found comments without trailing period. Comments has to be full sentences.\n\n\n." \
 	 	&& false; \
 	 fi;
 

--- a/cmd/thanos/bucket.go
+++ b/cmd/thanos/bucket.go
@@ -96,7 +96,7 @@ func registerBucketVerify(m map[string]setupFunc, root *kingpin.CmdClause, name 
 				return errors.New("repair is specified, so backup client is required")
 			}
 		} else {
-			// nil Prometheus registerer: don't create conflicting metrics
+			// nil Prometheus registerer: don't create conflicting metrics.
 			backupBkt, err = client.NewBucket(logger, backupconfContentYaml, nil, name)
 			if err != nil {
 				return err
@@ -300,7 +300,7 @@ func registerBucketInspect(m map[string]setupFunc, root *kingpin.CmdClause, name
 	}
 }
 
-// registerBucketWeb exposes a web interface for the state of remote store like `pprof web`
+// registerBucketWeb exposes a web interface for the state of remote store like `pprof web`.
 func registerBucketWeb(m map[string]setupFunc, root *kingpin.CmdClause, name string, objStoreConfig *pathOrContent) {
 	cmd := root.Command("web", "Web interface for remote storage bucket")
 	bind := cmd.Flag("listen", "HTTP host:port to listen on").Default("0.0.0.0:8080").String()
@@ -483,7 +483,7 @@ func getKeysAlphabetically(labels map[string]string) []string {
 }
 
 // matchesSelector checks if blockMeta contains every label from
-// the selector with the correct value
+// the selector with the correct value.
 func matchesSelector(blockMeta *metadata.Meta, selectorLabels labels.Labels) bool {
 	for _, l := range selectorLabels {
 		if v, ok := blockMeta.Thanos.Labels[l.Name]; !ok || v != l.Value {
@@ -493,7 +493,7 @@ func matchesSelector(blockMeta *metadata.Meta, selectorLabels labels.Labels) boo
 	return true
 }
 
-// getIndex calculates the index of s in strs
+// getIndex calculates the index of s in strs.
 func getIndex(strs []string, s string) int {
 	for i, col := range strs {
 		if col == s {

--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -206,7 +206,6 @@ func runCompact(
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
-
 	// Instantiate the compactor with different time slices. Timestamps in TSDB
 	// are in milliseconds.
 	comp, err := tsdb.NewLeveledCompactor(ctx, reg, logger, levels, downsample.NewPool())

--- a/cmd/thanos/main.go
+++ b/cmd/thanos/main.go
@@ -123,7 +123,7 @@ func main() {
 	}
 
 	// Running in container with limits but with empty/wrong value of GOMAXPROCS env var could lead to throttling by cpu
-	// maxprocs will automate adjustment by using cgroups info about cpu limit if it set as value for runtime.GOMAXPROCS
+	// maxprocs will automate adjustment by using cgroups info about cpu limit if it set as value for runtime.GOMAXPROCS.
 	undo, err := maxprocs.Set(maxprocs.Logger(loggerAdapter))
 	defer undo()
 	if err != nil {

--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -322,7 +322,7 @@ func runQuery(
 				Logger:        logger,
 				Reg:           reg,
 				MaxConcurrent: maxConcurrentQueries,
-				// TODO(bwplotka): Expose this as a flag: https://github.com/thanos-io/thanos/issues/703 .
+				// TODO(bwplotka): Expose this as a flag: https://github.com/thanos-io/thanos/issues/703.
 				MaxSamples: math.MaxInt32,
 				Timeout:    queryTimeout,
 			},

--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -322,7 +322,7 @@ func runQuery(
 				Logger:        logger,
 				Reg:           reg,
 				MaxConcurrent: maxConcurrentQueries,
-				// TODO(bwplotka): Expose this as a flag: https://github.com/thanos-io/thanos/issues/703
+				// TODO(bwplotka): Expose this as a flag: https://github.com/thanos-io/thanos/issues/703 .
 				MaxSamples: math.MaxInt32,
 				Timeout:    queryTimeout,
 			},
@@ -394,7 +394,7 @@ func runQuery(
 	{
 		router := route.New()
 
-		// redirect from / to /webRoutePrefix
+		// Redirect from / to /webRoutePrefix.
 		if webRoutePrefix != "" {
 			router.Get("/", func(w http.ResponseWriter, r *http.Request) {
 				http.Redirect(w, r, webRoutePrefix, http.StatusFound)

--- a/cmd/thanos/rule.go
+++ b/cmd/thanos/rule.go
@@ -336,7 +336,7 @@ func runRule(
 		}
 	}
 	{
-		// TODO(bwplotka): https://github.com/thanos-io/thanos/issues/660
+		// TODO(bwplotka): https://github.com/thanos-io/thanos/issues/660.
 		sdr := alert.NewSender(logger, reg, alertmgrs.get, nil, alertmgrsTimeout)
 		ctx, cancel := context.WithCancel(context.Background())
 
@@ -369,7 +369,7 @@ func runRule(
 			cancel()
 		})
 	}
-	// Run File Service Discovery and update the query addresses when the files are modified
+	// Run File Service Discovery and update the query addresses when the files are modified.
 	if fileSD != nil {
 		var fileSDUpdates chan []*targetgroup.Group
 		ctxRun, cancelRun := context.WithCancel(context.Background())
@@ -388,7 +388,7 @@ func runRule(
 			for {
 				select {
 				case update := <-fileSDUpdates:
-					// Discoverers sometimes send nil updates so need to check for it to avoid panics
+					// Discoverers sometimes send nil updates so need to check for it to avoid panics.
 					if update == nil {
 						continue
 					}
@@ -407,7 +407,7 @@ func runRule(
 	reload := make(chan struct{}, 1)
 	{
 		cancel := make(chan struct{})
-		reload <- struct{}{} // initial reload
+		reload <- struct{}{} // Initial reload.
 
 		g.Add(func() error {
 			for {
@@ -514,7 +514,7 @@ func runRule(
 	{
 		router := route.New()
 
-		// redirect from / to /webRoutePrefix
+		// Redirect from / to /webRoutePrefix.
 		if webRoutePrefix != "" {
 			router.Get("/", func(w http.ResponseWriter, r *http.Request) {
 				http.Redirect(w, r, webRoutePrefix, http.StatusFound)
@@ -736,7 +736,7 @@ func queryFunc(
 
 	return func(ctx context.Context, q string, t time.Time) (promql.Vector, error) {
 		// Add DNS resolved addresses from static flags and file SD.
-		// TODO(bwplotka): Consider generating addresses in *url.URL
+		// TODO(bwplotka): Consider generating addresses in *url.URL.
 		addrs := dnsProvider.Addresses()
 
 		removeDuplicateQueryAddrs(logger, duplicatedQuery, addrs)

--- a/cmd/thanos/rule_test.go
+++ b/cmd/thanos/rule_test.go
@@ -20,27 +20,27 @@ func Test_parseFlagLabels(t *testing.T) {
 			expectErr: false,
 		},
 		{
-			s:         []string{`label-Name="LabelVal"`}, //Unsupported labelname
+			s:         []string{`label-Name="LabelVal"`}, //Unsupported labelname.
 			expectErr: true,
 		},
 		{
-			s:         []string{`label:Name="LabelVal"`}, //Unsupported labelname
+			s:         []string{`label:Name="LabelVal"`}, //Unsupported labelname.
 			expectErr: true,
 		},
 		{
-			s:         []string{`1abelName="LabelVal"`}, //Unsupported labelname
+			s:         []string{`1abelName="LabelVal"`}, //Unsupported labelname.
 			expectErr: true,
 		},
 		{
-			s:         []string{`label_Name"LabelVal"`}, //Missing "=" seprator
+			s:         []string{`label_Name"LabelVal"`}, //Missing "=" seprator.
 			expectErr: true,
 		},
 		{
-			s:         []string{`label_Name= "LabelVal"`}, //Whitespace invalid syntax
+			s:         []string{`label_Name= "LabelVal"`}, //Whitespace invalid syntax.
 			expectErr: true,
 		},
 		{
-			s:         []string{`label_name=LabelVal`}, //Missing quotes invalid syntax
+			s:         []string{`label_name=LabelVal`}, //Missing quotes invalid syntax.
 			expectErr: true,
 		},
 	}

--- a/cmd/thanos/rule_test.go
+++ b/cmd/thanos/rule_test.go
@@ -20,27 +20,27 @@ func Test_parseFlagLabels(t *testing.T) {
 			expectErr: false,
 		},
 		{
-			s:         []string{`label-Name="LabelVal"`}, //Unsupported labelname.
+			s:         []string{`label-Name="LabelVal"`}, // Unsupported labelname.
 			expectErr: true,
 		},
 		{
-			s:         []string{`label:Name="LabelVal"`}, //Unsupported labelname.
+			s:         []string{`label:Name="LabelVal"`}, // Unsupported labelname.
 			expectErr: true,
 		},
 		{
-			s:         []string{`1abelName="LabelVal"`}, //Unsupported labelname.
+			s:         []string{`1abelName="LabelVal"`}, // Unsupported labelname.
 			expectErr: true,
 		},
 		{
-			s:         []string{`label_Name"LabelVal"`}, //Missing "=" seprator.
+			s:         []string{`label_Name"LabelVal"`}, // Missing "=" seprator.
 			expectErr: true,
 		},
 		{
-			s:         []string{`label_Name= "LabelVal"`}, //Whitespace invalid syntax.
+			s:         []string{`label_Name= "LabelVal"`}, // Whitespace invalid syntax.
 			expectErr: true,
 		},
 		{
-			s:         []string{`label_name=LabelVal`}, //Missing quotes invalid syntax.
+			s:         []string{`label_name=LabelVal`}, // Missing quotes invalid syntax.
 			expectErr: true,
 		},
 	}

--- a/pkg/alert/alert.go
+++ b/pkg/alert/alert.go
@@ -203,7 +203,7 @@ func (q *Queue) Push(alerts []*Alert) {
 	q.pushed.Add(float64(len(alerts)))
 
 	// Attach external labels and drop excluded labels before sending.
-	// TODO(bwplotka): User proper relabelling with https://github.com/thanos-io/thanos/issues/660
+	// TODO(bwplotka): User proper relabelling with https://github.com/thanos-io/thanos/issues/660 .
 	for _, a := range alerts {
 		lb := labels.NewBuilder(labels.Labels{})
 		for _, l := range a.Labels {
@@ -309,7 +309,7 @@ func NewSender(
 }
 
 // Send an alert batch to all given Alertmanager URLs.
-// TODO(bwplotka): https://github.com/thanos-io/thanos/issues/660
+// TODO(bwplotka): https://github.com/thanos-io/thanos/issues/660 .
 func (s *Sender) Send(ctx context.Context, alerts []*Alert) {
 	if len(alerts) == 0 {
 		return

--- a/pkg/alert/alert.go
+++ b/pkg/alert/alert.go
@@ -203,7 +203,7 @@ func (q *Queue) Push(alerts []*Alert) {
 	q.pushed.Add(float64(len(alerts)))
 
 	// Attach external labels and drop excluded labels before sending.
-	// TODO(bwplotka): User proper relabelling with https://github.com/thanos-io/thanos/issues/660 .
+	// TODO(bwplotka): User proper relabelling with https://github.com/thanos-io/thanos/issues/660.
 	for _, a := range alerts {
 		lb := labels.NewBuilder(labels.Labels{})
 		for _, l := range a.Labels {
@@ -309,7 +309,7 @@ func NewSender(
 }
 
 // Send an alert batch to all given Alertmanager URLs.
-// TODO(bwplotka): https://github.com/thanos-io/thanos/issues/660 .
+// TODO(bwplotka): https://github.com/thanos-io/thanos/issues/660.
 func (s *Sender) Send(ctx context.Context, alerts []*Alert) {
 	if len(alerts) == 0 {
 		return

--- a/pkg/block/block_test.go
+++ b/pkg/block/block_test.go
@@ -104,7 +104,7 @@ func TestUpload(t *testing.T) {
 		testutil.Equals(t, "not a block dir: ulid: bad data size when unmarshaling", err.Error())
 	}
 	{
-		// Empty block dir
+		// Empty block dir.
 		err := Upload(ctx, log.NewNopLogger(), bkt, path.Join(tmpDir, "test", b1.String()))
 		testutil.NotOk(t, err)
 		testutil.Assert(t, strings.HasSuffix(err.Error(), "/meta.json: no such file or directory"), "")
@@ -143,7 +143,7 @@ func TestUpload(t *testing.T) {
 	}
 	testutil.Ok(t, cpy(path.Join(tmpDir, b1.String(), MetaFilename), path.Join(tmpDir, "test", b1.String(), MetaFilename)))
 	{
-		// Full block
+		// Full block.
 		testutil.Ok(t, Upload(ctx, log.NewNopLogger(), bkt, path.Join(tmpDir, "test", b1.String())))
 		testutil.Equals(t, 4, len(bkt.Objects()))
 		testutil.Equals(t, 3751, len(bkt.Objects()[path.Join(b1.String(), ChunksDirname, "000001")]))

--- a/pkg/block/index.go
+++ b/pkg/block/index.go
@@ -454,7 +454,7 @@ type ignoreFnType func(mint, maxt int64, prev *chunks.Meta, curr *chunks.Meta) (
 // - all "complete" outsiders (they will not accessed anyway)
 // - removes all near "complete" outside chunks introduced by https://github.com/prometheus/tsdb/issues/347.
 // Fixable inconsistencies are resolved in the new block.
-// TODO(bplotka): https://github.com/thanos-io/thanos/issues/378 .
+// TODO(bplotka): https://github.com/thanos-io/thanos/issues/378.
 func Repair(logger log.Logger, dir string, id ulid.ULID, source metadata.SourceType, ignoreChkFns ...ignoreFnType) (resid ulid.ULID, err error) {
 	if len(ignoreChkFns) == 0 {
 		return resid, errors.New("no ignore chunk function specified")
@@ -518,7 +518,7 @@ func Repair(logger log.Logger, dir string, id ulid.ULID, source metadata.SourceT
 		return resid, err
 	}
 	// TSDB may rewrite metadata in bdir.
-	// TODO: This is not needed in newer TSDB code. See https://github.com/prometheus/tsdb/pull/637 .
+	// TODO: This is not needed in newer TSDB code. See https://github.com/prometheus/tsdb/pull/637.
 	if err := metadata.Write(logger, bdir, meta); err != nil {
 		return resid, err
 	}

--- a/pkg/block/index.go
+++ b/pkg/block/index.go
@@ -255,7 +255,7 @@ type Stats struct {
 	// OutOfOrderSeries represents number of series that have out of order chunks.
 	OutOfOrderSeries int
 
-	// OutOfOrderChunks represents number of chunks that are out of order (older time range is after younger one)
+	// OutOfOrderChunks represents number of chunks that are out of order (older time range is after younger one).
 	OutOfOrderChunks int
 	// DuplicatedChunks represents number of chunks with same time ranges within same series, potential duplicates.
 	DuplicatedChunks int
@@ -454,7 +454,7 @@ type ignoreFnType func(mint, maxt int64, prev *chunks.Meta, curr *chunks.Meta) (
 // - all "complete" outsiders (they will not accessed anyway)
 // - removes all near "complete" outside chunks introduced by https://github.com/prometheus/tsdb/issues/347.
 // Fixable inconsistencies are resolved in the new block.
-// TODO(bplotka): https://github.com/thanos-io/thanos/issues/378
+// TODO(bplotka): https://github.com/thanos-io/thanos/issues/378 .
 func Repair(logger log.Logger, dir string, id ulid.ULID, source metadata.SourceType, ignoreChkFns ...ignoreFnType) (resid ulid.ULID, err error) {
 	if len(ignoreChkFns) == 0 {
 		return resid, errors.New("no ignore chunk function specified")
@@ -508,8 +508,8 @@ func Repair(logger log.Logger, dir string, id ulid.ULID, source metadata.SourceT
 	// that has multiple.
 	resmeta := *meta
 	resmeta.ULID = resid
-	resmeta.Stats = tsdb.BlockStats{} // reset stats
-	resmeta.Thanos.Source = source    // update source
+	resmeta.Stats = tsdb.BlockStats{} // Reset stats.
+	resmeta.Thanos.Source = source    // Update source.
 
 	if err := rewrite(logger, indexr, chunkr, indexw, chunkw, &resmeta, ignoreChkFns); err != nil {
 		return resid, errors.Wrap(err, "rewrite block")
@@ -518,8 +518,7 @@ func Repair(logger log.Logger, dir string, id ulid.ULID, source metadata.SourceT
 		return resid, err
 	}
 	// TSDB may rewrite metadata in bdir.
-	// TODO: This is not needed in newer TSDB code. See
-	// https://github.com/prometheus/tsdb/pull/637
+	// TODO: This is not needed in newer TSDB code. See https://github.com/prometheus/tsdb/pull/637 .
 	if err := metadata.Write(logger, bdir, meta); err != nil {
 		return resid, err
 	}

--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -280,7 +280,7 @@ func (c *Syncer) downloadMeta(ctx context.Context, id ulid.ULID) (*metadata.Meta
 	// - repair created blocks
 	// - compactor created blocks
 	// NOTE: It is not safe to miss "old" block (even that it is newly created) in sync step. Compactor needs to aware of ALL old blocks.
-	// TODO(bplotka): https://github.com/thanos-io/thanos/issues/377 .
+	// TODO(bplotka): https://github.com/thanos-io/thanos/issues/377.
 	if ulid.Now()-id.Time() < uint64(c.consistencyDelay/time.Millisecond) &&
 		meta.Thanos.Source != metadata.BucketRepairSource &&
 		meta.Thanos.Source != metadata.CompactorSource &&
@@ -475,7 +475,7 @@ func (c *Syncer) garbageCollect(ctx context.Context, resolution int64) error {
 		}
 
 		// Immediately update our in-memory state so no further call to SyncMetas is needed
-		/// after running garbage collection.
+		// after running garbage collection.
 		delete(c.blocks, id)
 		c.metrics.garbageCollectedBlocks.Inc()
 	}

--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -280,7 +280,7 @@ func (c *Syncer) downloadMeta(ctx context.Context, id ulid.ULID) (*metadata.Meta
 	// - repair created blocks
 	// - compactor created blocks
 	// NOTE: It is not safe to miss "old" block (even that it is newly created) in sync step. Compactor needs to aware of ALL old blocks.
-	// TODO(bplotka): https://github.com/thanos-io/thanos/issues/377
+	// TODO(bplotka): https://github.com/thanos-io/thanos/issues/377 .
 	if ulid.Now()-id.Time() < uint64(c.consistencyDelay/time.Millisecond) &&
 		meta.Thanos.Source != metadata.BucketRepairSource &&
 		meta.Thanos.Source != metadata.CompactorSource &&
@@ -307,7 +307,7 @@ func (c *Syncer) removeIfMetaMalformed(ctx context.Context, id ulid.ULID) (remov
 	}
 
 	if ulid.Now()-id.Time() <= uint64(MinimumAgeForRemoval/time.Millisecond) {
-		// Minimum delay has not expired, ignore for now
+		// Minimum delay has not expired, ignore for now.
 		return true
 	}
 
@@ -876,7 +876,7 @@ func (cg *Group) compact(ctx context.Context, dir string, comp tsdb.Compactor) (
 				}
 			}
 		}
-		// Even though this block was empty, there may be more work to do
+		// Even though this block was empty, there may be more work to do.
 		return true, ulid.ULID{}, nil
 	}
 	level.Debug(cg.logger).Log("msg", "compacted blocks",

--- a/pkg/compact/compact_e2e_test.go
+++ b/pkg/compact/compact_e2e_test.go
@@ -208,7 +208,7 @@ func TestGroup_Compact_e2e(t *testing.T) {
 		b2, err := createEmptyBlock(prepareDir, 1001, 2000, extLset, 124)
 		testutil.Ok(t, err)
 
-		// blocks" count=3 mint=0 maxt=3000 ulid=01D1RQCRRJM77KQQ4GYDSC50GM sources="[01D1RQCRMNZBVHBPGRPG2M3NZQ 01D1RQCRPJMYN45T65YA1PRWB7 01D1RQCRNMTWJKTN5QQXFNKKH8]"
+		// blocks" count=3 mint=0 maxt=3000 ulid=01D1RQCRRJM77KQQ4GYDSC50GM sources="[01D1RQCRMNZBVHBPGRPG2M3NZQ 01D1RQCRPJMYN45T65YA1PRWB7 01D1RQCRNMTWJKTN5QQXFNKKH8]".
 
 		meta, err = metadata.Read(filepath.Join(prepareDir, b2.String()))
 		testutil.Ok(t, err)
@@ -303,7 +303,7 @@ func TestGroup_Compact_e2e(t *testing.T) {
 }
 
 // createEmptyBlock produces empty block like it was the case before fix: https://github.com/prometheus/tsdb/pull/374.
-// (Prometheus pre v2.7.0)
+// (Prometheus pre v2.7.0).
 func createEmptyBlock(dir string, mint int64, maxt int64, extLset labels.Labels, resolution int64) (ulid.ULID, error) {
 	entropy := rand.New(rand.NewSource(time.Now().UnixNano()))
 	uid := ulid.MustNew(ulid.Now(), entropy)

--- a/pkg/compact/downsample/downsample.go
+++ b/pkg/compact/downsample/downsample.go
@@ -23,15 +23,15 @@ import (
 
 // Standard downsampling resolution levels in Thanos.
 const (
-	ResLevel0 = int64(0)              // raw data
-	ResLevel1 = int64(5 * 60 * 1000)  // 5 minutes in milliseconds
-	ResLevel2 = int64(60 * 60 * 1000) // 1 hour in milliseconds
+	ResLevel0 = int64(0)              // Raw data.
+	ResLevel1 = int64(5 * 60 * 1000)  // 5 minutes in milliseconds.
+	ResLevel2 = int64(60 * 60 * 1000) // 1 hour in milliseconds.
 )
 
 // Downsampling ranges i.e. after what time we start to downsample blocks (in seconds).
 const (
-	DownsampleRange0 = 40 * 60 * 60 * 1000      // 40 hours
-	DownsampleRange1 = 10 * 24 * 60 * 60 * 1000 // 10 days
+	DownsampleRange0 = 40 * 60 * 60 * 1000      // 40 hours.
+	DownsampleRange1 = 10 * 24 * 60 * 60 * 1000 // 10 days.
 )
 
 // Downsample downsamples the given block. It writes a new block into dir and returns its ID.
@@ -199,14 +199,14 @@ func targetChunkCount(mint, maxt, inRes, outRes int64, count int) (x int) {
 
 // aggregator collects cumulative stats for a stream of values.
 type aggregator struct {
-	total   int     // total samples processed
-	count   int     // samples in current window
-	sum     float64 // value sum of current window
-	min     float64 // min of current window
-	max     float64 // max of current window
-	counter float64 // total counter state since beginning
-	resets  int     // number of counter resets since beginning
-	last    float64 // last added value
+	total   int     // Total samples processed.
+	count   int     // Samples in current window.
+	sum     float64 // Value sum of current window.
+	min     float64 // Min of current window.
+	max     float64 // Max of current window.
+	counter float64 // Total counter state since beginning.
+	resets  int     // Number of counter resets since beginning.
+	last    float64 // Last added value.
 }
 
 // reset the stats to start a new aggregation window.
@@ -536,14 +536,14 @@ type sample struct {
 // values as counter reset.
 // Additionally, it can deal with downsampled counter chunks, which set the last value of a chunk
 // to the original last value. The last value can be detected by checking whether the timestamp
-// did not increase w.r.t to the previous sample
+// did not increase w.r.t to the previous sample.
 type CounterSeriesIterator struct {
 	chks   []chunkenc.Iterator
-	i      int     // current chunk
-	total  int     // total number of processed samples
-	lastT  int64   // timestamp of the last sample
-	lastV  float64 // value of the last sample
-	totalV float64 // total counter state since beginning of series
+	i      int     // Current chunk.
+	total  int     // Total number of processed samples.
+	lastT  int64   // Timestamp of the last sample.
+	lastV  float64 // Value of the last sample.
+	totalV float64 // Total counter state since beginning of series.
 }
 
 func NewCounterSeriesIterator(chks ...chunkenc.Iterator) *CounterSeriesIterator {

--- a/pkg/compact/downsample/downsample_test.go
+++ b/pkg/compact/downsample/downsample_test.go
@@ -83,9 +83,9 @@ func TestDownsampleAggr(t *testing.T) {
 					{199, 5}, {299, 1}, {399, 10}, {400, -3}, {499, 10}, {699, 0}, {999, 100},
 				},
 				AggrCounter: {
-					{99, 100}, {299, 150}, {499, 210}, {499, 10}, // chunk 1
-					{599, 20}, {799, 50}, {999, 120}, {999, 50}, // chunk 2, no reset
-					{1099, 40}, {1199, 80}, {1299, 110}, // chunk 3, reset
+					{99, 100}, {299, 150}, {499, 210}, {499, 10}, // Chunk 1.
+					{599, 20}, {799, 50}, {999, 120}, {999, 50}, // Chunk 2, no reset.
+					{1099, 40}, {1199, 80}, {1299, 110}, // Chunk 3, reset.
 				},
 			},
 			output: map[AggrType][]sample{
@@ -244,10 +244,10 @@ func TestCounterSeriesIterator(t *testing.T) {
 
 	chunks := [][]sample{
 		{{100, 10}, {200, 20}, {300, 10}, {400, 20}, {400, 5}},
-		{{500, 10}, {600, 20}, {700, 30}, {800, 40}, {800, 10}}, // no actual reset
-		{{900, 5}, {1000, 10}, {1100, 15}},                      // actual reset
-		{{1200, 20}, {1250, staleMarker}, {1300, 40}},           // no special last sample, no reset
-		{{1400, 30}, {1500, 30}, {1600, 50}},                    // no special last sample, reset
+		{{500, 10}, {600, 20}, {700, 30}, {800, 40}, {800, 10}}, // No actual reset.
+		{{900, 5}, {1000, 10}, {1100, 15}},                      // Actual reset.
+		{{1200, 20}, {1250, staleMarker}, {1300, 40}},           // No special last sample, no reset.
+		{{1400, 30}, {1500, 30}, {1600, 50}},                    // No special last sample, reset.
 	}
 	exp := []sample{
 		{100, 10}, {200, 20}, {300, 30}, {400, 40}, {500, 45},

--- a/pkg/compact/downsample/streamed_block_writer.go
+++ b/pkg/compact/downsample/streamed_block_writer.go
@@ -49,9 +49,9 @@ func (lv labelsValues) add(labelSet labels.Labels) {
 // sealed afterwards, when there aren't more series to process.
 type streamedBlockWriter struct {
 	blockDir       string
-	finalized      bool // set to true, if Close was called
+	finalized      bool // Set to true, if Close was called.
 	logger         log.Logger
-	ignoreFinalize bool // if true Close does not finalize block due to internal error.
+	ignoreFinalize bool // If true Close does not finalize block due to internal error.
 	meta           metadata.Meta
 	totalChunks    uint64
 	totalSamples   uint64

--- a/pkg/objstore/azure/helpers.go
+++ b/pkg/objstore/azure/helpers.go
@@ -46,7 +46,7 @@ func getContainer(ctx context.Context, conf Config) (blob.ContainerURL, error) {
 	if err != nil {
 		return blob.ContainerURL{}, err
 	}
-	// Getting container properties to check if it exists or not. Returns error which will be parsed further
+	// Getting container properties to check if it exists or not. Returns error which will be parsed further.
 	_, err = c.GetProperties(ctx, blob.LeaseAccessConditions{})
 	return c, err
 }

--- a/pkg/objstore/objstore.go
+++ b/pkg/objstore/objstore.go
@@ -22,7 +22,7 @@ type Bucket interface {
 	BucketReader
 
 	// Upload the contents of the reader as an object into the bucket.
-	// Upload should be idempotent
+	// Upload should be idempotent.
 	Upload(ctx context.Context, name string, r io.Reader) error
 
 	// Delete removes the object with the given name.
@@ -77,7 +77,7 @@ func UploadDir(ctx context.Context, logger log.Logger, bkt Bucket, srcdir, dstdi
 }
 
 // UploadFile uploads the file with the given name to the bucket.
-// It is a caller responsibility to clean partial upload in case of failure
+// It is a caller responsibility to clean partial upload in case of failure.
 func UploadFile(ctx context.Context, logger log.Logger, bkt Bucket, src, dst string) error {
 	r, err := os.Open(src)
 	if err != nil {
@@ -295,7 +295,7 @@ func (b *metricBucket) Upload(ctx context.Context, name string, r io.Reader) err
 	if err != nil {
 		b.opsFailures.WithLabelValues(op).Inc()
 	} else {
-		//TODO: Use SetToCurrentTime() once we update the Prometheus client_golang
+		//TODO: Use SetToCurrentTime() once we update the Prometheus client_golang.
 		b.lastSuccessfullUploadTime.WithLabelValues(b.bkt.Name()).Set(float64(time.Now().UnixNano()) / 1e9)
 	}
 	b.ops.WithLabelValues(op).Inc()

--- a/pkg/objstore/objstore.go
+++ b/pkg/objstore/objstore.go
@@ -295,7 +295,7 @@ func (b *metricBucket) Upload(ctx context.Context, name string, r io.Reader) err
 	if err != nil {
 		b.opsFailures.WithLabelValues(op).Inc()
 	} else {
-		//TODO: Use SetToCurrentTime() once we update the Prometheus client_golang.
+		// TODO: Use SetToCurrentTime() once we update the Prometheus client_golang.
 		b.lastSuccessfullUploadTime.WithLabelValues(b.bkt.Name()).Set(float64(time.Now().UnixNano()) / 1e9)
 	}
 	b.ops.WithLabelValues(op).Inc()

--- a/pkg/objstore/s3/s3.go
+++ b/pkg/objstore/s3/s3.go
@@ -163,7 +163,7 @@ func NewBucketWithConfig(logger log.Logger, config Config, component string) (*B
 		// doesn't try to auto decode the body of objects with
 		// content-encoding set to `gzip`.
 		//
-		// Refer: https://golang.org/src/net/http/transport.go?h=roundTrip#L1843 .
+		// Refer: https://golang.org/src/net/http/transport.go?h=roundTrip#L1843.
 		DisableCompression: true,
 		TLSClientConfig:    &tls.Config{InsecureSkipVerify: config.HTTPConfig.InsecureSkipVerify},
 	})
@@ -404,7 +404,7 @@ func NewTestBucketFromConfig(t testing.TB, location string, c Config, reuseBucke
 	if c.Bucket == "" {
 		src := rand.NewSource(time.Now().UnixNano())
 
-		// Bucket name need to conform: https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-s3-bucket-naming-requirements.html .
+		// Bucket name need to conform: https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-s3-bucket-naming-requirements.html.
 		bktToCreate = strings.Replace(fmt.Sprintf("test_%s_%x", strings.ToLower(t.Name()), src.Int63()), "_", "-", -1)
 		if len(bktToCreate) >= 63 {
 			bktToCreate = bktToCreate[:63]

--- a/pkg/objstore/s3/s3.go
+++ b/pkg/objstore/s3/s3.go
@@ -163,8 +163,7 @@ func NewBucketWithConfig(logger log.Logger, config Config, component string) (*B
 		// doesn't try to auto decode the body of objects with
 		// content-encoding set to `gzip`.
 		//
-		// Refer:
-		//    https://golang.org/src/net/http/transport.go?h=roundTrip#L1843
+		// Refer: https://golang.org/src/net/http/transport.go?h=roundTrip#L1843 .
 		DisableCompression: true,
 		TLSClientConfig:    &tls.Config{InsecureSkipVerify: config.HTTPConfig.InsecureSkipVerify},
 	})
@@ -405,7 +404,7 @@ func NewTestBucketFromConfig(t testing.TB, location string, c Config, reuseBucke
 	if c.Bucket == "" {
 		src := rand.NewSource(time.Now().UnixNano())
 
-		// Bucket name need to conform: https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-s3-bucket-naming-requirements.html
+		// Bucket name need to conform: https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-s3-bucket-naming-requirements.html .
 		bktToCreate = strings.Replace(fmt.Sprintf("test_%s_%x", strings.ToLower(t.Name()), src.Int63()), "_", "-", -1)
 		if len(bktToCreate) >= 63 {
 			bktToCreate = bktToCreate[:63]

--- a/pkg/objstore/swift/swift.go
+++ b/pkg/objstore/swift/swift.go
@@ -160,7 +160,7 @@ func (c *Container) Delete(ctx context.Context, name string) error {
 }
 
 func (*Container) Close() error {
-	// nothing to close
+	// Nothing to close.
 	return nil
 }
 

--- a/pkg/pool/pool_test.go
+++ b/pkg/pool/pool_test.go
@@ -66,7 +66,7 @@ func TestRacePutGet(t *testing.T) {
 
 	// Start two goroutines: they always Get and Put two byte slices
 	// to which they write 'foo' / 'barbazbaz' and check if the data is still
-	// there after writing it, before putting it back
+	// there after writing it, before putting it back.
 	errs := make(chan error, 2)
 	stop := make(chan bool, 2)
 

--- a/pkg/promclient/promclient.go
+++ b/pkg/promclient/promclient.go
@@ -111,7 +111,7 @@ type Flags struct {
 func (f *Flags) UnmarshalJSON(b []byte) error {
 	// TODO(bwplotka): Avoid this custom unmarshal by:
 	// - prometheus/common: adding unmarshalJSON to modelDuration
-	// - prometheus/prometheus: flags should return proper JSON. (not bool in string)
+	// - prometheus/prometheus: flags should return proper JSON (not bool in string).
 	parsableFlags := struct {
 		TSDBPath           string        `json:"storage.tsdb.path"`
 		TSDBRetention      modelDuration `json:"storage.tsdb.retention"`
@@ -345,7 +345,7 @@ func QueryInstant(ctx context.Context, logger log.Logger, base *url.URL, query s
 	var vectorResult model.Vector
 
 	// Decode the Result depending on the ResultType
-	// Currently only `vector` and `scalar` types are supported
+	// Currently only `vector` and `scalar` types are supported.
 	switch m.Data.ResultType {
 	case promql.ValueTypeVector:
 		if err = json.Unmarshal(m.Data.Result, &vectorResult); err != nil {

--- a/pkg/promclient/promclient_e2e_test.go
+++ b/pkg/promclient/promclient_e2e_test.go
@@ -99,7 +99,7 @@ func TestSnapshot_e2e(t *testing.T) {
 
 		// Prometheus since 2.7.0 don't write empty blocks even if it's head block. So it's no matter passing skip_head true or false here
 		// Pass skipHead = true to support all prometheus versions and assert that snapshot creates only one file
-		// https://github.com/prometheus/tsdb/pull/374
+		// https://github.com/prometheus/tsdb/pull/374 .
 		dir, err := Snapshot(ctx, log.NewNopLogger(), u, true)
 		testutil.Ok(t, err)
 

--- a/pkg/promclient/promclient_e2e_test.go
+++ b/pkg/promclient/promclient_e2e_test.go
@@ -99,7 +99,7 @@ func TestSnapshot_e2e(t *testing.T) {
 
 		// Prometheus since 2.7.0 don't write empty blocks even if it's head block. So it's no matter passing skip_head true or false here
 		// Pass skipHead = true to support all prometheus versions and assert that snapshot creates only one file
-		// https://github.com/prometheus/tsdb/pull/374 .
+		// https://github.com/prometheus/tsdb/pull/374.
 		dir, err := Snapshot(ctx, log.NewNopLogger(), u, true)
 		testutil.Ok(t, err)
 

--- a/pkg/query/api/v1.go
+++ b/pkg/query/api/v1.go
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 // This package is a modified copy from
-// github.com/prometheus/prometheus/web/api/v1@2121b4628baa7d9d9406aa468712a6a332e77aff .
+// github.com/prometheus/prometheus/web/api/v1@2121b4628baa7d9d9406aa468712a6a332e77aff.
 
 package v1
 

--- a/pkg/query/api/v1.go
+++ b/pkg/query/api/v1.go
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 // This package is a modified copy from
-// github.com/prometheus/prometheus/web/api/v1@2121b4628baa7d9d9406aa468712a6a332e77aff
+// github.com/prometheus/prometheus/web/api/v1@2121b4628baa7d9d9406aa468712a6a332e77aff .
 
 package v1
 

--- a/pkg/query/api/v1_test.go
+++ b/pkg/query/api/v1_test.go
@@ -490,7 +490,7 @@ func TestEndpoints(t *testing.T) {
 			},
 			errType: errorBadData,
 		},
-		// Bad dedup parameter
+		// Bad dedup parameter.
 		{
 			endpoint: api.queryRange,
 			query: url.Values{

--- a/pkg/query/iter.go
+++ b/pkg/query/iter.go
@@ -211,7 +211,7 @@ func chunkEncoding(e storepb.Chunk_Encoding) chunkenc.Encoding {
 	case storepb.Chunk_XOR:
 		return chunkenc.EncXOR
 	}
-	return 255 // invalid
+	return 255 // Invalid.
 }
 
 type errSeriesIterator struct {
@@ -357,7 +357,7 @@ func (s *dedupSeriesSet) Next() bool {
 }
 
 // peekLset returns the label set of the current peek element stripped from the
-// replica label if it exists
+// replica label if it exists.
 func (s *dedupSeriesSet) peekLset() labels.Labels {
 	lset := s.peek.Labels()
 	if len(s.replicaLabels) == 0 {

--- a/pkg/query/querier.go
+++ b/pkg/query/querier.go
@@ -149,7 +149,7 @@ func aggrsFromFunc(f string) ([]storepb.Aggr, resAggr) {
 	if f == "count" || strings.HasPrefix(f, "count_") {
 		return []storepb.Aggr{storepb.Aggr_COUNT}, resAggrCount
 	}
-	// f == "sum" falls through here since we want the actual samples
+	// f == "sum" falls through here since we want the actual samples.
 	if strings.HasPrefix(f, "sum_") {
 		return []storepb.Aggr{storepb.Aggr_SUM}, resAggrSum
 	}

--- a/pkg/query/querier_test.go
+++ b/pkg/query/querier_test.go
@@ -46,12 +46,12 @@ func TestQuerier_DownsampledData(t *testing.T) {
 	defer leaktest.CheckTimeout(t, 10*time.Second)()
 	testProxy := &storeServer{
 		resps: []*storepb.SeriesResponse{
-			storeSeriesResponse(t, labels.FromStrings("__name__", "a", "zzz", "a", "aaa", "bbb"), []sample{{99, 1}, {199, 5}}),                   // Downsampled chunk from Store
-			storeSeriesResponse(t, labels.FromStrings("__name__", "a", "zzz", "b", "bbbb", "eee"), []sample{{99, 3}, {199, 8}}),                  // Downsampled chunk from Store
-			storeSeriesResponse(t, labels.FromStrings("__name__", "a", "zzz", "c", "qwe", "wqeqw"), []sample{{99, 5}, {199, 15}}),                // Downsampled chunk from Store
-			storeSeriesResponse(t, labels.FromStrings("__name__", "a", "zzz", "c", "htgtreytr", "vbnbv"), []sample{{99, 123}, {199, 15}}),        // Downsampled chunk from Store
-			storeSeriesResponse(t, labels.FromStrings("__name__", "a", "zzz", "d", "asdsad", "qweqwewq"), []sample{{22, 5}, {44, 8}, {199, 15}}), // Raw chunk from Sidecar
-			storeSeriesResponse(t, labels.FromStrings("__name__", "a", "zzz", "d", "asdsad", "qweqwebb"), []sample{{22, 5}, {44, 8}, {199, 15}}), // Raw chunk from Sidecar
+			storeSeriesResponse(t, labels.FromStrings("__name__", "a", "zzz", "a", "aaa", "bbb"), []sample{{99, 1}, {199, 5}}),                   // Downsampled chunk from Store.
+			storeSeriesResponse(t, labels.FromStrings("__name__", "a", "zzz", "b", "bbbb", "eee"), []sample{{99, 3}, {199, 8}}),                  // Downsampled chunk from Store.
+			storeSeriesResponse(t, labels.FromStrings("__name__", "a", "zzz", "c", "qwe", "wqeqw"), []sample{{99, 5}, {199, 15}}),                // Downsampled chunk from Store.
+			storeSeriesResponse(t, labels.FromStrings("__name__", "a", "zzz", "c", "htgtreytr", "vbnbv"), []sample{{99, 123}, {199, 15}}),        // Downsampled chunk from Store.
+			storeSeriesResponse(t, labels.FromStrings("__name__", "a", "zzz", "d", "asdsad", "qweqwewq"), []sample{{22, 5}, {44, 8}, {199, 15}}), // Raw chunk from Sidecar.
+			storeSeriesResponse(t, labels.FromStrings("__name__", "a", "zzz", "d", "asdsad", "qweqwebb"), []sample{{22, 5}, {44, 8}, {199, 15}}), // Raw chunk from Sidecar.
 		},
 	}
 

--- a/pkg/query/storeset_test.go
+++ b/pkg/query/storeset_test.go
@@ -234,6 +234,7 @@ func TestStoreSet_StaticStores_NoneAvailable(t *testing.T) {
 	testutil.Assert(t, len(storeSet.stores) == 0, "none of services should respond just fine, so we expect no client to be ready.")
 
 	// Leak test will ensure that we don't keep client connection around.
+
 }
 
 func TestStoreSet_AllAvailable_BlockExtLsetDuplicates(t *testing.T) {

--- a/pkg/receive/handler.go
+++ b/pkg/receive/handler.go
@@ -49,7 +49,7 @@ type Handler struct {
 	mtx      sync.RWMutex
 	hashring Hashring
 
-	// Metrics
+	// Metrics.
 	forwardRequestsTotal *prometheus.CounterVec
 }
 

--- a/pkg/reloader/example_test.go
+++ b/pkg/reloader/example_test.go
@@ -49,5 +49,5 @@ func ExampleReloadURLFromBase() {
 		log.Fatal(err)
 	}
 	fmt.Println(reloader.ReloadURLFromBase(u))
-	// Output: http://localhost:9090/-/reload
+	//    Output: http://localhost:9090/-/reload
 }

--- a/pkg/reloader/reloader.go
+++ b/pkg/reloader/reloader.go
@@ -3,7 +3,7 @@
 //
 // Reloader type is useful when you want to:
 //
-// 	* Watch on changes against certain file e.g (`cfgFile`) .
+// 	* Watch on changes against certain file e.g (`cfgFile`).
 // 	* Optionally, specify different different output file for watched `cfgFile` (`cfgOutputFile`).
 // 	This will also try decompress the `cfgFile` if needed and substitute ALL the envvars using Kubernetes substitution format: (`$(var)`)
 // 	* Watch on changes against certain directories (`ruleDires`).

--- a/pkg/reloader/reloader.go
+++ b/pkg/reloader/reloader.go
@@ -199,7 +199,7 @@ func (r *Reloader) apply(ctx context.Context) error {
 				return errors.Wrap(err, "read file")
 			}
 
-			// detect and extract gzipped file
+			// Detect and extract gzipped file.
 			if bytes.Equal(b[0:3], firstGzipBytes) {
 				zr, err := gzip.NewReader(bytes.NewReader(b))
 				if err != nil {

--- a/pkg/rule/api/v1_test.go
+++ b/pkg/rule/api/v1_test.go
@@ -65,7 +65,6 @@ func (m rulesRetrieverMock) RuleGroups() []thanosrule.Group {
 	var ar rulesRetrieverMock
 	arules := ar.AlertingRules()
 	storage := newStorage(m.testing)
-	//defer storage.Close()
 
 	engineOpts := promql.EngineOpts{
 		Logger:        nil,

--- a/pkg/shipper/shipper.go
+++ b/pkg/shipper/shipper.go
@@ -249,7 +249,7 @@ func (c *lazyOverlapChecker) IsOverlapping(ctx context.Context, newMeta tsdb.Blo
 //
 // If uploaded.
 //
-// It is not concurrency-safe, however it is compactor-safe (running concurrently with compactor is ok)
+// It is not concurrency-safe, however it is compactor-safe (running concurrently with compactor is ok).
 func (s *Shipper) Sync(ctx context.Context) (uploaded int, err error) {
 	meta, err := ReadMetaFile(s.dir)
 	if err != nil {

--- a/pkg/shipper/shipper_e2e_test.go
+++ b/pkg/shipper/shipper_e2e_test.go
@@ -125,7 +125,7 @@ func TestShipper_SyncBlocks_e2e(t *testing.T) {
 
 			testutil.Ok(t, enc.Encode(&meta))
 
-			// We will delete the fifth block and do not expect it to be re-uploaded later
+			// We will delete the fifth block and do not expect it to be re-uploaded later.
 			if i != 4 && i != 5 {
 				expBlocks[id] = struct{}{}
 
@@ -277,7 +277,7 @@ func TestShipper_SyncBlocksWithMigrating_e2e(t *testing.T) {
 
 			testutil.Ok(t, enc.Encode(&meta))
 
-			// We will delete the fifth block and do not expect it to be re-uploaded later
+			// We will delete the fifth block and do not expect it to be re-uploaded later.
 			if i != 4 {
 				expBlocks[id] = struct{}{}
 

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -1000,12 +1000,12 @@ func (s *BucketStore) LabelValues(ctx context.Context, req *storepb.LabelValuesR
 }
 
 // bucketBlockSet holds all blocks of an equal label set. It internally splits
-// them up by downsampling resolution and allows querying
+// them up by downsampling resolution and allows querying.
 type bucketBlockSet struct {
 	labels      labels.Labels
 	mtx         sync.RWMutex
-	resolutions []int64          // available resolution, high to low (in milliseconds)
-	blocks      [][]*bucketBlock // ordered buckets for the existing resolutions
+	resolutions []int64          // Available resolution, high to low (in milliseconds).
+	blocks      [][]*bucketBlock // Ordered buckets for the existing resolutions.
 }
 
 // newBucketBlockSet initializes a new set with the known downsampling windows hard-configured.
@@ -1306,8 +1306,7 @@ func (b *bucketBlock) Close() error {
 	return nil
 }
 
-// bucketIndexReader is a custom index reader (not conforming index.Reader interface) that gets postings
-// by
+// bucketIndexReader is a custom index reader (not conforming index.Reader interface) that gets postings.
 type bucketIndexReader struct {
 	logger log.Logger
 	ctx    context.Context
@@ -1438,7 +1437,7 @@ func toPostingGroup(lvalsFn func(name string) []string, m labels.Matcher) *posti
 
 	// If the matcher selects an empty value, it selects all the series which don't
 	// have the label name set too. See: https://github.com/prometheus/prometheus/issues/3575
-	// and https://github.com/prometheus/prometheus/pull/3578#issuecomment-351653555
+	// and https://github.com/prometheus/prometheus/pull/3578#issuecomment-351653555 .
 	if m.Matches("") {
 		allName, allValue := index.AllPostingsKey()
 

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -1437,7 +1437,7 @@ func toPostingGroup(lvalsFn func(name string) []string, m labels.Matcher) *posti
 
 	// If the matcher selects an empty value, it selects all the series which don't
 	// have the label name set too. See: https://github.com/prometheus/prometheus/issues/3575
-	// and https://github.com/prometheus/prometheus/pull/3578#issuecomment-351653555 .
+	// and https://github.com/prometheus/prometheus/pull/3578#issuecomment-351653555.
 	if m.Matches("") {
 		allName, allValue := index.AllPostingsKey()
 

--- a/pkg/store/bucket_e2e_test.go
+++ b/pkg/store/bucket_e2e_test.go
@@ -430,7 +430,7 @@ func (g naivePartitioner) Partition(length int, rng func(int) (uint64, uint64)) 
 
 // Naive partitioner splits the array equally (it does not combine anything).
 // This tests if our, sometimes concurrent, fetches for different parts works.
-// Regression test against: https://github.com/thanos-io/thanos/issues/829 .
+// Regression test against: https://github.com/thanos-io/thanos/issues/829.
 func TestBucketStore_ManyParts_e2e(t *testing.T) {
 	objtesting.ForeachStore(t, func(t testing.TB, bkt objstore.Bucket) {
 		ctx, cancel := context.WithCancel(context.Background())

--- a/pkg/store/bucket_e2e_test.go
+++ b/pkg/store/bucket_e2e_test.go
@@ -430,7 +430,7 @@ func (g naivePartitioner) Partition(length int, rng func(int) (uint64, uint64)) 
 
 // Naive partitioner splits the array equally (it does not combine anything).
 // This tests if our, sometimes concurrent, fetches for different parts works.
-// Regression test against: https://github.com/thanos-io/thanos/issues/829
+// Regression test against: https://github.com/thanos-io/thanos/issues/829 .
 func TestBucketStore_ManyParts_e2e(t *testing.T) {
 	objtesting.ForeachStore(t, func(t testing.TB, bkt objstore.Bucket) {
 		ctx, cancel := context.WithCancel(context.Background())

--- a/pkg/store/bucket_test.go
+++ b/pkg/store/bucket_test.go
@@ -42,20 +42,20 @@ func TestBucketBlock_Property(t *testing.T) {
 	input := []resBlock{
 		{window: downsample.ResLevel0, mint: 0, maxt: 100},
 		{window: downsample.ResLevel0, mint: 100, maxt: 200},
-		// Compaction level 2 begins but not downsampling (8 hour block length)
+		// Compaction level 2 begins but not downsampling (8 hour block length).
 		{window: downsample.ResLevel0, mint: 200, maxt: 600},
 		{window: downsample.ResLevel0, mint: 600, maxt: 1000},
-		// Compaction level 3 begins, Some of it is downsampled but still retained (48 hour block length)
+		// Compaction level 3 begins, Some of it is downsampled but still retained (48 hour block length).
 		{window: downsample.ResLevel0, mint: 1000, maxt: 1750},
 		{window: downsample.ResLevel1, mint: 1000, maxt: 1750},
-		// Compaction level 4 begins, different downsampling levels cover the same (336 hour block length)
+		// Compaction level 4 begins, different downsampling levels cover the same (336 hour block length).
 		{window: downsample.ResLevel0, mint: 1750, maxt: 7000},
 		{window: downsample.ResLevel1, mint: 1750, maxt: 7000},
 		{window: downsample.ResLevel2, mint: 1750, maxt: 7000},
-		// Compaction level 4 already happened, raw samples have been deleted
+		// Compaction level 4 already happened, raw samples have been deleted.
 		{window: downsample.ResLevel0, mint: 7000, maxt: 14000},
 		{window: downsample.ResLevel1, mint: 7000, maxt: 14000},
-		// Compaction level 4 already happened, raw and downsample res level 1 samples have been deleted
+		// Compaction level 4 already happened, raw and downsample res level 1 samples have been deleted.
 		{window: downsample.ResLevel2, mint: 14000, maxt: 21000},
 	}
 
@@ -77,7 +77,7 @@ func TestBucketBlock_Property(t *testing.T) {
 
 			res := set.getFor(low, high, maxResolution)
 
-			// The data that we get must all encompass our requested range
+			// The data that we get must all encompass our requested range.
 			if len(res) == 1 && (res[0].meta.Thanos.Downsample.Resolution > maxResolution ||
 				res[0].meta.MinTime > low) {
 				return false
@@ -116,7 +116,7 @@ func TestBucketBlock_Property(t *testing.T) {
 			maxResolution := downsample.ResLevel2
 			res := set.getFor(low, high, maxResolution)
 
-			// The data that we get must all encompass our requested range
+			// The data that we get must all encompass our requested range.
 			if len(res) == 1 && (res[0].meta.Thanos.Downsample.Resolution > maxResolution ||
 				res[0].meta.MinTime > low || res[0].meta.MaxTime < high) {
 				return false
@@ -441,21 +441,21 @@ func TestBucketStore_isBlockInMinMaxRange(t *testing.T) {
 	series := []labels.Labels{labels.FromStrings("a", "1", "b", "1")}
 	extLset := labels.FromStrings("ext1", "value1")
 
-	// Create a block in range [-2w, -1w]
+	// Create a block in range [-2w, -1w].
 	id1, err := testutil.CreateBlock(ctx, dir, series, 10,
 		timestamp.FromTime(time.Now().Add(-14*24*time.Hour)),
 		timestamp.FromTime(time.Now().Add(-7*24*time.Hour)),
 		extLset, 0)
 	testutil.Ok(t, err)
 
-	// Create a block in range [-1w, 0w]
+	// Create a block in range [-1w, 0w].
 	id2, err := testutil.CreateBlock(ctx, dir, series, 10,
 		timestamp.FromTime(time.Now().Add(-7*24*time.Hour)),
 		timestamp.FromTime(time.Now().Add(-0*24*time.Hour)),
 		extLset, 0)
 	testutil.Ok(t, err)
 
-	// Create a block in range [+1w, +2w]
+	// Create a block in range [+1w, +2w].
 	id3, err := testutil.CreateBlock(ctx, dir, series, 10,
 		timestamp.FromTime(time.Now().Add(7*24*time.Hour)),
 		timestamp.FromTime(time.Now().Add(14*24*time.Hour)),
@@ -471,11 +471,11 @@ func TestBucketStore_isBlockInMinMaxRange(t *testing.T) {
 	testutil.Ok(t, err)
 	testutil.Ok(t, metadata.Write(log.NewNopLogger(), dir2, meta2))
 
-	// Run actual test
+	// Run actual test.
 	hourBeforeDur := prommodel.Duration(-1 * time.Hour)
 	hourBefore := model.TimeOrDurationValue{Dur: &hourBeforeDur}
 
-	// bucketStore accepts blocks in range [0, now-1h]
+	// bucketStore accepts blocks in range [0, now-1h].
 	bucketStore, err := NewBucketStore(nil, nil, inmem.NewBucket(), dir, noopCache{}, 0, 0, 20, false, 20,
 		&FilterConfig{
 			MinTime: minTimeDuration,

--- a/pkg/store/cache/cache.go
+++ b/pkg/store/cache/cache.go
@@ -41,7 +41,7 @@ func (c cacheKey) size() uint64 {
 		// ULID + 2 slice headers + number of chars in value and name.
 		return 16 + 2*sliceHeaderSize + uint64(len(k.Value)+len(k.Name))
 	case cacheKeySeries:
-		return 16 + 8 // ULID + uint64
+		return 16 + 8 // ULID + uint64.
 	}
 	return 0
 }

--- a/pkg/store/prometheus.go
+++ b/pkg/store/prometheus.go
@@ -217,7 +217,7 @@ func (p *PrometheusStore) handleSampledPrometheusResponse(s storepb.Store_Series
 
 		// XOR encoding supports a max size of 2^16 - 1 samples, so we need
 		// to chunk all samples into groups of no more than 2^16 - 1
-		// See: https://github.com/thanos-io/thanos/pull/718 .
+		// See: https://github.com/thanos-io/thanos/pull/718.
 		aggregatedChunks, err := p.chunkSamples(e, math.MaxUint16)
 		if err != nil {
 			return err

--- a/pkg/store/prometheus.go
+++ b/pkg/store/prometheus.go
@@ -217,7 +217,7 @@ func (p *PrometheusStore) handleSampledPrometheusResponse(s storepb.Store_Series
 
 		// XOR encoding supports a max size of 2^16 - 1 samples, so we need
 		// to chunk all samples into groups of no more than 2^16 - 1
-		// See: https://github.com/thanos-io/thanos/pull/718
+		// See: https://github.com/thanos-io/thanos/pull/718 .
 		aggregatedChunks, err := p.chunkSamples(e, math.MaxUint16)
 		if err != nil {
 			return err

--- a/pkg/store/proxy.go
+++ b/pkg/store/proxy.go
@@ -52,7 +52,7 @@ type ProxyStore struct {
 }
 
 // NewProxyStore returns a new ProxyStore that uses the given clients that implements storeAPI to fan-in all series to the client.
-// Note that there is no deduplication support. Deduplication should be done on the highest level (just before PromQL)
+// Note that there is no deduplication support. Deduplication should be done on the highest level (just before PromQL).
 func NewProxyStore(
 	logger log.Logger,
 	stores func() []Client,
@@ -264,7 +264,7 @@ func (s *ProxyStore) Series(r *storepb.SeriesRequest, srv storepb.Store_SeriesSe
 
 		level.Debug(s.logger).Log("msg", strings.Join(storeDebugMsgs, ";"))
 		if len(seriesSet) == 0 {
-			// This is indicates that configured StoreAPIs are not the ones end user expects
+			// This is indicates that configured StoreAPIs are not the ones end user expects.
 			err := errors.New("No store matched for this query")
 			level.Warn(s.logger).Log("err", err, "stores", strings.Join(storeDebugMsgs, ";"))
 			respSender.send(storepb.NewWarnSeriesResponse(err))

--- a/pkg/store/tsdb.go
+++ b/pkg/store/tsdb.go
@@ -113,7 +113,7 @@ func (s *TSDBStore) Series(r *storepb.SeriesRequest, srv storepb.Store_SeriesSer
 		// limited benefit for now.
 		// NOTE: XOR encoding supports a max size of 2^16 - 1 samples, so we need
 		// to chunk all samples into groups of no more than 2^16 - 1
-		// See: https://github.com/thanos-io/thanos/pull/1038
+		// See: https://github.com/thanos-io/thanos/pull/1038 .
 		c, err := s.encodeChunks(series.Iterator(), math.MaxUint16)
 		if err != nil {
 			return status.Errorf(codes.Internal, "encode chunk: %s", err)

--- a/pkg/store/tsdb.go
+++ b/pkg/store/tsdb.go
@@ -113,7 +113,7 @@ func (s *TSDBStore) Series(r *storepb.SeriesRequest, srv storepb.Store_SeriesSer
 		// limited benefit for now.
 		// NOTE: XOR encoding supports a max size of 2^16 - 1 samples, so we need
 		// to chunk all samples into groups of no more than 2^16 - 1
-		// See: https://github.com/thanos-io/thanos/pull/1038 .
+		// See: https://github.com/thanos-io/thanos/pull/1038.
 		c, err := s.encodeChunks(series.Iterator(), math.MaxUint16)
 		if err != nil {
 			return status.Errorf(codes.Internal, "encode chunk: %s", err)

--- a/pkg/testutil/prometheus.go
+++ b/pkg/testutil/prometheus.go
@@ -170,7 +170,7 @@ func (p *Prometheus) start() error {
 	}
 	p.addr = fmt.Sprintf("localhost:%d", port)
 	args := append([]string{
-		"--storage.tsdb.retention=2d", // Pass retention cause prometheus since 2.8.0 don't show default value for that flags in web/api: https://github.com/prometheus/prometheus/pull/5433 .
+		"--storage.tsdb.retention=2d", // Pass retention cause prometheus since 2.8.0 don't show default value for that flags in web/api: https://github.com/prometheus/prometheus/pull/5433.
 		"--storage.tsdb.path=" + p.db.Dir(),
 		"--web.listen-address=" + p.addr,
 		"--web.route-prefix=" + p.prefix,

--- a/pkg/testutil/prometheus.go
+++ b/pkg/testutil/prometheus.go
@@ -170,7 +170,7 @@ func (p *Prometheus) start() error {
 	}
 	p.addr = fmt.Sprintf("localhost:%d", port)
 	args := append([]string{
-		"--storage.tsdb.retention=2d", // Pass retention cause prometheus since 2.8.0 don't show default value for that flags in web/api: https://github.com/prometheus/prometheus/pull/5433
+		"--storage.tsdb.retention=2d", // Pass retention cause prometheus since 2.8.0 don't show default value for that flags in web/api: https://github.com/prometheus/prometheus/pull/5433 .
 		"--storage.tsdb.path=" + p.db.Dir(),
 		"--web.listen-address=" + p.addr,
 		"--web.route-prefix=" + p.prefix,

--- a/pkg/tracing/jaeger/config_yaml.go
+++ b/pkg/tracing/jaeger/config_yaml.go
@@ -14,7 +14,7 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-// Config - YAML configuration. For details see to https://github.com/jaegertracing/jaeger-client-go#environment-variables .
+// Config - YAML configuration. For details see to https://github.com/jaegertracing/jaeger-client-go#environment-variables.
 type Config struct {
 	ServiceName            string        `yaml:"service_name"`
 	Disabled               bool          `yaml:"disabled"`

--- a/pkg/tracing/jaeger/config_yaml.go
+++ b/pkg/tracing/jaeger/config_yaml.go
@@ -14,7 +14,7 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-// Config - YAML configuration. For details see to https://github.com/jaegertracing/jaeger-client-go#environment-variables
+// Config - YAML configuration. For details see to https://github.com/jaegertracing/jaeger-client-go#environment-variables .
 type Config struct {
 	ServiceName            string        `yaml:"service_name"`
 	Disabled               bool          `yaml:"disabled"`

--- a/pkg/tracing/stackdriver/tracer.go
+++ b/pkg/tracing/stackdriver/tracer.go
@@ -26,7 +26,7 @@ type tracer struct {
 // GetTraceIDFromSpanContext return TraceID from span.Context.
 func (t *tracer) GetTraceIDFromSpanContext(ctx opentracing.SpanContext) (string, bool) {
 	if c, ok := ctx.(basictracer.SpanContext); ok {
-		// "%016x%016x" - ugly hack for gcloud find traces by ID https://console.cloud.google.com/traces/traces?project=<project_id>&tid=<62119f61b7c2663962119f61b7c26639>
+		// "%016x%016x" - ugly hack for gcloud find traces by ID https://console.cloud.google.com/traces/traces?project=<project_id>&tid=<62119f61b7c2663962119f61b7c26639> .
 		return fmt.Sprintf("%016x%016x", c.TraceID, c.TraceID), true
 	}
 	return "", false

--- a/pkg/tracing/stackdriver/tracer.go
+++ b/pkg/tracing/stackdriver/tracer.go
@@ -26,7 +26,7 @@ type tracer struct {
 // GetTraceIDFromSpanContext return TraceID from span.Context.
 func (t *tracer) GetTraceIDFromSpanContext(ctx opentracing.SpanContext) (string, bool) {
 	if c, ok := ctx.(basictracer.SpanContext); ok {
-		// "%016x%016x" - ugly hack for gcloud find traces by ID https://console.cloud.google.com/traces/traces?project=<project_id>&tid=<62119f61b7c2663962119f61b7c26639> .
+		// "%016x%016x" - ugly hack for gcloud find traces by ID https://console.cloud.google.com/traces/traces?project=<project_id>&tid=<62119f61b7c2663962119f61b7c26639>.
 		return fmt.Sprintf("%016x%016x", c.TraceID, c.TraceID), true
 	}
 	return "", false

--- a/pkg/ui/bucket.go
+++ b/pkg/ui/bucket.go
@@ -39,7 +39,7 @@ func (b *Bucket) Register(r *route.Router, ins extpromhttp.InstrumentationMiddle
 	r.Get("/static/*filepath", instrf("static", b.serveStaticAsset))
 }
 
-// Handle / of bucket UIs
+// Handle / of bucket UIs.
 func (b *Bucket) root(w http.ResponseWriter, r *http.Request) {
 	b.executeTemplate(w, "bucket.html", "", b)
 }

--- a/pkg/ui/query.go
+++ b/pkg/ui/query.go
@@ -81,11 +81,11 @@ func (q *Query) Register(r *route.Router, ins extpromhttp.InstrumentationMiddlew
 
 	r.Get("/static/*filepath", instrf("static", q.serveStaticAsset))
 	// TODO(bplotka): Consider adding more Thanos related data e.g:
-	// - what store nodes we see currently
-	// - what sidecars we see currently
+	// - What store nodes we see currently.
+	// - What sidecars we see currently.
 }
 
-// root redirects "/" requests to "/graph", taking into account the path prefix value
+// Root redirects "/" requests to "/graph", taking into account the path prefix value.
 func (q *Query) root(w http.ResponseWriter, r *http.Request) {
 	prefix := GetWebPrefix(q.logger, q.flagsMap, r)
 

--- a/pkg/ui/rule.go
+++ b/pkg/ui/rule.go
@@ -141,7 +141,7 @@ func (ru *Rule) rules(w http.ResponseWriter, r *http.Request) {
 	ru.executeTemplate(w, "rules.html", prefix, ru.ruleManagers)
 }
 
-// root redirects / requests to /graph, taking into account the path prefix value
+// Root redirects / requests to /graph, taking into account the path prefix value.
 func (ru *Rule) root(w http.ResponseWriter, r *http.Request) {
 	prefix := GetWebPrefix(ru.logger, ru.flagsMap, r)
 

--- a/pkg/ui/ui.go
+++ b/pkg/ui/ui.go
@@ -115,7 +115,7 @@ func SanitizePrefix(prefix string) (string, error) {
 		return "", err
 	}
 
-	// remove double slashes, convert to absolute path
+	// Remove double slashes, convert to absolute path.
 	sanitizedPrefix := strings.TrimPrefix(path.Clean(u.Path), ".")
 
 	if strings.HasSuffix(sanitizedPrefix, "/") {

--- a/test/e2e/spinup_test.go
+++ b/test/e2e/spinup_test.go
@@ -262,7 +262,7 @@ func storeGateway(http, grpc address, bucketConfig []byte) *serverScheduler {
 				"--http-address", http.HostPort(),
 				"--log.level", "debug",
 				"--objstore.config", string(bucketConfig),
-				// Accelerated sync time for quicker test (3m by default)
+				// Accelerated sync time for quicker test (3m by default).
 				"--sync-block-duration", "5s",
 			)), nil
 		},

--- a/tutorials/kubernetes-demo/blockgen/main.go
+++ b/tutorials/kubernetes-demo/blockgen/main.go
@@ -16,12 +16,12 @@ import (
 	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/tsdb"
 	"github.com/prometheus/prometheus/tsdb/labels"
-	kingpin "gopkg.in/alecthomas/kingpin.v2"
+	"gopkg.in/alecthomas/kingpin.v2"
 )
 
 // Allow for more realistic output.
 type series struct {
-	Type           string // gauge, counter (if conunter we treat below as rate aim)
+	Type           string // gauge, counter (if conunter we treat below as rate aim).
 	Jitter         float64
 	ChangeInterval string
 	Max            float64
@@ -104,8 +104,6 @@ func main() {
 			for n, v := range r.Metric {
 				lset = append(lset, labels.Label{Name: string(n), Value: string(v)})
 			}
-			//level.Debug(logger).Log("msg", "scheduled generation of series", "lset", lset)
-
 			var chInterval time.Duration
 			if in.ChangeInterval != "" {
 				chInterval, err = time.ParseDuration(in.ChangeInterval)


### PR DESCRIPTION
@bwplotka :))

It should check only last line if there are multiple comment lines.

For special cases allows to disable the check when leaving more than 3 spaces after the `//` 
example: `//    test`

Also, adds separate commit which fixes all currently invalid comments.

Example output:
![image](https://user-images.githubusercontent.com/6112562/66078089-a12a4080-e561-11e9-8bdc-db7d0be592de.png)


