### PR TITLE
Fix broken doc links

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -91,7 +91,7 @@ If you want to add yourself to this list, let us know!
 
 ## Operating
 
-See up to date [jsonnet mixins](https://github.com/thanos-io/thanos/tree/master/jsonnet/thanos-mixin)
+See up to date [jsonnet mixins](https://github.com/thanos-io/thanos/tree/master/mixin/thanos/README.md)
 We also have example Grafana dashboards [here](/examples/dashboards/dashboards.md) and some [alerts](/examples/alerts/alerts.md) to get you started.
 
 ## Talks

--- a/examples/dashboards/dashboards.md
+++ b/examples/dashboards/dashboards.md
@@ -15,4 +15,4 @@ These dashboards require Grafana 5 or above, importing them in older versions ar
 
 ## Configuration
 
-All dashboards are generated using [`thanos-mixin`](../../jsonnet/thanos-mixin) and check out [README](../../jsonnet/thanos-mixin/README.md) for further information.
+All dashboards are generated using [`thanos-mixin`](https://github.com/thanos-io/thanos/tree/master/mixin/thanos) and check out [README](https://github.com/thanos-io/thanos/tree/master/mixin/thanos/README.md) for further information.

--- a/mixin/thanos/README.md
+++ b/mixin/thanos/README.md
@@ -35,7 +35,7 @@ To install:
 go get github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb
 ```
 
-> An e.g. of how to install a given version of this library: `jb install github.com/thanos-io/thanos/jsonnet/thanos-mixin@master`.
+> An e.g. of how to install a given version of this library: `jb install github.com/thanos-io/thanos/mixin/thanos@master`.
 
 ## Use as a library
 
@@ -44,7 +44,7 @@ To use the `thanos-mixin` as a dependency, simply use the `jsonnet-bundler` inst
 $ mkdir thanos-mixin; cd thanos-mixin
 $ jb init  # Creates the initial/empty `jsonnetfile.json`
 # Install the thanos-mixin dependency
-$ jb install github.com/thanos-io/thanos/jsonnet/thanos-mixin@master # Creates `vendor/` & `jsonnetfile.lock.json`, and fills in `jsonnetfile.json`
+$ jb install github.com/thanos-io/thanos/mixin/thanos@master # Creates `vendor/` & `jsonnetfile.lock.json`, and fills in `jsonnetfile.json`
 ```
 
 To update the `thanos-mixin` as a dependency, simply use the `jsonnet-bundler` update functionality:


### PR DESCRIPTION
Signed-off-by: Kemal Akkoyun <kakkoyun@gmail.com>

This PR fixes broken links references `thanos-mixin`.
A follow up to #1760.


* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.
