### PR TITLE
receiver: Avoid flushing the WAL twice on startup

### DIFF
--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -199,7 +199,7 @@ func runReceive(
 
 			// Before actually starting, we need to make sure the
 			// WAL is flushed. The WAL is flushed after the
-			// hashring ring is loaded
+			// hashring ring is loaded.
 			startTimeMargin := int64(2 * time.Duration(tsdbCfg.MinBlockDuration).Seconds() * 1000)
 			if err := db.Open(); err != nil {
 				return errors.Wrap(err, "opening storage")


### PR DESCRIPTION
Avoid flushing the WAL twice when starting the receiver. Instead we wait for the hashring to be loaded which will force a WAL flush. When stopping the receiver we also stop the DB before flushing to avoid re-opening the DB unnecessarily.

Signed-off-by: Devin Trejo <dtrejo@palantir.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!-- Don't forget about CHANGELOG! -->

* [] I added CHANGELOG entry for this change.
* [X] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->