### PR TITLE
pkg/discovery: fix unit tests

### DIFF
--- a/pkg/discovery/cache/cache_test.go
+++ b/pkg/discovery/cache/cache_test.go
@@ -36,9 +36,7 @@ func TestCacheAddresses(t *testing.T) {
 	}
 
 	got := c.Addresses()
-	sort.Slice(got, func(i, j int) bool {
-		return i < j
-	})
+	sort.Strings(got)
 	if !reflect.DeepEqual(got, expected) {
 		t.Errorf("expected %v, want %v", got, expected)
 	}


### PR DESCRIPTION


* [ ] I added CHANGELOG entry for this change.
* [X] Change is not relevant to the end user.

## Changes

Make sure that the returned slice is sorted consistently.

## Verification

`go test -count 100 ./pkg/discovery/cache/.` returns successfully with this PR while a few instances fail on master.
