### PR TITLE
fix bug: reloading rule files with empty group doesn't take effect

### DIFF
--- a/pkg/rule/rule.go
+++ b/pkg/rule/rule.go
@@ -169,12 +169,11 @@ func (m *Manager) Update(evalInterval time.Duration, files []string) error {
 
 		// NOTE: This is very ugly, but we need to reparse it into tmp dir without the field to have to reuse
 		// rules.Manager. The problem is that it uses yaml.UnmarshalStrict for some reasons.
-		groupsByStrategy := map[storepb.PartialResponseStrategy]*rulefmt.RuleGroups{}
+		groupsByStrategy := map[storepb.PartialResponseStrategy]*rulefmt.RuleGroups{
+			storepb.PartialResponseStrategy_WARN:  &rulefmt.RuleGroups{},
+			storepb.PartialResponseStrategy_ABORT: &rulefmt.RuleGroups{},
+		}
 		for _, rg := range rg.Groups {
-			if _, ok := groupsByStrategy[*rg.PartialResponseStrategy]; !ok {
-				groupsByStrategy[*rg.PartialResponseStrategy] = &rulefmt.RuleGroups{}
-			}
-
 			groupsByStrategy[*rg.PartialResponseStrategy].Groups = append(
 				groupsByStrategy[*rg.PartialResponseStrategy].Groups,
 				rg.RuleGroup,


### PR DESCRIPTION
Signed-off-by: yapo.yang <yang_yapo@126.com>

reloading rule with empty group keep the orignal rules.
Steps to reproduce:
1. initialize rules with below yaml:
``` yaml
groups:
  - name: test-alert-group
    partial_response_strategy: "warn"
    interval: 2m
    rules:
      - alert: TestAlert
        expr: 1
        labels:
          key: value
        annotations:
          key: value

  - name: test-rule-group
    partial_response_strategy: "warn"
    interval: 2m
    rules:
      - record: test_metric
        expr: 1
```
2. change yaml to empty group:
``` yaml
groups: []
```
3. run http reload
``` bash
curl -X POST http://127.0.0.1:10902/-/reload
```
4. view rules in browser, thanos keeps the initial one instead of emty rule.