### PR TITLE
test/e2e: start Alertmanager without clustering

### DIFF
--- a/test/e2e/spinup_test.go
+++ b/test/e2e/spinup_test.go
@@ -298,6 +298,7 @@ receivers:
 			return newCmdExec(exec.Command(testutil.AlertmanagerBinary(),
 				"--config.file", dir+"/config.yaml",
 				"--web.listen-address", http.HostPort(),
+				"--cluster.listen-address", "",
 				"--log.level", "debug",
 			)), nil
 		},


### PR DESCRIPTION


<!-- 
    Don't forget about CHANGELOG! 
    
    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...
    
    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

When running the end-to-end tests locally, Alertmanager may fail to start if another instance of Alertmanager is already running. This is because both instances bind to the default clustering port (9094). Since e2e tests don't rely on Alertmanager clustering, we disable clustering by setting `--cluster.listen-address=""`.

## Verification

End-to-end tests should pass as before.
