### PR TITLE
Lower restriction for website scripts.

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -30,7 +30,7 @@ command = "(env && make web HUGO=$(which hugo) WEBSITE_BASE_URL=${DEPLOY_PRIME_U
     # Force HTTPS only.
     Strict-Transport-Security = "max-age=31536000; includeSubDomains"
     # Load scripts only via HTTPS and from allowed domains.
-    Content-Security-Policy = "default-src https:; script-src thanos.io"
+    Content-Security-Policy = "default-src https:"
     # Only send referred when HTTPS is used.
     Referrer-Policy = "strict-origin-when-cross-origin"
     # Disable certain magic features, lol.


### PR DESCRIPTION
`Refused to execute inline script because it violates the following Content Security Policy directive: "script-src thanos.io". Either the 'unsafe-inline' keyword, a hash ('sha256-3qFt4qPvMCWVUpjUxP5X57GBKae6RHYZ0rMjn9WuNF4='), or a nonce ('nonce-...') is required to enable inline execution.`

Fixed by not restricting by domain, just TLS.

Signed-off-by: Bartlomiej Plotka <bwplotka@gmail.com>

