### PR TITLE
Bucket Web - Sort chunks by thanos.downsample.resolution for better grouping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,9 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 ### Fixed
 
 - [#2238](https://github.com/thanos-io/thanos/pull/2238) Ruler: Fixed Issue #2204 bug in alert queue signalling filled up queue and alerts were dropped
+- [#2231](https://github.com/thanos-io/thanos/pull/2231) Bucket Web - Sort chunks by thanos.downsample.resolution for better grouping
 
-## [v0.11.0](https://github.com/thanos-io/thanos/releases/tag/v0.11.0-rc.1) - 2020.03.02
+## [v0.11.0](https://github.com/thanos-io/thanos/releases/tag/v0.11.0) - 2020.03.02
 
 ### Fixed
 

--- a/pkg/ui/static/js/bucket.js
+++ b/pkg/ui/static/js/bucket.js
@@ -29,6 +29,7 @@ function draw() {
         dataTable.addColumn({type: 'date', id: 'End'});
 
         dataTable.addRows(thanos.blocks
+            .sort((a, b) => a.thanos.downsample.resolution - b.thanos.downsample.resolution)
             .map(function(d) {
                 // Title is the first column of the timeline.
                 //


### PR DESCRIPTION

## Changes

Sort series on bucket viewer page to better group compaction levels

Before

<img width="753" alt="before" src="https://user-images.githubusercontent.com/89725/76154004-4ef4d900-6118-11ea-8fc6-7199a6f86f9d.png">

After

<img width="752" alt="after" src="https://user-images.githubusercontent.com/89725/76154005-51efc980-6118-11ea-9246-6d9a720d3911.png">

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.
