### PR TITLE
mixin, docs: Rename Compact -> Compactor

### DIFF
--- a/docs/components/compact.md
+++ b/docs/components/compact.md
@@ -1,10 +1,10 @@
 ---
-title: Compact
+title: Compactor
 type: docs
 menu: components
 ---
 
-# Compact
+# Compactor
 
 The compactor component of Thanos applies the compaction procedure of the Prometheus 2.0 storage engine to block data stored in object storage.
 It is generally not semantically concurrency safe and must be deployed as a singleton against a bucket.

--- a/examples/alerts/alerts.md
+++ b/examples/alerts/alerts.md
@@ -8,7 +8,7 @@ Here are some example alerts configured for Kubernetes environment.
 ```yaml
 name: thanos-compactor.rules
 rules:
-- alert: ThanosCompactorMultipleCompactsAreRunning
+- alert: ThanosCompactorMultipleCompactorsAreRunning
   annotations:
     message: You should never run more than one Thanos Compactor at once. You have
       {{ $value }}

--- a/examples/alerts/alerts.md
+++ b/examples/alerts/alerts.md
@@ -10,22 +10,22 @@ name: thanos-compactor.rules
 rules:
 - alert: ThanosCompactorMultipleCompactsAreRunning
   annotations:
-    message: You should never run more than one Thanos Compact at once. You have {{
-      $value }}
+    message: You should never run more than one Thanos Compactor at once. You have
+      {{ $value }}
   expr: sum(up{job=~"thanos-compactor.*"}) > 1
   for: 5m
   labels:
     severity: warning
 - alert: ThanosCompactorHalted
   annotations:
-    message: Thanos Compact {{$labels.job}} has failed to run and now is halted.
+    message: Thanos Compactor {{$labels.job}} has failed to run and now is halted.
   expr: thanos_compactor_halted{job=~"thanos-compactor.*"} == 1
   for: 5m
   labels:
     severity: warning
 - alert: ThanosCompactorHighCompactionFailures
   annotations:
-    message: Thanos Compact {{$labels.job}} is failing to execute {{ $value | humanize
+    message: Thanos Compactor {{$labels.job}} is failing to execute {{ $value | humanize
       }}% of compactions.
   expr: |
     (
@@ -39,7 +39,7 @@ rules:
     severity: warning
 - alert: ThanosCompactorBucketHighOperationFailures
   annotations:
-    message: Thanos Compact {{$labels.job}} Bucket is failing to execute {{ $value
+    message: Thanos Compactor {{$labels.job}} Bucket is failing to execute {{ $value
       | humanize }}% of operations.
   expr: |
     (
@@ -53,7 +53,7 @@ rules:
     severity: warning
 - alert: ThanosCompactorHasNotRun
   annotations:
-    message: Thanos Compact {{$labels.job}} has not uploaded anything for 24 hours.
+    message: Thanos Compactor {{$labels.job}} has not uploaded anything for 24 hours.
   expr: (time() - max(thanos_objstore_bucket_last_successful_upload_time{job=~"thanos-compactor.*"}))
     / 60 / 60 > 24
   labels:

--- a/examples/alerts/alerts.yaml
+++ b/examples/alerts/alerts.yaml
@@ -3,7 +3,7 @@ groups:
   rules:
   - alert: ThanosCompactorMultipleCompactsAreRunning
     annotations:
-      message: You should never run more than one Thanos Compact at once. You have
+      message: You should never run more than one Thanos Compactor at once. You have
         {{ $value }}
     expr: sum(up{job=~"thanos-compactor.*"}) > 1
     for: 5m
@@ -11,15 +11,15 @@ groups:
       severity: warning
   - alert: ThanosCompactorHalted
     annotations:
-      message: Thanos Compact {{$labels.job}} has failed to run and now is halted.
+      message: Thanos Compactor {{$labels.job}} has failed to run and now is halted.
     expr: thanos_compactor_halted{job=~"thanos-compactor.*"} == 1
     for: 5m
     labels:
       severity: warning
   - alert: ThanosCompactorHighCompactionFailures
     annotations:
-      message: Thanos Compact {{$labels.job}} is failing to execute {{ $value | humanize
-        }}% of compactions.
+      message: Thanos Compactor {{$labels.job}} is failing to execute {{ $value |
+        humanize }}% of compactions.
     expr: |
       (
         sum by (job) (rate(thanos_compact_group_compactions_failures_total{job=~"thanos-compactor.*"}[5m]))
@@ -32,7 +32,7 @@ groups:
       severity: warning
   - alert: ThanosCompactorBucketHighOperationFailures
     annotations:
-      message: Thanos Compact {{$labels.job}} Bucket is failing to execute {{ $value
+      message: Thanos Compactor {{$labels.job}} Bucket is failing to execute {{ $value
         | humanize }}% of operations.
     expr: |
       (
@@ -46,7 +46,7 @@ groups:
       severity: warning
   - alert: ThanosCompactorHasNotRun
     annotations:
-      message: Thanos Compact {{$labels.job}} has not uploaded anything for 24 hours.
+      message: Thanos Compactor {{$labels.job}} has not uploaded anything for 24 hours.
     expr: (time() - max(thanos_objstore_bucket_last_successful_upload_time{job=~"thanos-compactor.*"}))
       / 60 / 60 > 24
     labels:

--- a/examples/alerts/alerts.yaml
+++ b/examples/alerts/alerts.yaml
@@ -1,7 +1,7 @@
 groups:
 - name: thanos-compactor.rules
   rules:
-  - alert: ThanosCompactorMultipleCompactsAreRunning
+  - alert: ThanosCompactorMultipleCompactorsAreRunning
     annotations:
       message: You should never run more than one Thanos Compactor at once. You have
         {{ $value }}

--- a/examples/dashboards/overview.json
+++ b/examples/dashboards/overview.json
@@ -1968,7 +1968,7 @@
          "repeatIteration": null,
          "repeatRowId": null,
          "showTitle": true,
-         "title": "Compact",
+         "title": "Compactor",
          "titleSize": "h6"
       }
    ],

--- a/mixin/thanos/alerts/compactor.libsonnet
+++ b/mixin/thanos/alerts/compactor.libsonnet
@@ -10,7 +10,7 @@
         name: 'thanos-compactor.rules',
         rules: [
           {
-            alert: 'ThanosCompactorMultipleCompactsAreRunning',
+            alert: 'ThanosCompactorMultipleCompactorsAreRunning',
             annotations: {
               message: 'You should never run more than one Thanos Compactor at once. You have {{ $value }}',
             },

--- a/mixin/thanos/alerts/compactor.libsonnet
+++ b/mixin/thanos/alerts/compactor.libsonnet
@@ -1,8 +1,8 @@
 {
   local thanos = self,
   compactor+:: {
-    jobPrefix: error 'must provide job prefix for Thanos Compact alerts',
-    selector: error 'must provide selector for Thanos Compact alerts',
+    jobPrefix: error 'must provide job prefix for Thanos Compactor alerts',
+    selector: error 'must provide selector for Thanos Compactor alerts',
   },
   prometheusAlerts+:: {
     groups+: [
@@ -12,7 +12,7 @@
           {
             alert: 'ThanosCompactorMultipleCompactsAreRunning',
             annotations: {
-              message: 'You should never run more than one Thanos Compact at once. You have {{ $value }}',
+              message: 'You should never run more than one Thanos Compactor at once. You have {{ $value }}',
             },
             expr: 'sum(up{%(selector)s}) > 1' % thanos.compactor,
             'for': '5m',
@@ -23,7 +23,7 @@
           {
             alert: 'ThanosCompactorHalted',
             annotations: {
-              message: 'Thanos Compact {{$labels.job}} has failed to run and now is halted.',
+              message: 'Thanos Compactor {{$labels.job}} has failed to run and now is halted.',
             },
             expr: 'thanos_compactor_halted{%(selector)s} == 1' % thanos.compactor,
             'for': '5m',
@@ -34,7 +34,7 @@
           {
             alert: 'ThanosCompactorHighCompactionFailures',
             annotations: {
-              message: 'Thanos Compact {{$labels.job}} is failing to execute {{ $value | humanize }}% of compactions.',
+              message: 'Thanos Compactor {{$labels.job}} is failing to execute {{ $value | humanize }}% of compactions.',
             },
             expr: |||
               (
@@ -52,7 +52,7 @@
           {
             alert: 'ThanosCompactorBucketHighOperationFailures',
             annotations: {
-              message: 'Thanos Compact {{$labels.job}} Bucket is failing to execute {{ $value | humanize }}% of operations.',
+              message: 'Thanos Compactor {{$labels.job}} Bucket is failing to execute {{ $value | humanize }}% of operations.',
             },
             expr: |||
               (
@@ -70,7 +70,7 @@
           {
             alert: 'ThanosCompactorHasNotRun',
             annotations: {
-              message: 'Thanos Compact {{$labels.job}} has not uploaded anything for 24 hours.',
+              message: 'Thanos Compactor {{$labels.job}} has not uploaded anything for 24 hours.',
             },
             expr: '(time() - max(thanos_objstore_bucket_last_successful_upload_time{%(selector)s})) / 60 / 60 > 24' % thanos.compactor,
             labels: {

--- a/mixin/thanos/dashboards/compactor.libsonnet
+++ b/mixin/thanos/dashboards/compactor.libsonnet
@@ -3,9 +3,9 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
 {
   local thanos = self,
   compactor+:: {
-    jobPrefix: error 'must provide job prefix for Thanos Compact dashboard',
-    selector: error 'must provide selector for Thanos Compact dashboard',
-    title: error 'must provide title for Thanos Compact dashboard',
+    jobPrefix: error 'must provide job prefix for Thanos Compactor dashboard',
+    selector: error 'must provide selector for Thanos Compactor dashboard',
+    title: error 'must provide title for Thanos Compactor dashboard',
   },
   grafanaDashboards+:: {
     'compactor.json':
@@ -135,7 +135,7 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
       g.template('pod', 'kube_pod_info', 'namespace="$namespace",created_by_name=~"%(jobPrefix)s.*"' % thanos.compactor, true, '.*'),
 
     __overviewRows__+:: [
-      g.row('Compact')
+      g.row('Compactor')
       .addPanel(
         g.panel(
           'Compaction Rate',


### PR DESCRIPTION
This PR renames `compact` to `compactor` in mixin and docs.

As discussed in https://github.com/thanos-io/thanos/issues/1871

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

* `make examples`
* `make example-rules-lint`
* `make docs`
* `make check-docs`
