### PR TITLE
fix flaky test cache addresses

### DIFF
--- a/pkg/discovery/cache/cache_test.go
+++ b/pkg/discovery/cache/cache_test.go
@@ -2,6 +2,7 @@ package cache
 
 import (
 	"reflect"
+	"sort"
 	"testing"
 
 	"github.com/prometheus/common/model"
@@ -12,16 +13,16 @@ func TestCacheAddresses(t *testing.T) {
 	tgs := make(map[string]*targetgroup.Group)
 	tgs["g1"] = &targetgroup.Group{
 		Targets: []model.LabelSet{
-			model.LabelSet{model.AddressLabel: "localhost:9090"},
-			model.LabelSet{model.AddressLabel: "localhost:9091"},
-			model.LabelSet{model.AddressLabel: "localhost:9092"},
+			{model.AddressLabel: "localhost:9090"},
+			{model.AddressLabel: "localhost:9091"},
+			{model.AddressLabel: "localhost:9092"},
 		},
 	}
 	tgs["g2"] = &targetgroup.Group{
 		Targets: []model.LabelSet{
-			model.LabelSet{model.AddressLabel: "localhost:9091"},
-			model.LabelSet{model.AddressLabel: "localhost:9092"},
-			model.LabelSet{model.AddressLabel: "localhost:9093"},
+			{model.AddressLabel: "localhost:9091"},
+			{model.AddressLabel: "localhost:9092"},
+			{model.AddressLabel: "localhost:9093"},
 		},
 	}
 
@@ -33,7 +34,12 @@ func TestCacheAddresses(t *testing.T) {
 		"localhost:9092",
 		"localhost:9093",
 	}
-	if got := c.Addresses(); !reflect.DeepEqual(got, expected) {
+
+	got := c.Addresses()
+	sort.Slice(got, func(i, j int) bool {
+		return i < j
+	})
+	if !reflect.DeepEqual(got, expected) {
 		t.Errorf("expected %v, want %v", got, expected)
 	}
 }


### PR DESCRIPTION
Signed-off-by: yeya24 <yb532204897@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [X] Change is not relevant to the end user.

## Changes

Fix flaky test in #1920 

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
