### PR TITLE
chore: updated github PR template with changelog entry format

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,10 +3,19 @@
     about what components it touches e.g "query:" or ".*:"
 -->
 
-<!-- Don't forget about CHANGELOG! -->
+<!-- 
+    Don't forget about CHANGELOG! 
+    
+    Changelog entry format:
+    - [#<PR-id>](<PR-URL>) Thanos <Component> ...
+    
+    <PR-id> Id of your pull request.
+    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
+    <Component> Component affected by your changes such as Query, Store, Receive.
+-->
 
-* [] I added CHANGELOG entry for this change.
-* [] Change is not relevant to the end user.
+* [ ] I added CHANGELOG entry for this change.
+* [ ] Change is not relevant to the end user.
 
 ## Changes
 


### PR DESCRIPTION
* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

 ## Changes 

- updated the PR template so the checkboxes are by default displayed as empty (it always irritated me :D) 
- added example changelog entry, as once discussed, to lower the release burden with formatting changelog. 

