### PR TITLE
Add default label "prometheus" to bucket web.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 - [#1733](https://github.com/thanos-io/thanos/pull/1733) New metric `thanos_compactor_iterations_total` on Thanos Compactor which shows the number of successful iterations.
 - [#1758](https://github.com/thanos-io/thanos/pull/1758) `thanos bucket web` now supports `--web.external-prefix` for proxying on a subpath.
 - [#1770](https://github.com/thanos-io/thanos/pull/1770) Add `--web.prefix-header` flags to allow for bucket UI to be accessible behind a reverse proxy.
+- [#1756](https://github.com/thanos-io/thanos/pull/1756) Thanos Bucket Web now uses a default label of `prometheus`.
 
 ### Fixed
 

--- a/cmd/thanos/bucket.go
+++ b/cmd/thanos/bucket.go
@@ -315,7 +315,7 @@ func registerBucketWeb(m map[string]setupFunc, root *kingpin.CmdClause, name str
 	webPrefixHeaderName := cmd.Flag("web.prefix-header", "Name of HTTP request header used for dynamic prefixing of UI links and redirects. This option is ignored if web.external-prefix argument is set. Security risk: enable this option only if a reverse proxy in front of thanos is resetting the header. The --web.prefix-header=X-Forwarded-Prefix option can be useful, for example, if Thanos UI is served via Traefik reverse proxy with PathPrefixStrip option enabled, which sends the stripped prefix value in X-Forwarded-Prefix header. This allows thanos UI to be served on a sub-path.").Default("").String()
 	interval := cmd.Flag("refresh", "Refresh interval to download metadata from remote storage").Default("30m").Duration()
 	timeout := cmd.Flag("timeout", "Timeout to download metadata from remote storage").Default("5m").Duration()
-	label := cmd.Flag("label", "Prometheus label to use as timeline title").String()
+	label := cmd.Flag("label", "Prometheus label to use as timeline title").Default("prometheus").String()
 
 	m[name+" web"] = func(g *run.Group, logger log.Logger, reg *prometheus.Registry, _ opentracing.Tracer, _ bool) error {
 		ctx, cancel := context.WithCancel(context.Background())

--- a/docs/components/bucket.md
+++ b/docs/components/bucket.md
@@ -148,7 +148,7 @@ Flags:
       --refresh=30m             Refresh interval to download metadata from
                                 remote storage
       --timeout=5m              Timeout to download metadata from remote storage
-      --label=LABEL             Prometheus label to use as timeline title
+      --label="prometheus"      Prometheus label to use as timeline title
 
 ```
 


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!-- 
    Don't forget about CHANGELOG! 
    
    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...
    
    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes
Add a default label to `thanos web bucket` of `prometheus`. This is a common external label and would make a good default for most users so that the UI will show the different `prometheus` labels by default instead of integers 1,2,3, etc.

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
