### PR TITLE
Add _total suffix to two counter metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 ### Changed
 
 - [#1933](https://github.com/thanos-io/thanos/pull/1933) Add a flag `--tsdb.wal-compression` to configure whether to enable tsdb wal compression in ruler and receiver.
+- [#2021](https://github.com/thanos-io/thanos/pull/2021) Rename metric `thanos_query_duplicated_store_address` to `thanos_query_duplicated_store_addresses_total` and `thanos_rule_duplicated_query_address` to `thanos_rule_duplicated_query_addresses_total`.
 
 ## [v0.10.0](https://github.com/thanos-io/thanos/releases/tag/v0.10.0) - 2020.01.13
 

--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -201,7 +201,7 @@ func runQuery(
 ) error {
 	// TODO(bplotka in PR #513 review): Move arguments into struct.
 	duplicatedStores := prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "thanos_query_duplicated_store_address",
+		Name: "thanos_query_duplicated_store_addresses_total",
 		Help: "The number of times a duplicated store addresses is detected from the different configs in query",
 	})
 	reg.MustRegister(duplicatedStores)

--- a/cmd/thanos/rule.go
+++ b/cmd/thanos/rule.go
@@ -246,7 +246,7 @@ func runRule(
 		Help: "Timestamp of the last successful configuration reload.",
 	})
 	duplicatedQuery := prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "thanos_rule_duplicated_query_address",
+		Name: "thanos_rule_duplicated_query_addresses_total",
 		Help: "The number of times a duplicated query addresses is detected from the different configs in rule",
 	})
 	rulesLoaded := prometheus.NewGaugeVec(


### PR DESCRIPTION
Signed-off-by: yeya24 <yb532204897@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

I guess we need `_total` in counter metrics

## Verification

<!-- How you tested it? How do you know it works? -->
