### PR TITLE
Makefile: fix quay.io/coreos/jsonnet-ci image tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -316,7 +316,7 @@ JSONNET_CONTAINER_CMD:=docker run --rm \
 		-w "/go/src/github.com/thanos-io/thanos" \
 		-e USER=deadbeef \
 		-e GO111MODULE=on \
-		quay.io/coreos/jsonnet-ci
+		quay.io/coreos/jsonnet-ci:release-0.35
 
 .PHONY: examples-in-container
 examples-in-container:


### PR DESCRIPTION
Signed-off-by: Xiang Dai <764524258@qq.com>

Fix below error:
```
# make examples-in-container
>> Compiling and generating thanos-mixin
docker run --rm -u="0:0" -v "/root/.cache/go-build:/.cache/go-build" -v "/deploy/go/src/git
hub.com/thanos-io/thanos:/go/src/github.com/thanos-io/thanos:Z" -w "/go/src/github.com/than
os-io/thanos" -e USER=deadbeef -e GO111MODULE=on quay.io/coreos/jsonnet-ci make  JSONNET_BU
NDLER='/go/bin/jb' jsonnet-vendor
rm -rf mixin/vendor
/go/bin/jb install --jsonnetpkg-home="mixin/vendor"
GET https://github.com/grafana/grafonnet-lib/archive/69bc267211790a1c3f4ea6e6211f3e8ffe22f987.tar.gz 200
GET https://github.com/grafana/jsonnet-libs/archive/f4c59f64f80442f871a06c91edf74d014b82acaf.tar.gz 200
CLEAN mixin/vendor/.tmp
CLEAN mixin/vendor/github.com
CLEAN mixin/vendor/github.com/grafana
CLEAN mixin/vendor/github.com/grafana/grafonnet-lib
CLEAN mixin/vendor/github.com/grafana/grafonnet-lib/grafonnet
CLEAN mixin/vendor/github.com/grafana/jsonnet-libs
CLEAN mixin/vendor/github.com/grafana/jsonnet-libs/grafana-builder
jb: error: failed to install packages: symlink github.com/grafana/grafonnet-lib/grafonnet vendor/grafonnet: no such file or directory
make: *** [Makefile:356: jsonnet-vendor] Error 1
make: *** [examples-in-container] Error 2
```