### PR TITLE
Expanded series benchmarks; Added OneSeriesManySamples case with 100mln samples.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,7 @@ require (
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
 	golang.org/x/text v0.3.2
-	golang.org/x/tools v0.0.0-20200207224406-61798d64f025 // indirect
+	golang.org/x/tools v0.0.0-20200221152158-fe62aff31966 // indirect
 	google.golang.org/api v0.14.0
 	google.golang.org/genproto v0.0.0-20191115194625-c23dd37a84c9
 	google.golang.org/grpc v1.25.1

--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,7 @@ require (
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
 	golang.org/x/text v0.3.2
-	golang.org/x/tools v0.0.0-20200221152158-fe62aff31966 // indirect
+	golang.org/x/tools v0.0.0-20200221224223-e1da425f72fd // indirect
 	google.golang.org/api v0.14.0
 	google.golang.org/genproto v0.0.0-20191115194625-c23dd37a84c9
 	google.golang.org/grpc v1.25.1

--- a/go.sum
+++ b/go.sum
@@ -915,7 +915,6 @@ golang.org/x/tools v0.0.0-20191111182352-50fa39b762bc/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20191113191852-77e3bb0ad9e7/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191115202509-3a792d9c32b2 h1:EtTFh6h4SAKemS+CURDMTDIANuduG5zKEXShyy18bGA=
 golang.org/x/tools v0.0.0-20191115202509-3a792d9c32b2/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
-golang.org/x/tools v0.0.0-20200221152158-fe62aff31966/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200221224223-e1da425f72fd h1:hHkvGJK23seRCflePJnVa9IMv8fsuavSCWKd11kDQFs=
 golang.org/x/tools v0.0.0-20200221224223-e1da425f72fd/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/go.sum
+++ b/go.sum
@@ -917,6 +917,10 @@ golang.org/x/tools v0.0.0-20191115202509-3a792d9c32b2 h1:EtTFh6h4SAKemS+CURDMTDI
 golang.org/x/tools v0.0.0-20191115202509-3a792d9c32b2/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20200207224406-61798d64f025 h1:i84/3szN87uN9jFX/jRqUbszQto2oAsFlqPf6lbR8H4=
 golang.org/x/tools v0.0.0-20200207224406-61798d64f025/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
+golang.org/x/tools v0.0.0-20200220224806-8a925fa4c0df h1:oQFmpjL+rb2xLkgPCpdGSAGDdq1geTZVvIfCMxSB/wQ=
+golang.org/x/tools v0.0.0-20200220224806-8a925fa4c0df/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
+golang.org/x/tools v0.0.0-20200221152158-fe62aff31966 h1:anduI32gSABIQHvwp/y8hEslPaXuVTh5+qw7Eb4Js9c=
+golang.org/x/tools v0.0.0-20200221152158-fe62aff31966/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=

--- a/go.sum
+++ b/go.sum
@@ -915,12 +915,9 @@ golang.org/x/tools v0.0.0-20191111182352-50fa39b762bc/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20191113191852-77e3bb0ad9e7/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191115202509-3a792d9c32b2 h1:EtTFh6h4SAKemS+CURDMTDIANuduG5zKEXShyy18bGA=
 golang.org/x/tools v0.0.0-20191115202509-3a792d9c32b2/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
-golang.org/x/tools v0.0.0-20200207224406-61798d64f025 h1:i84/3szN87uN9jFX/jRqUbszQto2oAsFlqPf6lbR8H4=
-golang.org/x/tools v0.0.0-20200207224406-61798d64f025/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
-golang.org/x/tools v0.0.0-20200220224806-8a925fa4c0df h1:oQFmpjL+rb2xLkgPCpdGSAGDdq1geTZVvIfCMxSB/wQ=
-golang.org/x/tools v0.0.0-20200220224806-8a925fa4c0df/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
-golang.org/x/tools v0.0.0-20200221152158-fe62aff31966 h1:anduI32gSABIQHvwp/y8hEslPaXuVTh5+qw7Eb4Js9c=
 golang.org/x/tools v0.0.0-20200221152158-fe62aff31966/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
+golang.org/x/tools v0.0.0-20200221224223-e1da425f72fd h1:hHkvGJK23seRCflePJnVa9IMv8fsuavSCWKd11kDQFs=
+golang.org/x/tools v0.0.0-20200221224223-e1da425f72fd/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -1286,7 +1286,6 @@ func (b *bucketBlock) chunkReader(ctx context.Context) *bucketChunkReader {
 // Close waits for all pending readers to finish and then closes all underlying resources.
 func (b *bucketBlock) Close() error {
 	b.pendingReaders.Wait()
-
 	return b.indexHeaderReader.Close()
 }
 

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -1088,7 +1088,11 @@ func (s *bucketBlockSet) add(b *bucketBlock) error {
 	bs := append(s.blocks[i], b)
 	s.blocks[i] = bs
 
+	// Always sort blocks by min time, then max time.
 	sort.Slice(bs, func(j, k int) bool {
+		if bs[j].meta.MinTime == bs[k].meta.MinTime {
+			return bs[j].meta.MaxTime < bs[k].meta.MaxTime
+		}
 		return bs[j].meta.MinTime < bs[k].meta.MinTime
 	})
 	return nil
@@ -1120,6 +1124,9 @@ func int64index(s []int64, x int64) int {
 
 // getFor returns a time-ordered list of blocks that cover date between mint and maxt.
 // Blocks with the biggest resolution possible but not bigger than the given max resolution are returned.
+// It supports overlapping blocks.
+//
+// NOTE: s.blocks are expected to be sorted in minTime order.
 func (s *bucketBlockSet) getFor(mint, maxt, maxResolutionMillis int64) (bs []*bucketBlock) {
 	if mint > maxt {
 		return nil

--- a/pkg/store/proxy_test.go
+++ b/pkg/store/proxy_test.go
@@ -1310,6 +1310,8 @@ type storeSeriesServer struct {
 
 	SeriesSet []storepb.Series
 	Warnings  []string
+
+	Size int64
 }
 
 func newStoreSeriesServer(ctx context.Context) *storeSeriesServer {
@@ -1317,6 +1319,8 @@ func newStoreSeriesServer(ctx context.Context) *storeSeriesServer {
 }
 
 func (s *storeSeriesServer) Send(r *storepb.SeriesResponse) error {
+	s.Size += int64(r.Size())
+
 	if r.GetWarning() != "" {
 		s.Warnings = append(s.Warnings, r.GetWarning())
 		return nil

--- a/pkg/testutil/testorbench.go
+++ b/pkg/testutil/testorbench.go
@@ -27,6 +27,8 @@ type TB interface {
 	testing.TB
 	IsBenchmark() bool
 	Run(name string, f func(t TB)) bool
+
+	SetBytes(n int64)
 	N() int
 	ResetTimer()
 }
@@ -59,6 +61,14 @@ func (t *tb) N() int {
 		return b.N
 	}
 	return 1
+}
+
+// SetBytes records the number of bytes processed in a single operation for benchmark, noop otherwise.
+// If this is called, the benchmark will report ns/op and MB/s.
+func (t *tb) SetBytes(n int64) {
+	if b, ok := t.TB.(*testing.B); ok {
+		b.SetBytes(n)
+	}
 }
 
 // ResetTimer resets a timer, if it's a benchmark, noop otherwise.

--- a/pkg/testutil/testorbench_test.go
+++ b/pkg/testutil/testorbench_test.go
@@ -30,6 +30,7 @@ func testorbenchComplexTest(tb TB) {
 			}
 		})
 	})
+	tb.SetBytes(120220)
 	tb.Run("b", func(tb TB) {
 		tb.Run("bb", func(tb TB) {
 			tb.ResetTimer()


### PR DESCRIPTION
This will be my baseline for further benchmarks. I think moving out of mmap would be nice as it will actually show allocations made by mmap :/ Will test in next PRs.

```
goos: linux
goarch: amd64
pkg: github.com/thanos-io/thanos/pkg/store
BenchmarkSeries/10e6SeriesWithOneSample/1of10000000-12         	       2	20763847906 ns/op	1578012024 B/op	20077109 allocs/op
BenchmarkSeries/10e6SeriesWithOneSample/10of10000000-12        	       2	19857501482 ns/op	1577936288 B/op	20076943 allocs/op
BenchmarkSeries/10e6SeriesWithOneSample/100of10000000-12       	       2	19582049218 ns/op	1578040744 B/op	20077604 allocs/op
BenchmarkSeries/10e6SeriesWithOneSample/1000of10000000-12      	       2	19267030930 ns/op	1578414776 B/op	20081687 allocs/op
BenchmarkSeries/10e6SeriesWithOneSample/10000of10000000-12     	       2	20037802242 ns/op	1587259112 B/op	20127104 allocs/op
BenchmarkSeries/10e6SeriesWithOneSample/100000of10000000-12    	       2	19719690656 ns/op	1672230968 B/op	20580776 allocs/op
BenchmarkSeries/10e6SeriesWithOneSample/1000000of10000000-12   	       2	25441012216 ns/op	2538823828 B/op	25115243 allocs/op
BenchmarkSeries/1MlnSeriesWithOneSample/10000000of10000000-12  	       3	12852508396 ns/op	15881988552 B/op	130614114 allocs/op  // Response size: 1074715836 B (1GB)

goos: linux
goarch: amd64
pkg: github.com/thanos-io/thanos/pkg/store
BenchmarkSeries/OneSeriesWith100e6Samples/1of100000000-12      	     236	 155053945 ns/op	59252845 B/op	     253 allocs/op
BenchmarkSeries/OneSeriesWith100e6Samples/10of100000000-12     	     234	 153623891 ns/op	59252614 B/op	     252 allocs/op
BenchmarkSeries/OneSeriesWith100e6Samples/100of100000000-12    	     231	 155141191 ns/op	59252629 B/op	     252 allocs/op
BenchmarkSeries/OneSeriesWith100e6Samples/1000of100000000-12   	     235	 152167429 ns/op	59236145 B/op	     271 allocs/op
BenchmarkSeries/OneSeriesWith100e6Samples/10000of100000000-12  	     236	 152849434 ns/op	59347490 B/op	     430 allocs/op
BenchmarkSeries/OneSeriesWith100e6Samples/100000of100000000-12 	     230	 155588912 ns/op	60409917 B/op	    1965 allocs/op
BenchmarkSeries/OneSeriesWith100e6Samples/1000000of100000000-12         	     192	 185165100 ns/op	69049497 B/op	   17213 allocs/op 
BenchmarkSeries/OneSeriesWith100e6Samples/10000000of100000000-12        	      46	 757730877 ns/op	297757162 B/op  169459 allocs/op  // Response size: 75496354 B (70MB)
// Can't benchmem on my machine 100e6 samples, but response size is 755361421 B (720 MB)
```

Observations:

* Chunks are not sorted within series.
* Asking for one series is 1GB, asking for 100k series is also using 1GB... Querying 1mln is 2GB, 10mln: 15GB. Interesting!
* Mem blow out can be enormous: Asking for 10mln series is like 15x 0.o Takes 15GB, response size is 1GB.
* Memory usage does not really depend on series size, but rather series overall in block.

Signed-off-by: Bartlomiej Plotka <bwplotka@gmail.com>