### PR TITLE
api/v1: add cache-control header

### DIFF
--- a/pkg/query/api/v1.go
+++ b/pkg/query/api/v1.go
@@ -536,7 +536,9 @@ func (api *API) series(r *http.Request) (interface{}, []error, *ApiError) {
 
 func Respond(w http.ResponseWriter, data interface{}, warnings []error) {
 	w.Header().Set("Content-Type", "application/json")
-	w.Header().Set("Cache-Control", "no-store")
+	if len(warnings) > 0 {
+		w.Header().Set("Cache-Control", "no-store")
+	}
 	w.WriteHeader(http.StatusOK)
 
 	resp := &response{

--- a/pkg/query/api/v1.go
+++ b/pkg/query/api/v1.go
@@ -553,6 +553,7 @@ func Respond(w http.ResponseWriter, data interface{}, warnings []error) {
 
 func RespondError(w http.ResponseWriter, apiErr *ApiError, data interface{}) {
 	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
 
 	var code int
 	switch apiErr.Typ {

--- a/pkg/query/api/v1.go
+++ b/pkg/query/api/v1.go
@@ -536,6 +536,7 @@ func (api *API) series(r *http.Request) (interface{}, []error, *ApiError) {
 
 func Respond(w http.ResponseWriter, data interface{}, warnings []error) {
 	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
 	w.WriteHeader(http.StatusOK)
 
 	resp := &response{


### PR DESCRIPTION
Let's set `Cache-Control` to `no-store` if there were any warnings while
the query was being executed i.e. it is a partial response or we got
some other problem.

Seems like this works successfully in tandem with https://github.com/cortexproject/cortex/pull/1974.

Tested by turning off one sidecar which leads to warnings and then Cortex Query Frontend did not save anything into the cache when querying.

Signed-off-by: Giedrius Statkevičius <giedriuswork@gmail.com>
