### PR TITLE
cmd/thanos: add labels len check when running.

### DIFF
--- a/cmd/thanos/sidecar.go
+++ b/cmd/thanos/sidecar.go
@@ -223,6 +223,10 @@ func runSidecar(
 					lastHeartbeat.Set(float64(time.Now().UnixNano()) / 1e9)
 				}
 
+				if len(m.Labels()) == 0 {
+					return errors.New("no external labels configured on Prometheus server, uniquely identifying external labels must be configured")
+				}
+
 				return nil
 			})
 		}, func(error) {


### PR DESCRIPTION
The external labels check of Prometheus may also become illegal during operation after first passing.

https://github.com/thanos-io/thanos/blob/7e11afe64af0c096743a3de8a594616abf52be45/cmd/thanos/sidecar.go#L208-L227