### PR TITLE
tracing: Support sampling on Elastic APM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 - [#1939](https://github.com/thanos-io/thanos/pull/1939) Ruler: Add TLS and authentication support for query endpoints with the `--query.config` and `--query.config-file` CLI flags. See [documentation](docs/components/rule.md/#configuration) for further information.
 - [#1982](https://github.com/thanos-io/thanos/pull/1982) Ruler: Add support for Alertmanager v2 API endpoints.
 - #2030 Query: Add `thanos_proxy_store_empty_stream_responses_total` metric for number of empty responses from stores.
+- [#2049](https://github.com/thanos-io/thanos/pull/2049) Tracing: Support sampling on Elastic APM with new sample_rate setting.
 
 ### Changed
 

--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -100,6 +100,7 @@ config:
   service_name: ""
   service_version: ""
   service_environment: ""
+  sample_rate: 1.0
 ```
 
 ### Lightstep

--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -100,7 +100,7 @@ config:
   service_name: ""
   service_version: ""
   service_environment: ""
-  sample_rate: 1.0
+  sample_rate: 0
 ```
 
 ### Lightstep

--- a/pkg/tracing/elasticapm/elastic_apm.go
+++ b/pkg/tracing/elasticapm/elastic_apm.go
@@ -10,9 +10,10 @@ import (
 )
 
 type Config struct {
-	ServiceName        string `yaml:"service_name"`
-	ServiceVersion     string `yaml:"service_version"`
-	ServiceEnvironment string `yaml:"service_environment"`
+	ServiceName        string  `yaml:"service_name"`
+	ServiceVersion     string  `yaml:"service_version"`
+	ServiceEnvironment string  `yaml:"service_environment"`
+	SampleRate         float64 `yaml:"sample_rate"`
 }
 
 func NewTracer(conf []byte) (opentracing.Tracer, io.Closer, error) {
@@ -28,6 +29,7 @@ func NewTracer(conf []byte) (opentracing.Tracer, io.Closer, error) {
 	if err != nil {
 		return nil, nil, err
 	}
+	tracer.SetSampler(apm.NewRatioSampler(config.SampleRate))
 	return apmot.New(apmot.WithTracer(tracer)), tracerCloser{tracer}, nil
 }
 


### PR DESCRIPTION
This is a patch to address thanos-io/thanos#2039.

Tracing every request can be quite expensive. By introducing a sample rate (similar to what stackdriver and jaeger already support), the overhead and trace storage cost can be controlled.

This patch adds sampling for Elastic APM tracing.

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

* tracing: Support sampling on Elastic APM with new `sample_rate` setting

## Verification

* I still need to run a proper integration test. Is there a standalone-ish way of running thanos locally that would enable such testing?
* Since the default value for sample rate is `0`, this will break anyone currently using the elastic APM backend. It might make sense to have a proper default value of `1` -- this applies to various settings on other tracing backends.