### PR TITLE
[compact] Increase default consistency delay to 24h

### DIFF
--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -86,7 +86,7 @@ func registerCompact(m map[string]setupFunc, app *kingpin.Application) {
 	objStoreConfig := regCommonObjStoreFlags(cmd, "", true)
 
 	consistencyDelay := modelDuration(cmd.Flag("consistency-delay", fmt.Sprintf("Minimum age of fresh (non-compacted) blocks before they are being processed. Malformed blocks older than the maximum of consistency-delay and %s will be removed.", compact.MinimumAgeForRemoval)).
-		Default("30m"))
+		Default("24h"))
 
 	retentionRaw := modelDuration(cmd.Flag("retention.resolution-raw", "How long to retain raw samples in bucket. 0d - disables this retention").Default("0d"))
 	retention5m := modelDuration(cmd.Flag("retention.resolution-5m", "How long to retain samples of resolution 1 (5 minutes) in bucket. 0d - disables this retention").Default("0d"))


### PR DESCRIPTION
Firstly, thanks for adding sharding to compact/store using relabeling config - I took part in a previous discussion on this and it's great to have the ability to do it now 🎉 

We've run into an issue which caused some data loss. We have very large blocks that can take hours to upload to S3. When running multiple shards, we found that the malformed block check caused erroneous deletions:

```
• shard A compacts blocks X and Y, creating block Z on disk
• it starts to upload Z, starting with chunk 1 and going sequentially
• shard B scans the bucket, finds partially uploaded block Z
• it thinks Z is malformed because meta.json isn’t there (it gets uploaded last, after all chunks)
• shard B deletes block Z
• meanwhile, shard A is still uploading, so you end up with some of the latter blocks uploaded, and meta.json
```

As a quick fix, upping the consistency deadline makes things safer. But I wonder if we should also disable the malformed block deletion by default (and log a warning) if a relabeling config exists, so that the user can manually inspect and delete those blocks.

If we're happy to go ahead I'll add a changelog entry.