### PR TITLE
pkg/receive: eliminate duplicate tracing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,6 @@ require (
 	github.com/oklog/run v1.0.0
 	github.com/oklog/ulid v1.3.1
 	github.com/olekukonko/tablewriter v0.0.1
-	github.com/opentracing-contrib/go-stdlib v0.0.0-20190519235532-cf7a6c988dc9
 	github.com/opentracing/basictracer-go v1.0.0
 	github.com/opentracing/opentracing-go v1.1.0
 	github.com/pkg/errors v0.8.1


### PR DESCRIPTION
The receive component currently has duplicate spans for requests handled
by its HTTP server. This is due to the fact that the server is
instrumented once using the global singleton tracer and then a second
time with the tracer configured via the CLI. This commit eliminates the
duplicate instrumentation via the global singleton in favor of the
explicit specified tracer, which is consistent with the practice of
other Thanos components.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>

Example of duplicate span:
![image](https://user-images.githubusercontent.com/20484159/68209979-d8fb2c80-ffd4-11e9-8915-bda1a900d891.png)

Note that:
* both `/receive HTTP[server]` and `POST /api/v1/receive` represent the same operation; and that
* the span created by the global singleton, `POST /api/v1/receive` is erroneously setting the HTTP status code to `0`.