### PR TITLE
pkg/store/proxy.go: optimize help info

### DIFF
--- a/pkg/store/proxy.go
+++ b/pkg/store/proxy.go
@@ -294,7 +294,7 @@ func (s *ProxyStore) Series(r *storepb.SeriesRequest, srv storepb.Store_SeriesSe
 		level.Debug(s.logger).Log("msg", strings.Join(storeDebugMsgs, ";"))
 		if len(seriesSet) == 0 {
 			// This is indicates that configured StoreAPIs are not the ones end user expects.
-			err := errors.New("No store matched for this query")
+			err := errors.New("No StoreAPIs matched for this query")
 			level.Warn(s.logger).Log("err", err, "stores", strings.Join(storeDebugMsgs, ";"))
 			respSender.send(storepb.NewWarnSeriesResponse(err))
 			return nil


### PR DESCRIPTION
Fix #2091 

There is not only one case for query failure:
- no storeAPIs available
- no storeAPIs matched
- include all above cases

Also, querier use not only storer, but also sidecar, may be other, use storeAPIs here is better.

Signed-off-by: Xiang Dai <764524258@qq.com>