### PR TITLE
Refactor of commands and flag parsing

### DIFF
--- a/cmd/thanos/flags.go
+++ b/cmd/thanos/flags.go
@@ -7,9 +7,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/thanos-io/thanos/pkg/extflag"
-
 	"github.com/prometheus/common/model"
+	"github.com/thanos-io/thanos/pkg/extflag"
 	"gopkg.in/alecthomas/kingpin.v2"
 )
 


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->
Introduce config structs for sidecar component.
<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] Change is not relevant to the end user.

## Changes

As per #2248  - this change parses flags into structs before passing into the sidecar run func
