### PR TITLE
Makefile: fix lint and check-docs targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -181,10 +181,7 @@ check-docs: $(EMBEDMD) $(LICHE) build
 	@$(LICHE) --recursive docs --exclude "(cloud.tencent.com|alibabacloud.com)" --document-root .
 	@$(LICHE) --exclude "(cloud.tencent.com|goreportcard.com|alibabacloud.com)" --document-root . *.md
 	@find -type f -name "*.md" | xargs scripts/cleanup-white-noise.sh
-	@if [[ ! git diff-files --quiet --ignore-submodules -- ]]; then \
-		echo >&2 "please clean up white noise in all docs"; \
-		exit 1; \
-	fi
+	$(call require_clean_work_tree,"check documentation")
 
 # checks Go code comments if they have trailing period (excludes protobuffers and vendor files).
 # Comments with more than 3 spaces at beginning are omitted from the check, example: '//    - foo'.
@@ -304,10 +301,7 @@ lint: check-git $(GOLANGCILINT) $(MISSPELL)
 	@find . -type f | grep -v vendor/ | grep -vE '\./\..*' | xargs $(MISSPELL) -error
 	@echo ">> detecting white noise"
 	@find . -type f \( -name "*.md" -o -name "*.go" \) | xargs scripts/cleanup-white-noise.sh
-	@if [[ ! git diff-files --quiet --ignore-submodules -- ]]; then \
-		echo >&2 "please clean up white noise in all docs or Go files"; \
-		exit 1; \
-	fi
+	$(call require_clean_work_tree,"lint")
 
 .PHONY: web-serve
 web-serve: web-pre-process $(HUGO)


### PR DESCRIPTION
Those errors didn't trigger a CI failure because `quay.io/thanos/thanos-ci` (or rather `circleci/golang`) uses `sh` as the interpreter which doesn't fail on incorrect test expressions.

```
$ if [[ ! ls ezae; ]]; then echo yes; fi
/bin/sh: 14: [[: not found  
/bin/sh: 14: ]]: not found  
$ echo $?
0
$ ps 
  PID TTY          TIME CMD 
    1 pts/0    00:00:00 sh 
 7457 pts/0    00:00:00 ps
$ bash
circleci@47ec4d9adda4:/go/thanos$ if [[ ! ls ezae; ]]; then echo yes; fi
bash: conditional binary operator expected
bash: syntax error near `;'
circleci@47ec4d9adda4:/go/thanos$ echo $?
2
```