### PR TITLE
cmd/thanos/main.go: simplify pprof registration

### DIFF
--- a/cmd/thanos/main.go
+++ b/cmd/thanos/main.go
@@ -236,10 +236,6 @@ func registerProfile(mux *http.ServeMux) {
 	mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
 	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
 	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
-	mux.Handle("/debug/pprof/block", pprof.Handler("block"))
-	mux.Handle("/debug/pprof/goroutine", pprof.Handler("goroutine"))
-	mux.Handle("/debug/pprof/heap", pprof.Handler("heap"))
-	mux.Handle("/debug/pprof/threadcreate", pprof.Handler("threadcreate"))
 }
 
 func registerMetrics(mux *http.ServeMux, g prometheus.Gatherer) {


### PR DESCRIPTION
This commit simplifies the registration of pprof HTTP endpoints. The
pprof.Index handler automatically takes care of delegating to the
correct handler for each profile depending on the request path:
https://golang.org/src/net/http/pprof/pprof.go?s=8862:9042#L260
The following profiles are handled:
https://golang.org/src/net/http/pprof/pprof.go?s=7565:8570#L248
Note that this also includes the `allocs` profile, which was previously
not explicitly added.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>

## Verification

Built binary and verified all pprof endpoints continue to function.

cc @bwplotka 