### PR TITLE
Fixed the gate duration metric unit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 
 - [#1856](https://github.com/thanos-io/thanos/pull/1856) Receive: close DBReadOnly after flushing to fix a memory leak.
 - [#1882](https://github.com/thanos-io/thanos/pull/1882) Receive: upload to object storage as 'receive' rather than 'sidecar'.
+- [#1907](https://github.com/thanos-io/thanos/pull/1907) Store: Fixed the duration unit for the metric `thanos_bucket_store_series_gate_duration_seconds`.
 
 ### Added
 - [#1852](https://github.com/thanos-io/thanos/pull/1852) Add support for `AWS_CONTAINER_CREDENTIALS_FULL_URI` by upgrading to minio-go v6.0.44

--- a/pkg/store/gate.go
+++ b/pkg/store/gate.go
@@ -41,7 +41,7 @@ func NewGate(maxConcurrent int, reg prometheus.Registerer) *Gate {
 func (g *Gate) IsMyTurn(ctx context.Context) error {
 	start := time.Now()
 	defer func() {
-		g.gateTiming.Observe(float64(time.Since(start)))
+		g.gateTiming.Observe(time.Since(start).Seconds())
 	}()
 
 	if err := g.g.Start(ctx); err != nil {


### PR DESCRIPTION
The `thanos_bucket_store_series_gate_duration_seconds` metric is currently measured as nanoseconds and not seconds, so every measurement basically ends up in the `+Inf` bucket. This PR fixes it.

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

- Fixed the gate duration metric unit

## Verification

Manual tests.
