### PR TITLE
Add metalmatze as release shepard for v0.11

### DIFF
--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -32,7 +32,8 @@ Release shepherd responsibilities:
 
 | Release   | Time of first RC         | Shepherd (GitHub handle) |
 |-----------|--------------------------|--------------------------|
-| v0.11.0   | (planned) 2020.02.19     | TBD                      |
+| v0.12.0   | (planned) 2020.04.01     | TBD                      |
+| v0.11.0   | 2020.02.19               | `@metalmatze`            |
 | v0.10.0   | 2020.01.08               | `@GiedriusS`             |
 | v0.9.0    | 2019.11.26               | `@bwplotka`              |
 | v0.8.0    | 2019.10.09               | `@bwplotka`              |


### PR DESCRIPTION
I'm happy  to shepard the v0.11.x release this month. 
For the next v0.12 release I simply added 6 weeks to the current date - which is April 1st.

/cc @thanos-io/thanos-maintainers 