### PR TITLE
Updated stale bot as agreed offline on #thanos-dev.

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -10,11 +10,9 @@ daysUntilClose: 7
 # Only issues or pull requests with all of these labels are check if stale. Defaults to `[]` (disabled)
 onlyLabels: []
 
-# Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
-exemptLabels:
-  - "priority: P0"
-  - bug
-  - pinned
+# Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable.
+# We want stale bot to notify us that something is stale so we can revisit it.
+exemptLabels: []
 
 # Set to true to ignore issues in a project (defaults to false)
 exemptProjects: false
@@ -30,8 +28,8 @@ staleLabel: stale
 
 # Comment to post when marking as stale. Set to `false` to disable
 markComment: >
-  This issue has been automatically marked as stale because it has not had
-  recent activity. It will be closed if no further activity occurs. Thank you
+  This issue/PR is has been automatically marked as stale because it has not had
+  recent activity. Please comment on status otherwise the issue will be closed in a week. Thank you
   for your contributions.
 
 # Comment to post when removing the stale label.


### PR DESCRIPTION
## Changes

* Updated mark stale info
* No way to label issue/pr in a way that it will get ignored by stale bot.

cc @daixiang0

Signed-off-by: Bartlomiej Plotka <bwplotka@gmail.com>

