### PR TITLE
query: add 'sticky' store nodes

### DIFF
--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -73,7 +73,7 @@ func registerQuery(m map[string]setupFunc, app *kingpin.Application) {
 	selectorLabels := cmd.Flag("selector-label", "Query selector labels that will be exposed in info endpoint (repeated).").
 		PlaceHolder("<name>=\"<value>\"").Strings()
 
-	stores := cmd.Flag("store", "Addresses of statically configured store API servers (repeatable). The scheme may be prefixed with 'dns+' or 'dnssrv+' to detect store API servers through respective DNS lookups.").
+	stores := cmd.Flag("store", "Addresses of statically configured store API servers (repeatable). The scheme may be prefixed with 'dns+' or 'dnssrv+' to detect store API servers through respective DNS lookups. The suffix '+sticky' will make the store API server sticky.").
 		PlaceHolder("<store>").Strings()
 
 	fileSDFiles := cmd.Flag("store.sd-files", "Path to files that contain addresses of store API servers. The path can be a glob pattern (repeatable).").
@@ -227,8 +227,8 @@ func runQuery(
 			reg,
 			func() (specs []query.StoreSpec) {
 				// Add DNS resolved addresses from static flags and file SD.
-				for _, addr := range dnsProvider.Addresses() {
-					specs = append(specs, query.NewGRPCStoreSpec(addr))
+				for _, mt := range dnsProvider.Addresses() {
+					specs = append(specs, query.NewGRPCStoreSpec(mt.GetAddr(), mt.IsSticky()))
 				}
 
 				specs = removeDuplicateStoreSpecs(logger, duplicatedStores, specs)

--- a/docs/components/query.md
+++ b/docs/components/query.md
@@ -162,6 +162,8 @@ This is useful in the cases where you have some kind of caching layer in front o
 
 To make a node sticky you need to add a suffix `+sticky` to the end of the address.
 
+Sticky nodes have a yellow `UP` status in the `Stores` page if we have failed to check their data but we still consider them available.
+
 ### Deduplication replica labels.
 
 | HTTP URL/FORM parameter | Type | Default | Example |

--- a/docs/components/query.md
+++ b/docs/components/query.md
@@ -154,6 +154,14 @@ Querier also allows to configure different timeouts:
 If you prefer availability over accuracy you can set tighter timeout to underlying StoreAPI than overall query timeout. If partial response
 strategy is NOT `abort`, this will "ignore" slower StoreAPIs producing just warning with 200 status code response.
 
+#### Sticky StoreAPI nodes
+
+Thanos Query periodically checks the health of the StoreAPI nodes that it knows about via the `Info()` gRPC call. However, if one is failing then it is not considered a part of the active set of StoreAPI nodes. To make them always part of the active set, you need to make them "sticky" - their last available information will be retained even in the face of a failure of a health-check.
+
+This is useful in the cases where you have some kind of caching layer in front of Thanos Query i.e. Cortex's `query-frontend` and you know that certain nodes must always be alive. It allows you to get a partial response when one of the sticky nodes goes down.
+
+To make a node sticky you need to add a suffix `+sticky` to the end of the address.
+
 ### Deduplication replica labels.
 
 | HTTP URL/FORM parameter | Type | Default | Example |
@@ -325,7 +333,8 @@ Flags:
                                  servers (repeatable). The scheme may be
                                  prefixed with 'dns+' or 'dnssrv+' to detect
                                  store API servers through respective DNS
-                                 lookups.
+                                 lookups. The suffix '+sticky' will make the
+                                 store API server sticky.
       --store.sd-files=<path> ...
                                  Path to files that contain addresses of store
                                  API servers. The path can be a glob pattern

--- a/pkg/cacheutil/memcached_client.go
+++ b/pkg/cacheutil/memcached_client.go
@@ -435,9 +435,13 @@ func (c *memcachedClient) resolveAddrs() error {
 	c.dnsProvider.Resolve(ctx, c.config.Addresses)
 
 	// Fail in case no server address is resolved.
-	servers := c.dnsProvider.Addresses()
-	if len(servers) == 0 {
+	metatargets := c.dnsProvider.Addresses()
+	if len(metatargets) == 0 {
 		return errors.New("no server address resolved")
+	}
+	servers := []string{}
+	for _, mt := range metatargets {
+		servers = append(servers, mt.GetAddr())
 	}
 
 	return c.selector.SetServers(servers...)

--- a/pkg/discovery/dns/provider_test.go
+++ b/pkg/discovery/dns/provider_test.go
@@ -35,33 +35,45 @@ func TestProvider(t *testing.T) {
 
 	prv.Resolve(ctx, []string{"any+x"})
 	result := prv.Addresses()
-	sort.Strings(result)
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].GetAddr() < result[j].GetAddr()
+	})
 	testutil.Equals(t, []string(nil), result)
 
 	prv.Resolve(ctx, []string{"any+a", "any+b", "any+c"})
 	result = prv.Addresses()
-	sort.Strings(result)
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].GetAddr() < result[j].GetAddr()
+	})
 	testutil.Equals(t, ips, result)
 
 	prv.Resolve(ctx, []string{"any+b", "any+c"})
 	result = prv.Addresses()
-	sort.Strings(result)
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].GetAddr() < result[j].GetAddr()
+	})
 	testutil.Equals(t, ips[2:], result)
 
 	prv.Resolve(ctx, []string{"any+x"})
 	result = prv.Addresses()
-	sort.Strings(result)
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].GetAddr() < result[j].GetAddr()
+	})
 	testutil.Equals(t, []string(nil), result)
 
 	prv.Resolve(ctx, []string{"any+a", "any+b", "any+c"})
 	result = prv.Addresses()
-	sort.Strings(result)
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].GetAddr() < result[j].GetAddr()
+	})
 	testutil.Equals(t, ips, result)
 
 	prv.resolver = &mockResolver{err: errors.New("failed to resolve urls")}
 	prv.Resolve(ctx, []string{"any+a", "any+b", "any+c"})
 	result = prv.Addresses()
-	sort.Strings(result)
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].GetAddr() < result[j].GetAddr()
+	})
 	testutil.Equals(t, ips, result)
 }
 

--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -21,6 +21,7 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/thanos-io/thanos/pkg/discovery/cache"
+	"github.com/thanos-io/thanos/pkg/discovery/dns"
 )
 
 // ClientConfig configures an HTTP client.
@@ -164,7 +165,7 @@ func (c FileSDConfig) convert() (file.SDConfig, error) {
 
 type AddressProvider interface {
 	Resolve(context.Context, []string)
-	Addresses() []string
+	Addresses() []dns.MetaTarget
 }
 
 // Client represents a client that can send requests to a cluster of HTTP-based endpoints.
@@ -216,11 +217,11 @@ func (c *Client) Do(req *http.Request) (*http.Response, error) {
 // Endpoints returns the list of known endpoints.
 func (c *Client) Endpoints() []*url.URL {
 	var urls []*url.URL
-	for _, addr := range c.provider.Addresses() {
+	for _, mt := range c.provider.Addresses() {
 		urls = append(urls,
 			&url.URL{
 				Scheme: c.scheme,
-				Host:   addr,
+				Host:   mt.GetAddr(),
 				Path:   path.Join("/", c.prefix),
 			},
 		)

--- a/pkg/query/storeset_test.go
+++ b/pkg/query/storeset_test.go
@@ -181,7 +181,7 @@ func TestStoreSet_Update(t *testing.T) {
 	discoveredStoreAddr = append(discoveredStoreAddr, discoveredStoreAddr[0])
 	storeSet := NewStoreSet(nil, nil, func() (specs []StoreSpec) {
 		for _, addr := range discoveredStoreAddr {
-			specs = append(specs, NewGRPCStoreSpec(addr))
+			specs = append(specs, NewGRPCStoreSpec(addr, false))
 		}
 		return specs
 	}, testGRPCOpts, time.Minute)
@@ -523,7 +523,7 @@ func TestStoreSet_Update_NoneAvailable(t *testing.T) {
 
 	storeSet := NewStoreSet(nil, nil, func() (specs []StoreSpec) {
 		for _, addr := range initialStoreAddr {
-			specs = append(specs, NewGRPCStoreSpec(addr))
+			specs = append(specs, NewGRPCStoreSpec(addr, false))
 		}
 		return specs
 	}, testGRPCOpts, time.Minute)

--- a/pkg/ui/templates/stores.html
+++ b/pkg/ui/templates/stores.html
@@ -28,7 +28,11 @@
             <td>{{$store.Name}}</td>
             <td class="state">
                 {{if not $store.LastError}}
-                <span class="alert alert-success state_indicator text-uppercase">up</span>
+                    {{ if $store.Sticky }}
+                    <span class="alert alert-warning state_indicator text-uppercase">up</span>
+                    {{ else }}
+                    <span class="alert alert-success state_indicator text-uppercase">up</span>
+                    {{ end }}
                 {{else}}
                 <span class="alert alert-danger state_indicator text-uppercase">down</span>
                 {{end}}

--- a/pkg/ui/templates/stores.html
+++ b/pkg/ui/templates/stores.html
@@ -28,13 +28,13 @@
             <td>{{$store.Name}}</td>
             <td class="state">
                 {{if not $store.LastError}}
+                <span class="alert alert-success state_indicator text-uppercase">up</span>
+                {{else}}
                     {{ if $store.Sticky }}
                     <span class="alert alert-warning state_indicator text-uppercase">up</span>
                     {{ else }}
-                    <span class="alert alert-success state_indicator text-uppercase">up</span>
+                    <span class="alert alert-danger state_indicator text-uppercase">down</span>
                     {{ end }}
-                {{else}}
-                <span class="alert alert-danger state_indicator text-uppercase">down</span>
                 {{end}}
             </td>
             <td>


### PR DESCRIPTION
Add the ability to have 'sticky' store nodes - we will always consider them available and retain their clients. This makes it possible to have consistent partial responses when a node goes down when we know that it must be up at all times. The relevant part from the documentation which explains more:

```
Thanos Query periodically checks the health of the StoreAPI nodes that it knows about via the `Info()` gRPC call. However, if one is failing then it is not considered a part of the active set of StoreAPI nodes. To make them always part of the active set, you need to make them "sticky" - their last available information will be retained even in the face of a failure of a health-check.

This is useful in the cases where you have some kind of caching layer in front of Thanos Query i.e. Cortex's `query-frontend` and you know that certain nodes must always be alive. It allows you to get a partial response when one of the sticky nodes goes down.

To make a node sticky you need to add a suffix `+sticky` to the end of the address.

Sticky nodes have a yellow `UP` status in the `Stores` page if we have failed to check their data but we still consider them available.
```

Ad-hoc tests:

Tested locally. Turned off one store node which made it get removed from the `healthyStores`. Sending queries for a short time still gave an error but it went away after the refresh delay.

Added a `+sticky` suffix then. Shut off the same node and tried sending queries again. Got errors that Thanos Query couldn't connect to that node. Disabling partial response made it into an error.

Looking for feedback on:
* Does it even make sense?! :smile: 
* The code, ofc
* Is it okay to have this as a suffix? Or should we make static targets 'sticky' by default? But that would change Thanos Query's behavior for our users and maybe someone wants to stay with the current behavior. IMHO we should leave this possibility to add a suffix.

WIP:
* Still want to add a test for the parsing part
* Looking for feedback

Relevant issue: https://github.com/thanos-io/thanos/issues/1651.