### PR TITLE
pkg/query: add lock sync.

### DIFF
--- a/pkg/query/storeset.go
+++ b/pkg/query/storeset.go
@@ -376,9 +376,8 @@ func (s *StoreSet) Update(ctx context.Context) {
 	s.storesMetric.Update(stats)
 	s.storesMtx.Lock()
 	s.stores = stores
-	s.storesMtx.Unlock()
-
 	s.cleanUpStoreStatuses(stores)
+	s.storesMtx.Unlock()
 }
 
 func (s *StoreSet) getHealthyStores(ctx context.Context, stores map[string]*storeRef) map[string]*storeRef {


### PR DESCRIPTION
There are concurrent access conflicts, `s.cleanUpStoreStatuses(stores)` need lock sync.

https://github.com/thanos-io/thanos/blob/7e11afe64af0c096743a3de8a594616abf52be45/pkg/query/storeset.go#L376-L381

goroutine 1
https://github.com/thanos-io/thanos/blob/7e11afe64af0c096743a3de8a594616abf52be45/cmd/thanos/query.go#L301

goroutine 2
https://github.com/thanos-io/thanos/blob/7e11afe64af0c096743a3de8a594616abf52be45/cmd/thanos/query.go#L333