### PR TITLE
cmd/thanos/receive: remote-write client+server TLS

### DIFF
--- a/cmd/thanos/rule.go
+++ b/cmd/thanos/rule.go
@@ -506,7 +506,7 @@ func runRule(
 
 		store := store.NewTSDBStore(logger, reg, db, component.Rule, lset)
 
-		opts, err := defaultGRPCServerOpts(logger, cert, key, clientCA)
+		opts, err := defaultGRPCTLSServerOpts(logger, cert, key, clientCA)
 		if err != nil {
 			return errors.Wrap(err, "setup gRPC options")
 		}

--- a/cmd/thanos/sidecar.go
+++ b/cmd/thanos/sidecar.go
@@ -231,7 +231,7 @@ func runSidecar(
 			return errors.Wrap(err, "create Prometheus store")
 		}
 
-		opts, err := defaultGRPCServerOpts(logger, cert, key, clientCA)
+		opts, err := defaultGRPCTLSServerOpts(logger, cert, key, clientCA)
 		if err != nil {
 			return errors.Wrap(err, "setup gRPC server")
 		}

--- a/cmd/thanos/store.go
+++ b/cmd/thanos/store.go
@@ -214,7 +214,7 @@ func runStore(
 		return errors.Wrap(err, "listen API address")
 	}
 
-	opts, err := defaultGRPCServerOpts(logger, cert, key, clientCA)
+	opts, err := defaultGRPCTLSServerOpts(logger, cert, key, clientCA)
 	if err != nil {
 		return errors.Wrap(err, "grpc server options")
 	}


### PR DESCRIPTION
This commit gives the Thanos receive component the capability to use TLS
in both the remote-write client and server. This means that Thanos
receive can now authenticate all requests.

In order to accomplish this change, this commit abstracts the majority
of the logic of `defaultGRPCServerOpts` into a reusable func for gRPC
and HTTP servers and creates a similar func for TLS client
configurations.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>

cc @bwplotka @brancz, this is following our conversation yesterday about missing authn and encryption options for Thanos receive.