### PR TITLE
docs: Fixed links to Grafana dashboards json files.

### DIFF
--- a/examples/dashboards/dashboards.md
+++ b/examples/dashboards/dashboards.md
@@ -2,14 +2,14 @@
 
 There exists Grafana dashboards for each component (not all of them complete) targeted for environments running Kubernetes:
 
-- [Thanos Overview](thanos-overview.json)
-- [Thanos Compact](thanos-compactor.json)
-- [Thanos Querier](thanos-querier.json)
-- [Thanos Store](thanos-store.json)
-- [Thanos Receiver](thanos-receiver.json)
-- [Thanos Sidecar](thanos-sidecar.json)
-- [Thanos Ruler](thanos-ruler.json)
-- [Thanos Replicate](thanos-bucket-replicate.json)
+- [Thanos Overview](overview.json)
+- [Thanos Compact](compact.json)
+- [Thanos Querier](query.json)
+- [Thanos Store](store.json)
+- [Thanos Receiver](receive.json)
+- [Thanos Sidecar](sidecar.json)
+- [Thanos Ruler](rule.json)
+- [Thanos Replicate](bucket_replicate.json)
 
 You can import them via `Import -> Paste JSON` in Grafana.
 These dashboards require Grafana 5 or above, importing them in older versions are known not to work.


### PR DESCRIPTION
## Changes

Fixed links to Grafana dashboards JSON files in the documentation.

## Verification

Links work now!