### PR TITLE
receive: allow custom connection pooling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 
 ## Unreleased
 
+- [#1966](https://github.com/thanos-io/thanos/issues/1966) Receive: Allow custom connection pool sizing
+
 ### Fixed
 
 - [#1919](https://github.com/thanos-io/thanos/issues/1919) Compactor: Fixed potential data loss when uploading older blocks, or upload taking long time while compactor is

--- a/pkg/exthttp/transport.go
+++ b/pkg/exthttp/transport.go
@@ -1,0 +1,24 @@
+package exthttp
+
+import (
+	"net"
+	"net/http"
+	"time"
+)
+
+// NewTransport creates a new http.Transport with default settings
+func NewTransport() *http.Transport {
+	return &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+			DualStack: true,
+		}).DialContext,
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
+}


### PR DESCRIPTION
* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Receive: enable custom connection pool sizing. With the default configuration machines with very high load (over 500 requests per second) will cycle TCP connections too frequently and run out of available ports. See more [here](https://tleyden.github.io/blog/2016/11/21/tuning-the-go-http-client-library-for-load-testing/)

## Verification

Running a custom build in production. Also see #1955 
