### PR TITLE
tracing: track query sent to prometheus via remote read api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 - [#2030](https://github.com/thanos-io/thanos/pull/2030) Query: Add `thanos_proxy_store_empty_stream_responses_total` metric for number of empty responses from stores.
 - [#2049](https://github.com/thanos-io/thanos/pull/2049) Tracing: Support sampling on Elastic APM with new sample_rate setting.
 - [#2008](https://github.com/thanos-io/thanos/pull/2008) Querier, Receiver, Sidecar, Store: Add gRPC [health check](https://github.com/grpc/grpc/blob/master/doc/health-checking.md) endpoints.
+- [#2145](https://github.com/thanos-io/thanos/pull/2145) Tracing: track query sent to prometheus via remote read api.
 
 ### Changed
 


### PR DESCRIPTION
This patch extends tracing to include a `prometheus.query` tag for queries against the prometheus remote read API (`/api/v1/read`).

Previously there wasn't much information about the call being made, since that API uses protobuf over POST bodies. Now there is a JSON encoding of the protobuf request body in the trace.

One potential downside of this change is that there is JSON encoding and allocation overhead on every request. I wasn't able to find an easy way to make those conditional (input very welcome).

I also moved `spanReqDo.Finish()` before the error handling. I believe we want to finish the span in any case -- though if leaving it open was intentional, I'm happy to change it back.

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

* tracing: Add `prometheus.query` tag to `query_prometheus_request` span

## Verification

<!-- How you tested it? How do you know it works? -->

I ran thanos locally with tracing configured for elastic APM and confirmed the addition of the `prometheus.query` tag. Example value:

```
{"start_timestamp_ms":1581930268943,"end_timestamp_ms":1581934168943,"matchers":[{"name":"__name__","value":"up"}]}
```