### PR TITLE
pkg/receive: simplify hashring file

### DIFF
--- a/pkg/receive/hashring.go
+++ b/pkg/receive/hashring.go
@@ -7,9 +7,8 @@ import (
 	"sort"
 	"sync"
 
-	"github.com/prometheus/prometheus/prompb"
-
 	"github.com/cespare/xxhash"
+	"github.com/prometheus/prometheus/prompb"
 )
 
 const sep = '\xff'
@@ -120,12 +119,9 @@ func (m *multiHashring) GetN(tenant string, ts *prompb.TimeSeries, n uint64) (st
 		// considered a default hashring and matches everything.
 		if t == nil {
 			found = true
-		}
-		if _, ok := t[tenant]; ok {
+		} else if _, ok := t[tenant]; ok {
 			found = true
 		}
-		// If the hashring has no tenants, then it is
-		// considered a default hashring and matches everything.
 		if found {
 			m.mu.Lock()
 			m.cache[tenant] = m.hashrings[i]


### PR DESCRIPTION
This commit simplifies the receive/hashring.go file a bit. Most
significantly it changes two sequential `if`s that can never both be
true, to an `if/else`.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>

* [x] Change is not relevant to the end user.