### PR TITLE
bucket: Add --web.external-prefix to 'bucket web'

### DIFF
--- a/cmd/thanos/bucket.go
+++ b/cmd/thanos/bucket.go
@@ -327,7 +327,6 @@ func registerBucketWeb(m map[string]setupFunc, root *kingpin.CmdClause, name str
 		)
 
 		flagsMap := map[string]string{
-			// TODO(bplotka in PR #513 review): pass all flags, not only the flags needed by prefix rewriting.
 			"web.external-prefix": *webExternalPrefix,
 		}
 

--- a/docs/components/bucket.md
+++ b/docs/components/bucket.md
@@ -98,37 +98,44 @@ usage: thanos bucket web [<flags>]
 Web interface for remote storage bucket
 
 Flags:
-  -h, --help                  Show context-sensitive help (also try --help-long
-                              and --help-man).
-      --version               Show application version.
-      --log.level=info        Log filtering level.
-      --log.format=logfmt     Log format to use.
-      --tracing.config-file=<file-path>
-                              Path to YAML file with tracing configuration. See
-                              format details:
-                              https://thanos.io/tracing.md/#configuration
-      --tracing.config=<content>
-                              Alternative to 'tracing.config-file' flag (lower
-                              priority). Content of YAML file with tracing
-                              configuration. See format details:
-                              https://thanos.io/tracing.md/#configuration
-      --objstore.config-file=<file-path>
-                              Path to YAML file that contains object store
-                              configuration. See format details:
-                              https://thanos.io/storage.md/#configuration
-      --objstore.config=<content>
-                              Alternative to 'objstore.config-file' flag (lower
-                              priority). Content of YAML file that contains
-                              object store configuration. See format details:
-                              https://thanos.io/storage.md/#configuration
-      --http-address="0.0.0.0:10902"
-                              Listen host:port for HTTP endpoints.
-      --http-grace-period=2m  Time to wait after an interrupt received for HTTP
-                              Server.
-      --refresh=30m           Refresh interval to download metadata from remote
-                              storage
-      --timeout=5m            Timeout to download metadata from remote storage
-      --label=LABEL           Prometheus label to use as timeline title
+  -h, --help                    Show context-sensitive help (also try
+                                --help-long and --help-man).
+      --version                 Show application version.
+      --log.level=info          Log filtering level.
+      --log.format=logfmt       Log format to use.
+      --tracing.config-file=<file-path>  
+                                Path to YAML file with tracing configuration.
+                                See format details:
+                                https://thanos.io/tracing.md/#configuration
+      --tracing.config=<content>  
+                                Alternative to 'tracing.config-file' flag (lower
+                                priority). Content of YAML file with tracing
+                                configuration. See format details:
+                                https://thanos.io/tracing.md/#configuration
+      --objstore.config-file=<file-path>  
+                                Path to YAML file that contains object store
+                                configuration. See format details:
+                                https://thanos.io/storage.md/#configuration
+      --objstore.config=<content>  
+                                Alternative to 'objstore.config-file' flag
+                                (lower priority). Content of YAML file that
+                                contains object store configuration. See format
+                                details:
+                                https://thanos.io/storage.md/#configuration
+      --http-address="0.0.0.0:10902"  
+                                Listen host:port for HTTP endpoints.
+      --http-grace-period=2m    Time to wait after an interrupt received for
+                                HTTP Server.
+      --refresh=30m             Refresh interval to download metadata from
+                                remote storage
+      --timeout=5m              Timeout to download metadata from remote storage
+      --label=LABEL             Prometheus label to use as timeline title
+      --web.external-prefix=""  Static prefix for all HTML links and redirect
+                                URLs in the UI query web interface. Actual
+                                endpoints are still served on / or the
+                                web.route-prefix. This allows thanos UI to be
+                                served behind a reverse proxy that strips a URL
+                                sub-path.
 
 ```
 

--- a/pkg/ui/bucket.go
+++ b/pkg/ui/bucket.go
@@ -19,13 +19,15 @@ type Bucket struct {
 	Blocks      template.JS
 	RefreshedAt time.Time
 	Err         error
+	flagsMap map[string]string
 }
 
-func NewBucketUI(logger log.Logger, label string) *Bucket {
+func NewBucketUI(logger log.Logger, label string, flagsMap map[string]string) *Bucket {
 	return &Bucket{
 		BaseUI: NewBaseUI(logger, "bucket_menu.html", queryTmplFuncs()),
 		Blocks: "[]",
 		Label:  label,
+		flagsMap: flagsMap,
 	}
 }
 
@@ -41,7 +43,8 @@ func (b *Bucket) Register(r *route.Router, ins extpromhttp.InstrumentationMiddle
 
 // Handle / of bucket UIs.
 func (b *Bucket) root(w http.ResponseWriter, r *http.Request) {
-	b.executeTemplate(w, "bucket.html", "", b)
+	prefix := GetWebPrefix(b.logger, b.flagsMap, r)
+	b.executeTemplate(w, "bucket.html", prefix, b)
 }
 
 func (b *Bucket) Set(data string, err error) {


### PR DESCRIPTION

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Added `--web.external-prefix` to `thanos bucket web` to support proxying on a subpath.

## Verification

Built clean, worked as expected locally.
