### PR TITLE
Fix error in component status help message

### DIFF
--- a/pkg/prober/intrumentation.go
+++ b/pkg/prober/intrumentation.go
@@ -32,7 +32,7 @@ func NewInstrumentation(component component.Component, logger log.Logger, reg pr
 		logger:    logger,
 		status: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Name:        "status",
-			Help:        "Represents status (0 indicates success, 1 indicates failure) of the component.",
+			Help:        "Represents status (0 indicates failure, 1 indicates success) of the component.",
 			ConstLabels: map[string]string{"component": component.String()},
 		},
 			[]string{"check"},


### PR DESCRIPTION
## Changes

Prober help message indicated that error returned a value of 1 while success returned a value of 0.  Looking at the code it is apparent this should be the other way around, so just modified the help message.

I was unsure if this should be added to the CHANGELOG or not.  Please advise.

## Verification

Minor change in help message.
