### PR TITLE
bucket: Improve tooltip for bucket UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 
 - [#1933](https://github.com/thanos-io/thanos/pull/1933) Add a flag `--tsdb.wal-compression` to configure whether to enable tsdb wal compression in ruler and receiver.
 - [#2021](https://github.com/thanos-io/thanos/pull/2021) Rename metric `thanos_query_duplicated_store_address` to `thanos_query_duplicated_store_addresses_total` and `thanos_rule_duplicated_query_address` to `thanos_rule_duplicated_query_addresses_total`.
+- [#2166](https://github.com/thanos-io/thanos/pull/2166) Improve tooltip for bucket web UI.
 
 ## [v0.10.1](https://github.com/thanos-io/thanos/releases/tag/v0.10.1) - 2020.01.24
 

--- a/pkg/ui/templates/bucket.html
+++ b/pkg/ui/templates/bucket.html
@@ -3,6 +3,7 @@
 
     <script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
     <script src="{{ pathPrefix }}/static/js/bucket.js?v={{ buildVersion }}"></script>
+    <script src="{{ pathPrefix }}/static/vendor/moment/moment.min.js?v={{ buildVersion }}"></script>
 {{end}}
 
 {{define "content"}}


### PR DESCRIPTION

Related to:  #2149

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

I improved the tooltip on `bucket web`. It was reconstructed using bootstrap tools to show much more details than before:
**Before**
<img width="322" alt="Screenshot 2020-02-21 at 22 00 08" src="https://user-images.githubusercontent.com/12186336/75072374-b1828e00-54f7-11ea-9070-a54d82fd20e6.png">
**After**
<img width="483" alt="Screenshot 2020-02-21 at 22 04 35" src="https://user-images.githubusercontent.com/12186336/75072391-b9423280-54f7-11ea-9157-4788c39a0ec9.png">


## Verification

Visual testing only