### PR TITLE
pkg/receive: avoid false positive conflict err

### DIFF
--- a/pkg/receive/writer.go
+++ b/pkg/receive/writer.go
@@ -51,7 +51,7 @@ func (r *Writer) Write(wreq *prompb.WriteRequest) error {
 			}
 		}
 
-		// Append as many valid samples as possible, but keep track of the errors
+		// Append as many valid samples as possible, but keep track of the errors.
 		for _, s := range t.Samples {
 			_, err = app.Add(lset, s.Timestamp, s.Value)
 			switch err {


### PR DESCRIPTION
This commit ensures that the `replicate` func does not falsely identify
a replication error as a conflict. If the number of conflict errors
during replication is less than the minimum replication threshold, then
replication cannot be said to have failed due to a conflict and the
request should be retried.

Fixes: #1615

xref: #1563
Signed-off-by: Lucas Servén Marín <lserven@gmail.com>

cc @brancz @dtrejod 