### PR TITLE
Makefile: check embedmd in examples target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -333,7 +333,7 @@ examples-in-container:
 		examples
 
 .PHONY: examples
-examples: jsonnet-format ${THANOS_MIXIN}/README.md examples/alerts/alerts.md examples/alerts/alerts.yaml examples/alerts/rules.yaml examples/dashboards examples/tmp
+examples: jsonnet-format $(EMBEDMD) ${THANOS_MIXIN}/README.md examples/alerts/alerts.md examples/alerts/alerts.yaml examples/alerts/rules.yaml examples/dashboards examples/tmp
 	$(EMBEDMD) -w examples/alerts/alerts.md
 	$(EMBEDMD) -w ${THANOS_MIXIN}/README.md
 


### PR DESCRIPTION
Signed-off-by: Xiang Dai <764524258@qq.com>

Fix issue when run `make examples`:
```
# make examples
find . -name 'vendor' -prune -o -name '*.libsonnet' -print -o -name '*.jsonnet' -print | \
	xargs -n 1 -- jsonnetfmt -n 2 --max-blank-lines 2 --string-style s --comment-style s -i
/gopkg/bin/jsonnet-fbde25be2182caa4345b03f1532450911ac7d1f3 mixin/thanos/alerts.jsonnet | /gopkg/bin/gojsontoyaml-e8bd32d46b3d764bef60f12b3bada1c132c4be55 > examples/alerts/alerts.yaml
/gopkg/bin/jsonnet-fbde25be2182caa4345b03f1532450911ac7d1f3 mixin/thanos/rules.jsonnet | /gopkg/bin/gojsontoyaml-e8bd32d46b3d764bef60f12b3bada1c132c4be55 > examples/alerts/rules.yaml
rm -rf examples/dashboards/*.json
/gopkg/bin/jsonnet-fbde25be2182caa4345b03f1532450911ac7d1f3 -J mixin/vendor -m examples/dashboards mixin/thanos/dashboards.jsonnet
examples/dashboards/compact.json
examples/dashboards/overview.json
examples/dashboards/query.json
examples/dashboards/receive.json
examples/dashboards/rule.json
examples/dashboards/sidecar.json
examples/dashboards/store.json
rm -rf examples/tmp/
mkdir -p examples/tmp/
/gopkg/bin/jsonnet-fbde25be2182caa4345b03f1532450911ac7d1f3 -J mixin/vendor -m examples/tmp/ mixin/thanos/separated_alerts.jsonnet | xargs -I{} sh -c 'cat {} | /gopkg/bin/gojsontoyaml-e8bd32d46b3d764bef60f12b3bada1c132c4be55 > {}.yaml; rm -f {}' -- {}
/gopkg/bin/embedmd-97c13d6e41602fc6e397eb51c45f38069371a969 -w examples/alerts/alerts.md
make: /gopkg/bin/embedmd-97c13d6e41602fc6e397eb51c45f38069371a969: Command not found
Makefile:337: recipe for target 'examples' failed
make: *** [examples] Error 127
```