### PR TITLE
cmd/thanos/bucket: fix static fileserver

### DIFF
--- a/pkg/ui/bucket.go
+++ b/pkg/ui/bucket.go
@@ -6,8 +6,8 @@ import (
 	"time"
 
 	"github.com/go-kit/kit/log"
+	"github.com/prometheus/common/route"
 	extpromhttp "github.com/thanos-io/thanos/pkg/extprom/http"
-	httpserver "github.com/thanos-io/thanos/pkg/server/http"
 )
 
 // Bucket is a web UI representing state of buckets as a timeline.
@@ -30,13 +30,13 @@ func NewBucketUI(logger log.Logger, label string) *Bucket {
 }
 
 // Register registers http routes for bucket UI.
-func (b *Bucket) Register(s *httpserver.Server, ins extpromhttp.InstrumentationMiddleware) {
+func (b *Bucket) Register(r *route.Router, ins extpromhttp.InstrumentationMiddleware) {
 	instrf := func(name string, next func(w http.ResponseWriter, r *http.Request)) http.HandlerFunc {
 		return ins.NewHandler(name, http.HandlerFunc(next))
 	}
 
-	s.Handle("/", instrf("root", b.root))
-	s.Handle("/static/*filepath", instrf("static", b.serveStaticAsset))
+	r.Get("/", instrf("root", b.root))
+	r.Get("/static/*filepath", instrf("static", b.serveStaticAsset))
 }
 
 // Handle / of bucket UIs.


### PR DESCRIPTION
This commit fixes a regression introduced in #1702, where the signature
of the bucketui.Register method was changed. The bug was caused because
one of the registered paths relied on the HTTP parameter variable
support from github.com/julienschmidt/httprouter, which the standard
library does not support. The fix is instead to implement the change
recommended in
https://github.com/thanos-io/thanos/pull/1702#discussion_r341269556.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>

## Verification
Built and ran bucket web component and verified that the metrics and regular UI both work.