### PR TITLE
docs: Add section to sidecar docs for uploading compacted blocks

### DIFF
--- a/docs/components/sidecar.md
+++ b/docs/components/sidecar.md
@@ -67,6 +67,15 @@ config:
   bucket: example-bucket
 ```
 
+## Upload compacted blocks (EXPERIMENTAL)
+
+If you want to migrate from a pure Prometheus setup to Thanos and have to keep the historical data, you can use the flag `--shipper.upload-compacted`. This will also upload blocks that were compacted by Prometheus.
+
+To use this, the Prometheus compaction needs to be disabled. This can be done by setting the following flags for Prometheus:
+
+- `--storage.tsdb.min-block-duration=2h`
+- `--storage.tsdb.max-block-duration=2h`
+
 ## Flags
 
 [embedmd]:# (flags/sidecar.txt $)
@@ -134,12 +143,3 @@ Flags:
                                  Valid duration units are ms, s, m, h, d, w, y.
 
 ```
-
-## Upload compacted blocks (EXPERIMENTAL)
-
-If you want to migrate from a pure Prometheus setup to Thanos and have to keep the historical data, you can use the flag `--shipper.upload-compacted`. This will also upload blocks that were compacted by Prometheus.
-
-To use this, the Prometheus compaction needs to be disabled. This can be done by setting the following flags for Prometheus:
-
-- `--storage.tsdb.min-block-duration=2h`
-- `--storage.tsdb.max-block-duration=2h`

--- a/docs/components/sidecar.md
+++ b/docs/components/sidecar.md
@@ -134,3 +134,12 @@ Flags:
                                  Valid duration units are ms, s, m, h, d, w, y.
 
 ```
+
+## Upload compacted blocks (EXPERIMENTAL)
+
+If you want to migrate from a pure Prometheus setup to Thanos and have to keep the historical data, you can use the flag `--shipper.upload-compacted`. This will also upload blocks that were compacted by Prometheus.
+
+To use this, the Prometheus compaction needs to be disabled. This can be done by setting the following flags for Prometheus:
+
+- `--storage.tsdb.min-block-duration=2h`
+- `--storage.tsdb.max-block-duration=2h`


### PR DESCRIPTION
This adds a section to the sidecar docs about the experimental flag `--shipper.upload-compacted`.

We struggled to find a way to upload our historical Prometheus data to the object store and stumbled upon the issue #348 which mentions the flag.

## Changes

A section with the name "Upload compacted blocks (EXPERIMENTAL)" was added to the docs for the sidecar component explaining how to upload already compacted blocks for migrating to a Thanos setup.