### PR TITLE
Fix web.external-prefix 404s and add web.prefix-header for bucket web UI.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 - [#1712](https://github.com/thanos-io/thanos/pull/1712) Rename flag on bucket web component from `--listen` to `--http-address` to match other components.
 - [#1733](https://github.com/thanos-io/thanos/pull/1733) New metric `thanos_compactor_iterations_total` on Thanos Compactor which shows the number of successful iterations.
 - [#1758](https://github.com/thanos-io/thanos/pull/1758) `thanos bucket web` now supports `--web.external-prefix` for proxying on a subpath.
-- [#1762](https://github.com/thanos-io/thanos/pull/1762) Add `--web.prefix-header` flags to allow for bucket UI to be accessible behind a reverse proxy.
+- [#1770](https://github.com/thanos-io/thanos/pull/1770) Add `--web.prefix-header` flags to allow for bucket UI to be accessible behind a reverse proxy.
 
 ### Fixed
 
@@ -29,7 +29,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 - [#1669](https://github.com/thanos-io/thanos/pull/1669) Fixed store sharding. Now it does not load excluded meta.jsons and load/fetch index-cache.json files.
 - [#1670](https://github.com/thanos-io/thanos/pull/1670) Fixed un-ordered blocks upload. Sidecar now uploads the oldest blocks first.
 - [#1568](https://github.com/thanos-io/thanos/pull/1709) Thanos Store now retains the first raw value of a chunk during downsampling to avoid losing some counter resets that occur on an aggregation boundary.
-- [#1762](https://github.com/thanos-io/thanos/pull/1762) Fix `--web.external-prefix` 404s for static resources.
+- [#1770](https://github.com/thanos-io/thanos/pull/1770) Fix `--web.external-prefix` 404s for static resources.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 - [#1712](https://github.com/thanos-io/thanos/pull/1712) Rename flag on bucket web component from `--listen` to `--http-address` to match other components.
 - [#1733](https://github.com/thanos-io/thanos/pull/1733) New metric `thanos_compactor_iterations_total` on Thanos Compactor which shows the number of successful iterations.
 - [#1758](https://github.com/thanos-io/thanos/pull/1758) `thanos bucket web` now supports `--web.external-prefix` for proxying on a subpath.
-- [#1762](https://github.com/thanos-io/thanos/pull/1762) Fix `--web.external-prefix` and add `--web.prefix-header` flags to allow for bucket UI to be accessible behind a reverse proxy.
+- [#1762](https://github.com/thanos-io/thanos/pull/1762) Add `--web.prefix-header` flags to allow for bucket UI to be accessible behind a reverse proxy.
 
 ### Fixed
 
@@ -29,6 +29,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 - [#1669](https://github.com/thanos-io/thanos/pull/1669) Fixed store sharding. Now it does not load excluded meta.jsons and load/fetch index-cache.json files.
 - [#1670](https://github.com/thanos-io/thanos/pull/1670) Fixed un-ordered blocks upload. Sidecar now uploads the oldest blocks first.
 - [#1568](https://github.com/thanos-io/thanos/pull/1709) Thanos Store now retains the first raw value of a chunk during downsampling to avoid losing some counter resets that occur on an aggregation boundary.
+- [#1762](https://github.com/thanos-io/thanos/pull/1762) Fix `--web.external-prefix` 404s for static resources.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 - [#1712](https://github.com/thanos-io/thanos/pull/1712) Rename flag on bucket web component from `--listen` to `--http-address` to match other components.
 - [#1733](https://github.com/thanos-io/thanos/pull/1733) New metric `thanos_compactor_iterations_total` on Thanos Compactor which shows the number of successful iterations.
 - [#1758](https://github.com/thanos-io/thanos/pull/1758) `thanos bucket web` now supports `--web.external-prefix` for proxying on a subpath.
+- [#1762](https://github.com/thanos-io/thanos/pull/1762) Fix `--web.external-prefix` and add `--web.prefix-header` flags to allow for bucket UI to be accessible behind a reverse proxy.
 
 ### Fixed
 

--- a/cmd/thanos/bucket.go
+++ b/cmd/thanos/bucket.go
@@ -316,7 +316,6 @@ func registerBucketWeb(m map[string]setupFunc, root *kingpin.CmdClause, name str
 	interval := cmd.Flag("refresh", "Refresh interval to download metadata from remote storage").Default("30m").Duration()
 	timeout := cmd.Flag("timeout", "Timeout to download metadata from remote storage").Default("5m").Duration()
 	label := cmd.Flag("label", "Prometheus label to use as timeline title").String()
-	webExternalPrefix := cmd.Flag("web.external-prefix", "Static prefix for all HTML links and redirect URLs in the UI query web interface. Actual endpoints are still served on / or the web.route-prefix. This allows thanos UI to be served behind a reverse proxy that strips a URL sub-path.").Default("").String()
 
 	m[name+" web"] = func(g *run.Group, logger log.Logger, reg *prometheus.Registry, _ opentracing.Tracer, _ bool) error {
 		ctx, cancel := context.WithCancel(context.Background())
@@ -330,14 +329,10 @@ func registerBucketWeb(m map[string]setupFunc, root *kingpin.CmdClause, name str
 
 		flagsMap := map[string]string{
 			"web.external-prefix": *webExternalPrefix,
+			"web.prefix-header":   *webPrefixHeaderName,
 		}
 
 		router := route.New()
-
-		flagsMap := map[string]string{
-			"web.external-prefix": *webExternalPrefix,
-			"web.prefix-header":   *webPrefixHeaderName,
-		}
 
 		bucketUI := ui.NewBucketUI(logger, *label, flagsMap)
 		bucketUI.Register(router.WithPrefix(*webExternalPrefix), extpromhttp.NewInstrumentationMiddleware(reg))

--- a/cmd/thanos/bucket.go
+++ b/cmd/thanos/bucket.go
@@ -311,6 +311,8 @@ func registerBucketInspect(m map[string]setupFunc, root *kingpin.CmdClause, name
 func registerBucketWeb(m map[string]setupFunc, root *kingpin.CmdClause, name string, objStoreConfig *extflag.PathOrContent) {
 	cmd := root.Command("web", "Web interface for remote storage bucket")
 	httpBindAddr, httpGracePeriod := regHTTPFlags(cmd)
+	webExternalPrefix := cmd.Flag("web.external-prefix", "Static prefix for all HTML links and redirect URLs in the bucket web UI interface. Actual endpoints are still served on / or the web.route-prefix. This allows thanos bucket web UI to be served behind a reverse proxy that strips a URL sub-path.").Default("").String()
+	webPrefixHeaderName := cmd.Flag("web.prefix-header", "Name of HTTP request header used for dynamic prefixing of UI links and redirects. This option is ignored if web.external-prefix argument is set. Security risk: enable this option only if a reverse proxy in front of thanos is resetting the header. The --web.prefix-header=X-Forwarded-Prefix option can be useful, for example, if Thanos UI is served via Traefik reverse proxy with PathPrefixStrip option enabled, which sends the stripped prefix value in X-Forwarded-Prefix header. This allows thanos UI to be served on a sub-path.").Default("").String()
 	interval := cmd.Flag("refresh", "Refresh interval to download metadata from remote storage").Default("30m").Duration()
 	timeout := cmd.Flag("timeout", "Timeout to download metadata from remote storage").Default("5m").Duration()
 	label := cmd.Flag("label", "Prometheus label to use as timeline title").String()
@@ -331,8 +333,14 @@ func registerBucketWeb(m map[string]setupFunc, root *kingpin.CmdClause, name str
 		}
 
 		router := route.New()
+
+		flagsMap := map[string]string{
+			"web.external-prefix": *webExternalPrefix,
+			"web.prefix-header":   *webPrefixHeaderName,
+		}
+
 		bucketUI := ui.NewBucketUI(logger, *label, flagsMap)
-		bucketUI.Register(router, extpromhttp.NewInstrumentationMiddleware(reg))
+		bucketUI.Register(router.WithPrefix(*webExternalPrefix), extpromhttp.NewInstrumentationMiddleware(reg))
 		srv.Handle("/", router)
 
 		if *interval < 5*time.Minute {

--- a/docs/components/bucket.md
+++ b/docs/components/bucket.md
@@ -137,7 +137,7 @@ Flags:
                                 is ignored if web.external-prefix argument is
                                 set. Security risk: enable this option only if a
                                 reverse proxy in front of thanos is resetting
-                                the header.
+                                the header. The
                                 --web.prefix-header=X-Forwarded-Prefix option
                                 can be useful, for example, if Thanos UI is
                                 served via Traefik reverse proxy with

--- a/docs/components/bucket.md
+++ b/docs/components/bucket.md
@@ -57,7 +57,7 @@ Flags:
                            https://thanos.io/storage.md/#configuration
       --objstore.config=<content>  
                            Alternative to 'objstore.config-file' flag (lower
-                           priority). Content of YAML file that contains objec
+                           priority). Content of YAML file that contains object
                            store configuration. See format details:
                            https://thanos.io/storage.md/#configuration
 
@@ -119,7 +119,7 @@ Flags:
       --objstore.config=<content>  
                                 Alternative to 'objstore.config-file' flag
                                 (lower priority). Content of YAML file tha
-                                contains object store configuration. See forma
+                                contains object store configuration. See format
                                 details:
                                 https://thanos.io/storage.md/#configuration
       --http-address="0.0.0.0:10902"  
@@ -137,7 +137,7 @@ Flags:
                                 is ignored if web.external-prefix argument is
                                 set. Security risk: enable this option only if a
                                 reverse proxy in front of thanos is resetting
-                                the header. The
+                                the header.
                                 --web.prefix-header=X-Forwarded-Prefix option
                                 can be useful, for example, if Thanos UI is
                                 served via Traefik reverse proxy with
@@ -189,7 +189,7 @@ Flags:
                            https://thanos.io/storage.md/#configuration
       --objstore.config=<content>  
                            Alternative to 'objstore.config-file' flag (lower
-                           priority). Content of YAML file that contains objec
+                           priority). Content of YAML file that contains object
                            store configuration. See format details:
                            https://thanos.io/storage.md/#configuration
       --objstore-backup.config-file=<file-path>  
@@ -200,7 +200,7 @@ Flags:
       --objstore-backup.config=<content>  
                            Alternative to 'objstore-backup.config-file' flag
                            (lower priority). Content of YAML file that contains
-                           object store-backup configuration. See forma
+                           object store-backup configuration. See format
                            details: https://thanos.io/storage.md/#configuration
                            Used for repair logic to backup blocks before
                            removal.
@@ -254,7 +254,7 @@ Flags:
                            https://thanos.io/storage.md/#configuration
       --objstore.config=<content>  
                            Alternative to 'objstore.config-file' flag (lower
-                           priority). Content of YAML file that contains objec
+                           priority). Content of YAML file that contains object
                            store configuration. See format details:
                            https://thanos.io/storage.md/#configuration
   -o, --output=""          Optional format in which to print each block's

--- a/docs/components/bucket.md
+++ b/docs/components/bucket.md
@@ -118,7 +118,7 @@ Flags:
                                 https://thanos.io/storage.md/#configuration
       --objstore.config=<content>
                                 Alternative to 'objstore.config-file' flag
-                                (lower priority). Content of YAML file tha
+                                (lower priority). Content of YAML file that
                                 contains object store configuration. See format
                                 details:
                                 https://thanos.io/storage.md/#configuration
@@ -130,7 +130,7 @@ Flags:
                                 URLs in the bucket web UI interface. Actual
                                 endpoints are still served on / or the
                                 web.route-prefix. This allows thanos bucket web
-                                UI to be served behind a reverse proxy tha
+                                UI to be served behind a reverse proxy that
                                 strips a URL sub-path.
       --web.prefix-header=""    Name of HTTP request header used for dynamic
                                 prefixing of UI links and redirects. This option

--- a/docs/components/bucket.md
+++ b/docs/components/bucket.md
@@ -42,22 +42,22 @@ Flags:
       --version            Show application version.
       --log.level=info     Log filtering level.
       --log.format=logfmt  Log format to use.
-      --tracing.config-file=<file-path>
+      --tracing.config-file=<file-path>  
                            Path to YAML file with tracing configuration. See
                            format details:
                            https://thanos.io/tracing.md/#configuration
-      --tracing.config=<content>
+      --tracing.config=<content>  
                            Alternative to 'tracing.config-file' flag (lower
                            priority). Content of YAML file with tracing
                            configuration. See format details:
                            https://thanos.io/tracing.md/#configuration
-      --objstore.config-file=<file-path>
+      --objstore.config-file=<file-path>  
                            Path to YAML file that contains object store
                            configuration. See format details:
                            https://thanos.io/storage.md/#configuration
-      --objstore.config=<content>
+      --objstore.config=<content>  
                            Alternative to 'objstore.config-file' flag (lower
-                           priority). Content of YAML file that contains object
+                           priority). Content of YAML file that contains objec
                            store configuration. See format details:
                            https://thanos.io/storage.md/#configuration
 
@@ -103,15 +103,24 @@ Flags:
       --version                 Show application version.
       --log.level=info          Log filtering level.
       --log.format=logfmt       Log format to use.
+<<<<<<< HEAD
       --tracing.config-file=<file-path>
                                 Path to YAML file with tracing configuration.
                                 See format details:
                                 https://thanos.io/tracing.md/#configuration
       --tracing.config=<content>
+=======
+      --tracing.config-file=<file-path>  
+                                Path to YAML file with tracing configuration.
+                                See format details:
+                                https://thanos.io/tracing.md/#configuration
+      --tracing.config=<content>  
+>>>>>>> 146bd34e... Add externalPrefix base path.
                                 Alternative to 'tracing.config-file' flag (lower
                                 priority). Content of YAML file with tracing
                                 configuration. See format details:
                                 https://thanos.io/tracing.md/#configuration
+<<<<<<< HEAD
       --objstore.config-file=<file-path>
                                 Path to YAML file that contains object store
                                 configuration. See format details:
@@ -126,16 +135,54 @@ Flags:
                                 Listen host:port for HTTP endpoints.
       --http-grace-period=2m    Time to wait after an interrupt received for
                                 HTTP Server.
+=======
+      --objstore.config-file=<file-path>  
+                                Path to YAML file that contains object store
+                                configuration. See format details:
+                                https://thanos.io/storage.md/#configuration
+      --objstore.config=<content>  
+                                Alternative to 'objstore.config-file' flag
+                                (lower priority). Content of YAML file tha
+                                contains object store configuration. See forma
+                                details:
+                                https://thanos.io/storage.md/#configuration
+      --http-address="0.0.0.0:10902"  
+                                Listen host:port for HTTP endpoints.
+      --http-grace-period=2m    Time to wait after an interrupt received for
+                                HTTP Server.
+      --web.external-prefix=""  Static prefix for all HTML links and redirec
+                                URLs in the bucket web UI interface. Actual
+                                endpoints are still served on / or the
+                                web.route-prefix. This allows thanos bucket web
+                                UI to be served behind a reverse proxy tha
+                                strips a URL sub-path.
+      --web.prefix-header=""    Name of HTTP request header used for dynamic
+                                prefixing of UI links and redirects. This option
+                                is ignored if web.external-prefix argument is
+                                set. Security risk: enable this option only if a
+                                reverse proxy in front of thanos is resetting
+                                the header. The
+                                --web.prefix-header=X-Forwarded-Prefix option
+                                can be useful, for example, if Thanos UI is
+                                served via Traefik reverse proxy with
+                                PathPrefixStrip option enabled, which sends the
+                                stripped prefix value in X-Forwarded-Prefix
+                                header. This allows thanos UI to be served on a
+                                sub-path.
+>>>>>>> 146bd34e... Add externalPrefix base path.
       --refresh=30m             Refresh interval to download metadata from
                                 remote storage
       --timeout=5m              Timeout to download metadata from remote storage
       --label=LABEL             Prometheus label to use as timeline title
+<<<<<<< HEAD
       --web.external-prefix=""  Static prefix for all HTML links and redirect
                                 URLs in the UI query web interface. Actual
                                 endpoints are still served on / or the
                                 web.route-prefix. This allows thanos UI to be
                                 served behind a reverse proxy that strips a URL
                                 sub-path.
+=======
+>>>>>>> 146bd34e... Add externalPrefix base path.
 
 ```
 
@@ -161,43 +208,43 @@ Flags:
       --version            Show application version.
       --log.level=info     Log filtering level.
       --log.format=logfmt  Log format to use.
-      --tracing.config-file=<file-path>
+      --tracing.config-file=<file-path>  
                            Path to YAML file with tracing configuration. See
                            format details:
                            https://thanos.io/tracing.md/#configuration
-      --tracing.config=<content>
+      --tracing.config=<content>  
                            Alternative to 'tracing.config-file' flag (lower
                            priority). Content of YAML file with tracing
                            configuration. See format details:
                            https://thanos.io/tracing.md/#configuration
-      --objstore.config-file=<file-path>
+      --objstore.config-file=<file-path>  
                            Path to YAML file that contains object store
                            configuration. See format details:
                            https://thanos.io/storage.md/#configuration
-      --objstore.config=<content>
+      --objstore.config=<content>  
                            Alternative to 'objstore.config-file' flag (lower
-                           priority). Content of YAML file that contains object
+                           priority). Content of YAML file that contains objec
                            store configuration. See format details:
                            https://thanos.io/storage.md/#configuration
-      --objstore-backup.config-file=<file-path>
+      --objstore-backup.config-file=<file-path>  
                            Path to YAML file that contains object store-backup
                            configuration. See format details:
                            https://thanos.io/storage.md/#configuration Used for
                            repair logic to backup blocks before removal.
-      --objstore-backup.config=<content>
+      --objstore-backup.config=<content>  
                            Alternative to 'objstore-backup.config-file' flag
                            (lower priority). Content of YAML file that contains
-                           object store-backup configuration. See format
+                           object store-backup configuration. See forma
                            details: https://thanos.io/storage.md/#configuration
                            Used for repair logic to backup blocks before
                            removal.
   -r, --repair             Attempt to repair blocks for which issues were
                            detected
-  -i, --issues=index_issue... ...
+  -i, --issues=index_issue... ...  
                            Issues to verify (and optionally repair). Possible
                            values: [duplicated_compaction index_issue
                            overlapped_blocks]
-      --id-whitelist=ID-WHITELIST ...
+      --id-whitelist=ID-WHITELIST ...  
                            Block IDs to verify (and optionally repair) only. If
                            none is specified, all blocks will be verified.
                            Repeated field
@@ -226,22 +273,22 @@ Flags:
       --version            Show application version.
       --log.level=info     Log filtering level.
       --log.format=logfmt  Log format to use.
-      --tracing.config-file=<file-path>
+      --tracing.config-file=<file-path>  
                            Path to YAML file with tracing configuration. See
                            format details:
                            https://thanos.io/tracing.md/#configuration
-      --tracing.config=<content>
+      --tracing.config=<content>  
                            Alternative to 'tracing.config-file' flag (lower
                            priority). Content of YAML file with tracing
                            configuration. See format details:
                            https://thanos.io/tracing.md/#configuration
-      --objstore.config-file=<file-path>
+      --objstore.config-file=<file-path>  
                            Path to YAML file that contains object store
                            configuration. See format details:
                            https://thanos.io/storage.md/#configuration
-      --objstore.config=<content>
+      --objstore.config=<content>  
                            Alternative to 'objstore.config-file' flag (lower
-                           priority). Content of YAML file that contains object
+                           priority). Content of YAML file that contains objec
                            store configuration. See format details:
                            https://thanos.io/storage.md/#configuration
   -o, --output=""          Optional format in which to print each block's
@@ -271,25 +318,25 @@ Flags:
       --version              Show application version.
       --log.level=info       Log filtering level.
       --log.format=logfmt    Log format to use.
-      --tracing.config-file=<file-path>
+      --tracing.config-file=<file-path>  
                              Path to YAML file with tracing configuration. See
                              format details:
                              https://thanos.io/tracing.md/#configuration
-      --tracing.config=<content>
+      --tracing.config=<content>  
                              Alternative to 'tracing.config-file' flag (lower
                              priority). Content of YAML file with tracing
                              configuration. See format details:
                              https://thanos.io/tracing.md/#configuration
-      --objstore.config-file=<file-path>
+      --objstore.config-file=<file-path>  
                              Path to YAML file that contains object store
                              configuration. See format details:
                              https://thanos.io/storage.md/#configuration
-      --objstore.config=<content>
+      --objstore.config=<content>  
                              Alternative to 'objstore.config-file' flag (lower
                              priority). Content of YAML file that contains
                              object store configuration. See format details:
                              https://thanos.io/storage.md/#configuration
-  -l, --selector=<name>=\"<value>\" ...
+  -l, --selector=<name>=\"<value>\" ...  
                              Selects blocks based on label, e.g. '-l
                              key1=\"value1\" -l key2=\"value2\"'. All key value
                              pairs must match.

--- a/docs/components/bucket.md
+++ b/docs/components/bucket.md
@@ -103,39 +103,15 @@ Flags:
       --version                 Show application version.
       --log.level=info          Log filtering level.
       --log.format=logfmt       Log format to use.
-<<<<<<< HEAD
       --tracing.config-file=<file-path>
                                 Path to YAML file with tracing configuration.
                                 See format details:
                                 https://thanos.io/tracing.md/#configuration
       --tracing.config=<content>
-=======
-      --tracing.config-file=<file-path>  
-                                Path to YAML file with tracing configuration.
-                                See format details:
-                                https://thanos.io/tracing.md/#configuration
-      --tracing.config=<content>  
->>>>>>> 146bd34e... Add externalPrefix base path.
                                 Alternative to 'tracing.config-file' flag (lower
                                 priority). Content of YAML file with tracing
                                 configuration. See format details:
                                 https://thanos.io/tracing.md/#configuration
-<<<<<<< HEAD
-      --objstore.config-file=<file-path>
-                                Path to YAML file that contains object store
-                                configuration. See format details:
-                                https://thanos.io/storage.md/#configuration
-      --objstore.config=<content>
-                                Alternative to 'objstore.config-file' flag
-                                (lower priority). Content of YAML file that
-                                contains object store configuration. See format
-                                details:
-                                https://thanos.io/storage.md/#configuration
-      --http-address="0.0.0.0:10902"
-                                Listen host:port for HTTP endpoints.
-      --http-grace-period=2m    Time to wait after an interrupt received for
-                                HTTP Server.
-=======
       --objstore.config-file=<file-path>  
                                 Path to YAML file that contains object store
                                 configuration. See format details:
@@ -169,20 +145,10 @@ Flags:
                                 stripped prefix value in X-Forwarded-Prefix
                                 header. This allows thanos UI to be served on a
                                 sub-path.
->>>>>>> 146bd34e... Add externalPrefix base path.
       --refresh=30m             Refresh interval to download metadata from
                                 remote storage
       --timeout=5m              Timeout to download metadata from remote storage
       --label=LABEL             Prometheus label to use as timeline title
-<<<<<<< HEAD
-      --web.external-prefix=""  Static prefix for all HTML links and redirect
-                                URLs in the UI query web interface. Actual
-                                endpoints are still served on / or the
-                                web.route-prefix. This allows thanos UI to be
-                                served behind a reverse proxy that strips a URL
-                                sub-path.
-=======
->>>>>>> 146bd34e... Add externalPrefix base path.
 
 ```
 

--- a/docs/components/bucket.md
+++ b/docs/components/bucket.md
@@ -42,20 +42,20 @@ Flags:
       --version            Show application version.
       --log.level=info     Log filtering level.
       --log.format=logfmt  Log format to use.
-      --tracing.config-file=<file-path>  
+      --tracing.config-file=<file-path>
                            Path to YAML file with tracing configuration. See
                            format details:
                            https://thanos.io/tracing.md/#configuration
-      --tracing.config=<content>  
+      --tracing.config=<content>
                            Alternative to 'tracing.config-file' flag (lower
                            priority). Content of YAML file with tracing
                            configuration. See format details:
                            https://thanos.io/tracing.md/#configuration
-      --objstore.config-file=<file-path>  
+      --objstore.config-file=<file-path>
                            Path to YAML file that contains object store
                            configuration. See format details:
                            https://thanos.io/storage.md/#configuration
-      --objstore.config=<content>  
+      --objstore.config=<content>
                            Alternative to 'objstore.config-file' flag (lower
                            priority). Content of YAML file that contains object
                            store configuration. See format details:
@@ -112,21 +112,21 @@ Flags:
                                 priority). Content of YAML file with tracing
                                 configuration. See format details:
                                 https://thanos.io/tracing.md/#configuration
-      --objstore.config-file=<file-path>  
+      --objstore.config-file=<file-path>
                                 Path to YAML file that contains object store
                                 configuration. See format details:
                                 https://thanos.io/storage.md/#configuration
-      --objstore.config=<content>  
+      --objstore.config=<content>
                                 Alternative to 'objstore.config-file' flag
                                 (lower priority). Content of YAML file tha
                                 contains object store configuration. See format
                                 details:
                                 https://thanos.io/storage.md/#configuration
-      --http-address="0.0.0.0:10902"  
+      --http-address="0.0.0.0:10902"
                                 Listen host:port for HTTP endpoints.
       --http-grace-period=2m    Time to wait after an interrupt received for
                                 HTTP Server.
-      --web.external-prefix=""  Static prefix for all HTML links and redirec
+      --web.external-prefix=""  Static prefix for all HTML links and redirect
                                 URLs in the bucket web UI interface. Actual
                                 endpoints are still served on / or the
                                 web.route-prefix. This allows thanos bucket web
@@ -174,30 +174,30 @@ Flags:
       --version            Show application version.
       --log.level=info     Log filtering level.
       --log.format=logfmt  Log format to use.
-      --tracing.config-file=<file-path>  
+      --tracing.config-file=<file-path>
                            Path to YAML file with tracing configuration. See
                            format details:
                            https://thanos.io/tracing.md/#configuration
-      --tracing.config=<content>  
+      --tracing.config=<content>
                            Alternative to 'tracing.config-file' flag (lower
                            priority). Content of YAML file with tracing
                            configuration. See format details:
                            https://thanos.io/tracing.md/#configuration
-      --objstore.config-file=<file-path>  
+      --objstore.config-file=<file-path>
                            Path to YAML file that contains object store
                            configuration. See format details:
                            https://thanos.io/storage.md/#configuration
-      --objstore.config=<content>  
+      --objstore.config=<content>
                            Alternative to 'objstore.config-file' flag (lower
                            priority). Content of YAML file that contains object
                            store configuration. See format details:
                            https://thanos.io/storage.md/#configuration
-      --objstore-backup.config-file=<file-path>  
+      --objstore-backup.config-file=<file-path>
                            Path to YAML file that contains object store-backup
                            configuration. See format details:
                            https://thanos.io/storage.md/#configuration Used for
                            repair logic to backup blocks before removal.
-      --objstore-backup.config=<content>  
+      --objstore-backup.config=<content>
                            Alternative to 'objstore-backup.config-file' flag
                            (lower priority). Content of YAML file that contains
                            object store-backup configuration. See format
@@ -206,11 +206,11 @@ Flags:
                            removal.
   -r, --repair             Attempt to repair blocks for which issues were
                            detected
-  -i, --issues=index_issue... ...  
+  -i, --issues=index_issue... ...
                            Issues to verify (and optionally repair). Possible
                            values: [duplicated_compaction index_issue
                            overlapped_blocks]
-      --id-whitelist=ID-WHITELIST ...  
+      --id-whitelist=ID-WHITELIST ...
                            Block IDs to verify (and optionally repair) only. If
                            none is specified, all blocks will be verified.
                            Repeated field
@@ -239,20 +239,20 @@ Flags:
       --version            Show application version.
       --log.level=info     Log filtering level.
       --log.format=logfmt  Log format to use.
-      --tracing.config-file=<file-path>  
+      --tracing.config-file=<file-path>
                            Path to YAML file with tracing configuration. See
                            format details:
                            https://thanos.io/tracing.md/#configuration
-      --tracing.config=<content>  
+      --tracing.config=<content>
                            Alternative to 'tracing.config-file' flag (lower
                            priority). Content of YAML file with tracing
                            configuration. See format details:
                            https://thanos.io/tracing.md/#configuration
-      --objstore.config-file=<file-path>  
+      --objstore.config-file=<file-path>
                            Path to YAML file that contains object store
                            configuration. See format details:
                            https://thanos.io/storage.md/#configuration
-      --objstore.config=<content>  
+      --objstore.config=<content>
                            Alternative to 'objstore.config-file' flag (lower
                            priority). Content of YAML file that contains object
                            store configuration. See format details:
@@ -284,25 +284,25 @@ Flags:
       --version              Show application version.
       --log.level=info       Log filtering level.
       --log.format=logfmt    Log format to use.
-      --tracing.config-file=<file-path>  
+      --tracing.config-file=<file-path>
                              Path to YAML file with tracing configuration. See
                              format details:
                              https://thanos.io/tracing.md/#configuration
-      --tracing.config=<content>  
+      --tracing.config=<content>
                              Alternative to 'tracing.config-file' flag (lower
                              priority). Content of YAML file with tracing
                              configuration. See format details:
                              https://thanos.io/tracing.md/#configuration
-      --objstore.config-file=<file-path>  
+      --objstore.config-file=<file-path>
                              Path to YAML file that contains object store
                              configuration. See format details:
                              https://thanos.io/storage.md/#configuration
-      --objstore.config=<content>  
+      --objstore.config=<content>
                              Alternative to 'objstore.config-file' flag (lower
                              priority). Content of YAML file that contains
                              object store configuration. See format details:
                              https://thanos.io/storage.md/#configuration
-  -l, --selector=<name>=\"<value>\" ...  
+  -l, --selector=<name>=\"<value>\" ...
                              Selects blocks based on label, e.g. '-l
                              key1=\"value1\" -l key2=\"value2\"'. All key value
                              pairs must match.

--- a/pkg/ui/bucket.go
+++ b/pkg/ui/bucket.go
@@ -20,7 +20,6 @@ type Bucket struct {
 	Blocks      template.JS
 	RefreshedAt time.Time
 	Err         error
-	flagsMap    map[string]string
 }
 
 func NewBucketUI(logger log.Logger, label string, flagsMap map[string]string) *Bucket {

--- a/pkg/ui/bucket.go
+++ b/pkg/ui/bucket.go
@@ -45,10 +45,6 @@ func (b *Bucket) Register(r *route.Router, ins extpromhttp.InstrumentationMiddle
 // Handle / of bucket UIs.
 func (b *Bucket) root(w http.ResponseWriter, r *http.Request) {
 	prefix := GetWebPrefix(b.logger, b.flagsMap, r)
-<<<<<<< HEAD
-=======
-
->>>>>>> 146bd34e... Add externalPrefix base path.
 	b.executeTemplate(w, "bucket.html", prefix, b)
 }
 

--- a/pkg/ui/bucket.go
+++ b/pkg/ui/bucket.go
@@ -13,6 +13,7 @@ import (
 // Bucket is a web UI representing state of buckets as a timeline.
 type Bucket struct {
 	*BaseUI
+	flagsMap map[string]string
 	// Unique Prometheus label that identifies each shard, used as the title. If
 	// not present, all labels are displayed externally as a legend.
 	Label       string
@@ -44,6 +45,10 @@ func (b *Bucket) Register(r *route.Router, ins extpromhttp.InstrumentationMiddle
 // Handle / of bucket UIs.
 func (b *Bucket) root(w http.ResponseWriter, r *http.Request) {
 	prefix := GetWebPrefix(b.logger, b.flagsMap, r)
+<<<<<<< HEAD
+=======
+
+>>>>>>> 146bd34e... Add externalPrefix base path.
 	b.executeTemplate(w, "bucket.html", prefix, b)
 }
 


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!-- 
    Don't forget about CHANGELOG! 
    
    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...
    
    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes
Using the following build: quay.io/thanos/thanos:master-2019-11-20-af2a342b, I encountered 404s on static resources when trying to run the bucket web UI behind a Nginx proxy. 

- This PR fixes that by ensuring that the UI is handled at the provided external path.
- Added web.prefix-header to provide similar functionality available in the Query UI

<!-- Enumerate changes you made -->

## Verification
I am running an internal build of this branch behind a Nginx proxy with no issues.

<!-- How you tested it? How do you know it works? -->
Fixes: https://github.com/thanos-io/thanos/issues/1349