### PR TITLE
Make ruler for-outage-tolerance and for-grace-period configurable

### DIFF
--- a/docs/components/rule.md
+++ b/docs/components/rule.md
@@ -278,6 +278,12 @@ Flags:
                                  Can be in glob format (repeated).
       --resend-delay=1m          Minimum amount of time to wait before resending
                                  an alert to Alertmanager.
+      --for-outage-tolerance=1h  Max time to tolerate prometheus outage for
+                                 restoring "for" state of alert.
+      --for-grace-period=10m     Minimum duration between alert and restored
+                                 "for" state. This is maintained only for
+
+                                   alerts with configured \"for\" time greater than grace period.
       --eval-interval=30s        The default evaluation interval to use.
       --tsdb.block-duration=2h   Block duration for TSDB block.
       --tsdb.retention=48h       Block retention time on local disk.


### PR DESCRIPTION
Signed-off-by: yeya24 <yb532204897@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Add two flags in Ruler to configure  for-outage-tolerance and for-grace-period.
These two parameters are used in the rule manager to persist alert 'for' state across restarts.
See https://github.com/prometheus/prometheus/pull/4061


## Verification

<!-- How you tested it? How do you know it works? -->
