### PR TITLE
pkg/rule: support identical rule filenames in different directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 - [#1773](https://github.com/thanos-io/thanos/pull/1773) Thanos Ruler: fixed the /api/v1/rules endpoint that returned 500 status code with `failed to assert type of rule ...` message.
 - [#1770](https://github.com/thanos-io/thanos/pull/1770) Fix `--web.external-prefix` 404s for static resources.
 - [#1785](https://github.com/thanos-io/thanos/pull/1785) Thanos Ruler: the /api/v1/rules endpoints now returns the original rule filenames.
+- [#1791](https://github.com/thanos-io/thanos/pull/1791) Thanos Ruler now supports identical rule filenames in different directories.
 
 ### Changed
 

--- a/pkg/rule/rule.go
+++ b/pkg/rule/rule.go
@@ -1,6 +1,7 @@
 package thanosrule
 
 import (
+	"crypto/sha256"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -187,7 +188,7 @@ func (m *Manager) Update(evalInterval time.Duration, files []string) error {
 				continue
 			}
 
-			newFn := filepath.Join(m.workDir, filepath.Base(fn)+"."+s.String())
+			newFn := filepath.Join(m.workDir, fmt.Sprintf("%s.%x.%s", filepath.Base(fn), sha256.Sum256([]byte(fn)), s.String()))
 			if err := ioutil.WriteFile(newFn, b, os.ModePerm); err != nil {
 				errs = append(errs, errors.Wrap(err, newFn))
 				continue


### PR DESCRIPTION

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Thanos didn't deal correctly with rule files that have the same name but live in different directories (eg `thanos rule --rule-file foo/rules.yml  --rule-file bar/rules.yml`). This is because the "transofrmed" files are stored in the same output directory and the filenames don't differ if the partial response strategy is the same.

## Verification

Unit test added.
