### PR TITLE
[Demo] Query/SG: chopped queries

### DIFF
--- a/pkg/store/streaming_set2.go
+++ b/pkg/store/streaming_set2.go
@@ -1,0 +1,65 @@
+package store
+
+import (
+	"context"
+	"io"
+
+	"github.com/go-kit/kit/log"
+	"github.com/pkg/errors"
+	"github.com/thanos-io/thanos/pkg/store/storepb"
+)
+
+// streamSeriesSet iterates over incoming stream of series.
+// All errors are sent out of band via warning channel.
+type streamSeriesSet2 struct {
+	series []*storepb.Series
+	pos    int
+}
+
+func startStreamSeriesSet2(
+	ctx context.Context,
+	logger log.Logger,
+	stream storepb.Store_SeriesClient,
+) (*streamSeriesSet2, error) {
+	var series []*storepb.Series
+
+	for {
+		r, err := stream.Recv()
+
+		if err == io.EOF {
+			break
+		}
+
+		if err != nil {
+			return nil, errors.Wrap(err, "receive series")
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+			series = append(series, r.GetSeries())
+			continue
+		}
+	}
+
+	return &streamSeriesSet2{
+		series: series,
+		pos:    -1,
+	}, nil
+}
+
+// Next blocks until new message is received or stream is closed or operation is timed out.
+func (s *streamSeriesSet2) Next() (ok bool) {
+	s.pos++
+	return s.pos < len(s.series)
+}
+
+func (s *streamSeriesSet2) At() ([]storepb.Label, []storepb.AggrChunk) {
+	currSeries := s.series[s.pos]
+	return currSeries.Labels, currSeries.Chunks
+}
+
+func (s *streamSeriesSet2) Err() error {
+	return nil
+}

--- a/pkg/store/timechop.go
+++ b/pkg/store/timechop.go
@@ -10,6 +10,7 @@ type interval struct {
 	MaxTime int64
 }
 
+// chopTime splits interval into chunks of given duration.
 func chopTime(ctx context.Context, i interval, chopDuration time.Duration) <-chan interval {
 	res := make(chan interval)
 

--- a/pkg/store/timechop.go
+++ b/pkg/store/timechop.go
@@ -1,0 +1,40 @@
+package store
+
+import (
+	"context"
+	"time"
+)
+
+type interval struct {
+	MinTime int64
+	MaxTime int64
+}
+
+func chopTime(ctx context.Context, i interval, chopDuration time.Duration) <-chan interval {
+	res := make(chan interval)
+
+	go func() {
+		defer close(res)
+
+		if chopDuration <= 0 {
+			res <- i
+			return
+		}
+
+		mint := i.MinTime
+		maxt := mint + chopDuration.Milliseconds() - 1
+
+		for maxt <= i.MaxTime {
+			select {
+			case <-ctx.Done():
+				return
+			case res <- interval{MinTime: mint, MaxTime: maxt}:
+				mint = maxt + 1
+				maxt = mint + chopDuration.Milliseconds() - 1
+				continue
+			}
+		}
+	}()
+
+	return res
+}


### PR DESCRIPTION
# DEMO. NOT FOR MERGE

**TL;DR:** *NOT WORTH IT* (unless I did something dumb, in which case can revisit)

---

This is a small demo of the chunked queries:

- Part of the `[8.]` item in https://github.com/thanos-io/thanos/issues/1649
- PR is for historical purposes to record the results.


**Change:**

- The change is in querier.
- Given time interval `[mint, maxt]`, chop it into smaller `1h` intervals `[mint, mint+1h], [mint+1h, mint+2h] ... [maxt-1h, maxt]`.
- Ask Store Gateway (SG) to give results for each smaller chunk.
- Assemble results in the querier.


**Purpose:**

- See if this has positive impact on memory utilisation in both Querier and SG components;
- See if query execution time is affected in any negative way.


**Results:**

- SG memory utilisation is really much better (flat line).
- Querier is way way higher though.
- Also it's quite a bit slower.
- Query used: `count({__name__=~".+"}) by (__name__)`
- See stats and charts.

```
ORIGINAL IMPLEMENTATION:

    real    1m30.330s
    user    0m0.014s
    sys     0m0.021s

    Peak MEM:
        SG  22GB
        Q   16GB


CHUNKED:

    real    2m13.879s
    user    0m0.014s
    sys     0m0.022s

    Peak MEM:
        SG  6GB
        Q   25GB

```


**Conclusion:**

*NOT WORTH IT* 

- Looks to shift the problem from SG to Querier at the cost of latency.
- Questionable benefit.
- Unless I did something dumb, in which case can revisit later.


** Chart **

![Screenshot 2019-10-18 at 14 27 13](https://user-images.githubusercontent.com/300031/67101090-e2a12980-f1b8-11e9-94bd-0f19d7dacceb.png)
