### PR TITLE
Unify all CI base images to be built with Go 1.13.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ jobs:
   publish_master:
     docker:
       # Build by Thanos make docker-ci
-      - image: quay.io/thanos/thanos-ci:v0.1.0
+      - image: quay.io/thanos/thanos-ci:v0.2.0
     working_directory: /go/src/github.com/thanos-io/thanos
     steps:
       - checkout
@@ -78,8 +78,8 @@ jobs:
 
   publish_release:
     docker:
-      # Available from https://hub.docker.com/r/circleci/golang/
-      - image: circleci/golang:1.13.1
+      # Build by Thanos make docker-ci
+      - image: quay.io/thanos/thanos-ci:v0.2.0
     working_directory: /go/src/github.com/thanos-io/thanos
     environment:
       GOBIN: "/go/bin"


### PR DESCRIPTION
Fixes https://github.com/thanos-io/thanos/issues/1942

Master container images were built with Go 1.12 ):

Signed-off-by: Bartlomiej Plotka <bwplotka@gmail.com>

