### PR TITLE
receive: Validate hashring at initialization

### DIFF
--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -321,9 +321,7 @@ func runReceive(
 		if cw != nil {
 			ctx, cancel := context.WithCancel(context.Background())
 			g.Add(func() error {
-				// TODO: If config is empty we never start receiver. We might want to fail in this case.
-				receive.HashringFromConfig(ctx, updates, cw)
-				return nil
+				return receive.HashringFromConfig(ctx, updates, cw)
 			}, func(error) {
 				cancel()
 			})

--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -320,7 +320,7 @@ func runReceive(
 		updates := make(chan receive.Hashring, 1)
 
 		if cw != nil {
-			// Before scheduling a job, check if hashring config is valid.
+			// Check the hashring configuration on before running the watcher.
 			if err := cw.ValidateConfig(); err != nil {
 				close(updates)
 				return errors.Wrap(err, "failed to validate hashring configuration file")

--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -318,7 +318,14 @@ func runReceive(
 		// In the single-node case, which has no configuration
 		// watcher, we close the chan ourselves.
 		updates := make(chan receive.Hashring, 1)
+
 		if cw != nil {
+			// Before scheduling a job, check if hashring config is valid.
+			if err := cw.ValidateConfig(); err != nil {
+				close(updates)
+				return errors.Wrap(err, "failed to validate hashring configuration file")
+			}
+
 			ctx, cancel := context.WithCancel(context.Background())
 			g.Add(func() error {
 				return receive.HashringFromConfig(ctx, updates, cw)

--- a/pkg/receive/config.go
+++ b/pkg/receive/config.go
@@ -10,7 +10,6 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"os"
-	"reflect"
 	"time"
 
 	"github.com/go-kit/kit/log"
@@ -47,8 +46,8 @@ type ConfigWatcher struct {
 	hashringNodesGauge   *prometheus.GaugeVec
 	hashringTenantsGauge *prometheus.GaugeVec
 
-	// last is the last known configuration.
-	last []HashringConfig
+	// lastConfigHash is the last known hash of the loaded configuration.
+	lastConfigHash float64
 }
 
 // NewConfigWatcher creates a new ConfigWatcher.
@@ -180,6 +179,26 @@ func (cw *ConfigWatcher) C() <-chan []HashringConfig {
 	return cw.ch
 }
 
+// LoadConfig loads raw configuration content and returns a configuration.
+func (cw *ConfigWatcher) LoadConfig() ([]HashringConfig, float64, error) {
+	cfgContent, err := cw.readFile()
+	if err != nil {
+		return nil, 0, errors.Wrap(err, "failed to read configuration file")
+	}
+
+	config, err := cw.parseConfig(cfgContent)
+	if err != nil {
+		return nil, 0, errors.Wrap(err, "failed to load configuration file")
+	}
+
+	// If hashring is empty, return an error.
+	if len(config) == 0 {
+		return nil, 0, errors.New("hashring is empty")
+	}
+
+	return config, hashAsMetricValue(cfgContent), nil
+}
+
 // readFile reads the configured file and returns content of configuration file.
 func (cw *ConfigWatcher) readFile() ([]byte, error) {
 	fd, err := os.Open(cw.path)
@@ -195,8 +214,8 @@ func (cw *ConfigWatcher) readFile() ([]byte, error) {
 	return ioutil.ReadAll(fd)
 }
 
-// loadConfig loads raw configuration content and returns a configuration.
-func (cw *ConfigWatcher) loadConfig(content []byte) ([]HashringConfig, error) {
+// parseConfig parses the raw configuration content and returns a HashringConfig.
+func (cw *ConfigWatcher) parseConfig(content []byte) ([]HashringConfig, error) {
 	var config []HashringConfig
 	err := json.Unmarshal(content, &config)
 	return config, err
@@ -205,14 +224,8 @@ func (cw *ConfigWatcher) loadConfig(content []byte) ([]HashringConfig, error) {
 // refresh reads the configured file and sends the hashring configuration on the channel.
 func (cw *ConfigWatcher) refresh(ctx context.Context) {
 	cw.refreshCounter.Inc()
-	cfgContent, err := cw.readFile()
-	if err != nil {
-		cw.errorCounter.Inc()
-		level.Error(cw.logger).Log("msg", "failed to read configuration file", "err", err, "path", cw.path)
-		return
-	}
 
-	config, err := cw.loadConfig(cfgContent)
+	config, cfgHash, err := cw.LoadConfig()
 	if err != nil {
 		cw.errorCounter.Inc()
 		level.Error(cw.logger).Log("msg", "failed to load configuration file", "err", err, "path", cw.path)
@@ -220,15 +233,17 @@ func (cw *ConfigWatcher) refresh(ctx context.Context) {
 	}
 
 	// If there was no change to the configuration, return early.
-	if reflect.DeepEqual(cw.last, config) {
+	if cw.lastConfigHash == cfgHash {
 		return
 	}
+
 	cw.changesCounter.Inc()
+
 	// Save the last known configuration.
-	cw.last = config
+	cw.lastConfigHash = cfgHash
 	cw.successGauge.Set(1)
 	cw.lastSuccessTimeGauge.SetToCurrentTime()
-	cw.hashGauge.Set(hashAsMetricValue(cfgContent))
+	cw.hashGauge.Set(cfgHash)
 
 	for _, c := range config {
 		cw.hashringNodesGauge.WithLabelValues(c.Hashring).Set(float64(len(c.Endpoints)))

--- a/pkg/receive/config.go
+++ b/pkg/receive/config.go
@@ -20,9 +20,11 @@ import (
 	"gopkg.in/fsnotify.v1"
 )
 
-type EmptyHashringError string
+// An EmptyConfigurationError is returned by the ConfigWatcher when attempting to load an empty configuration file.
+// Note: This error is defined as a type to conviently test the behavior against errors.
+type EmptyConfigurationError string
 
-func (e EmptyHashringError) Error() string { return "hashring is empty" }
+func (e EmptyConfigurationError) Error() string { return "configuration file is empty: " + string(e) }
 
 // HashringConfig represents the configuration for a hashring
 // a receive node knows about.
@@ -184,7 +186,7 @@ func (cw *ConfigWatcher) C() <-chan []HashringConfig {
 	return cw.ch
 }
 
-// ValidateConfig returns an error if configuration that's being watched is not valid.
+// ValidateConfig returns an error if the configuration that's being watched is not valid.
 func (cw *ConfigWatcher) ValidateConfig() error {
 	_, _, err := cw.loadConfig()
 	return err
@@ -204,8 +206,7 @@ func (cw *ConfigWatcher) loadConfig() ([]HashringConfig, float64, error) {
 
 	// If hashring is empty, return an error.
 	if len(config) == 0 {
-		var err EmptyHashringError
-		return nil, 0, err
+		return nil, 0, EmptyConfigurationError(cw.path)
 	}
 
 	return config, hashAsMetricValue(cfgContent), nil
@@ -276,7 +277,7 @@ func (cw *ConfigWatcher) stop() {
 	level.Debug(cw.logger).Log("msg", "hashring configuration watcher stopped")
 }
 
-// readFile reads the configured file and returns content of configuration file.
+// readFile reads the configuration file and returns content of configuration file.
 func (cw *ConfigWatcher) readFile() ([]byte, error) {
 	fd, err := os.Open(cw.path)
 	if err != nil {

--- a/pkg/receive/config.go
+++ b/pkg/receive/config.go
@@ -20,11 +20,12 @@ import (
 	"gopkg.in/fsnotify.v1"
 )
 
-// An EmptyConfigurationError is returned by the ConfigWatcher when attempting to load an empty configuration file.
-// Note: This error is defined as a type to conviently test the behavior against errors.
-type EmptyConfigurationError string
-
-func (e EmptyConfigurationError) Error() string { return "configuration file is empty: " + string(e) }
+var (
+	// An errParseConfigurationFile is returned by the ConfigWatcher when parsing failed.
+	errParseConfigurationFile = errors.New("configuration file is not parsable")
+	// An errEmptyConfigurationFile is returned by the ConfigWatcher when attempting to load an empty configuration file.
+	errEmptyConfigurationFile = errors.New("configuration file is empty")
+)
 
 // HashringConfig represents the configuration for a hashring
 // a receive node knows about.
@@ -201,12 +202,12 @@ func (cw *ConfigWatcher) loadConfig() ([]HashringConfig, float64, error) {
 
 	config, err := cw.parseConfig(cfgContent)
 	if err != nil {
-		return nil, 0, errors.Wrap(err, "failed to load configuration file")
+		return nil, 0, errors.Wrapf(errParseConfigurationFile, "failed to parse configuration file: %v", err)
 	}
 
 	// If hashring is empty, return an error.
 	if len(config) == 0 {
-		return nil, 0, EmptyConfigurationError(cw.path)
+		return nil, 0, errors.Wrapf(errEmptyConfigurationFile, "failed to load configuration file, path: %s", cw.path)
 	}
 
 	return config, hashAsMetricValue(cfgContent), nil

--- a/pkg/receive/config_test.go
+++ b/pkg/receive/config_test.go
@@ -1,0 +1,77 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package receive
+
+import (
+	"encoding/json"
+	"errors"
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+func TestValidateConfig(t *testing.T) {
+	var emptyHashringErr EmptyHashringError
+
+	for _, tc := range []struct {
+		name string
+		cfg  interface{}
+		err  interface{}
+	}{
+		{
+			name: "<nil> config",
+			cfg:  nil,
+			err:  emptyHashringErr,
+		},
+		{
+			name: "empty config",
+			cfg:  []HashringConfig{},
+			err:  emptyHashringErr,
+		},
+		{
+			name: "unparsable config",
+			cfg:  struct{}{},
+			err:  json.UnsupportedTypeError{},
+		},
+		{
+			name: "valid config",
+			cfg: []HashringConfig{
+				{
+					Endpoints: []string{"node1"},
+				},
+			},
+			err: nil, // means it's valid.
+		},
+	} {
+		var content []byte
+		var err error
+		if content, err = json.Marshal(tc.cfg); err != nil {
+			t.Error(err)
+		}
+
+		tmpfile, err := ioutil.TempFile("", "configwatcher_test.*.json")
+		if err != nil {
+			t.Fatalf("case %q: unexpectedly failed creating the temp file: %v", tc.name, err)
+		}
+		defer os.Remove(tmpfile.Name())
+
+		if _, err := tmpfile.Write(content); err != nil {
+			t.Fatalf("case %q: unexpectedly failed writing to the temp file: %v", tc.name, err)
+		}
+
+		if err := tmpfile.Close(); err != nil {
+			t.Fatalf("case %q: unexpectedly failed closing the temp file: %v", tc.name, err)
+		}
+
+		cw, err := NewConfigWatcher(nil, nil, tmpfile.Name(), 1)
+		if err != nil {
+			t.Fatalf("case %q: unexpectedly failed creating config watcher: %v", tc.name, err)
+		}
+
+		if err := cw.ValidateConfig(); err != nil && !errors.As(err, &tc.err) {
+			t.Errorf("case %q: got unexpected error: %v", tc.name, err)
+			continue
+		}
+	}
+}

--- a/pkg/receive/config_test.go
+++ b/pkg/receive/config_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestValidateConfig(t *testing.T) {
-	var emptyHashringErr EmptyHashringError
+	var emptyCfgErr EmptyConfigurationError
 
 	for _, tc := range []struct {
 		name string
@@ -22,12 +22,12 @@ func TestValidateConfig(t *testing.T) {
 		{
 			name: "<nil> config",
 			cfg:  nil,
-			err:  emptyHashringErr,
+			err:  emptyCfgErr,
 		},
 		{
 			name: "empty config",
 			cfg:  []HashringConfig{},
-			err:  emptyHashringErr,
+			err:  emptyCfgErr,
 		},
 		{
 			name: "unparsable config",

--- a/pkg/receive/config_test.go
+++ b/pkg/receive/config_test.go
@@ -5,34 +5,33 @@ package receive
 
 import (
 	"encoding/json"
-	"errors"
 	"io/ioutil"
 	"os"
 	"testing"
+
+	"github.com/pkg/errors"
 )
 
 func TestValidateConfig(t *testing.T) {
-	var emptyCfgErr EmptyConfigurationError
-
 	for _, tc := range []struct {
 		name string
 		cfg  interface{}
-		err  interface{}
+		err  error
 	}{
 		{
 			name: "<nil> config",
 			cfg:  nil,
-			err:  emptyCfgErr,
+			err:  errEmptyConfigurationFile,
 		},
 		{
 			name: "empty config",
 			cfg:  []HashringConfig{},
-			err:  emptyCfgErr,
+			err:  errEmptyConfigurationFile,
 		},
 		{
 			name: "unparsable config",
 			cfg:  struct{}{},
-			err:  json.UnsupportedTypeError{},
+			err:  errParseConfigurationFile,
 		},
 		{
 			name: "valid config",
@@ -69,7 +68,7 @@ func TestValidateConfig(t *testing.T) {
 			t.Fatalf("case %q: unexpectedly failed creating config watcher: %v", tc.name, err)
 		}
 
-		if err := cw.ValidateConfig(); err != nil && !errors.As(err, &tc.err) {
+		if err := cw.ValidateConfig(); err != nil && !errors.Is(err, tc.err) {
 			t.Errorf("case %q: got unexpected error: %v", tc.name, err)
 			continue
 		}

--- a/pkg/receive/hashring.go
+++ b/pkg/receive/hashring.go
@@ -5,12 +5,12 @@ package receive
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"sort"
 	"sync"
 
 	"github.com/cespare/xxhash"
+	"github.com/pkg/errors"
 	"github.com/prometheus/prometheus/prompb"
 )
 

--- a/pkg/receive/hashring.go
+++ b/pkg/receive/hashring.go
@@ -166,12 +166,8 @@ func newMultiHashring(cfg []HashringConfig) Hashring {
 // by the tenants field of the hashring configuration.
 // The updates chan is closed before exiting.
 func HashringFromConfig(ctx context.Context, updates chan<- Hashring, cw *ConfigWatcher) error {
-	if err := cw.ValidateConfig(); err != nil {
-		return errors.Wrap(err, "failed to validate hashring configuration file")
-	}
-
-	go cw.Run(ctx)
 	defer close(updates)
+	go cw.Run(ctx)
 
 	for {
 		select {

--- a/pkg/receive/hashring.go
+++ b/pkg/receive/hashring.go
@@ -166,9 +166,8 @@ func newMultiHashring(cfg []HashringConfig) Hashring {
 // by the tenants field of the hashring configuration.
 // The updates chan is closed before exiting.
 func HashringFromConfig(ctx context.Context, updates chan<- Hashring, cw *ConfigWatcher) error {
-	_, _, err := cw.LoadConfig()
-	if err != nil {
-		return errors.Wrap(err, "failed to load hashring configuration file")
+	if err := cw.ValidateConfig(); err != nil {
+		return errors.Wrap(err, "failed to validate hashring configuration file")
 	}
 
 	go cw.Run(ctx)

--- a/pkg/receive/hashring.go
+++ b/pkg/receive/hashring.go
@@ -5,12 +5,12 @@ package receive
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 	"sync"
 
 	"github.com/cespare/xxhash"
-	"github.com/pkg/errors"
 	"github.com/prometheus/prometheus/prompb"
 )
 

--- a/pkg/receive/hashring.go
+++ b/pkg/receive/hashring.go
@@ -173,7 +173,7 @@ func HashringFromConfig(ctx context.Context, updates chan<- Hashring, cw *Config
 		select {
 		case cfg, ok := <-cw.C():
 			if !ok {
-				return errors.New("hashring config watcher stopped")
+				return errors.New("hashring config watcher stopped unexpectedly")
 			}
 			updates <- newMultiHashring(cfg)
 		case <-ctx.Done():


### PR DESCRIPTION
This PR checks if the hashring config is empty and fails if it is.

Fixes #2160 

cc @squat @bwplotka 

Signed-off-by: Kemal Akkoyun <kakkoyun@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

* checks if the hashring config is empty and fails if it is.

## Verification

* `make test-local`
* Run `REMOTE_WRITE_ENABLED=1 MINIO_ENABLED=1 ./scripts/quickstart.sh` with several modified versions of hashring file.