### PR TITLE
store: fix a small house-keeping data race

### DIFF
--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -824,12 +824,15 @@ func (s *BucketStore) Series(req *storepb.SeriesRequest, srv storepb.Store_Serie
 		}
 		blocks := bs.getFor(req.MinTime, req.MaxTime, req.MaxResolutionWindow)
 
+		mtx.Lock()
+		stats.blocksQueried += len(blocks)
+		mtx.Unlock()
+
 		if s.debugLogging {
 			debugFoundBlockSetOverview(s.logger, req.MinTime, req.MaxTime, req.MaxResolutionWindow, bs.labels, blocks)
 		}
 
 		for _, b := range blocks {
-			stats.blocksQueried++
 
 			b := b
 


### PR DESCRIPTION
`stats` is being accessed from the goroutines inside this function so it
needs to be protected here in the same way with `mtx`. Move the house
keeping out of the inner loop into the outer one to reduce the number of
times we will need to lock/unlock the mutex.

Signed-off-by: Giedrius Statkevičius <giedriuswork@gmail.com>