### PR TITLE
SECURITY.md: clean up doc

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,27 +1,31 @@
 # Security Policy
 
-As the Thanos team we are not security experts. However we try our best to avoid security concerns or to avoid
-writing features that handles sensitive information at all.
+As the Thanos team we are not security experts.
+However we try our best to avoid security concerns and to avoid writing features that handle sensitive information at all.
 
-It's worth to note that we assume the metric data to be sensitive and important.
-External labels and query API parameters are treated as less sensitive, as they are logged and put into metric/traces.
+It's worth noting that we assume metric data to be sensitive and important.
+External labels and query API parameters are considered less sensitive, as they are logged and put into metric/traces.
 
-## What you CAN expect:
+## What You CAN Expect:
 
-* We follow best programming practices. We test heavily including e2e tests against major object storages. We use vetting
-and static analysis tool on every PR. We use secure protocols for building process (e.g to produce docker images)
-* We don't log or put into our instrumentation any data that is stored in TSDB block.
-* If we use crypto tools we always rely on FLOSS and standard libraries like official [Go crypt](https://golang.org/pkg/crypto/)
+* We follow best programming practices.
+We test heavily, including e2e tests against major object storages.
+We use vetting and static analysis tools on every pull request.
+We use secure protocols for building process, e.g. when producing Docker images.
+* We don't put any data that is stored in TSDB into logs or instrumentation .
+* If we use crypto tools, we always rely on FLOSS and standard libraries, like the official [Go crypt](https://golang.org/pkg/crypto/)
   library.
 * We always use TLS by default for communication with all object storages.
-* We use stable Go versions to build our images and binaries. We update Go version as soon as new one is released.
+* We use stable Go versions to build our images and binaries.
+We update Go as soon as a new version is released.
 * We use only FLOSS tools.
 
-## What we DON'T do (yet):
+## What We DON'T Do (yet):
 
-* We don't encrypt metric on local storage (e.g on disk). We don't do client encryption for object storage. We recommend
-setting server side encryption for object storage.
-* We don't allow to specify authorization or TLS for Thanos server HTTP APIs.
+* We don't encrypt metrics in local storage, i.e. on disk.
+We don't do client-side encryption for object storage.
+We recommend setting server-side encryption for object storage.
+* We don't allow specifying authorization or TLS for Thanos server HTTP APIs.
 
 ## Supported Versions
 
@@ -32,4 +36,4 @@ setting server side encryption for object storage.
 
 ## Reporting a Vulnerability
 
-If you encounter security vulnerability, please let us know privately via Thanos Team email: thanos-io@googlegroups.com
+If you encounter a security vulnerability, please let us know privately via the Thanos Team email address: thanos-io@googlegroups.com.


### PR DESCRIPTION
This commit cleans up the grammar in the SECURITY.md file for better
readability.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>

* [x] Change is not relevant to the end user.