### PR TITLE
mixin: Fix broken links in docs

### DIFF
--- a/mixin/thanos/README.md
+++ b/mixin/thanos/README.md
@@ -54,7 +54,7 @@ $ jb update
 
 #### Configure
 
-This project is intended to be used as a library. You can extend and customize dashboards and alerting rules by creating for own generators, such as the generators ([alerts.jsonnet](alerts.jsonnet) and [dashboards.jsonnet](dashboards.jsonnet)) that are use to create [examples](examples). Default parameters are collected in [defaults.jsonnet](defaults.jsonnet), feel free to modify and generate your own definitons.
+This project is intended to be used as a library. You can extend and customize dashboards and alerting rules by creating for own generators, such as the generators ([alerts.jsonnet](alerts.jsonnet) and [dashboards.jsonnet](dashboards.jsonnet)) that are use to create [examples](../../examples). Default parameters are collected in [defaults.libsonnet](defaults.libsonnet), feel free to modify and generate your own definitons.
 
 [embedmd]:# (defaults.libsonnet)
 ```libsonnet
@@ -147,7 +147,7 @@ You validate your structural correctness of your Prometheus [alerting rules](htt
 $ make example-rules-lint
 ```
 
-Check out [test.yaml](examples/alerts/tests.yaml) to add/modify tests for the mixin. To learn more about how to write test for Prometheus, check out [official documentation](https://www.prometheus.io/docs/prometheus/latest/configuration/unit_testing_rules/).
+Check out [test.yaml](../../examples/alerts/tests.yaml) to add/modify tests for the mixin. To learn more about how to write test for Prometheus, check out [official documentation](https://www.prometheus.io/docs/prometheus/latest/configuration/unit_testing_rules/).
 
 You test alerts with:
 


### PR DESCRIPTION
I fixed broken links in `mixin/thanos/README.md` doc.
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

## Changes

<!-- Enumerate changes you made -->
- link to `examples` directory 
- link to renamed file:  `defaults.jsonnet` -> `defaults.libsonnet`
## Verification

<!-- How you tested it? How do you know it works? -->

Manually.