### PR TITLE
Fixes #1780 reload config when inode has changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 
 ### Fixed
 
+- [#1780](https://github.com/thanos-io/thanos/pull/1781) Thanos now trigger reload when the secret of config file on k8s updates.
 - [#1656](https://github.com/thanos-io/thanos/pull/1656) Thanos Store now starts metric and status probe HTTP server earlier in its start-up sequence. `/-/healthy` endpoint now starts to respond with success earlier. `/metrics` endpoint starts serving metrics earlier as well. Make sure to point your readiness probes to the `/-/ready` endpoint rather than `/metrics`.
 - [#1669](https://github.com/thanos-io/thanos/pull/1669) Fixed store sharding. Now it does not load excluded meta.jsons and load/fetch index-cache.json files.
 - [#1670](https://github.com/thanos-io/thanos/pull/1670) Fixed un-ordered blocks upload. Sidecar now uploads the oldest blocks first.


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!-- 
    Don't forget about CHANGELOG! 
    
    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...
    
    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

Reloader watching op=CHMOD events. Compare the before and after changes of the configuration file inode. restart watching when inode changes.

## Verification

<!-- How you tested it? How do you know it works? -->

1. prepare the demo

```
package main

import (
	"context"
	"fmt"
	"net/url"
	"os"

	"github.com/go-kit/kit/log"
	"github.com/thanos-io/thanos/pkg/reloader"
)

const (
	logFormatLogfmt = "logfmt"
	logFormatJson   = "json"
)

func main() {
	logger := log.NewLogfmtLogger(log.NewSyncWriter(os.Stdout))
	logger = log.With(logger, "ts", log.DefaultTimestampUTC)
	logger = log.With(logger, "caller", log.DefaultCaller)

	reloadURL, _ := url.Parse("http://localhost:9090/-/reload")
	r := reloader.New(logger, reloadURL, "/etc/prometheus/config/prometheus.yml", "/etc/prometheus/config_out/prometheus.yml", nil)
	ctx, cancel := context.WithCancel(context.Background())
	defer cancel()
	if err := r.Watch(ctx); err != nil {
		fmt.Println(err)
	}
}
```

2. prepare two config file

/etc/prometheus/config/prometheus.yml
```
global:
  scrape_interval: 30s
  scrape_timeout: 10s
  evaluation_interval: 30s
```

/etc/prometheus/config/prometheus1.yml
```
global:
  scrape_interval: 10s
  scrape_timeout: 10s
  evaluation_interval: 30s
```

3. running the demo

4. using `mv` command to overwrite config file

```
mv /etc/prometheus/config/prometheus1.yml /etc/prometheus/config/prometheus.yml
```

5. reloader trigger to reload

```
level=info ts=2019-11-22T10:52:26.7972049Z caller=reloader.go:315 msg="Prometheus reload triggered" cfg_in=/etc/prometheus/config/prometheus.yml cfg_out=/etc/prometheus/config_out/prometheus.yml rule_dirs=
level=info ts=2019-11-22T10:52:26.797255Z caller=reloader.go:162 msg="started watching config file and non-recursively rule dirs for changes" cfg=/etc/prometheus/config/prometheus.yml out=/etc/prometheus/config_out/prometheus.yml dirs=
level=debug ts=2019-11-22T10:52:30.3186309Z caller=reloader.go:195 msg="restarted watching config file in case of inode changed" op=CHMOD name=/etc/prometheus/config/prometheus.yml lastIno=86536461 currentIno=85509303
```
