### PR TITLE
cmd/thanos/bucket: expose metrics

### DIFF
--- a/cmd/thanos/bucket.go
+++ b/cmd/thanos/bucket.go
@@ -4,23 +4,23 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"net"
-	"net/http"
 	"os"
 	"sort"
 	"strings"
 	"text/template"
 	"time"
 
-	"github.com/thanos-io/thanos/pkg/extflag"
-
 	"github.com/thanos-io/thanos/pkg/block"
 	"github.com/thanos-io/thanos/pkg/block/metadata"
 	"github.com/thanos-io/thanos/pkg/compact"
+	"github.com/thanos-io/thanos/pkg/component"
+	"github.com/thanos-io/thanos/pkg/extflag"
 	extpromhttp "github.com/thanos-io/thanos/pkg/extprom/http"
 	"github.com/thanos-io/thanos/pkg/objstore"
 	"github.com/thanos-io/thanos/pkg/objstore/client"
+	"github.com/thanos-io/thanos/pkg/prober"
 	"github.com/thanos-io/thanos/pkg/runutil"
+	"github.com/thanos-io/thanos/pkg/server"
 	"github.com/thanos-io/thanos/pkg/ui"
 	"github.com/thanos-io/thanos/pkg/verifier"
 
@@ -32,7 +32,6 @@ import (
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/common/route"
 	"github.com/prometheus/prometheus/tsdb/labels"
 	"golang.org/x/text/language"
 	"golang.org/x/text/message"
@@ -312,6 +311,7 @@ func registerBucketInspect(m map[string]setupFunc, root *kingpin.CmdClause, name
 func registerBucketWeb(m map[string]setupFunc, root *kingpin.CmdClause, name string, objStoreConfig *extflag.PathOrContent) {
 	cmd := root.Command("web", "Web interface for remote storage bucket")
 	bind := cmd.Flag("listen", "HTTP host:port to listen on").Default("0.0.0.0:8080").String()
+	httpGracePeriod := regHTTPGracePeriodFlag(cmd)
 	interval := cmd.Flag("refresh", "Refresh interval to download metadata from remote storage").Default("30m").Duration()
 	timeout := cmd.Flag("timeout", "Timeout to download metadata from remote storage").Default("5m").Duration()
 	label := cmd.Flag("label", "Prometheus label to use as timeline title").String()
@@ -319,9 +319,15 @@ func registerBucketWeb(m map[string]setupFunc, root *kingpin.CmdClause, name str
 	m[name+" web"] = func(g *run.Group, logger log.Logger, reg *prometheus.Registry, _ opentracing.Tracer, _ bool) error {
 		ctx, cancel := context.WithCancel(context.Background())
 
-		router := route.New()
+		statusProber := prober.NewProber(component.Bucket, logger, prometheus.WrapRegistererWithPrefix("thanos_", reg))
+		// Initiate HTTP listener providing metrics endpoint and readiness/liveness probes.
+		srv := server.NewHTTP(logger, reg, component.Bucket, statusProber,
+			server.WithListen(*bind),
+			server.WithGracePeriod(time.Duration(*httpGracePeriod)),
+		)
+
 		bucketUI := ui.NewBucketUI(logger, *label)
-		bucketUI.Register(router, extpromhttp.NewInstrumentationMiddleware(reg))
+		bucketUI.Register(srv, extpromhttp.NewInstrumentationMiddleware(reg))
 
 		if *interval < 5*time.Minute {
 			level.Warn(logger).Log("msg", "Refreshing more often than 5m could lead to large data transfers")
@@ -341,17 +347,7 @@ func registerBucketWeb(m map[string]setupFunc, root *kingpin.CmdClause, name str
 			cancel()
 		})
 
-		l, err := net.Listen("tcp", *bind)
-		if err != nil {
-			return errors.Wrapf(err, "listen HTTP on address %s", *bind)
-		}
-
-		g.Add(func() error {
-			level.Info(logger).Log("msg", "Listening for query and metrics", "address", *bind)
-			return errors.Wrap(http.Serve(l, router), "serve web")
-		}, func(error) {
-			runutil.CloseWithLogOnErr(logger, l, "http listener")
-		})
+		g.Add(srv.ListenAndServe, srv.Shutdown)
 
 		return nil
 	}

--- a/docs/components/bucket.md
+++ b/docs/components/bucket.md
@@ -122,6 +122,8 @@ Flags:
                                object store configuration. See format details:
                                https://thanos.io/storage.md/#configuration
       --listen="0.0.0.0:8080"  HTTP host:port to listen on
+      --http-grace-period=5s   Time to wait after an interrupt received for HTTP
+                               Server.
       --refresh=30m            Refresh interval to download metadata from remote
                                storage
       --timeout=5m             Timeout to download metadata from remote storage

--- a/pkg/ui/bucket.go
+++ b/pkg/ui/bucket.go
@@ -6,8 +6,8 @@ import (
 	"time"
 
 	"github.com/go-kit/kit/log"
-	"github.com/prometheus/common/route"
 	extpromhttp "github.com/thanos-io/thanos/pkg/extprom/http"
+	"github.com/thanos-io/thanos/pkg/server"
 )
 
 // Bucket is a web UI representing state of buckets as a timeline.
@@ -30,13 +30,13 @@ func NewBucketUI(logger log.Logger, label string) *Bucket {
 }
 
 // Register registers http routes for bucket UI.
-func (b *Bucket) Register(r *route.Router, ins extpromhttp.InstrumentationMiddleware) {
+func (b *Bucket) Register(s server.Server, ins extpromhttp.InstrumentationMiddleware) {
 	instrf := func(name string, next func(w http.ResponseWriter, r *http.Request)) http.HandlerFunc {
 		return ins.NewHandler(name, http.HandlerFunc(next))
 	}
 
-	r.Get("/", instrf("root", b.root))
-	r.Get("/static/*filepath", instrf("static", b.serveStaticAsset))
+	s.Handle("/", instrf("root", b.root))
+	s.Handle("/static/*filepath", instrf("static", b.serveStaticAsset))
 }
 
 // Handle / of bucket UIs.


### PR DESCRIPTION
Currently, the bucket web command generates and registers metrics but
they are never actually exposed. This commit ensures that the metrics
are exposed and leverages the recently created server package for
consistency.

This cleanup also helps prepare for the upcoming changes for
https://github.com/thanos-io/thanos/issues/1657.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>

Changelog entry is already covered by #1680 

## Verification
Launched bucket web component before and after change and ensured that metrics are exposed.