### PR TITLE
Improve store timeouts

### DIFF
--- a/pkg/store/proxy.go
+++ b/pkg/store/proxy.go
@@ -403,6 +403,7 @@ func startStreamSeriesSet(
 			go func() {
 				r, err := s.stream.Recv()
 				rCh <- &recvResponse{r: r, err: err}
+				close(rCh)
 			}()
 
 			select {
@@ -414,7 +415,6 @@ func startStreamSeriesSet(
 				return
 			case rr = <-rCh:
 			}
-			close(rCh)
 
 			if rr.err == io.EOF {
 				return


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!-- 
    Don't forget about CHANGELOG! 
    
    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...
    
    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

We want to increase stability Thanos infrastructure with many stores/sidecars (49 in our case) when some stores respond slowly.

## Changes

* [ ] Fix and improve TestProxyStore_SeriesSlowStores:
  * [ ] Fixed broken test
  * [ ] Add some use-cases
  * [ ]  check on elapsed time on get data from stores.
* [ ] Change logic in ProxyStore:
  * [ ] store response timeout moved from MergedSet.Next() function to goroutine in startStreamSeriesSet to check timeouts in parallel
  * [ ] add ProxyStore metrics

More details in comments.

## Verification

* [ ] Tests
* [ ] On production in our system with 49 store backends already 2 weeks.
