### PR TITLE
query: support store config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 - [#2145](https://github.com/thanos-io/thanos/pull/2145) Tracing: track query sent to prometheus via remote read api.
 - [#1848](https://github.com/thanos-io/thanos/pull/1848) Ruler: Return error messages when trigger reload with http.
 - [#2113](https://github.com/thanos-io/thanos/pull/2113) Bucket: Added `thanos bucket replicate`.
-- [#TODO](https://github.com/thanos-io/thanos/pull/TODO) Query: Add ability to mix Store TLS configuration with the `--store.config` amd `--store.config-file` CLI flags. See [documentation](docs/components/query.md/#configuration) for further information.
+- [#2226](https://github.com/thanos-io/thanos/pull/2226) Query: Add ability to mix Store TLS configuration with the `--store.config` amd `--store.config-file` CLI flags. See [documentation](docs/components/query.md/#configuration) for further information.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 - [#2145](https://github.com/thanos-io/thanos/pull/2145) Tracing: track query sent to prometheus via remote read api.
 - [#1848](https://github.com/thanos-io/thanos/pull/1848) Ruler: Return error messages when trigger reload with http.
 - [#2113](https://github.com/thanos-io/thanos/pull/2113) Bucket: Added `thanos bucket replicate`.
+- [#TODO](https://github.com/thanos-io/thanos/pull/TODO) Query: Add ability to mix Store TLS configuration with the `--store.config` amd `--store.config-file` CLI flags. See [documentation](docs/components/query.md/#configuration) for further information.
 
 ### Changed
 

--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -230,7 +230,7 @@ func runQuery(
 		var err error
 		storesConfig, err = store.LoadConfig(storeConfigYAML)
 		if err != nil {
-			return err
+			return errors.Wrap(err, "loading store config")
 		}
 	} else {
 		for _, addr := range storeAddrs {

--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -293,7 +293,6 @@ func runQuery(
 		fileSDCache := cache.New()
 		dnsProvider := dns.NewProvider(
 			logger,
-			// todo: sml: looks a bit iffy
 			extprom.WrapRegistererWith(
 				map[string]string{"config_name": config.Name},
 				extprom.WrapRegistererWithPrefix("thanos_querier_store_apis_", reg),

--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -361,8 +361,8 @@ func runQuery(
 				Timeout:    queryTimeout,
 			},
 		)
-		grpcProbe = prober.NewGRPC()
-		httpProbe = prober.NewHTTP()
+		grpcProbe    = prober.NewGRPC()
+		httpProbe    = prober.NewHTTP()
 		statusProber = prober.Combine(
 			httpProbe,
 			grpcProbe,

--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -227,7 +227,6 @@ func runQuery(
 	})
 	reg.MustRegister(duplicatedStores)
 
-
 	var storesConfig []store.Config
 	if len(storeConfigYAML) > 0 {
 		var err error
@@ -242,26 +241,26 @@ func runQuery(
 			}
 		}
 
-		endpointsConfig := store.EndpointsConfig {
+		endpointsConfig := store.EndpointsConfig{
 			StaticAddresses: storeAddrs,
 		}
 		if fileSDConfig != nil {
 			endpointsConfig.FileSDConfigs = []file.SDConfig{*fileSDConfig}
 		}
 		storeConfig := store.Config{
-			Name: "default",
+			Name:            "default",
 			EndpointsConfig: endpointsConfig,
 		}
 		if secure {
-			storeConfig.TlsConfig = &store.TlsConfig {
-				Cert: cert,
-				Key: key,
-				CaCert: caCert,
+			storeConfig.TlsConfig = &store.TlsConfig{
+				Cert:       cert,
+				Key:        key,
+				CaCert:     caCert,
 				ServerName: serverName,
 			}
 		}
 
-		storesConfig = []store.Config{ storeConfig }
+		storesConfig = []store.Config{storeConfig}
 	}
 
 	// todo: sml: remove - for debugging
@@ -312,12 +311,11 @@ func runQuery(
 			logger,
 			// todo: sml: looks a bit iffy
 			extprom.WrapRegistererWith(
-				map[string]string{"config_name":config.Name},
+				map[string]string{"config_name": config.Name},
 				extprom.WrapRegistererWithPrefix("thanos_querier_store_apis_", reg),
-		    ),
+			),
 			dns.ResolverType(dnsSDResolver),
 		)
-
 
 		stores := query.NewStoreSet(
 			logger,
@@ -354,11 +352,10 @@ func runQuery(
 		// Run File Service Discovery and update the store set when the files are modified.
 		if config.EndpointsConfig.FileSDConfigs != nil && len(config.EndpointsConfig.FileSDConfigs) > 0 {
 			var fileSDUpdates chan []*targetgroup.Group
-			ctxRun, cancelRun := context.WithCancel(context.Background())
-
 			fileSDUpdates = make(chan []*targetgroup.Group)
 
 			for _, fsdConfig := range config.EndpointsConfig.FileSDConfigs {
+				ctxRun, cancelRun := context.WithCancel(context.Background())
 				fileSD := file.NewDiscovery(&fsdConfig, logger)
 				g.Add(func() error {
 					fileSD.Run(ctxRun, fileSDUpdates)

--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -286,20 +286,11 @@ func runQuery(
 		)
 	)
 
-	// run through once so we don't leave funcs hanging
-	perConfigDialOpts := make(map[string][]grpc.DialOption)
 	for _, config := range storesConfig {
-
 		dialOpts, err := extgrpc.StoreClientGRPCOptsFromTlsConfig(logger, config.Name, reg, tracer, config.TlsConfig)
 		if err != nil {
 			return errors.Wrap(err, "building gRPC client")
 		}
-		perConfigDialOpts[config.Name] = dialOpts
-	}
-
-	for _, config := range storesConfig {
-
-		dialOpts := perConfigDialOpts[config.Name]
 
 		fileSDCache := cache.New()
 		dnsProvider := dns.NewProvider(

--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -233,31 +233,10 @@ func runQuery(
 			return errors.Wrap(err, "loading store config")
 		}
 	} else {
-		for _, addr := range storeAddrs {
-			if addr == "" {
-				return errors.New("static store address cannot be empty")
-			}
+		storeConfig, err := store.NewConfig(storeAddrs, fileSDConfig, secure, cert, key, caCert, serverName)
+		if err != nil {
+			return errors.Wrap(err, "initialising stores config from individual flags")
 		}
-
-		endpointsConfig := store.EndpointsConfig{
-			StaticAddresses: storeAddrs,
-		}
-		if fileSDConfig != nil {
-			endpointsConfig.FileSDConfigs = []file.SDConfig{*fileSDConfig}
-		}
-		storeConfig := store.Config{
-			Name:            "default",
-			EndpointsConfig: endpointsConfig,
-		}
-		if secure {
-			storeConfig.TlsConfig = &store.TlsConfig{
-				Cert:       cert,
-				Key:        key,
-				CaCert:     caCert,
-				ServerName: serverName,
-			}
-		}
-
 		storesConfig = []store.Config{storeConfig}
 	}
 

--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -6,7 +6,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/thanos-io/thanos/pkg/extflag"
 	"google.golang.org/grpc"
 	"gopkg.in/yaml.v2"
 	"math"
@@ -31,6 +30,7 @@ import (
 	"github.com/thanos-io/thanos/pkg/component"
 	"github.com/thanos-io/thanos/pkg/discovery/cache"
 	"github.com/thanos-io/thanos/pkg/discovery/dns"
+	"github.com/thanos-io/thanos/pkg/extflag"
 	"github.com/thanos-io/thanos/pkg/extgrpc"
 	"github.com/thanos-io/thanos/pkg/extprom"
 	extpromhttp "github.com/thanos-io/thanos/pkg/extprom/http"
@@ -351,8 +351,7 @@ func runQuery(
 		}
 		// Run File Service Discovery and update the store set when the files are modified.
 		if config.EndpointsConfig.FileSDConfigs != nil && len(config.EndpointsConfig.FileSDConfigs) > 0 {
-			var fileSDUpdates chan []*targetgroup.Group
-			fileSDUpdates = make(chan []*targetgroup.Group)
+			fileSDUpdates := make(chan []*targetgroup.Group)
 
 			for _, fsdConfig := range config.EndpointsConfig.FileSDConfigs {
 				ctxRun, cancelRun := context.WithCancel(context.Background())

--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -12,8 +12,6 @@ import (
 	"strings"
 	"time"
 
-	"google.golang.org/grpc"
-
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/oklog/run"

--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -295,6 +295,8 @@ func runQuery(
 
 		dialOpts, err := extgrpc.StoreClientGRPCOptsFromTlsConfig(logger, config.Name, reg, tracer, config.TlsConfig)
 		if err != nil {
+			_, cancelRun := context.WithCancel(context.Background())
+			cancelRun()
 			return errors.Wrap(err, "building gRPC client")
 		}
 

--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -6,6 +6,8 @@ package main
 import (
 	"context"
 	"fmt"
+	"github.com/thanos-io/thanos/pkg/extflag"
+	"gopkg.in/yaml.v2"
 	"math"
 	"net/http"
 	"path"
@@ -77,6 +79,8 @@ func registerQuery(m map[string]setupFunc, app *kingpin.Application) {
 	stores := cmd.Flag("store", "Addresses of statically configured store API servers (repeatable). The scheme may be prefixed with 'dns+' or 'dnssrv+' to detect store API servers through respective DNS lookups.").
 		PlaceHolder("<store>").Strings()
 
+	storeConfig := extflag.RegisterPathOrContent(cmd, "store.config", "YAML file that contains store API servers configuration. See format details: https://thanos.io/components/query.md/#configuration. If defined, it takes precedence over the '--store' and '--store.sd-files' flags.", false)
+
 	fileSDFiles := cmd.Flag("store.sd-files", "Path to files that contain addresses of store API servers. The path can be a glob pattern (repeatable).").
 		PlaceHolder("<path>").Strings()
 
@@ -117,13 +121,23 @@ func registerQuery(m map[string]setupFunc, app *kingpin.Application) {
 			lookupStores[s] = struct{}{}
 		}
 
-		var fileSD *file.Discovery
+		storeConfigYAML, err := storeConfig.Content()
+		if err != nil {
+			return err
+		}
+		if len(*fileSDFiles) == 0 && len(*stores) == 0 && len(storeConfigYAML) == 0 {
+			return errors.New("no --store parameter was given")
+		}
+		if (len(*fileSDFiles) != 0 || len(*stores) != 0) && len(storeConfigYAML) != 0 {
+			return errors.New("--store/--store.sd-files and --store.config* parameters cannot be defined at the same time")
+		}
+
+		var fileSDConfig *file.SDConfig
 		if len(*fileSDFiles) > 0 {
-			conf := &file.SDConfig{
+			fileSDConfig = &file.SDConfig{
 				Files:           *fileSDFiles,
 				RefreshInterval: *fileSDInterval,
 			}
-			fileSD = file.NewDiscovery(conf, logger)
 		}
 
 		promql.SetDefaultEvaluationInterval(time.Duration(*defaultEvaluationInterval))
@@ -156,7 +170,8 @@ func registerQuery(m map[string]setupFunc, app *kingpin.Application) {
 			*stores,
 			*enableAutodownsampling,
 			*enablePartialResponse,
-			fileSD,
+			fileSDConfig,
+			storeConfigYAML,
 			time.Duration(*dnsSDInterval),
 			*dnsSDResolver,
 			time.Duration(*unhealthyStoreTimeout),
@@ -196,7 +211,8 @@ func runQuery(
 	storeAddrs []string,
 	enableAutodownsampling bool,
 	enablePartialResponse bool,
-	fileSD *file.Discovery,
+	fileSDConfig *file.SDConfig,
+	storeConfigYAML []byte,
 	dnsSDInterval time.Duration,
 	dnsSDResolver string,
 	unhealthyStoreTimeout time.Duration,
@@ -210,21 +226,93 @@ func runQuery(
 	})
 	reg.MustRegister(duplicatedStores)
 
-	dialOpts, err := extgrpc.StoreClientGRPCOpts(logger, reg, tracer, secure, cert, key, caCert, serverName)
-	if err != nil {
-		return errors.Wrap(err, "building gRPC client")
+
+	var storesConfig []store.Config
+	if len(storeConfigYAML) > 0 {
+		var err error
+		storesConfig, err = store.LoadConfig(storeConfigYAML)
+		if err != nil {
+			return err
+		}
+	} else {
+		for _, addr := range storeAddrs {
+			if addr == "" {
+				return errors.New("static store address cannot be empty")
+			}
+		}
+
+		endpointsConfig := store.EndpointsConfig {
+			StaticAddresses: storeAddrs,
+		}
+		if fileSDConfig != nil {
+			endpointsConfig.FileSDConfigs = []file.SDConfig{*fileSDConfig}
+		}
+		storeConfig := store.Config{
+			Name: "default",
+			EndpointsConfig: endpointsConfig,
+		}
+		if secure {
+			storeConfig.TlsConfig = &store.TlsConfig {
+				Cert: cert,
+				Key: key,
+				CaCert: caCert,
+				ServerName: serverName,
+			}
+		}
+
+		storesConfig = []store.Config{ storeConfig }
 	}
 
-	fileSDCache := cache.New()
-	dnsProvider := dns.NewProvider(
-		logger,
-		extprom.WrapRegistererWithPrefix("thanos_querier_store_apis_", reg),
-		dns.ResolverType(dnsSDResolver),
+	// todo: sml: remove - for debugging
+	level.Info(logger).Log("msg", fmt.Sprintf("%v", storesConfig))
+	storeBytes, _ := yaml.Marshal(storesConfig)
+	level.Info(logger).Log("msg", string(storeBytes))
+
+	var storeSets []*query.StoreSet
+	var (
+		allClients = func() []store.Client {
+			var ret []store.Client
+			for _, ss := range storeSets {
+				ret = append(ret, ss.Get()...)
+			}
+			return ret
+		}
+		proxy            = store.NewProxyStore(logger, reg, allClients, component.Query, selectorLset, storeResponseTimeout)
+		queryableCreator = query.NewQueryableCreator(logger, proxy)
+		engine           = promql.NewEngine(
+			promql.EngineOpts{
+				Logger:        logger,
+				Reg:           reg,
+				MaxConcurrent: maxConcurrentQueries,
+				// TODO(bwplotka): Expose this as a flag: https://github.com/thanos-io/thanos/issues/703.
+				MaxSamples: math.MaxInt32,
+				Timeout:    queryTimeout,
+			},
+		)
 	)
 
-	var (
-		stores = query.NewStoreSet(
+	for _, config := range storesConfig {
+
+		dialOpts, err := extgrpc.StoreClientGRPCOptsFromTlsConfig(logger, config.Name, reg, tracer, config.TlsConfig)
+		if err != nil {
+			return errors.Wrap(err, "building gRPC client")
+		}
+
+		fileSDCache := cache.New()
+		dnsProvider := dns.NewProvider(
 			logger,
+			// todo: sml: looks a bit iffy
+			extprom.WrapRegistererWith(
+				map[string]string{"config_name":config.Name},
+				extprom.WrapRegistererWithPrefix("thanos_querier_store_apis_", reg),
+		    ),
+			dns.ResolverType(dnsSDResolver),
+		)
+
+
+		stores := query.NewStoreSet(
+			logger,
+			config.Name,
 			reg,
 			func() (specs []query.StoreSpec) {
 				// Add DNS resolved addresses from static flags and file SD.
@@ -239,78 +327,73 @@ func runQuery(
 			dialOpts,
 			unhealthyStoreTimeout,
 		)
-		proxy            = store.NewProxyStore(logger, reg, stores.Get, component.Query, selectorLset, storeResponseTimeout)
-		queryableCreator = query.NewQueryableCreator(logger, proxy)
-		engine           = promql.NewEngine(
-			promql.EngineOpts{
-				Logger:        logger,
-				Reg:           reg,
-				MaxConcurrent: maxConcurrentQueries,
-				// TODO(bwplotka): Expose this as a flag: https://github.com/thanos-io/thanos/issues/703.
-				MaxSamples: math.MaxInt32,
-				Timeout:    queryTimeout,
-			},
-		)
-	)
-	// Periodically update the store set with the addresses we see in our cluster.
-	{
-		ctx, cancel := context.WithCancel(context.Background())
-		g.Add(func() error {
-			return runutil.Repeat(5*time.Second, ctx.Done(), func() error {
-				stores.Update(ctx)
-				return nil
-			})
-		}, func(error) {
-			cancel()
-			stores.Close()
-		})
-	}
-	// Run File Service Discovery and update the store set when the files are modified.
-	if fileSD != nil {
-		var fileSDUpdates chan []*targetgroup.Group
-		ctxRun, cancelRun := context.WithCancel(context.Background())
+		storeSets = append(storeSets, stores)
 
-		fileSDUpdates = make(chan []*targetgroup.Group)
-
-		g.Add(func() error {
-			fileSD.Run(ctxRun, fileSDUpdates)
-			return nil
-		}, func(error) {
-			cancelRun()
-		})
-
-		ctxUpdate, cancelUpdate := context.WithCancel(context.Background())
-		g.Add(func() error {
-			for {
-				select {
-				case update := <-fileSDUpdates:
-					// Discoverers sometimes send nil updates so need to check for it to avoid panics.
-					if update == nil {
-						continue
-					}
-					fileSDCache.Update(update)
-					stores.Update(ctxUpdate)
-					dnsProvider.Resolve(ctxUpdate, append(fileSDCache.Addresses(), storeAddrs...))
-				case <-ctxUpdate.Done():
+		// Periodically update the store set with the addresses we see in our cluster.
+		{
+			ctx, cancel := context.WithCancel(context.Background())
+			g.Add(func() error {
+				return runutil.Repeat(5*time.Second, ctx.Done(), func() error {
+					stores.Update(ctx)
 					return nil
-				}
-			}
-		}, func(error) {
-			cancelUpdate()
-			close(fileSDUpdates)
-		})
-	}
-	// Periodically update the addresses from static flags and file SD by resolving them using DNS SD if necessary.
-	{
-		ctx, cancel := context.WithCancel(context.Background())
-		g.Add(func() error {
-			return runutil.Repeat(dnsSDInterval, ctx.Done(), func() error {
-				dnsProvider.Resolve(ctx, append(fileSDCache.Addresses(), storeAddrs...))
-				return nil
+				})
+			}, func(error) {
+				cancel()
+				stores.Close()
 			})
-		}, func(error) {
-			cancel()
-		})
+		}
+		// Run File Service Discovery and update the store set when the files are modified.
+		if config.EndpointsConfig.FileSDConfigs != nil && len(config.EndpointsConfig.FileSDConfigs) > 0 {
+			var fileSDUpdates chan []*targetgroup.Group
+			ctxRun, cancelRun := context.WithCancel(context.Background())
+
+			fileSDUpdates = make(chan []*targetgroup.Group)
+
+			for _, fsdConfig := range config.EndpointsConfig.FileSDConfigs {
+				fileSD := file.NewDiscovery(&fsdConfig, logger)
+				g.Add(func() error {
+					fileSD.Run(ctxRun, fileSDUpdates)
+					return nil
+				}, func(error) {
+					cancelRun()
+				})
+			}
+
+			ctxUpdate, cancelUpdate := context.WithCancel(context.Background())
+			staticAddresses := config.EndpointsConfig.StaticAddresses
+			g.Add(func() error {
+				for {
+					select {
+					case update := <-fileSDUpdates:
+						// Discoverers sometimes send nil updates so need to check for it to avoid panics.
+						if update == nil {
+							continue
+						}
+						fileSDCache.Update(update)
+						stores.Update(ctxUpdate)
+						dnsProvider.Resolve(ctxUpdate, append(fileSDCache.Addresses(), staticAddresses...))
+					case <-ctxUpdate.Done():
+						return nil
+					}
+				}
+			}, func(error) {
+				cancelUpdate()
+				close(fileSDUpdates)
+			})
+		}
+		// Periodically update the addresses from static flags and file SD by resolving them using DNS SD if necessary.
+		{
+			ctx, cancel := context.WithCancel(context.Background())
+			staticAddresses := config.EndpointsConfig.StaticAddresses
+			g.Add(func() error {
+				return runutil.Repeat(dnsSDInterval, ctx.Done(), func() error {
+					dnsProvider.Resolve(ctx, append(fileSDCache.Addresses(), staticAddresses...))
+					return nil
+				})
+			}, func(error) {
+				cancel()
+			})
+		}
 	}
 
 	grpcProbe := prober.NewGRPC()
@@ -342,8 +425,15 @@ func runQuery(
 			"web.prefix-header":   webPrefixHeaderName,
 		}
 
+		getAllStoreStatuses := func() []query.StoreStatus {
+			var ret []query.StoreStatus
+			for _, stores := range storeSets {
+				ret = append(ret, stores.GetStoreStatus()...)
+			}
+			return ret
+		}
 		ins := extpromhttp.NewInstrumentationMiddleware(reg)
-		ui.NewQueryUI(logger, reg, stores, flagsMap).Register(router, ins)
+		ui.NewQueryUI(logger, reg, getAllStoreStatuses, flagsMap).Register(router, ins)
 
 		api := v1.NewAPI(logger, reg, engine, queryableCreator, enableAutodownsampling, enablePartialResponse, replicaLabels, instantDefaultMaxSourceResolution)
 

--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -6,13 +6,14 @@ package main
 import (
 	"context"
 	"fmt"
-	"google.golang.org/grpc"
-	"gopkg.in/yaml.v2"
 	"math"
 	"net/http"
 	"path"
 	"strings"
 	"time"
+
+	"google.golang.org/grpc"
+	"gopkg.in/yaml.v2"
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"

--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -264,11 +264,6 @@ func runQuery(
 		storesConfig = []store.Config{storeConfig}
 	}
 
-	// todo: sml: remove - for debugging
-	level.Info(logger).Log("msg", fmt.Sprintf("%v", storesConfig))
-	storeBytes, _ := yaml.Marshal(storesConfig)
-	level.Info(logger).Log("msg", string(storeBytes))
-
 	var storeSets []*query.StoreSet
 	var (
 		allClients = func() []store.Client {

--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"google.golang.org/grpc"
-	"gopkg.in/yaml.v2"
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"

--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -194,7 +194,7 @@ func runReceive(
 	if err != nil {
 		return err
 	}
-	dialOpts, err := extgrpc.StoreClientGRPCOpts(logger, reg, tracer, rwServerCert != "", rwClientCert, rwClientKey, rwClientServerCA, rwClientServerName)
+	dialOpts, err := extgrpc.StoreClientGRPCOpts(logger, nil, reg, tracer, rwServerCert != "", rwClientCert, rwClientKey, rwClientServerCA, rwClientServerName)
 	if err != nil {
 		return err
 	}

--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -194,7 +194,7 @@ func runReceive(
 	if err != nil {
 		return err
 	}
-	dialOpts, err := extgrpc.StoreClientGRPCOpts(logger, nil, reg, tracer, rwServerCert != "", rwClientCert, rwClientKey, rwClientServerCA, rwClientServerName)
+	dialOpts, err := extgrpc.StoreClientGRPCOpts(logger, "", reg, tracer, rwServerCert != "", rwClientCert, rwClientKey, rwClientServerCA, rwClientServerName)
 	if err != nil {
 		return err
 	}

--- a/docs/components/query.md
+++ b/docs/components/query.md
@@ -364,7 +364,8 @@ The configuration format is the following:
 
 [embedmd]:# (../flags/config_query_store.txt yaml)
 ```yaml
-- tls_config:
+- name: "default"
+  tls_config:
     ca_file: ""
     cert_file: ""
     key_file: ""
@@ -375,4 +376,4 @@ The configuration format is the following:
     refresh_interval: 0s
 ```
 
-If `tls_config` is omitted or set to `null` then TLS will not be used.
+If `tls_config` is omitted or set to `null` then TLS will not be used. Configs must have a name and they must be unique.

--- a/docs/components/query.md
+++ b/docs/components/query.md
@@ -327,6 +327,19 @@ Flags:
                                  prefixed with 'dns+' or 'dnssrv+' to detect
                                  store API servers through respective DNS
                                  lookups.
+      --store.config-file=<file-path>
+                                 Path to YAML file that contains store API
+                                 servers configuration. See format details:
+                                 https://thanos.io/components/query.md/#configuration.
+                                 If defined, it takes precedence over the
+                                 '--store' and '--store.sd-files' flags.
+      --store.config=<content>   Alternative to 'store.config-file' flag (lower
+                                 priority). Content of YAML file that contains
+                                 store API servers configuration. See forma
+                                 details:
+                                 https://thanos.io/components/query.md/#configuration.
+                                 If defined, it takes precedence over the
+                                 '--store' and '--store.sd-files' flags.
       --store.sd-files=<path> ...
                                  Path to files that contain addresses of store
                                  API servers. The path can be a glob pattern
@@ -364,16 +377,15 @@ The configuration format is the following:
 
 [embedmd]:# (../flags/config_query_store.txt yaml)
 ```yaml
-- name: "default"
+- name: default
   tls_config:
-    ca_file: ""
     cert_file: ""
     key_file: ""
+    ca_file: ""
     server_name: ""
   static_configs: []
   file_sd_configs:
   - files: []
-    refresh_interval: 0s
 ```
 
 If `tls_config` is omitted or set to `null` then TLS will not be used. Configs must have a name and they must be unique.

--- a/docs/components/query.md
+++ b/docs/components/query.md
@@ -354,3 +354,25 @@ Flags:
                                  enabled. 0 disables timeout.
 
 ```
+## Configuration
+
+### Store API
+
+The `--store.config` and `--store.config-file` flags allow specifying multiple store endpoints.
+
+The configuration format is the following:
+
+[embedmd]:# (../flags/config_query_store.txt yaml)
+```yaml
+- tls_config:
+    ca_file: ""
+    cert_file: ""
+    key_file: ""
+    server_name: ""
+  static_configs: []
+  file_sd_configs:
+  - files: []
+    refresh_interval: 0s
+```
+
+If `tls_config` is omitted or set to `null` then TLS will not be used.

--- a/docs/components/query.md
+++ b/docs/components/query.md
@@ -335,7 +335,7 @@ Flags:
                                  '--store' and '--store.sd-files' flags.
       --store.config=<content>   Alternative to 'store.config-file' flag (lower
                                  priority). Content of YAML file that contains
-                                 store API servers configuration. See forma
+                                 store API servers configuration. See format
                                  details:
                                  https://thanos.io/components/query.md/#configuration.
                                  If defined, it takes precedence over the

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ require (
 	cloud.google.com/go v0.49.0
 	cloud.google.com/go/storage v1.3.0
 	github.com/Azure/azure-storage-blob-go v0.8.0
+	github.com/Azure/go-autorest/autorest v0.10.0 // indirect
 	github.com/NYTimes/gziphandler v1.1.1
 	github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d
 	github.com/aliyun/aliyun-oss-go-sdk v2.0.4+incompatible
@@ -47,7 +48,7 @@ require (
 	go.elastic.co/apm v1.5.0
 	go.elastic.co/apm/module/apmot v1.5.0
 	go.uber.org/automaxprocs v1.2.0
-	golang.org/x/crypto v0.0.0-20191112222119-e1110fd1c708
+	golang.org/x/crypto v0.0.0-20191206172530-e9b2fee46413
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
 	golang.org/x/text v0.3.2

--- a/go.sum
+++ b/go.sum
@@ -35,9 +35,13 @@ github.com/Azure/go-autorest v12.3.0+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSW
 github.com/Azure/go-autorest/autorest v0.9.0/go.mod h1:xyHB1BMZT0cuDHU7I0+g046+BFDTQ8rEZB0s4Yfa6bI=
 github.com/Azure/go-autorest/autorest v0.9.3-0.20191028180845-3492b2aff503 h1:uUhdsDMg2GbFLF5GfQPtLMWd5vdDZSfqvqQp3waafxQ=
 github.com/Azure/go-autorest/autorest v0.9.3-0.20191028180845-3492b2aff503/go.mod h1:xyHB1BMZT0cuDHU7I0+g046+BFDTQ8rEZB0s4Yfa6bI=
+github.com/Azure/go-autorest/autorest v0.10.0 h1:mvdtztBqcL8se7MdrUweNieTNi4kfNG6GOJuurQJpuY=
+github.com/Azure/go-autorest/autorest v0.10.0/go.mod h1:/FALq9T/kS7b5J5qsQ+RSTUdAmGFqi0vUdVNNx8q630=
 github.com/Azure/go-autorest/autorest/adal v0.5.0/go.mod h1:8Z9fGy2MpX0PvDjB1pEgQTmVqjGhiHBW7RJJEciWzS0=
 github.com/Azure/go-autorest/autorest/adal v0.8.1-0.20191028180845-3492b2aff503 h1:Hxqlh1uAA8aGpa1dFhDNhll7U/rkWtG8ZItFvRMr7l0=
 github.com/Azure/go-autorest/autorest/adal v0.8.1-0.20191028180845-3492b2aff503/go.mod h1:Z6vX6WXXuyieHAXwMj0S6HY6e6wcHn37qQMBQlvY3lc=
+github.com/Azure/go-autorest/autorest/adal v0.8.2 h1:O1X4oexUxnZCaEUGsvMnr8ZGj8HI37tNezwY4npRqA0=
+github.com/Azure/go-autorest/autorest/adal v0.8.2/go.mod h1:ZjhuQClTqx435SRJ2iMlOxPYt3d2C/T/7TiQCVZSn3Q=
 github.com/Azure/go-autorest/autorest/date v0.1.0/go.mod h1:plvfp3oPSKwf2DNjlBjWF/7vwR+cUD/ELuzDCXwHUVA=
 github.com/Azure/go-autorest/autorest/date v0.2.0 h1:yW+Zlqf26583pE43KhfnhFcdmSWlm5Ew6bxipnr/tbM=
 github.com/Azure/go-autorest/autorest/date v0.2.0/go.mod h1:vcORJHLJEh643/Ioh9+vPmf1Ij9AEBM5FuBIXLmIy0g=
@@ -750,6 +754,8 @@ golang.org/x/crypto v0.0.0-20190923035154-9ee001bba392/go.mod h1:/lpIB1dKB+9EgE3
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191112222119-e1110fd1c708 h1:pXVtWnwHkrWD9ru3sDxY/qFK/bfc0egRovX91EjWjf4=
 golang.org/x/crypto v0.0.0-20191112222119-e1110fd1c708/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20191206172530-e9b2fee46413 h1:ULYEB3JvPRE/IfO+9uO7vKV/xzVTO7XPAwm8xbf4w2g=
+golang.org/x/crypto v0.0.0-20191206172530-e9b2fee46413/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=

--- a/pkg/extgrpc/client.go
+++ b/pkg/extgrpc/client.go
@@ -4,7 +4,6 @@
 package extgrpc
 
 import (
-	"github.com/thanos-io/thanos/pkg/store"
 	"math"
 
 	"github.com/go-kit/kit/log"
@@ -13,6 +12,7 @@ import (
 	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/thanos-io/thanos/pkg/store"
 	"github.com/thanos-io/thanos/pkg/tls"
 	"github.com/thanos-io/thanos/pkg/tracing"
 	"google.golang.org/grpc"

--- a/pkg/extgrpc/client.go
+++ b/pkg/extgrpc/client.go
@@ -4,6 +4,7 @@
 package extgrpc
 
 import (
+	"github.com/thanos-io/thanos/pkg/store"
 	"math"
 
 	"github.com/go-kit/kit/log"
@@ -18,12 +19,31 @@ import (
 	"google.golang.org/grpc/credentials"
 )
 
+func StoreClientGRPCOptsFromTlsConfig(logger log.Logger, clientInstance string, reg *prometheus.Registry, tracer opentracing.Tracer, tlsConfig *store.TlsConfig) ([]grpc.DialOption, error) {
+	if tlsConfig != nil {
+		return StoreClientGRPCOpts(logger, &clientInstance, reg, tracer, true, tlsConfig.Cert, tlsConfig.Key, tlsConfig.CaCert, tlsConfig.ServerName)
+	} else {
+		return StoreClientGRPCOpts(logger, &clientInstance, reg, tracer, false, "", "", "", "")
+	}
+}
+
 // StoreClientGRPCOpts creates gRPC dial options for connecting to a store client.
-func StoreClientGRPCOpts(logger log.Logger, reg *prometheus.Registry, tracer opentracing.Tracer, secure bool, cert, key, caCert, serverName string) ([]grpc.DialOption, error) {
-	grpcMets := grpc_prometheus.NewClientMetrics()
-	grpcMets.EnableClientHandlingTimeHistogram(
-		grpc_prometheus.WithHistogramBuckets([]float64{0.001, 0.01, 0.1, 0.3, 0.6, 1, 3, 6, 9, 20, 30, 60, 90, 120}),
+func StoreClientGRPCOpts(logger log.Logger, clientInstance *string, reg *prometheus.Registry, tracer opentracing.Tracer, secure bool, cert, key, caCert, serverName string) ([]grpc.DialOption, error) {
+	var grpcMets *grpc_prometheus.ClientMetrics
+	histogramBuckets := grpc_prometheus.WithHistogramBuckets(
+		[]float64{0.001, 0.01, 0.1, 0.3, 0.6, 1, 3, 6, 9, 20, 30, 60, 90, 120},
 	)
+	if clientInstance != nil {
+		constLabels := map[string]string{"config_name": *clientInstance}
+		grpcMets = grpc_prometheus.NewClientMetrics(grpc_prometheus.WithConstLabels(constLabels))
+		grpcMets.EnableClientHandlingTimeHistogram(
+			grpc_prometheus.WithHistogramConstLabels(constLabels),
+			histogramBuckets,
+		)
+	} else {
+		grpcMets = grpc_prometheus.NewClientMetrics()
+		grpcMets.EnableClientHandlingTimeHistogram(histogramBuckets)
+	}
 	dialOpts := []grpc.DialOption{
 		// We want to make sure that we can receive huge gRPC messages from storeAPI.
 		// On TCP level we can be fine, but the gRPC overhead for huge messages could be significant.

--- a/pkg/extgrpc/client.go
+++ b/pkg/extgrpc/client.go
@@ -21,20 +21,19 @@ import (
 
 func StoreClientGRPCOptsFromTlsConfig(logger log.Logger, clientInstance string, reg *prometheus.Registry, tracer opentracing.Tracer, tlsConfig *store.TlsConfig) ([]grpc.DialOption, error) {
 	if tlsConfig != nil {
-		return StoreClientGRPCOpts(logger, &clientInstance, reg, tracer, true, tlsConfig.Cert, tlsConfig.Key, tlsConfig.CaCert, tlsConfig.ServerName)
-	} else {
-		return StoreClientGRPCOpts(logger, &clientInstance, reg, tracer, false, "", "", "", "")
+		return StoreClientGRPCOpts(logger, clientInstance, reg, tracer, true, tlsConfig.Cert, tlsConfig.Key, tlsConfig.CaCert, tlsConfig.ServerName)
 	}
+	return StoreClientGRPCOpts(logger, clientInstance, reg, tracer, false, "", "", "", "")
 }
 
 // StoreClientGRPCOpts creates gRPC dial options for connecting to a store client.
-func StoreClientGRPCOpts(logger log.Logger, clientInstance *string, reg *prometheus.Registry, tracer opentracing.Tracer, secure bool, cert, key, caCert, serverName string) ([]grpc.DialOption, error) {
+func StoreClientGRPCOpts(logger log.Logger, clientInstance string, reg *prometheus.Registry, tracer opentracing.Tracer, secure bool, cert, key, caCert, serverName string) ([]grpc.DialOption, error) {
 	var grpcMets *grpc_prometheus.ClientMetrics
 	histogramBuckets := grpc_prometheus.WithHistogramBuckets(
 		[]float64{0.001, 0.01, 0.1, 0.3, 0.6, 1, 3, 6, 9, 20, 30, 60, 90, 120},
 	)
-	if clientInstance != nil {
-		constLabels := map[string]string{"config_name": *clientInstance}
+	if clientInstance != "" {
+		constLabels := map[string]string{"config_name": clientInstance}
 		grpcMets = grpc_prometheus.NewClientMetrics(grpc_prometheus.WithConstLabels(constLabels))
 		grpcMets.EnableClientHandlingTimeHistogram(
 			grpc_prometheus.WithHistogramConstLabels(constLabels),

--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -149,7 +149,7 @@ type FileSDConfig struct {
 	RefreshInterval model.Duration `yaml:"refresh_interval"`
 }
 
-func (c FileSDConfig) convert() (file.SDConfig, error) {
+func (c FileSDConfig) Convert() (file.SDConfig, error) {
 	var fileSDConfig file.SDConfig
 	b, err := yaml.Marshal(c)
 	if err != nil {
@@ -190,7 +190,7 @@ func NewClient(logger log.Logger, cfg EndpointsConfig, client *http.Client, prov
 
 	var discoverers []*file.Discovery
 	for _, sdCfg := range cfg.FileSDConfigs {
-		fileSDCfg, err := sdCfg.convert()
+		fileSDCfg, err := sdCfg.Convert()
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/query/storeset.go
+++ b/pkg/query/storeset.go
@@ -211,7 +211,6 @@ type storeRef struct {
 	mtx  sync.RWMutex
 	cc   *grpc.ClientConn
 	addr string
-	dialOpts []grpc.DialOption
 
 	// Meta (can change during runtime).
 	labelSets []storepb.LabelSet

--- a/pkg/query/storeset.go
+++ b/pkg/query/storeset.go
@@ -84,8 +84,8 @@ type storeSetNodeCollector struct {
 	storeNodes      map[component.StoreAPI]map[string]int
 	storePerExtLset map[string]int
 
-	connectionsDesc    *prometheus.Desc
-	nodeInfoDesc       *prometheus.Desc
+	connectionsDesc *prometheus.Desc
+	nodeInfoDesc    *prometheus.Desc
 }
 
 func newStoreSetNodeCollector(configInstance string) *storeSetNodeCollector {
@@ -94,14 +94,14 @@ func newStoreSetNodeCollector(configInstance string) *storeSetNodeCollector {
 		connectionsDesc: prometheus.NewDesc(
 			"thanos_store_nodes_grpc_connections",
 			"Number of gRPC connection to Store APIs. Opened connection means healthy store APIs available for Querier.",
-			[]string{"external_labels", "store_type"}, map[string]string{"config_name":configInstance},
+			[]string{"external_labels", "store_type"}, map[string]string{"config_name": configInstance},
 		),
 		// TODO(bwplotka): Obsolete; Replaced by thanos_store_nodes_grpc_connections.
 		// Remove in next minor release.
 		nodeInfoDesc: prometheus.NewDesc(
 			"thanos_store_node_info",
 			"Deprecated, use thanos_store_nodes_grpc_connections instead.",
-			[]string{"external_labels"}, map[string]string{"config_name":configInstance},
+			[]string{"external_labels"}, map[string]string{"config_name": configInstance},
 		),
 	}
 }

--- a/pkg/query/storeset.go
+++ b/pkg/query/storeset.go
@@ -89,6 +89,10 @@ type storeSetNodeCollector struct {
 }
 
 func newStoreSetNodeCollector(configInstance string) *storeSetNodeCollector {
+	if configInstance == "" {
+		configInstance = "default"
+	}
+
 	return &storeSetNodeCollector{
 		storeNodes: map[component.StoreAPI]map[string]int{},
 		connectionsDesc: prometheus.NewDesc(

--- a/pkg/query/storeset_test.go
+++ b/pkg/query/storeset_test.go
@@ -179,7 +179,7 @@ func TestStoreSet_Update(t *testing.T) {
 
 	// Testing if duplicates can cause weird results.
 	discoveredStoreAddr = append(discoveredStoreAddr, discoveredStoreAddr[0])
-	storeSet := NewStoreSet(nil, nil, func() (specs []StoreSpec) {
+	storeSet := NewStoreSet(nil, "default", nil, func() (specs []StoreSpec) {
 		for _, addr := range discoveredStoreAddr {
 			specs = append(specs, NewGRPCStoreSpec(addr))
 		}
@@ -521,7 +521,7 @@ func TestStoreSet_Update_NoneAvailable(t *testing.T) {
 	st.CloseOne(initialStoreAddr[0])
 	st.CloseOne(initialStoreAddr[1])
 
-	storeSet := NewStoreSet(nil, nil, func() (specs []StoreSpec) {
+	storeSet := NewStoreSet(nil, "default", nil, func() (specs []StoreSpec) {
 		for _, addr := range initialStoreAddr {
 			specs = append(specs, NewGRPCStoreSpec(addr))
 		}

--- a/pkg/query/storeset_test.go
+++ b/pkg/query/storeset_test.go
@@ -179,7 +179,7 @@ func TestStoreSet_Update(t *testing.T) {
 
 	// Testing if duplicates can cause weird results.
 	discoveredStoreAddr = append(discoveredStoreAddr, discoveredStoreAddr[0])
-	storeSet := NewStoreSet(nil, "default", nil, func() (specs []StoreSpec) {
+	storeSet := NewStoreSet(nil, "", nil, func() (specs []StoreSpec) {
 		for _, addr := range discoveredStoreAddr {
 			specs = append(specs, NewGRPCStoreSpec(addr))
 		}

--- a/pkg/store/config.go
+++ b/pkg/store/config.go
@@ -1,0 +1,69 @@
+package store
+
+import (
+	"errors"
+	"gopkg.in/yaml.v2"
+
+	"github.com/prometheus/prometheus/discovery/file"
+)
+
+type Config struct {
+	Name string                      `yaml:"name"`
+	TlsConfig *TlsConfig             `yaml:"tls_config"`
+	EndpointsConfig  EndpointsConfig `yaml:",inline"`
+}
+
+type TlsConfig struct {
+	// TLS Certificates to use to identify this client to the server
+	Cert string       `yaml:"cert_file"`
+	// TLS Key for the client's certificate
+	Key string        `yaml:"key_file"`
+	// TLS CA Certificates to use to verify gRPC servers
+	CaCert string     `yaml:"ca_file"`
+	// Server name to verify the hostname on the returned gRPC certificates. See https://tools.ietf.org/html/rfc4366#section-3.1
+	ServerName string `yaml:"server_name"`
+}
+
+type EndpointsConfig struct {
+	// List of addresses with DNS prefixes.
+	StaticAddresses []string      `yaml:"static_configs"`
+	// List of file  configurations (our FileSD supports different DNS lookups).
+	FileSDConfigs []file.SDConfig `yaml:"file_sd_configs"`
+}
+
+
+
+func DefaultConfig() Config {
+	return Config{
+		Name: "default",
+		EndpointsConfig: EndpointsConfig{
+			StaticAddresses: []string{},
+			FileSDConfigs:   []file.SDConfig{},
+		},
+	}
+}
+
+// UnmarshalYAML implements the yaml.Unmarshaler interface.
+func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	*c = DefaultConfig()
+	type plain Config
+	return unmarshal((*plain)(c))
+}
+
+// LoadConfigs loads a list of Config from YAML data.
+func LoadConfig(confYAML []byte) ([]Config, error) {
+	var queryCfg []Config
+	if err := yaml.UnmarshalStrict(confYAML, &queryCfg); err != nil {
+		return nil, err
+	}
+	seenNames := map[string]string{}
+	for _, cfg := range queryCfg {
+		if _, exists := seenNames[cfg.Name]; exists {
+			return nil, errors.New("config must have a non-empty, unique name")
+		} else {
+			seenNames[cfg.Name] = cfg.Name
+		}
+
+	}
+	return queryCfg, nil
+}

--- a/pkg/store/config.go
+++ b/pkg/store/config.go
@@ -4,7 +4,6 @@
 package store
 
 import (
-	"errors"
 	"fmt"
 
 	"gopkg.in/yaml.v2"
@@ -52,7 +51,7 @@ func DefaultConfig() Config {
 func NewConfig(storeAddrs []string, fileSDConfig *file.SDConfig, secure bool, cert string, key string, caCert string, serverName string) (Config, error) {
 	for _, addr := range storeAddrs {
 		if addr == "" {
-			return Config{}, errors.New("static store address cannot be empty")
+			return Config{}, fmt.Errorf("static store address cannot be empty")
 		}
 	}
 

--- a/pkg/store/config.go
+++ b/pkg/store/config.go
@@ -11,14 +11,14 @@ import (
 	"github.com/prometheus/prometheus/discovery/file"
 )
 
-// Config represents the configuration of a set of Store API endpoints
+// Config represents the configuration of a set of Store API endpoints.
 type Config struct {
 	Name            string          `yaml:"name"`
 	TlsConfig       *TlsConfig      `yaml:"tls_config"`
 	EndpointsConfig EndpointsConfig `yaml:",inline"`
 }
 
-// TlsConfig represents the TLS configuration for a set of Store API endpoints
+// TlsConfig represents the TLS configuration for a set of Store API endpoints.
 type TlsConfig struct {
 	// TLS Certificates to use to identify this client to the server.
 	Cert string `yaml:"cert_file"`
@@ -30,7 +30,7 @@ type TlsConfig struct {
 	ServerName string `yaml:"server_name"`
 }
 
-// EndpointsConfig represents the address discovery configuration for a set of Store API endpoints
+// EndpointsConfig represents the address discovery configuration for a set of Store API endpoints.
 type EndpointsConfig struct {
 	// List of addresses with DNS prefixes.
 	StaticAddresses []string `yaml:"static_configs"`

--- a/pkg/store/config.go
+++ b/pkg/store/config.go
@@ -1,7 +1,10 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
 package store
 
 import (
-	"errors"
+	"fmt"
 	"gopkg.in/yaml.v2"
 
 	"github.com/prometheus/prometheus/discovery/file"
@@ -59,7 +62,7 @@ func LoadConfig(confYAML []byte) ([]Config, error) {
 	seenNames := map[string]string{}
 	for _, cfg := range queryCfg {
 		if _, exists := seenNames[cfg.Name]; exists {
-			return nil, errors.New("config must have a non-empty, unique name")
+			return nil, fmt.Errorf("config must have a non-empty, unique name")
 		} else {
 			seenNames[cfg.Name] = cfg.Name
 		}

--- a/pkg/store/config.go
+++ b/pkg/store/config.go
@@ -5,36 +5,35 @@ package store
 
 import (
 	"fmt"
+
 	"gopkg.in/yaml.v2"
 
 	"github.com/prometheus/prometheus/discovery/file"
 )
 
 type Config struct {
-	Name string                      `yaml:"name"`
-	TlsConfig *TlsConfig             `yaml:"tls_config"`
-	EndpointsConfig  EndpointsConfig `yaml:",inline"`
+	Name            string          `yaml:"name"`
+	TlsConfig       *TlsConfig      `yaml:"tls_config"`
+	EndpointsConfig EndpointsConfig `yaml:",inline"`
 }
 
 type TlsConfig struct {
 	// TLS Certificates to use to identify this client to the server
-	Cert string       `yaml:"cert_file"`
+	Cert string `yaml:"cert_file"`
 	// TLS Key for the client's certificate
-	Key string        `yaml:"key_file"`
+	Key string `yaml:"key_file"`
 	// TLS CA Certificates to use to verify gRPC servers
-	CaCert string     `yaml:"ca_file"`
+	CaCert string `yaml:"ca_file"`
 	// Server name to verify the hostname on the returned gRPC certificates. See https://tools.ietf.org/html/rfc4366#section-3.1
 	ServerName string `yaml:"server_name"`
 }
 
 type EndpointsConfig struct {
 	// List of addresses with DNS prefixes.
-	StaticAddresses []string      `yaml:"static_configs"`
+	StaticAddresses []string `yaml:"static_configs"`
 	// List of file  configurations (our FileSD supports different DNS lookups).
 	FileSDConfigs []file.SDConfig `yaml:"file_sd_configs"`
 }
-
-
 
 func DefaultConfig() Config {
 	return Config{

--- a/pkg/store/config.go
+++ b/pkg/store/config.go
@@ -4,6 +4,7 @@
 package store
 
 import (
+	"errors"
 	"fmt"
 
 	"gopkg.in/yaml.v2"
@@ -46,6 +47,34 @@ func DefaultConfig() Config {
 			FileSDConfigs:   []file.SDConfig{},
 		},
 	}
+}
+
+func NewConfig(storeAddrs []string, fileSDConfig *file.SDConfig, secure bool, cert string, key string, caCert string, serverName string) (Config, error) {
+	for _, addr := range storeAddrs {
+		if addr == "" {
+			return Config{}, errors.New("static store address cannot be empty")
+		}
+	}
+
+	endpointsConfig := EndpointsConfig{
+		StaticAddresses: storeAddrs,
+	}
+	if fileSDConfig != nil {
+		endpointsConfig.FileSDConfigs = []file.SDConfig{*fileSDConfig}
+	}
+	storeConfig := Config{
+		Name:            "default",
+		EndpointsConfig: endpointsConfig,
+	}
+	if secure {
+		storeConfig.TlsConfig = &TlsConfig{
+			Cert:       cert,
+			Key:        key,
+			CaCert:     caCert,
+			ServerName: serverName,
+		}
+	}
+	return storeConfig, nil
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.

--- a/pkg/store/config.go
+++ b/pkg/store/config.go
@@ -11,12 +11,14 @@ import (
 	"github.com/prometheus/prometheus/discovery/file"
 )
 
+// Config represents the configuration of a set of Store API endpoints
 type Config struct {
 	Name            string          `yaml:"name"`
 	TlsConfig       *TlsConfig      `yaml:"tls_config"`
 	EndpointsConfig EndpointsConfig `yaml:",inline"`
 }
 
+// TlsConfig represents the TLS configuration for a set of Store API endpoints
 type TlsConfig struct {
 	// TLS Certificates to use to identify this client to the server.
 	Cert string `yaml:"cert_file"`
@@ -28,6 +30,7 @@ type TlsConfig struct {
 	ServerName string `yaml:"server_name"`
 }
 
+// EndpointsConfig represents the address discovery configuration for a set of Store API endpoints
 type EndpointsConfig struct {
 	// List of addresses with DNS prefixes.
 	StaticAddresses []string `yaml:"static_configs"`

--- a/pkg/store/config.go
+++ b/pkg/store/config.go
@@ -18,11 +18,11 @@ type Config struct {
 }
 
 type TlsConfig struct {
-	// TLS Certificates to use to identify this client to the server
+	// TLS Certificates to use to identify this client to the server.
 	Cert string `yaml:"cert_file"`
-	// TLS Key for the client's certificate
+	// TLS Key for the client's certificate.
 	Key string `yaml:"key_file"`
-	// TLS CA Certificates to use to verify gRPC servers
+	// TLS CA Certificates to use to verify gRPC servers.
 	CaCert string `yaml:"ca_file"`
 	// Server name to verify the hostname on the returned gRPC certificates. See https://tools.ietf.org/html/rfc4366#section-3.1
 	ServerName string `yaml:"server_name"`

--- a/pkg/ui/query.go
+++ b/pkg/ui/query.go
@@ -24,7 +24,7 @@ import (
 
 type Query struct {
 	*BaseUI
-	storeSet *query.StoreSet
+	getStoreStatus func() []query.StoreStatus
 
 	flagsMap map[string]string
 
@@ -43,14 +43,14 @@ type thanosVersion struct {
 	GoVersion string `json:"goVersion"`
 }
 
-func NewQueryUI(logger log.Logger, reg prometheus.Registerer, storeSet *query.StoreSet, flagsMap map[string]string) *Query {
+func NewQueryUI(logger log.Logger, reg prometheus.Registerer, getStoreStatus func() []query.StoreStatus, flagsMap map[string]string) *Query {
 	cwd, err := os.Getwd()
 	if err != nil {
 		cwd = "<error retrieving current working directory>"
 	}
 	return &Query{
 		BaseUI:   NewBaseUI(logger, "query_menu.html", queryTmplFuncs()),
-		storeSet: storeSet,
+		getStoreStatus: getStoreStatus,
 		flagsMap: flagsMap,
 		cwd:      cwd,
 		birth:    time.Now(),
@@ -125,7 +125,7 @@ func (q *Query) status(w http.ResponseWriter, r *http.Request) {
 func (q *Query) stores(w http.ResponseWriter, r *http.Request) {
 	prefix := GetWebPrefix(q.logger, q.flagsMap, r)
 	statuses := make(map[component.StoreAPI][]query.StoreStatus)
-	for _, status := range q.storeSet.GetStoreStatus() {
+	for _, status := range q.getStoreStatus() {
 		statuses[status.StoreType] = append(statuses[status.StoreType], status)
 	}
 

--- a/pkg/ui/query.go
+++ b/pkg/ui/query.go
@@ -49,13 +49,13 @@ func NewQueryUI(logger log.Logger, reg prometheus.Registerer, getStoreStatus fun
 		cwd = "<error retrieving current working directory>"
 	}
 	return &Query{
-		BaseUI:   NewBaseUI(logger, "query_menu.html", queryTmplFuncs()),
+		BaseUI:         NewBaseUI(logger, "query_menu.html", queryTmplFuncs()),
 		getStoreStatus: getStoreStatus,
-		flagsMap: flagsMap,
-		cwd:      cwd,
-		birth:    time.Now(),
-		reg:      reg,
-		now:      model.Now,
+		flagsMap:       flagsMap,
+		cwd:            cwd,
+		birth:          time.Now(),
+		reg:            reg,
+		now:            model.Now,
 	}
 }
 

--- a/scripts/cfggen/main.go
+++ b/scripts/cfggen/main.go
@@ -5,6 +5,8 @@ package main
 
 import (
 	"fmt"
+	"github.com/prometheus/prometheus/discovery/file"
+	"github.com/thanos-io/thanos/pkg/store"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -102,6 +104,14 @@ func main() {
 	queryCfg.EndpointsConfig.FileSDConfigs = []http_util.FileSDConfig{http_util.FileSDConfig{}}
 	if err := generate([]query.Config{queryCfg}, "rule_query", *outputDir); err != nil {
 		level.Error(logger).Log("msg", "failed to generate", "type", "rule_query", "err", err)
+		os.Exit(1)
+	}
+
+	storeCfg := store.DefaultConfig()
+	storeCfg.EndpointsConfig.FileSDConfigs = []file.SDConfig{file.SDConfig{}}
+	storeCfg.TlsConfig = &store.TlsConfig{}
+	if err := generate([]store.Config{storeCfg}, "query_store", *outputDir); err != nil {
+		level.Error(logger).Log("msg", "failed to generate", "type", "query_store", "err", err)
 		os.Exit(1)
 	}
 	logger.Log("msg", "success")

--- a/scripts/cfggen/main.go
+++ b/scripts/cfggen/main.go
@@ -5,13 +5,14 @@ package main
 
 import (
 	"fmt"
-	"github.com/prometheus/prometheus/discovery/file"
-	"github.com/thanos-io/thanos/pkg/store"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
+
+	"github.com/prometheus/prometheus/discovery/file"
+	"github.com/thanos-io/thanos/pkg/store"
 
 	"github.com/fatih/structtag"
 	"github.com/go-kit/kit/log"

--- a/test/e2e/e2ethanos/services.go
+++ b/test/e2e/e2ethanos/services.go
@@ -6,7 +6,6 @@ package e2ethanos
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/thanos-io/thanos/pkg/store"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -19,6 +18,7 @@ import (
 	"github.com/thanos-io/thanos/pkg/objstore/client"
 	"github.com/thanos-io/thanos/pkg/query"
 	"github.com/thanos-io/thanos/pkg/receive"
+	"github.com/thanos-io/thanos/pkg/store"
 	"gopkg.in/yaml.v2"
 )
 

--- a/test/e2e/query_test.go
+++ b/test/e2e/query_test.go
@@ -120,7 +120,7 @@ func TestQuery(t *testing.T) {
 	sdFilePath, err := createSDFile(s.SharedDir(), "1", []string{sidecar3.GRPCNetworkEndpoint(), sidecar4.GRPCNetworkEndpoint()})
 	testutil.Ok(t, err)
 
-	// Both fileSD and directly by seperate configs
+	// Both fileSD and directly by separate configs
 	queryCfg := []store.Config{
 		{
 			Name: "static",

--- a/test/e2e/query_test.go
+++ b/test/e2e/query_test.go
@@ -120,7 +120,7 @@ func TestQuery(t *testing.T) {
 	sdFilePath, err := createSDFile(s.SharedDir(), "1", []string{sidecar3.GRPCNetworkEndpoint(), sidecar4.GRPCNetworkEndpoint()})
 	testutil.Ok(t, err)
 
-	// Both fileSD and directly by separate configs
+	// Both fileSD and directly by separate configs.
 	queryCfg := []store.Config{
 		{
 			Name: "static",

--- a/test/e2e/query_test.go
+++ b/test/e2e/query_test.go
@@ -6,10 +6,6 @@ package e2e_test
 import (
 	"context"
 	"fmt"
-	"github.com/prometheus/prometheus/discovery/file"
-	"github.com/prometheus/prometheus/discovery/targetgroup"
-	"github.com/thanos-io/thanos/pkg/store"
-	"gopkg.in/yaml.v2"
 	"io/ioutil"
 	"net/url"
 	"os"
@@ -17,6 +13,11 @@ import (
 	"sort"
 	"testing"
 	"time"
+
+	"github.com/prometheus/prometheus/discovery/file"
+	"github.com/prometheus/prometheus/discovery/targetgroup"
+	"github.com/thanos-io/thanos/pkg/store"
+	"gopkg.in/yaml.v2"
 
 	"github.com/cortexproject/cortex/integration/e2e"
 	"github.com/pkg/errors"
@@ -132,7 +133,7 @@ func TestQuery(t *testing.T) {
 			EndpointsConfig: store.EndpointsConfig{
 				FileSDConfigs: []file.SDConfig{
 					{
-						Files: []string{sdFilePath},
+						Files:           []string{sdFilePath},
 						RefreshInterval: model.Duration(time.Minute),
 					},
 				},

--- a/test/e2e/receive_test.go
+++ b/test/e2e/receive_test.go
@@ -5,6 +5,7 @@ package e2e_test
 
 import (
 	"context"
+	"github.com/thanos-io/thanos/pkg/store"
 	"testing"
 	"time"
 
@@ -64,7 +65,14 @@ func TestReceive(t *testing.T) {
 		testutil.Ok(t, err)
 		testutil.Ok(t, s.StartAndWaitReady(prom1, prom2, prom3))
 
-		q, err := e2ethanos.NewQuerier(s.SharedDir(), "1", []string{r1.GRPCNetworkEndpoint(), r2.GRPCNetworkEndpoint(), r3.GRPCNetworkEndpoint()}, nil)
+		storeCfg := []store.Config{
+			{
+				EndpointsConfig: store.EndpointsConfig{
+					StaticAddresses: []string{r1.GRPCNetworkEndpoint(), r2.GRPCNetworkEndpoint(), r3.GRPCNetworkEndpoint()},
+				},
+			},
+		}
+		q, err := e2ethanos.NewQuerier("1", storeCfg)
 		testutil.Ok(t, err)
 		testutil.Ok(t, s.StartAndWaitReady(q))
 
@@ -136,7 +144,14 @@ func TestReceive(t *testing.T) {
 		testutil.Ok(t, err)
 		testutil.Ok(t, s.StartAndWaitReady(prom1))
 
-		q, err := e2ethanos.NewQuerier(s.SharedDir(), "1", []string{r1.GRPCNetworkEndpoint(), r2.GRPCNetworkEndpoint(), r3.GRPCNetworkEndpoint()}, nil)
+		storeCfg := []store.Config{
+			{
+				EndpointsConfig: store.EndpointsConfig{
+					StaticAddresses: []string{r1.GRPCNetworkEndpoint(), r2.GRPCNetworkEndpoint(), r3.GRPCNetworkEndpoint()},
+				},
+			},
+		}
+		q, err := e2ethanos.NewQuerier("1", storeCfg)
 		testutil.Ok(t, err)
 		testutil.Ok(t, s.StartAndWaitReady(q))
 
@@ -205,7 +220,14 @@ func TestReceive(t *testing.T) {
 		testutil.Ok(t, err)
 		testutil.Ok(t, s.StartAndWaitReady(prom1))
 
-		q, err := e2ethanos.NewQuerier(s.SharedDir(), "1", []string{r1.GRPCNetworkEndpoint(), r2.GRPCNetworkEndpoint()}, nil)
+		storeCfg := []store.Config{
+			{
+				EndpointsConfig: store.EndpointsConfig{
+					StaticAddresses: []string{r1.GRPCNetworkEndpoint(), r2.GRPCNetworkEndpoint()},
+				},
+			},
+		}
+		q, err := e2ethanos.NewQuerier("1", storeCfg)
 		testutil.Ok(t, err)
 		testutil.Ok(t, s.StartAndWaitReady(q))
 

--- a/test/e2e/receive_test.go
+++ b/test/e2e/receive_test.go
@@ -5,9 +5,10 @@ package e2e_test
 
 import (
 	"context"
-	"github.com/thanos-io/thanos/pkg/store"
 	"testing"
 	"time"
+
+	"github.com/thanos-io/thanos/pkg/store"
 
 	"github.com/cortexproject/cortex/integration/e2e"
 	"github.com/prometheus/common/model"

--- a/test/e2e/rule_test.go
+++ b/test/e2e/rule_test.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
+	"github.com/thanos-io/thanos/pkg/store"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -235,7 +236,7 @@ func TestRule_AlertmanagerHTTPClient(t *testing.T) {
 		{
 			EndpointsConfig: http_util.EndpointsConfig{
 				StaticAddresses: func() []string {
-					q, err := e2ethanos.NewQuerier(s.SharedDir(), "1", nil, nil)
+					q, err := e2ethanos.NewQuerier("1", []store.Config{})
 					testutil.Ok(t, err)
 					return []string{q.NetworkHTTPEndpointFor(s.NetworkName())}
 				}(),
@@ -246,7 +247,14 @@ func TestRule_AlertmanagerHTTPClient(t *testing.T) {
 	testutil.Ok(t, err)
 	testutil.Ok(t, s.StartAndWaitReady(r))
 
-	q, err := e2ethanos.NewQuerier(s.SharedDir(), "1", []string{r.GRPCNetworkEndpoint()}, nil)
+	storeCfg := []store.Config{
+		{
+			EndpointsConfig: store.EndpointsConfig{
+				StaticAddresses: []string{r.GRPCNetworkEndpoint()},
+			},
+		},
+	}
+	q, err := e2ethanos.NewQuerier("1", storeCfg)
 	testutil.Ok(t, err)
 	testutil.Ok(t, s.StartAndWaitReady(q))
 
@@ -322,7 +330,14 @@ func TestRule(t *testing.T) {
 	testutil.Ok(t, err)
 	testutil.Ok(t, s.StartAndWaitReady(r))
 
-	q, err := e2ethanos.NewQuerier(s.SharedDir(), "1", []string{r.GRPCNetworkEndpoint()}, nil)
+	storeCfg := []store.Config{
+		{
+			EndpointsConfig: store.EndpointsConfig{
+				StaticAddresses: []string{r.GRPCNetworkEndpoint()},
+			},
+		},
+	}
+	q, err := e2ethanos.NewQuerier("1", storeCfg)
 	testutil.Ok(t, err)
 	testutil.Ok(t, s.StartAndWaitReady(q))
 

--- a/test/e2e/rule_test.go
+++ b/test/e2e/rule_test.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
-	"github.com/thanos-io/thanos/pkg/store"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -19,6 +18,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/thanos-io/thanos/pkg/store"
 
 	"github.com/cortexproject/cortex/integration/e2e"
 	"github.com/pkg/errors"

--- a/test/e2e/store_gateway_test.go
+++ b/test/e2e/store_gateway_test.go
@@ -5,6 +5,7 @@ package e2e_test
 
 import (
 	"context"
+	"github.com/thanos-io/thanos/pkg/store"
 	"os"
 	"path"
 	"path/filepath"
@@ -57,9 +58,14 @@ func TestStoreGateway(t *testing.T) {
 	testutil.Ok(t, err)
 	testutil.Ok(t, s.StartAndWaitReady(s1))
 
-	q, err := e2ethanos.NewQuerier(
-		s.SharedDir(), "1",
-		[]string{s1.GRPCNetworkEndpoint()}, nil)
+	storeCfg := []store.Config{
+		{
+			EndpointsConfig: store.EndpointsConfig{
+				StaticAddresses: []string{s1.GRPCNetworkEndpoint()},
+			},
+		},
+	}
+	q, err := e2ethanos.NewQuerier("1", storeCfg)
 	testutil.Ok(t, err)
 	testutil.Ok(t, s.StartAndWaitReady(q))
 

--- a/test/e2e/store_gateway_test.go
+++ b/test/e2e/store_gateway_test.go
@@ -5,12 +5,13 @@ package e2e_test
 
 import (
 	"context"
-	"github.com/thanos-io/thanos/pkg/store"
 	"os"
 	"path"
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/thanos-io/thanos/pkg/store"
 
 	"github.com/cortexproject/cortex/integration/e2e"
 	e2edb "github.com/cortexproject/cortex/integration/e2e/db"


### PR DESCRIPTION
Closes https://github.com/thanos-io/thanos/issues/977

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

This change adds support for reading stores from an external configuration file, with TLS and file SD configuration variable between sets of stores. The configuration file allows specification of one or more configurations in a similar manner to #1939 and #1982 . Have decided to mandate naming the configurations so that we can label metrics with these names since the primary use case driving this seems to be TLS vs non-TLS and the feeling around our team is that we'd like to see metrics split along these lines.

It is backwards compatible with existing flags for specifying stores, TLS and file SD.

## Verification

e2e tests have been updated to use the external store config file.