### PR TITLE
cmd/thanos/main_test.go: clarify backwards error

### DIFF
--- a/cmd/thanos/main_test.go
+++ b/cmd/thanos/main_test.go
@@ -81,7 +81,7 @@ func TestCleanupIndexCacheFolder(t *testing.T) {
 	testutil.GatherAndCompare(t, expReg, reg, metricIndexGenerateName)
 
 	_, err = os.Stat(dir)
-	testutil.Assert(t, os.IsNotExist(err), "index cache dir shouldn't not exist at the end of execution")
+	testutil.Assert(t, os.IsNotExist(err), "index cache dir should not exist at the end of execution")
 }
 
 func TestCleanupDownsampleCacheFolder(t *testing.T) {
@@ -116,5 +116,5 @@ func TestCleanupDownsampleCacheFolder(t *testing.T) {
 	testutil.Equals(t, 1.0, promtest.ToFloat64(metrics.downsamples.WithLabelValues(compact.GroupKey(meta.Thanos))))
 
 	_, err = os.Stat(dir)
-	testutil.Assert(t, os.IsNotExist(err), "index cache dir shouldn't not exist at the end of execution")
+	testutil.Assert(t, os.IsNotExist(err), "index cache dir should not exist at the end of execution")
 }


### PR DESCRIPTION
This small PR simply fixes an error message that confused me during a
review.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>