### PR TITLE
Makefile: optimize jsonnet-format target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -359,6 +359,9 @@ JSONNET_FMT := jsonnetfmt -n 2 --max-blank-lines 2 --string-style s --comment-st
 
 .PHONY: jsonnet-format
 jsonnet-format:
+	@which jsonnetfmt 2>/dev/null || ( \
+		echo "Cannot find jsonnetfmt command, please install from https://github.com/google/jsonnet/releases. If your C++ does not support GLIBCXX_3.4.20, please use xxx-in-container target like jsonnet-format-in-container." && exit 1
+	)
 	find . -name 'vendor' -prune -o -name '*.libsonnet' -print -o -name '*.jsonnet' -print | \
 		xargs -n 1 -- $(JSONNET_FMT) -i
 


### PR DESCRIPTION
Signed-off-by: Xiang Dai <764524258@qq.com>

Fix following error:
```
# make examples
find . -name 'vendor' -prune -o -name '*.libsonnet' -print -o -name '*.jsonnet' -print | \
	xargs -n 1 -- jsonnetfmt -n 2 --max-blank-lines 2 --string-style s --comment-style s -i
xargs: jsonnetfmt: No such file or directory
```