### PR TITLE
Updated to golang v1.14.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-            version: 17.07.0-ce
+          version: 17.07.0-ce
       - run:
           name: Create Secret if PR is not forked
           # GCS integration tests are run only for author's PR that have write access, because these tests
@@ -53,12 +53,12 @@ jobs:
     environment:
       GOBIN: "/home/circleci/.go_workspace/go/bin"
     steps:
-    - checkout
-    - run: make crossbuild
-    - persist_to_workspace:
-        root: .
-        paths:
-        - .build
+      - checkout
+      - run: make crossbuild
+      - persist_to_workspace:
+          root: .
+          paths:
+            - .build
 
   publish_master:
     <<: *defaults
@@ -106,30 +106,30 @@ workflows:
   version: 2
   thanos:
     jobs:
-    - test:
-        filters:
-          tags:
-            only: /.*/
-    - publish_master:
-        requires:
-        - test
-        filters:
-          branches:
-            only: master
-    - cross_build:
-        requires:
-        - test
-        filters:
-          tags:
-            only: /^v[0-9]+(\.[0-9]+){2}(-.+|[^-.]*)$/
-          branches:
-            ignore: /.*/
-    - publish_release:
-        requires:
-        - test
-        - cross_build
-        filters:
-          tags:
-            only: /^v[0-9]+(\.[0-9]+){2}(-.+|[^-.]*)$/
-          branches:
-            ignore: /.*/
+      - test:
+          filters:
+            tags:
+              only: /.*/
+      - publish_master:
+          requires:
+            - test
+          filters:
+            branches:
+              only: master
+      - cross_build:
+          requires:
+            - test
+          filters:
+            tags:
+              only: /^v[0-9]+(\.[0-9]+){2}(-.+|[^-.]*)$/
+            branches:
+              ignore: /.*/
+      - publish_release:
+          requires:
+            - test
+            - cross_build
+          filters:
+            tags:
+              only: /^v[0-9]+(\.[0-9]+){2}(-.+|[^-.]*)$/
+            branches:
+              ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2
 defaults: &defaults
   docker:
     # Built by Thanos make docker-ci
-    - image: quay.io/thanos/thanos-ci:v0.3.0
+    - image: quay.io/thanos/thanos-ci:go1.14.2-node
 jobs:
   test:
     <<: *defaults

--- a/.github/workflows/cross-build.yaml
+++ b/.github/workflows/cross-build.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Install Go.
         uses: actions/setup-go@v1
         with:
-          go-version: 1.13.6
+          go-version: 1.14.2
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v1

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: Install Go.
         uses: actions/setup-go@v1
         with:
-          go-version: 1.13.6
+          go-version: 1.14.2
 
       - name: Check out code into the Go module directory.
         uses: actions/checkout@v2

--- a/.promu.yml
+++ b/.promu.yml
@@ -1,5 +1,5 @@
 go:
-    version: 1.13.6
+    version: 1.14.2
 repository:
     path: github.com/thanos-io/thanos
 build:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 
 ### Changed
 
+- [#2194](https://github.com/thanos-io/thanos/pull/2194) Updated to golang v1.14.2
 - [#2505](https://github.com/thanos.io/thanos/pull/2505) Store: remove obsolete `thanos_store_node_info` metric.
 - [2513](https://github.com/thanos-io/thanos/pull/2513) Tools: Moved `thanos bucket` commands to `thanos tools bucket`, also
 moved `thanos check rules` to `thanos tools rules-check`. `thanos tools rules-check` also takes rules by `--rules` repeated flag not argument

--- a/Dockerfile.multi-stage
+++ b/Dockerfile.multi-stage
@@ -1,4 +1,4 @@
-FROM golang:1.13.6-alpine3.11 as builder
+FROM golang:1.14.2-alpine3.11 as builder
 
 WORKDIR $GOPATH/src/github.com/thanos-io/thanos
 # Change in the docker context invalidates the cache so to leverage docker

--- a/Dockerfile.thanos-ci
+++ b/Dockerfile.thanos-ci
@@ -1,5 +1,5 @@
 # Available from https://hub.docker.com/r/circleci/golang/
-FROM circleci/golang:1.13.6
+FROM circleci/golang:1.14.2-node
 
 ENV GOBIN=/go/bin
 


### PR DESCRIPTION
* [x] I added CHANGELOG entry for this change. 
* [x] Change is not relevant to the end-user.

## Changes

- Update golang to 1.14.2
- Generate thanos-ci:go1.14.2-node
This is a manual process that requires one of the maintainers to run the following:

```
make docker-ci DOCKER_CI_TAG=go1.14.2-node
```

~~Sadly `circleci/golang:1.14.0` is not yet available, so this PR would be on hold until it becomes available, hopefully sometime in the next few days.~~

## Rationale

Go 1.14 highlights:

- [Embedding interfaces with overlapping method sets ](https://golang.org/doc/go1.14#language)
- [Improved defer performance](https://golang.org/doc/go1.14#runtime)
- [Goroutines are asynchronously preemptible](https://golang.org/doc/go1.14#runtime)
- [The page allocator is more efficient](https://golang.org/doc/go1.14#runtime)
- [Internal timers are more efficient](https://golang.org/doc/go1.14#runtime)

 [Go 1.14 Announce](https://blog.golang.org/go1.14)
[Go 1.14 Full Release notes](https://golang.org/doc/go1.14)
[Go 1.14.1 Fixes](https://github.com/golang/go/issues?q=milestone%3AGo1.14.1+label%3ACherryPickApproved)