### PR TITLE
pkg/receive: fix regression and add testing for receive external API to avoid future regressions

### DIFF
--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -58,9 +58,9 @@ func registerReceive(m map[string]setupFunc, app *kingpin.Application) {
 
 	local := cmd.Flag("receive.local-endpoint", "Endpoint of local receive node. Used to identify the local node in the hashring configuration.").String()
 
-	tenantHeader := cmd.Flag("receive.tenant-header", "HTTP header to determine tenant for write requests.").Default("THANOS-TENANT").String()
+	tenantHeader := cmd.Flag("receive.tenant-header", "HTTP header to determine tenant for write requests.").Default(receive.DefaultTenantHeader).String()
 
-	replicaHeader := cmd.Flag("receive.replica-header", "HTTP header specifying the replica number of a write request.").Default("THANOS-REPLICA").String()
+	replicaHeader := cmd.Flag("receive.replica-header", "HTTP header specifying the replica number of a write request.").Default(receive.DefaultReplicaHeader).String()
 
 	replicationFactor := cmd.Flag("receive.replication-factor", "How many times to replicate incoming write requests.").Default("1").Uint64()
 

--- a/pkg/receive/handler_test.go
+++ b/pkg/receive/handler_test.go
@@ -1,11 +1,19 @@
 package receive
 
 import (
+	"bytes"
 	"net/http"
+	"net/http/httptest"
 	"strconv"
+	"sync"
 	"testing"
 
+	"github.com/go-kit/kit/log"
+	"github.com/gogo/protobuf/proto"
+	"github.com/golang/snappy"
 	"github.com/pkg/errors"
+	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/prometheus/prompb"
 	"github.com/prometheus/prometheus/storage"
 	terrors "github.com/prometheus/prometheus/tsdb/errors"
 )
@@ -119,4 +127,421 @@ func TestCountCause(t *testing.T) {
 			t.Errorf("test case %s: expected %d, got %d", tc.name, tc.out, n)
 		}
 	}
+}
+
+func newHandlerHashring(appendables []*fakeAppendable, replicationFactor uint64) ([]*Handler, Hashring, func()) {
+	cfg := []HashringConfig{
+		{
+			Hashring: "test",
+		},
+	}
+	var closers []func()
+	var handlers []*Handler
+	for i := range appendables {
+		h := NewHandler(nil, &Options{
+			TenantHeader:      DefaultTenantHeader,
+			ReplicaHeader:     DefaultReplicaHeader,
+			ReplicationFactor: replicationFactor,
+			Writer:            NewWriter(log.NewNopLogger(), appendables[i]),
+		})
+		handlers = append(handlers, h)
+		ts := httptest.NewServer(h.router)
+		closers = append(closers, ts.Close)
+		h.options.Endpoint = ts.URL + "/api/v1/receive"
+		cfg[0].Endpoints = append(cfg[0].Endpoints, h.options.Endpoint)
+	}
+	hashring := newMultiHashring(cfg)
+	for _, h := range handlers {
+		h.Hashring(hashring)
+	}
+	close := func() {
+		for _, closer := range closers {
+			closer()
+		}
+	}
+	return handlers, hashring, close
+}
+
+func TestReceive(t *testing.T) {
+	appenderErrFn := func() error { return errors.New("failed to get appender") }
+	conflictErrFn := func() error { return storage.ErrOutOfBounds }
+	commitErrFn := func() error { return errors.New("failed to commit") }
+	wreq1 := &prompb.WriteRequest{
+		Timeseries: []prompb.TimeSeries{
+			{
+				Labels: []prompb.Label{
+					{
+						Name:  "foo",
+						Value: "bar",
+					},
+				},
+				Samples: []prompb.Sample{
+					{
+						Value:     1,
+						Timestamp: 1,
+					},
+					{
+						Value:     2,
+						Timestamp: 2,
+					},
+					{
+						Value:     3,
+						Timestamp: 3,
+					},
+				},
+			},
+		},
+	}
+	for _, tc := range []struct {
+		name              string
+		status            int
+		replicationFactor uint64
+		wreq              *prompb.WriteRequest
+		appendables       []*fakeAppendable
+	}{
+		{
+			name:              "size 1 success",
+			status:            http.StatusOK,
+			replicationFactor: 1,
+			wreq:              wreq1,
+			appendables: []*fakeAppendable{
+				&fakeAppendable{
+					appender: newFakeAppender(nil, nil, nil, nil),
+				},
+			},
+		},
+		{
+			name:              "size 1 commit error",
+			status:            http.StatusInternalServerError,
+			replicationFactor: 1,
+			wreq:              wreq1,
+			appendables: []*fakeAppendable{
+				&fakeAppendable{
+					appender: newFakeAppender(nil, nil, commitErrFn, nil),
+				},
+			},
+		},
+		{
+			name:              "size 1 conflict",
+			status:            http.StatusConflict,
+			replicationFactor: 1,
+			wreq:              wreq1,
+			appendables: []*fakeAppendable{
+				&fakeAppendable{
+					appender: newFakeAppender(conflictErrFn, nil, nil, nil),
+				},
+			},
+		},
+		{
+			name:              "size 2 success",
+			status:            http.StatusOK,
+			replicationFactor: 1,
+			wreq:              wreq1,
+			appendables: []*fakeAppendable{
+				&fakeAppendable{
+					appender: newFakeAppender(nil, nil, nil, nil),
+				},
+				&fakeAppendable{
+					appender: newFakeAppender(nil, nil, nil, nil),
+				},
+			},
+		},
+		{
+			name:              "size 3 success",
+			status:            http.StatusOK,
+			replicationFactor: 1,
+			wreq:              wreq1,
+			appendables: []*fakeAppendable{
+				&fakeAppendable{
+					appender: newFakeAppender(nil, nil, nil, nil),
+				},
+				&fakeAppendable{
+					appender: newFakeAppender(nil, nil, nil, nil),
+				},
+				&fakeAppendable{
+					appender: newFakeAppender(nil, nil, nil, nil),
+				},
+			},
+		},
+		{
+			name:              "size 3 success with replication",
+			status:            http.StatusOK,
+			replicationFactor: 3,
+			wreq:              wreq1,
+			appendables: []*fakeAppendable{
+				&fakeAppendable{
+					appender: newFakeAppender(nil, nil, nil, nil),
+				},
+				&fakeAppendable{
+					appender: newFakeAppender(nil, nil, nil, nil),
+				},
+				&fakeAppendable{
+					appender: newFakeAppender(nil, nil, nil, nil),
+				},
+			},
+		},
+		{
+			name:              "size 3 commit error",
+			status:            http.StatusInternalServerError,
+			replicationFactor: 1,
+			wreq:              wreq1,
+			appendables: []*fakeAppendable{
+				&fakeAppendable{
+					appender: newFakeAppender(nil, nil, commitErrFn, nil),
+				},
+				&fakeAppendable{
+					appender: newFakeAppender(nil, nil, commitErrFn, nil),
+				},
+				&fakeAppendable{
+					appender: newFakeAppender(nil, nil, commitErrFn, nil),
+				},
+			},
+		},
+		{
+			name:              "size 3 commit error with replication",
+			status:            http.StatusInternalServerError,
+			replicationFactor: 3,
+			wreq:              wreq1,
+			appendables: []*fakeAppendable{
+				&fakeAppendable{
+					appender: newFakeAppender(nil, nil, commitErrFn, nil),
+				},
+				&fakeAppendable{
+					appender: newFakeAppender(nil, nil, commitErrFn, nil),
+				},
+				&fakeAppendable{
+					appender: newFakeAppender(nil, nil, commitErrFn, nil),
+				},
+			},
+		},
+		{
+			name:              "size 3 appender error with replication",
+			status:            http.StatusInternalServerError,
+			replicationFactor: 3,
+			wreq:              wreq1,
+			appendables: []*fakeAppendable{
+				&fakeAppendable{
+					appender:    newFakeAppender(nil, nil, nil, nil),
+					appenderErr: appenderErrFn,
+				},
+				&fakeAppendable{
+					appender:    newFakeAppender(nil, nil, nil, nil),
+					appenderErr: appenderErrFn,
+				},
+				&fakeAppendable{
+					appender:    newFakeAppender(nil, nil, nil, nil),
+					appenderErr: appenderErrFn,
+				},
+			},
+		},
+		{
+			name:              "size 3 conflict with replication",
+			status:            http.StatusConflict,
+			replicationFactor: 3,
+			wreq:              wreq1,
+			appendables: []*fakeAppendable{
+				&fakeAppendable{
+					appender: newFakeAppender(conflictErrFn, nil, nil, nil),
+				},
+				&fakeAppendable{
+					appender: newFakeAppender(conflictErrFn, nil, nil, nil),
+				},
+				&fakeAppendable{
+					appender: newFakeAppender(conflictErrFn, nil, nil, nil),
+				},
+			},
+		},
+		{
+			name:              "size 3 conflict and commit error with replication",
+			status:            http.StatusConflict,
+			replicationFactor: 3,
+			wreq:              wreq1,
+			appendables: []*fakeAppendable{
+				&fakeAppendable{
+					appender: newFakeAppender(conflictErrFn, nil, commitErrFn, nil),
+				},
+				&fakeAppendable{
+					appender: newFakeAppender(conflictErrFn, nil, commitErrFn, nil),
+				},
+				&fakeAppendable{
+					appender: newFakeAppender(conflictErrFn, nil, commitErrFn, nil),
+				},
+			},
+		},
+		{
+			name:              "size 3 with replication and one faulty",
+			status:            http.StatusOK,
+			replicationFactor: 3,
+			wreq:              wreq1,
+			appendables: []*fakeAppendable{
+				&fakeAppendable{
+					appender: newFakeAppender(cycleErrors([]error{storage.ErrOutOfBounds, storage.ErrOutOfOrderSample, storage.ErrDuplicateSampleForTimestamp}), nil, nil, nil),
+				},
+				&fakeAppendable{
+					appender: newFakeAppender(nil, nil, nil, nil),
+				},
+				&fakeAppendable{
+					appender: newFakeAppender(nil, nil, nil, nil),
+				},
+			},
+		},
+		{
+			name:              "size 3 with replication and one commit error",
+			status:            http.StatusOK,
+			replicationFactor: 3,
+			wreq:              wreq1,
+			appendables: []*fakeAppendable{
+				&fakeAppendable{
+					appender: newFakeAppender(nil, nil, commitErrFn, nil),
+				},
+				&fakeAppendable{
+					appender: newFakeAppender(nil, nil, nil, nil),
+				},
+				&fakeAppendable{
+					appender: newFakeAppender(nil, nil, nil, nil),
+				},
+			},
+		},
+		{
+			name:              "size 3 with replication and two conflicts",
+			status:            http.StatusConflict,
+			replicationFactor: 3,
+			wreq:              wreq1,
+			appendables: []*fakeAppendable{
+				&fakeAppendable{
+					appender: newFakeAppender(cycleErrors([]error{storage.ErrOutOfBounds, storage.ErrOutOfOrderSample, storage.ErrDuplicateSampleForTimestamp}), nil, nil, nil),
+				},
+				&fakeAppendable{
+					appender: newFakeAppender(conflictErrFn, nil, nil, nil),
+				},
+				&fakeAppendable{
+					appender: newFakeAppender(nil, nil, nil, nil),
+				},
+			},
+		},
+		{
+			name:              "size 3 with replication one conflict and one commit error",
+			status:            http.StatusInternalServerError,
+			replicationFactor: 3,
+			wreq:              wreq1,
+			appendables: []*fakeAppendable{
+				&fakeAppendable{
+					appender: newFakeAppender(cycleErrors([]error{storage.ErrOutOfBounds, storage.ErrOutOfOrderSample, storage.ErrDuplicateSampleForTimestamp}), nil, nil, nil),
+				},
+				&fakeAppendable{
+					appender: newFakeAppender(nil, nil, commitErrFn, nil),
+				},
+				&fakeAppendable{
+					appender: newFakeAppender(nil, nil, nil, nil),
+				},
+			},
+		},
+		{
+			name:              "size 3 with replication two commit errors",
+			status:            http.StatusInternalServerError,
+			replicationFactor: 3,
+			wreq:              wreq1,
+			appendables: []*fakeAppendable{
+				&fakeAppendable{
+					appender: newFakeAppender(nil, nil, commitErrFn, nil),
+				},
+				&fakeAppendable{
+					appender: newFakeAppender(nil, nil, commitErrFn, nil),
+				},
+				&fakeAppendable{
+					appender: newFakeAppender(nil, nil, nil, nil),
+				},
+			},
+		},
+	} {
+		handlers, hashring, close := newHandlerHashring(tc.appendables, tc.replicationFactor)
+		defer close()
+		tenant := "test"
+		// Test from the point of view of every node
+		// so that we know status code does not depend
+		// on which node is erroring and which node is receiving.
+		for i, handler := range handlers {
+			// Test that the correct status is returned.
+			status, err := makeRequest(handler, tenant, tc.wreq)
+			if err != nil {
+				t.Fatalf("test case %q, handler %d: unexpectedly failed making HTTP request: %v", tc.name, tc.status, err)
+			}
+			if status != tc.status {
+				t.Errorf("test case %q, handler %d: got unexpected HTTP status code: expected %d, got %d", tc.name, i, tc.status, status)
+			}
+		}
+		// Test that each time series is stored
+		// the correct amount of times in each fake DB.
+		for _, ts := range tc.wreq.Timeseries {
+			lset := make(labels.Labels, len(ts.Labels))
+			for j := range ts.Labels {
+				lset[j] = labels.Label{
+					Name:  ts.Labels[j].Name,
+					Value: ts.Labels[j].Value,
+				}
+			}
+			for j, a := range tc.appendables {
+				var expected int
+				got := uint64(len(a.appender.(*fakeAppender).samples[lset.String()]))
+				if a.appenderErr == nil && endpointHit(t, hashring, tc.replicationFactor, handlers[j].options.Endpoint, tenant, &ts) {
+					// We have len(handlers) copies of each sample because the test case
+					// is run once for each handler and they all use the same appender.
+					expected = len(handlers) * len(ts.Samples)
+				}
+				if uint64(expected) != got {
+					t.Errorf("test case %q, labels %q: expected %d samples, got %d", tc.name, lset.String(), expected, got)
+				}
+			}
+		}
+	}
+}
+
+// endpointHit is a helper to determine if a given endpoint in a hashring would be selected
+// for a given time series, tenant, and replication factor.
+func endpointHit(t *testing.T, h Hashring, rf uint64, endpoint, tenant string, timeSeries *prompb.TimeSeries) bool {
+	var i uint64
+	for i = 0; i < rf; i++ {
+		e, err := h.GetN(tenant, timeSeries, i)
+		if err != nil {
+			t.Fatalf("got unexpected error querying hashring: %v", err)
+		}
+		if e == endpoint {
+			return true
+		}
+	}
+	return false
+}
+
+// cycleErrors returns an error generator that cycles through every given error.
+func cycleErrors(errs []error) func() error {
+	var mu sync.Mutex
+	var i int
+	return func() error {
+		mu.Lock()
+		defer mu.Unlock()
+		err := errs[i]
+		i++
+		if i >= len(errs) {
+			i = 0
+		}
+		return err
+	}
+}
+
+// makeRequest is a helper to make a correct request against a remote write endpoint given a request.
+func makeRequest(h *Handler, tenant string, wreq *prompb.WriteRequest) (int, error) {
+	buf, err := proto.Marshal(wreq)
+	if err != nil {
+		return 0, errors.Wrap(err, "marshal request")
+	}
+	req, err := http.NewRequest("POST", h.options.Endpoint, bytes.NewBuffer(snappy.Encode(nil, buf)))
+	if err != nil {
+		return 0, errors.Wrap(err, "create request")
+	}
+	req.Header.Add(h.options.TenantHeader, tenant)
+	res, err := h.client.Do(req)
+	if err != nil {
+		return 0, errors.Wrap(err, "make request")
+	}
+	return res.StatusCode, nil
 }


### PR DESCRIPTION
This commit adds tests for the Thanos receive component's external HTTP
API. This rather large PR was motivated by fixing a regression that was
introduced in 19e59ef5369c2134ae3295bd29b86b05b82cb980, where returning
a MultiError threw off the error counting logic in the request
parallelization func, which could cause the wrong HTTP status code to be
returned. In order to protect against these regressions, we need
thorough testing of the external API.

cc @brancz @bwplotka 