### PR TITLE
Enrich Memcached client logs

### DIFF
--- a/pkg/cacheutil/memcached_client.go
+++ b/pkg/cacheutil/memcached_client.go
@@ -263,7 +263,7 @@ func (c *memcachedClient) SetAsync(ctx context.Context, key string, value []byte
 		})
 		if err != nil {
 			c.failures.WithLabelValues(opSet).Inc()
-			level.Warn(c.logger).Log("msg", "failed to store item to memcached", "key", key, "err", err)
+			level.Warn(c.logger).Log("msg", "failed to store item to memcached", "key", key, "size_bytes", len(value), "err", err)
 			return
 		}
 
@@ -272,9 +272,13 @@ func (c *memcachedClient) SetAsync(ctx context.Context, key string, value []byte
 }
 
 func (c *memcachedClient) GetMulti(ctx context.Context, keys []string) map[string][]byte {
+	if len(keys) == 0 {
+		return nil
+	}
+
 	batches, err := c.getMultiBatched(ctx, keys)
 	if err != nil {
-		level.Warn(c.logger).Log("msg", "failed to fetch items from memcached", "err", err)
+		level.Warn(c.logger).Log("msg", "failed to fetch items from memcached", "num_keys", len(keys), "first_key", keys[0], "err", err)
 
 		// In case we have both results and an error, it means some batch requests
 		// failed and other succeeded. In this case we prefer to log it and move on,

--- a/pkg/cacheutil/memcached_client.go
+++ b/pkg/cacheutil/memcached_client.go
@@ -263,7 +263,7 @@ func (c *memcachedClient) SetAsync(ctx context.Context, key string, value []byte
 		})
 		if err != nil {
 			c.failures.WithLabelValues(opSet).Inc()
-			level.Warn(c.logger).Log("msg", "failed to store item to memcached", "key", key, "size_bytes", len(value), "err", err)
+			level.Warn(c.logger).Log("msg", "failed to store item to memcached", "key", key, "sizeBytes", len(value), "err", err)
 			return
 		}
 

--- a/pkg/cacheutil/memcached_client.go
+++ b/pkg/cacheutil/memcached_client.go
@@ -278,7 +278,7 @@ func (c *memcachedClient) GetMulti(ctx context.Context, keys []string) map[strin
 
 	batches, err := c.getMultiBatched(ctx, keys)
 	if err != nil {
-		level.Warn(c.logger).Log("msg", "failed to fetch items from memcached", "num_keys", len(keys), "first_key", keys[0], "err", err)
+		level.Warn(c.logger).Log("msg", "failed to fetch items from memcached", "numKeys", len(keys), "firstKey", keys[0], "err", err)
 
 		// In case we have both results and an error, it means some batch requests
 		// failed and other succeeded. In this case we prefer to log it and move on,


### PR DESCRIPTION
While investigating some memcached errors I found a couple of additional logs (which I'm submitting in this PR) quite useful:

1. Size of a key on store failure
2. Number of keys (and their first key to see what's fetching) on get multi failure

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

- Enriched Memcached client logs

## Verification

Manual tests.
