### PR TITLE
remove reallocs and overallocs for s.lset in bucket.go

### DIFF
--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -680,7 +680,7 @@ func blockSeries(
 			return nil, nil, errors.Wrap(err, "read series")
 		}
 		s := seriesEntry{
-			lset: make([]storepb.Label, 0, len(lset)),
+			lset: make([]storepb.Label, 0, len(lset)+len(extLset)),
 			refs: make([]uint64, 0, len(chks)),
 			chks: make([]storepb.AggrChunk, 0, len(chks)),
 		}


### PR DESCRIPTION
## Changes

- append to s.lset caused reallocs and overallocs
- this is now fixed by properly setting capacity on s.lset
- pprof shows "-316.22MB, 5.00% of 6322.82MB total" for sample data set and query I used


## Verification

- Sample data generated with thanosbench using `realistic-k8s-1w-small` profile
- Query executed: `count({__name__=~".+"}) by (__name__)`
- Instrumented `BucketStore.Series` to dump heap profile at the start and end of the function call.
- Compared the profiles using pprof:

```
go tool pprof -sample_index=alloc_space -edgefraction=0 -lines -base heap-series-1-after-base.pb.gz  -http=:8080 heap-series-1-after-change.pb.gz
```

- PNG attached

- Heap profiles attached

![profile001](https://user-images.githubusercontent.com/300031/68210003-84ec4a00-ffcc-11e9-816b-9337a1c6119c.png)


[heap-series-1-after-base.pb.gz](https://github.com/thanos-io/thanos/files/3809061/heap-series-1-after-base.pb.gz)
[heap-series-1-after-change.pb.gz](https://github.com/thanos-io/thanos/files/3809062/heap-series-1-after-change.pb.gz)

----
## Edit

For what it's worth, here is my `HeapDump` func I used, in case anyone wants to instrument anything. Might save you looking for pprof docs :) 

```
func HeapDump(name string) {
	var fName = fmt.Sprintf("/Users/philip/thanos/github.com/ppanyukov/thanos-oom/scripts/%s.pb.gz", name)
	f, _ := os.Create(fName)
	defer f.Close()
	runtime.GC()
	pprof.WriteHeapProfile(f)
	fmt.Printf("WRITTEN HEAP DUMP TO %s\n", fName)
}
```

