### PR TITLE
mixin: Fix querier store DNS query alert

### DIFF
--- a/examples/alerts/alerts.md
+++ b/examples/alerts/alerts.md
@@ -279,7 +279,7 @@ name: thanos-querier.rules
 rules:
 - alert: ThanosQuerierHttpRequestQueryErrorRateHigh
   annotations:
-    message: Thanos Query {{$labels.job}} is failing to handle {{ $value | humanize
+    message: Thanos Querier {{$labels.job}} is failing to handle {{ $value | humanize
       }}% of "query" requests.
   expr: |
     (
@@ -292,7 +292,7 @@ rules:
     severity: critical
 - alert: ThanosQuerierHttpRequestQueryRangeErrorRateHigh
   annotations:
-    message: Thanos Query {{$labels.job}} is failing to handle {{ $value | humanize
+    message: Thanos Querier {{$labels.job}} is failing to handle {{ $value | humanize
       }}% of "query_range" requests.
   expr: |
     (
@@ -305,7 +305,7 @@ rules:
     severity: critical
 - alert: ThanosQuerierGrpcServerErrorRate
   annotations:
-    message: Thanos Query {{$labels.job}} is failing to handle {{ $value | humanize
+    message: Thanos Querier {{$labels.job}} is failing to handle {{ $value | humanize
       }}% of requests.
   expr: |
     (
@@ -319,34 +319,33 @@ rules:
     severity: warning
 - alert: ThanosQuerierGrpcClientErrorRate
   annotations:
-    message: Thanos Query {{$labels.job}} is failing to send {{ $value | humanize
+    message: Thanos Querier {{$labels.job}} is failing to send {{ $value | humanize
       }}% of requests.
   expr: |
     (
       sum by (job) (rate(grpc_client_handled_total{grpc_code!="OK", job=~"thanos-querier.*"}[5m]))
     /
       sum by (job) (rate(grpc_client_started_total{job=~"thanos-querier.*"}[5m]))
-    * 100 > 5
-    )
+    ) * 100 > 5
   for: 5m
   labels:
     severity: warning
 - alert: ThanosQuerierHighDNSFailures
   annotations:
-    message: Thanos Querys {{$labels.job}} have {{ $value }} of failing DNS queries.
+    message: Thanos Queriers {{$labels.job}} have {{ $value | humanize }}% of failing
+      DNS queries for store endpoints.
   expr: |
     (
-      sum by (job) (rate(thanos_query_store_apis_dns_failures_total{job=~"thanos-querier.*"}[5m]))
+      sum by (job) (rate(thanos_querier_store_apis_dns_failures_total{job=~"thanos-querier.*"}[5m]))
     /
-      sum by (job) (rate(thanos_query_store_apis_dns_lookups_total{job=~"thanos-querier.*"}[5m]))
-    > 1
-    )
+      sum by (job) (rate(thanos_querier_store_apis_dns_lookups_total{job=~"thanos-querier.*"}[5m]))
+    ) * 100 > 1
   for: 15m
   labels:
     severity: warning
 - alert: ThanosQuerierInstantLatencyHigh
   annotations:
-    message: Thanos Query {{$labels.job}} has a 99th percentile latency of {{ $value
+    message: Thanos Querier {{$labels.job}} has a 99th percentile latency of {{ $value
       }} seconds for instant queries.
   expr: |
     (
@@ -359,7 +358,7 @@ rules:
     severity: critical
 - alert: ThanosQuerierRangeLatencyHigh
   annotations:
-    message: Thanos Query {{$labels.job}} has a 99th percentile latency of {{ $value
+    message: Thanos Querier {{$labels.job}} has a 99th percentile latency of {{ $value
       }} seconds for instant queries.
   expr: |
     (

--- a/examples/alerts/alerts.yaml
+++ b/examples/alerts/alerts.yaml
@@ -55,7 +55,7 @@ groups:
   rules:
   - alert: ThanosQuerierHttpRequestQueryErrorRateHigh
     annotations:
-      message: Thanos Query {{$labels.job}} is failing to handle {{ $value | humanize
+      message: Thanos Querier {{$labels.job}} is failing to handle {{ $value | humanize
         }}% of "query" requests.
     expr: |
       (
@@ -68,7 +68,7 @@ groups:
       severity: critical
   - alert: ThanosQuerierHttpRequestQueryRangeErrorRateHigh
     annotations:
-      message: Thanos Query {{$labels.job}} is failing to handle {{ $value | humanize
+      message: Thanos Querier {{$labels.job}} is failing to handle {{ $value | humanize
         }}% of "query_range" requests.
     expr: |
       (
@@ -81,7 +81,7 @@ groups:
       severity: critical
   - alert: ThanosQuerierGrpcServerErrorRate
     annotations:
-      message: Thanos Query {{$labels.job}} is failing to handle {{ $value | humanize
+      message: Thanos Querier {{$labels.job}} is failing to handle {{ $value | humanize
         }}% of requests.
     expr: |
       (
@@ -95,35 +95,34 @@ groups:
       severity: warning
   - alert: ThanosQuerierGrpcClientErrorRate
     annotations:
-      message: Thanos Query {{$labels.job}} is failing to send {{ $value | humanize
+      message: Thanos Querier {{$labels.job}} is failing to send {{ $value | humanize
         }}% of requests.
     expr: |
       (
         sum by (job) (rate(grpc_client_handled_total{grpc_code!="OK", job=~"thanos-querier.*"}[5m]))
       /
         sum by (job) (rate(grpc_client_started_total{job=~"thanos-querier.*"}[5m]))
-      * 100 > 5
-      )
+      ) * 100 > 5
     for: 5m
     labels:
       severity: warning
   - alert: ThanosQuerierHighDNSFailures
     annotations:
-      message: Thanos Querys {{$labels.job}} have {{ $value }} of failing DNS queries.
+      message: Thanos Queriers {{$labels.job}} have {{ $value | humanize }}% of failing
+        DNS queries for store endpoints.
     expr: |
       (
-        sum by (job) (rate(thanos_query_store_apis_dns_failures_total{job=~"thanos-querier.*"}[5m]))
+        sum by (job) (rate(thanos_querier_store_apis_dns_failures_total{job=~"thanos-querier.*"}[5m]))
       /
-        sum by (job) (rate(thanos_query_store_apis_dns_lookups_total{job=~"thanos-querier.*"}[5m]))
-      > 1
-      )
+        sum by (job) (rate(thanos_querier_store_apis_dns_lookups_total{job=~"thanos-querier.*"}[5m]))
+      ) * 100 > 1
     for: 15m
     labels:
       severity: warning
   - alert: ThanosQuerierInstantLatencyHigh
     annotations:
-      message: Thanos Query {{$labels.job}} has a 99th percentile latency of {{ $value
-        }} seconds for instant queries.
+      message: Thanos Querier {{$labels.job}} has a 99th percentile latency of {{
+        $value }} seconds for instant queries.
     expr: |
       (
         histogram_quantile(0.99, sum by (job, le) (http_request_duration_seconds_bucket{job=~"thanos-querier.*", handler="query"})) > 10
@@ -135,8 +134,8 @@ groups:
       severity: critical
   - alert: ThanosQuerierRangeLatencyHigh
     annotations:
-      message: Thanos Query {{$labels.job}} has a 99th percentile latency of {{ $value
-        }} seconds for instant queries.
+      message: Thanos Querier {{$labels.job}} has a 99th percentile latency of {{
+        $value }} seconds for instant queries.
     expr: |
       (
         histogram_quantile(0.99, sum by (job, le) (http_request_duration_seconds_bucket{job=~"thanos-querier.*", handler="query_range"})) > 10

--- a/mixin/thanos/alerts/querier.libsonnet
+++ b/mixin/thanos/alerts/querier.libsonnet
@@ -12,7 +12,7 @@
           {
             alert: 'ThanosQuerierHttpRequestQueryErrorRateHigh',
             annotations: {
-              message: 'Thanos Query {{$labels.job}} is failing to handle {{ $value | humanize }}% of "query" requests.',
+              message: 'Thanos Querier {{$labels.job}} is failing to handle {{ $value | humanize }}% of "query" requests.',
             },
             expr: |||
               (
@@ -29,7 +29,7 @@
           {
             alert: 'ThanosQuerierHttpRequestQueryRangeErrorRateHigh',
             annotations: {
-              message: 'Thanos Query {{$labels.job}} is failing to handle {{ $value | humanize }}% of "query_range" requests.',
+              message: 'Thanos Querier {{$labels.job}} is failing to handle {{ $value | humanize }}% of "query_range" requests.',
             },
             expr: |||
               (
@@ -46,7 +46,7 @@
           {
             alert: 'ThanosQuerierGrpcServerErrorRate',
             annotations: {
-              message: 'Thanos Query {{$labels.job}} is failing to handle {{ $value | humanize }}% of requests.',
+              message: 'Thanos Querier {{$labels.job}} is failing to handle {{ $value | humanize }}% of requests.',
             },
             expr: |||
               (
@@ -64,15 +64,14 @@
           {
             alert: 'ThanosQuerierGrpcClientErrorRate',
             annotations: {
-              message: 'Thanos Query {{$labels.job}} is failing to send {{ $value | humanize }}% of requests.',
+              message: 'Thanos Querier {{$labels.job}} is failing to send {{ $value | humanize }}% of requests.',
             },
             expr: |||
               (
                 sum by (job) (rate(grpc_client_handled_total{grpc_code!="OK", %(selector)s}[5m]))
               /
                 sum by (job) (rate(grpc_client_started_total{%(selector)s}[5m]))
-              * 100 > 5
-              )
+              ) * 100 > 5
             ||| % thanos.querier,
             'for': '5m',
             labels: {
@@ -82,15 +81,14 @@
           {
             alert: 'ThanosQuerierHighDNSFailures',
             annotations: {
-              message: 'Thanos Querys {{$labels.job}} have {{ $value }} of failing DNS queries.',
+              message: 'Thanos Queriers {{$labels.job}} have {{ $value | humanize }}% of failing DNS queries for store endpoints.',
             },
             expr: |||
               (
-                sum by (job) (rate(thanos_query_store_apis_dns_failures_total{%(selector)s}[5m]))
+                sum by (job) (rate(thanos_querier_store_apis_dns_failures_total{%(selector)s}[5m]))
               /
-                sum by (job) (rate(thanos_query_store_apis_dns_lookups_total{%(selector)s}[5m]))
-              > 1
-              )
+                sum by (job) (rate(thanos_querier_store_apis_dns_lookups_total{%(selector)s}[5m]))
+              ) * 100 > 1
             ||| % thanos.querier,
             'for': '15m',
             labels: {
@@ -100,7 +98,7 @@
           {
             alert: 'ThanosQuerierInstantLatencyHigh',
             annotations: {
-              message: 'Thanos Query {{$labels.job}} has a 99th percentile latency of {{ $value }} seconds for instant queries.',
+              message: 'Thanos Querier {{$labels.job}} has a 99th percentile latency of {{ $value }} seconds for instant queries.',
             },
             expr: |||
               (
@@ -117,7 +115,7 @@
           {
             alert: 'ThanosQuerierRangeLatencyHigh',
             annotations: {
-              message: 'Thanos Query {{$labels.job}} has a 99th percentile latency of {{ $value }} seconds for instant queries.',
+              message: 'Thanos Querier {{$labels.job}} has a 99th percentile latency of {{ $value }} seconds for instant queries.',
             },
             expr: |||
               (


### PR DESCRIPTION
This PR fixes querier store DNS query failures promQL issue. 

https://github.com/thanos-io/thanos/pull/2027 brought this to my attention.
cc @metalmatze @simonpasquier 

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

* Fix querier alert ratio calcualtion.
* Fix querier alert messages.

## Verification

* `make example-rules-lint`
