### PR TITLE
cmd/thanos/compact: add bucket UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 
 - [#2265](https://github.com/thanos-io/thanos/pull/2265) Compactor: Add `--wait-interval` to specify compaction wait interval between consecutive compact runs when `--wait` enabled.
 - [#2250](https://github.com/thanos-io/thanos/pull/2250) Compactor: Enable vertical compaction for offline deduplication (Experimental). Uses `--deduplication.replica-label` flag to specify the replica label to deduplicate on (Hidden). Please note that this uses a NAIVE algorithm for merging (no smart replica deduplication, just chaining samples together). This works well for deduplication of blocks with **precisely the same samples** like produced by Receiver replication. We plan to add a smarter algorithm in the following weeks.
+- [#1714](https://github.com/thanos-io/thanos/pull/1714) Run the bucket web UI in the compact component when it is run as a long-lived process.
 
 ### Changed
 

--- a/docs/components/compact.md
+++ b/docs/components/compact.md
@@ -82,83 +82,113 @@ usage: thanos compact [<flags>]
 continuously compacts blocks in an object store bucket
 
 Flags:
-  -h, --help                   Show context-sensitive help (also try --help-long
-                               and --help-man).
-      --version                Show application version.
-      --log.level=info         Log filtering level.
-      --log.format=logfmt      Log format to use. Possible options: logfmt or
-                               json.
+  -h, --help                    Show context-sensitive help (also try
+                                --help-long and --help-man).
+      --version                 Show application version.
+      --log.level=info          Log filtering level.
+      --log.format=logfmt       Log format to use. Possible options: logfmt or
+                                json.
       --tracing.config-file=<file-path>
-                               Path to YAML file with tracing configuration. See
-                               format details:
-                               https://thanos.io/tracing.md/#configuration
+                                Path to YAML file with tracing configuration.
+                                See format details:
+                                https://thanos.io/tracing.md/#configuration
       --tracing.config=<content>
-                               Alternative to 'tracing.config-file' flag (lower
-                               priority). Content of YAML file with tracing
-                               configuration. See format details:
-                               https://thanos.io/tracing.md/#configuration
+                                Alternative to 'tracing.config-file' flag (lower
+                                priority). Content of YAML file with tracing
+                                configuration. See format details:
+                                https://thanos.io/tracing.md/#configuration
       --http-address="0.0.0.0:10902"
-                               Listen host:port for HTTP endpoints.
-      --http-grace-period=2m   Time to wait after an interrupt received for HTTP
-                               Server.
-      --data-dir="./data"      Data directory in which to cache blocks and
-                               process compactions.
+                                Listen host:port for HTTP endpoints.
+      --http-grace-period=2m    Time to wait after an interrupt received for
+                                HTTP Server.
+      --data-dir="./data"       Data directory in which to cache blocks and
+                                process compactions.
       --objstore.config-file=<file-path>
-                               Path to YAML file that contains object store
-                               configuration. See format details:
-                               https://thanos.io/storage.md/#configuration
+                                Path to YAML file that contains object store
+                                configuration. See format details:
+                                https://thanos.io/storage.md/#configuration
       --objstore.config=<content>
-                               Alternative to 'objstore.config-file' flag (lower
-                               priority). Content of YAML file that contains
-                               object store configuration. See format details:
-                               https://thanos.io/storage.md/#configuration
-      --consistency-delay=30m  Minimum age of fresh (non-compacted) blocks
-                               before they are being processed. Malformed blocks
-                               older than the maximum of consistency-delay and
-                               48h0m0s will be removed.
+                                Alternative to 'objstore.config-file' flag
+                                (lower priority). Content of YAML file that
+                                contains object store configuration. See format
+                                details:
+                                https://thanos.io/storage.md/#configuration
+      --consistency-delay=30m   Minimum age of fresh (non-compacted) blocks
+                                before they are being processed. Malformed
+                                blocks older than the maximum of
+                                consistency-delay and 48h0m0s will be removed.
       --retention.resolution-raw=0d
-                               How long to retain raw samples in bucket. Setting
-                               this to 0d will retain samples of this resolution
-                               forever
+                                How long to retain raw samples in bucket.
+                                Setting this to 0d will retain samples of this
+                                resolution forever
       --retention.resolution-5m=0d
-                               How long to retain samples of resolution 1 (5
-                               minutes) in bucket. Setting this to 0d will
-                               retain samples of this resolution forever
+                                How long to retain samples of resolution 1 (5
+                                minutes) in bucket. Setting this to 0d will
+                                retain samples of this resolution forever
       --retention.resolution-1h=0d
-                               How long to retain samples of resolution 2 (1
-                               hour) in bucket. Setting this to 0d will retain
-                               samples of this resolution forever
-  -w, --wait                   Do not exit after all compactions have been
-                               processed and wait for new work.
-      --wait-interval=5m       Wait interval between consecutive compaction
-                               runs. Only works when --wait flag specified.
-      --downsampling.disable   Disables downsampling. This is not recommended as
-                               querying long time ranges without non-downsampled
-                               data is not efficient and useful e.g it is not
-                               possible to render all samples for a human eye
-                               anyway
+                                How long to retain samples of resolution 2 (1
+                                hour) in bucket. Setting this to 0d will retain
+                                samples of this resolution forever
+  -w, --wait                    Do not exit after all compactions have been
+                                processed and wait for new work.
+      --wait-interval=5m        Wait interval between consecutive compaction
+                                runs and bucket refreshes. Only works when
+                                --wait flag specified.
+      --downsampling.disable    Disables downsampling. This is not recommended
+                                as querying long time ranges without
+                                non-downsampled data is not efficient and useful
+                                e.g it is not possible to render all samples for
+                                a human eye anyway
       --block-sync-concurrency=20
-                               Number of goroutines to use when syncing block
-                               metadata from object storage.
-      --compact.concurrency=1  Number of goroutines to use when compacting
-                               groups.
+                                Number of goroutines to use when syncing block
+                                metadata from object storage.
+      --compact.concurrency=1   Number of goroutines to use when compacting
+                                groups.
+      --delete-delay=48h        Time before a block marked for deletion is
+                                deleted from bucket. If delete-delay is non
+                                zero, blocks will be marked for deletion and
+                                compactor component will delete blocks marked
+                                for deletion from the bucket. If delete-delay is
+                                0, blocks will be deleted straight away. Note
+                                that deleting blocks immediately can cause query
+                                failures, if store gateway still has the block
+                                loaded, or compactor is ignoring the deletion
+                                because it's compacting the block at the same
+                                time.
       --selector.relabel-config-file=<file-path>
-                               Path to YAML file that contains relabeling
-                               configuration that allows selecting blocks. It
-                               follows native Prometheus relabel-config syntax.
-                               See format details:
-                               https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
+                                Path to YAML file that contains relabeling
+                                configuration that allows selecting blocks. It
+                                follows native Prometheus relabel-config syntax.
+                                See format details:
+                                https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
       --selector.relabel-config=<content>
-                               Alternative to 'selector.relabel-config-file'
-                               flag (lower priority). Content of YAML file that
-                               contains relabeling configuration that allows
-                               selecting blocks. It follows native Prometheus
-                               relabel-config syntax. See format details:
-                               https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
-      --delete-delay=48h       Time before a block marked for deletion is deleted from bucket.
-		                           If delete-delay is non zero, blocks will be marked for deletion and compactor component will delete blocks marked for deletion from the bucket.
-		                           If delete-delay is 0, blocks will be deleted straight away.
-                               Use this if you want to get rid of or move the block immediately.
-		                           Note that deleting blocks immediately can cause query failures, if store gateway still has the block
-                               loaded, or compactor is ignoring the deletion because it's compacting the block at the same time.
+                                Alternative to 'selector.relabel-config-file'
+                                flag (lower priority). Content of YAML file that
+                                contains relabeling configuration that allows
+                                selecting blocks. It follows native Prometheus
+                                relabel-config syntax. See format details:
+                                https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
+      --web.external-prefix=""  Static prefix for all HTML links and redirect
+                                URLs in the bucket web UI interface. Actual
+                                endpoints are still served on / or the
+                                web.route-prefix. This allows thanos bucket web
+                                UI to be served behind a reverse proxy that
+                                strips a URL sub-path.
+      --web.prefix-header=""    Name of HTTP request header used for dynamic
+                                prefixing of UI links and redirects. This option
+                                is ignored if web.external-prefix argument is
+                                set. Security risk: enable this option only if a
+                                reverse proxy in front of thanos is resetting
+                                the header. The
+                                --web.prefix-header=X-Forwarded-Prefix option
+                                can be useful, for example, if Thanos UI is
+                                served via Traefik reverse proxy with
+                                PathPrefixStrip option enabled, which sends the
+                                stripped prefix value in X-Forwarded-Prefix
+                                header. This allows thanos UI to be served on a
+                                sub-path.
+      --bucket-web-label=BUCKET-WEB-LABEL
+                                Prometheus label to use as timeline title in the
+                                bucket web UI
+
 ```


### PR DESCRIPTION
This commit enhances the compact component so that it runs the bucket UI
whenever the --wait flag is also passed. In order to reduce the overhead
of running the UI in addition to the compactor, this commit also
introduces an abstraction around downloading block meta files allowing
the metadata to be downloaded once and cached. This ensures that the
compactor does not unnecessarily download every metadata file twice.

Fixes: #1657

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>

* [x] I added CHANGELOG entry for this change.

## Verification
Ran the compact component with `--wait` with an objstore config against
a minio instance with blocks in it.

cc @bwplotka 