### PR TITLE
Simplify prober

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 - [#1666](https://github.com/thanos-io/thanos/pull/1666) `thanos_compact_group_compactions_total` now counts block compactions, so operations that resulted in a compacted block. The old behaviour
 is now exposed by new metric: `thanos_compact_group_compaction_runs_started_total` and `thanos_compact_group_compaction_runs_completed_total` which counts compaction runs overall.
 - [#1748](https://github.com/thanos-io/thanos/pull/1748) Updated all dependencies.
+- [#1694](https://github.com/thanos-io/thanos/pull/1694) `prober_ready` and `prober_healthy` metrics are removed, for sake of `status`. Now `status` exposes same metric with a label, `check`. `check` can have "healty" or "ready" depending on status of the probe.
 
 ## [v0.8.1](https://github.com/thanos-io/thanos/releases/tag/v0.8.1) - 2019.10.14
 

--- a/cmd/thanos/bucket.go
+++ b/cmd/thanos/bucket.go
@@ -318,7 +318,7 @@ func registerBucketWeb(m map[string]setupFunc, root *kingpin.CmdClause, name str
 	m[name+" web"] = func(g *run.Group, logger log.Logger, reg *prometheus.Registry, _ opentracing.Tracer, _ bool) error {
 		ctx, cancel := context.WithCancel(context.Background())
 
-		statusProber := prober.NewProber(component.Bucket, logger, prometheus.WrapRegistererWithPrefix("thanos_", reg))
+		statusProber := prober.New(component.Bucket, logger, prometheus.WrapRegistererWithPrefix("thanos_", reg))
 		// Initiate HTTP listener providing metrics endpoint and readiness/liveness probes.
 		srv := httpserver.New(logger, reg, component.Bucket, statusProber,
 			httpserver.WithListen(*httpBindAddr),

--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -189,9 +189,12 @@ func runCompact(
 
 	g.Add(func() error {
 		statusProber.Healthy()
+
 		return srv.ListenAndServe()
 	}, func(err error) {
 		statusProber.NotReady(err)
+		defer statusProber.NotHealthy(err)
+
 		srv.Shutdown(err)
 	})
 

--- a/cmd/thanos/downsample.go
+++ b/cmd/thanos/downsample.go
@@ -96,14 +96,14 @@ func runDownsample(
 	}()
 
 	metrics := newDownsampleMetrics(reg)
-	statusProber := prober.NewProber(comp, logger, prometheus.WrapRegistererWithPrefix("thanos_", reg))
+	statusProber := prober.New(comp, logger, prometheus.WrapRegistererWithPrefix("thanos_", reg))
 	// Start cycle of syncing blocks from the bucket and garbage collecting the bucket.
 	{
 		ctx, cancel := context.WithCancel(context.Background())
 
 		g.Add(func() error {
 			defer runutil.CloseWithLogOnErr(logger, bkt, "bucket client")
-			statusProber.SetReady()
+			statusProber.Ready()
 
 			level.Info(logger).Log("msg", "start first pass of downsampling")
 
@@ -128,7 +128,13 @@ func runDownsample(
 		httpserver.WithListen(httpBindAddr),
 		httpserver.WithGracePeriod(httpGracePeriod),
 	)
-	g.Add(srv.ListenAndServe, srv.Shutdown)
+	g.Add(func() error {
+		statusProber.Healthy()
+		return srv.ListenAndServe()
+	}, func(err error) {
+		statusProber.NotReady(err)
+		srv.Shutdown(err)
+	})
 
 	level.Info(logger).Log("msg", "starting downsample node")
 	return nil

--- a/cmd/thanos/downsample.go
+++ b/cmd/thanos/downsample.go
@@ -130,9 +130,12 @@ func runDownsample(
 	)
 	g.Add(func() error {
 		statusProber.Healthy()
+
 		return srv.ListenAndServe()
 	}, func(err error) {
 		statusProber.NotReady(err)
+		defer statusProber.NotHealthy(err)
+
 		srv.Shutdown(err)
 	})
 

--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -388,9 +388,12 @@ func runQuery(
 
 		g.Add(func() error {
 			statusProber.Healthy()
+
 			return srv.ListenAndServe()
 		}, func(err error) {
 			statusProber.NotReady(err)
+			defer statusProber.NotHealthy(err)
+
 			srv.Shutdown(err)
 		})
 	}

--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -355,7 +355,7 @@ func runQuery(
 	}
 	// Start query API + UI HTTP server.
 
-	statusProber := prober.NewProber(comp, logger, reg)
+	statusProber := prober.New(comp, logger, reg)
 	{
 		router := route.New()
 
@@ -386,7 +386,13 @@ func runQuery(
 		)
 		srv.Handle("/", router)
 
-		g.Add(srv.ListenAndServe, srv.Shutdown)
+		g.Add(func() error {
+			statusProber.Healthy()
+			return srv.ListenAndServe()
+		}, func(err error) {
+			statusProber.NotReady(err)
+			srv.Shutdown(err)
+		})
 	}
 	// Start query (proxy) gRPC StoreAPI.
 	{
@@ -402,10 +408,10 @@ func runQuery(
 		)
 
 		g.Add(func() error {
-			statusProber.SetReady()
+			statusProber.Ready()
 			return s.ListenAndServe()
-		}, func(err error) {
-			statusProber.SetNotReady(err)
+		}, func(error) {
+			statusProber.NotReady(err)
 			s.Shutdown(err)
 		})
 	}

--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -339,9 +339,12 @@ func runReceive(
 	)
 	g.Add(func() error {
 		statusProber.Healthy()
+
 		return srv.ListenAndServe()
 	}, func(err error) {
 		statusProber.NotReady(err)
+		defer statusProber.NotHealthy(err)
+
 		srv.Shutdown(err)
 	})
 

--- a/cmd/thanos/rule.go
+++ b/cmd/thanos/rule.go
@@ -562,9 +562,12 @@ func runRule(
 
 		g.Add(func() error {
 			statusProber.Healthy()
+
 			return srv.ListenAndServe()
 		}, func(err error) {
 			statusProber.NotReady(err)
+			defer statusProber.NotHealthy(err)
+
 			srv.Shutdown(err)
 		})
 	}

--- a/cmd/thanos/sidecar.go
+++ b/cmd/thanos/sidecar.go
@@ -148,9 +148,12 @@ func runSidecar(
 
 	g.Add(func() error {
 		statusProber.Healthy()
+
 		return srv.ListenAndServe()
 	}, func(err error) {
 		statusProber.NotReady(err)
+		defer statusProber.NotHealthy(err)
+
 		srv.Shutdown(err)
 	})
 

--- a/cmd/thanos/sidecar.go
+++ b/cmd/thanos/sidecar.go
@@ -140,13 +140,19 @@ func runSidecar(
 	}
 
 	// Initiate HTTP listener providing metrics endpoint and readiness/liveness probes.
-	statusProber := prober.NewProber(comp, logger, prometheus.WrapRegistererWithPrefix("thanos_", reg))
+	statusProber := prober.New(comp, logger, prometheus.WrapRegistererWithPrefix("thanos_", reg))
 	srv := httpserver.New(logger, reg, comp, statusProber,
 		httpserver.WithListen(httpBindAddr),
 		httpserver.WithGracePeriod(httpGracePeriod),
 	)
 
-	g.Add(srv.ListenAndServe, srv.Shutdown)
+	g.Add(func() error {
+		statusProber.Healthy()
+		return srv.ListenAndServe()
+	}, func(err error) {
+		statusProber.NotReady(err)
+		srv.Shutdown(err)
+	})
 
 	// Setup all the concurrent groups.
 	{
@@ -179,7 +185,7 @@ func runSidecar(
 						"err", err,
 					)
 					promUp.Set(0)
-					statusProber.SetNotReady(err)
+					statusProber.NotReady(err)
 					return err
 				}
 
@@ -188,7 +194,7 @@ func runSidecar(
 					"external_labels", m.Labels().String(),
 				)
 				promUp.Set(1)
-				statusProber.SetReady()
+				statusProber.Ready()
 				lastHeartbeat.Set(float64(time.Now().UnixNano()) / 1e9)
 				return nil
 			})
@@ -247,10 +253,10 @@ func runSidecar(
 			grpcserver.WithTLSConfig(tlsCfg),
 		)
 		g.Add(func() error {
-			statusProber.SetReady()
+			statusProber.Ready()
 			return s.ListenAndServe()
 		}, func(err error) {
-			statusProber.SetNotReady(err)
+			statusProber.NotReady(err)
 			s.Shutdown(err)
 		})
 	}

--- a/cmd/thanos/store.go
+++ b/cmd/thanos/store.go
@@ -140,9 +140,12 @@ func runStore(
 
 	g.Add(func() error {
 		statusProber.Healthy()
+
 		return srv.ListenAndServe()
 	}, func(err error) {
 		statusProber.NotReady(err)
+		defer statusProber.NotHealthy(err)
+
 		srv.Shutdown(err)
 	})
 


### PR DESCRIPTION
This PR aims to simplify `prober` implementation by keeping its existing behaviour.
It also tries to simplify API and tries to use more idiomatic go naming for methods.
It also moves prober API touchpoints to `server/http` call sites to make the usage more explicit.
These changes are purely cosmetic and just to increase the maintainability of the package, you can ignore this PR, if you think the changes don't provide any value.

Signed-off-by: Kemal Akkoyun <kakkoyun@gmail.com>

* [X] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

* Refactor `prober` and its usages for sake of simplicity.

## Verification

Runs local test to ensure nothing changed, `make test-local`.
