### PR TITLE
cmd/thanos/flags: remove unhelpful flags helper

### DIFF
--- a/cmd/thanos/flags.go
+++ b/cmd/thanos/flags.go
@@ -29,23 +29,6 @@ func regGRPCFlags(cmd *kingpin.CmdClause) (
 		grpcTLSSrvClientCA
 }
 
-// TODO(povilasv): we don't need this anymore.
-func regCommonServerFlags(cmd *kingpin.CmdClause) (
-	grpcBindAddr *string,
-	httpBindAddr *string,
-	grpcTLSSrvCert *string,
-	grpcTLSSrvKey *string,
-	grpcTLSSrvClientCA *string) {
-	httpBindAddr = regHTTPAddrFlag(cmd)
-	grpcBindAddr, grpcTLSSrvCert, grpcTLSSrvKey, grpcTLSSrvClientCA = regGRPCFlags(cmd)
-
-	return grpcBindAddr,
-		httpBindAddr,
-		grpcTLSSrvCert,
-		grpcTLSSrvKey,
-		grpcTLSSrvClientCA
-}
-
 func regHTTPAddrFlag(cmd *kingpin.CmdClause) *string {
 	return cmd.Flag("http-address", "Listen host:port for HTTP endpoints.").Default("0.0.0.0:10902").String()
 }

--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -47,7 +47,8 @@ func registerQuery(m map[string]setupFunc, app *kingpin.Application) {
 	comp := component.Query
 	cmd := app.Command(comp.String(), "query node exposing PromQL enabled Query API with data retrieved from multiple store nodes")
 
-	grpcBindAddr, httpBindAddr, srvCert, srvKey, srvClientCA := regCommonServerFlags(cmd)
+	httpBindAddr := regHTTPAddrFlag(cmd)
+	grpcBindAddr, srvCert, srvKey, srvClientCA := regGRPCFlags(cmd)
 
 	secure := cmd.Flag("grpc-client-tls-secure", "Use TLS when talking to the gRPC server").Default("false").Bool()
 	cert := cmd.Flag("grpc-client-tls-cert", "TLS Certificates to use to identify this client to the server").Default("").String()

--- a/cmd/thanos/rule.go
+++ b/cmd/thanos/rule.go
@@ -61,7 +61,8 @@ func registerRule(m map[string]setupFunc, app *kingpin.Application) {
 	comp := component.Rule
 	cmd := app.Command(comp.String(), "ruler evaluating Prometheus rules against given Query nodes, exposing Store API and storing old blocks in bucket")
 
-	grpcBindAddr, httpBindAddr, cert, key, clientCA := regCommonServerFlags(cmd)
+	httpBindAddr := regHTTPAddrFlag(cmd)
+	grpcBindAddr, cert, key, clientCA := regGRPCFlags(cmd)
 
 	labelStrs := cmd.Flag("label", "Labels to be applied to all generated metrics (repeated). Similar to external labels for Prometheus, used to identify ruler and its blocks as unique source.").
 		PlaceHolder("<name>=\"<value>\"").Strings()

--- a/cmd/thanos/sidecar.go
+++ b/cmd/thanos/sidecar.go
@@ -37,7 +37,8 @@ const waitForExternalLabelsTimeout = 10 * time.Minute
 func registerSidecar(m map[string]setupFunc, app *kingpin.Application) {
 	cmd := app.Command(component.Sidecar.String(), "sidecar for Prometheus server")
 
-	grpcBindAddr, httpBindAddr, cert, key, clientCA := regCommonServerFlags(cmd)
+	httpBindAddr := regHTTPAddrFlag(cmd)
+	grpcBindAddr, cert, key, clientCA := regGRPCFlags(cmd)
 
 	promURL := cmd.Flag("prometheus.url", "URL at which to reach Prometheus's API. For better performance use local network.").
 		Default("http://localhost:9090").URL()

--- a/cmd/thanos/store.go
+++ b/cmd/thanos/store.go
@@ -29,7 +29,8 @@ import (
 func registerStore(m map[string]setupFunc, app *kingpin.Application) {
 	cmd := app.Command(component.Store.String(), "store node giving access to blocks in a bucket provider. Now supported GCS, S3, Azure, Swift and Tencent COS.")
 
-	grpcBindAddr, httpBindAddr, cert, key, clientCA := regCommonServerFlags(cmd)
+	httpBindAddr := regHTTPAddrFlag(cmd)
+	grpcBindAddr, cert, key, clientCA := regGRPCFlags(cmd)
 
 	dataDir := cmd.Flag("data-dir", "Data directory in which to cache remote blocks.").
 		Default("./data").String()


### PR DESCRIPTION
This commit cleans up a TODO in the flags.go file and eliminates the
regCommonServerFlags func, which added almost no additional utility
beyond calling regGRPCFlags and regHTTPAddrFlag.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>

low-priority cleanup.

cc @povilasv @bwplotka 