### PR TITLE
ruler: Fix #2204 bug where alert queue is unpoppable causing full queue and dropped alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 
 ## Unreleased
 
+### Fixed
+
+- [#TODO](https://github.com/thanos-io/thanos/pull/#TODO) Ruler: Fixed Issue #2204 bug in alert queue signalling filled up queue and alerts were dropped
+
 ## [v0.11.0](https://github.com/thanos-io/thanos/releases/tag/v0.11.0-rc.1) - 2020.03.02
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 
 ### Fixed
 
-- [#TODO](https://github.com/thanos-io/thanos/pull/#TODO) Ruler: Fixed Issue #2204 bug in alert queue signalling filled up queue and alerts were dropped
+- [#2238](https://github.com/thanos-io/thanos/pull/2238) Ruler: Fixed Issue #2204 bug in alert queue signalling filled up queue and alerts were dropped
 
 ## [v0.11.0](https://github.com/thanos-io/thanos/releases/tag/v0.11.0-rc.1) - 2020.03.02
 

--- a/pkg/alert/alert.go
+++ b/pkg/alert/alert.go
@@ -195,6 +195,12 @@ func (q *Queue) Pop(termc <-chan struct{}) []*Alert {
 
 	q.popped.Add(float64(n))
 
+	if len(q.queue) > 0 {
+		select {
+		case q.morec <- struct{}{}:
+		default:
+		}
+	}
 	return as[:n]
 }
 

--- a/pkg/alert/alert_test.go
+++ b/pkg/alert/alert_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func TestQueue_Pop_all_Pushed(t *testing.T) {
-	qcapacity := 5
+	qcapacity := 10
 	batchsize := 1
 	pushes := 3
 
@@ -34,13 +34,14 @@ func TestQueue_Pop_all_Pushed(t *testing.T) {
 		})
 	}
 
-	timeoutc := time.After(time.Second)
+	timeoutc := make(chan struct{}, 1)
+	time.AfterFunc(time.Second, func() { timeoutc <- struct{}{} })
 	popped := 0
 	for p := q.Pop(timeoutc); p != nil; p = q.Pop(timeoutc) {
 		popped += len(p)
 	}
 
-	testutil.Equals(t, qcapacity, popped)
+	testutil.Equals(t, pushes*2, popped)
 }
 
 func TestQueue_Push_Relabelled(t *testing.T) {

--- a/pkg/alert/alert_test.go
+++ b/pkg/alert/alert_test.go
@@ -19,6 +19,30 @@ import (
 	"github.com/thanos-io/thanos/pkg/testutil"
 )
 
+func TestQueue_Pop_all_Pushed(t *testing.T) {
+	qcapacity := 5
+	batchsize := 1
+	pushes := 3
+
+	q := NewQueue(
+		nil, nil, qcapacity, batchsize, nil, nil,
+	)
+	for i := 0; i < pushes; i++ {
+		q.Push([]*Alert{
+			{},
+			{},
+		})
+	}
+
+	timeoutc := time.After(time.Second)
+	popped := 0
+	for p := q.Pop(timeoutc); p != nil; p = q.Pop(timeoutc) {
+		popped += len(p)
+	}
+
+	testutil.Equals(t, qcapacity, popped)
+}
+
 func TestQueue_Push_Relabelled(t *testing.T) {
 	q := NewQueue(
 		nil, nil, 10, 10,


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Fixes Issue #2204. The bug is that `alert.Queue.Push` can be called multiple times to add alerts to the queue, but it only provides a single signal on `morec` for `alert.Queue.Pop` to know that the queue has changed, i.e. there are alerts waiting. Further calls to `Push` can fill the queue and use `select` ... `default:` to skip signalling if the `morec` channel's buffer (size 1) is full. However, Pop will only remove `maxBatchSize` alerts from the queue and further calls to `Pop` block because the signal has been read. Therefore Pop fails to remove remaining alerts until `Push` has been called at least once again to restore the signal on `morec`.
This fix adds to `alert.Queue.Pop` so that if the queue is not empty after popping it restores the signal it read on the `morec` channel to indicate there are still more alerts it hasn't removed.

## Verification

1. This bug was noticed in production where the `thanos_alert_queue_alerts_pushed_total` metric was increasing in a short timespan but the `thanos_alert_queue_alerts_popped_total` was not keeping up, and `thanos_alert_queue_length` grew to almost 10,000 and remained there.

2. This change adds a test to ensure that after multiple calls to `alert.Queue.Push` to add more than `maxBatchSize` alerts to the queue, multiple calls to `alert.Queue.Pop` will work until all the pushed alerts have been popped.
