### PR TITLE
bucket: Add `--web.external-prefix` for proxying on a subpath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 - [#1680](https://github.com/thanos-io/thanos/pull/1680) Add a new `--http-grace-period` CLI option to components which serve HTTP to set how long to wait until HTTP Server shuts down.
 - [#1712](https://github.com/thanos-io/thanos/pull/1712) Rename flag on bucket web component from `--listen` to `--http-address` to match other components.
 - [#1733](https://github.com/thanos-io/thanos/pull/1733) New metric `thanos_compactor_iterations_total` on Thanos Compactor which shows the number of successful iterations.
-- [#1757](https://github.com/thanos-io/thanos/pull/1757) `thanos bucket web` now supports `--web.external-prefix` for proxying on a subpath.
+- [#1758](https://github.com/thanos-io/thanos/pull/1758) `thanos bucket web` now supports `--web.external-prefix` for proxying on a subpath.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 - [#1680](https://github.com/thanos-io/thanos/pull/1680) Add a new `--http-grace-period` CLI option to components which serve HTTP to set how long to wait until HTTP Server shuts down.
 - [#1712](https://github.com/thanos-io/thanos/pull/1712) Rename flag on bucket web component from `--listen` to `--http-address` to match other components.
 - [#1733](https://github.com/thanos-io/thanos/pull/1733) New metric `thanos_compactor_iterations_total` on Thanos Compactor which shows the number of successful iterations.
+- [#1757](https://github.com/thanos-io/thanos/pull/1757) `thanos bucket web` now supports `--web.external-prefix` for proxying on a subpath.
 
 ### Fixed
 

--- a/cmd/thanos/bucket.go
+++ b/cmd/thanos/bucket.go
@@ -314,6 +314,7 @@ func registerBucketWeb(m map[string]setupFunc, root *kingpin.CmdClause, name str
 	interval := cmd.Flag("refresh", "Refresh interval to download metadata from remote storage").Default("30m").Duration()
 	timeout := cmd.Flag("timeout", "Timeout to download metadata from remote storage").Default("5m").Duration()
 	label := cmd.Flag("label", "Prometheus label to use as timeline title").String()
+	webExternalPrefix := cmd.Flag("web.external-prefix", "Static prefix for all HTML links and redirect URLs in the UI query web interface. Actual endpoints are still served on / or the web.route-prefix. This allows thanos UI to be served behind a reverse proxy that strips a URL sub-path.").Default("").String()
 
 	m[name+" web"] = func(g *run.Group, logger log.Logger, reg *prometheus.Registry, _ opentracing.Tracer, _ bool) error {
 		ctx, cancel := context.WithCancel(context.Background())
@@ -325,8 +326,12 @@ func registerBucketWeb(m map[string]setupFunc, root *kingpin.CmdClause, name str
 			httpserver.WithGracePeriod(time.Duration(*httpGracePeriod)),
 		)
 
+		flagsMap := map[string]string{
+			"web.external-prefix": *webExternalPrefix,
+		}
+
 		router := route.New()
-		bucketUI := ui.NewBucketUI(logger, *label)
+		bucketUI := ui.NewBucketUI(logger, *label, flagsMap)
 		bucketUI.Register(router, extpromhttp.NewInstrumentationMiddleware(reg))
 		srv.Handle("/", router)
 

--- a/docs/components/bucket.md
+++ b/docs/components/bucket.md
@@ -98,37 +98,44 @@ usage: thanos bucket web [<flags>]
 Web interface for remote storage bucket
 
 Flags:
-  -h, --help                  Show context-sensitive help (also try --help-long
-                              and --help-man).
-      --version               Show application version.
-      --log.level=info        Log filtering level.
-      --log.format=logfmt     Log format to use.
-      --tracing.config-file=<file-path>
-                              Path to YAML file with tracing configuration. See
-                              format details:
-                              https://thanos.io/tracing.md/#configuration
-      --tracing.config=<content>
-                              Alternative to 'tracing.config-file' flag (lower
-                              priority). Content of YAML file with tracing
-                              configuration. See format details:
-                              https://thanos.io/tracing.md/#configuration
-      --objstore.config-file=<file-path>
-                              Path to YAML file that contains object store
-                              configuration. See format details:
-                              https://thanos.io/storage.md/#configuration
-      --objstore.config=<content>
-                              Alternative to 'objstore.config-file' flag (lower
-                              priority). Content of YAML file that contains
-                              object store configuration. See format details:
-                              https://thanos.io/storage.md/#configuration
-      --http-address="0.0.0.0:10902"
-                              Listen host:port for HTTP endpoints.
-      --http-grace-period=2m  Time to wait after an interrupt received for HTTP
-                              Server.
-      --refresh=30m           Refresh interval to download metadata from remote
-                              storage
-      --timeout=5m            Timeout to download metadata from remote storage
-      --label=LABEL           Prometheus label to use as timeline title
+  -h, --help                    Show context-sensitive help (also try
+                                --help-long and --help-man).
+      --version                 Show application version.
+      --log.level=info          Log filtering level.
+      --log.format=logfmt       Log format to use.
+      --tracing.config-file=<file-path>  
+                                Path to YAML file with tracing configuration.
+                                See format details:
+                                https://thanos.io/tracing.md/#configuration
+      --tracing.config=<content>  
+                                Alternative to 'tracing.config-file' flag (lower
+                                priority). Content of YAML file with tracing
+                                configuration. See format details:
+                                https://thanos.io/tracing.md/#configuration
+      --objstore.config-file=<file-path>  
+                                Path to YAML file that contains object store
+                                configuration. See format details:
+                                https://thanos.io/storage.md/#configuration
+      --objstore.config=<content>  
+                                Alternative to 'objstore.config-file' flag
+                                (lower priority). Content of YAML file that
+                                contains object store configuration. See format
+                                details:
+                                https://thanos.io/storage.md/#configuration
+      --http-address="0.0.0.0:10902"  
+                                Listen host:port for HTTP endpoints.
+      --http-grace-period=2m    Time to wait after an interrupt received for
+                                HTTP Server.
+      --refresh=30m             Refresh interval to download metadata from
+                                remote storage
+      --timeout=5m              Timeout to download metadata from remote storage
+      --label=LABEL             Prometheus label to use as timeline title
+      --web.external-prefix=""  Static prefix for all HTML links and redirect
+                                URLs in the UI query web interface. Actual
+                                endpoints are still served on / or the
+                                web.route-prefix. This allows thanos UI to be
+                                served behind a reverse proxy that strips a URL
+                                sub-path.
 
 ```
 

--- a/docs/components/bucket.md
+++ b/docs/components/bucket.md
@@ -103,26 +103,26 @@ Flags:
       --version                 Show application version.
       --log.level=info          Log filtering level.
       --log.format=logfmt       Log format to use.
-      --tracing.config-file=<file-path>  
+      --tracing.config-file=<file-path>
                                 Path to YAML file with tracing configuration.
                                 See format details:
                                 https://thanos.io/tracing.md/#configuration
-      --tracing.config=<content>  
+      --tracing.config=<content>
                                 Alternative to 'tracing.config-file' flag (lower
                                 priority). Content of YAML file with tracing
                                 configuration. See format details:
                                 https://thanos.io/tracing.md/#configuration
-      --objstore.config-file=<file-path>  
+      --objstore.config-file=<file-path>
                                 Path to YAML file that contains object store
                                 configuration. See format details:
                                 https://thanos.io/storage.md/#configuration
-      --objstore.config=<content>  
+      --objstore.config=<content>
                                 Alternative to 'objstore.config-file' flag
                                 (lower priority). Content of YAML file that
                                 contains object store configuration. See format
                                 details:
                                 https://thanos.io/storage.md/#configuration
-      --http-address="0.0.0.0:10902"  
+      --http-address="0.0.0.0:10902"
                                 Listen host:port for HTTP endpoints.
       --http-grace-period=2m    Time to wait after an interrupt received for
                                 HTTP Server.

--- a/pkg/ui/bucket.go
+++ b/pkg/ui/bucket.go
@@ -19,14 +19,14 @@ type Bucket struct {
 	Blocks      template.JS
 	RefreshedAt time.Time
 	Err         error
-	flagsMap map[string]string
+	flagsMap    map[string]string
 }
 
 func NewBucketUI(logger log.Logger, label string, flagsMap map[string]string) *Bucket {
 	return &Bucket{
-		BaseUI: NewBaseUI(logger, "bucket_menu.html", queryTmplFuncs()),
-		Blocks: "[]",
-		Label:  label,
+		BaseUI:   NewBaseUI(logger, "bucket_menu.html", queryTmplFuncs()),
+		Blocks:   "[]",
+		Label:    label,
 		flagsMap: flagsMap,
 	}
 }

--- a/pkg/ui/bucket.go
+++ b/pkg/ui/bucket.go
@@ -19,13 +19,15 @@ type Bucket struct {
 	Blocks      template.JS
 	RefreshedAt time.Time
 	Err         error
+	flagsMap map[string]string
 }
 
-func NewBucketUI(logger log.Logger, label string) *Bucket {
+func NewBucketUI(logger log.Logger, label string, flagsMap map[string]string) *Bucket {
 	return &Bucket{
 		BaseUI: NewBaseUI(logger, "bucket_menu.html", queryTmplFuncs()),
 		Blocks: "[]",
 		Label:  label,
+		flagsMap: flagsMap,
 	}
 }
 
@@ -41,7 +43,8 @@ func (b *Bucket) Register(r *route.Router, ins extpromhttp.InstrumentationMiddle
 
 // Handle / of bucket UIs.
 func (b *Bucket) root(w http.ResponseWriter, r *http.Request) {
-	b.executeTemplate(w, "bucket.html", "", b)
+	prefix := GetWebPrefix(b.logger, b.flagsMap, r)
+	b.executeTemplate(w, "bucket.html", prefix, b)
 }
 
 func (b *Bucket) Set(data string, err error) {


### PR DESCRIPTION
* [x]  I added CHANGELOG entry for this change.
* [ ]  Change is not relevant to the end user.

## Changes

* Added `--web.external-prefix` to `thanos bucket web` to support proxying on a subpath.
* Updated docs with current `thanos bucket web --help` output.

## Verification

Built clean, worked as expected locally.
