### PR TITLE
Add extra benchmark GithubAction job to CI for each PRs, master push and releases.

### DIFF
--- a/.github/workflows/benchmark-master.yaml
+++ b/.github/workflows/benchmark-master.yaml
@@ -1,0 +1,29 @@
+name: benchmark
+
+on:
+  push:
+    branches:
+      - "master"
+
+jobs:
+  master-series:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Go.
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.13.6
+
+      - name: Check out code into the Go module directory.
+        uses: actions/checkout@v2
+
+      - name: Give me just shared dir GitHub Action!
+        run: mkdir /tmp/cache
+
+      - uses: actions/cache@v1
+        with:
+          path: /tmp/cache
+          key: benchmark-results
+
+      - name: Run selected benchmarks and compare with newest release.
+        run: make bench-master THANOS_BENCH_FUNC="BenchmarkSeries|BenchmarkBucketIndexReader_ExpandedPostings"

--- a/.github/workflows/benchmark-master.yaml
+++ b/.github/workflows/benchmark-master.yaml
@@ -13,17 +13,13 @@ jobs:
         uses: actions/setup-go@v1
         with:
           go-version: 1.13.6
-
       - name: Check out code into the Go module directory.
         uses: actions/checkout@v2
-
       - name: Give me just shared dir GitHub Action!
         run: mkdir /tmp/cache
-
       - uses: actions/cache@v1
         with:
           path: /tmp/cache
           key: benchmark-results
-
       - name: Run selected benchmarks and compare with newest release.
-        run: make bench-master THANOS_BENCH_FUNC="BenchmarkSeries|BenchmarkBucketIndexReader_ExpandedPostings"
+        run: make bench-master THANOS_BENCH_FUNC="BenchmarkSeries"

--- a/.github/workflows/benchmark-pr.yaml
+++ b/.github/workflows/benchmark-pr.yaml
@@ -13,17 +13,13 @@ jobs:
         uses: actions/setup-go@v1
         with:
           go-version: 1.13.6
-
       - name: Check out code into the Go module directory.
         uses: actions/checkout@v2
-
-      - name: Give me just shared dir lol GitHub Action!
+      - name: Give me just shared dir GitHub Action!
         run: mkdir /tmp/cache
-
       - uses: actions/cache@v1
         with:
           path: /tmp/cache
           key: benchmark-results
-
       - name: Run selected benchmarks and compare with newest release.
-        run: make bench THANOS_BENCH_FUNC="BenchmarkSeries|BenchmarkBucketIndexReader_ExpandedPostings"
+        run: make bench THANOS_BENCH_FUNC="BenchmarkSeries"

--- a/.github/workflows/benchmark-pr.yaml
+++ b/.github/workflows/benchmark-pr.yaml
@@ -1,0 +1,29 @@
+name: benchmark
+
+on:
+  push:
+    paths-ignore:
+      - 'docs/**'
+
+jobs:
+  pr-series:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Go.
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.13.6
+
+      - name: Check out code into the Go module directory.
+        uses: actions/checkout@v2
+
+      - name: Give me just shared dir lol GitHub Action!
+        run: mkdir /tmp/cache
+
+      - uses: actions/cache@v1
+        with:
+          path: /tmp/cache
+          key: benchmark-results
+
+      - name: Run selected benchmarks and compare with newest release.
+        run: make bench THANOS_BENCH_FUNC="BenchmarkSeries|BenchmarkBucketIndexReader_ExpandedPostings"

--- a/.github/workflows/benchmark-release.yaml
+++ b/.github/workflows/benchmark-release.yaml
@@ -16,17 +16,13 @@ jobs:
         uses: actions/setup-go@v1
         with:
           go-version: 1.13.6
-
       - name: Check out code into the Go module directory.
         uses: actions/checkout@v2
-
-      - name: Give me just shared dir lol GitHub Action!
+      - name: Give me just shared dir GitHub Action!
         run: mkdir /tmp/cache
-
       - uses: actions/cache@v1
         with:
           path: /tmp/cache
           key: benchmark-results
-
       - name: Run selected benchmarks and compare with older release.
-        run: make bench-release THANOS_BENCH_FUNC="BenchmarkSeries|BenchmarkBucketIndexReader_ExpandedPostings"
+        run: make bench-release THANOS_BENCH_FUNC="BenchmarkSeries"

--- a/.github/workflows/benchmark-release.yaml
+++ b/.github/workflows/benchmark-release.yaml
@@ -1,0 +1,32 @@
+name: benchmark
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  release-series:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set release version
+        id: vars
+        run: echo ::set-output name=tag::${GITHUB_REF:10}
+      - name: Install Go.
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.13.6
+
+      - name: Check out code into the Go module directory.
+        uses: actions/checkout@v2
+
+      - name: Give me just shared dir lol GitHub Action!
+        run: mkdir /tmp/cache
+
+      - uses: actions/cache@v1
+        with:
+          path: /tmp/cache
+          key: benchmark-results
+
+      - name: Run selected benchmarks and compare with older release.
+        run: make bench-release THANOS_BENCH_FUNC="BenchmarkSeries|BenchmarkBucketIndexReader_ExpandedPostings"

--- a/Makefile
+++ b/Makefile
@@ -170,19 +170,19 @@ assets: $(GOBINDATA)
 bench: ## Run $(THANOS_BENCH_FUNC) benchmarks and compare with master using https://github.com/prometheus/test-infra/tree/master/funcbench.
 bench: $(FUNCBENCH)
 	@echo ">> benchmark $(THANOS_BENCH_FUNC) and compare with master"
-	@$(FUNCBENCH) -v --bench-time=30s --timeout=2h --result-cache=/tmp/cache master $(THANOS_BENCH_FUNC)
+	@$(FUNCBENCH) -v --bench-time=30s --timeout=2h --result-cache=/tmp/cache master '"$(THANOS_BENCH_FUNC)"'
 
 .PHONY: bench-master
 bench-master: ## Run $(THANOS_BENCH_FUNC) benchmarks and compare with newest using https://github.com/prometheus/test-infra/tree/master/funcbench.
 bench-master: $(FUNCBENCH)
 	@echo ">> benchmark $(THANOS_BENCH_FUNC) and compare with: $(shell git tag | grep -E ^v[0-9]+\.[0-9]\.[0-9]+$$ | sort -t . -k1,1n -k2,2n -k3,3n | tail -1)"
-	@$(FUNCBENCH) -v --bench-time=30s --timeout=2h --result-cache=/tmp/cache  "$(shell git tag | grep -E ^v[0-9]+\.[0-9]\.[0-9]+$$ | sort -t . -k1,1n -k2,2n -k3,3n | tail -1)" $(THANOS_BENCH_FUNC)
+	@$(FUNCBENCH) -v --bench-time=30s --timeout=2h --result-cache=/tmp/cache  "$(shell git tag | grep -E ^v[0-9]+\.[0-9]\.[0-9]+$$ | sort -t . -k1,1n -k2,2n -k3,3n | tail -1)" '"$(THANOS_BENCH_FUNC)"'
 
 .PHONY: bench-release
 bench-release: ## Run $(THANOS_BENCH_FUNC) benchmarks and compare with older release using https://github.com/prometheus/test-infra/tree/master/funcbench.
 bench-release: $(FUNCBENCH)
 	@echo ">> benchmark $(THANOS_BENCH_FUNC) and compare with"
-	@$(FUNCBENCH) -v --bench-time=30s --timeout=2h --result-cache=/tmp/cache "$(shell git tag | grep -E ^v[0-9]+\.[0-9]\.[0-9]+$$ | sort -t . -k1,1n -k2,2n -k3,3n | grep -B1 $(CURRENT_RELEASE) | head -1)" $(THANOS_BENCH_FUNC)
+	@$(FUNCBENCH) -v --bench-time=30s --timeout=2h --result-cache=/tmp/cache "$(shell git tag | grep -E ^v[0-9]+\.[0-9]\.[0-9]+$$ | sort -t . -k1,1n -k2,2n -k3,3n | grep -B1 $(CURRENT_RELEASE) | head -1)" '"$(THANOS_BENCH_FUNC)"'
 
 .PHONY: build
 build: ## Builds Thanos binary using `promu`.

--- a/Makefile
+++ b/Makefile
@@ -35,12 +35,10 @@ HUGO              ?= $(GOBIN)/hugo-$(HUGO_VERSION)
 GOBINDATA_VERSION ?= a9c83481b38ebb1c4eb8f0168fd4b10ca1d3c523
 GOBINDATA         ?= $(GOBIN)/go-bindata-$(GOBINDATA_VERSION)
 GIT               ?= $(shell which git)
-
 GOLANGCILINT_VERSION ?= d2b1eea2c6171a1a1141a448a745335ce2e928a1
 GOLANGCILINT         ?= $(GOBIN)/golangci-lint-$(GOLANGCILINT_VERSION)
 MISSPELL_VERSION     ?= c0b55c8239520f6b5aa15a0207ca8b28027ba49e
 MISSPELL             ?= $(GOBIN)/misspell-$(MISSPELL_VERSION)
-
 GOJSONTOYAML_VERSION    ?= e8bd32d46b3d764bef60f12b3bada1c132c4be55
 GOJSONTOYAML            ?= $(GOBIN)/gojsontoyaml-$(GOJSONTOYAML_VERSION)
 # v0.14.0
@@ -52,6 +50,9 @@ JSONNET_BUNDLER         ?= $(GOBIN)/jb-$(JSONNET_BUNDLER_VERSION)
 # Prometheus v2.14.0
 PROMTOOL_VERSION        ?= edeb7a44cbf745f1d8be4ea6f215e79e651bfe19
 PROMTOOL                ?= $(GOBIN)/promtool-$(PROMTOOL_VERSION)
+FUNCBENCH_VERSION       ?= 36bc2803457da1bb58ae220523c78ed229834546
+FUNCBENCH               ?= $(GOBIN)/funcbench-$(FUNCBENCH_VERSION)
+THANOS_BENCH_FUNC		?="*"
 
 # Support gsed on OSX (installed via brew), falling back to sed. On Linux
 # systems gsed won't be installed, so will use sed as expected.
@@ -105,6 +106,32 @@ define fetch_go_bin_version
 
 endef
 
+# fetch_go_bin_version_mod downloads (go gets) the binary from specific version and installs it in $(GOBIN)/<bin>-<version>
+# arguments:
+# $(1): Install path. (e.g github.com/campoy/embedmd)
+# $(2): Tag or revision for checkout.
+# TODO(bwplotka): Move to just using modules, however make sure to not use or edit Thanos go.mod file!
+define fetch_go_bin_version_mod
+	@mkdir -p $(GOBIN)
+	@mkdir -p $(TMP_GOPATH)
+
+	@echo ">> fetching $(1)@$(2) revision/version"
+	@if [ ! -d '$(TMP_GOPATH)/src/$(1)' ]; then \
+    GOPATH='$(TMP_GOPATH)' GO111MODULE='off' go get -d -u '$(1)/...'; \
+  else \
+    CDPATH='' cd -- '$(TMP_GOPATH)/src/$(1)' && git fetch; \
+  fi
+	@CDPATH='' cd -- '$(TMP_GOPATH)/src/$(1)' && git checkout -f -q '$(2)'
+	@echo ">> installing $(1)@$(2)"
+	@ # Extra step for those who does not vendor deps.
+	@CDPATH='' cd -- '$(TMP_GOPATH)/src/$(1)' && go mod vendor
+	@GOBIN='$(TMP_GOPATH)/bin' GOPATH='$(TMP_GOPATH)' GO111MODULE='off' go install '$(1)'
+	@mv -- '$(TMP_GOPATH)/bin/$(shell basename $(1))' '$(GOBIN)/$(shell basename $(1))-$(2)'
+	@echo ">> produced $(GOBIN)/$(shell basename $(1))-$(2)"
+
+endef
+
+
 define require_clean_work_tree
 	@git update-index -q --ignore-submodules --refresh
 
@@ -138,6 +165,24 @@ assets: $(GOBINDATA)
 	@echo ">> writing assets"
 	@$(GOBINDATA) $(bindata_flags) -pkg ui -o pkg/ui/bindata.go -ignore '(.*\.map|bootstrap\.js|bootstrap-theme\.css|bootstrap\.css)'  pkg/ui/templates/... pkg/ui/static/...
 	@go fmt ./pkg/ui
+
+.PHONY: bench
+bench: ## Run $(THANOS_BENCH_FUNC) benchmarks and compare with master using https://github.com/prometheus/test-infra/tree/master/funcbench.
+bench: $(FUNCBENCH)
+	@echo ">> benchmark $(THANOS_BENCH_FUNC) and compare with master"
+	@$(FUNCBENCH) -v --bench-time=30s --timeout=2h --result-cache=/tmp/cache master $(THANOS_BENCH_FUNC)
+
+.PHONY: bench-master
+bench-master: ## Run $(THANOS_BENCH_FUNC) benchmarks and compare with newest using https://github.com/prometheus/test-infra/tree/master/funcbench.
+bench-master: $(FUNCBENCH)
+	@echo ">> benchmark $(THANOS_BENCH_FUNC) and compare with: $(shell git tag | grep -E ^v[0-9]+\.[0-9]\.[0-9]+$$ | sort -t . -k1,1n -k2,2n -k3,3n | tail -1)"
+	@$(FUNCBENCH) -v --bench-time=30s --timeout=2h --result-cache=/tmp/cache  "$(shell git tag | grep -E ^v[0-9]+\.[0-9]\.[0-9]+$$ | sort -t . -k1,1n -k2,2n -k3,3n | tail -1)" $(THANOS_BENCH_FUNC)
+
+.PHONY: bench-release
+bench-release: ## Run $(THANOS_BENCH_FUNC) benchmarks and compare with older release using https://github.com/prometheus/test-infra/tree/master/funcbench.
+bench-release: $(FUNCBENCH)
+	@echo ">> benchmark $(THANOS_BENCH_FUNC) and compare with"
+	@$(FUNCBENCH) -v --bench-time=30s --timeout=2h --result-cache=/tmp/cache "$(shell git tag | grep -E ^v[0-9]+\.[0-9]\.[0-9]+$$ | sort -t . -k1,1n -k2,2n -k3,3n | grep -B1 $(CURRENT_RELEASE) | head -1)" $(THANOS_BENCH_FUNC)
 
 .PHONY: build
 build: ## Builds Thanos binary using `promu`.
@@ -457,3 +502,6 @@ $(JSONNET_BUNDLER):
 
 $(PROMTOOL):
 	$(call fetch_go_bin_version,github.com/prometheus/prometheus/cmd/promtool,$(PROMTOOL_VERSION))
+
+$(FUNCBENCH):
+	$(call fetch_go_bin_version_mod,github.com/prometheus/test-infra/funcbench,$(FUNCBENCH_VERSION))


### PR DESCRIPTION
Fixes https://github.com/thanos-io/thanos/pull/2095

With this we run ALL benchmarks:

* For All PRs: Run all go  bench benchmarks for the current PR and compare with `master`
* For push to master: Run all go  bench benchmarks in master and compare with `latest release"
* For new release: Run all go  bench benchmarks for the release and compare with `the previous minor release`

Benchmark runs should be cached as well.

Signed-off-by: Bartlomiej Plotka <bwplotka@gmail.com>

