### PR TITLE
Store Fix: Removed dir on loadmeta failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 
 ### Fixed
 
+- [#1807](https://github.com/thanos-io/thanos/pull/1807) Store: Cleanup block dir on loadmeta failure.
 - [#1656](https://github.com/thanos-io/thanos/pull/1656) Store Gateway: Store now starts metric and status probe HTTP server earlier in its start-up sequence. `/-/healthy` endpoint now starts to respond with success earlier. `/metrics` endpoint starts serving metrics earlier as well. Make sure to point your readiness probes to the `/-/ready` endpoint rather than `/metrics`.
 - [#1669](https://github.com/thanos-io/thanos/pull/1669) Store Gateway: Fixed store sharding. Now it does not load excluded meta.jsons and load/fetch index-cache.json files.
 - [#1670](https://github.com/thanos-io/thanos/pull/1670) Sidecar: Fixed un-ordered blocks upload. Sidecar now uploads the oldest blocks first.

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -343,7 +343,8 @@ func (s *BucketStore) SyncBlocks(ctx context.Context) error {
 		bdir := path.Join(s.dir, id.String())
 		meta, err := loadMeta(ctx, s.logger, s.bucket, bdir, id)
 		if err != nil {
-			return errors.Wrap(os.RemoveAll(bdir), "load meta")
+			level.Warn(s.logger).Log("msg", "error loading meta", "block", id, "err", err)
+			return os.RemoveAll(bdir)
 		}
 
 		inRange, err := s.isBlockInMinMaxRange(ctx, meta)

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -343,7 +343,7 @@ func (s *BucketStore) SyncBlocks(ctx context.Context) error {
 		bdir := path.Join(s.dir, id.String())
 		meta, err := loadMeta(ctx, s.logger, s.bucket, bdir, id)
 		if err != nil {
-			return errors.Wrap(err, "load meta")
+			return errors.Wrap(os.RemoveAll(bdir), "load meta")
 		}
 
 		inRange, err := s.isBlockInMinMaxRange(ctx, meta)


### PR DESCRIPTION
If loadmeta fails during SyncBlocks, the block directory is left behind,
resulting in subsequent failures to read the meta file since loadmeta just looks for the directory to exist.

FailureToLoadMeta unit test

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Calls `os.RemoveAll` on the blockdir when returning error from load meta

## Verification

Added unit test that checks if a sync against a block that's missing a meta.json gets removed. 
