### PR TITLE
Typo corrections quick-tutorial.md

### DIFF
--- a/docs/quick-tutorial.md
+++ b/docs/quick-tutorial.md
@@ -39,9 +39,9 @@ Following the [KISS](https://en.wikipedia.org/wiki/KISS_principle) and Unix phil
 * Sidecar: connects to Prometheus, reads its data for query and/or uploads it to cloud storage.
 * Store Gateway: serves metrics inside of a cloud storage bucket.
 * Compactor: compacts, downsamples and applies retention on the data stored in cloud storage bucket.
-* Receiver: receives data from Prometheus' remote-write WAL, exposes it and/or upload it to cloud storage.
+* Receiver: receives data from Prometheus's remote-write WAL, exposes it and/or upload it to cloud storage.
 * Ruler/Rule: evaluates recording and alerting rules against data in Thanos for exposition and/or upload.
-* Querier/Query: implements Prometheus' v1 API to aggregate data from the underlying components.
+* Querier/Query: implements Prometheus's v1 API to aggregate data from the underlying components.
 
 See those components on this diagram:
 
@@ -57,7 +57,7 @@ The Sidecar makes use of the `reload` Prometheus endpoint. Make sure it's enable
 
 #### External storage
 
-The following configures the sidecar to write Prometheus' data into a configured object storage:
+The following configures the sidecar to write Prometheus's data into a configured object storage:
 
 ```bash
 thanos sidecar \
@@ -208,7 +208,7 @@ The store gateway occupies small amounts of disk space for caching basic informa
 
 A local Prometheus installation periodically compacts older data to improve query efficiency. Since the sidecar backs up data as soon as possible, we need a way to apply the same process to data in the object storage.
 
-The compactor component simple scans the object storage and processes compaction where required. At the same time it is responsible for creating downsampled copies of data to speed up queries.
+The compactor component simply scans the object storage and processes compaction where required. At the same time it is responsible for creating downsampled copies of data to speed up queries.
 
 ```bash
 thanos compact \


### PR DESCRIPTION
* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

* Corrected all Prometheus possessives to read `Prometheus's`, this matches Prometheus's own documentation.
* Corrected `simple` to `simply` when describing compactor scanning behaviour

## Verification

N/A
