### PR TITLE
cmd/thanos/rule.go: simplify deduplication

### DIFF
--- a/cmd/thanos/rule.go
+++ b/cmd/thanos/rule.go
@@ -704,17 +704,15 @@ func labelsTSDBToProm(lset labels.Labels) (res labels.Labels) {
 
 func removeDuplicateQueryAddrs(logger log.Logger, duplicatedQueriers prometheus.Counter, addrs []string) []string {
 	set := make(map[string]struct{})
+	deduplicated := make([]string, 0, len(addrs))
 	for _, addr := range addrs {
 		if _, ok := set[addr]; ok {
 			level.Warn(logger).Log("msg", "duplicate query address is provided - %v", addr)
 			duplicatedQueriers.Inc()
+			continue
 		}
+		deduplicated = append(deduplicated, addr)
 		set[addr] = struct{}{}
-	}
-
-	deduplicated := make([]string, 0, len(set))
-	for key := range set {
-		deduplicated = append(deduplicated, key)
 	}
 	return deduplicated
 }


### PR DESCRIPTION
This commit changes the querier address deduplication logic so that we
only iterate over the input once, rather than twice.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>

* [x] Change is not relevant to the end user.

Noticed this while reviewing a PR today