### PR TITLE
[bugfix] pkg/reloader: add return which miss.

### DIFF
--- a/pkg/reloader/reloader.go
+++ b/pkg/reloader/reloader.go
@@ -291,6 +291,7 @@ func (r *Reloader) apply(ctx context.Context) error {
 		return nil
 	}); err != nil {
 		level.Error(r.logger).Log("msg", "Failed to trigger reload. Retrying.", "err", err)
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
https://github.com/thanos-io/thanos/blob/bd9aa1b4be3bb5d841cb7271c29d02ebb5eb5168/pkg/reloader/reloader.go#L292-L294

`return` statement lost.