### PR TITLE
fix wrong defalut value

### DIFF
--- a/docs/components/query.md
+++ b/docs/components/query.md
@@ -141,8 +141,8 @@ you might lucky enough that you actually get the correct data as the broken Stor
 If partial response happen QueryAPI returns human readable warnings explained [here](query.md#custom-response-fields).
 
 Now support two strategy:
-* "warn"(defalut)
-* "abort"
+* "warn"
+* "abort"(defalut)
 
 NOTE: Having warning does not necessary means partial response (e.g no store matched query warning).
 

--- a/docs/components/query.md
+++ b/docs/components/query.md
@@ -142,7 +142,7 @@ If partial response happen QueryAPI returns human readable warnings explained [h
 
 Now it supports two strategies:
 * "warn"
-* "abort" (defalut)
+* "abort" (default)
 
 NOTE: Having warning does not necessary means partial response (e.g no store matched query warning).
 

--- a/docs/components/query.md
+++ b/docs/components/query.md
@@ -140,9 +140,9 @@ you might lucky enough that you actually get the correct data as the broken Stor
 
 If partial response happen QueryAPI returns human readable warnings explained [here](query.md#custom-response-fields).
 
-Now support two strategy:
+Now it supports two strategies:
 * "warn"
-* "abort"(defalut)
+* "abort" (defalut)
 
 NOTE: Having warning does not necessary means partial response (e.g no store matched query warning).
 


### PR DESCRIPTION
Signed-off-by: Xiang Dai <764524258@qq.com>

Refer to CHANGELOG.md:376:
```
- [#970](https://github.com/thanos-io/thanos/pull/970) Deprecated `partial_response_disabled` proto field. Added `partial_response_strategy` instead. Both in gRPC and Query API.
  No `PartialResponseStrategy` field for `RuleGroups` by default means `abort` strategy (old PartialResponse disabled) as this is recommended option for Rules and alerts.
```