### PR TITLE
rule: fix bug that ignore deduplicate addrs.

### DIFF
--- a/cmd/thanos/rule.go
+++ b/cmd/thanos/rule.go
@@ -742,7 +742,7 @@ func queryFunc(
 		// TODO(bwplotka): Consider generating addresses in *url.URL.
 		addrs := dnsProvider.Addresses()
 
-		removeDuplicateQueryAddrs(logger, duplicatedQuery, addrs)
+		addrs = removeDuplicateQueryAddrs(logger, duplicatedQuery, addrs)
 
 		for _, i := range rand.Perm(len(addrs)) {
 			u, err := url.Parse(fmt.Sprintf("http://%s", addrs[i]))


### PR DESCRIPTION
https://github.com/thanos-io/thanos/blob/f5b7bacf762197c5fa8ec728257bbca264072e35/cmd/thanos/rule.go#L745

function `removeDuplicateQueryAddrs`  does not modify `addrs` but return the deduplicated value.  It may be a bug.

If it only logs the number of duplicated addresses, it's better to change the name of the function.