### PR TITLE
pkg/store/cache/inmemory.go: Use maxInt instead of math.MaxInt64

### DIFF
--- a/pkg/store/cache/inmemory.go
+++ b/pkg/store/cache/inmemory.go
@@ -5,7 +5,6 @@ package storecache
 
 import (
 	"context"
-	"math"
 	"reflect"
 	"sync"
 	"unsafe"
@@ -27,6 +26,8 @@ var (
 		MaxItemSize: 125 * 1024 * 1024,
 	}
 )
+
+const maxInt = int(^uint(0) >> 1)
 
 type InMemoryIndexCache struct {
 	mtx sync.Mutex
@@ -161,7 +162,7 @@ func NewInMemoryIndexCacheWithConfig(logger log.Logger, reg prometheus.Registere
 
 	// Initialize LRU cache with a high size limit since we will manage evictions ourselves
 	// based on stored size using `RemoveOldest` method.
-	l, err := lru.NewLRU(math.MaxInt64, c.onEvict)
+	l, err := lru.NewLRU(maxInt, c.onEvict)
 	if err != nil {
 		return nil, err
 	}
@@ -171,7 +172,7 @@ func NewInMemoryIndexCacheWithConfig(logger log.Logger, reg prometheus.Registere
 		"msg", "created in-memory index cache",
 		"maxItemSizeBytes", c.maxItemSizeBytes,
 		"maxSizeBytes", c.maxSizeBytes,
-		"maxItems", "math.MaxInt64",
+		"maxItems", "maxInt",
 	)
 	return c, nil
 }


### PR DESCRIPTION
Thanos uses `math.MaxInt64` constant for `int` parameter, which fails when building linux/arm builds. Found via vendoring Thanos in Cortex, and vendoring Cortex in Loki, which does linux/arm builds.

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

I've run `GOOS=linux GOARCH=arm go build ./cmd/thanos/` with this fix. Without the fix, it fails with

```
$ GOOS=linux GOARCH=arm go build ./cmd/thanos/
# github.com/thanos-io/thanos/pkg/store/cache
pkg/store/cache/inmemory.go:164:22: constant 9223372036854775807 overflows int
```
