### PR TITLE
pkg/alert: factorize HTTP client code into separate package

### DIFF
--- a/pkg/alert/client_test.go
+++ b/pkg/alert/client_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/thanos-io/thanos/pkg/http"
 	"github.com/thanos-io/thanos/pkg/testutil"
 )
 
@@ -60,8 +61,8 @@ func TestBuildAlertmanagerConfiguration(t *testing.T) {
 		{
 			address: "http://user:pass@localhost:9093",
 			expected: AlertmanagerConfig{
-				HTTPClientConfig: HTTPClientConfig{
-					BasicAuth: BasicAuth{
+				HTTPClientConfig: http.ClientConfig{
+					BasicAuth: http.BasicAuth{
 						Username: "user",
 						Password: "pass",
 					},

--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -1,0 +1,116 @@
+// Package http is a wrapper around github.com/prometheus/common/config.
+package http
+
+import (
+	"fmt"
+	"net/http"
+
+	config_util "github.com/prometheus/common/config"
+	"github.com/prometheus/common/version"
+	"gopkg.in/yaml.v2"
+)
+
+// ClientConfig configures an HTTP client.
+type ClientConfig struct {
+	// The HTTP basic authentication credentials for the targets.
+	BasicAuth BasicAuth `yaml:"basic_auth"`
+	// The bearer token for the targets.
+	BearerToken string `yaml:"bearer_token"`
+	// The bearer token file for the targets.
+	BearerTokenFile string `yaml:"bearer_token_file"`
+	// HTTP proxy server to use to connect to the targets.
+	ProxyURL string `yaml:"proxy_url"`
+	// TLSConfig to use to connect to the targets.
+	TLSConfig TLSConfig `yaml:"tls_config"`
+}
+
+// TLSConfig configures TLS connections.
+type TLSConfig struct {
+	// The CA cert to use for the targets.
+	CAFile string `yaml:"ca_file"`
+	// The client cert file for the targets.
+	CertFile string `yaml:"cert_file"`
+	// The client key file for the targets.
+	KeyFile string `yaml:"key_file"`
+	// Used to verify the hostname for the targets.
+	ServerName string `yaml:"server_name"`
+	// Disable target certificate validation.
+	InsecureSkipVerify bool `yaml:"insecure_skip_verify"`
+}
+
+// BasicAuth configures basic authentication for HTTP clients.
+type BasicAuth struct {
+	Username     string `yaml:"username"`
+	Password     string `yaml:"password"`
+	PasswordFile string `yaml:"password_file"`
+}
+
+// IsZero returns false if basic authentication isn't enabled.
+func (b BasicAuth) IsZero() bool {
+	return b.Username == "" && b.Password == "" && b.PasswordFile == ""
+}
+
+// NewClient returns a new HTTP client.
+func NewClient(cfg ClientConfig, name string) (*http.Client, error) {
+	httpClientConfig := config_util.HTTPClientConfig{
+		BearerToken:     config_util.Secret(cfg.BearerToken),
+		BearerTokenFile: cfg.BearerTokenFile,
+		TLSConfig: config_util.TLSConfig{
+			CAFile:             cfg.TLSConfig.CAFile,
+			CertFile:           cfg.TLSConfig.CertFile,
+			KeyFile:            cfg.TLSConfig.KeyFile,
+			ServerName:         cfg.TLSConfig.ServerName,
+			InsecureSkipVerify: cfg.TLSConfig.InsecureSkipVerify,
+		},
+	}
+	if cfg.ProxyURL != "" {
+		var proxy config_util.URL
+		err := yaml.Unmarshal([]byte(cfg.ProxyURL), &proxy)
+		if err != nil {
+			return nil, err
+		}
+		httpClientConfig.ProxyURL = proxy
+	}
+	if !cfg.BasicAuth.IsZero() {
+		httpClientConfig.BasicAuth = &config_util.BasicAuth{
+			Username:     cfg.BasicAuth.Username,
+			Password:     config_util.Secret(cfg.BasicAuth.Password),
+			PasswordFile: cfg.BasicAuth.PasswordFile,
+		}
+	}
+	if err := httpClientConfig.Validate(); err != nil {
+		return nil, err
+	}
+
+	client, err := config_util.NewClientFromConfig(httpClientConfig, name, false)
+	if err != nil {
+		return nil, err
+	}
+	client.Transport = &userAgentRoundTripper{name: userAgent, rt: client.Transport}
+	return client, nil
+}
+
+var userAgent = fmt.Sprintf("Thanos/%s", version.Version)
+
+type userAgentRoundTripper struct {
+	name string
+	rt   http.RoundTripper
+}
+
+// RoundTrip implements the http.RoundTripper interface.
+func (u userAgentRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
+	if r.UserAgent() == "" {
+		// The specification of http.RoundTripper says that it shouldn't mutate
+		// the request so make a copy of req.Header since this is all that is
+		// modified.
+		r2 := new(http.Request)
+		*r2 = *r
+		r2.Header = make(http.Header)
+		for k, s := range r.Header {
+			r2.Header[k] = s
+		}
+		r2.Header.Set("User-Agent", u.name)
+		r = r2
+	}
+	return u.rt.RoundTrip(r)
+}

--- a/test/e2e/rule_test.go
+++ b/test/e2e/rule_test.go
@@ -25,6 +25,7 @@ import (
 	yaml "gopkg.in/yaml.v2"
 
 	"github.com/thanos-io/thanos/pkg/alert"
+	http_util "github.com/thanos-io/thanos/pkg/http"
 	"github.com/thanos-io/thanos/pkg/promclient"
 	rapi "github.com/thanos-io/thanos/pkg/rule/api"
 	"github.com/thanos-io/thanos/pkg/runutil"
@@ -200,8 +201,8 @@ func TestRuleAlertmanagerHTTPClient(t *testing.T) {
 			PathPrefix:      "/prefix/",
 		},
 		alert.AlertmanagerConfig{
-			HTTPClientConfig: alert.HTTPClientConfig{
-				TLSConfig: alert.TLSConfig{
+			HTTPClientConfig: http_util.ClientConfig{
+				TLSConfig: http_util.TLSConfig{
 					CAFile: caFile,
 				},
 				BearerToken: "secret",


### PR DESCRIPTION

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [X] Change is not relevant to the end user.

## Changes

This change moves the HTTP client code (including configuration) to a separate package so it can be easily reused for implementing TLS and authentication for queries in Thanos Ruler.

## Verification

Unit and e2e tests should pass.
