### PR TITLE
comment url scheme

### DIFF
--- a/cmd/thanos/rule.go
+++ b/cmd/thanos/rule.go
@@ -81,7 +81,7 @@ func registerRule(m map[string]setupFunc, app *kingpin.Application) {
 	tsdbRetention := modelDuration(cmd.Flag("tsdb.retention", "Block retention time on local disk.").
 		Default("48h"))
 
-	alertmgrs := cmd.Flag("alertmanagers.url", "Alertmanager replica URLs to push firing alerts. Ruler claims success if push to at least one alertmanager from discovered succeeds. The scheme may be prefixed with 'dns+' or 'dnssrv+' to detect Alertmanager IPs through respective DNS lookups. The port defaults to 9093 or the SRV record's value. The URL path is used as a prefix for the regular Alertmanager API path.").
+	alertmgrs := cmd.Flag("alertmanagers.url", "Alertmanager replica URLs to push firing alerts. Ruler claims success if push to at least one alertmanager from discovered succeeds. The scheme should not be empty e.g `http` might be used. The scheme may be prefixed with 'dns+' or 'dnssrv+' to detect Alertmanager IPs through respective DNS lookups. The port defaults to 9093 or the SRV record's value. The URL path is used as a prefix for the regular Alertmanager API path.").
 		Strings()
 
 	alertmgrsTimeout := cmd.Flag("alertmanagers.send-timeout", "Timeout for sending alerts to alertmanager").Default("10s").Duration()

--- a/docs/components/rule.md
+++ b/docs/components/rule.md
@@ -201,12 +201,13 @@ Flags:
                                  Alertmanager replica URLs to push firing
                                  alerts. Ruler claims success if push to at
                                  least one alertmanager from discovered
-                                 succeeds. The scheme may be prefixed with
-                                 'dns+' or 'dnssrv+' to detect Alertmanager IPs
-                                 through respective DNS lookups. The port
-                                 defaults to 9093 or the SRV record's value. The
-                                 URL path is used as a prefix for the regular
-                                 Alertmanager API path.
+                                 succeeds. The scheme should not be empty e.g
+                                 `http` might be used. The scheme may be
+                                 prefixed with 'dns+' or 'dnssrv+' to detect
+                                 Alertmanager IPs through respective DNS
+                                 lookups. The port defaults to 9093 or the SRV
+                                 record's value. The URL path is used as a
+                                 prefix for the regular Alertmanager API path.
       --alertmanagers.send-timeout=10s
                                  Timeout for sending alerts to alertmanager
       --alert.query-url=ALERT.QUERY-URL


### PR DESCRIPTION
Signed-off-by: Xiang Dai <764524258@qq.com>

Since now alertmanager url is auto parse into url.URL, the scheme should exist and not empty, or would parse warn:
```
thanos rule --alertmanagers.url=localhost:9093 --rule-file=rule.yaml --query=localhost:19999
...
level=warn ts=2019-12-04T03:45:28.597397054Z caller=alert.go:342 msg="sending alerts failed" alertmanager= numAlerts=2 err="send request to \"localhost:///api/v1/alerts\": Post 
localhost:///api/v1/alerts: unsupported protocol scheme \"localhost\""
```

Without scheme, this warn is error indeed since can not send alerts forever.
