### PR TITLE
test/e2e: Fix false metric name in Store GW e2e test

### DIFF
--- a/test/e2e/store_gateway_test.go
+++ b/test/e2e/store_gateway_test.go
@@ -102,7 +102,7 @@ func TestStoreGateway(t *testing.T) {
 	// Wait for store to sync blocks.
 	// thanos_blocks_meta_synced: 2x loadedMeta 1x labelExcludedMeta 1x TooFreshMeta.
 	testutil.Ok(t, s1.WaitSumMetrics(e2e.Equals(4), "thanos_blocks_meta_synced"))
-	testutil.Ok(t, s1.WaitSumMetrics(e2e.Equals(0), "thanos_blocks_meta_thanos_blocks_meta_sync_failures_total"))
+	testutil.Ok(t, s1.WaitSumMetrics(e2e.Equals(0), "thanos_blocks_meta_sync_failures_total"))
 
 	testutil.Ok(t, s1.WaitSumMetrics(e2e.Equals(2), "thanos_bucket_store_blocks_loaded"))
 	testutil.Ok(t, s1.WaitSumMetrics(e2e.Equals(0), "thanos_bucket_store_block_drops_total"))


### PR DESCRIPTION
Fix false metric name in `test/e2e/store_gateway_test.go`.

Actually, `WaitSumMetrics` has to fail if an expected metric is not present in the scraped metrics, however apparently it is not the case, see: https://github.com/cortexproject/cortex/blob/c0b0238da2b88e64857a692fb90b43a8815f667a/integration/e2e/service.go#L536-L544

Signed-off-by: Kemal Akkoyun <kakkoyun@gmail.com>

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

* Fix false metric name in `test/e2e/store_gateway_test.go`

## Verification

* `make test-local`
* `make test-e2e`
