### PR TITLE
compactor: Clear up wording around 0d retention times in docs

### DIFF
--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -96,9 +96,9 @@ func registerCompact(m map[string]setupFunc, app *kingpin.Application) {
 	consistencyDelay := modelDuration(cmd.Flag("consistency-delay", fmt.Sprintf("Minimum age of fresh (non-compacted) blocks before they are being processed. Malformed blocks older than the maximum of consistency-delay and %v will be removed.", compact.PartialUploadThresholdAge)).
 		Default("30m"))
 
-	retentionRaw := modelDuration(cmd.Flag("retention.resolution-raw", "How long to retain raw samples in bucket. 0d - disables this retention").Default("0d"))
-	retention5m := modelDuration(cmd.Flag("retention.resolution-5m", "How long to retain samples of resolution 1 (5 minutes) in bucket. 0d - disables this retention").Default("0d"))
-	retention1h := modelDuration(cmd.Flag("retention.resolution-1h", "How long to retain samples of resolution 2 (1 hour) in bucket. 0d - disables this retention").Default("0d"))
+	retentionRaw := modelDuration(cmd.Flag("retention.resolution-raw", "How long to retain raw samples in bucket. Setting this to 0d will retain samples of this resolution forever").Default("0d"))
+	retention5m := modelDuration(cmd.Flag("retention.resolution-5m", "How long to retain samples of resolution 1 (5 minutes) in bucket. Setting this to 0d will retain samples of this resolution forever").Default("0d"))
+	retention1h := modelDuration(cmd.Flag("retention.resolution-1h", "How long to retain samples of resolution 2 (1 hour) in bucket. Setting this to 0d will retain samples of this resolution forever").Default("0d"))
 
 	wait := cmd.Flag("wait", "Do not exit after all compactions have been processed and wait for new work.").
 		Short('w').Bool()

--- a/docs/components/compact.md
+++ b/docs/components/compact.md
@@ -47,6 +47,8 @@ There's also a case when you might want to disable downsampling at all with `deb
 
 Ideally, you will have equal retention set (or no retention at all) to all resolutions which allow both "zoom in" capabilities as well as performant long ranges queries. Since object storages are usually quite cheap, storage size might not matter that much, unless your goal with thanos is somewhat very specific and you know exactly what you're doing.
 
+Not setting this flag, or setting it to `0d`, i.e. `--retention.resolution-X=0d`, will mean that samples at the `X` resolution level will be kept forever.
+
 ## Storage space consumption
 
 In fact, downsampling doesn't save you any space but instead it adds 2 more blocks for each raw block which are only slightly smaller or relatively similar size to raw block. This is required by internal downsampling implementation which to be mathematically correct holds various aggregations. This means that downsampling can increase the size of your storage a bit (~3x), but it gives massive advantage on querying long ranges.
@@ -105,14 +107,17 @@ Flags:
                                older than the maximum of consistency-delay and
                                48h0m0s will be removed.
       --retention.resolution-raw=0d
-                               How long to retain raw samples in bucket. 0d -
-                               disables this retention
+                               How long to retain raw samples in bucket. Setting
+                               this to 0d will retain samples of this resolution
+                               forever
       --retention.resolution-5m=0d
                                How long to retain samples of resolution 1 (5
-                               minutes) in bucket. 0d - disables this retention
+                               minutes) in bucket. Setting this to 0d will
+                               retain samples of this resolution forever
       --retention.resolution-1h=0d
                                How long to retain samples of resolution 2 (1
-                               hour) in bucket. 0d - disables this retention
+                               hour) in bucket. Setting this to 0d will retain
+                               samples of this resolution forever
   -w, --wait                   Do not exit after all compactions have been
                                processed and wait for new work.
       --downsampling.disable   Disables downsampling. This is not recommended as


### PR DESCRIPTION
* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.
(This is a docs-only change - does it need to go in the changelog? If so, I'm more than happy to add it in 🙂)

## Changes

I was confused by the wording around 0d rerentions in the docs - does 0d retention mean that samples aren't retained at all, or that they're not evicted? - so I went through the code, and as far as I can tell, 0d retention means that samples aren't evicted.

I went through the docs and the CLI help text, and added explanations that 0d retention means that samples are never evicted.

## Verification

- Ran `make build`, and then `./thanos compactor -h`, verifying the the new help text was there
- Ran `make web`, then opened up `website/public/components/compact.md/index.html`, and verified that the text I'd added to the docs was present
