### PR TITLE
compactor: Add wait-interval flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 - [#2238](https://github.com/thanos-io/thanos/pull/2238) Ruler: Fixed Issue #2204 bug in alert queue signalling filled up queue and alerts were dropped
 - [#2231](https://github.com/thanos-io/thanos/pull/2231) Bucket Web - Sort chunks by thanos.downsample.resolution for better grouping
 
+### Added
+
+- [#2265](https://github.com/thanos-io/thanos/pull/2265) Compactor: Add `--wait-interval` to specify compaction wait interval between consecutive compact runs when `--wait` enabled.
+
 ## [v0.11.0](https://github.com/thanos-io/thanos/releases/tag/v0.11.0) - 2020.03.02
 
 ### Fixed

--- a/docs/components/compact.md
+++ b/docs/components/compact.md
@@ -121,6 +121,8 @@ Flags:
                                samples of this resolution forever
   -w, --wait                   Do not exit after all compactions have been
                                processed and wait for new work.
+      --wait-interval=5m       Wait interval between consecutive compaction
+                               runs. Only works when --wait flag specified.
       --downsampling.disable   Disables downsampling. This is not recommended as
                                querying long time ranges without non-downsampled
                                data is not efficient and useful e.g it is not


### PR DESCRIPTION
Add a new `--wait-interval` flag that specifies compactor run interval.
This is helpful, especially for the end-to-end tests. See #2250 

Signed-off-by: Kemal Akkoyun <kakkoyun@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

* Add `--wait-interval` flag.

## Verification

* `make build`
* `make test-local`
