### PR TITLE
mixin: Fix wrong querier metric name

### DIFF
--- a/examples/alerts/alerts.md
+++ b/examples/alerts/alerts.md
@@ -263,9 +263,9 @@ rules:
     message: Thanos Querys {{$labels.job}} have {{ $value }} of failing DNS queries.
   expr: |
     (
-      sum by (job) (rate(thanos_query_store_apis_dns_failures_total{job=~"thanos-querier.*"}[5m]))
+      sum by (job) (rate(thanos_querier_store_apis_dns_failures_total{job=~"thanos-querier.*"}[5m]))
     /
-      sum by (job) (rate(thanos_query_store_apis_dns_lookups_total{job=~"thanos-querier.*"}[5m]))
+      sum by (job) (rate(thanos_querier_store_apis_dns_lookups_total{job=~"thanos-querier.*"}[5m]))
     > 1
     )
   for: 15m

--- a/examples/alerts/alerts.yaml
+++ b/examples/alerts/alerts.yaml
@@ -112,9 +112,9 @@ groups:
       message: Thanos Querys {{$labels.job}} have {{ $value }} of failing DNS queries.
     expr: |
       (
-        sum by (job) (rate(thanos_query_store_apis_dns_failures_total{job=~"thanos-querier.*"}[5m]))
+        sum by (job) (rate(thanos_querier_store_apis_dns_failures_total{job=~"thanos-querier.*"}[5m]))
       /
-        sum by (job) (rate(thanos_query_store_apis_dns_lookups_total{job=~"thanos-querier.*"}[5m]))
+        sum by (job) (rate(thanos_querier_store_apis_dns_lookups_total{job=~"thanos-querier.*"}[5m]))
       > 1
       )
     for: 15m

--- a/mixin/thanos/alerts/querier.libsonnet
+++ b/mixin/thanos/alerts/querier.libsonnet
@@ -86,9 +86,9 @@
             },
             expr: |||
               (
-                sum by (job) (rate(thanos_query_store_apis_dns_failures_total{%(selector)s}[5m]))
+                sum by (job) (rate(thanos_querier_store_apis_dns_failures_total{%(selector)s}[5m]))
               /
-                sum by (job) (rate(thanos_query_store_apis_dns_lookups_total{%(selector)s}[5m]))
+                sum by (job) (rate(thanos_querier_store_apis_dns_lookups_total{%(selector)s}[5m]))
               > 1
               )
             ||| % thanos.querier,


### PR DESCRIPTION
This PR fixes wrong querier metric name.

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes
 * Rename `thanos_query_store_apis_dns_failures_total` to `thanos_querier_store_apis_dns_failures_total`

## Verification

1. `make examples-lint`
1. Manuel test using promdash.