### PR TITLE
rule/docs: Add scheme to the alertmanagers.url in ruler example

### DIFF
--- a/docs/components/rule.md
+++ b/docs/components/rule.md
@@ -25,7 +25,7 @@ $ thanos rule \
     --eval-interval        "30s" \
     --rule-file            "/path/to/rules/*.rules.yaml" \
     --alert.query-url      "http://0.0.0.0:9090" \ # This tells what query URL to link to in UI.
-    --alertmanagers.url    "alert.thanos.io" \
+    --alertmanagers.url    "http://alert.thanos.io" \
     --query                "query.example.org" \
     --query                "query2.example.org" \
     --objstore.config-file "bucket.yml" \


### PR DESCRIPTION
Using the URL format shown in the example will cause the following error:
```
Post mysite.example.com/api/v1/alerts: unsupported protocol scheme ""
```

And according to the ruler docs:
>The scheme should not be empty e.g `http` might be used.

This PR adds the http scheme to the example to avoid misunderstanding.