### PR TITLE
Use block.MetaFetcher in Store Gateway.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 
 ### Fixed
 
+- []() Store: Improved synchronization of meta JSON files. Store now properly handles corrupted disk cache. Added meta.json sync metrics.
 - [#1856](https://github.com/thanos-io/thanos/pull/1856) Receive: close DBReadOnly after flushing to fix a memory leak.
 - [#1882](https://github.com/thanos-io/thanos/pull/1882) Receive: upload to object storage as 'receive' rather than 'sidecar'.
 - [#1907](https://github.com/thanos-io/thanos/pull/1907) Store: Fixed the duration unit for the metric `thanos_bucket_store_series_gate_duration_seconds`.

--- a/docs/components/store.md
+++ b/docs/components/store.md
@@ -85,7 +85,7 @@ Flags:
                                  for chunks.
       --store.grpc.series-sample-limit=0
                                  Maximum amount of samples returned via a single
-                                 Series call. 0 means no limit. NOTE: for
+                                 Series call. 0 means no limit. NOTE: For
                                  efficiency we take 120 as the number of samples
                                  in chunk (it cannot be bigger than that), so
                                  the actual number of samples might be lower,
@@ -105,8 +105,8 @@ Flags:
       --sync-block-duration=3m   Repeat interval for syncing the blocks between
                                  local and remote view.
       --block-sync-concurrency=20
-                                 Number of goroutines to use when syncing blocks
-                                 from object storage.
+                                 Number of goroutines to use when constructing
+                                 index-cache.json blocks from object storage.
       --min-time=0000-01-01T00:00:00Z
                                  Start of time range limit to serve. Thanos
                                  Store will serve only metrics, which happened


### PR DESCRIPTION
Fixes: https://github.com/thanos-io/thanos/issues/1874

Depends on: https://github.com/thanos-io/thanos/pull/1934
## Changes

* Corrupted disk cache for meta.json is handled gracefully.
* Synchronize was not taking into account deletion by removing meta.json.
* Prepare for future implementation of https://thanos.io/proposals/201901-read-write-operations-bucket.md/
* Better observability for syncronize process.
* More logs for store startup process.

TODO in separate PR:
* More observability for index-cache loading / adding: e.g duration time. 

## Verification

* Unit + e2e tests.

Signed-off-by: Bartlomiej Plotka <bwplotka@gmail.com>
