### PR TITLE
Don't calculate compact group key multiple times

### DIFF
--- a/pkg/verifier/overlapped_blocks.go
+++ b/pkg/verifier/overlapped_blocks.go
@@ -53,7 +53,8 @@ func fetchOverlaps(ctx context.Context, logger log.Logger, bkt objstore.Bucket, 
 
 	groupMetasMap := map[string][]tsdb.BlockMeta{}
 	for _, meta := range metas {
-		groupMetasMap[compact.GroupKey(meta.Thanos)] = append(groupMetasMap[compact.GroupKey(meta.Thanos)], meta.BlockMeta)
+		groupKey := compact.GroupKey(meta.Thanos)
+		groupMetasMap[groupKey] = append(groupMetasMap[groupKey], meta.BlockMeta)
 	}
 
 	overlaps := map[string]tsdb.Overlaps{}


### PR DESCRIPTION
Signed-off-by: yeya24 <yb532204897@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

Use a variable to keep the group key instead of calculating it multiple times 

## Verification

<!-- How you tested it? How do you know it works? -->
