### PR TITLE
.*: Add new http-grace-period flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 
 - [#1660](https://github.com/thanos-io/thanos/pull/1660) Add a new `--prometheus.ready_timeout` CLI option to the sidecar to set how long to wait until Prometheus starts up.
 - [#1573](https://github.com/thanos-io/thanos/pull/1573) `AliYun OSS` object storage, see [documents](docs/storage.md#aliyun-oss-configuration) for further information.
+- [#1680](https://github.com/thanos-io/thanos/pull/1680) Add a new `--http-grace-period` CLI option to components which serve HTTP to set how long to wait until HTTP Server shuts down.
 
 ### Fixed
 

--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -179,7 +179,7 @@ func runCompact(
 
 	statusProber := prober.NewProber(component, logger, prometheus.WrapRegistererWithPrefix("thanos_", reg))
 	// Initiate HTTP listener providing metrics endpoint and readiness/liveness probes.
-	srv := server.New(logger, reg, component, statusProber,
+	srv := server.NewHTTP(logger, reg, component, statusProber,
 		server.WithListen(httpBindAddr),
 		server.WithGracePeriod(httpGracePeriod),
 	)

--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/thanos-io/thanos/pkg/extflag"
+	"github.com/thanos-io/thanos/pkg/server"
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
@@ -79,6 +80,7 @@ func registerCompact(m map[string]setupFunc, app *kingpin.Application) {
 		Hidden().Default("false").Bool()
 
 	httpAddr := regHTTPAddrFlag(cmd)
+	httpGracePeriod := regHTTPGracePeriodFlag(cmd)
 
 	dataDir := cmd.Flag("data-dir", "Data directory in which to cache blocks and process compactions.").
 		Default("./data").String()
@@ -116,6 +118,7 @@ func registerCompact(m map[string]setupFunc, app *kingpin.Application) {
 	m[component.Compact.String()] = func(g *run.Group, logger log.Logger, reg *prometheus.Registry, tracer opentracing.Tracer, _ bool) error {
 		return runCompact(g, logger, reg,
 			*httpAddr,
+			time.Duration(*httpGracePeriod),
 			*dataDir,
 			objStoreConfig,
 			time.Duration(*consistencyDelay),
@@ -143,6 +146,7 @@ func runCompact(
 	logger log.Logger,
 	reg *prometheus.Registry,
 	httpBindAddr string,
+	httpGracePeriod time.Duration,
 	dataDir string,
 	objStoreConfig *extflag.PathOrContent,
 	consistencyDelay time.Duration,
@@ -175,9 +179,12 @@ func runCompact(
 
 	statusProber := prober.NewProber(component, logger, prometheus.WrapRegistererWithPrefix("thanos_", reg))
 	// Initiate HTTP listener providing metrics endpoint and readiness/liveness probes.
-	if err := scheduleHTTPServer(g, logger, reg, statusProber, httpBindAddr, nil, component); err != nil {
-		return errors.Wrap(err, "schedule HTTP server with probes")
-	}
+	srv := server.New(logger, reg, component, statusProber,
+		server.WithListen(httpBindAddr),
+		server.WithGracePeriod(httpGracePeriod),
+	)
+
+	g.Add(srv.ListenAndServe, srv.Shutdown)
 
 	confContentYaml, err := objStoreConfig.Content()
 	if err != nil {

--- a/cmd/thanos/downsample.go
+++ b/cmd/thanos/downsample.go
@@ -126,7 +126,7 @@ func runDownsample(
 	}
 
 	// Initiate HTTP listener providing metrics endpoint and readiness/liveness probes.
-	srv := server.New(logger, reg, comp, statusProber,
+	srv := server.NewHTTP(logger, reg, comp, statusProber,
 		server.WithListen(httpBindAddr),
 		server.WithGracePeriod(httpGracePeriod),
 	)

--- a/cmd/thanos/flags.go
+++ b/cmd/thanos/flags.go
@@ -10,6 +10,13 @@ import (
 	"gopkg.in/alecthomas/kingpin.v2"
 )
 
+func modelDuration(flags *kingpin.FlagClause) *model.Duration {
+	value := new(model.Duration)
+	flags.SetValue(value)
+
+	return value
+}
+
 func regGRPCFlags(cmd *kingpin.CmdClause) (
 	grpcBindAddr *string,
 	grpcTLSSrvCert *string,
@@ -33,11 +40,8 @@ func regHTTPAddrFlag(cmd *kingpin.CmdClause) *string {
 	return cmd.Flag("http-address", "Listen host:port for HTTP endpoints.").Default("0.0.0.0:10902").String()
 }
 
-func modelDuration(flags *kingpin.FlagClause) *model.Duration {
-	value := new(model.Duration)
-	flags.SetValue(value)
-
-	return value
+func regHTTPGracePeriodFlag(cmd *kingpin.CmdClause) *model.Duration {
+	return modelDuration(cmd.Flag("http-grace-period", "The time to wait after an interrupt received.").Default("5s"))
 }
 
 func regCommonObjStoreFlags(cmd *kingpin.CmdClause, suffix string, required bool, extraDesc ...string) *extflag.PathOrContent {

--- a/cmd/thanos/flags.go
+++ b/cmd/thanos/flags.go
@@ -41,7 +41,7 @@ func regHTTPAddrFlag(cmd *kingpin.CmdClause) *string {
 }
 
 func regHTTPGracePeriodFlag(cmd *kingpin.CmdClause) *model.Duration {
-	return modelDuration(cmd.Flag("http-grace-period", "The time to wait after an interrupt received.").Default("5s"))
+	return modelDuration(cmd.Flag("http-grace-period", "Time to wait after an interrupt received for HTTP Server.").Default("5s"))
 }
 
 func regCommonObjStoreFlags(cmd *kingpin.CmdClause, suffix string, required bool, extraDesc ...string) *extflag.PathOrContent {

--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -380,7 +380,7 @@ func runQuery(
 		api.Register(router.WithPrefix(path.Join(webRoutePrefix, "/api/v1")), tracer, logger, ins)
 
 		// Initiate HTTP listener providing metrics endpoint and readiness/liveness probes.
-		srv := server.New(logger, reg, comp, statusProber,
+		srv := server.NewHTTP(logger, reg, comp, statusProber,
 			server.WithListen(httpBindAddr),
 			server.WithGracePeriod(httpGracePeriod),
 		)

--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -31,6 +31,7 @@ import (
 	"github.com/thanos-io/thanos/pkg/query"
 	v1 "github.com/thanos-io/thanos/pkg/query/api"
 	"github.com/thanos-io/thanos/pkg/runutil"
+	"github.com/thanos-io/thanos/pkg/server"
 	"github.com/thanos-io/thanos/pkg/store"
 	"github.com/thanos-io/thanos/pkg/tracing"
 	"github.com/thanos-io/thanos/pkg/ui"
@@ -45,6 +46,7 @@ func registerQuery(m map[string]setupFunc, app *kingpin.Application) {
 	cmd := app.Command(comp.String(), "query node exposing PromQL enabled Query API with data retrieved from multiple store nodes")
 
 	httpBindAddr := regHTTPAddrFlag(cmd)
+	httpGracePeriod := regHTTPGracePeriodFlag(cmd)
 	grpcBindAddr, srvCert, srvKey, srvClientCA := regGRPCFlags(cmd)
 
 	secure := cmd.Flag("grpc-client-tls-secure", "Use TLS when talking to the gRPC server").Default("false").Bool()
@@ -140,6 +142,7 @@ func registerQuery(m map[string]setupFunc, app *kingpin.Application) {
 			*caCert,
 			*serverName,
 			*httpBindAddr,
+			time.Duration(*httpGracePeriod),
 			*webRoutePrefix,
 			*webExternalPrefix,
 			*webPrefixHeaderName,
@@ -222,6 +225,7 @@ func runQuery(
 	caCert string,
 	serverName string,
 	httpBindAddr string,
+	httpGracePeriod time.Duration,
 	webRoutePrefix string,
 	webExternalPrefix string,
 	webPrefixHeaderName string,
@@ -376,9 +380,13 @@ func runQuery(
 		api.Register(router.WithPrefix(path.Join(webRoutePrefix, "/api/v1")), tracer, logger, ins)
 
 		// Initiate HTTP listener providing metrics endpoint and readiness/liveness probes.
-		if err := scheduleHTTPServer(g, logger, reg, statusProber, httpBindAddr, router, comp); err != nil {
-			return errors.Wrap(err, "schedule HTTP server with probes")
-		}
+		srv := server.New(logger, reg, comp, statusProber,
+			server.WithListen(httpBindAddr),
+			server.WithGracePeriod(httpGracePeriod),
+		)
+		srv.Handle("/", router)
+
+		g.Add(srv.ListenAndServe, srv.Shutdown)
 	}
 	// Start query (proxy) gRPC StoreAPI.
 	{

--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/thanos-io/thanos/pkg/extflag"
+	"github.com/thanos-io/thanos/pkg/server"
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
@@ -36,6 +37,7 @@ func registerReceive(m map[string]setupFunc, app *kingpin.Application) {
 	cmd := app.Command(comp.String(), "Accept Prometheus remote write API requests and write to local tsdb (EXPERIMENTAL, this may change drastically without notice)")
 
 	httpBindAddr := regHTTPAddrFlag(cmd)
+	httpGracePeriod := regHTTPGracePeriodFlag(cmd)
 	grpcBindAddr, grpcCert, grpcKey, grpcClientCA := regGRPCFlags(cmd)
 
 	rwAddress := cmd.Flag("remote-write.address", "Address to listen on for remote write requests.").
@@ -109,6 +111,7 @@ func registerReceive(m map[string]setupFunc, app *kingpin.Application) {
 			*grpcKey,
 			*grpcClientCA,
 			*httpBindAddr,
+			time.Duration(*httpGracePeriod),
 			*rwAddress,
 			*rwServerCert,
 			*rwServerKey,
@@ -142,6 +145,7 @@ func runReceive(
 	grpcKey string,
 	grpcClientCA string,
 	httpBindAddr string,
+	httpGracePeriod time.Duration,
 	rwAddress string,
 	rwServerCert string,
 	rwServerKey string,
@@ -335,9 +339,11 @@ func runReceive(
 
 	level.Debug(logger).Log("msg", "setting up http server")
 	// Initiate HTTP listener providing metrics endpoint and readiness/liveness probes.
-	if err := scheduleHTTPServer(g, logger, reg, statusProber, httpBindAddr, nil, comp); err != nil {
-		return errors.Wrap(err, "schedule HTTP server with probes")
-	}
+	srv := server.New(logger, reg, comp, statusProber,
+		server.WithListen(httpBindAddr),
+		server.WithGracePeriod(httpGracePeriod),
+	)
+	g.Add(srv.ListenAndServe, srv.Shutdown)
 
 	level.Debug(logger).Log("msg", "setting up grpc server")
 	{

--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -339,7 +339,7 @@ func runReceive(
 
 	level.Debug(logger).Log("msg", "setting up http server")
 	// Initiate HTTP listener providing metrics endpoint and readiness/liveness probes.
-	srv := server.New(logger, reg, comp, statusProber,
+	srv := server.NewHTTP(logger, reg, comp, statusProber,
 		server.WithListen(httpBindAddr),
 		server.WithGracePeriod(httpGracePeriod),
 	)

--- a/cmd/thanos/rule.go
+++ b/cmd/thanos/rule.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/thanos-io/thanos/pkg/extflag"
+	"github.com/thanos-io/thanos/pkg/server"
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
@@ -62,6 +63,7 @@ func registerRule(m map[string]setupFunc, app *kingpin.Application) {
 	cmd := app.Command(comp.String(), "ruler evaluating Prometheus rules against given Query nodes, exposing Store API and storing old blocks in bucket")
 
 	httpBindAddr := regHTTPAddrFlag(cmd)
+	httpGracePeriod := regHTTPGracePeriodFlag(cmd)
 	grpcBindAddr, cert, key, clientCA := regGRPCFlags(cmd)
 
 	labelStrs := cmd.Flag("label", "Labels to be applied to all generated metrics (repeated). Similar to external labels for Prometheus, used to identify ruler and its blocks as unique source.").
@@ -161,6 +163,7 @@ func registerRule(m map[string]setupFunc, app *kingpin.Application) {
 			*key,
 			*clientCA,
 			*httpBindAddr,
+			time.Duration(*httpGracePeriod),
 			*webRoutePrefix,
 			*webExternalPrefix,
 			*webPrefixHeaderName,
@@ -196,6 +199,7 @@ func runRule(
 	key string,
 	clientCA string,
 	httpBindAddr string,
+	httpGracePeriod time.Duration,
 	webRoutePrefix string,
 	webExternalPrefix string,
 	webPrefixHeaderName string,
@@ -548,9 +552,13 @@ func runRule(
 		api.Register(router.WithPrefix(path.Join(webRoutePrefix, "/api/v1")), tracer, logger, ins)
 
 		// Initiate HTTP listener providing metrics endpoint and readiness/liveness probes.
-		if err := scheduleHTTPServer(g, logger, reg, statusProber, httpBindAddr, router, comp); err != nil {
-			return errors.Wrap(err, "schedule HTTP server with probes")
-		}
+		srv := server.New(logger, reg, comp, statusProber,
+			server.WithListen(httpBindAddr),
+			server.WithGracePeriod(httpGracePeriod),
+		)
+		srv.Handle("/", router)
+
+		g.Add(srv.ListenAndServe, srv.Shutdown)
 	}
 
 	confContentYaml, err := objStoreConfig.Content()

--- a/cmd/thanos/rule.go
+++ b/cmd/thanos/rule.go
@@ -552,7 +552,7 @@ func runRule(
 		api.Register(router.WithPrefix(path.Join(webRoutePrefix, "/api/v1")), tracer, logger, ins)
 
 		// Initiate HTTP listener providing metrics endpoint and readiness/liveness probes.
-		srv := server.New(logger, reg, comp, statusProber,
+		srv := server.NewHTTP(logger, reg, comp, statusProber,
 			server.WithListen(httpBindAddr),
 			server.WithGracePeriod(httpGracePeriod),
 		)

--- a/cmd/thanos/sidecar.go
+++ b/cmd/thanos/sidecar.go
@@ -140,7 +140,7 @@ func runSidecar(
 
 	// Initiate HTTP listener providing metrics endpoint and readiness/liveness probes.
 	statusProber := prober.NewProber(comp, logger, prometheus.WrapRegistererWithPrefix("thanos_", reg))
-	srv := server.New(logger, reg, comp, statusProber,
+	srv := server.NewHTTP(logger, reg, comp, statusProber,
 		server.WithListen(httpBindAddr),
 		server.WithGracePeriod(httpGracePeriod),
 	)

--- a/cmd/thanos/store.go
+++ b/cmd/thanos/store.go
@@ -132,7 +132,7 @@ func runStore(
 ) error {
 	// Initiate HTTP listener providing metrics endpoint and readiness/liveness probes.
 	statusProber := prober.NewProber(component, logger, prometheus.WrapRegistererWithPrefix("thanos_", reg))
-	srv := server.New(logger, reg, component, statusProber,
+	srv := server.NewHTTP(logger, reg, component, statusProber,
 		server.WithListen(httpBindAddr),
 		server.WithGracePeriod(httpGracePeriod),
 	)

--- a/cmd/thanos/store.go
+++ b/cmd/thanos/store.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/thanos-io/thanos/pkg/extflag"
+	"github.com/thanos-io/thanos/pkg/server"
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
@@ -30,6 +31,7 @@ func registerStore(m map[string]setupFunc, app *kingpin.Application) {
 	cmd := app.Command(component.Store.String(), "store node giving access to blocks in a bucket provider. Now supported GCS, S3, Azure, Swift and Tencent COS.")
 
 	httpBindAddr := regHTTPAddrFlag(cmd)
+	httpGracePeriod := regHTTPGracePeriodFlag(cmd)
 	grpcBindAddr, cert, key, clientCA := regGRPCFlags(cmd)
 
 	dataDir := cmd.Flag("data-dir", "Data directory in which to cache remote blocks.").
@@ -83,6 +85,7 @@ func registerStore(m map[string]setupFunc, app *kingpin.Application) {
 			*key,
 			*clientCA,
 			*httpBindAddr,
+			time.Duration(*httpGracePeriod),
 			uint64(*indexCacheSize),
 			uint64(*chunkPoolSize),
 			uint64(*maxSampleCount),
@@ -114,6 +117,7 @@ func runStore(
 	key string,
 	clientCA string,
 	httpBindAddr string,
+	httpGracePeriod time.Duration,
 	indexCacheSizeBytes uint64,
 	chunkPoolSizeBytes uint64,
 	maxSampleCount uint64,
@@ -128,9 +132,12 @@ func runStore(
 ) error {
 	// Initiate HTTP listener providing metrics endpoint and readiness/liveness probes.
 	statusProber := prober.NewProber(component, logger, prometheus.WrapRegistererWithPrefix("thanos_", reg))
-	if err := scheduleHTTPServer(g, logger, reg, statusProber, httpBindAddr, nil, component); err != nil {
-		return errors.Wrap(err, "schedule HTTP server")
-	}
+	srv := server.New(logger, reg, component, statusProber,
+		server.WithListen(httpBindAddr),
+		server.WithGracePeriod(httpGracePeriod),
+	)
+
+	g.Add(srv.ListenAndServe, srv.Shutdown)
 
 	confContentYaml, err := objStoreConfig.Content()
 	if err != nil {

--- a/docs/components/compact.md
+++ b/docs/components/compact.md
@@ -84,6 +84,8 @@ Flags:
                                https://thanos.io/tracing.md/#configuration
       --http-address="0.0.0.0:10902"
                                Listen host:port for HTTP endpoints.
+      --http-grace-period=5s   Time to wait after an interrupt received for HTTP
+                               Server.
       --data-dir="./data"      Data directory in which to cache blocks and
                                process compactions.
       --objstore.config-file=<file-path>

--- a/docs/components/query.md
+++ b/docs/components/query.md
@@ -259,6 +259,8 @@ Flags:
                                  https://thanos.io/tracing.md/#configuration
       --http-address="0.0.0.0:10902"
                                  Listen host:port for HTTP endpoints.
+      --http-grace-period=5s     Time to wait after an interrupt received for
+                                 HTTP Server.
       --grpc-address="0.0.0.0:10901"
                                  Listen ip:port address for gRPC endpoints
                                  (StoreAPI). Make sure this address is routable

--- a/docs/components/rule.md
+++ b/docs/components/rule.md
@@ -168,6 +168,8 @@ Flags:
                                  https://thanos.io/tracing.md/#configuration
       --http-address="0.0.0.0:10902"
                                  Listen host:port for HTTP endpoints.
+      --http-grace-period=5s     Time to wait after an interrupt received for
+                                 HTTP Server.
       --grpc-address="0.0.0.0:10901"
                                  Listen ip:port address for gRPC endpoints
                                  (StoreAPI). Make sure this address is routable

--- a/docs/components/sidecar.md
+++ b/docs/components/sidecar.md
@@ -101,6 +101,8 @@ Flags:
                                  https://thanos.io/tracing.md/#configuration
       --http-address="0.0.0.0:10902"
                                  Listen host:port for HTTP endpoints.
+      --http-grace-period=5s     Time to wait after an interrupt received for
+                                 HTTP Server.
       --grpc-address="0.0.0.0:10901"
                                  Listen ip:port address for gRPC endpoints
                                  (StoreAPI). Make sure this address is routable

--- a/docs/components/store.md
+++ b/docs/components/store.md
@@ -51,6 +51,8 @@ Flags:
                                  https://thanos.io/tracing.md/#configuration
       --http-address="0.0.0.0:10902"
                                  Listen host:port for HTTP endpoints.
+      --http-grace-period=5s     Time to wait after an interrupt received for
+                                 HTTP Server.
       --grpc-address="0.0.0.0:10901"
                                  Listen ip:port address for gRPC endpoints
                                  (StoreAPI). Make sure this address is routable

--- a/pkg/server/http.go
+++ b/pkg/server/http.go
@@ -1,0 +1,102 @@
+package server
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/pprof"
+	"time"
+
+	"github.com/thanos-io/thanos/pkg/component"
+	"github.com/thanos-io/thanos/pkg/prober"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+type Server struct {
+	logger log.Logger
+	comp   component.Component
+	prober *prober.Prober
+
+	mux      *http.ServeMux
+	srv      *http.Server
+	listener net.Listener
+
+	opts options
+}
+
+func New(logger log.Logger, reg *prometheus.Registry, comp component.Component, prober *prober.Prober, opts ...Option) Server {
+	options := options{
+		gracePeriod: 5 * time.Second,
+		listen:      "0.0.0.0:10902",
+	}
+
+	for _, o := range opts {
+		o.apply(&options)
+	}
+
+	mux := http.NewServeMux()
+	registerMetrics(mux, reg)
+	registerProfiler(mux)
+	prober.RegisterInMux(mux)
+
+	return Server{
+		logger: log.With(logger, "service", "http/server"),
+		comp:   comp,
+		prober: prober,
+		mux:    mux,
+		srv:    &http.Server{Addr: options.listen, Handler: mux},
+		opts:   options,
+	}
+}
+
+func (s *Server) ListenAndServe() error {
+	l, err := net.Listen("tcp", s.opts.listen)
+	if err != nil {
+		return errors.Wrap(err, "listen metrics address")
+	}
+	s.listener = l
+	s.prober.SetHealthy()
+	level.Info(s.logger).Log("msg", "listening for requests and metrics", "component", s.comp.String(), "address", s.opts.listen)
+
+	return errors.Wrapf(http.Serve(l, s.mux), "serve %s and metrics", s.comp.String())
+}
+
+func (s *Server) Shutdown(err error) {
+	s.prober.SetNotReady(err)
+	defer s.prober.SetNotHealthy(err)
+
+	if err == http.ErrServerClosed {
+		level.Warn(s.logger).Log("msg", "internal server closed unexpectedly")
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), s.opts.gracePeriod)
+	defer cancel()
+
+	level.Info(s.logger).Log("msg", "server shut down internal server")
+
+	if err := s.srv.Shutdown(ctx); err != nil {
+		level.Error(s.logger).Log("msg", "server shut down failed", "err", err, "component", s.comp.String())
+	}
+}
+
+func (s *Server) Handle(pattern string, handler http.Handler) {
+	s.mux.Handle(pattern, handler)
+}
+
+func registerProfiler(mux *http.ServeMux) {
+	mux.HandleFunc("/debug/pprof/", pprof.Index)
+	mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+}
+
+func registerMetrics(mux *http.ServeMux, g prometheus.Gatherer) {
+	mux.Handle("/metrics", promhttp.HandlerFor(g, promhttp.HandlerOpts{}))
+}

--- a/pkg/server/http.go
+++ b/pkg/server/http.go
@@ -29,7 +29,7 @@ type Server struct {
 	opts options
 }
 
-func New(logger log.Logger, reg *prometheus.Registry, comp component.Component, prober *prober.Prober, opts ...Option) Server {
+func NewHTTP(logger log.Logger, reg *prometheus.Registry, comp component.Component, prober *prober.Prober, opts ...Option) Server {
 	options := options{
 		gracePeriod: 5 * time.Second,
 		listen:      "0.0.0.0:10902",

--- a/pkg/server/option.go
+++ b/pkg/server/option.go
@@ -1,0 +1,33 @@
+package server
+
+import (
+	"time"
+)
+
+type options struct {
+	gracePeriod time.Duration
+	listen      string
+}
+
+// Option overrides behavior of Server.
+type Option interface {
+	apply(*options)
+}
+
+type optionFunc func(*options)
+
+func (f optionFunc) apply(o *options) {
+	f(o)
+}
+
+func WithGracePeriod(t time.Duration) Option {
+	return optionFunc(func(o *options) {
+		o.gracePeriod = t
+	})
+}
+
+func WithListen(s string) Option {
+	return optionFunc(func(o *options) {
+		o.listen = s
+	})
+}


### PR DESCRIPTION
This PR adds a new CLI flag to components which serve HTTP, called `--http-grace-period`.
Also refactors existing code and introduces a new HTTP server package, to increase the clarity of the `run.Group` scheduling.

cc @bwplotka @FUSAKLA 

Signed-off-by: Kemal Akkoyun <kakkoyun@gmail.com>

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end-user.

## Changes

* Adds new `--http-grace-period` CLI flag to components which serve HTTP.
* Removes `scheduleHTTPServer` function and introduces a new package to handle HTTP serving.

## Verification

* `make local-test`
* `./scripts/quickstart.sh`
