### PR TITLE
Skip deleting files that we just deleted

### DIFF
--- a/pkg/block/block.go
+++ b/pkg/block/block.go
@@ -147,10 +147,7 @@ func Delete(ctx context.Context, logger log.Logger, bkt objstore.Bucket, id ulid
 
 	// Delete the bucket, but skip the metaFile, if found. As we just deleted that.
 	return deleteDirRec(ctx, logger, bkt, id.String(), func(name string) bool {
-		if name == metaFile {
-			return true
-		}
-		return false
+		return name == metaFile
 	})
 }
 

--- a/pkg/block/block.go
+++ b/pkg/block/block.go
@@ -156,6 +156,11 @@ func deleteDir(ctx context.Context, logger log.Logger, bkt objstore.Bucket, dir 
 		if strings.HasSuffix(name, objstore.DirDelim) {
 			return deleteDir(ctx, logger, bkt, name)
 		}
+		metaFile := path.Join(id.String(), MetaFilename)
+		if name == metaFile {
+			// skip this file if we found it, it was already deleted
+			continue
+		}
 		if err := bkt.Delete(ctx, name); err != nil {
 			return err
 		}

--- a/pkg/block/block.go
+++ b/pkg/block/block.go
@@ -156,7 +156,7 @@ func deleteDir(ctx context.Context, logger log.Logger, bkt objstore.Bucket, dir 
 		if strings.HasSuffix(name, objstore.DirDelim) {
 			return deleteDir(ctx, logger, bkt, name)
 		}
-		metaFile := path.Join(id.String(), MetaFilename)
+		metaFile := path.Join(dir, MetaFilename)
 		if name == metaFile { // the metaFile was already deleted in Delete(), but might still appear in the Iter() list
 			level.Debug(logger).Log("msg", "skipping deletion of meta file, as it should already be deleted", "file", name, "bucket", bkt.Name())
 			return nil

--- a/pkg/block/block.go
+++ b/pkg/block/block.go
@@ -157,7 +157,7 @@ func deleteDir(ctx context.Context, logger log.Logger, bkt objstore.Bucket, dir 
 			return deleteDir(ctx, logger, bkt, name)
 		}
 		metaFile := path.Join(dir, MetaFilename)
-		if name == metaFile { // the metaFile was already deleted in Delete(), but might still appear in the Iter() list
+		if name == metaFile { // the metaFile was already deleted in Delete(), but might still appear in the Iter() list.
 			level.Debug(logger).Log("msg", "skipping deletion of meta file, as it should already be deleted", "file", name, "bucket", bkt.Name())
 			return nil
 		}

--- a/pkg/block/block.go
+++ b/pkg/block/block.go
@@ -157,9 +157,9 @@ func deleteDir(ctx context.Context, logger log.Logger, bkt objstore.Bucket, dir 
 			return deleteDir(ctx, logger, bkt, name)
 		}
 		metaFile := path.Join(id.String(), MetaFilename)
-		if name == metaFile {
-			// skip this file if we found it, it was already deleted
-			continue
+		if name == metaFile { // the metaFile was already deleted in Delete(), but might still appear in the Iter() list
+			level.Debug(logger).Log("msg", "skipping deletion of meta file, as it should already be deleted", "file", name, "bucket", bkt.Name())
+			return nil
 		}
 		if err := bkt.Delete(ctx, name); err != nil {
 			return err


### PR DESCRIPTION
We see this happening with Swift. Because the consistency of swift is eventual, swift sometimes didn't process the deletion of the meta file yet, and so it turns up in the bkt.Iter(). The second deletion then causes a 404 and compaction fails.

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
