### PR TITLE
Fixed crash in the memcached servers selector when there's only 1 server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 
 - [#1969](https://github.com/thanos-io/thanos/pull/1969) Sidecar: allow setting http connection pool size via flags
 - [#1967](https://github.com/thanos-io/thanos/issues/1967) Receive: Allow local TSDB compaction
+- [#1975](https://github.com/thanos-io/thanos/pull/1975) Store Gateway: fixed panic caused by memcached servers selector when there's 1 memcached node
 
 ### Fixed
 

--- a/pkg/cacheutil/memcached_server_selector.go
+++ b/pkg/cacheutil/memcached_server_selector.go
@@ -74,9 +74,12 @@ func (s *MemcachedJumpHashSelector) PickServer(key string) (net.Addr, error) {
 		return nil, memcache.ErrNoServers
 	}
 	if len(addrs) == 1 {
+		picked := addrs[0]
+
 		addrs = (addrs)[:0]
 		addrsPool.Put(&addrs)
-		return (addrs)[0], nil
+
+		return picked, nil
 	}
 
 	// Pick a server using the jump hash.

--- a/pkg/cacheutil/memcached_server_selector_test.go
+++ b/pkg/cacheutil/memcached_server_selector_test.go
@@ -76,7 +76,7 @@ func TestMemcachedJumpHashSelector_PickServer(t *testing.T) {
 		actualAddr, err := s.PickServer(test.key)
 
 		if test.expectedErr != nil {
-			testutil.NotOk(t, err)
+			testutil.Equals(t, test.expectedErr, err)
 			testutil.Equals(t, nil, actualAddr)
 		} else {
 			testutil.Ok(t, err)


### PR DESCRIPTION
Fixes https://github.com/thanos-io/thanos/issues/1974

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Verification

Unit tests.
