### PR TITLE
cmd/thanos/bucket: remove unused flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 - [#1660](https://github.com/thanos-io/thanos/pull/1660) Add a new `--prometheus.ready_timeout` CLI option to the sidecar to set how long to wait until Prometheus starts up.
 - [#1573](https://github.com/thanos-io/thanos/pull/1573) `AliYun OSS` object storage, see [documents](docs/storage.md#aliyun-oss) for further information.
 - [#1680](https://github.com/thanos-io/thanos/pull/1680) Add a new `--http-grace-period` CLI option to components which serve HTTP to set how long to wait until HTTP Server shuts down.
+- [#1712](https://github.com/thanos-io/thanos/pull/1712) Rename flag on bucket web component from `--listen` to `--http-address` to match other components.
 
 ### Fixed
 

--- a/cmd/thanos/bucket.go
+++ b/cmd/thanos/bucket.go
@@ -309,8 +309,7 @@ func registerBucketInspect(m map[string]setupFunc, root *kingpin.CmdClause, name
 // registerBucketWeb exposes a web interface for the state of remote store like `pprof web`.
 func registerBucketWeb(m map[string]setupFunc, root *kingpin.CmdClause, name string, objStoreConfig *extflag.PathOrContent) {
 	cmd := root.Command("web", "Web interface for remote storage bucket")
-	bind := cmd.Flag("listen", "HTTP host:port to listen on").Default("0.0.0.0:8080").String()
-	_, httpGracePeriod := regHTTPFlags(cmd)
+	httpBindAddr, httpGracePeriod := regHTTPFlags(cmd)
 	interval := cmd.Flag("refresh", "Refresh interval to download metadata from remote storage").Default("30m").Duration()
 	timeout := cmd.Flag("timeout", "Timeout to download metadata from remote storage").Default("5m").Duration()
 	label := cmd.Flag("label", "Prometheus label to use as timeline title").String()
@@ -321,7 +320,7 @@ func registerBucketWeb(m map[string]setupFunc, root *kingpin.CmdClause, name str
 		statusProber := prober.NewProber(component.Bucket, logger, prometheus.WrapRegistererWithPrefix("thanos_", reg))
 		// Initiate HTTP listener providing metrics endpoint and readiness/liveness probes.
 		srv := httpserver.New(logger, reg, component.Bucket, statusProber,
-			httpserver.WithListen(*bind),
+			httpserver.WithListen(*httpBindAddr),
 			httpserver.WithGracePeriod(time.Duration(*httpGracePeriod)),
 		)
 

--- a/docs/components/bucket.md
+++ b/docs/components/bucket.md
@@ -98,38 +98,37 @@ usage: thanos bucket web [<flags>]
 Web interface for remote storage bucket
 
 Flags:
-  -h, --help                   Show context-sensitive help (also try --help-long
-                               and --help-man).
-      --version                Show application version.
-      --log.level=info         Log filtering level.
-      --log.format=logfmt      Log format to use.
+  -h, --help                  Show context-sensitive help (also try --help-long
+                              and --help-man).
+      --version               Show application version.
+      --log.level=info        Log filtering level.
+      --log.format=logfmt     Log format to use.
       --tracing.config-file=<file-path>
-                               Path to YAML file with tracing configuration. See
-                               format details:
-                               https://thanos.io/tracing.md/#configuration
+                              Path to YAML file with tracing configuration. See
+                              format details:
+                              https://thanos.io/tracing.md/#configuration
       --tracing.config=<content>
-                               Alternative to 'tracing.config-file' flag (lower
-                               priority). Content of YAML file with tracing
-                               configuration. See format details:
-                               https://thanos.io/tracing.md/#configuration
+                              Alternative to 'tracing.config-file' flag (lower
+                              priority). Content of YAML file with tracing
+                              configuration. See format details:
+                              https://thanos.io/tracing.md/#configuration
       --objstore.config-file=<file-path>
-                               Path to YAML file that contains object store
-                               configuration. See format details:
-                               https://thanos.io/storage.md/#configuration
+                              Path to YAML file that contains object store
+                              configuration. See format details:
+                              https://thanos.io/storage.md/#configuration
       --objstore.config=<content>
-                               Alternative to 'objstore.config-file' flag (lower
-                               priority). Content of YAML file that contains
-                               object store configuration. See format details:
-                               https://thanos.io/storage.md/#configuration
-      --listen="0.0.0.0:8080"  HTTP host:port to listen on
+                              Alternative to 'objstore.config-file' flag (lower
+                              priority). Content of YAML file that contains
+                              object store configuration. See format details:
+                              https://thanos.io/storage.md/#configuration
       --http-address="0.0.0.0:10902"
-                               Listen host:port for HTTP endpoints.
-      --http-grace-period=2m   Time to wait after an interrupt received for HTTP
-                               Server.
-      --refresh=30m            Refresh interval to download metadata from remote
-                               storage
-      --timeout=5m             Timeout to download metadata from remote storage
-      --label=LABEL            Prometheus label to use as timeline title
+                              Listen host:port for HTTP endpoints.
+      --http-grace-period=2m  Time to wait after an interrupt received for HTTP
+                              Server.
+      --refresh=30m           Refresh interval to download metadata from remote
+                              storage
+      --timeout=5m            Timeout to download metadata from remote storage
+      --label=LABEL           Prometheus label to use as timeline title
 
 ```
 


### PR DESCRIPTION
While standardizing some flags, commit
9d4d0bf408ed86eaab371c8f0c52d7bb5fe6e164 accidentally added
a `--http-address` flag to the bucket web component that is never used.
However, rather than remove this new flag, this commit removes the
`--listen` flag that the component defines so that the component is in
line with the flags defined by other components.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>

cc @kakkoyun @bwplotka 