### PR TITLE
rununtil: do not log if already closed

### DIFF
--- a/pkg/runutil/runutil.go
+++ b/pkg/runutil/runutil.go
@@ -111,6 +111,11 @@ func CloseWithLogOnErr(logger log.Logger, closer io.Closer, format string, a ...
 		return
 	}
 
+	// Not a problem if it has been closed already.
+	if errors.Is(err, os.ErrClosed) {
+		return
+	}
+
 	if logger == nil {
 		logger = log.NewLogfmtLogger(os.Stderr)
 	}

--- a/pkg/runutil/runutil_test.go
+++ b/pkg/runutil/runutil_test.go
@@ -5,9 +5,12 @@ package runutil
 
 import (
 	"io"
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/pkg/errors"
+	"github.com/thanos-io/thanos/pkg/testutil"
 )
 
 type testCloser struct {
@@ -71,4 +74,51 @@ func TestCloseWithErrCapture(t *testing.T) {
 			return
 		}
 	}
+}
+
+type loggerCapturer struct {
+	// WasCalled is true if the Log() function has been called.
+	WasCalled bool
+}
+
+func (lc *loggerCapturer) Log(keyvals ...interface{}) error {
+	lc.WasCalled = true
+	return nil
+}
+
+type emulatedCloser struct {
+	io.Reader
+
+	calls int
+}
+
+func (e *emulatedCloser) Close() error {
+	e.calls++
+	if e.calls == 1 {
+		return nil
+	}
+	if e.calls == 2 {
+		return errors.Wrap(os.ErrClosed, "can even be a wrapped one")
+	}
+	return errors.New("something very bad happened")
+}
+
+// newEmulatedCloser returns a ReadCloser with a Close method
+// that at first returns success but then returns that
+// it has been closed already. After that, it returns that
+// something very bad had happened.
+func newEmulatedCloser(r io.Reader) io.ReadCloser {
+	return &emulatedCloser{Reader: r}
+}
+
+func TestCloseMoreThanOnce(t *testing.T) {
+	lc := &loggerCapturer{}
+	r := newEmulatedCloser(strings.NewReader("somestring"))
+
+	CloseWithLogOnErr(lc, r, "should not be called")
+	CloseWithLogOnErr(lc, r, "should not be called")
+	testutil.Equals(t, false, lc.WasCalled)
+
+	CloseWithLogOnErr(lc, r, "should be called")
+	testutil.Equals(t, true, lc.WasCalled)
 }


### PR DESCRIPTION
Check in `CloseWithLogOnErr()` if it has been closed already. If it has
been then it's certainly not a problem and can be safely ignored.

Signed-off-by: Giedrius Statkevičius <giedriuswork@gmail.com>

Closes: https://github.com/thanos-io/thanos/pull/1489.
Closes: https://github.com/thanos-io/thanos/issues/2082.

Tested:
* `make test-local`
* `make lint`