### PR TITLE
Makefile: update jsonnet-ci image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -317,7 +317,7 @@ JSONNET_CONTAINER_CMD:=docker run --rm \
 		-w "/go/src/github.com/thanos-io/thanos" \
 		-e USER=deadbeef \
 		-e GO111MODULE=on \
-		quay.io/coreos/jsonnet-ci:release-0.35
+		quay.io/coreos/jsonnet-ci:release-0.36
 
 .PHONY: examples-in-container
 examples-in-container:


### PR DESCRIPTION
Signed-off-by: Xiang Dai <764524258@qq.com>

Fix following issue introduced by #2133 :
```
[root@test thanos]# make examples-in-container
>> Compiling and generating thanos-mixin
docker run --rm -u="0:0" -v "/root/.cache/go-build:/.cache/go-build" -v "/deploy/go/src/github.com/thanos-io/thanos:/go/src/github.com/thanos-io/thanos:Z" -w "/go/src/github.com/thanos-io/thanos" -e USER=deadbeef -e GO111MODULE=on quay.io/coreos/jsonnet-ci:release-0.35 make  JSONNET_BUNDLER='/go/bin/jb' jsonnet-vendor
rm -rf mixin/vendor
cd mixin && /go/bin/jb install
jb: error: failed to install packages: downloading: failed to create tmp dir: stat vendor/.tmp: no such file or directory
make: *** [Makefile:360: jsonnet-vendor] Error 1
make: *** [examples-in-container] Error 2
```