### PR TITLE
Use 32bit number for index cache init so Thanos will build on 32bit OS

### DIFF
--- a/pkg/store/cache/inmemory.go
+++ b/pkg/store/cache/inmemory.go
@@ -163,7 +163,7 @@ func NewInMemoryIndexCacheWithConfig(logger log.Logger, reg prometheus.Registere
 
 	// Initialize LRU cache with a high size limit since we will manage evictions ourselves
 	// based on stored size using `RemoveOldest` method.
-	l, err := lru.NewLRU(math.MaxInt64, c.onEvict)
+	l, err := lru.NewLRU(math.MaxInt32, c.onEvict)
 	if err != nil {
 		return nil, err
 	}
@@ -173,7 +173,7 @@ func NewInMemoryIndexCacheWithConfig(logger log.Logger, reg prometheus.Registere
 		"msg", "created in-memory index cache",
 		"maxItemSizeBytes", c.maxItemSizeBytes,
 		"maxSizeBytes", c.maxSizeBytes,
-		"maxItems", "math.MaxInt64",
+		"maxItems", "math.MaxInt32",
 	)
 	return c, nil
 }


### PR DESCRIPTION

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

Previously the index cache was initialized with `math.MaxInt64` however this will cause Thanos to fail to compile for a 32bit system (Raspberry Pi), It seems a reasonable compromise here is to init the cache with `math.MaxInt32` which addresses the issue.  This does however change the cache to hold 2^32 objects vs 2^64, though I think this should still be plenty??

Another alternative would be something like this:

```
l, err := lru.NewLRU(int(int64(math.MaxInt64)), c.onEvict)
```

However this kind of feels worse to me unless there is an expectation to have more than ~4billion entries in this cache?

Relevant Go issue: https://github.com/golang/go/issues/23086

Signed-off-by: Edward Welch <edward.welch@grafana.com>