### PR TITLE
remove docker hub part

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,9 +70,7 @@ jobs:
       - run: ln -s .build/linux-amd64/thanos thanos
       - run: make docker
       - run: docker run thanos --help
-      # Upload to both dockerhub and quay.io.
-      - run: echo "${DOCKERHUB_PASSWORD}" | docker login -u="${DOCKERHUB_USERNAME}" --password-stdin
-      - run: make docker-push DOCKER_IMAGE_REPO=thanosio/thanos
+      # Upload to quay.io.
       - run: echo "${QUAY_PASSWORD}" | docker login -u="${QUAY_USERNAME}" quay.io --password-stdin
       - run: make docker-push
 
@@ -96,9 +94,7 @@ jobs:
       - run: ln -s .build/linux-amd64/thanos thanos
       - run: make docker
       - run: docker run thanos --help
-      # Upload to both dockerhub and quay.io.
-      - run: echo "${DOCKERHUB_PASSWORD}" | docker login -u="${DOCKERHUB_USERNAME}" --password-stdin
-      - run: make docker-push DOCKER_IMAGE_REPO=thanosio/thanos DOCKER_IMAGE_TAG=$CIRCLE_TAG
+      # Upload to quay.io.
       - run: echo "${QUAY_PASSWORD}" | docker login -u="${QUAY_USERNAME}" quay.io --password-stdin
       - run: make docker-push DOCKER_IMAGE_TAG=$CIRCLE_TAG
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The philosophy of Thanos and our community is borrowing much from UNIX philosoph
 
 ## Releases
 
-Master should be stable and usable. Every commit to master builds docker image named `master-<data>-<sha>` in [quay.io/thanos/thanos](https://quay.io/repository/thanos/thanos) and [thanosio/thanos dockerhub (mirror)](https://hub.docker.com/r/thanosio/thanos)
+Master should be stable and usable. Every commit to master builds docker image named `master-<data>-<sha>` in [quay.io/thanos/thanos](https://quay.io/repository/thanos/thanos).
 
 We also perform minor releases every 6 weeks.
 

--- a/website/layouts/index.html
+++ b/website/layouts/index.html
@@ -25,11 +25,6 @@
                     </a>
                 </li>
                 <li class="list-inline-item my-3">
-                    <a href="https://hub.docker.com/r/{{ .Site.Params.DockerHubUser }}/{{ .Site.Params.DockerHubRepository }}" class="btn btn-outline-secondary">
-                        <i class="mr-1 fab fa-fw fa-docker"></i> DockerHub
-                    </a>
-                </li>
-                <li class="list-inline-item my-3">
                     <a href="https://github.com/{{ .Site.Params.GithubUser }}/{{ .Site.Params.GithubProject }}" class="btn btn-outline-secondary">
                         <i class="mr-1 fab fa-fw fa-github"></i> Github
                     </a>


### PR DESCRIPTION
Signed-off-by: Xiang Dai <764524258@qq.com>

## Changes

Since we've moved to quay and do not update docker hub, remove all docker hub part.

I see that we mirror it in docker hub in changelog, but in fact, we have not mirrored it recently refer to https://hub.docker.com/r/improbable/thanos/tags.
