### PR TITLE
pkg/shipper: Improve help text for shipper metrics.

### DIFF
--- a/pkg/shipper/shipper.go
+++ b/pkg/shipper/shipper.go
@@ -39,7 +39,7 @@ func newMetrics(r prometheus.Registerer, uploadCompacted bool) *metrics {
 
 	m.dirSyncs = prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "thanos_shipper_dir_syncs_total",
-		Help: "Total dir sync attempts",
+		Help: "Total number of dir syncs",
 	})
 	m.dirSyncFailures = prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "thanos_shipper_dir_sync_failures_total",
@@ -47,11 +47,11 @@ func newMetrics(r prometheus.Registerer, uploadCompacted bool) *metrics {
 	})
 	m.uploads = prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "thanos_shipper_uploads_total",
-		Help: "Total object upload attempts",
+		Help: "Total number of uploaded blocks",
 	})
 	m.uploadFailures = prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "thanos_shipper_upload_failures_total",
-		Help: "Total number of failed object uploads",
+		Help: "Total number of block upload failures",
 	})
 	m.uploadedCompacted = prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "thanos_shipper_upload_compacted_done",


### PR DESCRIPTION
## Changes

This PR improves help text of `thanos_shipper_dir_syncs_total`, `thanos_shipper_uploads_total` and `thanos_shipper_upload_failures_total` metrics.

## Verification

I did not test this 😱 [but it's a trivial change]

* [x] Change is not relevant to the end user.
