### PR TITLE
Add a new prometheus.ready_timeout CLI option to the sidecar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 
 ## Unreleased
 
+### Added
+
+- [#1660](https://github.com/thanos-io/thanos/pull/1660) Add a new `--prometheus.ready_timeout` CLI option to the sidecar to set how long to wait until Prometheus starts up.
+
 ## [v0.8.1](https://github.com/thanos-io/thanos/releases/tag/v0.8.1) - 2019.10.14
 
 ### Fixed

--- a/docs/components/sidecar.md
+++ b/docs/components/sidecar.md
@@ -116,6 +116,9 @@ Flags:
       --prometheus.url=http://localhost:9090
                                  URL at which to reach Prometheus's API. For
                                  better performance use local network.
+      --prometheus.ready_timeout=10m
+                                 Maximum time to wait for the Prometheus
+                                 instance to start up
       --tsdb.path="./data"       Data directory of TSDB.
       --reloader.config-file=""  Config file watched by the reloader.
       --reloader.config-envsubst-file=""


### PR DESCRIPTION
* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

The current timeout while the Prometheus instance is starting up is a constant 10 minutes.
As reading the WAL can take a long time we would like to set a custom timeout value, so the Thanos sidecar container is not erroring out every 10 minutes.

## Verification

I ran `make test` with the in-memory store tests.
