### PR TITLE
*: fix tracing for alerts

### DIFF
--- a/cmd/thanos/rule.go
+++ b/cmd/thanos/rule.go
@@ -452,6 +452,7 @@ func runRule(
 	{
 		sdr := alert.NewSender(logger, reg, alertmgrs)
 		ctx, cancel := context.WithCancel(context.Background())
+		ctx = tracing.ContextWithTracer(ctx, tracer)
 
 		g.Add(func() error {
 			for {


### PR DESCRIPTION
Running Thanos Ruler on master generates warnings in the logs because the tracer isn't passed down to `Sender.Send()`:

```
level=warn ts=2020-01-10T11:24:49.434277378Z caller=http.go:57 msg="Tracer not found in context."
```

* [ ] I added CHANGELOG entry for this change.
* [X] Change is not relevant to the end user.

## Changes

Pass the tracer in the context and generate spans when calling the Alertmanager API endpoint.

## Verification

No more warning in the logs.
![image](https://user-images.githubusercontent.com/2587585/72150108-07b2cc00-33a5-11ea-9ca3-4fdcb22f8275.png)
