### PR TITLE
sidecar: don't require Prometheus min/max block durations to be equal

### DIFF
--- a/cmd/thanos/sidecar.go
+++ b/cmd/thanos/sidecar.go
@@ -60,6 +60,8 @@ func registerSidecar(m map[string]setupFunc, app *kingpin.Application) {
 
 	uploadCompacted := cmd.Flag("shipper.upload-compacted", "If true sidecar will try to upload compacted blocks as well. Useful for migration purposes. Works only if compaction is disabled on Prometheus. Do it once and then disable the flag when done.").Default("false").Bool()
 
+	ignoreBlockSize := cmd.Flag("shipper.ignore-unequal-block-size", "If true sidecar will not require prometheus min and max block size flags to be set to the same value. Only use this if you want to keep long retention and compaction enabled on your Prometheus instance, as in the worst case it can result in ~2h data loss for your Thanos bucket storage.").Default("false").Hidden().Bool()
+
 	minTime := thanosmodel.TimeOrDuration(cmd.Flag("min-time", "Start of time range limit to serve. Thanos sidecar will serve only metrics, which happened later than this value. Option can be a constant time in RFC3339 format or time duration relative to current time, such as -1d or 2h45m. Valid duration units are ms, s, m, h, d, w, y.").
 		Default("0000-01-01T00:00:00Z"))
 
@@ -90,6 +92,7 @@ func registerSidecar(m map[string]setupFunc, app *kingpin.Application) {
 			objStoreConfig,
 			rl,
 			*uploadCompacted,
+			*ignoreBlockSize,
 			component.Sidecar,
 			*minTime,
 		)
@@ -114,6 +117,7 @@ func runSidecar(
 	objStoreConfig *extflag.PathOrContent,
 	reloader *reloader.Reloader,
 	uploadCompacted bool,
+	ignoreBlockSize bool,
 	comp component.Component,
 	limitMinTime thanosmodel.TimeOrDurationValue,
 ) error {
@@ -174,7 +178,7 @@ func runSidecar(
 			// Only check Prometheus's flags when upload is enabled.
 			if uploads {
 				// Check prometheus's flags to ensure sane sidecar flags.
-				if err := validatePrometheus(ctx, logger, m); err != nil {
+				if err := validatePrometheus(ctx, logger, ignoreBlockSize, m); err != nil {
 					return errors.Wrap(err, "validate Prometheus flags")
 				}
 			}
@@ -328,7 +332,7 @@ func runSidecar(
 	return nil
 }
 
-func validatePrometheus(ctx context.Context, logger log.Logger, m *promMetadata) error {
+func validatePrometheus(ctx context.Context, logger log.Logger, ignoreBlockSize bool, m *promMetadata) error {
 	var (
 		flagErr error
 		flags   promclient.Flags
@@ -351,10 +355,12 @@ func validatePrometheus(ctx context.Context, logger log.Logger, m *promMetadata)
 
 	// Check if compaction is disabled.
 	if flags.TSDBMinTime != flags.TSDBMaxTime {
-		return errors.Errorf("found that TSDB Max time is %s and Min time is %s. "+
-			"Compaction needs to be disabled (storage.tsdb.min-block-duration = storage.tsdb.max-block-duration)", flags.TSDBMaxTime, flags.TSDBMinTime)
+		if !ignoreBlockSize {
+			return errors.Errorf("found that TSDB Max time is %s and Min time is %s. "+
+				"Compaction needs to be disabled (storage.tsdb.min-block-duration = storage.tsdb.max-block-duration)", flags.TSDBMaxTime, flags.TSDBMinTime)
+		}
+		level.Warn(logger).Log("msg", "flag to ignore Prometheus min/max block duration flags differing is being used. If the upload of a 2h block fails and a Prometheus compaction happens that block may be missing from your Thanos bucket storage.")
 	}
-
 	// Check if block time is 2h.
 	if flags.TSDBMinTime != model.Duration(2*time.Hour) {
 		level.Warn(logger).Log("msg", "found that TSDB block time is not 2h. Only 2h block time is recommended.", "block-time", flags.TSDBMinTime)


### PR DESCRIPTION
@bwplotka

Adds a flag that allows users to disable the requirement that their Prometheus instances have equal min/max block durations if they have enabled block upload. 

As discussed on slack; because only uncompacted blocks are uploaded, in the event of an upload failure or network issues that last longer than 4h there is the potential for data loss (in the bucket storage) if blocks are compacted by Prometheus during that time

Signed-off-by: Callum Styan <callumstyan@gmail.com>
cc @gouthamve @beorn7 

* [x] I added CHANGELOG entry for this change.

