### PR TITLE
store: S3 object store via AWS SDK

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d
 	github.com/aliyun/aliyun-oss-go-sdk v2.0.4+incompatible
 	github.com/armon/go-metrics v0.3.0
+	github.com/aws/aws-sdk-go v1.25.48
 	github.com/baiyubin/aliyun-sts-go-sdk v0.0.0-20180326062324-cfa1a18b161f // indirect
 	github.com/bradfitz/gomemcache v0.0.0-20190913173617-a41fca850d0b
 	github.com/cespare/xxhash v1.1.0

--- a/pkg/objstore/aws/aws.go
+++ b/pkg/objstore/aws/aws.go
@@ -123,7 +123,7 @@ func NewBucketWithConfig(logger log.Logger, config Config, component string) (*B
 		TLSClientConfig:    &tls.Config{InsecureSkipVerify: config.HTTPConfig.InsecureSkipVerify},
 	}}
 	session, err := session.NewSession(&aws.Config{
-		Region:     aws.String("us-west-2"),
+		Region:     aws.String(config.Region),
 		HTTPClient: httpClient,
 	})
 	client := s3.New(session)
@@ -155,6 +155,9 @@ func (b *Bucket) Name() string {
 
 // validate checks to see the config options are set.
 func validate(conf Config) error {
+	if conf.Region == "" {
+		return errors.New("Region not specified in config file")
+	}
 	if conf.AccessKey == "" && conf.SecretKey != "" {
 		return errors.New("no s3 acccess_key specified while secret_key is present in config file; either both should be present in config or envvars/IAM should be used")
 	}

--- a/pkg/objstore/aws/aws.go
+++ b/pkg/objstore/aws/aws.go
@@ -59,7 +59,8 @@ type HTTPConfig struct {
 	InsecureSkipVerify    bool           `yaml:"insecureSkipVerify"`
 }
 
-var defaultConfig = Config{
+// DefaultConfig for object storage.
+var DefaultConfig = Config{
 	UserMetadata: map[string]*string{},
 	HTTPConfig: HTTPConfig{
 		IdleConnTimeout:       model.Duration(90 * time.Second),

--- a/pkg/objstore/aws/aws.go
+++ b/pkg/objstore/aws/aws.go
@@ -283,7 +283,10 @@ func (b *Bucket) Upload(ctx context.Context, name string, r io.Reader) error {
 		partSize = 0
 	}
 	buffer := make([]byte, size)
-	r.Read(buffer)
+	_, err := r.Read(buffer)
+	if err != nil {
+		return errors.Wrap(err, "Upload: failed to read file into buffer")
+	}
 	fileBytes := bytes.NewReader(buffer) // converted to io.ReadSeeker type.
 
 	if _, err := b.client.PutObjectWithContext(ctx, &s3.PutObjectInput{Bucket: aws.String(b.name),
@@ -317,7 +320,7 @@ func (b *Bucket) Delete(ctx context.Context, name string) error {
 		return err
 	}
 
-	b.client.WaitUntilObjectNotExists(&s3.HeadObjectInput{Bucket: aws.String(b.name), Key: aws.String(name)})
+	err = b.client.WaitUntilObjectNotExists(&s3.HeadObjectInput{Bucket: aws.String(b.name), Key: aws.String(name)})
 	if err != nil {
 		return err
 	}

--- a/pkg/objstore/aws/aws.go
+++ b/pkg/objstore/aws/aws.go
@@ -52,9 +52,9 @@ type Config struct {
 	SecretKey       string             `yaml:"secret_key"`
 	PutUserMetadata map[string]*string `yaml:"put_user_metadata"`
 	HTTPConfig      HTTPConfig         `yaml:"http_config"`
-	TraceConfig     TraceConfig        `yaml:"trace"`
 	maxPartSize     int64              `yaml:"maxPartSize"`
 	maxRetries      int                `yaml:"maxRetries"`
+	TraceConfig     TraceConfig        `yaml:"trace"`
 }
 
 // TraceConfig enables or disables tracing.

--- a/pkg/objstore/aws/aws.go
+++ b/pkg/objstore/aws/aws.go
@@ -332,7 +332,7 @@ func (b *Bucket) Upload(ctx context.Context, name string, r io.Reader) error {
 		level.Error(b.logger).Log("err", err.Error())
 		return err
 	}
-	level.Debug(b.logger).Log("msg", "Successfullly uploaded file", "name", completeResponse.String())
+	level.Debug(b.logger).Log("msg", "Successfully uploaded file", "name", completeResponse.String())
 
 	return nil
 }

--- a/pkg/objstore/aws/aws.go
+++ b/pkg/objstore/aws/aws.go
@@ -48,8 +48,6 @@ type Config struct {
 	Region          string             `yaml:"region"`
 	AccessKey       string             `yaml:"access_key"`
 	ACL             string             `yaml:"acl"`
-	Insecure        bool               `yaml:"insecure"`
-	SignatureV2     bool               `yaml:"signature_version2"`
 	SSEEncryption   bool               `yaml:"encrypt_sse"`
 	SecretKey       string             `yaml:"secret_key"`
 	PutUserMetadata map[string]*string `yaml:"put_user_metadata"`
@@ -348,9 +346,7 @@ func configFromEnv() Config {
 		SecretKey: os.Getenv("S3_SECRET_KEY"),
 	}
 
-	c.Insecure, _ = strconv.ParseBool(os.Getenv("S3_INSECURE"))
 	c.HTTPConfig.InsecureSkipVerify, _ = strconv.ParseBool(os.Getenv("S3_INSECURE_SKIP_VERIFY"))
-	c.SignatureV2, _ = strconv.ParseBool(os.Getenv("S3_SIGNATURE_VERSION2"))
 	return c
 }
 

--- a/pkg/objstore/aws/aws.go
+++ b/pkg/objstore/aws/aws.go
@@ -16,7 +16,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
-	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/minio/minio-go/v6/pkg/encrypt"
@@ -113,13 +112,6 @@ func NewBucketWithConfig(logger log.Logger, config Config, component string) (*B
 	if err != nil {
 		return nil, errors.Wrap(err, "initialize s3 client")
 	}
-	svc := sts.New(session)
-	input := &sts.GetCallerIdentityInput{}
-	result, err := svc.GetCallerIdentity(input)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to call sts")
-	}
-	level.Info(logger).Log("msg", "sts result", "arn", result.Arn)
 
 	//client.SetAppInfo(fmt.Sprintf("thanos-%s", component), fmt.Sprintf("%s (%s)", version.Version, runtime.Version()))
 	//client.SetCustomTransport(&http.Transport{
@@ -302,7 +294,6 @@ func (b *Bucket) guessFileSize(name string, r io.Reader) int64 {
 
 // Upload the contents of the reader as an object into the bucket.
 func (b *Bucket) Upload(ctx context.Context, name string, r io.Reader) error {
-	level.Info(b.logger).Log("msg", "in upload", "name", name)
 	// TODO(https://github.com/thanos-io/thanos/issues/678): Remove guessing length when minio provider will support multipart upload without this.
 	size := b.guessFileSize(name, r)
 

--- a/pkg/objstore/aws/aws.go
+++ b/pkg/objstore/aws/aws.go
@@ -207,7 +207,6 @@ func (b *Bucket) Iter(ctx context.Context, dir string, f func(string) error) err
 			return err
 		}
 
-		keys := []string{object.Contents.Keys}
 		for _, obj := range object.Contents {
 			if *obj.Key == "" {
 				continue

--- a/pkg/objstore/aws/aws_test.go
+++ b/pkg/objstore/aws/aws_test.go
@@ -102,18 +102,19 @@ http_config:
 
 	cfg, err := parseConfig(input)
 	testutil.Ok(t, err)
-	testutil.Assert(t, cfg.PartSize == 1024*1024*128, "when part size not set it should default to 128MiB")
+	testutil.Assert(t, cfg.maxPartSize == 1024*1024*5, "when part size not set it should default to 5MiB")
 
 	input2 := []byte(`bucket: "bucket-name"
 access_key: "access_key"
-encrypt_sse: false
+encrypt_sse: true
+maxRetries: 6
 secret_key: "secret_key"
-part_size: 104857600
+maxPartSize: 104857600
 http_config:
   insecure_skip_verify: false
   idle_conn_timeout: 50s`)
 
 	cfg2, err := parseConfig(input2)
 	testutil.Ok(t, err)
-	testutil.Assert(t, cfg2.PartSize == 1024*1024*100, "when part size should be set to 100MiB")
+	testutil.Assert(t, cfg2.maxPartSize == 1024*1024*5, "when part size should be set to 100MiB")
 }

--- a/pkg/objstore/aws/aws_test.go
+++ b/pkg/objstore/aws/aws_test.go
@@ -42,9 +42,9 @@ func TestParseConfig_DefaultHTTPConfig(t *testing.T) {
 func TestParseConfig_CustomHTTPConfig(t *testing.T) {
 	input := []byte(`bucket: abcd
 http_config:
-  insecure_skip_verify: true
-  idle_conn_timeout: 50s
-  response_header_timeout: 1m`)
+  insecureSkipVerify: true
+  idleConnectTimeout: 50s
+  responseHeaderTimeout: 1m`)
 	cfg, err := parseConfig(input)
 	testutil.Ok(t, err)
 
@@ -65,56 +65,55 @@ http_config:
 
 func TestValidate_OK(t *testing.T) {
 	input := []byte(`bucket: "bucket-name"
-access_key: "access_key"
-encrypt_sse: false
-secret_key: "secret_key"
-http_config:
-  insecure_skip_verify: false
-  idle_conn_timeout: 50s`)
+accessKey: "access_key"
+encryptSSE: false
+secretKey: "secret_key"
+httpConfig:
+  insecureSkipVerify: false
+  idleConnectTimeout: 50s`)
 	cfg, err := parseConfig(input)
 	testutil.Ok(t, err)
 	testutil.Ok(t, validate(cfg))
-	testutil.Assert(t, cfg.PutUserMetadata != nil, "map should not be nil")
+	testutil.Assert(t, cfg.UserMetadata != nil, "map should not be nil")
 
 	input2 := []byte(`bucket: "bucket-name"
-access_key: "access_key"
+accessKey: "access_key"
 encrypt_sse: false
-secret_key: "secret_key"
-put_user_metadata:
+secretKey: "secret_key"
+userMetadata:
   "X-Amz-Acl": "bucket-owner-full-control"
-http_config:
+httpConfig:
   idle_conn_timeout: 0s`)
 	cfg2, err := parseConfig(input2)
 	testutil.Ok(t, err)
 	testutil.Ok(t, validate(cfg2))
 
-	testutil.Equals(t, "bucket-owner-full-control", cfg2.PutUserMetadata["X-Amz-Acl"])
+	testutil.Equals(t, "bucket-owner-full-control", cfg2.UserMetadata["X-Amz-Acl"])
 }
 
 func TestParseConfig_PartSize(t *testing.T) {
 	input := []byte(`bucket: "bucket-name"
-access_key: "access_key"
-encrypt_sse: false
-secret_key: "secret_key"
-http_config:
-  insecure_skip_verify: false
-  idle_conn_timeout: 50s`)
+accessKey: "access_key"
+encryptSSE: false
+secretKey: "secret_key"
+httpConfig:
+  insecureSkipVerify: false
+  idleConnectTimeout: 50s`)
 
 	cfg, err := parseConfig(input)
 	testutil.Ok(t, err)
-	testutil.Assert(t, cfg.maxPartSize == 1024*1024*5, "when part size not set it should default to 5MiB")
+	testutil.Assert(t, cfg.PartSize == 1024*1024*5, "when part size not set it should default to 5MiB")
 
 	input2 := []byte(`bucket: "bucket-name"
-access_key: "access_key"
-encrypt_sse: true
-maxRetries: 6
-secret_key: "secret_key"
+accessKey: "access_key"
+encryptSSE: true
+secretKey: "secret_key"
 maxPartSize: 104857600
-http_config:
-  insecure_skip_verify: false
-  idle_conn_timeout: 50s`)
+httpConfig:
+  insecureSkipVerify: false
+  idleConnectTimeout: 50s`)
 
 	cfg2, err := parseConfig(input2)
 	testutil.Ok(t, err)
-	testutil.Assert(t, cfg2.maxPartSize == 1024*1024*5, "when part size should be set to 100MiB")
+	testutil.Assert(t, cfg2.PartSize == 1024*1024*100, "when part size should be set to 100MiB")
 }

--- a/pkg/objstore/aws/aws_test.go
+++ b/pkg/objstore/aws/aws_test.go
@@ -1,0 +1,119 @@
+package aws
+
+import (
+	"testing"
+	"time"
+
+	"github.com/thanos-io/thanos/pkg/testutil"
+)
+
+func TestParseConfig(t *testing.T) {
+	input := []byte(`bucket: abcd`)
+
+	cfg, err := parseConfig(input)
+	testutil.Ok(t, err)
+
+	if cfg.Bucket != "abcd" {
+		t.Errorf("parsing of bucket failed: got %v, expected %v", cfg.Bucket, "abcd")
+	}
+}
+
+func TestParseConfig_DefaultHTTPConfig(t *testing.T) {
+	input := []byte(`bucket: abcd`)
+
+	cfg, err := parseConfig(input)
+	testutil.Ok(t, err)
+
+	if time.Duration(cfg.HTTPConfig.IdleConnTimeout) != time.Duration(90*time.Second) {
+		t.Errorf("parsing of idle_conn_timeout failed: got %v, expected %v",
+			time.Duration(cfg.HTTPConfig.IdleConnTimeout), time.Duration(90*time.Second))
+	}
+
+	if time.Duration(cfg.HTTPConfig.ResponseHeaderTimeout) != time.Duration(2*time.Minute) {
+		t.Errorf("parsing of response_header_timeout failed: got %v, expected %v",
+			time.Duration(cfg.HTTPConfig.IdleConnTimeout), time.Duration(2*time.Minute))
+	}
+
+	if cfg.HTTPConfig.InsecureSkipVerify {
+		t.Errorf("parsing of insecure_skip_verify failed: got %v, expected %v", cfg.HTTPConfig.InsecureSkipVerify, false)
+	}
+}
+
+func TestParseConfig_CustomHTTPConfig(t *testing.T) {
+	input := []byte(`bucket: abcd
+http_config:
+  insecure_skip_verify: true
+  idle_conn_timeout: 50s
+  response_header_timeout: 1m`)
+	cfg, err := parseConfig(input)
+	testutil.Ok(t, err)
+
+	if time.Duration(cfg.HTTPConfig.IdleConnTimeout) != time.Duration(50*time.Second) {
+		t.Errorf("parsing of idle_conn_timeout failed: got %v, expected %v",
+			time.Duration(cfg.HTTPConfig.IdleConnTimeout), time.Duration(50*time.Second))
+	}
+
+	if time.Duration(cfg.HTTPConfig.ResponseHeaderTimeout) != time.Duration(1*time.Minute) {
+		t.Errorf("parsing of response_header_timeout failed: got %v, expected %v",
+			time.Duration(cfg.HTTPConfig.IdleConnTimeout), time.Duration(1*time.Minute))
+	}
+
+	if !cfg.HTTPConfig.InsecureSkipVerify {
+		t.Errorf("parsing of insecure_skip_verify failed: got %v, expected %v", cfg.HTTPConfig.InsecureSkipVerify, false)
+	}
+}
+
+func TestValidate_OK(t *testing.T) {
+	input := []byte(`bucket: "bucket-name"
+access_key: "access_key"
+encrypt_sse: false
+secret_key: "secret_key"
+http_config:
+  insecure_skip_verify: false
+  idle_conn_timeout: 50s`)
+	cfg, err := parseConfig(input)
+	testutil.Ok(t, err)
+	testutil.Ok(t, validate(cfg))
+	testutil.Assert(t, cfg.PutUserMetadata != nil, "map should not be nil")
+
+	input2 := []byte(`bucket: "bucket-name"
+access_key: "access_key"
+encrypt_sse: false
+secret_key: "secret_key"
+put_user_metadata:
+  "X-Amz-Acl": "bucket-owner-full-control"
+http_config:
+  idle_conn_timeout: 0s`)
+	cfg2, err := parseConfig(input2)
+	testutil.Ok(t, err)
+	testutil.Ok(t, validate(cfg2))
+
+	testutil.Equals(t, "bucket-owner-full-control", cfg2.PutUserMetadata["X-Amz-Acl"])
+}
+
+func TestParseConfig_PartSize(t *testing.T) {
+	input := []byte(`bucket: "bucket-name"
+access_key: "access_key"
+encrypt_sse: false
+secret_key: "secret_key"
+http_config:
+  insecure_skip_verify: false
+  idle_conn_timeout: 50s`)
+
+	cfg, err := parseConfig(input)
+	testutil.Ok(t, err)
+	testutil.Assert(t, cfg.PartSize == 1024*1024*128, "when part size not set it should default to 128MiB")
+
+	input2 := []byte(`bucket: "bucket-name"
+access_key: "access_key"
+encrypt_sse: false
+secret_key: "secret_key"
+part_size: 104857600
+http_config:
+  insecure_skip_verify: false
+  idle_conn_timeout: 50s`)
+
+	cfg2, err := parseConfig(input2)
+	testutil.Ok(t, err)
+	testutil.Assert(t, cfg2.PartSize == 1024*1024*100, "when part size should be set to 100MiB")
+}

--- a/pkg/objstore/client/factory.go
+++ b/pkg/objstore/client/factory.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/thanos-io/thanos/pkg/objstore"
+	"github.com/thanos-io/thanos/pkg/objstore/aws"
 	"github.com/thanos-io/thanos/pkg/objstore/azure"
 	"github.com/thanos-io/thanos/pkg/objstore/cos"
 	"github.com/thanos-io/thanos/pkg/objstore/filesystem"
@@ -26,6 +27,7 @@ const (
 	FILESYSTEM ObjProvider = "FILESYSTEM"
 	GCS        ObjProvider = "GCS"
 	S3         ObjProvider = "S3"
+	AWS        ObjProvider = "AWS_S3"
 	AZURE      ObjProvider = "AZURE"
 	SWIFT      ObjProvider = "SWIFT"
 	COS        ObjProvider = "COS"
@@ -57,6 +59,8 @@ func NewBucket(logger log.Logger, confContentYaml []byte, reg prometheus.Registe
 		bucket, err = gcs.NewBucket(context.Background(), logger, config, component)
 	case string(S3):
 		bucket, err = s3.NewBucket(logger, config, component)
+	case string(AWS):
+		bucket, err = aws.NewBucket(logger, config, component)
 	case string(AZURE):
 		bucket, err = azure.NewBucket(logger, config, component)
 	case string(SWIFT):

--- a/pkg/objstore/objtesting/foreach.go
+++ b/pkg/objstore/objtesting/foreach.go
@@ -10,6 +10,7 @@ import (
 	"github.com/thanos-io/thanos/pkg/objstore/filesystem"
 
 	"github.com/thanos-io/thanos/pkg/objstore"
+	"github.com/thanos-io/thanos/pkg/objstore/aws"
 	"github.com/thanos-io/thanos/pkg/objstore/azure"
 	"github.com/thanos-io/thanos/pkg/objstore/cos"
 	"github.com/thanos-io/thanos/pkg/objstore/gcs"
@@ -90,6 +91,19 @@ func ForeachStore(t *testing.T, testFn func(t *testing.T, bkt objstore.Bucket)) 
 			// TODO(bwplotka): Add leaktest when we fix potential leak in minio library.
 			// We cannot use leaktest for detecting our own potential leaks, when leaktest detects leaks in minio itself.
 			// This needs to be investigated more.
+
+			testFn(t, bkt)
+		})
+	}
+
+	// Optionals AWS S3.
+	if !IsObjStoreSkipped(t, client.AWS) {
+		t.Run("aws_sdk_s3", func(t *testing.T) {
+			bkt, closeFn, err := aws.NewTestBucket(t, "us-west-2")
+			testutil.Ok(t, err)
+
+			t.Parallel()
+			defer closeFn()
 
 			testFn(t, bkt)
 		})

--- a/scripts/cfggen/main.go
+++ b/scripts/cfggen/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/thanos-io/thanos/pkg/alert"
 	"github.com/thanos-io/thanos/pkg/cacheutil"
 	http_util "github.com/thanos-io/thanos/pkg/http"
+	"github.com/thanos-io/thanos/pkg/objstore/aws"
 	"github.com/thanos-io/thanos/pkg/objstore/azure"
 	"github.com/thanos-io/thanos/pkg/objstore/client"
 	"github.com/thanos-io/thanos/pkg/objstore/cos"
@@ -39,6 +40,7 @@ var (
 		client.AZURE:      azure.Config{},
 		client.GCS:        gcs.Config{},
 		client.S3:         s3.DefaultConfig,
+		client.AWS:        aws.DefaultConfig,
 		client.SWIFT:      swift.SwiftConfig{},
 		client.COS:        cos.Config{},
 		client.ALIYUNOSS:  oss.Config{},


### PR DESCRIPTION
This PR allows supporting of the following setup:

* AWS Account A
    * A S3 bucket with a policy allowing Account B to PutObject
* AWS Account B/C/D/...
   * An IAM Role with the policy PutObject on bucket in Account A

Various Prometheus + Thanos clusters are running in Account B/C/D/.. and writing their storage to S3 bucket in Account A. In Account A I have Thanos Querier, Compact, etc running.

In the above scenario the default ACL assigned to an object only allows the owner access (Account B). Account A has no permissions to that object thus the Thanos components can't read the contents uploaded by the sub-accounts.

The current S3 implementation coded against Minio doesn't support setting ACL (as Minio server doesn't support ACL). The other option would be to use an assume role but the Minio client doesn't support this either. 

This implementation of the S3 storage allows setting an ACL on PutObject.

## Changes

* Added object storage for S3 utilizing the AWS SDK

## Verification

Currently only manual.
