### PR TITLE
Toggle SkipVerify for StoreAPI 

### DIFF
--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -209,7 +209,7 @@ func runQuery(
 	})
 	reg.MustRegister(duplicatedStores)
 
-	dialOpts, err := extgrpc.StoreClientGRPCOpts(logger, reg, tracer, secure, skipVerify, cert, key, caCert, serverName)
+	dialOpts, err := extgrpc.StoreClientGRPCOpts(logger, reg, tracer, secure, cert, key, caCert, serverName, skipVerify)
 	if err != nil {
 		return errors.Wrap(err, "building gRPC client")
 	}

--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -46,8 +46,11 @@ func registerQuery(m map[string]setupFunc, app *kingpin.Application) {
 	httpBindAddr, httpGracePeriod := regHTTPFlags(cmd)
 	grpcBindAddr, grpcGracePeriod, grpcCert, grpcKey, grpcClientCA := regGRPCFlags(cmd)
 
+	client verifies the
+	  // server's certificate chain and host name
+
 	secure := cmd.Flag("grpc-client-tls-secure", "Use TLS when talking to the gRPC server").Default("false").Bool()
-	skipVerify := cmd.Flag("grpc-client-skip-verify", "Controls whether a client verifies the server's certificate chain and host name").Default("false").Bool()
+	skipVerify := cmd.Flag("grpc-client-skip-verify", "Disable client verification of server's certificate chain and host name").Default("false").Bool()
 	cert := cmd.Flag("grpc-client-tls-cert", "TLS Certificates to use to identify this client to the server").Default("").String()
 	key := cmd.Flag("grpc-client-tls-key", "TLS Key for the client's certificate").Default("").String()
 	caCert := cmd.Flag("grpc-client-tls-ca", "TLS CA Certificates to use to verify gRPC servers").Default("").String()

--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -46,9 +46,6 @@ func registerQuery(m map[string]setupFunc, app *kingpin.Application) {
 	httpBindAddr, httpGracePeriod := regHTTPFlags(cmd)
 	grpcBindAddr, grpcGracePeriod, grpcCert, grpcKey, grpcClientCA := regGRPCFlags(cmd)
 
-	client verifies the
-	  // server's certificate chain and host name
-
 	secure := cmd.Flag("grpc-client-tls-secure", "Use TLS when talking to the gRPC server").Default("false").Bool()
 	skipVerify := cmd.Flag("grpc-client-skip-verify", "Disable client verification of server's certificate chain and host name").Default("false").Bool()
 	cert := cmd.Flag("grpc-client-tls-cert", "TLS Certificates to use to identify this client to the server").Default("").String()

--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -47,6 +47,7 @@ func registerQuery(m map[string]setupFunc, app *kingpin.Application) {
 	grpcBindAddr, grpcGracePeriod, grpcCert, grpcKey, grpcClientCA := regGRPCFlags(cmd)
 
 	secure := cmd.Flag("grpc-client-tls-secure", "Use TLS when talking to the gRPC server").Default("false").Bool()
+	skipVerify := cmd.Flag("grpc-client-skip-verify", "Controls whether a client verifies the server's certificate chain and host name").Default("false").Bool()
 	cert := cmd.Flag("grpc-client-tls-cert", "TLS Certificates to use to identify this client to the server").Default("").String()
 	key := cmd.Flag("grpc-client-tls-key", "TLS Key for the client's certificate").Default("").String()
 	caCert := cmd.Flag("grpc-client-tls-ca", "TLS CA Certificates to use to verify gRPC servers").Default("").String()
@@ -135,6 +136,7 @@ func registerQuery(m map[string]setupFunc, app *kingpin.Application) {
 			*grpcKey,
 			*grpcClientCA,
 			*secure,
+			*skipVerify,
 			*cert,
 			*key,
 			*caCert,
@@ -175,6 +177,7 @@ func runQuery(
 	grpcKey string,
 	grpcClientCA string,
 	secure bool,
+	skipVerify bool,
 	cert string,
 	key string,
 	caCert string,
@@ -206,7 +209,7 @@ func runQuery(
 	})
 	reg.MustRegister(duplicatedStores)
 
-	dialOpts, err := extgrpc.StoreClientGRPCOpts(logger, reg, tracer, secure, cert, key, caCert, serverName)
+	dialOpts, err := extgrpc.StoreClientGRPCOpts(logger, reg, tracer, secure, skipVerify, cert, key, caCert, serverName)
 	if err != nil {
 		return errors.Wrap(err, "building gRPC client")
 	}

--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -191,7 +191,7 @@ func runReceive(
 	if err != nil {
 		return err
 	}
-	dialOpts, err := extgrpc.StoreClientGRPCOpts(logger, reg, tracer, rwServerCert != "", false, rwClientCert, rwClientKey, rwClientServerCA, rwClientServerName)
+	dialOpts, err := extgrpc.StoreClientGRPCOpts(logger, reg, tracer, rwServerCert != "", rwClientCert, rwClientKey, rwClientServerCA, rwClientServerName, false)
 	if err != nil {
 		return err
 	}

--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -187,11 +187,11 @@ func runReceive(
 	if err != nil {
 		return err
 	}
-	rwTLSClientConfig, err := tls.NewClientConfig(logger, rwClientCert, rwClientKey, rwClientServerCA, rwClientServerName)
+	rwTLSClientConfig, err := tls.NewClientConfig(logger, rwClientCert, rwClientKey, rwClientServerCA, rwClientServerName, false)
 	if err != nil {
 		return err
 	}
-	dialOpts, err := extgrpc.StoreClientGRPCOpts(logger, reg, tracer, rwServerCert != "", rwClientCert, rwClientKey, rwClientServerCA, rwClientServerName)
+	dialOpts, err := extgrpc.StoreClientGRPCOpts(logger, reg, tracer, rwServerCert != "", false, rwClientCert, rwClientKey, rwClientServerCA, rwClientServerName)
 	if err != nil {
 		return err
 	}

--- a/docs/components/query.md
+++ b/docs/components/query.md
@@ -278,6 +278,8 @@ Flags:
                                  CA is specified, there is no client
                                  verification on server side. (tls.NoClientCert)
       --grpc-client-tls-secure   Use TLS when talking to the gRPC server
+      --grpc-client-skip-verify  Disable client verification of server's certificate
+                                 chain and host name
       --grpc-client-tls-cert=""  TLS Certificates to use to identify this client
                                  to the server
       --grpc-client-tls-key=""   TLS Key for the client's certificate

--- a/docs/components/query.md
+++ b/docs/components/query.md
@@ -278,8 +278,8 @@ Flags:
                                  CA is specified, there is no client
                                  verification on server side. (tls.NoClientCert)
       --grpc-client-tls-secure   Use TLS when talking to the gRPC server
-      --grpc-client-skip-verify  Disable client verification of server's certificate
-                                 chain and host name
+      --grpc-client-skip-verify  Disable client verification of server's
+                                 certificate chain and host name
       --grpc-client-tls-cert=""  TLS Certificates to use to identify this client
                                  to the server
       --grpc-client-tls-key=""   TLS Key for the client's certificate

--- a/pkg/extgrpc/client.go
+++ b/pkg/extgrpc/client.go
@@ -16,7 +16,7 @@ import (
 )
 
 // StoreClientGRPCOpts creates gRPC dial options for connecting to a store client.
-func StoreClientGRPCOpts(logger log.Logger, reg *prometheus.Registry, tracer opentracing.Tracer, secure bool, skipVerify bool, cert, key, caCert, serverName string) ([]grpc.DialOption, error) {
+func StoreClientGRPCOpts(logger log.Logger, reg *prometheus.Registry, tracer opentracing.Tracer, secure bool, cert, key, caCert, serverName string, skipVerify bool) ([]grpc.DialOption, error) {
 	grpcMets := grpc_prometheus.NewClientMetrics()
 	grpcMets.EnableClientHandlingTimeHistogram(
 		grpc_prometheus.WithHistogramBuckets([]float64{0.001, 0.01, 0.1, 0.3, 0.6, 1, 3, 6, 9, 20, 30, 60, 90, 120}),

--- a/pkg/extgrpc/client.go
+++ b/pkg/extgrpc/client.go
@@ -16,7 +16,7 @@ import (
 )
 
 // StoreClientGRPCOpts creates gRPC dial options for connecting to a store client.
-func StoreClientGRPCOpts(logger log.Logger, reg *prometheus.Registry, tracer opentracing.Tracer, secure bool, cert, key, caCert, serverName string) ([]grpc.DialOption, error) {
+func StoreClientGRPCOpts(logger log.Logger, reg *prometheus.Registry, tracer opentracing.Tracer, secure bool, skipVerify bool, cert, key, caCert, serverName string) ([]grpc.DialOption, error) {
 	grpcMets := grpc_prometheus.NewClientMetrics()
 	grpcMets.EnableClientHandlingTimeHistogram(
 		grpc_prometheus.WithHistogramBuckets([]float64{0.001, 0.01, 0.1, 0.3, 0.6, 1, 3, 6, 9, 20, 30, 60, 90, 120}),
@@ -51,7 +51,7 @@ func StoreClientGRPCOpts(logger log.Logger, reg *prometheus.Registry, tracer ope
 
 	level.Info(logger).Log("msg", "enabling client to server TLS")
 
-	tlsCfg, err := tls.NewClientConfig(logger, cert, key, caCert, serverName)
+	tlsCfg, err := tls.NewClientConfig(logger, cert, key, caCert, serverName, skipVerify)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/tls/options.go
+++ b/pkg/tls/options.go
@@ -58,7 +58,7 @@ func NewServerConfig(logger log.Logger, cert, key, clientCA string) (*tls.Config
 }
 
 // NewClientConfig provides new client TLS configuration.
-func NewClientConfig(logger log.Logger, cert, key, caCert, serverName string) (*tls.Config, error) {
+func NewClientConfig(logger log.Logger, cert, key, caCert, serverName string, skipVerify bool) (*tls.Config, error) {
 	var certPool *x509.CertPool
 	if caCert != "" {
 		caPEM, err := ioutil.ReadFile(caCert)
@@ -91,6 +91,8 @@ func NewClientConfig(logger log.Logger, cert, key, caCert, serverName string) (*
 	if (key != "") != (cert != "") {
 		return nil, errors.New("both client key and certificate must be provided")
 	}
+
+	tlsCfg.InsecureSkipVerify = skipVerify
 
 	if cert != "" {
 		cert, err := tls.LoadX509KeyPair(cert, key)


### PR DESCRIPTION
I am deploying Prometheus in multiple private (internal) clusters. The Thanos sidecar is exposed via the Nginx Ingress Controller. The ability to support GRPC is supported only over TLS. The ingress is created with a self-signed certificate (as I would prefer not to have to manage certificates) therefore I require the ability to skip verification of the certificate when connecting to the StoreAPI.
## Changes

Add new bool option `grpc-client-skip-verify`, which defaults to false to maintain backwards compatibility, that when set to true skips certificate validation. 

## Verification

Tested against a StoreAPI exposed with a self-signed certificate. 
