### PR TITLE
rule: fix query addr parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 
 ### Fixed
 
+- [#2288](https://github.com/thanos-io/thanos/pull/2288) Ruler: Fixes issue #2281 bug in ruler with parsing query addr with path prefix
 - [#2238](https://github.com/thanos-io/thanos/pull/2238) Ruler: Fixed Issue #2204 bug in alert queue signalling filled up queue and alerts were dropped
 - [#2231](https://github.com/thanos-io/thanos/pull/2231) Bucket Web - Sort chunks by thanos.downsample.resolution for better grouping
 - [#2254](https://github.com/thanos-io/thanos/pull/2254) Bucket: Fix metrics registered multiple times in bucket replicate

--- a/cmd/thanos/rule.go
+++ b/cmd/thanos/rule.go
@@ -288,14 +288,13 @@ func runRule(
 	metrics := newRuleMetrics(reg)
 
 	var queryCfg []query.Config
+	var err error
 	if len(queryConfigYAML) > 0 {
-		var err error
 		queryCfg, err = query.LoadConfigs(queryConfigYAML)
 		if err != nil {
 			return err
 		}
 	} else {
-		var err error
 		queryCfg, err = query.BuildQueryConfig(queryAddrs)
 		if err != nil {
 			return err

--- a/cmd/thanos/rule.go
+++ b/cmd/thanos/rule.go
@@ -295,10 +295,10 @@ func runRule(
 			return err
 		}
 	} else {
-		for _, addr := range queryAddrs {
-			if addr == "" {
-				return errors.New("static querier address cannot be empty")
-			}
+		var err error
+		queryCfg, err = query.BuildQueryConfig(queryAddrs)
+		if err != nil {
+			return err
 		}
 
 		// Build the query configuration from the legacy query flags.
@@ -308,16 +308,15 @@ func runRule(
 				Files:           querySDFiles,
 				RefreshInterval: model.Duration(querySDInterval),
 			})
-		}
-		queryCfg = append(queryCfg,
-			query.Config{
-				EndpointsConfig: http_util.EndpointsConfig{
-					Scheme:          "http",
-					StaticAddresses: queryAddrs,
-					FileSDConfigs:   fileSDConfigs,
+			queryCfg = append(queryCfg,
+				query.Config{
+					EndpointsConfig: http_util.EndpointsConfig{
+						Scheme:        "http",
+						FileSDConfigs: fileSDConfigs,
+					},
 				},
-			},
-		)
+			)
+		}
 	}
 
 	queryProvider := dns.NewProvider(

--- a/pkg/query/config.go
+++ b/pkg/query/config.go
@@ -48,9 +48,9 @@ func LoadConfigs(confYAML []byte) ([]Config, error) {
 // BuildQueryConfig returns a query client configuration from a static address.
 func BuildQueryConfig(queryAddrs []string) ([]Config, error) {
 	configs := make([]Config, 0, len(queryAddrs))
-	for _, addr := range queryAddrs {
+	for i, addr := range queryAddrs {
 		if addr == "" {
-			return nil, errors.New("static querier address cannot be empty")
+			return nil, errors.Errorf("static querier address cannot be empty at index %d", i)
 		}
 		// If addr is missing schema, add http.
 		if !strings.Contains(addr, "://") {
@@ -59,6 +59,9 @@ func BuildQueryConfig(queryAddrs []string) ([]Config, error) {
 		u, err := url.Parse(addr)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to parse addr %q", addr)
+		}
+		if u.Scheme != "http" && u.Scheme != "https" {
+			return nil, errors.Errorf("%q is not supported scheme for querier address", u.Scheme)
 		}
 		configs = append(configs, Config{
 			EndpointsConfig: http_util.EndpointsConfig{

--- a/pkg/query/config.go
+++ b/pkg/query/config.go
@@ -6,6 +6,7 @@ package query
 import (
 	"fmt"
 	"net/url"
+	"strings"
 
 	"gopkg.in/yaml.v2"
 
@@ -51,7 +52,11 @@ func BuildQueryConfig(queryAddrs []string) ([]Config, error) {
 		if addr == "" {
 			return nil, errors.New("static querier address cannot be empty")
 		}
-		u, err := url.Parse(fmt.Sprintf("http://%s", addr))
+		// If addr is missing schema, add http.
+		if !strings.Contains(addr, "://") {
+			addr = fmt.Sprintf("http://%s", addr)
+		}
+		u, err := url.Parse(addr)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to parse addr %q", addr)
 		}

--- a/pkg/query/config.go
+++ b/pkg/query/config.go
@@ -45,7 +45,7 @@ func LoadConfigs(confYAML []byte) ([]Config, error) {
 	return queryCfg, nil
 }
 
-// BuildQueryConfig initializes and returns an Query client configuration from a static address.
+// BuildQueryConfig returns a query client configuration from a static address.
 func BuildQueryConfig(queryAddrs []string) ([]Config, error) {
 	configs := make([]Config, 0, len(queryAddrs))
 	for _, addr := range queryAddrs {

--- a/pkg/query/config_test.go
+++ b/pkg/query/config_test.go
@@ -18,7 +18,7 @@ func TestBuildQueryConfig(t *testing.T) {
 		expected  []Config
 	}{
 		{
-			desc:      "signe addr without path",
+			desc:      "single addr without path",
 			addresses: []string{"localhost:9093"},
 			expected: []Config{{
 				EndpointsConfig: http.EndpointsConfig{
@@ -47,7 +47,7 @@ func TestBuildQueryConfig(t *testing.T) {
 			},
 		},
 		{
-			desc:      "signe addr with path and http scheme",
+			desc:      "single addr with path and http scheme",
 			addresses: []string{"http://localhost:9093"},
 			expected: []Config{{
 				EndpointsConfig: http.EndpointsConfig{
@@ -57,7 +57,7 @@ func TestBuildQueryConfig(t *testing.T) {
 			}},
 		},
 		{
-			desc:      "signe addr with path and https scheme",
+			desc:      "single addr with path and https scheme",
 			addresses: []string{"https://localhost:9093"},
 			expected: []Config{{
 				EndpointsConfig: http.EndpointsConfig{
@@ -67,8 +67,18 @@ func TestBuildQueryConfig(t *testing.T) {
 			}},
 		},
 		{
+			desc:      "not supported scheme",
+			addresses: []string{"ttp://localhost:9093"},
+			err:       true,
+		},
+		{
 			desc:      "invalid addr",
 			addresses: []string{"this is not a valid addr"},
+			err:       true,
+		},
+		{
+			desc:      "empty addr",
+			addresses: []string{""},
 			err:       true,
 		},
 	} {

--- a/pkg/query/config_test.go
+++ b/pkg/query/config_test.go
@@ -1,0 +1,65 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package query
+
+import (
+	"testing"
+
+	"github.com/thanos-io/thanos/pkg/http"
+	"github.com/thanos-io/thanos/pkg/testutil"
+)
+
+func TestBuildQueryConfig(t *testing.T) {
+	for _, tc := range []struct {
+		desc      string
+		addresses []string
+		err       bool
+		expected  []Config
+	}{
+		{
+			desc:      "signe addr without path",
+			addresses: []string{"localhost:9093"},
+			expected: []Config{{
+				EndpointsConfig: http.EndpointsConfig{
+					StaticAddresses: []string{"localhost:9093"},
+					Scheme:          "http",
+				},
+			}},
+		},
+		{
+			desc:      "1st addr without path, 2nd with",
+			addresses: []string{"localhost:9093", "localhost:9094/prefix"},
+			expected: []Config{
+				{
+					EndpointsConfig: http.EndpointsConfig{
+						StaticAddresses: []string{"localhost:9093"},
+						Scheme:          "http",
+					},
+				},
+				{
+					EndpointsConfig: http.EndpointsConfig{
+						StaticAddresses: []string{"localhost:9094"},
+						Scheme:          "http",
+						PathPrefix:      "/prefix",
+					},
+				},
+			},
+		},
+		{
+			desc:      "invalid addr",
+			addresses: []string{"this is not a valid addr"},
+			err:       true,
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			cfg, err := BuildQueryConfig(tc.addresses)
+			if tc.err {
+				testutil.NotOk(t, err)
+				return
+			}
+
+			testutil.Equals(t, tc.expected, cfg)
+		})
+	}
+}

--- a/pkg/query/config_test.go
+++ b/pkg/query/config_test.go
@@ -47,6 +47,26 @@ func TestBuildQueryConfig(t *testing.T) {
 			},
 		},
 		{
+			desc:      "signe addr with path and http scheme",
+			addresses: []string{"http://localhost:9093"},
+			expected: []Config{{
+				EndpointsConfig: http.EndpointsConfig{
+					StaticAddresses: []string{"localhost:9093"},
+					Scheme:          "http",
+				},
+			}},
+		},
+		{
+			desc:      "signe addr with path and https scheme",
+			addresses: []string{"https://localhost:9093"},
+			expected: []Config{{
+				EndpointsConfig: http.EndpointsConfig{
+					StaticAddresses: []string{"localhost:9093"},
+					Scheme:          "https",
+				},
+			}},
+		},
+		{
 			desc:      "invalid addr",
 			addresses: []string{"this is not a valid addr"},
 			err:       true,


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->
- Fixes issue #2281 bug in ruler with parsing query addr with path prefix
Note: Right now `querySDFiles` will be added as new element to `query.Config` slice as suggested in https://github.com/thanos-io/thanos/issues/2281#issuecomment-600546052.

## Verification

<!-- How you tested it? How do you know it works? -->

I have added unit test for parsing config, however I haven't tested it live. Is there and easy way of doing it?
