### PR TITLE
Display partial response strategy in ruler UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 - [#2030](https://github.com/thanos-io/thanos/pull/2030) Query: Add `thanos_proxy_store_empty_stream_responses_total` metric for number of empty responses from stores.
 - [#2049](https://github.com/thanos-io/thanos/pull/2049) Tracing: Support sampling on Elastic APM with new sample_rate setting.
 - [#2008](https://github.com/thanos-io/thanos/pull/2008) Querier, Receiver, Sidecar, Store: Add gRPC [health check](https://github.com/grpc/grpc/blob/master/doc/health-checking.md) endpoints.
+- [#2085](https://github.com/thanos-io/thanos/pull/2085) Ruler: Display partial response strategy in UI.
 
 ### Changed
 

--- a/pkg/ui/rule.go
+++ b/pkg/ui/rule.go
@@ -135,14 +135,12 @@ func (ru *Rule) alerts(w http.ResponseWriter, r *http.Request) {
 
 	prefix := GetWebPrefix(ru.logger, ru.flagsMap, r)
 
-	// TODO(bwplotka): Update HTML to include partial response.
 	ru.executeTemplate(w, "alerts.html", prefix, alertStatus)
 }
 
 func (ru *Rule) rules(w http.ResponseWriter, r *http.Request) {
 	prefix := GetWebPrefix(ru.logger, ru.flagsMap, r)
 
-	// TODO(bwplotka): Update HTML to include partial response.
 	ru.executeTemplate(w, "rules.html", prefix, ru.ruleManager)
 }
 

--- a/pkg/ui/templates/alerts.html
+++ b/pkg/ui/templates/alerts.html
@@ -31,7 +31,7 @@
                         {{.OriginalFile}} > {{.Name}}
                     </td>
                 </tr>
-                {{range .AlertingRules}}
+                {{range .GetAlertingRules}}
                     {{$activeAlerts := .ActiveAlerts}}
                     <tr class="alert alert-{{index $alertStateToRowClass .State}} alert_header">
                         <td><i class="icon-chevron-down"></i> <b>{{.Name}}</b> ({{len $activeAlerts}} active)</td>

--- a/pkg/ui/templates/rules.html
+++ b/pkg/ui/templates/rules.html
@@ -22,7 +22,7 @@
             <td style="font-weight:bold">Last Evaluation</td>
             <td style="font-weight:bold">Evaluation Time</td>
           </tr>
-          {{range .Rules}}
+          {{range .GetRules}}
           <tr>
             <td class="rule_cell">{{.HTMLSnippet queryURL}}</td>
             <td class="state">


### PR DESCRIPTION
Signed-off-by: yeya24 <yb532204897@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Support displaying partial response strategy in ruler UI

<!-- Enumerate changes you made -->

## Verification

![image](https://user-images.githubusercontent.com/25150124/73572921-09216280-4440-11ea-9461-4ba292845fcf.png)

![image](https://user-images.githubusercontent.com/25150124/73572938-14748e00-4440-11ea-997f-49fbe47e287d.png)

