### PR TITLE
mixin: Rename rule to ruler

### DIFF
--- a/examples/dashboards/overview.json
+++ b/examples/dashboards/overview.json
@@ -1784,7 +1784,7 @@
          "repeatIteration": null,
          "repeatRowId": null,
          "showTitle": true,
-         "title": "Rule",
+         "title": "Ruler",
          "titleSize": "h6"
       },
       {

--- a/mixin/thanos/README.md
+++ b/mixin/thanos/README.md
@@ -1,7 +1,7 @@
 # thanos-mixin
 
 > Note that everything is experimental and may change significantly at any time.
-> Also it still has missing alert and dashboard definitions for certain components, e.g. rule and sidecar. Please feel free to contribute.
+> Also it still has missing alert and dashboard definitions for certain components, e.g. ruler and sidecar. Please feel free to contribute.
 
 This directory contains extensible and customizable monitoring definitons for Thanos. [Grafana](http://grafana.com/) dashboards, and [Prometheus rules](https://prometheus.io/docs/prometheus/latest/configuration/recording_rules/) combined with documentation and scripts to provide easy monitoring experience for Thanos.
 

--- a/mixin/thanos/dashboards/ruler.libsonnet
+++ b/mixin/thanos/dashboards/ruler.libsonnet
@@ -126,7 +126,7 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
       g.template('pod', 'kube_pod_info', 'namespace="$namespace",created_by_name=~"%(jobPrefix)s.*"' % thanos.ruler, true, '.*'),
 
     __overviewRows__+:: [
-      g.row('Rule')
+      g.row('Ruler')
       .addPanel(
         g.panel('Alert Sent Rate', 'Shows rate of alerts that successfully sent to alert manager.') +
         g.queryPanel(


### PR DESCRIPTION
This PR renames `rule` to `ruler` in mixin.

As discussed in https://github.com/thanos-io/thanos/issues/1871

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

* `make examples`
* `make example-rules-lint`
* `make docs`
* `make check-docs`
