### PR TITLE
Fx ruler ui alerts click

### DIFF
--- a/pkg/ui/templates/alerts.html
+++ b/pkg/ui/templates/alerts.html
@@ -39,7 +39,7 @@
                     <tr class="alert_details">
                         <td>
                             <div>
-                                <pre style="display:block; padding:9.5px; font-size:13px; color:#333; word-break:break-all; background-color:#f5f5f5; border:1px solid #ccc; border-radius:4px;" ><code>{{.HTMLSnippet pathPrefix}}</code></pre>
+                                <pre style="display:block; padding:9.5px; font-size:13px; color:#333; word-break:break-all; background-color:#f5f5f5; border:1px solid #ccc; border-radius:4px;" ><code>{{.HTMLSnippet queryURL}}</code></pre>
                             </div>
                             {{if $activeAlerts}}
                                 <table class="table table-bordered table-hover table-sm alert_elements_table">


### PR DESCRIPTION
Signed-off-by: yeya24 <yb532204897@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Fixes https://github.com/thanos-io/thanos/issues/2024

In https://github.com/thanos-io/thanos/pull/1854, I mistakenly changed the click behavior of the alerts section in Ruler UI.

Now change back to `queryURL` and it works now. I have already tested in my local env
## Verification

<!-- How you tested it? How do you know it works? -->
