### PR TITLE
bucket: Set state of status prober properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 
 - [#2015](https://github.com/thanos-io/thanos/pull/2015) Sidecar: Querier /api/v1/series bug fixed when time range was ignored inside sidecar.
 The bug was noticeable for example when using Grafana template variables.
+- [#2120](https://github.com/thanos-io/thanos/pull/2120) Bucket Web: Set state of status prober properly.
 
 ## [v0.10.0](https://github.com/thanos-io/thanos/releases/tag/v0.10.0) - 2020.01.13
 

--- a/cmd/thanos/bucket.go
+++ b/cmd/thanos/bucket.go
@@ -355,6 +355,8 @@ func registerBucketWeb(m map[string]setupFunc, root *kingpin.CmdClause, name str
 		}
 
 		g.Add(func() error {
+			statusProber.Ready()
+
 			return refresh(ctx, logger, bucketUI, *interval, *timeout, name, reg, objStoreConfig)
 		}, func(error) {
 			cancel()

--- a/scripts/quickstart.sh
+++ b/scripts/quickstart.sh
@@ -212,4 +212,15 @@ for i in $(seq 0 1); do
     ${STORES} &
 done
 
+sleep 0.5
+
+if [ -n "${GCS_BUCKET}" -o -n "${S3_ENDPOINT}" ]; then
+  ${THANOS_EXECUTABLE} bucket web \
+    --debug.name bucket-web \
+    --log.level debug \
+    --http-address 0.0.0.0:10933 \
+    --http-grace-period 1s \
+    ${OBJSTORECFG} &
+fi
+
 wait


### PR DESCRIPTION
This PR adds missing instruction to set probe status for bucket web UI.

Fixes #2115 

Signed-off-by: Kemal Akkoyun <kakkoyun@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

*  Set state of status prober properly

## Verification

* `make test-local`
* ` MINIO_ENABLED=1 ./scripts/quickstart.sh`
