### PR TITLE
[QUERY] Add metric for status of stores for query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 We use *breaking* word for marking changes that are not backward compatible (relates only to v0.y.z releases.)
 
 ## Unreleased
+- [#1618](https://github.com/thanos-io/thanos/pull/1618) Add new metric `thanos_store_status` for query component which represents the status of the stores API that this query needs to talk to as shows on `/store` endpoint.
 
 ## [v0.8.1](https://github.com/thanos-io/thanos/releases/tag/v0.8.1) - 2019.10.14
 

--- a/pkg/query/storeset.go
+++ b/pkg/query/storeset.go
@@ -184,7 +184,8 @@ func NewStoreSet(
 		Help: "The status of stores as indicated on the /stores page. 1 is UP 0 is DOWN",
 	},
 		[]string{
-			"address",
+			"labelset",
+			"labelset_hash",
 		},
 	)
 	if reg != nil {
@@ -467,7 +468,10 @@ func (s *StoreSet) updateStoreStatus(store *storeRef, err error) {
 
 	status.LastError = err
 	status.LastCheck = time.Now()
-	s.storeStatus.WithLabelValues(store.addr).Set(0)
+	s.storeStatus.WithLabelValues(
+		storepb.LabelSetsToString(store.labelSets),
+		storepb.LabelSetsToHash(store.labelSets),
+	).Set(0)
 
 	if err == nil {
 
@@ -476,7 +480,10 @@ func (s *StoreSet) updateStoreStatus(store *storeRef, err error) {
 		status.StoreType = store.StoreType()
 		status.MinTime = mint
 		status.MaxTime = maxt
-		s.storeStatus.WithLabelValues(store.addr).Set(1)
+		s.storeStatus.WithLabelValues(
+			storepb.LabelSetsToString(store.labelSets),
+			storepb.LabelSetsToHash(store.labelSets),
+		).Set(1)
 	}
 
 	s.storeStatuses[store.addr] = &status

--- a/pkg/store/storepb/custom.go
+++ b/pkg/store/storepb/custom.go
@@ -1,6 +1,8 @@
 package storepb
 
 import (
+	"crypto/sha1"
+	"encoding/hex"
 	"strings"
 
 	"github.com/prometheus/prometheus/pkg/labels"
@@ -181,9 +183,16 @@ func LabelsToString(lset []Label) string {
 }
 
 func LabelSetsToString(lsets []LabelSet) string {
-	s := []string{}
+	var s []string
 	for _, ls := range lsets {
 		s = append(s, LabelsToString(ls.Labels))
 	}
 	return strings.Join(s, "")
+}
+
+func LabelSetsToHash(lsets []LabelSet) string {
+	h := sha1.New()
+	h.Write([]byte(LabelSetsToString(lsets)))
+
+	return hex.EncodeToString(h.Sum(nil))
 }

--- a/pkg/store/storepb/custom.go
+++ b/pkg/store/storepb/custom.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"strings"
 
+	"github.com/pkg/errors"
 	"github.com/prometheus/prometheus/pkg/labels"
 )
 
@@ -190,9 +191,12 @@ func LabelSetsToString(lsets []LabelSet) string {
 	return strings.Join(s, "")
 }
 
-func LabelSetsToHash(lsets []LabelSet) string {
+func LabelSetsToHash(lsets []LabelSet) (string, error) {
 	h := sha1.New()
-	h.Write([]byte(LabelSetsToString(lsets)))
+	_, err := h.Write([]byte(LabelSetsToString(lsets)))
+	if err != nil {
+		return "", errors.Wrap(err, "hashing label sets failed")
+	}
 
-	return hex.EncodeToString(h.Sum(nil))
+	return hex.EncodeToString(h.Sum(nil)), nil
 }


### PR DESCRIPTION
Signed-off-by: Kevin Hellemun <17928966+OGKevin@users.noreply.github.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!-- 
    Don't forget about CHANGELOG! 
    
    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...
    
    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->
1. Add a new metric `thanos_store_status` for query component that indicates if a store is up or down for the query.

## Verification

<!-- How you tested it? How do you know it works? -->

```
# HELP thanos_store_status The status of stores as indicated on the /stores page. 1 is UP 0 is DOWN
# TYPE thanos_store_status gauge
thanos_store_status{labelset="",labelset_hash="da39a3ee5e6b4b0d3255bfef95601890afd80709"} 0
```
<img width="694" alt="Screenshot" src="https://user-images.githubusercontent.com/17928966/66575317-b7c52e80-eb43-11e9-97bb-c3159d8c749d.png">
