### PR TITLE
#946: Implement SSE-KMS and SSE-C for AWS S3

### DIFF
--- a/docs/storage.md
+++ b/docs/storage.md
@@ -92,7 +92,7 @@ config:
   trace:
     enable: false
   part_size: 134217728
-  encrypt_sse: false # legacy, supersceded by `sse_e3`
+  encrypt_sse: false
   sse_s3: false
   sse_c_key: ""
   sse_kms_id: ""

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -83,7 +83,6 @@ config:
   access_key: ""
   insecure: false
   signature_version2: false
-  encrypt_sse: false
   secret_key: ""
   put_user_metadata: {}
   http_config:
@@ -93,6 +92,11 @@ config:
   trace:
     enable: false
   part_size: 134217728
+  encrypt_sse: false # legacy, supersceded by `sse_e3`
+  sse_s3: false
+  sse_c_key: ""
+  sse_kms_id: ""
+  sse_kms_context: {}
 ```
 
 At a minimum, you will need to provide a value for the `bucket`, `endpoint`, `access_key`, and `secret_key` keys. The rest of the keys are optional.
@@ -100,6 +104,16 @@ At a minimum, you will need to provide a value for the `bucket`, `endpoint`, `ac
 The AWS region to endpoint mapping can be found in this [link](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region).
 
 Make sure you use a correct signature version. Currently AWS requires signature v4, so it needs `signature-version2: false`. If you don't specify it, you will get an `Access Denied` error. On the other hand, several S3 compatible APIs use `signature-version2: true`.
+
+For server-side encryption:
+ - `encrypt_sse` - An alias for `sse_s3`.
+ - `sse_s3` - When true, enables SSE-S3. Ignored if KMS or C are enabled. `encrypt_sse` is kept as a legacy alias for this.
+ - `sse_c_key` - When set to a filepath, enables SSE-C. Overrides `sse_s3`.
+ - `sse_kms_id` - When set, enables SSE-KMS. Overrides `sse_s3`. A KMS context can be optionally set via `sse_kms_context`.
+ - `sse_kms_context` - If `sse_kms_id` is set, attaches the given context to all KMS requests.
+
+NOTE: If both `sse_c_key` and `sse_kms_id` are set, we throw an error, as it's unclear what the operator wants.
+See https://docs.aws.amazon.com/AmazonS3/latest/dev/ServerSideEncryptionCustomerKeys.html for more details on the SSE-S3, SSE-KMS, and SSE-C options.
 
 You can configure the timeout settings for the HTTP client by setting the `http_config.idle_conn_timeout` and `http_config.response_header_timeout` keys. As a rule of thumb, if you are seeing errors like `timeout awaiting response headers` in your logs, you may want to increase the value of `http_config.response_header_timeout`.
 

--- a/pkg/objstore/s3/s3.go
+++ b/pkg/objstore/s3/s3.go
@@ -109,10 +109,6 @@ func parseConfig(conf []byte) (Config, error) {
 		return Config{}, err
 	}
 
-	if config.SSEKMSID != "" && config.SSECustomerKeyPath != "" {
-		return Config{}, ErrSSEConfig
-	}
-
 	if config.SSEEncryptionLegacy {
 		config.SSEEncryption = config.SSEEncryptionLegacy
 	}
@@ -194,7 +190,7 @@ func NewBucketWithConfig(logger log.Logger, config Config, component string) (*B
 	})
 
 	var sse encrypt.ServerSide
-	if config.SSEEncryption {
+	if config.SSEEncryption || config.SSEKMSID != "" || config.SSECustomerKeyPath != "" {
 		var err error
 		switch {
 		case config.SSEKMSID != "":
@@ -251,6 +247,11 @@ func validate(conf Config) error {
 	if conf.AccessKey != "" && conf.SecretKey == "" {
 		return errors.New("no s3 secret_key specified while access_key is present in config file; either both should be present in config or envvars/IAM should be used.")
 	}
+
+	if conf.SSEKMSID != "" && conf.SSECustomerKeyPath != "" {
+		return ErrSSEConfig
+	}
+
 	return nil
 }
 

--- a/pkg/objstore/s3/s3_test.go
+++ b/pkg/objstore/s3/s3_test.go
@@ -104,6 +104,38 @@ http_config:
 	testutil.Equals(t, "bucket-owner-full-control", cfg2.PutUserMetadata["X-Amz-Acl"])
 }
 
+func TestParseConfig_SSE(t *testing.T) {
+	input := []byte(`
+encrypt_sse: true
+sse_s3: false`,
+	)
+	cfg, err := parseConfig(input)
+	testutil.Ok(t, err)
+	testutil.Assert(t, cfg.SSEEncryption == true, "encrypt_sse should map to SSEEncryption when true")
+
+	input = []byte(`
+encrypt_sse: false
+sse_s3: true`,
+	)
+	cfg, err = parseConfig(input)
+	testutil.Ok(t, err)
+	testutil.Assert(t, cfg.SSEEncryption == true, "encrypt_sse should not override sse_s3 when false")
+}
+
+func TestValidate_SSE(t *testing.T) {
+	input := []byte(`
+endpoint: "s3-endpoint"
+access_key: "access_key"
+secret_key: "secret_key"
+sse_kms_id: "some_key"
+sse_c_key: "some/file/path"
+`,
+	)
+	cfg, err := parseConfig(input)
+	testutil.Ok(t, err)
+	testutil.Assert(t, validate(cfg) == ErrSSEConfig, "sse_kms_id and sse_c_key are mutually exclusive")
+}
+
 func TestParseConfig_PartSize(t *testing.T) {
 	input := []byte(`bucket: "bucket-name"
 endpoint: "s3-endpoint"


### PR DESCRIPTION
Implements #946 
<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [] I added CHANGELOG entry for this change.
* [] Change is not relevant to the end user.

## Changes

Added support for parsing and passing along AWS S3 SSE-KMS and SSE-C mode configuration details. Seemed pretty easy.

Adds the following config vars:
 - `sse_s3` - essentially the new `encrypt_sse`, enables SSE-S3 mode.
 - `sse_kms_id` - enables SSE-KMS mode when set.
 - `sse_kms_context` - optional map of string keys and values for the KMS Context.
 - `sse_c_key` - enables SSE-C mode when set. expects a filepath.

`encrypt_sse` is kept as an alias for `sse_s3`, as that's what `encrypt_sse` currently does, and it seems silly to break valid configuration files from prior to this change for little reason.

Note that KMS and C mode both supersede and override SSE-S3 mode currently. This allows for syntax like:
```
encrypt_sse: true
sse_c_key: "/path/to/my/key"
```
to work as expected.

KMS and C mode are mutually exclusive, and trying to enable both currently throws an error.
E.G. 
```
# this is invalid and will throw an error during validation
sse_c_key: "/path/to/my/key"
sse_kms_id: "myid"
```

## Verification

Haven't yet really... would like some help from @jujugrrr to validate the code does what I think it does before going any further really.
