### PR TITLE
*: Adapt alerts and dashboards to naming conventions

### DIFF
--- a/examples/alerts/alerts.md
+++ b/examples/alerts/alerts.md
@@ -4,57 +4,57 @@ Here are some example alerts configured for Kubernetes environment.
 
 ## Compaction
 
-[embedmd]:# (../tmp/thanos-compactor.rules.yaml yaml)
+[embedmd]:# (../tmp/thanos-compact.rules.yaml yaml)
 ```yaml
-name: thanos-compactor.rules
+name: thanos-compact.rules
 rules:
-- alert: ThanosCompactorMultipleCompactorsAreRunning
+- alert: ThanosCompactMultipleRunning
   annotations:
-    message: You should never run more than one Thanos Compactor at once. You have
-      {{ $value }}
-  expr: sum(up{job=~"thanos-compactor.*"}) > 1
+    message: No more than one Thanos Compact instance should be running at once. There
+      are {{ $value }}
+  expr: sum(up{job=~"thanos-compact.*"}) > 1
   for: 5m
   labels:
     severity: warning
-- alert: ThanosCompactorHalted
+- alert: ThanosCompactHalted
   annotations:
-    message: Thanos Compactor {{$labels.job}} has failed to run and now is halted.
-  expr: thanos_compactor_halted{job=~"thanos-compactor.*"} == 1
+    message: Thanos Compact {{$labels.job}} has failed to run and now is halted.
+  expr: thanos_compactor_halted{job=~"thanos-compact.*"} == 1
   for: 5m
   labels:
     severity: warning
-- alert: ThanosCompactorHighCompactionFailures
+- alert: ThanosCompactHighCompactionFailures
   annotations:
-    message: Thanos Compactor {{$labels.job}} is failing to execute {{ $value | humanize
+    message: Thanos Compact {{$labels.job}} is failing to execute {{ $value | humanize
       }}% of compactions.
   expr: |
     (
-      sum by (job) (rate(thanos_compact_group_compactions_failures_total{job=~"thanos-compactor.*"}[5m]))
+      sum by (job) (rate(thanos_compact_group_compactions_failures_total{job=~"thanos-compact.*"}[5m]))
     /
-      sum by (job) (rate(thanos_compact_group_compactions_total{job=~"thanos-compactor.*"}[5m]))
+      sum by (job) (rate(thanos_compact_group_compactions_total{job=~"thanos-compact.*"}[5m]))
     * 100 > 5
     )
   for: 15m
   labels:
     severity: warning
-- alert: ThanosCompactorBucketHighOperationFailures
+- alert: ThanosCompactBucketHighOperationFailures
   annotations:
-    message: Thanos Compactor {{$labels.job}} Bucket is failing to execute {{ $value
+    message: Thanos Compact {{$labels.job}} Bucket is failing to execute {{ $value
       | humanize }}% of operations.
   expr: |
     (
-      sum by (job) (rate(thanos_objstore_bucket_operation_failures_total{job=~"thanos-compactor.*"}[5m]))
+      sum by (job) (rate(thanos_objstore_bucket_operation_failures_total{job=~"thanos-compact.*"}[5m]))
     /
-      sum by (job) (rate(thanos_objstore_bucket_operations_total{job=~"thanos-compactor.*"}[5m]))
+      sum by (job) (rate(thanos_objstore_bucket_operations_total{job=~"thanos-compact.*"}[5m]))
     * 100 > 5
     )
   for: 15m
   labels:
     severity: warning
-- alert: ThanosCompactorHasNotRun
+- alert: ThanosCompactHasNotRun
   annotations:
-    message: Thanos Compactor {{$labels.job}} has not uploaded anything for 24 hours.
-  expr: (time() - max(thanos_objstore_bucket_last_successful_upload_time{job=~"thanos-compactor.*"}))
+    message: Thanos Compact {{$labels.job}} has not uploaded anything for 24 hours.
+  expr: (time() - max(thanos_objstore_bucket_last_successful_upload_time{job=~"thanos-compact.*"}))
     / 60 / 60 > 24
   labels:
     severity: warning
@@ -64,107 +64,107 @@ rules:
 
 For Thanos ruler we run some alerts in local Prometheus, to make sure that Thanos Rule is working:
 
-[embedmd]:# (../tmp/thanos-ruler.rules.yaml yaml)
+[embedmd]:# (../tmp/thanos-rule.rules.yaml yaml)
 ```yaml
-name: thanos-ruler.rules
+name: thanos-rule.rules
 rules:
-- alert: ThanosRulerQueueIsDroppingAlerts
+- alert: ThanosRuleQueueIsDroppingAlerts
   annotations:
-    message: Thanos Ruler {{$labels.job}} {{$labels.pod}} is failing to queue alerts.
+    message: Thanos Rule {{$labels.job}} {{$labels.pod}} is failing to queue alerts.
   expr: |
-    sum by (job) (rate(thanos_alert_queue_alerts_dropped_total{job=~"thanos-ruler.*"}[5m])) > 0
+    sum by (job) (rate(thanos_alert_queue_alerts_dropped_total{job=~"thanos-rule.*"}[5m])) > 0
   for: 5m
   labels:
     severity: critical
-- alert: ThanosRulerSenderIsFailingAlerts
+- alert: ThanosRuleSenderIsFailingAlerts
   annotations:
-    message: Thanos Ruler {{$labels.job}} {{$labels.pod}} is failing to send alerts
+    message: Thanos Rule {{$labels.job}} {{$labels.pod}} is failing to send alerts
       to alertmanager.
   expr: |
-    sum by (job) (rate(thanos_alert_sender_alerts_dropped_total{job=~"thanos-ruler.*"}[5m])) > 0
+    sum by (job) (rate(thanos_alert_sender_alerts_dropped_total{job=~"thanos-rule.*"}[5m])) > 0
   for: 5m
   labels:
     severity: critical
-- alert: ThanosRulerHighRuleEvaluationFailures
+- alert: ThanosRuleHighRuleEvaluationFailures
   annotations:
-    message: Thanos Ruler {{$labels.job}} {{$labels.pod}} is failing to evaluate rules.
+    message: Thanos Rule {{$labels.job}} {{$labels.pod}} is failing to evaluate rules.
   expr: |
     (
-      sum by (job) (rate(prometheus_rule_evaluation_failures_total{job=~"thanos-ruler.*"}[5m]))
+      sum by (job) (rate(prometheus_rule_evaluation_failures_total{job=~"thanos-rule.*"}[5m]))
     /
-      sum by (job) (rate(prometheus_rule_evaluations_total{job=~"thanos-ruler.*"}[5m]))
+      sum by (job) (rate(prometheus_rule_evaluations_total{job=~"thanos-rule.*"}[5m]))
     * 100 > 5
     )
   for: 5m
   labels:
     severity: warning
-- alert: ThanosRulerHighRuleEvaluationWarnings
+- alert: ThanosRuleHighRuleEvaluationWarnings
   annotations:
-    message: Thanos Ruler {{$labels.job}} {{$labels.pod}} has high number of evaluation
+    message: Thanos Rule {{$labels.job}} {{$labels.pod}} has high number of evaluation
       warnings.
   expr: |
-    sum by (job) (rate(thanos_rule_evaluation_with_warnings_total{job=~"thanos-ruler.*"}[5m])) > 0
+    sum by (job) (rate(thanos_rule_evaluation_with_warnings_total{job=~"thanos-rule.*"}[5m])) > 0
   for: 15m
   labels:
     severity: warning
-- alert: ThanosRulerRuleEvaluationLatencyHigh
+- alert: ThanosRuleRuleEvaluationLatencyHigh
   annotations:
-    message: Thanos Ruler {{$labels.job}}/{{$labels.pod}} has higher evaluation latency
+    message: Thanos Rule {{$labels.job}}/{{$labels.pod}} has higher evaluation latency
       than interval for {{$labels.rule_group}}.
   expr: |
     (
-      sum by (job, pod, rule_group) (prometheus_rule_group_last_duration_seconds{job=~"thanos-ruler.*"})
+      sum by (job, pod, rule_group) (prometheus_rule_group_last_duration_seconds{job=~"thanos-rule.*"})
     >
-      sum by (job, pod, rule_group) (prometheus_rule_group_interval_seconds{job=~"thanos-ruler.*"})
+      sum by (job, pod, rule_group) (prometheus_rule_group_interval_seconds{job=~"thanos-rule.*"})
     )
   for: 5m
   labels:
     severity: warning
-- alert: ThanosRulerGrpcErrorRate
+- alert: ThanosRuleGrpcErrorRate
   annotations:
-    message: Thanos Ruler {{$labels.job}} is failing to handle {{ $value | humanize
+    message: Thanos Rule {{$labels.job}} is failing to handle {{ $value | humanize
       }}% of requests.
   expr: |
     (
-      sum by (job) (rate(grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded", job=~"thanos-ruler.*"}[5m]))
+      sum by (job) (rate(grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded", job=~"thanos-rule.*"}[5m]))
     /
-      sum by (job) (rate(grpc_server_started_total{job=~"thanos-ruler.*"}[5m]))
+      sum by (job) (rate(grpc_server_started_total{job=~"thanos-rule.*"}[5m]))
     * 100 > 5
     )
   for: 5m
   labels:
     severity: warning
-- alert: ThanosRulerConfigReloadFailure
+- alert: ThanosRuleConfigReloadFailure
   annotations:
-    message: Thanos Ruler {{$labels.job}} has not been able to reload its configuration.
-  expr: avg(thanos_rule_config_last_reload_successful{job=~"thanos-ruler.*"}) by (job)
+    message: Thanos Rule {{$labels.job}} has not been able to reload its configuration.
+  expr: avg(thanos_rule_config_last_reload_successful{job=~"thanos-rule.*"}) by (job)
     != 1
   for: 5m
   labels:
     severity: warning
-- alert: ThanosRulerQueryHighDNSFailures
+- alert: ThanosRuleQueryHighDNSFailures
   annotations:
-    message: Thanos Ruler {{$labels.job}} have {{ $value | humanize }}% of failing
+    message: Thanos Rule {{$labels.job}} have {{ $value | humanize }}% of failing
       DNS queries for query endpoints.
   expr: |
     (
-      sum by (job) (rate(thanos_ruler_query_apis_dns_failures_total{job=~"thanos-ruler.*"}[5m]))
+      sum by (job) (rate(thanos_ruler_query_apis_dns_failures_total{job=~"thanos-rule.*"}[5m]))
     /
-      sum by (job) (rate(thanos_ruler_query_apis_dns_lookups_total{job=~"thanos-ruler.*"}[5m]))
+      sum by (job) (rate(thanos_ruler_query_apis_dns_lookups_total{job=~"thanos-rule.*"}[5m]))
     * 100 > 1
     )
   for: 15m
   labels:
     severity: warning
-- alert: ThanosRulerAlertmanagerHighDNSFailures
+- alert: ThanosRuleAlertmanagerHighDNSFailures
   annotations:
-    message: Thanos Ruler {{$labels.job}} have {{ $value | humanize }}% of failing
+    message: Thanos Rule {{$labels.job}} have {{ $value | humanize }}% of failing
       DNS queries for Alertmanager endpoints.
   expr: |
     (
-      sum by (job) (rate(thanos_ruler_alertmanagers_dns_failures_total{job=~"thanos-ruler.*"}[5m]))
+      sum by (job) (rate(thanos_ruler_alertmanagers_dns_failures_total{job=~"thanos-rule.*"}[5m]))
     /
-      sum by (job) (rate(thanos_ruler_alertmanagers_dns_lookups_total{job=~"thanos-ruler.*"}[5m]))
+      sum by (job) (rate(thanos_ruler_alertmanagers_dns_lookups_total{job=~"thanos-rule.*"}[5m]))
     * 100 > 1
     )
   for: 15m
@@ -260,98 +260,98 @@ rules:
 
 ## Query
 
-[embedmd]:# (../tmp/thanos-querier.rules.yaml yaml)
+[embedmd]:# (../tmp/thanos-query.rules.yaml yaml)
 ```yaml
-name: thanos-querier.rules
+name: thanos-query.rules
 rules:
-- alert: ThanosQuerierHttpRequestQueryErrorRateHigh
+- alert: ThanosQueryHttpRequestQueryErrorRateHigh
   annotations:
-    message: Thanos Querier {{$labels.job}} is failing to handle {{ $value | humanize
+    message: Thanos Query {{$labels.job}} is failing to handle {{ $value | humanize
       }}% of "query" requests.
   expr: |
     (
-      sum(rate(http_requests_total{code=~"5..", job=~"thanos-querier.*", handler="query"}[5m]))
+      sum(rate(http_requests_total{code=~"5..", job=~"thanos-query.*", handler="query"}[5m]))
     /
-      sum(rate(http_requests_total{job=~"thanos-querier.*", handler="query"}[5m]))
+      sum(rate(http_requests_total{job=~"thanos-query.*", handler="query"}[5m]))
     ) * 100 > 5
   for: 5m
   labels:
     severity: critical
-- alert: ThanosQuerierHttpRequestQueryRangeErrorRateHigh
+- alert: ThanosQueryHttpRequestQueryRangeErrorRateHigh
   annotations:
-    message: Thanos Querier {{$labels.job}} is failing to handle {{ $value | humanize
+    message: Thanos Query {{$labels.job}} is failing to handle {{ $value | humanize
       }}% of "query_range" requests.
   expr: |
     (
-      sum(rate(http_requests_total{code=~"5..", job=~"thanos-querier.*", handler="query_range"}[5m]))
+      sum(rate(http_requests_total{code=~"5..", job=~"thanos-query.*", handler="query_range"}[5m]))
     /
-      sum(rate(http_requests_total{job=~"thanos-querier.*", handler="query_range"}[5m]))
+      sum(rate(http_requests_total{job=~"thanos-query.*", handler="query_range"}[5m]))
     ) * 100 > 5
   for: 5m
   labels:
     severity: critical
-- alert: ThanosQuerierGrpcServerErrorRate
+- alert: ThanosQueryGrpcServerErrorRate
   annotations:
-    message: Thanos Querier {{$labels.job}} is failing to handle {{ $value | humanize
+    message: Thanos Query {{$labels.job}} is failing to handle {{ $value | humanize
       }}% of requests.
   expr: |
     (
-      sum by (job) (rate(grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded", job=~"thanos-querier.*"}[5m]))
+      sum by (job) (rate(grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded", job=~"thanos-query.*"}[5m]))
     /
-      sum by (job) (rate(grpc_server_started_total{job=~"thanos-querier.*"}[5m]))
+      sum by (job) (rate(grpc_server_started_total{job=~"thanos-query.*"}[5m]))
     * 100 > 5
     )
   for: 5m
   labels:
     severity: warning
-- alert: ThanosQuerierGrpcClientErrorRate
+- alert: ThanosQueryGrpcClientErrorRate
   annotations:
-    message: Thanos Querier {{$labels.job}} is failing to send {{ $value | humanize
+    message: Thanos Query {{$labels.job}} is failing to send {{ $value | humanize
       }}% of requests.
   expr: |
     (
-      sum by (job) (rate(grpc_client_handled_total{grpc_code!="OK", job=~"thanos-querier.*"}[5m]))
+      sum by (job) (rate(grpc_client_handled_total{grpc_code!="OK", job=~"thanos-query.*"}[5m]))
     /
-      sum by (job) (rate(grpc_client_started_total{job=~"thanos-querier.*"}[5m]))
+      sum by (job) (rate(grpc_client_started_total{job=~"thanos-query.*"}[5m]))
     ) * 100 > 5
   for: 5m
   labels:
     severity: warning
-- alert: ThanosQuerierHighDNSFailures
+- alert: ThanosQueryHighDNSFailures
   annotations:
-    message: Thanos Queriers {{$labels.job}} have {{ $value | humanize }}% of failing
+    message: Thanos Query {{$labels.job}} have {{ $value | humanize }}% of failing
       DNS queries for store endpoints.
   expr: |
     (
-      sum by (job) (rate(thanos_querier_store_apis_dns_failures_total{job=~"thanos-querier.*"}[5m]))
+      sum by (job) (rate(thanos_querier_store_apis_dns_failures_total{job=~"thanos-query.*"}[5m]))
     /
-      sum by (job) (rate(thanos_querier_store_apis_dns_lookups_total{job=~"thanos-querier.*"}[5m]))
+      sum by (job) (rate(thanos_querier_store_apis_dns_lookups_total{job=~"thanos-query.*"}[5m]))
     ) * 100 > 1
   for: 15m
   labels:
     severity: warning
-- alert: ThanosQuerierInstantLatencyHigh
+- alert: ThanosQueryInstantLatencyHigh
   annotations:
-    message: Thanos Querier {{$labels.job}} has a 99th percentile latency of {{ $value
+    message: Thanos Query {{$labels.job}} has a 99th percentile latency of {{ $value
       }} seconds for instant queries.
   expr: |
     (
-      histogram_quantile(0.99, sum by (job, le) (http_request_duration_seconds_bucket{job=~"thanos-querier.*", handler="query"})) > 10
+      histogram_quantile(0.99, sum by (job, le) (http_request_duration_seconds_bucket{job=~"thanos-query.*", handler="query"})) > 10
     and
-      sum by (job) (rate(http_request_duration_seconds_bucket{job=~"thanos-querier.*", handler="query"}[5m])) > 0
+      sum by (job) (rate(http_request_duration_seconds_bucket{job=~"thanos-query.*", handler="query"}[5m])) > 0
     )
   for: 10m
   labels:
     severity: critical
-- alert: ThanosQuerierRangeLatencyHigh
+- alert: ThanosQueryRangeLatencyHigh
   annotations:
-    message: Thanos Querier {{$labels.job}} has a 99th percentile latency of {{ $value
+    message: Thanos Query {{$labels.job}} has a 99th percentile latency of {{ $value
       }} seconds for instant queries.
   expr: |
     (
-      histogram_quantile(0.99, sum by (job, le) (http_request_duration_seconds_bucket{job=~"thanos-querier.*", handler="query_range"})) > 10
+      histogram_quantile(0.99, sum by (job, le) (http_request_duration_seconds_bucket{job=~"thanos-query.*", handler="query_range"})) > 10
     and
-      sum by (job) (rate(http_request_duration_seconds_count{job=~"thanos-querier.*", handler="query_range"}[5m])) > 0
+      sum by (job) (rate(http_request_duration_seconds_count{job=~"thanos-query.*", handler="query_range"}[5m])) > 0
     )
   for: 10m
   labels:
@@ -360,68 +360,68 @@ rules:
 
 ## Receive
 
-[embedmd]:# (../tmp/thanos-receiver.rules.yaml yaml)
+[embedmd]:# (../tmp/thanos-receive.rules.yaml yaml)
 ```yaml
-name: thanos-receiver.rules
+name: thanos-receive.rules
 rules:
-- alert: ThanosReceiverHttpRequestErrorRateHigh
+- alert: ThanosReceiveHttpRequestErrorRateHigh
   annotations:
     message: Thanos Receive {{$labels.job}} is failing to handle {{ $value | humanize
       }}% of requests.
   expr: |
     (
-      sum(rate(http_requests_total{code=~"5..", job=~"thanos-receiver.*", handler="receive"}[5m]))
+      sum(rate(http_requests_total{code=~"5..", job=~"thanos-receive.*", handler="receive"}[5m]))
     /
-      sum(rate(http_requests_total{job=~"thanos-receiver.*", handler="receive"}[5m]))
+      sum(rate(http_requests_total{job=~"thanos-receive.*", handler="receive"}[5m]))
     ) * 100 > 5
   for: 5m
   labels:
     severity: critical
-- alert: ThanosReceiverHttpRequestLatencyHigh
+- alert: ThanosReceiveHttpRequestLatencyHigh
   annotations:
     message: Thanos Receive {{$labels.job}} has a 99th percentile latency of {{ $value
       }} seconds for requests.
   expr: |
     (
-      histogram_quantile(0.99, sum by (job, le) (http_request_duration_seconds_bucket{job=~"thanos-receiver.*", handler="receive"})) > 10
+      histogram_quantile(0.99, sum by (job, le) (http_request_duration_seconds_bucket{job=~"thanos-receive.*", handler="receive"})) > 10
     and
-      sum by (job) (rate(http_request_duration_seconds_count{job=~"thanos-receiver.*", handler="receive"}[5m])) > 0
+      sum by (job) (rate(http_request_duration_seconds_count{job=~"thanos-receive.*", handler="receive"}[5m])) > 0
     )
   for: 10m
   labels:
     severity: critical
-- alert: ThanosReceiverHighForwardRequestFailures
+- alert: ThanosReceiveHighForwardRequestFailures
   annotations:
     message: Thanos Receive {{$labels.job}} is failing to forward {{ $value | humanize
       }}% of requests.
   expr: |
     (
-      sum by (job) (rate(thanos_receive_forward_requests_total{result="error", job=~"thanos-receiver.*"}[5m]))
+      sum by (job) (rate(thanos_receive_forward_requests_total{result="error", job=~"thanos-receive.*"}[5m]))
     /
-      sum by (job) (rate(thanos_receive_forward_requests_total{job=~"thanos-receiver.*"}[5m]))
+      sum by (job) (rate(thanos_receive_forward_requests_total{job=~"thanos-receive.*"}[5m]))
     * 100 > 5
     )
   for: 5m
   labels:
     severity: critical
-- alert: ThanosReceiverHighHashringFileRefreshFailures
+- alert: ThanosReceiveHighHashringFileRefreshFailures
   annotations:
     message: Thanos Receive {{$labels.job}} is failing to refresh hashring file, {{
       $value | humanize }} of attempts failed.
   expr: |
     (
-      sum by (job) (rate(thanos_receive_hashrings_file_errors_total{job=~"thanos-receiver.*"}[5m]))
+      sum by (job) (rate(thanos_receive_hashrings_file_errors_total{job=~"thanos-receive.*"}[5m]))
     /
-      sum by (job) (rate(thanos_receive_hashrings_file_refreshes_total{job=~"thanos-receiver.*"}[5m]))
+      sum by (job) (rate(thanos_receive_hashrings_file_refreshes_total{job=~"thanos-receive.*"}[5m]))
     > 0
     )
   for: 15m
   labels:
     severity: warning
-- alert: ThanosReceiverConfigReloadFailure
+- alert: ThanosReceiveConfigReloadFailure
   annotations:
     message: Thanos Receive {{$labels.job}} has not been able to reload hashring configurations.
-  expr: avg(thanos_receive_config_last_reload_successful{job=~"thanos-receiver.*"})
+  expr: avg(thanos_receive_config_last_reload_successful{job=~"thanos-receive.*"})
     by (job) != 1
   for: 5m
   labels:
@@ -436,35 +436,35 @@ rules:
 ```yaml
 name: thanos-component-absent.rules
 rules:
-- alert: ThanosCompactorIsDown
+- alert: ThanosCompactIsDown
   annotations:
-    message: ThanosCompactor has disappeared from Prometheus target discovery.
+    message: ThanosCompact has disappeared from Prometheus target discovery.
   expr: |
-    absent(up{job=~"thanos-compactor.*"} == 1)
+    absent(up{job=~"thanos-compact.*"} == 1)
   for: 5m
   labels:
     severity: critical
-- alert: ThanosQuerierIsDown
+- alert: ThanosQueryIsDown
   annotations:
-    message: ThanosQuerier has disappeared from Prometheus target discovery.
+    message: ThanosQuery has disappeared from Prometheus target discovery.
   expr: |
-    absent(up{job=~"thanos-querier.*"} == 1)
+    absent(up{job=~"thanos-query.*"} == 1)
   for: 5m
   labels:
     severity: critical
-- alert: ThanosReceiverIsDown
+- alert: ThanosReceiveIsDown
   annotations:
-    message: ThanosReceiver has disappeared from Prometheus target discovery.
+    message: ThanosReceive has disappeared from Prometheus target discovery.
   expr: |
-    absent(up{job=~"thanos-receiver.*"} == 1)
+    absent(up{job=~"thanos-receive.*"} == 1)
   for: 5m
   labels:
     severity: critical
-- alert: ThanosRulerIsDown
+- alert: ThanosRuleIsDown
   annotations:
-    message: ThanosRuler has disappeared from Prometheus target discovery.
+    message: ThanosRule has disappeared from Prometheus target discovery.
   expr: |
-    absent(up{job=~"thanos-ruler.*"} == 1)
+    absent(up{job=~"thanos-rule.*"} == 1)
   for: 5m
   labels:
     severity: critical

--- a/examples/alerts/alerts.yaml
+++ b/examples/alerts/alerts.yaml
@@ -1,211 +1,211 @@
 groups:
-- name: thanos-compactor.rules
+- name: thanos-compact.rules
   rules:
-  - alert: ThanosCompactorMultipleCompactorsAreRunning
+  - alert: ThanosCompactMultipleRunning
     annotations:
-      message: You should never run more than one Thanos Compactor at once. You have
-        {{ $value }}
-    expr: sum(up{job=~"thanos-compactor.*"}) > 1
+      message: No more than one Thanos Compact instance should be running at once.
+        There are {{ $value }}
+    expr: sum(up{job=~"thanos-compact.*"}) > 1
     for: 5m
     labels:
       severity: warning
-  - alert: ThanosCompactorHalted
+  - alert: ThanosCompactHalted
     annotations:
-      message: Thanos Compactor {{$labels.job}} has failed to run and now is halted.
-    expr: thanos_compactor_halted{job=~"thanos-compactor.*"} == 1
+      message: Thanos Compact {{$labels.job}} has failed to run and now is halted.
+    expr: thanos_compactor_halted{job=~"thanos-compact.*"} == 1
     for: 5m
     labels:
       severity: warning
-  - alert: ThanosCompactorHighCompactionFailures
+  - alert: ThanosCompactHighCompactionFailures
     annotations:
-      message: Thanos Compactor {{$labels.job}} is failing to execute {{ $value |
-        humanize }}% of compactions.
+      message: Thanos Compact {{$labels.job}} is failing to execute {{ $value | humanize
+        }}% of compactions.
     expr: |
       (
-        sum by (job) (rate(thanos_compact_group_compactions_failures_total{job=~"thanos-compactor.*"}[5m]))
+        sum by (job) (rate(thanos_compact_group_compactions_failures_total{job=~"thanos-compact.*"}[5m]))
       /
-        sum by (job) (rate(thanos_compact_group_compactions_total{job=~"thanos-compactor.*"}[5m]))
+        sum by (job) (rate(thanos_compact_group_compactions_total{job=~"thanos-compact.*"}[5m]))
       * 100 > 5
       )
     for: 15m
     labels:
       severity: warning
-  - alert: ThanosCompactorBucketHighOperationFailures
+  - alert: ThanosCompactBucketHighOperationFailures
     annotations:
-      message: Thanos Compactor {{$labels.job}} Bucket is failing to execute {{ $value
+      message: Thanos Compact {{$labels.job}} Bucket is failing to execute {{ $value
         | humanize }}% of operations.
     expr: |
       (
-        sum by (job) (rate(thanos_objstore_bucket_operation_failures_total{job=~"thanos-compactor.*"}[5m]))
+        sum by (job) (rate(thanos_objstore_bucket_operation_failures_total{job=~"thanos-compact.*"}[5m]))
       /
-        sum by (job) (rate(thanos_objstore_bucket_operations_total{job=~"thanos-compactor.*"}[5m]))
+        sum by (job) (rate(thanos_objstore_bucket_operations_total{job=~"thanos-compact.*"}[5m]))
       * 100 > 5
       )
     for: 15m
     labels:
       severity: warning
-  - alert: ThanosCompactorHasNotRun
+  - alert: ThanosCompactHasNotRun
     annotations:
-      message: Thanos Compactor {{$labels.job}} has not uploaded anything for 24 hours.
-    expr: (time() - max(thanos_objstore_bucket_last_successful_upload_time{job=~"thanos-compactor.*"}))
+      message: Thanos Compact {{$labels.job}} has not uploaded anything for 24 hours.
+    expr: (time() - max(thanos_objstore_bucket_last_successful_upload_time{job=~"thanos-compact.*"}))
       / 60 / 60 > 24
     labels:
       severity: warning
-- name: thanos-querier.rules
+- name: thanos-query.rules
   rules:
-  - alert: ThanosQuerierHttpRequestQueryErrorRateHigh
+  - alert: ThanosQueryHttpRequestQueryErrorRateHigh
     annotations:
-      message: Thanos Querier {{$labels.job}} is failing to handle {{ $value | humanize
+      message: Thanos Query {{$labels.job}} is failing to handle {{ $value | humanize
         }}% of "query" requests.
     expr: |
       (
-        sum(rate(http_requests_total{code=~"5..", job=~"thanos-querier.*", handler="query"}[5m]))
+        sum(rate(http_requests_total{code=~"5..", job=~"thanos-query.*", handler="query"}[5m]))
       /
-        sum(rate(http_requests_total{job=~"thanos-querier.*", handler="query"}[5m]))
+        sum(rate(http_requests_total{job=~"thanos-query.*", handler="query"}[5m]))
       ) * 100 > 5
     for: 5m
     labels:
       severity: critical
-  - alert: ThanosQuerierHttpRequestQueryRangeErrorRateHigh
+  - alert: ThanosQueryHttpRequestQueryRangeErrorRateHigh
     annotations:
-      message: Thanos Querier {{$labels.job}} is failing to handle {{ $value | humanize
+      message: Thanos Query {{$labels.job}} is failing to handle {{ $value | humanize
         }}% of "query_range" requests.
     expr: |
       (
-        sum(rate(http_requests_total{code=~"5..", job=~"thanos-querier.*", handler="query_range"}[5m]))
+        sum(rate(http_requests_total{code=~"5..", job=~"thanos-query.*", handler="query_range"}[5m]))
       /
-        sum(rate(http_requests_total{job=~"thanos-querier.*", handler="query_range"}[5m]))
+        sum(rate(http_requests_total{job=~"thanos-query.*", handler="query_range"}[5m]))
       ) * 100 > 5
     for: 5m
     labels:
       severity: critical
-  - alert: ThanosQuerierGrpcServerErrorRate
+  - alert: ThanosQueryGrpcServerErrorRate
     annotations:
-      message: Thanos Querier {{$labels.job}} is failing to handle {{ $value | humanize
+      message: Thanos Query {{$labels.job}} is failing to handle {{ $value | humanize
         }}% of requests.
     expr: |
       (
-        sum by (job) (rate(grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded", job=~"thanos-querier.*"}[5m]))
+        sum by (job) (rate(grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded", job=~"thanos-query.*"}[5m]))
       /
-        sum by (job) (rate(grpc_server_started_total{job=~"thanos-querier.*"}[5m]))
+        sum by (job) (rate(grpc_server_started_total{job=~"thanos-query.*"}[5m]))
       * 100 > 5
       )
     for: 5m
     labels:
       severity: warning
-  - alert: ThanosQuerierGrpcClientErrorRate
+  - alert: ThanosQueryGrpcClientErrorRate
     annotations:
-      message: Thanos Querier {{$labels.job}} is failing to send {{ $value | humanize
+      message: Thanos Query {{$labels.job}} is failing to send {{ $value | humanize
         }}% of requests.
     expr: |
       (
-        sum by (job) (rate(grpc_client_handled_total{grpc_code!="OK", job=~"thanos-querier.*"}[5m]))
+        sum by (job) (rate(grpc_client_handled_total{grpc_code!="OK", job=~"thanos-query.*"}[5m]))
       /
-        sum by (job) (rate(grpc_client_started_total{job=~"thanos-querier.*"}[5m]))
+        sum by (job) (rate(grpc_client_started_total{job=~"thanos-query.*"}[5m]))
       ) * 100 > 5
     for: 5m
     labels:
       severity: warning
-  - alert: ThanosQuerierHighDNSFailures
+  - alert: ThanosQueryHighDNSFailures
     annotations:
-      message: Thanos Queriers {{$labels.job}} have {{ $value | humanize }}% of failing
+      message: Thanos Query {{$labels.job}} have {{ $value | humanize }}% of failing
         DNS queries for store endpoints.
     expr: |
       (
-        sum by (job) (rate(thanos_querier_store_apis_dns_failures_total{job=~"thanos-querier.*"}[5m]))
+        sum by (job) (rate(thanos_querier_store_apis_dns_failures_total{job=~"thanos-query.*"}[5m]))
       /
-        sum by (job) (rate(thanos_querier_store_apis_dns_lookups_total{job=~"thanos-querier.*"}[5m]))
+        sum by (job) (rate(thanos_querier_store_apis_dns_lookups_total{job=~"thanos-query.*"}[5m]))
       ) * 100 > 1
     for: 15m
     labels:
       severity: warning
-  - alert: ThanosQuerierInstantLatencyHigh
+  - alert: ThanosQueryInstantLatencyHigh
     annotations:
-      message: Thanos Querier {{$labels.job}} has a 99th percentile latency of {{
-        $value }} seconds for instant queries.
+      message: Thanos Query {{$labels.job}} has a 99th percentile latency of {{ $value
+        }} seconds for instant queries.
     expr: |
       (
-        histogram_quantile(0.99, sum by (job, le) (http_request_duration_seconds_bucket{job=~"thanos-querier.*", handler="query"})) > 10
+        histogram_quantile(0.99, sum by (job, le) (http_request_duration_seconds_bucket{job=~"thanos-query.*", handler="query"})) > 10
       and
-        sum by (job) (rate(http_request_duration_seconds_bucket{job=~"thanos-querier.*", handler="query"}[5m])) > 0
+        sum by (job) (rate(http_request_duration_seconds_bucket{job=~"thanos-query.*", handler="query"}[5m])) > 0
       )
     for: 10m
     labels:
       severity: critical
-  - alert: ThanosQuerierRangeLatencyHigh
+  - alert: ThanosQueryRangeLatencyHigh
     annotations:
-      message: Thanos Querier {{$labels.job}} has a 99th percentile latency of {{
-        $value }} seconds for instant queries.
+      message: Thanos Query {{$labels.job}} has a 99th percentile latency of {{ $value
+        }} seconds for instant queries.
     expr: |
       (
-        histogram_quantile(0.99, sum by (job, le) (http_request_duration_seconds_bucket{job=~"thanos-querier.*", handler="query_range"})) > 10
+        histogram_quantile(0.99, sum by (job, le) (http_request_duration_seconds_bucket{job=~"thanos-query.*", handler="query_range"})) > 10
       and
-        sum by (job) (rate(http_request_duration_seconds_count{job=~"thanos-querier.*", handler="query_range"}[5m])) > 0
+        sum by (job) (rate(http_request_duration_seconds_count{job=~"thanos-query.*", handler="query_range"}[5m])) > 0
       )
     for: 10m
     labels:
       severity: critical
-- name: thanos-receiver.rules
+- name: thanos-receive.rules
   rules:
-  - alert: ThanosReceiverHttpRequestErrorRateHigh
+  - alert: ThanosReceiveHttpRequestErrorRateHigh
     annotations:
       message: Thanos Receive {{$labels.job}} is failing to handle {{ $value | humanize
         }}% of requests.
     expr: |
       (
-        sum(rate(http_requests_total{code=~"5..", job=~"thanos-receiver.*", handler="receive"}[5m]))
+        sum(rate(http_requests_total{code=~"5..", job=~"thanos-receive.*", handler="receive"}[5m]))
       /
-        sum(rate(http_requests_total{job=~"thanos-receiver.*", handler="receive"}[5m]))
+        sum(rate(http_requests_total{job=~"thanos-receive.*", handler="receive"}[5m]))
       ) * 100 > 5
     for: 5m
     labels:
       severity: critical
-  - alert: ThanosReceiverHttpRequestLatencyHigh
+  - alert: ThanosReceiveHttpRequestLatencyHigh
     annotations:
       message: Thanos Receive {{$labels.job}} has a 99th percentile latency of {{
         $value }} seconds for requests.
     expr: |
       (
-        histogram_quantile(0.99, sum by (job, le) (http_request_duration_seconds_bucket{job=~"thanos-receiver.*", handler="receive"})) > 10
+        histogram_quantile(0.99, sum by (job, le) (http_request_duration_seconds_bucket{job=~"thanos-receive.*", handler="receive"})) > 10
       and
-        sum by (job) (rate(http_request_duration_seconds_count{job=~"thanos-receiver.*", handler="receive"}[5m])) > 0
+        sum by (job) (rate(http_request_duration_seconds_count{job=~"thanos-receive.*", handler="receive"}[5m])) > 0
       )
     for: 10m
     labels:
       severity: critical
-  - alert: ThanosReceiverHighForwardRequestFailures
+  - alert: ThanosReceiveHighForwardRequestFailures
     annotations:
       message: Thanos Receive {{$labels.job}} is failing to forward {{ $value | humanize
         }}% of requests.
     expr: |
       (
-        sum by (job) (rate(thanos_receive_forward_requests_total{result="error", job=~"thanos-receiver.*"}[5m]))
+        sum by (job) (rate(thanos_receive_forward_requests_total{result="error", job=~"thanos-receive.*"}[5m]))
       /
-        sum by (job) (rate(thanos_receive_forward_requests_total{job=~"thanos-receiver.*"}[5m]))
+        sum by (job) (rate(thanos_receive_forward_requests_total{job=~"thanos-receive.*"}[5m]))
       * 100 > 5
       )
     for: 5m
     labels:
       severity: critical
-  - alert: ThanosReceiverHighHashringFileRefreshFailures
+  - alert: ThanosReceiveHighHashringFileRefreshFailures
     annotations:
       message: Thanos Receive {{$labels.job}} is failing to refresh hashring file,
         {{ $value | humanize }} of attempts failed.
     expr: |
       (
-        sum by (job) (rate(thanos_receive_hashrings_file_errors_total{job=~"thanos-receiver.*"}[5m]))
+        sum by (job) (rate(thanos_receive_hashrings_file_errors_total{job=~"thanos-receive.*"}[5m]))
       /
-        sum by (job) (rate(thanos_receive_hashrings_file_refreshes_total{job=~"thanos-receiver.*"}[5m]))
+        sum by (job) (rate(thanos_receive_hashrings_file_refreshes_total{job=~"thanos-receive.*"}[5m]))
       > 0
       )
     for: 15m
     labels:
       severity: warning
-  - alert: ThanosReceiverConfigReloadFailure
+  - alert: ThanosReceiveConfigReloadFailure
     annotations:
       message: Thanos Receive {{$labels.job}} has not been able to reload hashring
         configurations.
-    expr: avg(thanos_receive_config_last_reload_successful{job=~"thanos-receiver.*"})
+    expr: avg(thanos_receive_config_last_reload_successful{job=~"thanos-receive.*"})
       by (job) != 1
     for: 5m
     labels:
@@ -284,106 +284,106 @@ groups:
     for: 10m
     labels:
       severity: warning
-- name: thanos-ruler.rules
+- name: thanos-rule.rules
   rules:
-  - alert: ThanosRulerQueueIsDroppingAlerts
+  - alert: ThanosRuleQueueIsDroppingAlerts
     annotations:
-      message: Thanos Ruler {{$labels.job}} {{$labels.pod}} is failing to queue alerts.
+      message: Thanos Rule {{$labels.job}} {{$labels.pod}} is failing to queue alerts.
     expr: |
-      sum by (job) (rate(thanos_alert_queue_alerts_dropped_total{job=~"thanos-ruler.*"}[5m])) > 0
+      sum by (job) (rate(thanos_alert_queue_alerts_dropped_total{job=~"thanos-rule.*"}[5m])) > 0
     for: 5m
     labels:
       severity: critical
-  - alert: ThanosRulerSenderIsFailingAlerts
+  - alert: ThanosRuleSenderIsFailingAlerts
     annotations:
-      message: Thanos Ruler {{$labels.job}} {{$labels.pod}} is failing to send alerts
+      message: Thanos Rule {{$labels.job}} {{$labels.pod}} is failing to send alerts
         to alertmanager.
     expr: |
-      sum by (job) (rate(thanos_alert_sender_alerts_dropped_total{job=~"thanos-ruler.*"}[5m])) > 0
+      sum by (job) (rate(thanos_alert_sender_alerts_dropped_total{job=~"thanos-rule.*"}[5m])) > 0
     for: 5m
     labels:
       severity: critical
-  - alert: ThanosRulerHighRuleEvaluationFailures
+  - alert: ThanosRuleHighRuleEvaluationFailures
     annotations:
-      message: Thanos Ruler {{$labels.job}} {{$labels.pod}} is failing to evaluate
+      message: Thanos Rule {{$labels.job}} {{$labels.pod}} is failing to evaluate
         rules.
     expr: |
       (
-        sum by (job) (rate(prometheus_rule_evaluation_failures_total{job=~"thanos-ruler.*"}[5m]))
+        sum by (job) (rate(prometheus_rule_evaluation_failures_total{job=~"thanos-rule.*"}[5m]))
       /
-        sum by (job) (rate(prometheus_rule_evaluations_total{job=~"thanos-ruler.*"}[5m]))
+        sum by (job) (rate(prometheus_rule_evaluations_total{job=~"thanos-rule.*"}[5m]))
       * 100 > 5
       )
     for: 5m
     labels:
       severity: warning
-  - alert: ThanosRulerHighRuleEvaluationWarnings
+  - alert: ThanosRuleHighRuleEvaluationWarnings
     annotations:
-      message: Thanos Ruler {{$labels.job}} {{$labels.pod}} has high number of evaluation
+      message: Thanos Rule {{$labels.job}} {{$labels.pod}} has high number of evaluation
         warnings.
     expr: |
-      sum by (job) (rate(thanos_rule_evaluation_with_warnings_total{job=~"thanos-ruler.*"}[5m])) > 0
+      sum by (job) (rate(thanos_rule_evaluation_with_warnings_total{job=~"thanos-rule.*"}[5m])) > 0
     for: 15m
     labels:
       severity: warning
-  - alert: ThanosRulerRuleEvaluationLatencyHigh
+  - alert: ThanosRuleRuleEvaluationLatencyHigh
     annotations:
-      message: Thanos Ruler {{$labels.job}}/{{$labels.pod}} has higher evaluation
-        latency than interval for {{$labels.rule_group}}.
+      message: Thanos Rule {{$labels.job}}/{{$labels.pod}} has higher evaluation latency
+        than interval for {{$labels.rule_group}}.
     expr: |
       (
-        sum by (job, pod, rule_group) (prometheus_rule_group_last_duration_seconds{job=~"thanos-ruler.*"})
+        sum by (job, pod, rule_group) (prometheus_rule_group_last_duration_seconds{job=~"thanos-rule.*"})
       >
-        sum by (job, pod, rule_group) (prometheus_rule_group_interval_seconds{job=~"thanos-ruler.*"})
+        sum by (job, pod, rule_group) (prometheus_rule_group_interval_seconds{job=~"thanos-rule.*"})
       )
     for: 5m
     labels:
       severity: warning
-  - alert: ThanosRulerGrpcErrorRate
+  - alert: ThanosRuleGrpcErrorRate
     annotations:
-      message: Thanos Ruler {{$labels.job}} is failing to handle {{ $value | humanize
+      message: Thanos Rule {{$labels.job}} is failing to handle {{ $value | humanize
         }}% of requests.
     expr: |
       (
-        sum by (job) (rate(grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded", job=~"thanos-ruler.*"}[5m]))
+        sum by (job) (rate(grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded", job=~"thanos-rule.*"}[5m]))
       /
-        sum by (job) (rate(grpc_server_started_total{job=~"thanos-ruler.*"}[5m]))
+        sum by (job) (rate(grpc_server_started_total{job=~"thanos-rule.*"}[5m]))
       * 100 > 5
       )
     for: 5m
     labels:
       severity: warning
-  - alert: ThanosRulerConfigReloadFailure
+  - alert: ThanosRuleConfigReloadFailure
     annotations:
-      message: Thanos Ruler {{$labels.job}} has not been able to reload its configuration.
-    expr: avg(thanos_rule_config_last_reload_successful{job=~"thanos-ruler.*"}) by
+      message: Thanos Rule {{$labels.job}} has not been able to reload its configuration.
+    expr: avg(thanos_rule_config_last_reload_successful{job=~"thanos-rule.*"}) by
       (job) != 1
     for: 5m
     labels:
       severity: warning
-  - alert: ThanosRulerQueryHighDNSFailures
+  - alert: ThanosRuleQueryHighDNSFailures
     annotations:
-      message: Thanos Ruler {{$labels.job}} have {{ $value | humanize }}% of failing
+      message: Thanos Rule {{$labels.job}} have {{ $value | humanize }}% of failing
         DNS queries for query endpoints.
     expr: |
       (
-        sum by (job) (rate(thanos_ruler_query_apis_dns_failures_total{job=~"thanos-ruler.*"}[5m]))
+        sum by (job) (rate(thanos_ruler_query_apis_dns_failures_total{job=~"thanos-rule.*"}[5m]))
       /
-        sum by (job) (rate(thanos_ruler_query_apis_dns_lookups_total{job=~"thanos-ruler.*"}[5m]))
+        sum by (job) (rate(thanos_ruler_query_apis_dns_lookups_total{job=~"thanos-rule.*"}[5m]))
       * 100 > 1
       )
     for: 15m
     labels:
       severity: warning
-  - alert: ThanosRulerAlertmanagerHighDNSFailures
+  - alert: ThanosRuleAlertmanagerHighDNSFailures
     annotations:
-      message: Thanos Ruler {{$labels.job}} have {{ $value | humanize }}% of failing
+      message: Thanos Rule {{$labels.job}} have {{ $value | humanize }}% of failing
         DNS queries for Alertmanager endpoints.
     expr: |
       (
-        sum by (job) (rate(thanos_ruler_alertmanagers_dns_failures_total{job=~"thanos-ruler.*"}[5m]))
+        sum by (job) (rate(thanos_ruler_alertmanagers_dns_failures_total{job=~"thanos-rule.*"}[5m]))
       /
-        sum by (job) (rate(thanos_ruler_alertmanagers_dns_lookups_total{job=~"thanos-ruler.*"}[5m]))
+        sum by (job) (rate(thanos_ruler_alertmanagers_dns_lookups_total{job=~"thanos-rule.*"}[5m]))
       * 100 > 1
       )
     for: 15m
@@ -391,35 +391,35 @@ groups:
       severity: warning
 - name: thanos-component-absent.rules
   rules:
-  - alert: ThanosCompactorIsDown
+  - alert: ThanosCompactIsDown
     annotations:
-      message: ThanosCompactor has disappeared from Prometheus target discovery.
+      message: ThanosCompact has disappeared from Prometheus target discovery.
     expr: |
-      absent(up{job=~"thanos-compactor.*"} == 1)
+      absent(up{job=~"thanos-compact.*"} == 1)
     for: 5m
     labels:
       severity: critical
-  - alert: ThanosQuerierIsDown
+  - alert: ThanosQueryIsDown
     annotations:
-      message: ThanosQuerier has disappeared from Prometheus target discovery.
+      message: ThanosQuery has disappeared from Prometheus target discovery.
     expr: |
-      absent(up{job=~"thanos-querier.*"} == 1)
+      absent(up{job=~"thanos-query.*"} == 1)
     for: 5m
     labels:
       severity: critical
-  - alert: ThanosReceiverIsDown
+  - alert: ThanosReceiveIsDown
     annotations:
-      message: ThanosReceiver has disappeared from Prometheus target discovery.
+      message: ThanosReceive has disappeared from Prometheus target discovery.
     expr: |
-      absent(up{job=~"thanos-receiver.*"} == 1)
+      absent(up{job=~"thanos-receive.*"} == 1)
     for: 5m
     labels:
       severity: critical
-  - alert: ThanosRulerIsDown
+  - alert: ThanosRuleIsDown
     annotations:
-      message: ThanosRuler has disappeared from Prometheus target discovery.
+      message: ThanosRule has disappeared from Prometheus target discovery.
     expr: |
-      absent(up{job=~"thanos-ruler.*"} == 1)
+      absent(up{job=~"thanos-rule.*"} == 1)
     for: 5m
     labels:
       severity: critical

--- a/examples/alerts/rules.yaml
+++ b/examples/alerts/rules.yaml
@@ -1,90 +1,90 @@
 groups:
-- name: thanos-querier.rules
+- name: thanos-query.rules
   rules:
   - expr: |
       (
-        sum(rate(grpc_client_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded", job=~"thanos-querier.*", grpc_type="unary"}[5m]))
+        sum(rate(grpc_client_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded", job=~"thanos-query.*", grpc_type="unary"}[5m]))
       /
-        sum(rate(grpc_client_started_total{job=~"thanos-querier.*", grpc_type="unary"}[5m]))
+        sum(rate(grpc_client_started_total{job=~"thanos-query.*", grpc_type="unary"}[5m]))
       )
     labels: {}
     record: :grpc_client_failures_per_unary:sum_rate
   - expr: |
       (
-        sum(rate(grpc_client_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded", job=~"thanos-querier.*", grpc_type="server_stream"}[5m]))
+        sum(rate(grpc_client_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded", job=~"thanos-query.*", grpc_type="server_stream"}[5m]))
       /
-        sum(rate(grpc_client_started_total{job=~"thanos-querier.*", grpc_type="server_stream"}[5m]))
+        sum(rate(grpc_client_started_total{job=~"thanos-query.*", grpc_type="server_stream"}[5m]))
       )
     labels: {}
     record: :grpc_client_failures_per_stream:sum_rate
   - expr: |
       (
-        sum(rate(thanos_querier_store_apis_dns_failures_total{job=~"thanos-querier.*"}[5m]))
+        sum(rate(thanos_querier_store_apis_dns_failures_total{job=~"thanos-query.*"}[5m]))
       /
-        sum(rate(thanos_querier_store_apis_dns_lookups_total{job=~"thanos-querier.*"}[5m]))
+        sum(rate(thanos_querier_store_apis_dns_lookups_total{job=~"thanos-query.*"}[5m]))
       )
     labels: {}
     record: :thanos_querier_store_apis_dns_failures_per_lookup:sum_rate
   - expr: |
       histogram_quantile(0.99,
-        sum(rate(http_request_duration_seconds_bucket{job=~"thanos-querier.*", handler="query"}[5m])) by (le)
+        sum(rate(http_request_duration_seconds_bucket{job=~"thanos-query.*", handler="query"}[5m])) by (le)
       )
     labels:
       quantile: "0.99"
     record: :query_duration_seconds:histogram_quantile
   - expr: |
       histogram_quantile(0.99,
-        sum(rate(http_request_duration_seconds_bucket{job=~"thanos-querier.*", handler="query_range"}[5m])) by (le)
+        sum(rate(http_request_duration_seconds_bucket{job=~"thanos-query.*", handler="query_range"}[5m])) by (le)
       )
     labels:
       quantile: "0.99"
     record: :api_range_query_duration_seconds:histogram_quantile
-- name: thanos-receiver.rules
+- name: thanos-receive.rules
   rules:
   - expr: |
       sum(
-        rate(grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded", job=~"thanos-receiver.*", grpc_type="unary"}[5m])
+        rate(grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded", job=~"thanos-receive.*", grpc_type="unary"}[5m])
       /
-        rate(grpc_server_started_total{job=~"thanos-receiver.*", grpc_type="unary"}[5m])
+        rate(grpc_server_started_total{job=~"thanos-receive.*", grpc_type="unary"}[5m])
       )
     labels: {}
     record: :grpc_server_failures_per_unary:sum_rate
   - expr: |
       sum(
-        rate(grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded", job=~"thanos-receiver.*", grpc_type="server_stream"}[5m])
+        rate(grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded", job=~"thanos-receive.*", grpc_type="server_stream"}[5m])
       /
-        rate(grpc_server_started_total{job=~"thanos-receiver.*", grpc_type="server_stream"}[5m])
+        rate(grpc_server_started_total{job=~"thanos-receive.*", grpc_type="server_stream"}[5m])
       )
     labels: {}
     record: :grpc_server_failures_per_stream:sum_rate
   - expr: |
       sum(
-        rate(http_requests_total{handler="receive", job=~"thanos-receiver.*", code!~"5.."}[5m])
+        rate(http_requests_total{handler="receive", job=~"thanos-receive.*", code!~"5.."}[5m])
       /
-        rate(http_requests_total{handler="receive", job=~"thanos-receiver.*"}[5m])
+        rate(http_requests_total{handler="receive", job=~"thanos-receive.*"}[5m])
       )
     labels: {}
     record: :http_failure_per_request:sum_rate
   - expr: |
       histogram_quantile(0.99,
-        sum(rate(http_request_duration_seconds_bucket{handler="receive", job=~"thanos-receiver.*"}[5m])) by (le)
+        sum(rate(http_request_duration_seconds_bucket{handler="receive", job=~"thanos-receive.*"}[5m])) by (le)
       )
     labels:
       quantile: "0.99"
     record: :http_request_duration_seconds:histogram_quantile
   - expr: |
       (
-        sum(rate(thanos_receive_forward_requests_total{result="error", job=~"thanos-receiver.*"}[5m]))
+        sum(rate(thanos_receive_forward_requests_total{result="error", job=~"thanos-receive.*"}[5m]))
       /
-        sum(rate(thanos_receive_forward_requests_total{job=~"thanos-receiver.*"}[5m]))
+        sum(rate(thanos_receive_forward_requests_total{job=~"thanos-receive.*"}[5m]))
       )
     labels: {}
     record: :thanos_receive_forward_failure_per_requests:sum_rate
   - expr: |
       (
-        sum(rate(thanos_receive_hashrings_file_errors_total{job=~"thanos-receiver.*"}[5m]))
+        sum(rate(thanos_receive_hashrings_file_errors_total{job=~"thanos-receive.*"}[5m]))
       /
-        sum(rate(thanos_receive_hashrings_file_refreshes_total{job=~"thanos-receiver.*"}[5m]))
+        sum(rate(thanos_receive_hashrings_file_refreshes_total{job=~"thanos-receive.*"}[5m]))
       )
     labels: {}
     record: :thanos_receive_hashring_file_failure_per_refresh:sum_rate

--- a/examples/dashboards/compact.json
+++ b/examples/dashboards/compact.json
@@ -19,8 +19,8 @@
                "dashLength": 10,
                "dashes": false,
                "datasource": "$datasource",
-               "description": "Shows rate of dropped alerts.",
-               "fill": 1,
+               "description": "Shows rate of execution for compactions against blocks that are stored in the bucket by compaction group.",
+               "fill": 10,
                "id": 1,
                "legend": {
                   "avg": false,
@@ -32,423 +32,6 @@
                   "values": false
                },
                "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 3,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(rate(thanos_alert_sender_alerts_dropped_total{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job, alertmanager)",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{job}} {{alertmanager}}",
-                     "legendLink": null,
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Dropped Rate",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Shows rate of alerts that successfully sent to alert manager.",
-               "fill": 10,
-               "id": 2,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 3,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(rate(thanos_alert_sender_alerts_sent_total{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job, alertmanager)",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{job}} {{alertmanager}}",
-                     "legendLink": null,
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Sent Rate",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            },
-            {
-               "aliasColors": {
-                  "error": "#E24D42"
-               },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Shows ratio of errors compared to the total number of sent alerts.",
-               "fill": 10,
-               "id": 3,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 3,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(rate(thanos_alert_sender_errors_total{namespace=\"$namespace\",job=~\"$job\"}[$interval])) / sum(rate(thanos_alert_sender_alerts_sent_total{namespace=\"$namespace\",job=~\"$job\"}[$interval]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "error",
-                     "refId": "A",
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Sent Errors",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "percentunit",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Shows how long has it taken to send alerts to alert manager.",
-               "fill": 1,
-               "id": 4,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 3,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "histogram_quantile(0.99, sum(rate(thanos_alert_sender_latency_seconds_bucket{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job, le)) * 1",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "P99 {{job}}",
-                     "refId": "A",
-                     "step": 10
-                  },
-                  {
-                     "expr": "sum(rate(thanos_alert_sender_latency_seconds_sum{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job) * 1 / sum(rate(thanos_alert_sender_latency_seconds_count{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job)",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "mean {{job}}",
-                     "refId": "B",
-                     "step": 10
-                  },
-                  {
-                     "expr": "histogram_quantile(0.50, sum(rate(thanos_alert_sender_latency_seconds_bucket{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job, le)) * 1",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "P50 {{job}}",
-                     "refId": "C",
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Sent Duration",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "s",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            }
-         ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Alert Sent",
-         "titleSize": "h6"
-      },
-      {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Shows rate of queued alerts.",
-               "fill": 1,
-               "id": 5,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 6,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(rate(thanos_alert_queue_alerts_dropped_total{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job, pod)",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{job}} {{pod}}",
-                     "legendLink": null,
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Push Rate",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            },
-            {
-               "aliasColors": {
-                  "error": "#E24D42"
-               },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Shows ratio of dropped alerts compared to the total number of queued alerts.",
-               "fill": 10,
-               "id": 6,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
                "linewidth": 0,
                "links": [ ],
                "nullPointMode": "null as zero",
@@ -463,119 +46,11 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "sum(rate(thanos_alert_queue_alerts_dropped_total{namespace=\"$namespace\",job=~\"$job\"}[$interval])) / sum(rate(thanos_alert_queue_alerts_pushed_total{namespace=\"$namespace\",job=~\"$job\"}[$interval]))",
+                     "expr": "sum(rate(thanos_compact_group_compactions_total{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job, group)",
                      "format": "time_series",
                      "intervalFactor": 2,
-                     "legendFormat": "error",
-                     "refId": "A",
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Drop Ratio",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "percentunit",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            }
-         ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Alert Queue",
-         "titleSize": "h6"
-      },
-      {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
-            {
-               "aliasColors": {
-                  "Aborted": "#EAB839",
-                  "AlreadyExists": "#7EB26D",
-                  "Canceled": "#E24D42",
-                  "DataLoss": "#E24D42",
-                  "DeadlineExceeded": "#E24D42",
-                  "FailedPrecondition": "#6ED0E0",
-                  "Internal": "#E24D42",
-                  "InvalidArgument": "#EF843C",
-                  "NotFound": "#EF843C",
-                  "OK": "#7EB26D",
-                  "OutOfRange": "#E24D42",
-                  "PermissionDenied": "#EF843C",
-                  "ResourceExhausted": "#E24D42",
-                  "Unauthenticated": "#EF843C",
-                  "Unavailable": "#E24D42",
-                  "Unimplemented": "#6ED0E0",
-                  "Unknown": "#E24D42",
-                  "error": "#E24D42"
-               },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Shows rate of handled Unary gRPC requests.",
-               "fill": 10,
-               "id": 7,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(rate(grpc_server_handled_total{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"unary\"}[$interval])) by (job, grpc_code)",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{job}} {{grpc_code}}",
-                     "refId": "A",
+                     "legendFormat": "compaction {{job}} {{group}}",
+                     "legendLink": null,
                      "step": 10
                   }
                ],
@@ -623,7 +98,525 @@
                "dashLength": 10,
                "dashes": false,
                "datasource": "$datasource",
-               "description": "Shows ratio of errors compared to the total number of handled requests.",
+               "description": "Shows ratio of errors compared to the total number of executed compactions against blocks that are stored in the bucket.",
+               "fill": 10,
+               "id": 2,
+               "legend": {
+                  "avg": false,
+                  "current": false,
+                  "max": false,
+                  "min": false,
+                  "show": true,
+                  "total": false,
+                  "values": false
+               },
+               "lines": true,
+               "linewidth": 0,
+               "links": [ ],
+               "nullPointMode": "null as zero",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "span": 6,
+               "stack": true,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "sum(rate(thanos_compact_group_compactions_failures_total{namespace=\"$namespace\",job=~\"$job\"}[$interval])) / sum(rate(thanos_compact_group_compactions_total{namespace=\"$namespace\",job=~\"$job\"}[$interval]))",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "error",
+                     "refId": "A",
+                     "step": 10
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Errors",
+               "tooltip": {
+                  "shared": false,
+                  "sort": 0,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "percentunit",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": false
+                  }
+               ]
+            }
+         ],
+         "repeat": null,
+         "repeatIteration": null,
+         "repeatRowId": null,
+         "showTitle": true,
+         "title": "Group Compaction",
+         "titleSize": "h6"
+      },
+      {
+         "collapse": false,
+         "height": "250px",
+         "panels": [
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$datasource",
+               "description": "Shows rate of execution for downsampling against blocks that are stored in the bucket by compaction group.",
+               "fill": 10,
+               "id": 3,
+               "legend": {
+                  "avg": false,
+                  "current": false,
+                  "max": false,
+                  "min": false,
+                  "show": true,
+                  "total": false,
+                  "values": false
+               },
+               "lines": true,
+               "linewidth": 0,
+               "links": [ ],
+               "nullPointMode": "null as zero",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "span": 6,
+               "stack": true,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "sum(rate(thanos_compact_downsample_total{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job, group)",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "downsample {{job}} {{group}}",
+                     "legendLink": null,
+                     "step": 10
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Rate",
+               "tooltip": {
+                  "shared": false,
+                  "sort": 0,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": false
+                  }
+               ]
+            },
+            {
+               "aliasColors": {
+                  "error": "#E24D42"
+               },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$datasource",
+               "description": "Shows ratio of errors compared to the total number of executed downsampling against blocks that are stored in the bucket.",
+               "fill": 10,
+               "id": 4,
+               "legend": {
+                  "avg": false,
+                  "current": false,
+                  "max": false,
+                  "min": false,
+                  "show": true,
+                  "total": false,
+                  "values": false
+               },
+               "lines": true,
+               "linewidth": 0,
+               "links": [ ],
+               "nullPointMode": "null as zero",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "span": 6,
+               "stack": true,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "sum(rate(thanos_compact_downsample_failed_total{namespace=\"$namespace\",job=~\"$job\"}[$interval])) / sum(rate(thanos_compact_downsample_total{namespace=\"$namespace\",job=~\"$job\"}[$interval]))",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "error",
+                     "refId": "A",
+                     "step": 10
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Errors",
+               "tooltip": {
+                  "shared": false,
+                  "sort": 0,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "percentunit",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": false
+                  }
+               ]
+            }
+         ],
+         "repeat": null,
+         "repeatIteration": null,
+         "repeatRowId": null,
+         "showTitle": true,
+         "title": "Downsample",
+         "titleSize": "h6"
+      },
+      {
+         "collapse": false,
+         "height": "250px",
+         "panels": [
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$datasource",
+               "description": "Shows rate of execution for removals of blocks if their data is available as part of a block with a higher compaction level.",
+               "fill": 10,
+               "id": 5,
+               "legend": {
+                  "avg": false,
+                  "current": false,
+                  "max": false,
+                  "min": false,
+                  "show": true,
+                  "total": false,
+                  "values": false
+               },
+               "lines": true,
+               "linewidth": 0,
+               "links": [ ],
+               "nullPointMode": "null as zero",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "span": 4,
+               "stack": true,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "sum(rate(thanos_compact_garbage_collection_total{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job)",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "garbage collection {{job}}",
+                     "legendLink": null,
+                     "step": 10
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Rate",
+               "tooltip": {
+                  "shared": false,
+                  "sort": 0,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": false
+                  }
+               ]
+            },
+            {
+               "aliasColors": {
+                  "error": "#E24D42"
+               },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$datasource",
+               "description": "Shows ratio of errors compared to the total number of executed garbage collections.",
+               "fill": 10,
+               "id": 6,
+               "legend": {
+                  "avg": false,
+                  "current": false,
+                  "max": false,
+                  "min": false,
+                  "show": true,
+                  "total": false,
+                  "values": false
+               },
+               "lines": true,
+               "linewidth": 0,
+               "links": [ ],
+               "nullPointMode": "null as zero",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "span": 4,
+               "stack": true,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "sum(rate(thanos_compact_garbage_collection_failures_total{namespace=\"$namespace\",job=~\"$job\"}[$interval])) / sum(rate(thanos_compact_garbage_collection_total{namespace=\"$namespace\",job=~\"$job\"}[$interval]))",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "error",
+                     "refId": "A",
+                     "step": 10
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Errors",
+               "tooltip": {
+                  "shared": false,
+                  "sort": 0,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "percentunit",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": false
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$datasource",
+               "description": "Shows how long has it taken to execute garbage collection in quantiles.",
+               "fill": 1,
+               "id": 7,
+               "legend": {
+                  "avg": false,
+                  "current": false,
+                  "max": false,
+                  "min": false,
+                  "show": true,
+                  "total": false,
+                  "values": false
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null as zero",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "span": 4,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "histogram_quantile(0.99, sum(rate(thanos_compact_garbage_collection_duration_seconds_bucket{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job, le)) * 1",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "P99 {{job}}",
+                     "refId": "A",
+                     "step": 10
+                  },
+                  {
+                     "expr": "sum(rate(thanos_compact_garbage_collection_duration_seconds_sum{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job) * 1 / sum(rate(thanos_compact_garbage_collection_duration_seconds_count{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job)",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "mean {{job}}",
+                     "refId": "B",
+                     "step": 10
+                  },
+                  {
+                     "expr": "histogram_quantile(0.50, sum(rate(thanos_compact_garbage_collection_duration_seconds_bucket{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job, le)) * 1",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "P50 {{job}}",
+                     "refId": "C",
+                     "step": 10
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Duration",
+               "tooltip": {
+                  "shared": false,
+                  "sort": 0,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "s",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": false
+                  }
+               ]
+            }
+         ],
+         "repeat": null,
+         "repeatIteration": null,
+         "repeatRowId": null,
+         "showTitle": true,
+         "title": "Garbage Collection",
+         "titleSize": "h6"
+      },
+      {
+         "collapse": false,
+         "height": "250px",
+         "panels": [
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$datasource",
+               "description": "Shows rate of execution for all meta files from blocks in the bucket into the memory.",
                "fill": 10,
                "id": 8,
                "legend": {
@@ -650,7 +643,86 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "sum(rate(grpc_server_handled_total{grpc_code=~\"Unknown|ResourceExhausted|Internal|Unavailable\",namespace=\"$namespace\",job=~\"$job\",grpc_type=\"unary\"}[$interval])) / sum(rate(grpc_server_started_total{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"unary\"}[$interval]))",
+                     "expr": "sum(rate(thanos_blocks_meta_syncs_total{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job)",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "sync {{job}}",
+                     "legendLink": null,
+                     "step": 10
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Rate",
+               "tooltip": {
+                  "shared": false,
+                  "sort": 0,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": false
+                  }
+               ]
+            },
+            {
+               "aliasColors": {
+                  "error": "#E24D42"
+               },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$datasource",
+               "description": "Shows ratio of errors compared to the total number of executed meta file sync.",
+               "fill": 10,
+               "id": 9,
+               "legend": {
+                  "avg": false,
+                  "current": false,
+                  "max": false,
+                  "min": false,
+                  "show": true,
+                  "total": false,
+                  "values": false
+               },
+               "lines": true,
+               "linewidth": 0,
+               "links": [ ],
+               "nullPointMode": "null as zero",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "span": 4,
+               "stack": true,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "sum(rate(thanos_blocks_meta_sync_failures_total{namespace=\"$namespace\",job=~\"$job\"}[$interval])) / sum(rate(thanos_blocks_meta_syncs_total{namespace=\"$namespace\",job=~\"$job\"}[$interval]))",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "error",
@@ -700,9 +772,9 @@
                "dashLength": 10,
                "dashes": false,
                "datasource": "$datasource",
-               "description": "Shows how long has it taken to handle requests, in quantiles.",
+               "description": "Shows how long has it taken to execute meta file sync, in quantiles.",
                "fill": 1,
-               "id": 9,
+               "id": 10,
                "legend": {
                   "avg": false,
                   "current": false,
@@ -727,27 +799,27 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"unary\"}[$interval])) by (job, le)) * 1",
+                     "expr": "histogram_quantile(0.99, sum(rate(thanos_blocks_meta_sync_duration_seconds_bucket{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job, le)) * 1",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "P99 {{job}}",
-                     "legendLink": null,
+                     "refId": "A",
                      "step": 10
                   },
                   {
-                     "expr": "sum(rate(grpc_server_handling_seconds_sum{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"unary\"}[$interval])) by (job) * 1\n/\nsum(rate(grpc_server_handling_seconds_count{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"unary\"}[$interval])) by (job)\n",
+                     "expr": "sum(rate(thanos_blocks_meta_sync_duration_seconds_sum{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job) * 1 / sum(rate(thanos_blocks_meta_sync_duration_seconds_count{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job)",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "mean {{job}}",
-                     "legendLink": null,
+                     "refId": "B",
                      "step": 10
                   },
                   {
-                     "expr": "histogram_quantile(0.50, sum(rate(grpc_server_handling_seconds_bucket{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"unary\"}[$interval])) by (job, le)) * 1",
+                     "expr": "histogram_quantile(0.50, sum(rate(thanos_blocks_meta_sync_duration_seconds_bucket{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job, le)) * 1",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "P50 {{job}}",
-                     "legendLink": null,
+                     "refId": "C",
                      "step": 10
                   }
                ],
@@ -792,11 +864,11 @@
          "repeatIteration": null,
          "repeatRowId": null,
          "showTitle": true,
-         "title": "gRPC (Unary)",
+         "title": "Sync Meta",
          "titleSize": "h6"
       },
       {
-         "collapse": true,
+         "collapse": false,
          "height": "250px",
          "panels": [
             {
@@ -805,84 +877,7 @@
                "dashLength": 10,
                "dashes": false,
                "datasource": "$datasource",
-               "description": "Shows rate of handled Unary gRPC requests.",
-               "fill": 10,
-               "id": 10,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(rate(grpc_server_handled_total{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"unary\"}[$interval])) by (job, grpc_method, grpc_code)",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{job}} {{grpc_method}} {{grpc_code}}",
-                     "refId": "A",
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Rate",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Shows ratio of errors compared to the total number of handled requests.",
+               "description": "Shows rate of execution for operations against the bucket.",
                "fill": 10,
                "id": 11,
                "legend": {
@@ -909,212 +904,11 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "sum(rate(grpc_server_handled_total{grpc_code!=\"OK\",namespace=\"$namespace\",job=~\"$job\",grpc_type=\"unary\"}[$interval])) by (job, grpc_method, grpc_code)\n",
+                     "expr": "sum(rate(thanos_objstore_bucket_operations_total{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job, operation)",
                      "format": "time_series",
                      "intervalFactor": 2,
-                     "legendFormat": "{{job}} {{grpc_method}} {{grpc_code}}",
+                     "legendFormat": "{{job}} {{operation}}",
                      "legendLink": null,
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Errors",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Shows how long has it taken to handle requests, in quantiles.",
-               "fill": 1,
-               "id": 12,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"unary\"}[$interval])) by (job, grpc_method, le)) * 1",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "P99 {{job}} {{grpc_method}}",
-                     "legendLink": null,
-                     "step": 10
-                  },
-                  {
-                     "expr": "sum(rate(grpc_server_handling_seconds_sum{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"unary\"}[$interval])) by (job) * 1\n/\nsum(rate(grpc_server_handling_seconds_count{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"unary\"}[$interval])) by (job)\n",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "mean {{job}} {{grpc_method}}",
-                     "legendLink": null,
-                     "step": 10
-                  },
-                  {
-                     "expr": "histogram_quantile(0.50, sum(rate(grpc_server_handling_seconds_bucket{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"unary\"}[$interval])) by (job, grpc_method, le)) * 1",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "P50 {{job}} {{grpc_method}}",
-                     "legendLink": null,
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Duration",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "s",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            }
-         ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Detailed",
-         "titleSize": "h6"
-      },
-      {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
-            {
-               "aliasColors": {
-                  "Aborted": "#EAB839",
-                  "AlreadyExists": "#7EB26D",
-                  "Canceled": "#E24D42",
-                  "DataLoss": "#E24D42",
-                  "DeadlineExceeded": "#E24D42",
-                  "FailedPrecondition": "#6ED0E0",
-                  "Internal": "#E24D42",
-                  "InvalidArgument": "#EF843C",
-                  "NotFound": "#EF843C",
-                  "OK": "#7EB26D",
-                  "OutOfRange": "#E24D42",
-                  "PermissionDenied": "#EF843C",
-                  "ResourceExhausted": "#E24D42",
-                  "Unauthenticated": "#EF843C",
-                  "Unavailable": "#E24D42",
-                  "Unimplemented": "#6ED0E0",
-                  "Unknown": "#E24D42",
-                  "error": "#E24D42"
-               },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Shows rate of handled Streamed gRPC requests.",
-               "fill": 10,
-               "id": 13,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(rate(grpc_server_handled_total{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"server_stream\"}[$interval])) by (job, grpc_code)",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{job}} {{grpc_code}}",
-                     "refId": "A",
                      "step": 10
                   }
                ],
@@ -1162,9 +956,9 @@
                "dashLength": 10,
                "dashes": false,
                "datasource": "$datasource",
-               "description": "Shows ratio of errors compared to the total number of handled requests.",
+               "description": "Shows ratio of errors compared to the total number of executed operations against the bucket.",
                "fill": 10,
-               "id": 14,
+               "id": 12,
                "legend": {
                   "avg": false,
                   "current": false,
@@ -1189,7 +983,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "sum(rate(grpc_server_handled_total{grpc_code=~\"Unknown|ResourceExhausted|Internal|Unavailable\",namespace=\"$namespace\",job=~\"$job\",grpc_type=\"server_stream\"}[$interval])) / sum(rate(grpc_server_started_total{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"server_stream\"}[$interval]))",
+                     "expr": "sum(rate(thanos_objstore_bucket_operation_failures_total{namespace=\"$namespace\",job=~\"$job\"}[$interval])) / sum(rate(thanos_objstore_bucket_operations_total{namespace=\"$namespace\",job=~\"$job\"}[$interval]))",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "error",
@@ -1239,9 +1033,9 @@
                "dashLength": 10,
                "dashes": false,
                "datasource": "$datasource",
-               "description": "Shows how long has it taken to handle requests, in quantiles",
+               "description": "Shows how long has it taken to execute operations against the bucket, in quantiles.",
                "fill": 1,
-               "id": 15,
+               "id": 13,
                "legend": {
                   "avg": false,
                   "current": false,
@@ -1266,27 +1060,27 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"server_stream\"}[$interval])) by (job, le)) * 1",
+                     "expr": "histogram_quantile(0.99, sum(rate(thanos_objstore_bucket_operation_duration_seconds_bucket{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job, le)) * 1",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "P99 {{job}}",
-                     "legendLink": null,
+                     "refId": "A",
                      "step": 10
                   },
                   {
-                     "expr": "sum(rate(grpc_server_handling_seconds_sum{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"server_stream\"}[$interval])) by (job) * 1\n/\nsum(rate(grpc_server_handling_seconds_count{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"server_stream\"}[$interval])) by (job)\n",
+                     "expr": "sum(rate(thanos_objstore_bucket_operation_duration_seconds_sum{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job) * 1 / sum(rate(thanos_objstore_bucket_operation_duration_seconds_count{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job)",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "mean {{job}}",
-                     "legendLink": null,
+                     "refId": "B",
                      "step": 10
                   },
                   {
-                     "expr": "histogram_quantile(0.50, sum(rate(grpc_server_handling_seconds_bucket{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"server_stream\"}[$interval])) by (job, le)) * 1",
+                     "expr": "histogram_quantile(0.50, sum(rate(thanos_objstore_bucket_operation_duration_seconds_bucket{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job, le)) * 1",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "P50 {{job}}",
-                     "legendLink": null,
+                     "refId": "C",
                      "step": 10
                   }
                ],
@@ -1331,266 +1125,7 @@
          "repeatIteration": null,
          "repeatRowId": null,
          "showTitle": true,
-         "title": "gRPC (Stream)",
-         "titleSize": "h6"
-      },
-      {
-         "collapse": true,
-         "height": "250px",
-         "panels": [
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Shows rate of handled Streamed gRPC requests.",
-               "fill": 10,
-               "id": 16,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(rate(grpc_server_handled_total{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"server_stream\"}[$interval])) by (job, grpc_method, grpc_code)",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{job}} {{grpc_method}} {{grpc_code}}",
-                     "refId": "A",
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Rate",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Shows ratio of errors compared to the total number of handled requests.",
-               "fill": 10,
-               "id": 17,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(rate(grpc_server_handled_total{grpc_code!=\"OK\",namespace=\"$namespace\",job=~\"$job\",grpc_type=\"server_stream\"}[$interval])) by (job, grpc_method, grpc_code)\n",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{job}} {{grpc_method}} {{grpc_code}}",
-                     "legendLink": null,
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Errors",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Shows how long has it taken to handle requests, in quantiles",
-               "fill": 1,
-               "id": 18,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"server_stream\"}[$interval])) by (job, grpc_method, le)) * 1",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "P99 {{job}} {{grpc_method}}",
-                     "legendLink": null,
-                     "step": 10
-                  },
-                  {
-                     "expr": "sum(rate(grpc_server_handling_seconds_sum{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"server_stream\"}[$interval])) by (job) * 1\n/\nsum(rate(grpc_server_handling_seconds_count{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"server_stream\"}[$interval])) by (job)\n",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "mean {{job}} {{grpc_method}}",
-                     "legendLink": null,
-                     "step": 10
-                  },
-                  {
-                     "expr": "histogram_quantile(0.50, sum(rate(grpc_server_handling_seconds_bucket{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"server_stream\"}[$interval])) by (job, grpc_method, le)) * 1",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "P50 {{job}} {{grpc_method}}",
-                     "legendLink": null,
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Duration",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "s",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            }
-         ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Detailed",
+         "title": "Object Store Operations",
          "titleSize": "h6"
       },
       {
@@ -1604,7 +1139,7 @@
                "dashes": false,
                "datasource": "$datasource",
                "fill": 1,
-               "id": 19,
+               "id": 14,
                "legend": {
                   "avg": false,
                   "current": false,
@@ -1720,7 +1255,7 @@
                "dashes": false,
                "datasource": "$datasource",
                "fill": 1,
-               "id": 20,
+               "id": 15,
                "legend": {
                   "avg": false,
                   "current": false,
@@ -1796,7 +1331,7 @@
                "dashes": false,
                "datasource": "$datasource",
                "fill": 1,
-               "id": 21,
+               "id": 16,
                "legend": {
                   "avg": false,
                   "current": false,
@@ -1916,7 +1451,7 @@
             "useTags": false
          },
          {
-            "allValue": "thanos-ruler.*",
+            "allValue": "thanos-compact.*",
             "current": {
                "text": "all",
                "value": "$__all"
@@ -1928,7 +1463,7 @@
             "multi": false,
             "name": "job",
             "options": [ ],
-            "query": "label_values(up{namespace=\"$namespace\",job=~\"thanos-ruler.*\"}, job)",
+            "query": "label_values(up{namespace=\"$namespace\",job=~\"thanos-compact.*\"}, job)",
             "refresh": 1,
             "regex": "",
             "sort": 2,
@@ -1951,7 +1486,7 @@
             "multi": false,
             "name": "pod",
             "options": [ ],
-            "query": "label_values(kube_pod_info{namespace=\"$namespace\",created_by_name=~\"thanos-ruler.*\"}, pod)",
+            "query": "label_values(kube_pod_info{namespace=\"$namespace\",created_by_name=~\"thanos-compact.*\"}, pod)",
             "refresh": 1,
             "regex": "",
             "sort": 2,
@@ -2008,7 +1543,7 @@
       ]
    },
    "timezone": "",
-   "title": "Thanos / Ruler",
-   "uid": "ecc62fafbb8ae0213cb9188ec4f3b553",
+   "title": "Thanos / Compact",
+   "uid": "651943d05a8123e32867b4673963f42b",
    "version": 0
 }

--- a/examples/dashboards/overview.json
+++ b/examples/dashboards/overview.json
@@ -43,10 +43,10 @@
                "linewidth": 0,
                "links": [
                   {
-                     "dashboard": "Thanos / Querier",
+                     "dashboard": "Thanos / Query",
                      "includeVars": true,
                      "keepTime": true,
-                     "title": "Thanos / Querier",
+                     "title": "Thanos / Query",
                      "type": "dashboard"
                   }
                ],
@@ -62,7 +62,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "sum(label_replace(rate(http_requests_total{namespace=\"$namespace\",job=~\"thanos-querier.*\",handler=\"query\"}[$interval]),\"status_code\", \"${1}xx\", \"code\", \"([0-9])..\")) by (job, status_code)",
+                     "expr": "sum(label_replace(rate(http_requests_total{namespace=\"$namespace\",job=~\"thanos-query.*\",handler=\"query\"}[$interval]),\"status_code\", \"${1}xx\", \"code\", \"([0-9])..\")) by (job, status_code)",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{job}} {{status_code}}",
@@ -130,10 +130,10 @@
                "linewidth": 0,
                "links": [
                   {
-                     "dashboard": "Thanos / Querier",
+                     "dashboard": "Thanos / Query",
                      "includeVars": true,
                      "keepTime": true,
-                     "title": "Thanos / Querier",
+                     "title": "Thanos / Query",
                      "type": "dashboard"
                   }
                ],
@@ -149,7 +149,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "sum(rate(http_requests_total{namespace=\"$namespace\",job=~\"thanos-querier.*\",handler=\"query\",code=~\"5..\"}[$interval])) / sum(rate(http_requests_total{namespace=\"$namespace\",job=~\"thanos-querier.*\",handler=\"query\"}[$interval]))",
+                     "expr": "sum(rate(http_requests_total{namespace=\"$namespace\",job=~\"thanos-query.*\",handler=\"query\",code=~\"5..\"}[$interval])) / sum(rate(http_requests_total{namespace=\"$namespace\",job=~\"thanos-query.*\",handler=\"query\"}[$interval]))",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "error",
@@ -215,10 +215,10 @@
                "linewidth": 1,
                "links": [
                   {
-                     "dashboard": "Thanos / Querier",
+                     "dashboard": "Thanos / Query",
                      "includeVars": true,
                      "keepTime": true,
-                     "title": "Thanos / Querier",
+                     "title": "Thanos / Query",
                      "type": "dashboard"
                   }
                ],
@@ -234,7 +234,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "histogram_quantile(0.99, sum(rate(http_request_duration_seconds_bucket{namespace=\"$namespace\",job=~\"thanos-querier.*\",handler=\"query\"}[$interval])) by (job, le))",
+                     "expr": "histogram_quantile(0.99, sum(rate(http_request_duration_seconds_bucket{namespace=\"$namespace\",job=~\"thanos-query.*\",handler=\"query\"}[$interval])) by (job, le))",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{job}} P99",
@@ -337,10 +337,10 @@
                "linewidth": 0,
                "links": [
                   {
-                     "dashboard": "Thanos / Querier",
+                     "dashboard": "Thanos / Query",
                      "includeVars": true,
                      "keepTime": true,
-                     "title": "Thanos / Querier",
+                     "title": "Thanos / Query",
                      "type": "dashboard"
                   }
                ],
@@ -356,7 +356,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "sum(label_replace(rate(http_requests_total{namespace=\"$namespace\",job=~\"thanos-querier.*\",handler=\"query_range\"}[$interval]),\"status_code\", \"${1}xx\", \"code\", \"([0-9])..\")) by (job, status_code)",
+                     "expr": "sum(label_replace(rate(http_requests_total{namespace=\"$namespace\",job=~\"thanos-query.*\",handler=\"query_range\"}[$interval]),\"status_code\", \"${1}xx\", \"code\", \"([0-9])..\")) by (job, status_code)",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{job}} {{status_code}}",
@@ -424,10 +424,10 @@
                "linewidth": 0,
                "links": [
                   {
-                     "dashboard": "Thanos / Querier",
+                     "dashboard": "Thanos / Query",
                      "includeVars": true,
                      "keepTime": true,
-                     "title": "Thanos / Querier",
+                     "title": "Thanos / Query",
                      "type": "dashboard"
                   }
                ],
@@ -443,7 +443,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "sum(rate(http_requests_total{namespace=\"$namespace\",job=~\"thanos-querier.*\",handler=\"query_range\",code=~\"5..\"}[$interval])) / sum(rate(http_requests_total{namespace=\"$namespace\",job=~\"thanos-querier.*\",handler=\"query_range\"}[$interval]))",
+                     "expr": "sum(rate(http_requests_total{namespace=\"$namespace\",job=~\"thanos-query.*\",handler=\"query_range\",code=~\"5..\"}[$interval])) / sum(rate(http_requests_total{namespace=\"$namespace\",job=~\"thanos-query.*\",handler=\"query_range\"}[$interval]))",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "error",
@@ -509,10 +509,10 @@
                "linewidth": 1,
                "links": [
                   {
-                     "dashboard": "Thanos / Querier",
+                     "dashboard": "Thanos / Query",
                      "includeVars": true,
                      "keepTime": true,
-                     "title": "Thanos / Querier",
+                     "title": "Thanos / Query",
                      "type": "dashboard"
                   }
                ],
@@ -528,7 +528,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "histogram_quantile(0.99, sum(rate(http_request_duration_seconds_bucket{namespace=\"$namespace\",job=~\"thanos-querier.*\",handler=\"query_range\"}[$interval])) by (job, le))",
+                     "expr": "histogram_quantile(0.99, sum(rate(http_request_duration_seconds_bucket{namespace=\"$namespace\",job=~\"thanos-query.*\",handler=\"query_range\"}[$interval])) by (job, le))",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{job}} P99",
@@ -1241,10 +1241,10 @@
                "linewidth": 0,
                "links": [
                   {
-                     "dashboard": "Thanos / Receiver",
+                     "dashboard": "Thanos / Receive",
                      "includeVars": true,
                      "keepTime": true,
-                     "title": "Thanos / Receiver",
+                     "title": "Thanos / Receive",
                      "type": "dashboard"
                   }
                ],
@@ -1260,7 +1260,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "sum(label_replace(rate(http_requests_total{handler=\"receive\",namespace=\"$namespace\",job=~\"thanos-receiver.*\"}[$interval]),\"status_code\", \"${1}xx\", \"code\", \"([0-9])..\")) by (job, status_code)",
+                     "expr": "sum(label_replace(rate(http_requests_total{handler=\"receive\",namespace=\"$namespace\",job=~\"thanos-receive.*\"}[$interval]),\"status_code\", \"${1}xx\", \"code\", \"([0-9])..\")) by (job, status_code)",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{job}} {{status_code}}",
@@ -1328,10 +1328,10 @@
                "linewidth": 0,
                "links": [
                   {
-                     "dashboard": "Thanos / Receiver",
+                     "dashboard": "Thanos / Receive",
                      "includeVars": true,
                      "keepTime": true,
-                     "title": "Thanos / Receiver",
+                     "title": "Thanos / Receive",
                      "type": "dashboard"
                   }
                ],
@@ -1347,7 +1347,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "sum(rate(http_requests_total{handler=\"receive\",namespace=\"$namespace\",job=~\"thanos-receiver.*\",code=~\"5..\"}[$interval])) / sum(rate(http_requests_total{handler=\"receive\",namespace=\"$namespace\",job=~\"thanos-receiver.*\"}[$interval]))",
+                     "expr": "sum(rate(http_requests_total{handler=\"receive\",namespace=\"$namespace\",job=~\"thanos-receive.*\",code=~\"5..\"}[$interval])) / sum(rate(http_requests_total{handler=\"receive\",namespace=\"$namespace\",job=~\"thanos-receive.*\"}[$interval]))",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "error",
@@ -1413,10 +1413,10 @@
                "linewidth": 1,
                "links": [
                   {
-                     "dashboard": "Thanos / Receiver",
+                     "dashboard": "Thanos / Receive",
                      "includeVars": true,
                      "keepTime": true,
-                     "title": "Thanos / Receiver",
+                     "title": "Thanos / Receive",
                      "type": "dashboard"
                   }
                ],
@@ -1432,7 +1432,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "histogram_quantile(0.99, sum(rate(http_request_duration_seconds_bucket{handler=\"receive\",namespace=\"$namespace\",job=~\"thanos-receiver.*\"}[$interval])) by (job, le))",
+                     "expr": "histogram_quantile(0.99, sum(rate(http_request_duration_seconds_bucket{handler=\"receive\",namespace=\"$namespace\",job=~\"thanos-receive.*\"}[$interval])) by (job, le))",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{job}} P99",
@@ -1527,10 +1527,10 @@
                "linewidth": 0,
                "links": [
                   {
-                     "dashboard": "Thanos / Ruler",
+                     "dashboard": "Thanos / Rule",
                      "includeVars": true,
                      "keepTime": true,
-                     "title": "Thanos / Ruler",
+                     "title": "Thanos / Rule",
                      "type": "dashboard"
                   }
                ],
@@ -1546,7 +1546,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "sum(rate(thanos_alert_sender_alerts_sent_total{namespace=\"$namespace\",job=~\"thanos-ruler.*\"}[$interval])) by (job, alertmanager)",
+                     "expr": "sum(rate(thanos_alert_sender_alerts_sent_total{namespace=\"$namespace\",job=~\"thanos-rule.*\"}[$interval])) by (job, alertmanager)",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{job}} {{alertmanager}}",
@@ -1614,10 +1614,10 @@
                "linewidth": 0,
                "links": [
                   {
-                     "dashboard": "Thanos / Ruler",
+                     "dashboard": "Thanos / Rule",
                      "includeVars": true,
                      "keepTime": true,
-                     "title": "Thanos / Ruler",
+                     "title": "Thanos / Rule",
                      "type": "dashboard"
                   }
                ],
@@ -1633,7 +1633,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "sum(rate(thanos_alert_sender_errors_total{namespace=\"$namespace\",job=~\"thanos-ruler.*\"}[$interval])) / sum(rate(thanos_alert_sender_alerts_sent_total{namespace=\"$namespace\",job=~\"thanos-ruler.*\"}[$interval]))",
+                     "expr": "sum(rate(thanos_alert_sender_errors_total{namespace=\"$namespace\",job=~\"thanos-rule.*\"}[$interval])) / sum(rate(thanos_alert_sender_alerts_sent_total{namespace=\"$namespace\",job=~\"thanos-rule.*\"}[$interval]))",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "error",
@@ -1699,10 +1699,10 @@
                "linewidth": 1,
                "links": [
                   {
-                     "dashboard": "Thanos / Ruler",
+                     "dashboard": "Thanos / Rule",
                      "includeVars": true,
                      "keepTime": true,
-                     "title": "Thanos / Ruler",
+                     "title": "Thanos / Rule",
                      "type": "dashboard"
                   }
                ],
@@ -1718,7 +1718,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "histogram_quantile(0.99, sum(rate(thanos_alert_sender_latency_seconds_bucket{namespace=\"$namespace\",job=~\"thanos-ruler.*\"}[$interval])) by (job, le))",
+                     "expr": "histogram_quantile(0.99, sum(rate(thanos_alert_sender_latency_seconds_bucket{namespace=\"$namespace\",job=~\"thanos-rule.*\"}[$interval])) by (job, le))",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{job}} P99",
@@ -1813,10 +1813,10 @@
                "linewidth": 0,
                "links": [
                   {
-                     "dashboard": "Thanos / Compactor",
+                     "dashboard": "Thanos / Compact",
                      "includeVars": true,
                      "keepTime": true,
-                     "title": "Thanos / Compactor",
+                     "title": "Thanos / Compact",
                      "type": "dashboard"
                   }
                ],
@@ -1832,7 +1832,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "sum(rate(thanos_compact_group_compactions_total{namespace=\"$namespace\",job=~\"thanos-compactor.*\"}[$interval])) by (job)",
+                     "expr": "sum(rate(thanos_compact_group_compactions_total{namespace=\"$namespace\",job=~\"thanos-compact.*\"}[$interval])) by (job)",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "compaction {{job}}",
@@ -1900,10 +1900,10 @@
                "linewidth": 0,
                "links": [
                   {
-                     "dashboard": "Thanos / Compactor",
+                     "dashboard": "Thanos / Compact",
                      "includeVars": true,
                      "keepTime": true,
-                     "title": "Thanos / Compactor",
+                     "title": "Thanos / Compact",
                      "type": "dashboard"
                   }
                ],
@@ -1919,7 +1919,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "sum(rate(thanos_compact_group_compactions_failures_total{namespace=\"$namespace\",job=~\"thanos-compactor.*\"}[$interval])) / sum(rate(thanos_compact_group_compactions_total{namespace=\"$namespace\",job=~\"thanos-compactor.*\"}[$interval]))",
+                     "expr": "sum(rate(thanos_compact_group_compactions_failures_total{namespace=\"$namespace\",job=~\"thanos-compact.*\"}[$interval])) / sum(rate(thanos_compact_group_compactions_total{namespace=\"$namespace\",job=~\"thanos-compact.*\"}[$interval]))",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "error",
@@ -1968,7 +1968,7 @@
          "repeatIteration": null,
          "repeatRowId": null,
          "showTitle": true,
-         "title": "Compactor",
+         "title": "Compact",
          "titleSize": "h6"
       }
    ],

--- a/examples/dashboards/query.json
+++ b/examples/dashboards/query.json
@@ -2383,7 +2383,7 @@
             "useTags": false
          },
          {
-            "allValue": "thanos-querier.*",
+            "allValue": "thanos-query.*",
             "current": {
                "text": "all",
                "value": "$__all"
@@ -2395,7 +2395,7 @@
             "multi": false,
             "name": "job",
             "options": [ ],
-            "query": "label_values(up{namespace=\"$namespace\",job=~\"thanos-querier.*\"}, job)",
+            "query": "label_values(up{namespace=\"$namespace\",job=~\"thanos-query.*\"}, job)",
             "refresh": 1,
             "regex": "",
             "sort": 2,
@@ -2418,7 +2418,7 @@
             "multi": false,
             "name": "pod",
             "options": [ ],
-            "query": "label_values(kube_pod_info{namespace=\"$namespace\",created_by_name=~\"thanos-querier.*\"}, pod)",
+            "query": "label_values(kube_pod_info{namespace=\"$namespace\",created_by_name=~\"thanos-query.*\"}, pod)",
             "refresh": 1,
             "regex": "",
             "sort": 2,
@@ -2475,7 +2475,7 @@
       ]
    },
    "timezone": "",
-   "title": "Thanos / Querier",
-   "uid": "98fde97ddeaf2981041745f1f2ba68c2",
+   "title": "Thanos / Query",
+   "uid": "af36c91291a603f1d9fbdabdd127ac4a",
    "version": 0
 }

--- a/examples/dashboards/receive.json
+++ b/examples/dashboards/receive.json
@@ -2238,7 +2238,7 @@
             "useTags": false
          },
          {
-            "allValue": "thanos-receiver.*",
+            "allValue": "thanos-receive.*",
             "current": {
                "text": "all",
                "value": "$__all"
@@ -2250,7 +2250,7 @@
             "multi": false,
             "name": "job",
             "options": [ ],
-            "query": "label_values(up{namespace=\"$namespace\",job=~\"thanos-receiver.*\"}, job)",
+            "query": "label_values(up{namespace=\"$namespace\",job=~\"thanos-receive.*\"}, job)",
             "refresh": 1,
             "regex": "",
             "sort": 2,
@@ -2273,7 +2273,7 @@
             "multi": false,
             "name": "pod",
             "options": [ ],
-            "query": "label_values(kube_pod_info{namespace=\"$namespace\",created_by_name=~\"thanos-receiver.*\"}, pod)",
+            "query": "label_values(kube_pod_info{namespace=\"$namespace\",created_by_name=~\"thanos-receive.*\"}, pod)",
             "refresh": 1,
             "regex": "",
             "sort": 2,
@@ -2330,7 +2330,7 @@
       ]
    },
    "timezone": "",
-   "title": "Thanos / Receiver",
-   "uid": "b5958da86b143e45752506d3c09c4f92",
+   "title": "Thanos / Receive",
+   "uid": "916a852b00ccc5ed81056644718fa4fb",
    "version": 0
 }

--- a/examples/dashboards/rule.json
+++ b/examples/dashboards/rule.json
@@ -19,8 +19,8 @@
                "dashLength": 10,
                "dashes": false,
                "datasource": "$datasource",
-               "description": "Shows rate of execution for compactions against blocks that are stored in the bucket by compaction group.",
-               "fill": 10,
+               "description": "Shows rate of dropped alerts.",
+               "fill": 1,
                "id": 1,
                "legend": {
                   "avg": false,
@@ -32,7 +32,7 @@
                   "values": false
                },
                "lines": true,
-               "linewidth": 0,
+               "linewidth": 1,
                "links": [ ],
                "nullPointMode": "null as zero",
                "percentage": false,
@@ -41,15 +41,15 @@
                "renderer": "flot",
                "seriesOverrides": [ ],
                "spaceLength": 10,
-               "span": 6,
-               "stack": true,
+               "span": 3,
+               "stack": false,
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "sum(rate(thanos_compact_group_compactions_total{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job, group)",
+                     "expr": "sum(rate(thanos_alert_sender_alerts_dropped_total{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job, alertmanager)",
                      "format": "time_series",
                      "intervalFactor": 2,
-                     "legendFormat": "compaction {{job}} {{group}}",
+                     "legendFormat": "{{job}} {{alertmanager}}",
                      "legendLink": null,
                      "step": 10
                   }
@@ -57,7 +57,7 @@
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "Rate",
+               "title": "Dropped Rate",
                "tooltip": {
                   "shared": false,
                   "sort": 0,
@@ -91,14 +91,12 @@
                ]
             },
             {
-               "aliasColors": {
-                  "error": "#E24D42"
-               },
+               "aliasColors": { },
                "bars": false,
                "dashLength": 10,
                "dashes": false,
                "datasource": "$datasource",
-               "description": "Shows ratio of errors compared to the total number of executed compactions against blocks that are stored in the bucket.",
+               "description": "Shows rate of alerts that successfully sent to alert manager.",
                "fill": 10,
                "id": 2,
                "legend": {
@@ -120,23 +118,23 @@
                "renderer": "flot",
                "seriesOverrides": [ ],
                "spaceLength": 10,
-               "span": 6,
+               "span": 3,
                "stack": true,
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "sum(rate(thanos_compact_group_compactions_failures_total{namespace=\"$namespace\",job=~\"$job\"}[$interval])) / sum(rate(thanos_compact_group_compactions_total{namespace=\"$namespace\",job=~\"$job\"}[$interval]))",
+                     "expr": "sum(rate(thanos_alert_sender_alerts_sent_total{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job, alertmanager)",
                      "format": "time_series",
                      "intervalFactor": 2,
-                     "legendFormat": "error",
-                     "refId": "A",
+                     "legendFormat": "{{job}} {{alertmanager}}",
+                     "legendLink": null,
                      "step": 10
                   }
                ],
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "Errors",
+               "title": "Sent Rate",
                "tooltip": {
                   "shared": false,
                   "sort": 0,
@@ -152,7 +150,7 @@
                },
                "yaxes": [
                   {
-                     "format": "percentunit",
+                     "format": "short",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -168,26 +166,16 @@
                      "show": false
                   }
                ]
-            }
-         ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Group Compaction",
-         "titleSize": "h6"
-      },
-      {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
+            },
             {
-               "aliasColors": { },
+               "aliasColors": {
+                  "error": "#E24D42"
+               },
                "bars": false,
                "dashLength": 10,
                "dashes": false,
                "datasource": "$datasource",
-               "description": "Shows rate of execution for downsampling against blocks that are stored in the bucket by compaction group.",
+               "description": "Shows ratio of errors compared to the total number of sent alerts.",
                "fill": 10,
                "id": 3,
                "legend": {
@@ -209,91 +197,12 @@
                "renderer": "flot",
                "seriesOverrides": [ ],
                "spaceLength": 10,
-               "span": 6,
+               "span": 3,
                "stack": true,
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "sum(rate(thanos_compact_downsample_total{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job, group)",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "downsample {{job}} {{group}}",
-                     "legendLink": null,
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Rate",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            },
-            {
-               "aliasColors": {
-                  "error": "#E24D42"
-               },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Shows ratio of errors compared to the total number of executed downsampling against blocks that are stored in the bucket.",
-               "fill": 10,
-               "id": 4,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 6,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(rate(thanos_compact_downsample_failed_total{namespace=\"$namespace\",job=~\"$job\"}[$interval])) / sum(rate(thanos_compact_downsample_total{namespace=\"$namespace\",job=~\"$job\"}[$interval]))",
+                     "expr": "sum(rate(thanos_alert_sender_errors_total{namespace=\"$namespace\",job=~\"$job\"}[$interval])) / sum(rate(thanos_alert_sender_alerts_sent_total{namespace=\"$namespace\",job=~\"$job\"}[$interval]))",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "error",
@@ -304,175 +213,7 @@
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "Errors",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "percentunit",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            }
-         ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Downsample",
-         "titleSize": "h6"
-      },
-      {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Shows rate of execution for removals of blocks if their data is available as part of a block with a higher compaction level.",
-               "fill": 10,
-               "id": 5,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(rate(thanos_compact_garbage_collection_total{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job)",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "garbage collection {{job}}",
-                     "legendLink": null,
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Rate",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            },
-            {
-               "aliasColors": {
-                  "error": "#E24D42"
-               },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Shows ratio of errors compared to the total number of executed garbage collections.",
-               "fill": 10,
-               "id": 6,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(rate(thanos_compact_garbage_collection_failures_total{namespace=\"$namespace\",job=~\"$job\"}[$interval])) / sum(rate(thanos_compact_garbage_collection_total{namespace=\"$namespace\",job=~\"$job\"}[$interval]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "error",
-                     "refId": "A",
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Errors",
+               "title": "Sent Errors",
                "tooltip": {
                   "shared": false,
                   "sort": 0,
@@ -511,9 +252,9 @@
                "dashLength": 10,
                "dashes": false,
                "datasource": "$datasource",
-               "description": "Shows how long has it taken to execute garbage collection in quantiles.",
+               "description": "Shows how long has it taken to send alerts to alert manager.",
                "fill": 1,
-               "id": 7,
+               "id": 4,
                "legend": {
                   "avg": false,
                   "current": false,
@@ -533,12 +274,12 @@
                "renderer": "flot",
                "seriesOverrides": [ ],
                "spaceLength": 10,
-               "span": 4,
+               "span": 3,
                "stack": false,
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "histogram_quantile(0.99, sum(rate(thanos_compact_garbage_collection_duration_seconds_bucket{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job, le)) * 1",
+                     "expr": "histogram_quantile(0.99, sum(rate(thanos_alert_sender_latency_seconds_bucket{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job, le)) * 1",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "P99 {{job}}",
@@ -546,7 +287,7 @@
                      "step": 10
                   },
                   {
-                     "expr": "sum(rate(thanos_compact_garbage_collection_duration_seconds_sum{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job) * 1 / sum(rate(thanos_compact_garbage_collection_duration_seconds_count{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job)",
+                     "expr": "sum(rate(thanos_alert_sender_latency_seconds_sum{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job) * 1 / sum(rate(thanos_alert_sender_latency_seconds_count{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job)",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "mean {{job}}",
@@ -554,7 +295,7 @@
                      "step": 10
                   },
                   {
-                     "expr": "histogram_quantile(0.50, sum(rate(thanos_compact_garbage_collection_duration_seconds_bucket{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job, le)) * 1",
+                     "expr": "histogram_quantile(0.50, sum(rate(thanos_alert_sender_latency_seconds_bucket{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job, le)) * 1",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "P50 {{job}}",
@@ -565,7 +306,7 @@
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "Duration",
+               "title": "Sent Duration",
                "tooltip": {
                   "shared": false,
                   "sort": 0,
@@ -603,7 +344,7 @@
          "repeatIteration": null,
          "repeatRowId": null,
          "showTitle": true,
-         "title": "Garbage Collection",
+         "title": "Alert Sent",
          "titleSize": "h6"
       },
       {
@@ -616,7 +357,273 @@
                "dashLength": 10,
                "dashes": false,
                "datasource": "$datasource",
-               "description": "Shows rate of execution for all meta files from blocks in the bucket into the memory.",
+               "description": "Shows rate of queued alerts.",
+               "fill": 1,
+               "id": 5,
+               "legend": {
+                  "avg": false,
+                  "current": false,
+                  "max": false,
+                  "min": false,
+                  "show": true,
+                  "total": false,
+                  "values": false
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null as zero",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "span": 6,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "sum(rate(thanos_alert_queue_alerts_dropped_total{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job, pod)",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{job}} {{pod}}",
+                     "legendLink": null,
+                     "step": 10
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Push Rate",
+               "tooltip": {
+                  "shared": false,
+                  "sort": 0,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": false
+                  }
+               ]
+            },
+            {
+               "aliasColors": {
+                  "error": "#E24D42"
+               },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$datasource",
+               "description": "Shows ratio of dropped alerts compared to the total number of queued alerts.",
+               "fill": 10,
+               "id": 6,
+               "legend": {
+                  "avg": false,
+                  "current": false,
+                  "max": false,
+                  "min": false,
+                  "show": true,
+                  "total": false,
+                  "values": false
+               },
+               "lines": true,
+               "linewidth": 0,
+               "links": [ ],
+               "nullPointMode": "null as zero",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "span": 6,
+               "stack": true,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "sum(rate(thanos_alert_queue_alerts_dropped_total{namespace=\"$namespace\",job=~\"$job\"}[$interval])) / sum(rate(thanos_alert_queue_alerts_pushed_total{namespace=\"$namespace\",job=~\"$job\"}[$interval]))",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "error",
+                     "refId": "A",
+                     "step": 10
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Drop Ratio",
+               "tooltip": {
+                  "shared": false,
+                  "sort": 0,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "percentunit",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": false
+                  }
+               ]
+            }
+         ],
+         "repeat": null,
+         "repeatIteration": null,
+         "repeatRowId": null,
+         "showTitle": true,
+         "title": "Alert Queue",
+         "titleSize": "h6"
+      },
+      {
+         "collapse": false,
+         "height": "250px",
+         "panels": [
+            {
+               "aliasColors": {
+                  "Aborted": "#EAB839",
+                  "AlreadyExists": "#7EB26D",
+                  "Canceled": "#E24D42",
+                  "DataLoss": "#E24D42",
+                  "DeadlineExceeded": "#E24D42",
+                  "FailedPrecondition": "#6ED0E0",
+                  "Internal": "#E24D42",
+                  "InvalidArgument": "#EF843C",
+                  "NotFound": "#EF843C",
+                  "OK": "#7EB26D",
+                  "OutOfRange": "#E24D42",
+                  "PermissionDenied": "#EF843C",
+                  "ResourceExhausted": "#E24D42",
+                  "Unauthenticated": "#EF843C",
+                  "Unavailable": "#E24D42",
+                  "Unimplemented": "#6ED0E0",
+                  "Unknown": "#E24D42",
+                  "error": "#E24D42"
+               },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$datasource",
+               "description": "Shows rate of handled Unary gRPC requests.",
+               "fill": 10,
+               "id": 7,
+               "legend": {
+                  "avg": false,
+                  "current": false,
+                  "max": false,
+                  "min": false,
+                  "show": true,
+                  "total": false,
+                  "values": false
+               },
+               "lines": true,
+               "linewidth": 0,
+               "links": [ ],
+               "nullPointMode": "null as zero",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "span": 4,
+               "stack": true,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "sum(rate(grpc_server_handled_total{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"unary\"}[$interval])) by (job, grpc_code)",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{job}} {{grpc_code}}",
+                     "refId": "A",
+                     "step": 10
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Rate",
+               "tooltip": {
+                  "shared": false,
+                  "sort": 0,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": false
+                  }
+               ]
+            },
+            {
+               "aliasColors": {
+                  "error": "#E24D42"
+               },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$datasource",
+               "description": "Shows ratio of errors compared to the total number of handled requests.",
                "fill": 10,
                "id": 8,
                "legend": {
@@ -643,86 +650,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "sum(rate(thanos_blocks_meta_syncs_total{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job)",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "sync {{job}}",
-                     "legendLink": null,
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Rate",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            },
-            {
-               "aliasColors": {
-                  "error": "#E24D42"
-               },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Shows ratio of errors compared to the total number of executed meta file sync.",
-               "fill": 10,
-               "id": 9,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(rate(thanos_blocks_meta_sync_failures_total{namespace=\"$namespace\",job=~\"$job\"}[$interval])) / sum(rate(thanos_blocks_meta_syncs_total{namespace=\"$namespace\",job=~\"$job\"}[$interval]))",
+                     "expr": "sum(rate(grpc_server_handled_total{grpc_code=~\"Unknown|ResourceExhausted|Internal|Unavailable\",namespace=\"$namespace\",job=~\"$job\",grpc_type=\"unary\"}[$interval])) / sum(rate(grpc_server_started_total{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"unary\"}[$interval]))",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "error",
@@ -772,9 +700,9 @@
                "dashLength": 10,
                "dashes": false,
                "datasource": "$datasource",
-               "description": "Shows how long has it taken to execute meta file sync, in quantiles.",
+               "description": "Shows how long has it taken to handle requests, in quantiles.",
                "fill": 1,
-               "id": 10,
+               "id": 9,
                "legend": {
                   "avg": false,
                   "current": false,
@@ -799,27 +727,27 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "histogram_quantile(0.99, sum(rate(thanos_blocks_meta_sync_duration_seconds_bucket{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job, le)) * 1",
+                     "expr": "histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"unary\"}[$interval])) by (job, le)) * 1",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "P99 {{job}}",
-                     "refId": "A",
+                     "legendLink": null,
                      "step": 10
                   },
                   {
-                     "expr": "sum(rate(thanos_blocks_meta_sync_duration_seconds_sum{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job) * 1 / sum(rate(thanos_blocks_meta_sync_duration_seconds_count{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job)",
+                     "expr": "sum(rate(grpc_server_handling_seconds_sum{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"unary\"}[$interval])) by (job) * 1\n/\nsum(rate(grpc_server_handling_seconds_count{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"unary\"}[$interval])) by (job)\n",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "mean {{job}}",
-                     "refId": "B",
+                     "legendLink": null,
                      "step": 10
                   },
                   {
-                     "expr": "histogram_quantile(0.50, sum(rate(thanos_blocks_meta_sync_duration_seconds_bucket{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job, le)) * 1",
+                     "expr": "histogram_quantile(0.50, sum(rate(grpc_server_handling_seconds_bucket{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"unary\"}[$interval])) by (job, le)) * 1",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "P50 {{job}}",
-                     "refId": "C",
+                     "legendLink": null,
                      "step": 10
                   }
                ],
@@ -864,11 +792,11 @@
          "repeatIteration": null,
          "repeatRowId": null,
          "showTitle": true,
-         "title": "Sync Meta",
+         "title": "gRPC (Unary)",
          "titleSize": "h6"
       },
       {
-         "collapse": false,
+         "collapse": true,
          "height": "250px",
          "panels": [
             {
@@ -877,7 +805,84 @@
                "dashLength": 10,
                "dashes": false,
                "datasource": "$datasource",
-               "description": "Shows rate of execution for operations against the bucket.",
+               "description": "Shows rate of handled Unary gRPC requests.",
+               "fill": 10,
+               "id": 10,
+               "legend": {
+                  "avg": false,
+                  "current": false,
+                  "max": false,
+                  "min": false,
+                  "show": true,
+                  "total": false,
+                  "values": false
+               },
+               "lines": true,
+               "linewidth": 0,
+               "links": [ ],
+               "nullPointMode": "null as zero",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "span": 4,
+               "stack": true,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "sum(rate(grpc_server_handled_total{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"unary\"}[$interval])) by (job, grpc_method, grpc_code)",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{job}} {{grpc_method}} {{grpc_code}}",
+                     "refId": "A",
+                     "step": 10
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Rate",
+               "tooltip": {
+                  "shared": false,
+                  "sort": 0,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": false
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$datasource",
+               "description": "Shows ratio of errors compared to the total number of handled requests.",
                "fill": 10,
                "id": 11,
                "legend": {
@@ -904,11 +909,212 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "sum(rate(thanos_objstore_bucket_operations_total{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job, operation)",
+                     "expr": "sum(rate(grpc_server_handled_total{grpc_code!=\"OK\",namespace=\"$namespace\",job=~\"$job\",grpc_type=\"unary\"}[$interval])) by (job, grpc_method, grpc_code)\n",
                      "format": "time_series",
                      "intervalFactor": 2,
-                     "legendFormat": "{{job}} {{operation}}",
+                     "legendFormat": "{{job}} {{grpc_method}} {{grpc_code}}",
                      "legendLink": null,
+                     "step": 10
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Errors",
+               "tooltip": {
+                  "shared": false,
+                  "sort": 0,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": false
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$datasource",
+               "description": "Shows how long has it taken to handle requests, in quantiles.",
+               "fill": 1,
+               "id": 12,
+               "legend": {
+                  "avg": false,
+                  "current": false,
+                  "max": false,
+                  "min": false,
+                  "show": true,
+                  "total": false,
+                  "values": false
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null as zero",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "span": 4,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"unary\"}[$interval])) by (job, grpc_method, le)) * 1",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "P99 {{job}} {{grpc_method}}",
+                     "legendLink": null,
+                     "step": 10
+                  },
+                  {
+                     "expr": "sum(rate(grpc_server_handling_seconds_sum{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"unary\"}[$interval])) by (job) * 1\n/\nsum(rate(grpc_server_handling_seconds_count{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"unary\"}[$interval])) by (job)\n",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "mean {{job}} {{grpc_method}}",
+                     "legendLink": null,
+                     "step": 10
+                  },
+                  {
+                     "expr": "histogram_quantile(0.50, sum(rate(grpc_server_handling_seconds_bucket{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"unary\"}[$interval])) by (job, grpc_method, le)) * 1",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "P50 {{job}} {{grpc_method}}",
+                     "legendLink": null,
+                     "step": 10
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Duration",
+               "tooltip": {
+                  "shared": false,
+                  "sort": 0,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "s",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": false
+                  }
+               ]
+            }
+         ],
+         "repeat": null,
+         "repeatIteration": null,
+         "repeatRowId": null,
+         "showTitle": true,
+         "title": "Detailed",
+         "titleSize": "h6"
+      },
+      {
+         "collapse": false,
+         "height": "250px",
+         "panels": [
+            {
+               "aliasColors": {
+                  "Aborted": "#EAB839",
+                  "AlreadyExists": "#7EB26D",
+                  "Canceled": "#E24D42",
+                  "DataLoss": "#E24D42",
+                  "DeadlineExceeded": "#E24D42",
+                  "FailedPrecondition": "#6ED0E0",
+                  "Internal": "#E24D42",
+                  "InvalidArgument": "#EF843C",
+                  "NotFound": "#EF843C",
+                  "OK": "#7EB26D",
+                  "OutOfRange": "#E24D42",
+                  "PermissionDenied": "#EF843C",
+                  "ResourceExhausted": "#E24D42",
+                  "Unauthenticated": "#EF843C",
+                  "Unavailable": "#E24D42",
+                  "Unimplemented": "#6ED0E0",
+                  "Unknown": "#E24D42",
+                  "error": "#E24D42"
+               },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$datasource",
+               "description": "Shows rate of handled Streamed gRPC requests.",
+               "fill": 10,
+               "id": 13,
+               "legend": {
+                  "avg": false,
+                  "current": false,
+                  "max": false,
+                  "min": false,
+                  "show": true,
+                  "total": false,
+                  "values": false
+               },
+               "lines": true,
+               "linewidth": 0,
+               "links": [ ],
+               "nullPointMode": "null as zero",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "span": 4,
+               "stack": true,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "sum(rate(grpc_server_handled_total{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"server_stream\"}[$interval])) by (job, grpc_code)",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{job}} {{grpc_code}}",
+                     "refId": "A",
                      "step": 10
                   }
                ],
@@ -956,9 +1162,9 @@
                "dashLength": 10,
                "dashes": false,
                "datasource": "$datasource",
-               "description": "Shows ratio of errors compared to the total number of executed operations against the bucket.",
+               "description": "Shows ratio of errors compared to the total number of handled requests.",
                "fill": 10,
-               "id": 12,
+               "id": 14,
                "legend": {
                   "avg": false,
                   "current": false,
@@ -983,7 +1189,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "sum(rate(thanos_objstore_bucket_operation_failures_total{namespace=\"$namespace\",job=~\"$job\"}[$interval])) / sum(rate(thanos_objstore_bucket_operations_total{namespace=\"$namespace\",job=~\"$job\"}[$interval]))",
+                     "expr": "sum(rate(grpc_server_handled_total{grpc_code=~\"Unknown|ResourceExhausted|Internal|Unavailable\",namespace=\"$namespace\",job=~\"$job\",grpc_type=\"server_stream\"}[$interval])) / sum(rate(grpc_server_started_total{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"server_stream\"}[$interval]))",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "error",
@@ -1033,9 +1239,9 @@
                "dashLength": 10,
                "dashes": false,
                "datasource": "$datasource",
-               "description": "Shows how long has it taken to execute operations against the bucket, in quantiles.",
+               "description": "Shows how long has it taken to handle requests, in quantiles",
                "fill": 1,
-               "id": 13,
+               "id": 15,
                "legend": {
                   "avg": false,
                   "current": false,
@@ -1060,27 +1266,27 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "histogram_quantile(0.99, sum(rate(thanos_objstore_bucket_operation_duration_seconds_bucket{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job, le)) * 1",
+                     "expr": "histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"server_stream\"}[$interval])) by (job, le)) * 1",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "P99 {{job}}",
-                     "refId": "A",
+                     "legendLink": null,
                      "step": 10
                   },
                   {
-                     "expr": "sum(rate(thanos_objstore_bucket_operation_duration_seconds_sum{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job) * 1 / sum(rate(thanos_objstore_bucket_operation_duration_seconds_count{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job)",
+                     "expr": "sum(rate(grpc_server_handling_seconds_sum{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"server_stream\"}[$interval])) by (job) * 1\n/\nsum(rate(grpc_server_handling_seconds_count{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"server_stream\"}[$interval])) by (job)\n",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "mean {{job}}",
-                     "refId": "B",
+                     "legendLink": null,
                      "step": 10
                   },
                   {
-                     "expr": "histogram_quantile(0.50, sum(rate(thanos_objstore_bucket_operation_duration_seconds_bucket{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job, le)) * 1",
+                     "expr": "histogram_quantile(0.50, sum(rate(grpc_server_handling_seconds_bucket{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"server_stream\"}[$interval])) by (job, le)) * 1",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "P50 {{job}}",
-                     "refId": "C",
+                     "legendLink": null,
                      "step": 10
                   }
                ],
@@ -1125,7 +1331,266 @@
          "repeatIteration": null,
          "repeatRowId": null,
          "showTitle": true,
-         "title": "Object Store Operations",
+         "title": "gRPC (Stream)",
+         "titleSize": "h6"
+      },
+      {
+         "collapse": true,
+         "height": "250px",
+         "panels": [
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$datasource",
+               "description": "Shows rate of handled Streamed gRPC requests.",
+               "fill": 10,
+               "id": 16,
+               "legend": {
+                  "avg": false,
+                  "current": false,
+                  "max": false,
+                  "min": false,
+                  "show": true,
+                  "total": false,
+                  "values": false
+               },
+               "lines": true,
+               "linewidth": 0,
+               "links": [ ],
+               "nullPointMode": "null as zero",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "span": 4,
+               "stack": true,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "sum(rate(grpc_server_handled_total{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"server_stream\"}[$interval])) by (job, grpc_method, grpc_code)",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{job}} {{grpc_method}} {{grpc_code}}",
+                     "refId": "A",
+                     "step": 10
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Rate",
+               "tooltip": {
+                  "shared": false,
+                  "sort": 0,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": false
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$datasource",
+               "description": "Shows ratio of errors compared to the total number of handled requests.",
+               "fill": 10,
+               "id": 17,
+               "legend": {
+                  "avg": false,
+                  "current": false,
+                  "max": false,
+                  "min": false,
+                  "show": true,
+                  "total": false,
+                  "values": false
+               },
+               "lines": true,
+               "linewidth": 0,
+               "links": [ ],
+               "nullPointMode": "null as zero",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "span": 4,
+               "stack": true,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "sum(rate(grpc_server_handled_total{grpc_code!=\"OK\",namespace=\"$namespace\",job=~\"$job\",grpc_type=\"server_stream\"}[$interval])) by (job, grpc_method, grpc_code)\n",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{job}} {{grpc_method}} {{grpc_code}}",
+                     "legendLink": null,
+                     "step": 10
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Errors",
+               "tooltip": {
+                  "shared": false,
+                  "sort": 0,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": false
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$datasource",
+               "description": "Shows how long has it taken to handle requests, in quantiles",
+               "fill": 1,
+               "id": 18,
+               "legend": {
+                  "avg": false,
+                  "current": false,
+                  "max": false,
+                  "min": false,
+                  "show": true,
+                  "total": false,
+                  "values": false
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null as zero",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "span": 4,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"server_stream\"}[$interval])) by (job, grpc_method, le)) * 1",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "P99 {{job}} {{grpc_method}}",
+                     "legendLink": null,
+                     "step": 10
+                  },
+                  {
+                     "expr": "sum(rate(grpc_server_handling_seconds_sum{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"server_stream\"}[$interval])) by (job) * 1\n/\nsum(rate(grpc_server_handling_seconds_count{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"server_stream\"}[$interval])) by (job)\n",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "mean {{job}} {{grpc_method}}",
+                     "legendLink": null,
+                     "step": 10
+                  },
+                  {
+                     "expr": "histogram_quantile(0.50, sum(rate(grpc_server_handling_seconds_bucket{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"server_stream\"}[$interval])) by (job, grpc_method, le)) * 1",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "P50 {{job}} {{grpc_method}}",
+                     "legendLink": null,
+                     "step": 10
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Duration",
+               "tooltip": {
+                  "shared": false,
+                  "sort": 0,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "s",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": false
+                  }
+               ]
+            }
+         ],
+         "repeat": null,
+         "repeatIteration": null,
+         "repeatRowId": null,
+         "showTitle": true,
+         "title": "Detailed",
          "titleSize": "h6"
       },
       {
@@ -1139,7 +1604,7 @@
                "dashes": false,
                "datasource": "$datasource",
                "fill": 1,
-               "id": 14,
+               "id": 19,
                "legend": {
                   "avg": false,
                   "current": false,
@@ -1255,7 +1720,7 @@
                "dashes": false,
                "datasource": "$datasource",
                "fill": 1,
-               "id": 15,
+               "id": 20,
                "legend": {
                   "avg": false,
                   "current": false,
@@ -1331,7 +1796,7 @@
                "dashes": false,
                "datasource": "$datasource",
                "fill": 1,
-               "id": 16,
+               "id": 21,
                "legend": {
                   "avg": false,
                   "current": false,
@@ -1451,7 +1916,7 @@
             "useTags": false
          },
          {
-            "allValue": "thanos-compactor.*",
+            "allValue": "thanos-rule.*",
             "current": {
                "text": "all",
                "value": "$__all"
@@ -1463,7 +1928,7 @@
             "multi": false,
             "name": "job",
             "options": [ ],
-            "query": "label_values(up{namespace=\"$namespace\",job=~\"thanos-compactor.*\"}, job)",
+            "query": "label_values(up{namespace=\"$namespace\",job=~\"thanos-rule.*\"}, job)",
             "refresh": 1,
             "regex": "",
             "sort": 2,
@@ -1486,7 +1951,7 @@
             "multi": false,
             "name": "pod",
             "options": [ ],
-            "query": "label_values(kube_pod_info{namespace=\"$namespace\",created_by_name=~\"thanos-compactor.*\"}, pod)",
+            "query": "label_values(kube_pod_info{namespace=\"$namespace\",created_by_name=~\"thanos-rule.*\"}, pod)",
             "refresh": 1,
             "regex": "",
             "sort": 2,
@@ -1543,7 +2008,7 @@
       ]
    },
    "timezone": "",
-   "title": "Thanos / Compactor",
-   "uid": "8378cc7f803b0bfae5809a101991ed76",
+   "title": "Thanos / Rule",
+   "uid": "35da848f5f92b2dc612e0c3a0577b8a1",
    "version": 0
 }

--- a/mixin/thanos/README.md
+++ b/mixin/thanos/README.md
@@ -59,30 +59,30 @@ This project is intended to be used as a library. You can extend and customize d
 [embedmd]:# (defaults.libsonnet)
 ```libsonnet
 {
-  querier+:: {
-    jobPrefix: 'thanos-querier',
+  query+:: {
+    jobPrefix: 'thanos-query',
     selector: 'job=~"%s.*"' % self.jobPrefix,
-    title: '%(prefix)sQuerier' % $.dashboard.prefix,
+    title: '%(prefix)sQuery' % $.dashboard.prefix,
   },
   store+:: {
     jobPrefix: 'thanos-store',
     selector: 'job=~"%s.*"' % self.jobPrefix,
     title: '%(prefix)sStore' % $.dashboard.prefix,
   },
-  receiver+:: {
-    jobPrefix: 'thanos-receiver',
+  receive+:: {
+    jobPrefix: 'thanos-receive',
     selector: 'job=~"%s.*"' % self.jobPrefix,
-    title: '%(prefix)sReceiver' % $.dashboard.prefix,
+    title: '%(prefix)sReceive' % $.dashboard.prefix,
   },
-  ruler+:: {
-    jobPrefix: 'thanos-ruler',
+  rule+:: {
+    jobPrefix: 'thanos-rule',
     selector: 'job=~"%s.*"' % self.jobPrefix,
-    title: '%(prefix)sRuler' % $.dashboard.prefix,
+    title: '%(prefix)sRule' % $.dashboard.prefix,
   },
-  compactor+:: {
-    jobPrefix: 'thanos-compactor',
+  compact+:: {
+    jobPrefix: 'thanos-compact',
     selector: 'job=~"%s.*"' % self.jobPrefix,
-    title: '%(prefix)sCompactor' % $.dashboard.prefix,
+    title: '%(prefix)sCompact' % $.dashboard.prefix,
   },
   sidecar+:: {
     jobPrefix: 'thanos-sidecar',

--- a/mixin/thanos/alerts/absent.libsonnet
+++ b/mixin/thanos/alerts/absent.libsonnet
@@ -3,11 +3,11 @@
 
   // We build alerts for the presence of all these jobs.
   jobs:: {
-    ThanosQuerier: thanos.querier.selector,
+    ThanosQuery: thanos.query.selector,
     ThanosStore: thanos.store.selector,
-    ThanosReceiver: thanos.receiver.selector,
-    ThanosRuler: thanos.ruler.selector,
-    ThanosCompactor: thanos.compactor.selector,
+    ThanosReceive: thanos.receive.selector,
+    ThanosRule: thanos.rule.selector,
+    ThanosCompact: thanos.compact.selector,
     ThanosSidecar: thanos.sidecar.selector,
   },
 

--- a/mixin/thanos/alerts/alerts.libsonnet
+++ b/mixin/thanos/alerts/alerts.libsonnet
@@ -1,7 +1,7 @@
-(import 'compactor.libsonnet') +
-(import 'querier.libsonnet') +
-(import 'receiver.libsonnet') +
+(import 'compact.libsonnet') +
+(import 'query.libsonnet') +
+(import 'receive.libsonnet') +
 (import 'sidecar.libsonnet') +
 (import 'store.libsonnet') +
-(import 'ruler.libsonnet') +
+(import 'rule.libsonnet') +
 (import 'absent.libsonnet')

--- a/mixin/thanos/alerts/compact.libsonnet
+++ b/mixin/thanos/alerts/compact.libsonnet
@@ -1,40 +1,40 @@
 {
   local thanos = self,
-  compactor+:: {
-    jobPrefix: error 'must provide job prefix for Thanos Compactor alerts',
-    selector: error 'must provide selector for Thanos Compactor alerts',
+  compact+:: {
+    jobPrefix: error 'must provide job prefix for Thanos Compact alerts',
+    selector: error 'must provide selector for Thanos Compact alerts',
   },
   prometheusAlerts+:: {
     groups+: [
       {
-        name: 'thanos-compactor.rules',
+        name: 'thanos-compact.rules',
         rules: [
           {
-            alert: 'ThanosCompactorMultipleCompactorsAreRunning',
+            alert: 'ThanosCompactMultipleRunning',
             annotations: {
-              message: 'You should never run more than one Thanos Compactor at once. You have {{ $value }}',
+              message: 'No more than one Thanos Compact instance should be running at once. There are {{ $value }}',
             },
-            expr: 'sum(up{%(selector)s}) > 1' % thanos.compactor,
+            expr: 'sum(up{%(selector)s}) > 1' % thanos.compact,
             'for': '5m',
             labels: {
               severity: 'warning',
             },
           },
           {
-            alert: 'ThanosCompactorHalted',
+            alert: 'ThanosCompactHalted',
             annotations: {
-              message: 'Thanos Compactor {{$labels.job}} has failed to run and now is halted.',
+              message: 'Thanos Compact {{$labels.job}} has failed to run and now is halted.',
             },
-            expr: 'thanos_compactor_halted{%(selector)s} == 1' % thanos.compactor,
+            expr: 'thanos_compactor_halted{%(selector)s} == 1' % thanos.compact,
             'for': '5m',
             labels: {
               severity: 'warning',
             },
           },
           {
-            alert: 'ThanosCompactorHighCompactionFailures',
+            alert: 'ThanosCompactHighCompactionFailures',
             annotations: {
-              message: 'Thanos Compactor {{$labels.job}} is failing to execute {{ $value | humanize }}% of compactions.',
+              message: 'Thanos Compact {{$labels.job}} is failing to execute {{ $value | humanize }}% of compactions.',
             },
             expr: |||
               (
@@ -43,16 +43,16 @@
                 sum by (job) (rate(thanos_compact_group_compactions_total{%(selector)s}[5m]))
               * 100 > 5
               )
-            ||| % thanos.compactor,
+            ||| % thanos.compact,
             'for': '15m',
             labels: {
               severity: 'warning',
             },
           },
           {
-            alert: 'ThanosCompactorBucketHighOperationFailures',
+            alert: 'ThanosCompactBucketHighOperationFailures',
             annotations: {
-              message: 'Thanos Compactor {{$labels.job}} Bucket is failing to execute {{ $value | humanize }}% of operations.',
+              message: 'Thanos Compact {{$labels.job}} Bucket is failing to execute {{ $value | humanize }}% of operations.',
             },
             expr: |||
               (
@@ -61,18 +61,18 @@
                 sum by (job) (rate(thanos_objstore_bucket_operations_total{%(selector)s}[5m]))
               * 100 > 5
               )
-            ||| % thanos.compactor,
+            ||| % thanos.compact,
             'for': '15m',
             labels: {
               severity: 'warning',
             },
           },
           {
-            alert: 'ThanosCompactorHasNotRun',
+            alert: 'ThanosCompactHasNotRun',
             annotations: {
-              message: 'Thanos Compactor {{$labels.job}} has not uploaded anything for 24 hours.',
+              message: 'Thanos Compact {{$labels.job}} has not uploaded anything for 24 hours.',
             },
-            expr: '(time() - max(thanos_objstore_bucket_last_successful_upload_time{%(selector)s})) / 60 / 60 > 24' % thanos.compactor,
+            expr: '(time() - max(thanos_objstore_bucket_last_successful_upload_time{%(selector)s})) / 60 / 60 > 24' % thanos.compact,
             labels: {
               severity: 'warning',
             },

--- a/mixin/thanos/alerts/query.libsonnet
+++ b/mixin/thanos/alerts/query.libsonnet
@@ -1,18 +1,18 @@
 {
   local thanos = self,
-  querier+:: {
+  query+:: {
     jobPrefix: error 'must provide job prefix for Thanos Query alerts',
     selector: error 'must provide selector for Thanos Query alerts',
   },
   prometheusAlerts+:: {
     groups+: [
       {
-        name: 'thanos-querier.rules',
+        name: 'thanos-query.rules',
         rules: [
           {
-            alert: 'ThanosQuerierHttpRequestQueryErrorRateHigh',
+            alert: 'ThanosQueryHttpRequestQueryErrorRateHigh',
             annotations: {
-              message: 'Thanos Querier {{$labels.job}} is failing to handle {{ $value | humanize }}% of "query" requests.',
+              message: 'Thanos Query {{$labels.job}} is failing to handle {{ $value | humanize }}% of "query" requests.',
             },
             expr: |||
               (
@@ -20,16 +20,16 @@
               /
                 sum(rate(http_requests_total{%(selector)s, handler="query"}[5m]))
               ) * 100 > 5
-            ||| % thanos.querier,
+            ||| % thanos.query,
             'for': '5m',
             labels: {
               severity: 'critical',
             },
           },
           {
-            alert: 'ThanosQuerierHttpRequestQueryRangeErrorRateHigh',
+            alert: 'ThanosQueryHttpRequestQueryRangeErrorRateHigh',
             annotations: {
-              message: 'Thanos Querier {{$labels.job}} is failing to handle {{ $value | humanize }}% of "query_range" requests.',
+              message: 'Thanos Query {{$labels.job}} is failing to handle {{ $value | humanize }}% of "query_range" requests.',
             },
             expr: |||
               (
@@ -37,16 +37,16 @@
               /
                 sum(rate(http_requests_total{%(selector)s, handler="query_range"}[5m]))
               ) * 100 > 5
-            ||| % thanos.querier,
+            ||| % thanos.query,
             'for': '5m',
             labels: {
               severity: 'critical',
             },
           },
           {
-            alert: 'ThanosQuerierGrpcServerErrorRate',
+            alert: 'ThanosQueryGrpcServerErrorRate',
             annotations: {
-              message: 'Thanos Querier {{$labels.job}} is failing to handle {{ $value | humanize }}% of requests.',
+              message: 'Thanos Query {{$labels.job}} is failing to handle {{ $value | humanize }}% of requests.',
             },
             expr: |||
               (
@@ -55,16 +55,16 @@
                 sum by (job) (rate(grpc_server_started_total{%(selector)s}[5m]))
               * 100 > 5
               )
-            ||| % thanos.querier,
+            ||| % thanos.query,
             'for': '5m',
             labels: {
               severity: 'warning',
             },
           },
           {
-            alert: 'ThanosQuerierGrpcClientErrorRate',
+            alert: 'ThanosQueryGrpcClientErrorRate',
             annotations: {
-              message: 'Thanos Querier {{$labels.job}} is failing to send {{ $value | humanize }}% of requests.',
+              message: 'Thanos Query {{$labels.job}} is failing to send {{ $value | humanize }}% of requests.',
             },
             expr: |||
               (
@@ -72,16 +72,16 @@
               /
                 sum by (job) (rate(grpc_client_started_total{%(selector)s}[5m]))
               ) * 100 > 5
-            ||| % thanos.querier,
+            ||| % thanos.query,
             'for': '5m',
             labels: {
               severity: 'warning',
             },
           },
           {
-            alert: 'ThanosQuerierHighDNSFailures',
+            alert: 'ThanosQueryHighDNSFailures',
             annotations: {
-              message: 'Thanos Queriers {{$labels.job}} have {{ $value | humanize }}% of failing DNS queries for store endpoints.',
+              message: 'Thanos Query {{$labels.job}} have {{ $value | humanize }}% of failing DNS queries for store endpoints.',
             },
             expr: |||
               (
@@ -89,16 +89,16 @@
               /
                 sum by (job) (rate(thanos_querier_store_apis_dns_lookups_total{%(selector)s}[5m]))
               ) * 100 > 1
-            ||| % thanos.querier,
+            ||| % thanos.query,
             'for': '15m',
             labels: {
               severity: 'warning',
             },
           },
           {
-            alert: 'ThanosQuerierInstantLatencyHigh',
+            alert: 'ThanosQueryInstantLatencyHigh',
             annotations: {
-              message: 'Thanos Querier {{$labels.job}} has a 99th percentile latency of {{ $value }} seconds for instant queries.',
+              message: 'Thanos Query {{$labels.job}} has a 99th percentile latency of {{ $value }} seconds for instant queries.',
             },
             expr: |||
               (
@@ -106,16 +106,16 @@
               and
                 sum by (job) (rate(http_request_duration_seconds_bucket{%(selector)s, handler="query"}[5m])) > 0
               )
-            ||| % thanos.querier,
+            ||| % thanos.query,
             'for': '10m',
             labels: {
               severity: 'critical',
             },
           },
           {
-            alert: 'ThanosQuerierRangeLatencyHigh',
+            alert: 'ThanosQueryRangeLatencyHigh',
             annotations: {
-              message: 'Thanos Querier {{$labels.job}} has a 99th percentile latency of {{ $value }} seconds for instant queries.',
+              message: 'Thanos Query {{$labels.job}} has a 99th percentile latency of {{ $value }} seconds for instant queries.',
             },
             expr: |||
               (
@@ -123,7 +123,7 @@
               and
                 sum by (job) (rate(http_request_duration_seconds_count{%(selector)s, handler="query_range"}[5m])) > 0
               )
-            ||| % thanos.querier,
+            ||| % thanos.query,
             'for': '10m',
             labels: {
               severity: 'critical',

--- a/mixin/thanos/alerts/receive.libsonnet
+++ b/mixin/thanos/alerts/receive.libsonnet
@@ -1,16 +1,16 @@
 {
   local thanos = self,
-  receiver+:: {
+  receive+:: {
     jobPrefix: error 'must provide job prefix for Thanos Receive alerts',
     selector: error 'must provide selector for Thanos Receive alerts',
   },
   prometheusAlerts+:: {
     groups+: [
       {
-        name: 'thanos-receiver.rules',
+        name: 'thanos-receive.rules',
         rules: [
           {
-            alert: 'ThanosReceiverHttpRequestErrorRateHigh',
+            alert: 'ThanosReceiveHttpRequestErrorRateHigh',
             annotations: {
               message: 'Thanos Receive {{$labels.job}} is failing to handle {{ $value | humanize }}% of requests.',
             },
@@ -20,14 +20,14 @@
               /
                 sum(rate(http_requests_total{%(selector)s, handler="receive"}[5m]))
               ) * 100 > 5
-            ||| % thanos.receiver,
+            ||| % thanos.receive,
             'for': '5m',
             labels: {
               severity: 'critical',
             },
           },
           {
-            alert: 'ThanosReceiverHttpRequestLatencyHigh',
+            alert: 'ThanosReceiveHttpRequestLatencyHigh',
             annotations: {
               message: 'Thanos Receive {{$labels.job}} has a 99th percentile latency of {{ $value }} seconds for requests.',
             },
@@ -37,14 +37,14 @@
               and
                 sum by (job) (rate(http_request_duration_seconds_count{%(selector)s, handler="receive"}[5m])) > 0
               )
-            ||| % thanos.receiver,
+            ||| % thanos.receive,
             'for': '10m',
             labels: {
               severity: 'critical',
             },
           },
           {
-            alert: 'ThanosReceiverHighForwardRequestFailures',
+            alert: 'ThanosReceiveHighForwardRequestFailures',
             annotations: {
               message: 'Thanos Receive {{$labels.job}} is failing to forward {{ $value | humanize }}% of requests.',
             },
@@ -55,14 +55,14 @@
                 sum by (job) (rate(thanos_receive_forward_requests_total{%(selector)s}[5m]))
               * 100 > 5
               )
-            ||| % thanos.receiver,
+            ||| % thanos.receive,
             'for': '5m',
             labels: {
               severity: 'critical',
             },
           },
           {
-            alert: 'ThanosReceiverHighHashringFileRefreshFailures',
+            alert: 'ThanosReceiveHighHashringFileRefreshFailures',
             annotations: {
               message: 'Thanos Receive {{$labels.job}} is failing to refresh hashring file, {{ $value | humanize }} of attempts failed.',
             },
@@ -73,18 +73,18 @@
                 sum by (job) (rate(thanos_receive_hashrings_file_refreshes_total{%(selector)s}[5m]))
               > 0
               )
-            ||| % thanos.receiver,
+            ||| % thanos.receive,
             'for': '15m',
             labels: {
               severity: 'warning',
             },
           },
           {
-            alert: 'ThanosReceiverConfigReloadFailure',
+            alert: 'ThanosReceiveConfigReloadFailure',
             annotations: {
               message: 'Thanos Receive {{$labels.job}} has not been able to reload hashring configurations.',
             },
-            expr: 'avg(thanos_receive_config_last_reload_successful{%(selector)s}) by (job) != 1' % thanos.receiver,
+            expr: 'avg(thanos_receive_config_last_reload_successful{%(selector)s}) by (job) != 1' % thanos.receive,
             'for': '5m',
             labels: {
               severity: 'warning',

--- a/mixin/thanos/alerts/rule.libsonnet
+++ b/mixin/thanos/alerts/rule.libsonnet
@@ -1,44 +1,44 @@
 {
   local thanos = self,
-  ruler+:: {
-    jobPrefix: error 'must provide job prefix for Thanos Ruler alerts',
-    selector: error 'must provide selector for Thanos Ruler alerts',
+  rule+:: {
+    jobPrefix: error 'must provide job prefix for Thanos Rule alerts',
+    selector: error 'must provide selector for Thanos Rule alerts',
   },
   prometheusAlerts+:: {
     groups+: [
       {
-        name: 'thanos-ruler.rules',
+        name: 'thanos-rule.rules',
         rules: [
           {
-            alert: 'ThanosRulerQueueIsDroppingAlerts',
+            alert: 'ThanosRuleQueueIsDroppingAlerts',
             annotations: {
-              message: 'Thanos Ruler {{$labels.job}} {{$labels.pod}} is failing to queue alerts.',
+              message: 'Thanos Rule {{$labels.job}} {{$labels.pod}} is failing to queue alerts.',
             },
             expr: |||
               sum by (job) (rate(thanos_alert_queue_alerts_dropped_total{%(selector)s}[5m])) > 0
-            ||| % thanos.ruler,
+            ||| % thanos.rule,
             'for': '5m',
             labels: {
               severity: 'critical',
             },
           },
           {
-            alert: 'ThanosRulerSenderIsFailingAlerts',
+            alert: 'ThanosRuleSenderIsFailingAlerts',
             annotations: {
-              message: 'Thanos Ruler {{$labels.job}} {{$labels.pod}} is failing to send alerts to alertmanager.',
+              message: 'Thanos Rule {{$labels.job}} {{$labels.pod}} is failing to send alerts to alertmanager.',
             },
             expr: |||
               sum by (job) (rate(thanos_alert_sender_alerts_dropped_total{%(selector)s}[5m])) > 0
-            ||| % thanos.ruler,
+            ||| % thanos.rule,
             'for': '5m',
             labels: {
               severity: 'critical',
             },
           },
           {
-            alert: 'ThanosRulerHighRuleEvaluationFailures',
+            alert: 'ThanosRuleHighRuleEvaluationFailures',
             annotations: {
-              message: 'Thanos Ruler {{$labels.job}} {{$labels.pod}} is failing to evaluate rules.',
+              message: 'Thanos Rule {{$labels.job}} {{$labels.pod}} is failing to evaluate rules.',
             },
             expr: |||
               (
@@ -47,7 +47,7 @@
                 sum by (job) (rate(prometheus_rule_evaluations_total{%(selector)s}[5m]))
               * 100 > 5
               )
-            ||| % thanos.ruler,
+            ||| % thanos.rule,
 
             'for': '5m',
             labels: {
@@ -55,13 +55,13 @@
             },
           },
           {
-            alert: 'ThanosRulerHighRuleEvaluationWarnings',
+            alert: 'ThanosRuleHighRuleEvaluationWarnings',
             annotations: {
-              message: 'Thanos Ruler {{$labels.job}} {{$labels.pod}} has high number of evaluation warnings.',
+              message: 'Thanos Rule {{$labels.job}} {{$labels.pod}} has high number of evaluation warnings.',
             },
             expr: |||
               sum by (job) (rate(thanos_rule_evaluation_with_warnings_total{%(selector)s}[5m])) > 0
-            ||| % thanos.ruler,
+            ||| % thanos.rule,
 
             'for': '15m',
             labels: {
@@ -69,9 +69,9 @@
             },
           },
           {
-            alert: 'ThanosRulerRuleEvaluationLatencyHigh',
+            alert: 'ThanosRuleRuleEvaluationLatencyHigh',
             annotations: {
-              message: 'Thanos Ruler {{$labels.job}}/{{$labels.pod}} has higher evaluation latency than interval for {{$labels.rule_group}}.',
+              message: 'Thanos Rule {{$labels.job}}/{{$labels.pod}} has higher evaluation latency than interval for {{$labels.rule_group}}.',
             },
             expr: |||
               (
@@ -79,16 +79,16 @@
               >
                 sum by (job, pod, rule_group) (prometheus_rule_group_interval_seconds{%(selector)s})
               )
-            ||| % thanos.ruler,
+            ||| % thanos.rule,
             'for': '5m',
             labels: {
               severity: 'warning',
             },
           },
           {
-            alert: 'ThanosRulerGrpcErrorRate',
+            alert: 'ThanosRuleGrpcErrorRate',
             annotations: {
-              message: 'Thanos Ruler {{$labels.job}} is failing to handle {{ $value | humanize }}% of requests.',
+              message: 'Thanos Rule {{$labels.job}} is failing to handle {{ $value | humanize }}% of requests.',
             },
             expr: |||
               (
@@ -97,27 +97,27 @@
                 sum by (job) (rate(grpc_server_started_total{%(selector)s}[5m]))
               * 100 > 5
               )
-            ||| % thanos.ruler,
+            ||| % thanos.rule,
             'for': '5m',
             labels: {
               severity: 'warning',
             },
           },
           {
-            alert: 'ThanosRulerConfigReloadFailure',
+            alert: 'ThanosRuleConfigReloadFailure',
             annotations: {
-              message: 'Thanos Ruler {{$labels.job}} has not been able to reload its configuration.',
+              message: 'Thanos Rule {{$labels.job}} has not been able to reload its configuration.',
             },
-            expr: 'avg(thanos_rule_config_last_reload_successful{%(selector)s}) by (job) != 1' % thanos.ruler,
+            expr: 'avg(thanos_rule_config_last_reload_successful{%(selector)s}) by (job) != 1' % thanos.rule,
             'for': '5m',
             labels: {
               severity: 'warning',
             },
           },
           {
-            alert: 'ThanosRulerQueryHighDNSFailures',
+            alert: 'ThanosRuleQueryHighDNSFailures',
             annotations: {
-              message: 'Thanos Ruler {{$labels.job}} have {{ $value | humanize }}% of failing DNS queries for query endpoints.',
+              message: 'Thanos Rule {{$labels.job}} have {{ $value | humanize }}% of failing DNS queries for query endpoints.',
             },
             expr: |||
               (
@@ -126,16 +126,16 @@
                 sum by (job) (rate(thanos_ruler_query_apis_dns_lookups_total{%(selector)s}[5m]))
               * 100 > 1
               )
-            ||| % thanos.ruler,
+            ||| % thanos.rule,
             'for': '15m',
             labels: {
               severity: 'warning',
             },
           },
           {
-            alert: 'ThanosRulerAlertmanagerHighDNSFailures',
+            alert: 'ThanosRuleAlertmanagerHighDNSFailures',
             annotations: {
-              message: 'Thanos Ruler {{$labels.job}} have {{ $value | humanize }}% of failing DNS queries for Alertmanager endpoints.',
+              message: 'Thanos Rule {{$labels.job}} have {{ $value | humanize }}% of failing DNS queries for Alertmanager endpoints.',
             },
             expr: |||
               (
@@ -144,7 +144,7 @@
                 sum by (job) (rate(thanos_ruler_alertmanagers_dns_lookups_total{%(selector)s}[5m]))
               * 100 > 1
               )
-            ||| % thanos.ruler,
+            ||| % thanos.rule,
             'for': '15m',
             labels: {
               severity: 'warning',

--- a/mixin/thanos/dashboards/compact.libsonnet
+++ b/mixin/thanos/dashboards/compact.libsonnet
@@ -2,14 +2,14 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
 
 {
   local thanos = self,
-  compactor+:: {
-    jobPrefix: error 'must provide job prefix for Thanos Compactor dashboard',
-    selector: error 'must provide selector for Thanos Compactor dashboard',
-    title: error 'must provide title for Thanos Compactor dashboard',
+  compact+:: {
+    jobPrefix: error 'must provide job prefix for Thanos Compact dashboard',
+    selector: error 'must provide selector for Thanos Compact dashboard',
+    title: error 'must provide title for Thanos Compact dashboard',
   },
   grafanaDashboards+:: {
-    'compactor.json':
-      g.dashboard(thanos.compactor.title)
+    'compact.json':
+      g.dashboard(thanos.compact.title)
       .addRow(
         g.row('Group Compaction')
         .addPanel(
@@ -131,22 +131,22 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
         g.resourceUtilizationRow()
       ) +
       g.template('namespace', thanos.dashboard.namespaceQuery) +
-      g.template('job', 'up', 'namespace="$namespace",%(selector)s' % thanos.compactor, true, '%(jobPrefix)s.*' % thanos.compactor) +
-      g.template('pod', 'kube_pod_info', 'namespace="$namespace",created_by_name=~"%(jobPrefix)s.*"' % thanos.compactor, true, '.*'),
+      g.template('job', 'up', 'namespace="$namespace",%(selector)s' % thanos.compact, true, '%(jobPrefix)s.*' % thanos.compact) +
+      g.template('pod', 'kube_pod_info', 'namespace="$namespace",created_by_name=~"%(jobPrefix)s.*"' % thanos.compact, true, '.*'),
 
     __overviewRows__+:: [
-      g.row('Compactor')
+      g.row('Compact')
       .addPanel(
         g.panel(
           'Compaction Rate',
           'Shows rate of execution for compactions against blocks that are stored in the bucket by compaction group.'
         ) +
         g.queryPanel(
-          'sum(rate(thanos_compact_group_compactions_total{namespace="$namespace",%(selector)s}[$interval])) by (job)' % thanos.compactor,
+          'sum(rate(thanos_compact_group_compactions_total{namespace="$namespace",%(selector)s}[$interval])) by (job)' % thanos.compact,
           'compaction {{job}}'
         ) +
         g.stack +
-        g.addDashboardLink(thanos.compactor.title)
+        g.addDashboardLink(thanos.compact.title)
       )
       .addPanel(
         g.panel(
@@ -154,10 +154,10 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
           'Shows ratio of errors compared to the total number of executed compactions against blocks that are stored in the bucket.'
         ) +
         g.qpsErrTotalPanel(
-          'thanos_compact_group_compactions_failures_total{namespace="$namespace",%(selector)s}' % thanos.compactor,
-          'thanos_compact_group_compactions_total{namespace="$namespace",%(selector)s}' % thanos.compactor,
+          'thanos_compact_group_compactions_failures_total{namespace="$namespace",%(selector)s}' % thanos.compact,
+          'thanos_compact_group_compactions_total{namespace="$namespace",%(selector)s}' % thanos.compact,
         ) +
-        g.addDashboardLink(thanos.compactor.title)
+        g.addDashboardLink(thanos.compact.title)
       ) +
       g.collapse,
     ],

--- a/mixin/thanos/dashboards/dashboards.libsonnet
+++ b/mixin/thanos/dashboards/dashboards.libsonnet
@@ -1,8 +1,8 @@
-(import 'querier.libsonnet') +
+(import 'query.libsonnet') +
 (import 'store.libsonnet') +
 (import 'sidecar.libsonnet') +
-(import 'receiver.libsonnet') +
-(import 'ruler.libsonnet') +
-(import 'compactor.libsonnet') +
+(import 'receive.libsonnet') +
+(import 'rule.libsonnet') +
+(import 'compact.libsonnet') +
 (import 'overview.libsonnet') +
 (import 'defaults.libsonnet')

--- a/mixin/thanos/dashboards/query.libsonnet
+++ b/mixin/thanos/dashboards/query.libsonnet
@@ -2,14 +2,14 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
 
 {
   local thanos = self,
-  querier+:: {
+  query+:: {
     jobPrefix: error 'must provide job prefix for Thanos Query dashboard',
     selector: error 'must provide selector for Thanos Query dashboard',
     title: error 'must provide title for Thanos Query dashboard',
   },
   grafanaDashboards+:: {
-    'querier.json':
-      g.dashboard(thanos.querier.title)
+    'query.json':
+      g.dashboard(thanos.query.title)
       .addRow(
         g.row('Instant Query API')
         .addPanel(
@@ -139,54 +139,54 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
         g.resourceUtilizationRow()
       ) +
       g.template('namespace', thanos.dashboard.namespaceQuery) +
-      g.template('job', 'up', 'namespace="$namespace",%(selector)s' % thanos.querier, true, '%(jobPrefix)s.*' % thanos.querier) +
-      g.template('pod', 'kube_pod_info', 'namespace="$namespace",created_by_name=~"%(jobPrefix)s.*"' % thanos.querier, true, '.*'),
+      g.template('job', 'up', 'namespace="$namespace",%(selector)s' % thanos.query, true, '%(jobPrefix)s.*' % thanos.query) +
+      g.template('pod', 'kube_pod_info', 'namespace="$namespace",created_by_name=~"%(jobPrefix)s.*"' % thanos.query, true, '.*'),
 
     __overviewRows__+:: [
       g.row('Instant Query')
       .addPanel(
         g.panel('Requests Rate', 'Shows rate of requests against /query for the given time.') +
-        g.httpQpsPanel('http_requests_total', 'namespace="$namespace",%(selector)s,handler="query"' % thanos.querier) +
-        g.addDashboardLink(thanos.querier.title)
+        g.httpQpsPanel('http_requests_total', 'namespace="$namespace",%(selector)s,handler="query"' % thanos.query) +
+        g.addDashboardLink(thanos.query.title)
       )
       .addPanel(
         g.panel('Requests Errors', 'Shows ratio of errors compared to the the total number of handled requests against /query.') +
-        g.httpErrPanel('http_requests_total', 'namespace="$namespace",%(selector)s,handler="query"' % thanos.querier) +
-        g.addDashboardLink(thanos.querier.title)
+        g.httpErrPanel('http_requests_total', 'namespace="$namespace",%(selector)s,handler="query"' % thanos.query) +
+        g.addDashboardLink(thanos.query.title)
       )
       .addPanel(
         g.sloLatency(
           'Latency 99th Percentile',
           'Shows how long has it taken to handle requests.',
-          'http_request_duration_seconds_bucket{namespace="$namespace",%(selector)s,handler="query"}' % thanos.querier,
+          'http_request_duration_seconds_bucket{namespace="$namespace",%(selector)s,handler="query"}' % thanos.query,
           0.99,
           0.5,
           1
         ) +
-        g.addDashboardLink(thanos.querier.title)
+        g.addDashboardLink(thanos.query.title)
       ),
 
       g.row('Range Query')
       .addPanel(
         g.panel('Requests Rate', 'Shows rate of requests against /query_range for the given time range.') +
-        g.httpQpsPanel('http_requests_total', 'namespace="$namespace",%(selector)s,handler="query_range"' % thanos.querier) +
-        g.addDashboardLink(thanos.querier.title)
+        g.httpQpsPanel('http_requests_total', 'namespace="$namespace",%(selector)s,handler="query_range"' % thanos.query) +
+        g.addDashboardLink(thanos.query.title)
       )
       .addPanel(
         g.panel('Requests Errors', 'Shows ratio of errors compared to the the total number of handled requests against /query_range.') +
-        g.httpErrPanel('http_requests_total', 'namespace="$namespace",%(selector)s,handler="query_range"' % thanos.querier) +
-        g.addDashboardLink(thanos.querier.title)
+        g.httpErrPanel('http_requests_total', 'namespace="$namespace",%(selector)s,handler="query_range"' % thanos.query) +
+        g.addDashboardLink(thanos.query.title)
       )
       .addPanel(
         g.sloLatency(
           'Latency 99th Percentile',
           'Shows how long has it taken to handle requests.',
-          'http_request_duration_seconds_bucket{namespace="$namespace",%(selector)s,handler="query_range"}' % thanos.querier,
+          'http_request_duration_seconds_bucket{namespace="$namespace",%(selector)s,handler="query_range"}' % thanos.query,
           0.99,
           0.5,
           1
         ) +
-        g.addDashboardLink(thanos.querier.title)
+        g.addDashboardLink(thanos.query.title)
       ),
     ],
   },

--- a/mixin/thanos/dashboards/receive.libsonnet
+++ b/mixin/thanos/dashboards/receive.libsonnet
@@ -2,14 +2,14 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
 
 {
   local thanos = self,
-  receiver+:: {
+  receive+:: {
     jobPrefix: error 'must provide job prefix for Thanos Receive dashboard',
     selector: error 'must provide selector for Thanos Receive dashboard',
     title: error 'must provide title for Thanos Receive dashboard',
   },
   grafanaDashboards+:: {
-    'receiver.json':
-      g.dashboard(thanos.receiver.title)
+    'receive.json':
+      g.dashboard(thanos.receive.title)
       .addRow(
         g.row('Incoming Request')
         .addPanel(
@@ -140,31 +140,31 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
         g.resourceUtilizationRow()
       ) +
       g.template('namespace', thanos.dashboard.namespaceQuery) +
-      g.template('job', 'up', 'namespace="$namespace",%(selector)s' % thanos.receiver, true, '%(jobPrefix)s.*' % thanos.receiver) +
-      g.template('pod', 'kube_pod_info', 'namespace="$namespace",created_by_name=~"%(jobPrefix)s.*"' % thanos.receiver, true, '.*'),
+      g.template('job', 'up', 'namespace="$namespace",%(selector)s' % thanos.receive, true, '%(jobPrefix)s.*' % thanos.receive) +
+      g.template('pod', 'kube_pod_info', 'namespace="$namespace",created_by_name=~"%(jobPrefix)s.*"' % thanos.receive, true, '.*'),
 
     __overviewRows__+:: [
       g.row('Receive')
       .addPanel(
         g.panel('Incoming Requests Rate', 'Shows rate of incoming requests.') +
-        g.httpQpsPanel('http_requests_total', 'handler="receive",namespace="$namespace",%(selector)s' % thanos.receiver) +
-        g.addDashboardLink(thanos.receiver.title)
+        g.httpQpsPanel('http_requests_total', 'handler="receive",namespace="$namespace",%(selector)s' % thanos.receive) +
+        g.addDashboardLink(thanos.receive.title)
       )
       .addPanel(
         g.panel('Incoming Requests Errors', 'Shows ratio of errors compared to the total number of handled incoming requests.') +
-        g.httpErrPanel('http_requests_total', 'handler="receive",namespace="$namespace",%(selector)s' % thanos.receiver) +
-        g.addDashboardLink(thanos.receiver.title)
+        g.httpErrPanel('http_requests_total', 'handler="receive",namespace="$namespace",%(selector)s' % thanos.receive) +
+        g.addDashboardLink(thanos.receive.title)
       )
       .addPanel(
         g.sloLatency(
           'Incoming Requests Latency 99th Percentile',
           'Shows how long has it taken to handle incoming requests.',
-          'http_request_duration_seconds_bucket{handler="receive",namespace="$namespace",%(selector)s}' % thanos.receiver,
+          'http_request_duration_seconds_bucket{handler="receive",namespace="$namespace",%(selector)s}' % thanos.receive,
           0.99,
           0.5,
           1
         ) +
-        g.addDashboardLink(thanos.receiver.title)
+        g.addDashboardLink(thanos.receive.title)
       ),
     ],
   },

--- a/mixin/thanos/dashboards/rule.libsonnet
+++ b/mixin/thanos/dashboards/rule.libsonnet
@@ -2,14 +2,14 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
 
 {
   local thanos = self,
-  ruler+:: {
-    jobPrefix: error 'must provide job prefix for Thanos Ruler dashboard',
-    selector: error 'must provide selector for Thanos Ruler dashboard',
-    title: error 'must provide title for Thanos Ruler dashboard',
+  rule+:: {
+    jobPrefix: error 'must provide job prefix for Thanos Rule dashboard',
+    selector: error 'must provide selector for Thanos Rule dashboard',
+    title: error 'must provide title for Thanos Rule dashboard',
   },
   grafanaDashboards+:: {
-    'ruler.json':
-      g.dashboard(thanos.ruler.title)
+    'rule.json':
+      g.dashboard(thanos.rule.title)
       .addRow(
         g.row('Alert Sent')
         .addPanel(
@@ -122,38 +122,38 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
         g.resourceUtilizationRow()
       ) +
       g.template('namespace', thanos.dashboard.namespaceQuery) +
-      g.template('job', 'up', 'namespace="$namespace",%(selector)s' % thanos.ruler, true, '%(jobPrefix)s.*' % thanos.ruler) +
-      g.template('pod', 'kube_pod_info', 'namespace="$namespace",created_by_name=~"%(jobPrefix)s.*"' % thanos.ruler, true, '.*'),
+      g.template('job', 'up', 'namespace="$namespace",%(selector)s' % thanos.rule, true, '%(jobPrefix)s.*' % thanos.rule) +
+      g.template('pod', 'kube_pod_info', 'namespace="$namespace",created_by_name=~"%(jobPrefix)s.*"' % thanos.rule, true, '.*'),
 
     __overviewRows__+:: [
       g.row('Rule')
       .addPanel(
         g.panel('Alert Sent Rate', 'Shows rate of alerts that successfully sent to alert manager.') +
         g.queryPanel(
-          'sum(rate(thanos_alert_sender_alerts_sent_total{namespace="$namespace",%(selector)s}[$interval])) by (job, alertmanager)' % thanos.ruler,
+          'sum(rate(thanos_alert_sender_alerts_sent_total{namespace="$namespace",%(selector)s}[$interval])) by (job, alertmanager)' % thanos.rule,
           '{{job}} {{alertmanager}}'
         ) +
-        g.addDashboardLink(thanos.ruler.title) +
+        g.addDashboardLink(thanos.rule.title) +
         g.stack
       )
       .addPanel(
         g.panel('Alert Sent Errors', 'Shows ratio of errors compared to the total number of sent alerts.') +
         g.qpsErrTotalPanel(
-          'thanos_alert_sender_errors_total{namespace="$namespace",%(selector)s}' % thanos.ruler,
-          'thanos_alert_sender_alerts_sent_total{namespace="$namespace",%(selector)s}' % thanos.ruler,
+          'thanos_alert_sender_errors_total{namespace="$namespace",%(selector)s}' % thanos.rule,
+          'thanos_alert_sender_alerts_sent_total{namespace="$namespace",%(selector)s}' % thanos.rule,
         ) +
-        g.addDashboardLink(thanos.ruler.title)
+        g.addDashboardLink(thanos.rule.title)
       )
       .addPanel(
         g.sloLatency(
           'Alert Sent Duration',
           'Shows how long has it taken to send alerts to alert manager.',
-          'thanos_alert_sender_latency_seconds_bucket{namespace="$namespace",%(selector)s}' % thanos.ruler,
+          'thanos_alert_sender_latency_seconds_bucket{namespace="$namespace",%(selector)s}' % thanos.rule,
           0.99,
           0.5,
           1
         ) +
-        g.addDashboardLink(thanos.ruler.title)
+        g.addDashboardLink(thanos.rule.title)
       ) +
       g.collapse,
     ],

--- a/mixin/thanos/defaults.libsonnet
+++ b/mixin/thanos/defaults.libsonnet
@@ -1,28 +1,28 @@
 {
-  querier+:: {
-    jobPrefix: 'thanos-querier',
+  query+:: {
+    jobPrefix: 'thanos-query',
     selector: 'job=~"%s.*"' % self.jobPrefix,
-    title: '%(prefix)sQuerier' % $.dashboard.prefix,
+    title: '%(prefix)sQuery' % $.dashboard.prefix,
   },
   store+:: {
     jobPrefix: 'thanos-store',
     selector: 'job=~"%s.*"' % self.jobPrefix,
     title: '%(prefix)sStore' % $.dashboard.prefix,
   },
-  receiver+:: {
-    jobPrefix: 'thanos-receiver',
+  receive+:: {
+    jobPrefix: 'thanos-receive',
     selector: 'job=~"%s.*"' % self.jobPrefix,
-    title: '%(prefix)sReceiver' % $.dashboard.prefix,
+    title: '%(prefix)sReceive' % $.dashboard.prefix,
   },
-  ruler+:: {
-    jobPrefix: 'thanos-ruler',
+  rule+:: {
+    jobPrefix: 'thanos-rule',
     selector: 'job=~"%s.*"' % self.jobPrefix,
-    title: '%(prefix)sRuler' % $.dashboard.prefix,
+    title: '%(prefix)sRule' % $.dashboard.prefix,
   },
-  compactor+:: {
-    jobPrefix: 'thanos-compactor',
+  compact+:: {
+    jobPrefix: 'thanos-compact',
     selector: 'job=~"%s.*"' % self.jobPrefix,
-    title: '%(prefix)sCompactor' % $.dashboard.prefix,
+    title: '%(prefix)sCompact' % $.dashboard.prefix,
   },
   sidecar+:: {
     jobPrefix: 'thanos-sidecar',

--- a/mixin/thanos/rules/query.libsonnet
+++ b/mixin/thanos/rules/query.libsonnet
@@ -1,12 +1,12 @@
 {
   local thanos = self,
-  querier+:: {
+  query+:: {
     selector: error 'must provide selector for Thanos Query recording rules',
   },
   prometheusRules+:: {
     groups+: [
       {
-        name: 'thanos-querier.rules',
+        name: 'thanos-query.rules',
         rules: [
           {
             record: ':grpc_client_failures_per_unary:sum_rate',
@@ -16,7 +16,7 @@
               /
                 sum(rate(grpc_client_started_total{%(selector)s, grpc_type="unary"}[5m]))
               )
-            ||| % thanos.querier,
+            ||| % thanos.query,
             labels: {
             },
           },
@@ -28,7 +28,7 @@
               /
                 sum(rate(grpc_client_started_total{%(selector)s, grpc_type="server_stream"}[5m]))
               )
-            ||| % thanos.querier,
+            ||| % thanos.query,
             labels: {
             },
           },
@@ -40,7 +40,7 @@
               /
                 sum(rate(thanos_querier_store_apis_dns_lookups_total{%(selector)s}[5m]))
               )
-            ||| % thanos.querier,
+            ||| % thanos.query,
             labels: {
             },
           },
@@ -50,7 +50,7 @@
               histogram_quantile(0.99,
                 sum(rate(http_request_duration_seconds_bucket{%(selector)s, handler="query"}[5m])) by (le)
               )
-            ||| % thanos.querier,
+            ||| % thanos.query,
             labels: {
               quantile: '0.99',
             },
@@ -61,7 +61,7 @@
               histogram_quantile(0.99,
                 sum(rate(http_request_duration_seconds_bucket{%(selector)s, handler="query_range"}[5m])) by (le)
               )
-            ||| % thanos.querier,
+            ||| % thanos.query,
             labels: {
               quantile: '0.99',
             },

--- a/mixin/thanos/rules/receive.libsonnet
+++ b/mixin/thanos/rules/receive.libsonnet
@@ -1,12 +1,12 @@
 {
   local thanos = self,
-  receiver+:: {
+  receive+:: {
     selector: error 'must provide selector for Thanos Receive recording rules',
   },
   prometheusRules+:: {
     groups+: [
       {
-        name: 'thanos-receiver.rules',
+        name: 'thanos-receive.rules',
         rules: [
           {
             record: ':grpc_server_failures_per_unary:sum_rate',
@@ -16,7 +16,7 @@
               /
                 rate(grpc_server_started_total{%(selector)s, grpc_type="unary"}[5m])
               )
-            ||| % thanos.receiver,
+            ||| % thanos.receive,
             labels: {
             },
           },
@@ -28,7 +28,7 @@
               /
                 rate(grpc_server_started_total{%(selector)s, grpc_type="server_stream"}[5m])
               )
-            ||| % thanos.receiver,
+            ||| % thanos.receive,
             labels: {
             },
           },
@@ -40,7 +40,7 @@
               /
                 rate(http_requests_total{handler="receive", %(selector)s}[5m])
               )
-            ||| % thanos.receiver,
+            ||| % thanos.receive,
             labels: {
             },
           },
@@ -50,7 +50,7 @@
               histogram_quantile(0.99,
                 sum(rate(http_request_duration_seconds_bucket{handler="receive", %(selector)s}[5m])) by (le)
               )
-            ||| % thanos.receiver,
+            ||| % thanos.receive,
             labels: {
               quantile: '0.99',
             },
@@ -63,7 +63,7 @@
               /
                 sum(rate(thanos_receive_forward_requests_total{%(selector)s}[5m]))
               )
-            ||| % thanos.receiver,
+            ||| % thanos.receive,
             labels: {
             },
           },
@@ -75,7 +75,7 @@
               /
                 sum(rate(thanos_receive_hashrings_file_refreshes_total{%(selector)s}[5m]))
               )
-            ||| % thanos.receiver,
+            ||| % thanos.receive,
             labels: {
             },
           },

--- a/mixin/thanos/rules/rules.libsonnet
+++ b/mixin/thanos/rules/rules.libsonnet
@@ -1,3 +1,3 @@
-(import 'querier.libsonnet') +
-(import 'receiver.libsonnet') +
+(import 'query.libsonnet') +
+(import 'receive.libsonnet') +
 (import 'store.libsonnet')


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

This adapts alerting rules and dashboarding where applicable to comply to the agreed upon conventions documented in: https://github.com/thanos-io/thanos/blob/master/CONTRIBUTING.md#components-naming.

I mostly did `sed` over the repo, and reviewed it myself, but another couple of pairs of eyes reviewing this would be great :) .

Let me know if you feel this needs a changelog entry, and if so what you think it should be.

@thanos-io/thanos-maintainers @kakkoyun 

## Verification

Promtool checks and tests continue to pass.
