### PR TITLE
Fix wrong Banzai Cloud blog post link

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -126,7 +126,7 @@ We also have example Grafana dashboards [here](/examples/dashboards/dashboards.m
 
 * 2020:
 
-  * [Banzai Cloud user story](https://monzo.com/blog/2018/07/27/how-we-monitor-monzo)
+  * [Banzai Cloud user story](https://banzaicloud.com/blog/multi-cluster-monitoring/)
 
 ## Integrations
 


### PR DESCRIPTION
Signed-off-by: yeya24 <yb532204897@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

The link of the latest Banzai Cloud blog post is wrong.

## Verification

<!-- How you tested it? How do you know it works? -->
