### PR TITLE
Replace objstore.Exists function calls with bkt.Exists

### DIFF
--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -497,7 +497,7 @@ func generateIndexCacheFile(
 	cachePath := filepath.Join(bdir, block.IndexCacheFilename)
 	cache := path.Join(meta.ULID.String(), block.IndexCacheFilename)
 
-	ok, err := objstore.Exists(ctx, bkt, cache)
+	ok, err := bkt.Exists(ctx, cache)
 	if ok {
 		return nil
 	}

--- a/pkg/block/block.go
+++ b/pkg/block/block.go
@@ -131,7 +131,7 @@ func cleanUp(logger log.Logger, bkt objstore.Bucket, id ulid.ULID, err error) er
 // MarkForDeletion creates a file which stores information about when the block was marked for deletion.
 func MarkForDeletion(ctx context.Context, logger log.Logger, bkt objstore.Bucket, id ulid.ULID) error {
 	deletionMarkFile := path.Join(id.String(), metadata.DeletionMarkFilename)
-	deletionMarkExists, err := objstore.Exists(ctx, bkt, deletionMarkFile)
+	deletionMarkExists, err := bkt.Exists(ctx, deletionMarkFile)
 	if err != nil {
 		return errors.Wrapf(err, "check exists %s in bucket", deletionMarkFile)
 	}

--- a/pkg/objstore/objstore.go
+++ b/pkg/objstore/objstore.go
@@ -172,23 +172,6 @@ func DownloadDir(ctx context.Context, logger log.Logger, bkt BucketReader, src, 
 	return nil
 }
 
-// Exists returns true, if file exists, otherwise false and nil error if presence IsObjNotFoundErr, otherwise false with
-// returning error.
-func Exists(ctx context.Context, bkt Bucket, src string) (bool, error) {
-	rc, err := bkt.Get(ctx, src)
-	if rc != nil {
-		_ = rc.Close()
-	}
-	if err != nil {
-		if bkt.IsObjNotFoundErr(err) {
-			return false, nil
-		}
-		return false, errors.Wrap(err, "stat object")
-	}
-
-	return true, nil
-}
-
 const (
 	iterOp     = "iter"
 	sizeOp     = "objectsize"


### PR DESCRIPTION
Signed-off-by: khyatisoneji <khyatisoneji5@gmail.com>

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

* Since Bucket Interface already has Exists function, it is better to use `bkt.Exists` directly rather than using `objstore.Exists`. 
This should also address the CI pipeline failures seen here: https://circleci.com/gh/thanos-io/thanos/7875
