### PR TITLE
store: Postings fetching optimizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 Since there are no consistency guarantees provided by some Object Storage providers, this PR adds a consistent lock-free way of dealing with Object Storage irrespective of the choice of object storage. In order to achieve this co-ordination, blocks are not deleted directly. Instead, blocks are marked for deletion by uploading `deletion-mark.json` file for the block that was chosen to be deleted. This file contains unix time of when the block was marked for deletion.
 
 - [#2090](https://github.com/thanos-io/thanos/issues/2090) *breaking* Downsample command: the `downsample` command has moved as the `thanos bucket` sub-command, and cannot be called via `thanos downsample` any more.
+- [#2294](https://github.com/thanos-io/thanos/pull/2294) store: optimizations for fetching postings. Queries using `=~".*"` matchers or negation matchers (`!=...` or `!~...`) benefit the most.
 
 ## [v0.11.0](https://github.com/thanos-io/thanos/releases/tag/v0.11.0) - 2020.03.02
 

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -1359,8 +1359,8 @@ func (r *bucketIndexReader) ExpandedPostings(ms []*labels.Matcher) ([]uint64, er
 		return nil, errors.Wrap(err, "get postings")
 	}
 
-	// get add/remove postings from groups. While we iterate over postingGroups and their keys
-	// again, this is exactly the same order as before, when building the groups, so we can simply
+	// Get "add" and "remove" postings from groups. We iterate over postingGroups and their keys
+	// again, and this is exactly the same order as before (when building the groups), so we can simply
 	// use one incrementing index to fetch postings from returned slice.
 	postingIndex := 0
 

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -1324,7 +1324,7 @@ func (r *bucketIndexReader) ExpandedPostings(ms []*labels.Matcher) ([]uint64, er
 			return nil, errors.Wrap(err, "toPostingGroup")
 		}
 
-		// intersection would return no postings anyway
+		// Intersection with empty postings would return no postings anyway.
 		if pg.alwaysEmptyPostings() {
 			return nil, nil
 		}
@@ -1333,9 +1333,9 @@ func (r *bucketIndexReader) ExpandedPostings(ms []*labels.Matcher) ([]uint64, er
 		allRequested = allRequested || pg.addAll
 		hasAdds = hasAdds || len(pg.addKeys) > 0
 
-		// postings returned by fetchPostings will be in the same order as keys
+		// Postings returned by fetchPostings will be in the same order as keys
 		// so it's important that we iterate them in the same order later,
-		// since we don't build any label -> keys index map
+		// since we don't build any label -> keys index map.
 		keys = append(keys, pg.addKeys...)
 		keys = append(keys, pg.removeKeys...)
 	}
@@ -1347,8 +1347,8 @@ func (r *bucketIndexReader) ExpandedPostings(ms []*labels.Matcher) ([]uint64, er
 	allKeyIndex := -1
 	// we only need All postings if there are no other adds. If there are, we can skip fetching ALL postings completely.
 	if allRequested && !hasAdds {
-		// remember the index (will be used later as a flag, and also to access postings),
-		// and ask fetchPostings to fetch ALL postings too
+		// Remember the index (will be used later as a flag, and also to access postings),
+		// and ask fetchPostings to fetch ALL postings too.
 		allKeyIndex = len(keys)
 		keys = append(keys, getAllPostingsKeyLabel())
 	}
@@ -1365,7 +1365,7 @@ func (r *bucketIndexReader) ExpandedPostings(ms []*labels.Matcher) ([]uint64, er
 
 	var groupAdds, removals []index.Postings
 	for _, g := range postingGroups {
-		// we cannot add empty set to groupAdds, since they are intersected
+		// We cannot add empty set to groupAdds, since they are intersected.
 		if len(g.addKeys) > 0 {
 			var toMerge []index.Postings
 			for _, l := range g.addKeys {
@@ -1383,7 +1383,7 @@ func (r *bucketIndexReader) ExpandedPostings(ms []*labels.Matcher) ([]uint64, er
 	}
 
 	if allKeyIndex >= 0 {
-		// if we have fetched "ALL" postings, add it
+		// If we have fetched "ALL" postings, add it.
 		groupAdds = append(groupAdds, checkNilPosting(getAllPostingsKeyLabel(), fetchedPostings[allKeyIndex]))
 	}
 
@@ -1443,14 +1443,13 @@ func checkNilPosting(l labels.Label, p index.Postings) index.Postings {
 
 // NOTE: Derived from tsdb.postingsForMatcher. index.Merge is equivalent to map duplication.
 func toPostingGroup(lvalsFn func(name string) ([]string, error), m *labels.Matcher) (*postingGroup, error) {
+	// This matches all values, including no value. If it is the only matcher, it will return all postings.
 	if m.Type == labels.MatchRegexp && (m.Value == ".*" || m.Value == "^.*$") {
-		// This matches all values, including no value. If it is the only matcher, it will return all postings.
 		return newPostingGroup(true, nil, nil), nil
 	}
 
 	// NOT matching any value = match nothing. We can shortcut this easily.
 	if m.Type == labels.MatchNotRegexp && (m.Value == ".*" || m.Value == "^.*$") {
-		// empty result
 		return newPostingGroup(false, nil, nil), nil
 	}
 

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -1498,6 +1498,8 @@ type postingPtr struct {
 }
 
 // fetchPostings fill postings requested by posting groups.
+// It returns one postings for each key, in the same order.
+// If postings for given key is not fetched, entry at given index will be nil.
 func (r *bucketIndexReader) fetchPostings(keys []labels.Label) ([]index.Postings, error) {
 	var ptrs []postingPtr
 

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -1325,8 +1325,9 @@ func (r *bucketIndexReader) ExpandedPostings(ms []*labels.Matcher) ([]uint64, er
 			return nil, errors.Wrap(err, "toPostingGroup")
 		}
 
-		// If this groups adds nothing, it's an empty group. Intersection with empty postings would return no postings anyway.
-		// E.g. label="non-existing-value" also returns empty group.
+		// If this groups adds nothing, it's an empty group. We can shortcut this, since intersection with empty
+		// postings would return no postings anyway.
+		// E.g. label="non-existing-value" returns empty group.
 		if !pg.addAll && len(pg.addKeys) == 0 {
 			return nil, nil
 		}

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -1405,10 +1405,10 @@ func (r *bucketIndexReader) ExpandedPostings(ms []*labels.Matcher) ([]uint64, er
 	return ps, nil
 }
 
-// Logical result of each individual group is:
+// postingGroup keeps posting keys for single matcher. Logical result of the group is:
 // If addAll is set: special All postings minus postings for removeKeys labels. No need to merge postings for addKeys in this case.
 // If addAll is not set: Merge of postings for "addKeys" labels minus postings for removeKeys labels
-// This happens in ExpandedPostings.
+// This computation happens in ExpandedPostings.
 type postingGroup struct {
 	addAll     bool
 	addKeys    []labels.Label

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -1325,8 +1325,9 @@ func (r *bucketIndexReader) ExpandedPostings(ms []*labels.Matcher) ([]uint64, er
 			return nil, errors.Wrap(err, "toPostingGroup")
 		}
 
-		// Intersection with empty postings would return no postings anyway.
-		if pg == emptyPostingsGroup {
+		// If this groups adds nothing, it's an empty group. Intersection with empty postings would return no postings anyway.
+		// E.g. label="non-existing-value" also returns empty group.
+		if !pg.addAll && len(pg.addKeys) == 0 {
 			return nil, nil
 		}
 

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -1312,7 +1312,7 @@ func newBucketIndexReader(ctx context.Context, block *bucketBlock) *bucketIndexR
 func (r *bucketIndexReader) ExpandedPostings(ms []*labels.Matcher) ([]uint64, error) {
 	var postingGroups []*postingGroup
 
-	all := false
+	allRequested := false
 	hasAdds := false
 	keys := []labels.Label(nil)
 
@@ -1330,7 +1330,7 @@ func (r *bucketIndexReader) ExpandedPostings(ms []*labels.Matcher) ([]uint64, er
 		}
 
 		postingGroups = append(postingGroups, pg)
-		all = all || pg.addAll
+		allRequested = allRequested || pg.addAll
 		hasAdds = hasAdds || len(pg.addKeys) > 0
 
 		// postings returned by fetchPostings will be in the same order as keys
@@ -1346,7 +1346,7 @@ func (r *bucketIndexReader) ExpandedPostings(ms []*labels.Matcher) ([]uint64, er
 
 	allKeyIndex := -1
 	// we only need All postings if there are no other adds. If there are, we can skip fetching ALL postings completely.
-	if all && !hasAdds {
+	if allRequested && !hasAdds {
 		// remember the index (will be used later as a flag, and also to access postings),
 		// and ask fetchPostings to fetch ALL postings too
 		allKeyIndex = len(keys)

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -1324,7 +1324,7 @@ func (r *bucketIndexReader) ExpandedPostings(ms []*labels.Matcher) ([]uint64, er
 			return nil, errors.Wrap(err, "toPostingGroup")
 		}
 
-		// interesction would return no postings anyway
+		// intersection would return no postings anyway
 		if pg.alwaysEmptyPostings() {
 			return nil, nil
 		}

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -1310,11 +1310,12 @@ func newBucketIndexReader(ctx context.Context, block *bucketBlock) *bucketIndexR
 // chunk where the series contains the matching label-value pair for a given block of data. Postings can be fetched by
 // single label name=value.
 func (r *bucketIndexReader) ExpandedPostings(ms []*labels.Matcher) ([]uint64, error) {
-	var postingGroups []*postingGroup
-
-	allRequested := false
-	hasAdds := false
-	keys := []labels.Label(nil)
+	var (
+		postingGroups []*postingGroup
+		allRequested  = false
+		hasAdds       = false
+		keys          []labels.Label
+	)
 
 	// NOTE: Derived from tsdb.PostingsForMatchers.
 	for _, m := range ms {


### PR DESCRIPTION
* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.


This PR implements has some postings fetching optimizations:
- "ALL" postings are only fetched if they are required, and then they are fetched only once. Before this PR, "ALL" postings could have been fetched multiple times.
- label =~ ".*" is now shortcut to return ALL postings
- label !~ ".*" is now shortcut to return NO results :)

To implement this, `postingGroup` now only holds `add` and `remove` keys (labels). Postings for "Add" keys in each individual group are merged together and intersected between groups, and postings for "remove" keys are then subtracted from "added" ones. This all now happens in `ExpandedPostings`. `postingGroup` also has boolean flag `addAll`, which indicates whether "ALL" postings should be added or not. `ExpandedPostings` will only add ALL postings, if there are no other "added" postings – if there are, ALL can be skipped.

`fetchPostings` now gets the keys to fetch, and returns postings in the same order. `ExpandedPostings` relies on this behaviour: first it builds the keys, then it iterates the groups and keys in the same order and uses subsequent postings from `fetchPostings`. I added comments to the code that explain it. Reason to do it this way is so that `fetchPostings` doesn't need to deal with groups and add/remove keys in a special way. All this logic is in `ExpandedPostings` only.

I didn't add any new tests for this... it seems that existing test cases cover this pretty well (and found some bugs in my code).

Benchmarks... Improvements are visible in l=~".*" cases, or negation cases with some other positive matcher as well (ALL is not needed then).

Update: Benchmarks updated with latest changes as of c784dda.

```
name                                                                 old time/op    new time/op    delta
BucketIndexReader_ExpandedPostings/n="1"-4                             3.93ms ± 1%    3.94ms ± 1%     ~     (p=0.481 n=10+10)
BucketIndexReader_ExpandedPostings/n="1",j="foo"-4                     31.9ms ± 0%    31.3ms ± 1%   -1.85%  (p=0.000 n=9+9)
BucketIndexReader_ExpandedPostings/j="foo",n="1"-4                     32.3ms ± 1%    31.5ms ± 1%   -2.43%  (p=0.000 n=10+9)
BucketIndexReader_ExpandedPostings/n="1",j!="foo"-4                     229ms ± 0%      23ms ± 0%  -89.87%  (p=0.000 n=9+9)
BucketIndexReader_ExpandedPostings/i=~".*"-4                            157ms ± 0%      66ms ± 0%  -57.58%  (p=0.000 n=10+10)
BucketIndexReader_ExpandedPostings/i=~".+"-4                            453ms ± 1%     455ms ± 1%     ~     (p=0.052 n=10+10)
BucketIndexReader_ExpandedPostings/i=~""-4                              519ms ± 1%     526ms ± 1%   +1.30%  (p=0.000 n=10+10)
BucketIndexReader_ExpandedPostings/i!=""-4                              373ms ± 1%     376ms ± 1%   +1.04%  (p=0.000 n=10+9)
BucketIndexReader_ExpandedPostings/n="1",i=~".*",j="foo"-4              155ms ± 1%      31ms ± 1%  -79.69%  (p=0.000 n=10+10)
BucketIndexReader_ExpandedPostings/n="1",i=~".*",i!="2",j="foo"-4       192ms ± 1%      40ms ± 1%  -79.42%  (p=0.000 n=10+10)
BucketIndexReader_ExpandedPostings/n="1",i!=""-4                        168ms ± 1%     169ms ± 1%     ~     (p=0.095 n=9+10)
BucketIndexReader_ExpandedPostings/n="1",i!="",j="foo"-4                192ms ± 0%     192ms ± 1%   +0.40%  (p=0.017 n=9+10)
BucketIndexReader_ExpandedPostings/n="1",i=~".+",j="foo"-4              271ms ± 0%     272ms ± 1%     ~     (p=0.315 n=8+10)
BucketIndexReader_ExpandedPostings/n="1",i=~"1.+",j="foo"-4            47.1ms ± 1%    46.8ms ± 0%   -0.53%  (p=0.002 n=8+9)
BucketIndexReader_ExpandedPostings/n="1",i=~".+",i!="2",j="foo"-4       326ms ± 1%     279ms ± 1%  -14.21%  (p=0.000 n=9+9)
BucketIndexReader_ExpandedPostings/n="1",i=~".+",i!~"2.*",j="foo"-4     385ms ± 1%     316ms ± 1%  -18.12%  (p=0.000 n=10+10)

name                                                                 old alloc/op   new alloc/op   delta
BucketIndexReader_ExpandedPostings/n="1"-4                             11.4MB ± 0%    11.4MB ± 0%   +0.00%  (p=0.001 n=10+9)
BucketIndexReader_ExpandedPostings/n="1",j="foo"-4                     23.5MB ± 0%    23.5MB ± 0%   +0.00%  (p=0.000 n=10+10)
BucketIndexReader_ExpandedPostings/j="foo",n="1"-4                     23.5MB ± 0%    23.5MB ± 0%   +0.00%  (p=0.000 n=10+10)
BucketIndexReader_ExpandedPostings/n="1",j!="foo"-4                    90.6MB ± 0%    23.5MB ± 0%  -74.04%  (p=0.000 n=8+10)
BucketIndexReader_ExpandedPostings/i=~".*"-4                            335MB ± 0%     284MB ± 0%  -15.29%  (p=0.000 n=6+10)
BucketIndexReader_ExpandedPostings/i=~".+"-4                            384MB ± 0%     382MB ± 0%   -0.55%  (p=0.000 n=10+10)
BucketIndexReader_ExpandedPostings/i=~""-4                              235MB ± 0%     240MB ± 0%   +2.36%  (p=0.000 n=10+10)
BucketIndexReader_ExpandedPostings/i!=""-4                              384MB ± 0%     382MB ± 0%   -0.55%  (p=0.000 n=9+10)
BucketIndexReader_ExpandedPostings/n="1",i=~".*",j="foo"-4              142MB ± 0%      24MB ± 0%  -83.41%  (p=0.000 n=10+10)
BucketIndexReader_ExpandedPostings/n="1",i=~".*",i!="2",j="foo"-4       144MB ± 0%      26MB ± 0%  -82.19%  (p=0.000 n=9+10)
BucketIndexReader_ExpandedPostings/n="1",i!=""-4                        179MB ± 0%     177MB ± 0%   -1.17%  (p=0.000 n=10+10)
BucketIndexReader_ExpandedPostings/n="1",i!="",j="foo"-4                191MB ± 0%     189MB ± 0%   -1.10%  (p=0.000 n=10+10)
BucketIndexReader_ExpandedPostings/n="1",i=~".+",j="foo"-4              191MB ± 0%     189MB ± 0%   -1.10%  (p=0.000 n=10+10)
BucketIndexReader_ExpandedPostings/n="1",i=~"1.+",j="foo"-4            83.8MB ± 0%    83.6MB ± 0%   -0.23%  (p=0.000 n=10+10)
BucketIndexReader_ExpandedPostings/n="1",i=~".+",i!="2",j="foo"-4       260MB ± 0%     191MB ± 0%  -26.57%  (p=0.000 n=9+9)
BucketIndexReader_ExpandedPostings/n="1",i=~".+",i!~"2.*",j="foo"-4     315MB ± 0%     247MB ± 0%  -21.68%  (p=0.000 n=7+10)

name                                                                 old allocs/op  new allocs/op  delta
BucketIndexReader_ExpandedPostings/n="1"-4                               74.0 ± 0%      76.0 ± 0%   +2.70%  (p=0.000 n=10+10)
BucketIndexReader_ExpandedPostings/n="1",j="foo"-4                        110 ± 0%       112 ± 0%   +1.82%  (p=0.000 n=10+10)
BucketIndexReader_ExpandedPostings/j="foo",n="1"-4                        110 ± 0%       112 ± 0%   +1.82%  (p=0.000 n=10+10)
BucketIndexReader_ExpandedPostings/n="1",j!="foo"-4                       145 ± 0%       111 ± 0%  -23.45%  (p=0.000 n=10+10)
BucketIndexReader_ExpandedPostings/i=~".*"-4                             97.0 ± 0%      92.0 ± 0%   -5.15%  (p=0.000 n=9+10)
BucketIndexReader_ExpandedPostings/i=~".+"-4                             300k ± 0%      300k ± 0%   +0.00%  (p=0.000 n=10+8)
BucketIndexReader_ExpandedPostings/i=~""-4                               300k ± 0%      300k ± 0%   +0.01%  (p=0.000 n=9+10)
BucketIndexReader_ExpandedPostings/i!=""-4                               300k ± 0%      300k ± 0%   +0.00%  (p=0.000 n=8+9)
BucketIndexReader_ExpandedPostings/n="1",i=~".*",j="foo"-4                152 ± 0%       113 ± 0%  -25.66%  (p=0.000 n=10+10)
BucketIndexReader_ExpandedPostings/n="1",i=~".*",i!="2",j="foo"-4         188 ± 0%       145 ± 0%  -22.87%  (p=0.000 n=9+10)
BucketIndexReader_ExpandedPostings/n="1",i!=""-4                         300k ± 0%      300k ± 0%   +0.00%  (p=0.000 n=10+10)
BucketIndexReader_ExpandedPostings/n="1",i!="",j="foo"-4                 300k ± 0%      300k ± 0%   +0.00%  (p=0.000 n=10+10)
BucketIndexReader_ExpandedPostings/n="1",i=~".+",j="foo"-4               300k ± 0%      300k ± 0%   +0.00%  (p=0.000 n=10+10)
BucketIndexReader_ExpandedPostings/n="1",i=~"1.+",j="foo"-4             33.5k ± 0%     33.5k ± 0%   +0.01%  (p=0.000 n=8+9)
BucketIndexReader_ExpandedPostings/n="1",i=~".+",i!="2",j="foo"-4        300k ± 0%      300k ± 0%   -0.00%  (p=0.000 n=9+9)
BucketIndexReader_ExpandedPostings/n="1",i=~".+",i!~"2.*",j="foo"-4      334k ± 0%      334k ± 0%   +0.00%  (p=0.000 n=8+10)
```