### PR TITLE
Clean up white noise and format all codes

### DIFF
--- a/docs/components/compact.md
+++ b/docs/components/compact.md
@@ -9,7 +9,7 @@ menu: components
 The compactor component of Thanos applies the compaction procedure of the Prometheus 2.0 storage engine to block data stored in object storage.
 It is generally not semantically concurrency safe and must be deployed as a singleton against a bucket.
 
-It is also responsible for downsampling of data: 
+It is also responsible for downsampling of data:
 
 * creating 5m downsampling for blocks larger than **40 hours** (2d, 2w)
 * creating 1h downsampling for blocks larger than **10 days** (2w).

--- a/docs/quick-tutorial.md
+++ b/docs/quick-tutorial.md
@@ -95,7 +95,7 @@ thanos sidecar \
 
 ### Uploading old metrics.
 
-When sidecar is run with the `--shipper.upload-compacted` flag it will sync all older existing blocks from the Prometheus local storage on startup. 
+When sidecar is run with the `--shipper.upload-compacted` flag it will sync all older existing blocks from the Prometheus local storage on startup.
 NOTE: This assumes you never run sidecar with block uploading against this bucket. Otherwise manual steps are needed to remove overlapping blocks from the bucket.
 Those will be suggested by the sidecar verification process.
 

--- a/docs/service-discovery.md
+++ b/docs/service-discovery.md
@@ -13,7 +13,7 @@ SD is currently used in the following places within Thanos:
 
 * `Thanos Query` needs to know about [StoreAPI](https://github.com/thanos-io/thanos/blob/d3fb337da94d11c78151504b1fccb1d7e036f394/pkg/store/storepb/rpc.proto#L14) servers in order to query metrics from them.
 * `Thanos Rule` needs to know about `QueryAPI` servers in order to evaluate recording and alerting rules.
-* `Thanos Rule` needs to know about `Alertmanagers` HA replicas in order to send alerts; only static option with DNS discovery. 
+* `Thanos Rule` needs to know about `Alertmanagers` HA replicas in order to send alerts; only static option with DNS discovery.
 
 There are currently several ways to configure SD, described below in more detail:
 

--- a/pkg/objstore/oss/oss.go
+++ b/pkg/objstore/oss/oss.go
@@ -139,7 +139,7 @@ func (b *Bucket) Delete(ctx context.Context, name string) error {
 
 // ObjectSize returns the size of the specified object.
 func (b *Bucket) ObjectSize(ctx context.Context, name string) (uint64, error) {
-	// https://github.com/aliyun/aliyun-oss-go-sdk/blob/cee409f5b4d75d7ad077cacb7e6f4590a7f2e172/oss/bucket.go#L668
+	// refer to https://github.com/aliyun/aliyun-oss-go-sdk/blob/cee409f5b4d75d7ad077cacb7e6f4590a7f2e172/oss/bucket.go#L668.
 	m, err := b.bucket.GetObjectMeta(name)
 	if err != nil {
 		return 0, err


### PR DESCRIPTION
Signed-off-by: Xiang Dai <764524258@qq.com>

Based on #1801, finish format and lint for current codes and docs.

## Changes

- clean up all white noise calling `make docs`
- fix comment issue calling `make format`:
```
>> checking Go comments trailing periods


./pkg/objstore/oss/oss.go:
func (b *Bucket) ObjectSize(ctx context.Context, name string) (uint64, error) {
	// https://github.com/aliyun/aliyun-oss-go-sdk/blob/cee409f5b4d75d7ad077cacb7e6f4590a7f2e172/oss/bucket.go#L668
	m, err := b.bucket.GetObjectMeta(name)




 Error: Found comments without trailing period. Comments has to be full sentences.
```