### PR TITLE
pkg/rule: retain original path for rule files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 - [#1568](https://github.com/thanos-io/thanos/pull/1709) Thanos Store now retains the first raw value of a chunk during downsampling to avoid losing some counter resets that occur on an aggregation boundary.
 - [#1773](https://github.com/thanos-io/thanos/pull/1773) Thanos Ruler: fixed the /api/v1/rules endpoint that returned 500 status code with `failed to assert type of rule ...` message.
 - [#1770](https://github.com/thanos-io/thanos/pull/1770) Fix `--web.external-prefix` 404s for static resources.
+- [#1785](https://github.com/thanos-io/thanos/pull/1785) Thanos Ruler: the /api/v1/rules endpoints now returns the original rule filenames.
 
 ### Changed
 

--- a/pkg/rule/api/v1.go
+++ b/pkg/rule/api/v1.go
@@ -69,7 +69,7 @@ func (api *API) rules(r *http.Request) (interface{}, []error, *qapi.ApiError) {
 	for _, grp := range api.ruleRetriever.RuleGroups() {
 		apiRuleGroup := &RuleGroup{
 			Name:                    grp.Name(),
-			File:                    grp.File(),
+			File:                    grp.OriginalFile(),
 			Interval:                grp.Interval().Seconds(),
 			Rules:                   []rule{},
 			PartialResponseStrategy: grp.PartialResponseStrategy.String(),

--- a/pkg/ui/rule.go
+++ b/pkg/ui/rule.go
@@ -16,7 +16,6 @@ import (
 	"github.com/prometheus/prometheus/rules"
 	extpromhttp "github.com/thanos-io/thanos/pkg/extprom/http"
 	thanosrule "github.com/thanos-io/thanos/pkg/rule"
-	"github.com/thanos-io/thanos/pkg/store/storepb"
 )
 
 type Rule struct {
@@ -24,18 +23,18 @@ type Rule struct {
 
 	flagsMap map[string]string
 
-	ruleManagers thanosrule.Managers
-	queryURL     string
-	reg          prometheus.Registerer
+	ruleManager *thanosrule.Manager
+	queryURL    string
+	reg         prometheus.Registerer
 }
 
-func NewRuleUI(logger log.Logger, reg prometheus.Registerer, ruleManagers map[storepb.PartialResponseStrategy]*rules.Manager, queryURL string, flagsMap map[string]string) *Rule {
+func NewRuleUI(logger log.Logger, reg prometheus.Registerer, ruleManager *thanosrule.Manager, queryURL string, flagsMap map[string]string) *Rule {
 	return &Rule{
-		BaseUI:       NewBaseUI(logger, "rule_menu.html", ruleTmplFuncs(queryURL)),
-		flagsMap:     flagsMap,
-		ruleManagers: ruleManagers,
-		queryURL:     queryURL,
-		reg:          reg,
+		BaseUI:      NewBaseUI(logger, "rule_menu.html", ruleTmplFuncs(queryURL)),
+		flagsMap:    flagsMap,
+		ruleManager: ruleManager,
+		queryURL:    queryURL,
+		reg:         reg,
 	}
 }
 
@@ -115,7 +114,7 @@ func ruleTmplFuncs(queryURL string) template.FuncMap {
 }
 
 func (ru *Rule) alerts(w http.ResponseWriter, r *http.Request) {
-	alerts := ru.ruleManagers.AlertingRules()
+	alerts := ru.ruleManager.AlertingRules()
 	alertsSorter := byAlertStateAndNameSorter{alerts: alerts}
 	sort.Sort(alertsSorter)
 
@@ -138,7 +137,7 @@ func (ru *Rule) rules(w http.ResponseWriter, r *http.Request) {
 	prefix := GetWebPrefix(ru.logger, ru.flagsMap, r)
 
 	// TODO(bwplotka): Update HTML to include partial response.
-	ru.executeTemplate(w, "rules.html", prefix, ru.ruleManagers)
+	ru.executeTemplate(w, "rules.html", prefix, ru.ruleManager)
 }
 
 // Root redirects / requests to /graph, taking into account the path prefix value.


### PR DESCRIPTION
This change ensures that the /api/v1/rules endpoint returns the original path of the rule file instead of the path of the temporary file generated by Thanos ruler.

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!-- 
    Don't forget about CHANGELOG! 
    
    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...
    
    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

The mapping from the original rule filenames to the temporary filenames is stored in the `github.com/thanos-io/thanos/pkg/rule.Manager` struct. 

## Verification

Added end-to-end tests.
