### PR TITLE
receive: add receive writer metrics.

### DIFF
--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -286,7 +286,7 @@ func runReceive(
 					}
 					level.Info(logger).Log("msg", "tsdb started")
 					localStorage.Set(db.Get(), startTimeMargin)
-					webHandler.SetWriter(receive.NewWriter(log.With(logger, "component", "receive-writer"), localStorage))
+					webHandler.SetWriter(receive.NewWriter(log.With(logger, "component", "receive-writer"), reg, localStorage))
 					statusProber.Ready()
 					level.Info(logger).Log("msg", "server is ready to receive web requests.")
 					dbReady <- struct{}{}

--- a/pkg/receive/handler_test.go
+++ b/pkg/receive/handler_test.go
@@ -161,7 +161,7 @@ func newHandlerHashring(appendables []*fakeAppendable, replicationFactor uint64)
 			TenantHeader:      DefaultTenantHeader,
 			ReplicaHeader:     DefaultReplicaHeader,
 			ReplicationFactor: replicationFactor,
-			Writer:            NewWriter(log.NewNopLogger(), appendables[i]),
+			Writer:            NewWriter(log.NewNopLogger(), nil, appendables[i]),
 		})
 		handlers = append(handlers, h)
 		h.peers = peers


### PR DESCRIPTION
https://github.com/thanos-io/thanos/blob/ac4967e044f41606bf094a053b8d345c251dfebc/pkg/receive/writer.go#L21-L24

`Writer` has no metrics for below counter:

https://github.com/thanos-io/thanos/blob/ac4967e044f41606bf094a053b8d345c251dfebc/pkg/receive/writer.go#L35-L37

Add metrics for `Writer` to watch the values.