### PR TITLE
Fixed the compactor successfully exiting when actually an error occurred while compacting a blocks group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 - [#1856](https://github.com/thanos-io/thanos/pull/1856) Receive: close DBReadOnly after flushing to fix a memory leak.
 - [#1882](https://github.com/thanos-io/thanos/pull/1882) Receive: upload to object storage as 'receive' rather than 'sidecar'.
 - [#1907](https://github.com/thanos-io/thanos/pull/1907) Store: Fixed the duration unit for the metric `thanos_bucket_store_series_gate_duration_seconds`.
+- [#1931](https://github.com/thanos-io/thanos/pull/1931) Compact: Fixed the compactor successfully exiting when actually an error occurred while compacting a blocks group.
 
 ### Added
 - [#1852](https://github.com/thanos-io/thanos/pull/1852) Add support for `AWS_CONTAINER_CREDENTIALS_FULL_URI` by upgrading to minio-go v6.0.44


### PR DESCRIPTION
There are conditions under which the `BucketCompactor.Compact()` returns no error even if an error occurred.

This happens when the number of groups left to compact is <= the concurrency. In this scenario, all jobs have been pushed to workers, so the code executions moves to [`wg.Wait()`](https://github.com/thanos-io/thanos/compare/master...pracucci:fix-bucket-compactor-error-handling#diff-921a1164068d3a04217b2d85714b16adR1146) and any subsequent error is not catched and then returned.

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

- Fixed the compactor successfully exiting when actually an error occurred while compacting a blocks group

## Verification

Manual tests.