### PR TITLE
pkg/receive: add tracing to forwarded requests

### DIFF
--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -160,6 +160,7 @@ func runReceive(
 		TenantHeader:      tenantHeader,
 		ReplicaHeader:     replicaHeader,
 		ReplicationFactor: replicationFactor,
+		Tracer:            tracer,
 	})
 
 	statusProber := prober.NewProber(comp, logger, prometheus.WrapRegistererWithPrefix("thanos_", reg))

--- a/pkg/tracing/http.go
+++ b/pkg/tracing/http.go
@@ -12,8 +12,8 @@ import (
 	"github.com/opentracing/opentracing-go/ext"
 )
 
-// HTTPMiddleware returns HTTP handler that injects given tracer and starts new server span. If any client span is fetched
-// wire we include that as our parent.
+// HTTPMiddleware returns an HTTP handler that injects the given tracer and starts a new server span.
+// If any client span is fetched from the wire, we include that as our parent.
 func HTTPMiddleware(tracer opentracing.Tracer, name string, logger log.Logger, next http.Handler) http.HandlerFunc {
 	operationName := fmt.Sprintf("/%s HTTP[server]", name)
 


### PR DESCRIPTION
This commit instruments the Thanos receive component's HTTP server with
the specified tracer. Specifically, it adds spans for each request
forwarded between receive nodes.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>

Change is not relevant to the end user.

cc @brancz @bwplotka 