### PR TITLE
Added non-memmap index-header implementation for comparison.

### DIFF
--- a/pkg/block/indexheader/json_reader.go
+++ b/pkg/block/indexheader/json_reader.go
@@ -56,9 +56,7 @@ func (b realByteSlice) Range(start, end int) []byte {
 	return b[start:end]
 }
 
-func (b realByteSlice) Sub(start, end int) index.ByteSlice {
-	return b[start:end]
-}
+func (b realByteSlice) Err() error { return nil }
 
 // readSymbols reads the symbol table fully into memory and allocates proper strings for them.
 // Strings backed by the mmap'd memory would cause memory faults if applications keep using them

--- a/pkg/store/bucket_test.go
+++ b/pkg/store/bucket_test.go
@@ -893,10 +893,19 @@ func TestBucketIndexReader_ExpandedPostings(t *testing.T) {
 
 	id := uploadTestBlock(tb, tmpDir, bkt, 500)
 
-	r, err := indexheader.NewBinaryReader(context.Background(), log.NewNopLogger(), bkt, tmpDir, id)
-	testutil.Ok(tb, err)
+	tb.Run("file", func(tb testutil.TB) {
+		r, err := indexheader.NewBinaryReader(context.Background(), log.NewNopLogger(), bkt, tmpDir, id)
+		testutil.Ok(tb, err)
 
-	benchmarkExpandedPostings(tb, bkt, id, r, 500)
+		benchmarkExpandedPostings(tb, bkt, id, r, 500)
+	})
+
+	tb.Run("mmap", func(tb testutil.TB) {
+		r, err := indexheader.NewMemMapBinaryReader(context.Background(), log.NewNopLogger(), bkt, tmpDir, id)
+		testutil.Ok(tb, err)
+
+		benchmarkExpandedPostings(tb, bkt, id, r, 500)
+	})
 }
 
 func BenchmarkBucketIndexReader_ExpandedPostings(b *testing.B) {
@@ -911,10 +920,20 @@ func BenchmarkBucketIndexReader_ExpandedPostings(b *testing.B) {
 	defer func() { testutil.Ok(tb, bkt.Close()) }()
 
 	id := uploadTestBlock(tb, tmpDir, bkt, 50e5)
-	r, err := indexheader.NewBinaryReader(context.Background(), log.NewNopLogger(), bkt, tmpDir, id)
-	testutil.Ok(tb, err)
 
-	benchmarkExpandedPostings(tb, bkt, id, r, 50e5)
+	tb.Run("file", func(tb testutil.TB) {
+		r, err := indexheader.NewBinaryReader(context.Background(), log.NewNopLogger(), bkt, tmpDir, id)
+		testutil.Ok(tb, err)
+
+		benchmarkExpandedPostings(tb, bkt, id, r, 50e5)
+	})
+
+	tb.Run("mmap", func(tb testutil.TB) {
+		r, err := indexheader.NewMemMapBinaryReader(context.Background(), log.NewNopLogger(), bkt, tmpDir, id)
+		testutil.Ok(tb, err)
+
+		benchmarkExpandedPostings(tb, bkt, id, r, 50e5)
+	})
 }
 
 // Make entries ~50B in size, to emulate real-world high cardinality.


### PR DESCRIPTION
**Chained PR**

Depends on  https://github.com/thanos-io/thanos/pull/2078

## Rationales:

On top of other downsides, Memmap is unsafe, dangerous and is extremely difficult to monitor (memory). Will describe all memmap issues more in the separate issue/blog post.

This PR adds just IO implementation, which replaces mmap one in Store Gateway. Benchmarks to follow, so we can compare results.

cc @tomwilkie @pracucci @brancz  :hugs: 

Signed-off-by: Bartlomiej Plotka <bwplotka@gmail.com>