### PR TITLE
Simplify running tests with excluding certain providers.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,13 +51,8 @@ $ make build
 $ <Iterate your development>
 $ git push origin <your_branch_for_new_pr>
 ```
-5. If you don't have a live object store ready add these envvars to skip tests for these:
-- THANOS_SKIP_GCS_TESTS to skip GCS tests.
-- THANOS_SKIP_S3_AWS_TESTS to skip AWS tests.
-- THANOS_SKIP_AZURE_TESTS to skip Azure tests.
-- THANOS_SKIP_SWIFT_TESTS to skip SWIFT tests.
-- THANOS_SKIP_TENCENT_COS_TESTS to skip Tencent COS tests.
-- THANOS_SKIP_ALIYUN_OSS_TESTS to skip Aliyun OSS tests.
+5. If you don't have a live object store ready add this envvar to skip tests for these:
+- THANOS_TEST_OBJSTORE_SKIP=GCS,S3,AZURE,SWIFT,COS,ALIYUNOSS
 
 If you skip all of these, the store specific tests will be run against memory object storage only.
 CI runs GCS and inmem tests only for now. Not having these variables will produce auth errors against GCS, AWS, Azure or COS tests.

--- a/Makefile
+++ b/Makefile
@@ -226,28 +226,19 @@ test: check-git install-deps
 	@go install github.com/thanos-io/thanos/cmd/thanos
 	# Be careful on GOCACHE. Those tests are sometimes using built Thanos/Prometheus binaries directly. Don't cache those.
 	@rm -rf ${GOCACHE}
-	@echo ">> running all tests. Do export THANOS_SKIP_GCS_TESTS='true' or/and THANOS_SKIP_S3_AWS_TESTS='true' or/and THANOS_SKIP_AZURE_TESTS='true' and/or THANOS_SKIP_SWIFT_TESTS='true' and/or THANOS_SKIP_ALIYUN_OSS_TESTS='true' and/or THANOS_SKIP_TENCENT_COS_TESTS='true' if you want to skip e2e tests against real store buckets"
+	@echo ">> running all tests. Do export THANOS_TEST_OBJSTORE_SKIP=GCS,S3,AZURE,SWIFT,COS,ALIYUNOSS if you want to skip e2e tests against all real store buckets. Current value: ${THANOS_TEST_OBJSTORE_SKIP}"
 	@go test $(shell go list ./... | grep -v /vendor/);
 
 .PHONY: test-ci
-test-ci: export THANOS_SKIP_AZURE_TESTS = true
-test-ci: export THANOS_SKIP_SWIFT_TESTS = true
-test-ci: export THANOS_SKIP_TENCENT_COS_TESTS = true
-test-ci: export THANOS_SKIP_ALIYUN_OSS_TESTS = true
+test-ci: export THANOS_TEST_OBJSTORE_SKIP=AZURE,SWIFT,COS,ALIYUNOSS
 test-ci:
-	@echo ">> Skipping AZURE tests"
-	@echo ">> Skipping SWIFT tests"
-	@echo ">> Skipping TENCENT tests"
-	@echo ">> Skipping ALIYUN tests"
+	@echo ">> Skipping ${THANOS_TEST_OBJSTORE_SKIP} tests"
 	$(MAKE) test
 
 .PHONY: test-local
-test-local: export THANOS_SKIP_GCS_TESTS = true
-test-local: export THANOS_SKIP_S3_AWS_TESTS = true
+test-local: export THANOS_TEST_OBJSTORE_SKIP=GCS,S3,AZURE,SWIFT,COS,ALIYUNOSS
 test-local:
-	@echo ">> Skipping GCE tests"
-	@echo ">> Skipping S3 tests"
-	$(MAKE) test-ci
+	$(MAKE) test
 
 # install-deps installs dependencies for e2e tetss.
 # It installs supported versions of Prometheus and alertmanager to test against in e2e.

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -157,8 +157,11 @@ Example working AWS IAM policy for user:
 (No bucket policy)
 
 To test the policy, set env vars for S3 access for *empty, not used* bucket as well as:
-THANOS_SKIP_GCS_TESTS=true
+
+```
+THANOS_TEST_OBJSTORE_SKIP=GCS,AZURE,SWIFT,COS,ALIYUNOSS
 THANOS_ALLOW_EXISTING_BUCKET_USE=true
+```
 
 And run: `GOCACHE=off go test -v -run TestObjStore_AcceptanceTest_e2e ./pkg/...`
 
@@ -190,7 +193,7 @@ We need access to CreateBucket and DeleteBucket and access to all buckets:
 }
 ```
 
-With this policy you should be able to run set `THANOS_SKIP_GCS_TESTS=true` and unset `S3_BUCKET` and run all tests using `make test`.
+With this policy you should be able to run set `THANOS_TEST_OBJSTORE_SKIP=GCS,AZURE,SWIFT,COS,ALIYUNOSS` and unset `S3_BUCKET` and run all tests using `make test`.
 
 Details about AWS policies: https://docs.aws.amazon.com/AmazonS3/latest/dev/using-with-s3-actions.html
 


### PR DESCRIPTION
Still by default run all. Making it more difficult to skip makes sure we don't forget to run those.

Signed-off-by: Bartek Plotka <bwplotka@gmail.com>