### PR TITLE
bugfix: adjust the timeout.

### DIFF
--- a/pkg/query/storeset.go
+++ b/pkg/query/storeset.go
@@ -193,7 +193,7 @@ func NewStoreSet(
 		storeSpecs:            storeSpecs,
 		dialOpts:              dialOpts,
 		storesMetric:          storesMetric,
-		gRPCInfoCallTimeout:   10 * time.Second,
+		gRPCInfoCallTimeout:   5 * time.Second,
 		stores:                make(map[string]*storeRef),
 		storeStatuses:         make(map[string]*StoreStatus),
 		unhealthyStoreTimeout: unhealthyStoreTimeout,


### PR DESCRIPTION
repeat timeout:
https://github.com/thanos-io/thanos/blob/2f29975982e25632a3eaccaf47d2401dcbfeef4b/cmd/thanos/query.go#L299-L303

update grpc timeout:
https://github.com/thanos-io/thanos/blob/2f29975982e25632a3eaccaf47d2401dcbfeef4b/pkg/query/storeset.go#L406

the `grpc timeout` should be lower than `repeat timeout`. 
