### PR TITLE
Use original file in rules loaded metric

### DIFF
--- a/cmd/thanos/rule.go
+++ b/cmd/thanos/rule.go
@@ -459,7 +459,7 @@ func runRule(
 
 				rulesLoaded.Reset()
 				for _, group := range ruleMgr.RuleGroups() {
-					rulesLoaded.WithLabelValues(group.PartialResponseStrategy.String(), group.File(), group.Name()).Set(float64(len(group.Rules())))
+					rulesLoaded.WithLabelValues(group.PartialResponseStrategy.String(), group.OriginalFile(), group.Name()).Set(float64(len(group.Rules())))
 				}
 
 			}


### PR DESCRIPTION
Signed-off-by: yeya24 <yb532204897@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!-- 
    Don't forget about CHANGELOG! 
    
    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...
    
    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->
Use the original rule file name as the label in load rules metric

## Verification

<!-- How you tested it? How do you know it works? -->
