### PR TITLE
store: Optimize StoreGW.Series

### DIFF
--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -693,9 +693,10 @@ func blockSeries(
 				Value: lv,
 			})
 		}
-		sort.Slice(s.lset, func(i, j int) bool {
-			return s.lset[i].Name < s.lset[j].Name
-		})
+		// 22.8%
+		//sort.Slice(s.lset, func(i, j int) bool {
+		//	return s.lset[i].Name < s.lset[j].Name
+		//})
 
 		for _, meta := range chks {
 			if meta.MaxTime < req.MinTime {
@@ -1771,6 +1772,7 @@ func (r *bucketIndexReader) LoadedSeries(ref uint64, lset *labels.Labels, chks *
 	r.stats.seriesTouched++
 	r.stats.seriesTouchedSizeSum += len(b)
 
+	// Lookup symbol here takes 17.8% of 1.469603449 so 260 MB (Why?)
 	return r.dec.Series(b, lset, chks)
 }
 

--- a/pkg/store/bucket_test.go
+++ b/pkg/store/bucket_test.go
@@ -1087,12 +1087,12 @@ func TestSeries(t *testing.T) {
 func BenchmarkSeries(b *testing.B) {
 	tb := testutil.NewTB(b)
 	tb.Run("10e6SeriesWithOneSample", func(tb testutil.TB) {
-		benchSeries(tb, 10e6, seriesDimension, 1, 10, 10e1, 10e2, 10e3, 10e4, 10e5) // This is too big for my machine: 10e6.
+		benchSeries(tb, 10e6, seriesDimension, 1) //  10, 10e1, 10e2, 10e3, 10e4, 10e5) // This is too big for my machine: 10e6.
 	})
-	tb.Run("OneSeriesWith100e6Samples", func(tb testutil.TB) {
-		// 100e6 samples = ~17361 days with 15s scrape.
-		benchSeries(tb, 100e6, samplesDimension, 1, 10, 10e1, 10e2, 10e3, 10e4, 10e5, 10e6) // This is too big for my machine: 100e6.
-	})
+	//tb.Run("OneSeriesWith100e6Samples", func(tb testutil.TB) {
+	//	// 100e6 samples = ~17361 days with 15s scrape.
+	//	benchSeries(tb, 100e6, samplesDimension, 1, 10, 10e1, 10e2, 10e3, 10e4, 10e5, 10e6) // This is too big for my machine: 100e6.
+	//})
 }
 
 func createBlockWithOneSample(t testutil.TB, dir string, blockIndex int, totalSeries int) (ulid.ULID, []storepb.Series) {
@@ -1338,6 +1338,17 @@ func benchSeries(t testutil.TB, number int, dimension Dimension, cases ...int) {
 				MaxTime: int64(c) - 1,
 				Matchers: []storepb.LabelMatcher{
 					{Type: storepb.LabelMatcher_EQ, Name: "foo", Value: "bar"},
+				},
+			},
+			expected: expected,
+		})
+		bCases = append(bCases, &benchSeriesCase{
+			name: fmt.Sprintf("%dof%d-neg-matcher", c, 4*numberPerBlock),
+			req: &storepb.SeriesRequest{
+				MinTime: 0,
+				MaxTime: int64(c) - 1,
+				Matchers: []storepb.LabelMatcher{
+					{Type: storepb.LabelMatcher_NEQ, Name: "i", Value: ""},
 				},
 			},
 			expected: expected,


### PR DESCRIPTION
Started with the case for Many series, as it has the most overhead.

## Changes:


## Baseline:

BenchmarkSeries/10e6SeriesWithOneSample/1of10000000-12               1577974688       1577974688     +0.00%
BenchmarkSeries/10e6SeriesWithOneSample/10of10000000-12              1577932488       1577932488     +0.00%
BenchmarkSeries/10e6SeriesWithOneSample/100of10000000-12             1578024936       1578024936     +0.00%
BenchmarkSeries/10e6SeriesWithOneSample/1000of10000000-12            1578459232       1578459232     +0.00%
BenchmarkSeries/10e6SeriesWithOneSample/10000of10000000-12           1587281048       1587281048     +0.00%
BenchmarkSeries/10e6SeriesWithOneSample/100000of10000000-12          1671271176       1671271176     +0.00%
BenchmarkSeries/10e6SeriesWithOneSample/1000000of10000000-12         2538825120       2538825120     +0.00%
BenchmarkSeries/OneSeriesWith100e6Samples/1of100000000-12            59252843         59252843       +0.00%
BenchmarkSeries/OneSeriesWith100e6Samples/10of100000000-12           59252737         59252737       +0.00%
BenchmarkSeries/OneSeriesWith100e6Samples/100of100000000-12          59252665         59252665       +0.00%
BenchmarkSeries/OneSeriesWith100e6Samples/1000of100000000-12         59236158         59236158       +0.00%
BenchmarkSeries/OneSeriesWith100e6Samples/10000of100000000-12        59347444         59347444       +0.00%
BenchmarkSeries/OneSeriesWith100e6Samples/100000of100000000-12       60409881         60409881       +0.00%
BenchmarkSeries/OneSeriesWith100e6Samples/1000000of100000000-12      69049852         69049852       +0.00%
BenchmarkSeries/OneSeriesWith100e6Samples/10000000of100000000-12     297757658        297757658      +0.00%

## End Result:

Signed-off-by: Bartlomiej Plotka <bwplotka@gmail.com>
