### PR TITLE
receive: close DBReadOnly after flushing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 We use *breaking* word for marking changes that are not backward compatible (relates only to v0.y.z releases.)
 
 ## Unreleased
+### Fixed
+
+- [#1856](https://github.com/thanos-io/thanos/pull/1856) Receive: close DBReadOnly after flushing to fix a memory leak.
+
 ### Added
 - [#1852](https://github.com/thanos-io/thanos/pull/1852) Add support for `AWS_CONTAINER_CREDENTIALS_FULL_URI` by upgrading to minio-go v6.0.44
 

--- a/pkg/receive/tsdb.go
+++ b/pkg/receive/tsdb.go
@@ -92,6 +92,7 @@ func (f *FlushableStorage) Flush() error {
 	if err != nil {
 		return errors.Wrap(err, "opening read-only DB")
 	}
+	defer ro.Close()
 	if err := ro.FlushWAL(f.path); err != nil {
 		return errors.Wrap(err, "flushing WAL")
 	}


### PR DESCRIPTION
We are running thanos receive in production with 1w retention. When the receiver starts up it consumes about 20% memory on each of our 32 nodes. After the initial WAL flush the memory footprint progressively grows over time. I originally reported this in CNCF Slack. I initially tried to delete the WAL and restart the nodes but that didn’t solve the issue. The only solution was to clear out some TSDB blocks

Potentially fixes #1855 

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Close the DBReadOnly connection after `FlushableStorage.Flush()`

## Verification

I’ve not been able to verify this just yet. I’ll try to build the image with this patch and see if I see an improvement. 
