### PR TITLE
Fix invalid start/end params in series api

### DIFF
--- a/pkg/model/timeduration.go
+++ b/pkg/model/timeduration.go
@@ -42,7 +42,7 @@ func (tdv *TimeOrDurationValue) Set(s string) error {
 	return nil
 }
 
-// String returns either tume or duration.
+// String returns either time or duration.
 func (tdv *TimeOrDurationValue) String() string {
 	switch {
 	case tdv.Time != nil:

--- a/pkg/store/prometheus.go
+++ b/pkg/store/prometheus.go
@@ -12,8 +12,10 @@ import (
 	"net/url"
 	"path"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
@@ -23,6 +25,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/common/version"
 	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/prometheus/pkg/timestamp"
 	"github.com/prometheus/prometheus/prompb"
 	"github.com/prometheus/prometheus/storage/remote"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
@@ -663,9 +666,9 @@ func (p *PrometheusStore) seriesLabels(ctx context.Context, matchers []storepb.L
 	}
 
 	q.Add("match[]", metric)
+	q.Add("start", formatTime(timestamp.Time(startTime)))
+	q.Add("end", formatTime(timestamp.Time(endTime)))
 	u.RawQuery = q.Encode()
-	q.Add("start", string(startTime))
-	q.Add("end", string(endTime))
 
 	req, err := http.NewRequest("GET", u.String(), nil)
 	if err != nil {
@@ -714,4 +717,8 @@ func (p *PrometheusStore) seriesLabels(ctx context.Context, matchers []storepb.L
 	}
 
 	return m.Data, nil
+}
+
+func formatTime(t time.Time) string {
+	return strconv.FormatFloat(float64(t.Unix())+float64(t.Nanosecond())/1e9, 'f', -1, 64)
 }

--- a/pkg/store/prometheus_test.go
+++ b/pkg/store/prometheus_test.go
@@ -199,6 +199,8 @@ func TestPrometheusStore_SeriesLabels_e2e(t *testing.T) {
 	testutil.Ok(t, err)
 	_, err = a.Add(labels.FromStrings("a", "d", "job", "test"), baseT+300, 3)
 	testutil.Ok(t, err)
+	_, err = a.Add(labels.FromStrings("job", "test"), baseT+400, 4)
+	testutil.Ok(t, err)
 	testutil.Ok(t, a.Commit())
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -209,14 +211,13 @@ func TestPrometheusStore_SeriesLabels_e2e(t *testing.T) {
 	u, err := url.Parse(fmt.Sprintf("http://%s", p.Addr()))
 	testutil.Ok(t, err)
 
-	limitMinT := int64(0)
-	proxy, err := NewPrometheusStore(nil, nil, u, component.Sidecar,
+	promStore, err := NewPrometheusStore(nil, nil, u, component.Sidecar,
 		func() labels.Labels { return labels.FromStrings("region", "eu-west") },
-		func() (int64, int64) { return limitMinT, -1 }) // Maxt does not matter.
+		func() (int64, int64) { return math.MinInt64/1000 + 62135596801, math.MaxInt64/1000 - 62135596801 })
 	testutil.Ok(t, err)
 
 	{
-		res, err := proxy.seriesLabels(ctx, []storepb.LabelMatcher{
+		res, err := promStore.seriesLabels(ctx, []storepb.LabelMatcher{
 			{Type: storepb.LabelMatcher_EQ, Name: "a", Value: "b"},
 		}, baseT, baseT+300)
 		testutil.Ok(t, err)
@@ -225,7 +226,7 @@ func TestPrometheusStore_SeriesLabels_e2e(t *testing.T) {
 		testutil.Equals(t, labels.FromMap(res[0]), labels.Labels{{Name: "a", Value: "b"}})
 	}
 	{
-		res, err := proxy.seriesLabels(ctx, []storepb.LabelMatcher{
+		res, err := promStore.seriesLabels(ctx, []storepb.LabelMatcher{
 			{Type: storepb.LabelMatcher_EQ, Name: "job", Value: "foo"},
 		}, baseT, baseT+300)
 		testutil.Ok(t, err)
@@ -233,7 +234,7 @@ func TestPrometheusStore_SeriesLabels_e2e(t *testing.T) {
 		testutil.Equals(t, len(res), 0)
 	}
 	{
-		res, err := proxy.seriesLabels(ctx, []storepb.LabelMatcher{
+		res, err := promStore.seriesLabels(ctx, []storepb.LabelMatcher{
 			{Type: storepb.LabelMatcher_NEQ, Name: "a", Value: "b"},
 			{Type: storepb.LabelMatcher_EQ, Name: "job", Value: "test"},
 		}, baseT, baseT+300)
@@ -247,7 +248,7 @@ func TestPrometheusStore_SeriesLabels_e2e(t *testing.T) {
 		}
 	}
 	{
-		res, err := proxy.seriesLabels(ctx, []storepb.LabelMatcher{
+		res, err := promStore.seriesLabels(ctx, []storepb.LabelMatcher{
 			{Type: storepb.LabelMatcher_EQ, Name: "job", Value: "test"},
 		}, baseT, baseT+300)
 		testutil.Ok(t, err)
@@ -256,6 +257,29 @@ func TestPrometheusStore_SeriesLabels_e2e(t *testing.T) {
 		testutil.Equals(t, len(res), 2)
 		for _, r := range res {
 			testutil.Equals(t, labels.FromMap(r).Has("a"), true)
+			testutil.Equals(t, labels.FromMap(r).Get("job"), "test")
+		}
+	}
+	{
+		res, err := promStore.seriesLabels(ctx, []storepb.LabelMatcher{
+			{Type: storepb.LabelMatcher_EQ, Name: "job", Value: "test"},
+		}, baseT+400, baseT+400)
+		testutil.Ok(t, err)
+
+		// In baseT + 400 we can just get one series.
+		testutil.Equals(t, len(res), 1)
+		testutil.Equals(t, len(res[0]), 1)
+		testutil.Equals(t, labels.FromMap(res[0]).Get("job"), "test")
+	}
+	// This test case is to test when start time and end time is not specified.
+	{
+		minTime, maxTime := promStore.timestamps()
+		res, err := promStore.seriesLabels(ctx, []storepb.LabelMatcher{
+			{Type: storepb.LabelMatcher_EQ, Name: "job", Value: "test"},
+		}, minTime, maxTime)
+		testutil.Ok(t, err)
+		testutil.Equals(t, len(res), 3)
+		for _, r := range res {
 			testutil.Equals(t, labels.FromMap(r).Get("job"), "test")
 		}
 	}


### PR DESCRIPTION
Signed-off-by: yeya24 <yb532204897@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

Fixes #2011

cc @IKSIN  @GiedriusS 
## Verification

I have already tested both in Grafana and local API request.

```
curl -g 'http://localhost:10908/api/v1/series?' -d 'match[]={__name__="up"}'
{"status":"success","data":[{"__name__":"up","instance":"localhost:9090","job":"prometheus","replica":"test"},{"__name__":"up","instance":"localhost:9091","job":"prometheus","replica":"test"}]}

curl -g 'http://localhost:10908/api/v1/series?' -d 'match[]={__name__="up"}' -d 'start=1579551916'   
{"status":"success","data":[{"__name__":"up","instance":"localhost:9091","job":"prometheus","replica":"test"}]}
```
