### PR TITLE
[WIP] compact: Add vertical-deduplication for replica-labels as MetaFetcher filter

### DIFF
--- a/test/e2e/compact_test.go
+++ b/test/e2e/compact_test.go
@@ -1,0 +1,69 @@
+package e2e
+
+import (
+	"context"
+	"os"
+	"path"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/cortexproject/cortex/integration/e2e"
+	e2edb "github.com/cortexproject/cortex/integration/e2e/db"
+	"github.com/go-kit/kit/log"
+	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/prometheus/pkg/timestamp"
+	"github.com/thanos-io/thanos/pkg/objstore"
+	"github.com/thanos-io/thanos/pkg/objstore/client"
+	"github.com/thanos-io/thanos/pkg/objstore/s3"
+	"github.com/thanos-io/thanos/pkg/testutil"
+	"github.com/thanos-io/thanos/pkg/testutil/e2eutil"
+	"github.com/thanos-io/thanos/test/e2e/e2ethanos"
+)
+
+func TestCompact(t *testing.T) {
+	t.Parallel()
+	l := log.NewLogfmtLogger(os.Stdout)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+	defer cancel()
+
+	s, err := e2e.NewScenario("e2e_test_compact")
+	testutil.Ok(t, err)
+	defer s.Close()
+
+	const bucket = "thanos"
+
+	m := e2edb.NewMinio(80, bucket)
+	testutil.Ok(t, s.StartAndWaitReady(m))
+
+	s3Config := s3.Config{
+		Bucket:    bucket,
+		AccessKey: e2edb.MinioAccessKey,
+		SecretKey: e2edb.MinioSecretKey,
+		Endpoint:  m.NetworkHTTPEndpoint(),
+		Insecure:  true,
+	}
+
+	series := []labels.Labels{labels.FromStrings("a", "1", "b", "2")}
+	extLset := labels.FromStrings("ext1", "value1", "replica", "1")
+
+	bkt, err := s3.NewBucketWithConfig(l, s3Config, "test-feed")
+	testutil.Ok(t, err)
+
+	dir := filepath.Join(s.SharedDir(), "tmp")
+
+	now := time.Now()
+	id1, err := e2eutil.CreateBlockWithBlockDelay(ctx, dir, series, 10, timestamp.FromTime(now), timestamp.FromTime(now.Add(2*time.Hour)), 30*time.Minute, extLset, 0)
+	testutil.Ok(t, err)
+
+	testutil.Ok(t, objstore.UploadDir(ctx, l, bkt, path.Join(dir, id1.String()), id1.String()))
+
+	compact, err := e2ethanos.NewCompact(s.SharedDir(), "compact", client.BucketConfig{
+		Type:   client.S3,
+		Config: s3Config,
+	})
+	testutil.Ok(t, err)
+	testutil.Ok(t, s.StartAndWaitReady(compact))
+
+}


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end-user.

_Need to create the PR first to get a number :grin:_

## Changes

Add MetaFetcher filter called ReplicaLabelsFilter in: https://github.com/thanos-io/thanos/pull/2217/commits/c6828f9fd9fc1867f6dd4caa3c9fcf01d2e071d3
Other commits are to add e2e tests.

## Verification

This is the reason why it's still WIP. I want to finish the end to end tests, but I get minio errors. I'm not able to fix it right now.
```
compact_test.go:60: unexpected error: upload file /tmp/e2e_integration_test767365421/tmp/01E2NBJ5Q70000000000000000/chunks/000001 as 01E2NBJ5Q70000000000000000/chunks/000001: upload s3 object: Get "http://e2e_test_compact-minio-80/thanos/?location=": dial tcp: lookup e2e_test_compact-minio-80: no such host
```

/cc @brancz @bwplotka @squat 