### PR TITLE
pkg/alert: fix configuration from "legacy" flags

### DIFF
--- a/pkg/alert/config.go
+++ b/pkg/alert/config.go
@@ -123,6 +123,7 @@ func BuildAlertmanagerConfig(address string, timeout time.Duration) (Alertmanage
 			Scheme:          scheme,
 			StaticAddresses: []string{host},
 		},
-		Timeout: model.Duration(timeout),
+		Timeout:    model.Duration(timeout),
+		APIVersion: APIv1,
 	}, nil
 }

--- a/pkg/alert/config_test.go
+++ b/pkg/alert/config_test.go
@@ -55,6 +55,7 @@ func TestBuildAlertmanagerConfiguration(t *testing.T) {
 					StaticAddresses: []string{"localhost:9093"},
 					Scheme:          "http",
 				},
+				APIVersion: APIv1,
 			},
 		},
 		{
@@ -64,6 +65,7 @@ func TestBuildAlertmanagerConfiguration(t *testing.T) {
 					StaticAddresses: []string{"am.example.com"},
 					Scheme:          "https",
 				},
+				APIVersion: APIv1,
 			},
 		},
 		{
@@ -73,6 +75,7 @@ func TestBuildAlertmanagerConfiguration(t *testing.T) {
 					StaticAddresses: []string{"dns+localhost:9093"},
 					Scheme:          "http",
 				},
+				APIVersion: APIv1,
 			},
 		},
 		{
@@ -82,6 +85,7 @@ func TestBuildAlertmanagerConfiguration(t *testing.T) {
 					StaticAddresses: []string{"dnssrv+localhost"},
 					Scheme:          "http",
 				},
+				APIVersion: APIv1,
 			},
 		},
 		{
@@ -91,6 +95,7 @@ func TestBuildAlertmanagerConfiguration(t *testing.T) {
 					StaticAddresses: []string{"localhost"},
 					Scheme:          "ssh+http",
 				},
+				APIVersion: APIv1,
 			},
 		},
 		{
@@ -101,6 +106,7 @@ func TestBuildAlertmanagerConfiguration(t *testing.T) {
 					Scheme:          "https",
 					PathPrefix:      "/path/prefix/",
 				},
+				APIVersion: APIv1,
 			},
 		},
 		{
@@ -116,6 +122,7 @@ func TestBuildAlertmanagerConfiguration(t *testing.T) {
 					StaticAddresses: []string{"localhost:9093"},
 					Scheme:          "http",
 				},
+				APIVersion: APIv1,
 			},
 		},
 		{


### PR DESCRIPTION
* [ ] I added CHANGELOG entry for this change.
* [X] Change is not relevant to the end user.

## Changes

Regression introduced in #1982. `BuildAlertmanagerConfig()` didn't set the API version to use resulting in bad URL (e.g. `http://example.com:9093/api/alerts` instead of `http://example.com:9093/api/v1/alerts`).

## Verification

Tested locally.