### PR TITLE
Optimistically prealloc result slice in blockSeries func (bucket.go)

### DIFF
--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -671,7 +671,8 @@ func blockSeries(
 	// Transform all series into the response types and mark their relevant chunks
 	// for preloading.
 	var (
-		res  []seriesEntry
+		// Optimistically preallocate result slice to avoid reallocs and overallocs later during append.
+		res  = make([]seriesEntry, 0, len(ps))
 		lset labels.Labels
 		chks []chunks.Meta
 	)


### PR DESCRIPTION
## Changes

- Optimistically prealloc result slice in blockSeries func (bucket.go)
- This avoids reallocs and overallocs later when we append to it
- Optimistic as I am hoping that `len(s.chks) > 0` is true for majority of the time and thus we append to this result slice most of the time.
- My tests show reduced allocations by ~5% for queries
- pprof summary: "Showing nodes accounting for -327.26MB, 5.61% of 5831.41MB total"

Code-wise, here is the summary:

Now we allocate 60MB here
```
    674            .          .           		// Optimistically preallocate result slice to avoid reallocs and overallocs later during append. 
    675      60.23MB    60.23MB           		res  = make([]seriesEntry, 0, len(ps)) 
```

Benefit is we save 350MB of allocation during append
```
    726            .          .           		if len(s.chks) > 0 { 
    727    -343.99MB  -343.99MB           			res = append(res, s) 
    728            .          .           		} 
```

Overall, less memory is allocated because we allocate just as much as required. But also, since the results are accumulated up the stack, this also means lower memory usage overall.

As can be seen, there is an `if` statement which can cause the append not to happen, in which case we might no save much or anything at all with this fix, but I don't know if it's a realistic scenario.


## Verification

- Sample data generated with thanosbench using `realistic-k8s-1w-small` profile
- Query executed: `count({__name__=~".+"}) by (__name__)`
- Instrumented `BucketStore.Series` to dump heap profile at the start and end of the function call.
- Compared the profiles using pprof:

```
go tool pprof -sample_index=alloc_space -edgefraction=0 -lines -base heap-series-1-after-base.pb.gz  -http=:8080 heap-series-1-after-change.pb.gz
```

- PNG attached

- Heap profiles attached


![profile003](https://user-images.githubusercontent.com/300031/68238976-11fdc600-0002-11ea-81d5-99e714dc6bef.png)

[heap-series-1-after-base.pb.gz](https://github.com/thanos-io/thanos/files/3810826/heap-series-1-after-base.pb.gz)
[heap-series-1-after-change.pb.gz](https://github.com/thanos-io/thanos/files/3810827/heap-series-1-after-change.pb.gz)


