### PR TITLE
ruler: fix the /api/v1/rules endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 - [#1669](https://github.com/thanos-io/thanos/pull/1669) Fixed store sharding. Now it does not load excluded meta.jsons and load/fetch index-cache.json files.
 - [#1670](https://github.com/thanos-io/thanos/pull/1670) Fixed un-ordered blocks upload. Sidecar now uploads the oldest blocks first.
 - [#1568](https://github.com/thanos-io/thanos/pull/1709) Thanos Store now retains the first raw value of a chunk during downsampling to avoid losing some counter resets that occur on an aggregation boundary.
-- [#1773](https://github.com/thanos-io/thanos/pull/1773) Thanos Ruler: fixed the /api/v1/rules endpoint.
+- [#1773](https://github.com/thanos-io/thanos/pull/1773) Thanos Ruler: fixed the /api/v1/rules endpoint that returned 500 status code with `failed to assert type of rule ...` message.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 - [#1669](https://github.com/thanos-io/thanos/pull/1669) Fixed store sharding. Now it does not load excluded meta.jsons and load/fetch index-cache.json files.
 - [#1670](https://github.com/thanos-io/thanos/pull/1670) Fixed un-ordered blocks upload. Sidecar now uploads the oldest blocks first.
 - [#1568](https://github.com/thanos-io/thanos/pull/1709) Thanos Store now retains the first raw value of a chunk during downsampling to avoid losing some counter resets that occur on an aggregation boundary.
+- [#1773](https://github.com/thanos-io/thanos/pull/1773) Thanos Ruler: fixed the /api/v1/rules endpoint.
 
 ### Changed
 

--- a/pkg/rule/api/v1.go
+++ b/pkg/rule/api/v1.go
@@ -84,7 +84,7 @@ func (api *API) rules(r *http.Request) (interface{}, []error, *qapi.ApiError) {
 			}
 
 			switch rule := r.(type) {
-			case thanosrule.AlertingRule:
+			case *rules.AlertingRule:
 				enrichedRule = alertingRule{
 					Name:                    rule.Name(),
 					Query:                   rule.Query().String(),
@@ -95,7 +95,7 @@ func (api *API) rules(r *http.Request) (interface{}, []error, *qapi.ApiError) {
 					Health:                  rule.Health(),
 					LastError:               lastError,
 					Type:                    "alerting",
-					PartialResponseStrategy: rule.PartialResponseStrategy.String(),
+					PartialResponseStrategy: grp.PartialResponseStrategy.String(),
 				}
 			case *rules.RecordingRule:
 				enrichedRule = recordingRule{
@@ -107,7 +107,7 @@ func (api *API) rules(r *http.Request) (interface{}, []error, *qapi.ApiError) {
 					Type:      "recording",
 				}
 			default:
-				err := fmt.Errorf("failed to assert type of rule '%v'", rule.Name())
+				err := fmt.Errorf("rule %q: unsupported type %T", r.Name(), rule)
 				return nil, nil, &qapi.ApiError{Typ: qapi.ErrorInternal, Err: err}
 			}
 

--- a/pkg/rule/api/v1_test.go
+++ b/pkg/rule/api/v1_test.go
@@ -81,7 +81,7 @@ func (m rulesRetrieverMock) RuleGroups() []thanosrule.Group {
 	}
 
 	var r []rules.Rule
-	for _, ar := range alertingRules() {
+	for _, ar := range alertingRules(m.testing) {
 		r = append(r, ar)
 	}
 
@@ -98,20 +98,20 @@ func (m rulesRetrieverMock) RuleGroups() []thanosrule.Group {
 
 func (m rulesRetrieverMock) AlertingRules() []thanosrule.AlertingRule {
 	var ars []thanosrule.AlertingRule
-	for _, ar := range alertingRules() {
+	for _, ar := range alertingRules(m.testing) {
 		ars = append(ars, thanosrule.AlertingRule{AlertingRule: ar})
 	}
 	return ars
 }
 
-func alertingRules() []*rules.AlertingRule {
+func alertingRules(t *testing.T) []*rules.AlertingRule {
 	expr1, err := promql.ParseExpr(`absent(test_metric3) != 1`)
 	if err != nil {
-		panic(fmt.Sprintf("unable to parse alert expression: %s", err))
+		t.Fatalf("unable to parse alert expression: %s", err)
 	}
 	expr2, err := promql.ParseExpr(`up == 1`)
 	if err != nil {
-		panic(fmt.Sprintf("unable to parse alert expression: %s", err))
+		t.Fatalf("unable to parse alert expression: %s", err)
 	}
 
 	return []*rules.AlertingRule{


### PR DESCRIPTION
Closes #1189 
<!-- 
    Don't forget about CHANGELOG! 
    
    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...
    
    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Fixed the switch type in the `rules` handler because alerting rules are instances of `*rules.AlertingRule`, not `thanosrule.AlertingRule`. This is because the rules are returned from the Prometheus rule managers and have no notion of `PartialResponseStrategy`.

## Verification

The `/api/v1/rules` and `/api/v1/alerts` endpoints are now covered by the end-to-end tests.