### PR TITLE
compact: Avoid breaking the json log with series string

### DIFF
--- a/pkg/compact/downsample/streamed_block_writer.go
+++ b/pkg/compact/downsample/streamed_block_writer.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"io"
 	"path/filepath"
+	"strings"
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
@@ -111,7 +112,7 @@ func (w *streamedBlockWriter) WriteSeries(lset labels.Labels, chunks []chunks.Me
 	}
 
 	if len(chunks) == 0 {
-		level.Warn(w.logger).Log("empty chunks happened, skip series", lset)
+		level.Warn(w.logger).Log("msg", "empty chunks happened, skip series", "series", strings.ReplaceAll(lset.String(), "\"", "'"))
 		return nil
 	}
 


### PR DESCRIPTION
compact log line when encountering an empty chunk should be a valid JSON to avoid breaking logs parsing.
Otherwise you endup in something like this (Kibana) : 
<img width="1112" alt="Screenshot 2020-02-06 at 2 02 50 PM" src="https://user-images.githubusercontent.com/16538065/73939381-a1f52980-48e9-11ea-9b99-08d07058f638.png">


## Changes
label set is printed in the log as a single string when compact encounters empty chunks.

## Verification
get proper JSON log line