### PR TITLE
bucket: improve shard label handling

### DIFF
--- a/pkg/ui/static/js/bucket.js
+++ b/pkg/ui/static/js/bucket.js
@@ -33,16 +33,13 @@ function draw() {
                 // Title is the first column of the timeline.
                 //
                 // A unique Prometheus label that identifies each shard is used
-                // as the title if present, otherwise all labels are displayed
+                // as the title if present, otherwise labels are displayed
                 // externally as a legend.
                 title = function() {
-                    if (thanos.label != "") {
-                        var key = d.thanos.labels[thanos.label];
-                        if (key == undefined) {
-                            throw `Label ${thanos.label} not found in ${Object.keys(d.thanos.labels)}`;
-                        } else {
-                            return key;
-                        }
+                    var key = thanos.label != "" && d.thanos.labels[thanos.label];
+
+                    if (key != undefined) {
+                        return key;
                     } else {
                         title = titles[stringify(d.thanos.labels)];
                         if (title == undefined) {


### PR DESCRIPTION
* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

* Allow bucket web UI to continue labeling old blocks, even if they don't match up with current labeling conventions.

This allows someone to edit their external labels, and still see all their data inside the bucket web component. Currently, the bucket web component will just throw an error (in bucket.js) since some of the data is unlabeled (assuming that you pass `--label`).

The bucket component already handles shards with and without labels, this change simply allows you to mix the two. Any unlabeled shards will be assigned a number, exactly how the component behaves when no `--label` is passed. After the unlabeled shards are listed, any labeled shards will be listed.

## Verification

Tested with bucket containing some data with no external labels.
![image](https://user-images.githubusercontent.com/5648814/76017618-e5dd4d80-5eec-11ea-8298-9fb63c222085.png)

It is merged with newer data containing external labels.