### PR TITLE
pkg: fix staticcheck issues

### DIFF
--- a/pkg/model/timeduration_test.go
+++ b/pkg/model/timeduration_test.go
@@ -32,5 +32,5 @@ func TestTimeOrDurationValue(t *testing.T) {
 	testutil.Assert(t, minTime.PrometheusTimestamp() > prevTime, "minTime prometheus timestamp is less than time now.")
 	testutil.Assert(t, minTime.PrometheusTimestamp() < afterTime, "minTime prometheus timestamp is more than time now + 15s")
 
-	testutil.Assert(t, 253402300799000 == maxTime.PrometheusTimestamp(), "maxTime is not equal to 253402300799000")
+	testutil.Assert(t, maxTime.PrometheusTimestamp() == 253402300799000, "maxTime is not equal to 253402300799000")
 }

--- a/pkg/objstore/oss/oss.go
+++ b/pkg/objstore/oss/oss.go
@@ -63,15 +63,13 @@ func NewTestBucket(t testing.TB) (objstore.Bucket, func(), error) {
 }
 
 func calculateChunks(name string, r io.Reader) (int, int64, error) {
-	switch r.(type) {
+	switch f := r.(type) {
 	case *os.File:
-		f, _ := r.(*os.File)
 		if fileInfo, err := f.Stat(); err == nil {
 			s := fileInfo.Size()
 			return int(math.Floor(float64(s) / PartSize)), s % PartSize, nil
 		}
 	case *strings.Reader:
-		f, _ := r.(*strings.Reader)
 		return int(math.Floor(float64(f.Size()) / PartSize)), f.Size() % PartSize, nil
 	}
 	return -1, 0, errors.New("unsupported implement of io.Reader")


### PR DESCRIPTION
Signed-off-by: Matt Layher <mdlayher@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!-- 
    Don't forget about CHANGELOG! 
    
    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...
    
    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

Fix minor issues detected by staticcheck:

```
$ staticcheck ./...                                                                                                       
pkg/model/timeduration_test.go:35:21: don't use Yoda conditions (ST1017)                                                                            
pkg/objstore/oss/oss.go:66:9: assigning the result of this type assertion to a variable (switch r := r.(type)) could eliminate the following type as
sertions:                                                                                                                                          
        /home/matt/src/github.com/thanos-io/thanos/pkg/objstore/oss/oss.go:68:11                                                                   
        /home/matt/src/github.com/thanos-io/thanos/pkg/objstore/oss/oss.go:74:11 (S1034)
```

## Verification

<!-- How you tested it? How do you know it works? -->

`make test`, but I don't have any of the object store providers set up for testing yet.