### PR TITLE
store: added option to reencode and compress postings before storing them to the cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 - [#2250](https://github.com/thanos-io/thanos/pull/2250) Compactor: Enable vertical compaction for offline deduplication (Experimental). Uses `--deduplication.replica-label` flag to specify the replica label to deduplicate on (Hidden). Please note that this uses a NAIVE algorithm for merging (no smart replica deduplication, just chaining samples together). This works well for deduplication of blocks with **precisely the same samples** like produced by Receiver replication. We plan to add a smarter algorithm in the following weeks.
 - [#1714](https://github.com/thanos-io/thanos/pull/1714) Run the bucket web UI in the compact component when it is run as a long-lived process.
 - [#2304](https://github.com/thanos-io/thanos/pull/2304) Store: Added `max_item_size` config option to memcached-based index cache. This should be set to the max item size configured in memcached (`-I` flag) in order to not waste network round-trips to cache items larger than the limit configured in memcached.
-- [#2297](https://github.com/thanos-io/thanos/pull/2297) Store Gateway: Add `--experimental.enable-postings-compression` flag to enable reencoding and compressing postings before storing them into cache. Compressed postings take about 10% of the original size.
+- [#2297](https://github.com/thanos-io/thanos/pull/2297) Store Gateway: Add `--experimental.enable-index-cache-postings-compression` flag to enable reencoding and compressing postings before storing them into cache. Compressed postings take about 10% of the original size.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 - [#2250](https://github.com/thanos-io/thanos/pull/2250) Compactor: Enable vertical compaction for offline deduplication (Experimental). Uses `--deduplication.replica-label` flag to specify the replica label to deduplicate on (Hidden). Please note that this uses a NAIVE algorithm for merging (no smart replica deduplication, just chaining samples together). This works well for deduplication of blocks with **precisely the same samples** like produced by Receiver replication. We plan to add a smarter algorithm in the following weeks.
 - [#1714](https://github.com/thanos-io/thanos/pull/1714) Run the bucket web UI in the compact component when it is run as a long-lived process.
 - [#2304](https://github.com/thanos-io/thanos/pull/2304) Store: Added `max_item_size` config option to memcached-based index cache. This should be set to the max item size configured in memcached (`-I` flag) in order to not waste network round-trips to cache items larger than the limit configured in memcached.
+- [#2297](https://github.com/thanos-io/thanos/pull/2297) Store Gateway: Add `--experimental.enable-postings-compression` flag to enable reencoding and compressing postings before storing them into cache. Compressed postings take about 10% of the original size.
 
 ### Changed
 

--- a/cmd/thanos/store.go
+++ b/cmd/thanos/store.go
@@ -81,6 +81,9 @@ func registerStore(m map[string]setupFunc, app *kingpin.Application) {
 	enableIndexHeader := cmd.Flag("experimental.enable-index-header", "If true, Store Gateway will recreate index-header instead of index-cache.json for each block. This will replace index-cache.json permanently once it will be out of experimental stage.").
 		Hidden().Default("false").Bool()
 
+	enablePostingsCompression := cmd.Flag("experimental.enable-postings-compression", "If true, Store Gateway will reencode and compress postings before storing them into cache. Compressed postings take about 10% of the original size.").
+		Hidden().Default("false").Bool()
+
 	consistencyDelay := modelDuration(cmd.Flag("consistency-delay", "Minimum age of all blocks before they are being read. Set it to safe value (e.g 30m) if your object storage is eventually consistent. GCS and S3 are (roughly) strongly consistent.").
 		Default("0s"))
 
@@ -126,6 +129,7 @@ func registerStore(m map[string]setupFunc, app *kingpin.Application) {
 			selectorRelabelConf,
 			*advertiseCompatibilityLabel,
 			*enableIndexHeader,
+			*enablePostingsCompression,
 			time.Duration(*consistencyDelay),
 			time.Duration(*ignoreDeletionMarksDelay),
 		)
@@ -160,6 +164,7 @@ func runStore(
 	selectorRelabelConf *extflag.PathOrContent,
 	advertiseCompatibilityLabel bool,
 	enableIndexHeader bool,
+	enablePostingsCompression bool,
 	consistencyDelay time.Duration,
 	ignoreDeletionMarksDelay time.Duration,
 ) error {
@@ -265,6 +270,7 @@ func runStore(
 		filterConf,
 		advertiseCompatibilityLabel,
 		enableIndexHeader,
+		enablePostingsCompression,
 	)
 	if err != nil {
 		return errors.Wrap(err, "create object storage store")

--- a/cmd/thanos/store.go
+++ b/cmd/thanos/store.go
@@ -81,7 +81,7 @@ func registerStore(m map[string]setupFunc, app *kingpin.Application) {
 	enableIndexHeader := cmd.Flag("experimental.enable-index-header", "If true, Store Gateway will recreate index-header instead of index-cache.json for each block. This will replace index-cache.json permanently once it will be out of experimental stage.").
 		Hidden().Default("false").Bool()
 
-	enablePostingsCompression := cmd.Flag("experimental.enable-postings-compression", "If true, Store Gateway will reencode and compress postings before storing them into cache. Compressed postings take about 10% of the original size.").
+	enablePostingsCompression := cmd.Flag("experimental.enable-index-cache-postings-compression", "If true, Store Gateway will reencode and compress postings before storing them into cache. Compressed postings take about 10% of the original size.").
 		Hidden().Default("false").Bool()
 
 	consistencyDelay := modelDuration(cmd.Flag("consistency-delay", "Minimum age of all blocks before they are being read. Set it to safe value (e.g 30m) if your object storage is eventually consistent. GCS and S3 are (roughly) strongly consistent.").

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -223,6 +223,7 @@ type BucketStore struct {
 
 	// Reencode postings using diff+varint+snappy when storing to cache.
 	// This makes them smaller, but takes extra CPU and memory.
+	// When used with in-memory cache, memory usage should decrease overall, thanks to postings being smaller.
 	enablePostingsCompression bool
 }
 

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -1608,12 +1608,11 @@ func (r *bucketIndexReader) fetchPostings(keys []labels.Label) ([]index.Postings
 
 				if r.block.enablePostingsCompression {
 					// Reencode postings before storing to cache. If that fails, we store original bytes.
+					// This can only fail, if postings data was somehow corrupted,
+					// and there is nothing we can do about it. It's not worth reporting here.
 					data, err := diffVarintSnappyEncode(newBigEndianPostings(pBytes[4:]))
 					if err == nil {
 						storeData = data
-					} else {
-						// This can only fail, if postings data was somehow corrupted,
-						// and there is nothing we can do about it. It's not worth reporting here.
 					}
 				}
 

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -1526,8 +1526,10 @@ func (r *bucketIndexReader) fetchPostings(keys []labels.Label) ([]index.Postings
 
 			// Even if this instance is not using compression, there may be compressed
 			// entries in the cache written by other stores.
-			var l index.Postings
-			var err error
+			var (
+				l   index.Postings
+				err error
+			)
 			if isDiffVarintEncodedPostings(b) {
 				l, err = diffVarintDecode(b)
 			} else {

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -1530,8 +1530,8 @@ func (r *bucketIndexReader) fetchPostings(keys []labels.Label) ([]index.Postings
 				l   index.Postings
 				err error
 			)
-			if isDiffVarintEncodedPostings(b) {
-				l, err = diffVarintDecode(b)
+			if isDiffVarintSnappyEncodedPostings(b) {
+				l, err = diffVarintSnappyDecode(b)
 			} else {
 				_, l, err = r.dec.Postings(b)
 			}
@@ -1613,7 +1613,7 @@ func (r *bucketIndexReader) fetchPostings(keys []labels.Label) ([]index.Postings
 					// Reencode postings before storing to cache. If that fails, we store original bytes.
 					// This can only fail, if postings data was somehow corrupted,
 					// and there is nothing we can do about it. It's not worth reporting here.
-					data, err := diffVarintEncode(newBigEndianPostings(pBytes[4:]), true)
+					data, err := diffVarintSnappyEncode(newBigEndianPostings(pBytes[4:]))
 					if err == nil {
 						storeData = data
 					}

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -1610,7 +1610,7 @@ func (r *bucketIndexReader) fetchPostings(keys []labels.Label) ([]index.Postings
 					// Reencode postings before storing to cache. If that fails, we store original bytes.
 					// This can only fail, if postings data was somehow corrupted,
 					// and there is nothing we can do about it. It's not worth reporting here.
-					data, err := diffVarintSnappyEncode(newBigEndianPostings(pBytes[4:]))
+					data, err := diffVarintEncode(newBigEndianPostings(pBytes[4:]), true)
 					if err == nil {
 						storeData = data
 					}

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -97,6 +97,12 @@ type bucketStoreMetrics struct {
 	queriesDropped        prometheus.Counter
 	queriesLimit          prometheus.Gauge
 	seriesRefetches       prometheus.Counter
+
+	cachedPostingsOriginalSizeBytes      prometheus.Counter
+	cachedPostingsCompressedSizeBytes    prometheus.Counter
+	cachedPostingsCompressionTimeSeconds prometheus.Counter
+	cachedPostingsCompressions           prometheus.Counter
+	cachedPostingsCompressionErrors      prometheus.Counter
 }
 
 func newBucketStoreMetrics(reg prometheus.Registerer) *bucketStoreMetrics {
@@ -180,6 +186,28 @@ func newBucketStoreMetrics(reg prometheus.Registerer) *bucketStoreMetrics {
 		Name: "thanos_bucket_store_series_refetches_total",
 		Help: fmt.Sprintf("Total number of cases where %v bytes was not enough was to fetch series from index, resulting in refetch.", maxSeriesSize),
 	})
+
+	m.cachedPostingsCompressions = promauto.With(reg).NewCounter(prometheus.CounterOpts{
+		Name: "thanos_bucket_store_cached_postings_compressions_total",
+		Help: "Number of postings compressions before storing to index cache",
+	})
+	m.cachedPostingsCompressionErrors = promauto.With(reg).NewCounter(prometheus.CounterOpts{
+		Name: "thanos_bucket_store_cached_postings_compression_errors_total",
+		Help: "Number of postings compression errors",
+	})
+	m.cachedPostingsOriginalSizeBytes = promauto.With(reg).NewCounter(prometheus.CounterOpts{
+		Name: "thanos_bucket_store_cached_postings_original_size_bytes_total",
+		Help: "Original size of postings stored into cache.",
+	})
+	m.cachedPostingsCompressedSizeBytes = promauto.With(reg).NewCounter(prometheus.CounterOpts{
+		Name: "thanos_bucket_store_cached_postings_compressed_size_bytes_total",
+		Help: "Compressed size of postings stored into cache.",
+	})
+	m.cachedPostingsCompressionTimeSeconds = promauto.With(reg).NewCounter(prometheus.CounterOpts{
+		Name: "thanos_bucket_store_cached_postings_compression_time_seconds",
+		Help: "Time spent compressing postings before storing them into postings cache",
+	})
+
 	return &m
 }
 
@@ -904,6 +932,11 @@ func (s *BucketStore) Series(req *storepb.SeriesRequest, srv storepb.Store_Serie
 		s.metrics.seriesDataSizeTouched.WithLabelValues("chunks").Observe(float64(stats.chunksTouchedSizeSum))
 		s.metrics.seriesDataSizeFetched.WithLabelValues("chunks").Observe(float64(stats.chunksFetchedSizeSum))
 		s.metrics.resultSeriesCount.Observe(float64(stats.mergedSeriesCount))
+		s.metrics.cachedPostingsOriginalSizeBytes.Add(float64(stats.cachedPostingsOriginalSizeSum))
+		s.metrics.cachedPostingsCompressedSizeBytes.Add(float64(stats.cachedPostingsCompressedSizeSum))
+		s.metrics.cachedPostingsCompressionTimeSeconds.Add(stats.cachedPostingsCompressionTimeSum.Seconds())
+		s.metrics.cachedPostingsCompressions.Add(float64(stats.cachedPostingsCompressions))
+		s.metrics.cachedPostingsCompressionErrors.Add(float64(stats.cachedPostingsCompressionErrors))
 
 		level.Debug(s.logger).Log("msg", "stats query processed",
 			"stats", fmt.Sprintf("%+v", stats), "err", err)
@@ -1602,28 +1635,43 @@ func (r *bucketIndexReader) fetchPostings(keys []labels.Label) ([]index.Postings
 					return err
 				}
 
+				dataToCache := pBytes
+
+				compressionTime := time.Duration(0)
+				compressions, compressionErrors, compressedSize := 0, 0, 0
+
+				if r.block.enablePostingsCompression {
+					// Reencode postings before storing to cache. If that fails, we store original bytes.
+					// This can only fail, if postings data was somehow corrupted,
+					// and there is nothing we can do about it.
+					// Errors from corrupted postings will be reported when postings are used.
+					compressions++
+					s := time.Now()
+					data, err := diffVarintSnappyEncode(newBigEndianPostings(pBytes[4:]))
+					compressionTime = time.Since(s)
+					if err == nil {
+						dataToCache = data
+						compressedSize = len(data)
+					} else {
+						compressionErrors = 1
+					}
+				}
+
 				r.mtx.Lock()
 				// Return postings and fill LRU cache.
 				// Truncate first 4 bytes which are length of posting.
 				output[p.keyID] = newBigEndianPostings(pBytes[4:])
 
-				storeData := pBytes
-
-				if r.block.enablePostingsCompression {
-					// Reencode postings before storing to cache. If that fails, we store original bytes.
-					// This can only fail, if postings data was somehow corrupted,
-					// and there is nothing we can do about it. It's not worth reporting here.
-					data, err := diffVarintSnappyEncode(newBigEndianPostings(pBytes[4:]))
-					if err == nil {
-						storeData = data
-					}
-				}
-
-				r.block.indexCache.StorePostings(r.ctx, r.block.meta.ULID, keys[p.keyID], storeData)
+				r.block.indexCache.StorePostings(r.ctx, r.block.meta.ULID, keys[p.keyID], dataToCache)
 
 				// If we just fetched it we still have to update the stats for touched postings.
 				r.stats.postingsTouched++
 				r.stats.postingsTouchedSizeSum += len(pBytes)
+				r.stats.cachedPostingsCompressions += compressions
+				r.stats.cachedPostingsCompressionErrors += compressionErrors
+				r.stats.cachedPostingsOriginalSizeSum += len(pBytes)
+				r.stats.cachedPostingsCompressedSizeSum += compressedSize
+				r.stats.cachedPostingsCompressionTimeSum += compressionTime
 				r.mtx.Unlock()
 			}
 			return nil
@@ -1997,6 +2045,12 @@ type queryStats struct {
 	postingsFetchCount       int
 	postingsFetchDurationSum time.Duration
 
+	cachedPostingsCompressions       int
+	cachedPostingsCompressionErrors  int
+	cachedPostingsOriginalSizeSum    int
+	cachedPostingsCompressedSizeSum  int
+	cachedPostingsCompressionTimeSum time.Duration
+
 	seriesTouched          int
 	seriesTouchedSizeSum   int
 	seriesFetched          int
@@ -2026,6 +2080,12 @@ func (s queryStats) merge(o *queryStats) *queryStats {
 	s.postingsFetchedSizeSum += o.postingsFetchedSizeSum
 	s.postingsFetchCount += o.postingsFetchCount
 	s.postingsFetchDurationSum += o.postingsFetchDurationSum
+
+	s.cachedPostingsCompressions += o.cachedPostingsCompressions
+	s.cachedPostingsCompressionErrors += o.cachedPostingsCompressionErrors
+	s.cachedPostingsOriginalSizeSum += o.cachedPostingsOriginalSizeSum
+	s.cachedPostingsCompressedSizeSum += o.cachedPostingsCompressedSizeSum
+	s.cachedPostingsCompressionTimeSum += o.cachedPostingsCompressionTimeSum
 
 	s.seriesTouched += o.seriesTouched
 	s.seriesTouchedSizeSum += o.seriesTouchedSizeSum

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -98,11 +98,11 @@ type bucketStoreMetrics struct {
 	queriesLimit          prometheus.Gauge
 	seriesRefetches       prometheus.Counter
 
+	cachedPostingsCompressions             prometheus.Counter
+	cachedPostingsCompressionErrors        prometheus.Counter
 	cachedPostingsOriginalSizeBytes        prometheus.Counter
 	cachedPostingsCompressedSizeBytes      prometheus.Counter
 	cachedPostingsCompressionTimeSeconds   prometheus.Counter
-	cachedPostingsCompressions             prometheus.Counter
-	cachedPostingsCompressionErrors        prometheus.Counter
 	cachedPostingsDecompressions           prometheus.Counter
 	cachedPostingsDecompressionErrors      prometheus.Counter
 	cachedPostingsDecompressionTimeSeconds prometheus.Counter
@@ -947,11 +947,11 @@ func (s *BucketStore) Series(req *storepb.SeriesRequest, srv storepb.Store_Serie
 		s.metrics.seriesDataSizeTouched.WithLabelValues("chunks").Observe(float64(stats.chunksTouchedSizeSum))
 		s.metrics.seriesDataSizeFetched.WithLabelValues("chunks").Observe(float64(stats.chunksFetchedSizeSum))
 		s.metrics.resultSeriesCount.Observe(float64(stats.mergedSeriesCount))
+		s.metrics.cachedPostingsCompressions.Add(float64(stats.cachedPostingsCompressions))
+		s.metrics.cachedPostingsCompressionErrors.Add(float64(stats.cachedPostingsCompressionErrors))
 		s.metrics.cachedPostingsOriginalSizeBytes.Add(float64(stats.cachedPostingsOriginalSizeSum))
 		s.metrics.cachedPostingsCompressedSizeBytes.Add(float64(stats.cachedPostingsCompressedSizeSum))
 		s.metrics.cachedPostingsCompressionTimeSeconds.Add(stats.cachedPostingsCompressionTimeSum.Seconds())
-		s.metrics.cachedPostingsCompressions.Add(float64(stats.cachedPostingsCompressions))
-		s.metrics.cachedPostingsCompressionErrors.Add(float64(stats.cachedPostingsCompressionErrors))
 		s.metrics.cachedPostingsDecompressions.Add(float64(stats.cachedPostingsDecompressions))
 		s.metrics.cachedPostingsDecompressionErrors.Add(float64(stats.cachedPostingsDecompressionErrors))
 		s.metrics.cachedPostingsDecompressionTimeSeconds.Add(stats.cachedPostingsDecompressionTimeSum.Seconds())

--- a/pkg/store/bucket_e2e_test.go
+++ b/pkg/store/bucket_e2e_test.go
@@ -168,6 +168,7 @@ func prepareStoreWithTestBlocks(t testing.TB, dir string, bkt objstore.Bucket, m
 		filterConf,
 		true,
 		true,
+		true,
 	)
 	testutil.Ok(t, err)
 	s.store = store

--- a/pkg/store/bucket_test.go
+++ b/pkg/store/bucket_test.go
@@ -480,6 +480,7 @@ func TestBucketStore_Info(t *testing.T) {
 		allowAllFilterConf,
 		true,
 		true,
+		true,
 	)
 	testutil.Ok(t, err)
 
@@ -729,6 +730,7 @@ func testSharding(t *testing.T, reuseDisk string, bkt objstore.Bucket, all ...ul
 				false,
 				20,
 				allowAllFilterConf,
+				true,
 				true,
 				true,
 			)

--- a/pkg/store/bucket_test.go
+++ b/pkg/store/bucket_test.go
@@ -932,7 +932,23 @@ func uploadTestBlock(t testing.TB, tmpDir string, bkt objstore.Bucket, series in
 
 	logger := log.NewNopLogger()
 
-	app := h.Appender()
+	appendTestData(t, h.Appender(), series)
+
+	testutil.Ok(t, os.MkdirAll(filepath.Join(tmpDir, "tmp"), os.ModePerm))
+	id := createBlockFromHead(t, filepath.Join(tmpDir, "tmp"), h)
+
+	_, err = metadata.InjectThanos(log.NewNopLogger(), filepath.Join(tmpDir, "tmp", id.String()), metadata.Thanos{
+		Labels:     labels.Labels{{Name: "ext1", Value: "1"}}.Map(),
+		Downsample: metadata.ThanosDownsample{Resolution: 0},
+		Source:     metadata.TestSource,
+	}, nil)
+	testutil.Ok(t, err)
+	testutil.Ok(t, block.Upload(context.Background(), logger, bkt, filepath.Join(tmpDir, "tmp", id.String())))
+
+	return id
+}
+
+func appendTestData(t testing.TB, app tsdb.Appender, series int) {
 	addSeries := func(l labels.Labels) {
 		_, err := app.Add(l, 0, 0)
 		testutil.Ok(t, err)
@@ -950,19 +966,6 @@ func uploadTestBlock(t testing.TB, tmpDir string, bkt objstore.Bucket, series in
 		}
 	}
 	testutil.Ok(t, app.Commit())
-
-	testutil.Ok(t, os.MkdirAll(filepath.Join(tmpDir, "tmp"), os.ModePerm))
-	id := createBlockFromHead(t, filepath.Join(tmpDir, "tmp"), h)
-
-	_, err = metadata.InjectThanos(log.NewNopLogger(), filepath.Join(tmpDir, "tmp", id.String()), metadata.Thanos{
-		Labels:     labels.Labels{{Name: "ext1", Value: "1"}}.Map(),
-		Downsample: metadata.ThanosDownsample{Resolution: 0},
-		Source:     metadata.TestSource,
-	}, nil)
-	testutil.Ok(t, err)
-	testutil.Ok(t, block.Upload(context.Background(), logger, bkt, filepath.Join(tmpDir, "tmp", id.String())))
-
-	return id
 }
 
 func createBlockFromHead(t testing.TB, dir string, head *tsdb.Head) ulid.ULID {

--- a/pkg/store/postings_codec.go
+++ b/pkg/store/postings_codec.go
@@ -1,3 +1,6 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
 package store
 
 import (

--- a/pkg/store/postings_codec.go
+++ b/pkg/store/postings_codec.go
@@ -32,7 +32,7 @@ func isDiffVarintSnappyEncodedPostings(input []byte) bool {
 
 // diffVarintSnappyEncode encodes postings into diff+varint representation,
 // and applies snappy compression on the result.
-// Returned byte slice starts with codedHeaderSnappy header.
+// Returned byte slice starts with codecHeaderSnappy header.
 func diffVarintSnappyEncode(p index.Postings) ([]byte, error) {
 	buf, err := diffVarintEncodeNoHeader(p)
 	if err != nil {

--- a/pkg/store/postings_codec.go
+++ b/pkg/store/postings_codec.go
@@ -22,7 +22,7 @@ import (
 // significantly (to about 20% of original), snappy then halves it to ~10% of the original.
 
 const (
-	codecHeaderSnappy = "dvs" // as in "diff+varint+snappy"
+	codecHeaderSnappy = "dvs" // As in "diff+varint+snappy".
 )
 
 // isDiffVarintSnappyEncodedPostings returns true, if input looks like it has been encoded by diff+varint(+snappy) codec.

--- a/pkg/store/postings_codec.go
+++ b/pkg/store/postings_codec.go
@@ -123,8 +123,8 @@ func (it *diffVarintPostings) Seek(x uint64) bool {
 		return true
 	}
 
-	// we cannot do any search due to how values are stored,
-	// so we simply advance until we find the right value
+	// We cannot do any search due to how values are stored,
+	// so we simply advance until we find the right value.
 	for it.Next() {
 		if it.At() >= x {
 			return true

--- a/pkg/store/postings_codec.go
+++ b/pkg/store/postings_codec.go
@@ -35,8 +35,7 @@ func diffVarintEncode(p index.Postings, useSnappy bool) ([]byte, error) {
 	for p.Next() {
 		v := p.At()
 		if v < prev {
-			// Postings entries must be in increasing order.
-			return nil, errors.Errorf("decreasing entry, val: %d, prev: %d", v, prev)
+			return nil, errors.Errorf("postings entries must be in increasing order, current: %d, previous: %d", v, prev)
 		}
 
 		buf.PutUvarint64(v - prev)

--- a/pkg/store/postings_codec.go
+++ b/pkg/store/postings_codec.go
@@ -27,7 +27,6 @@ func isDiffVarintEncodedPostings(input []byte) bool {
 func diffVarintEncode(p index.Postings, useSnappy bool) ([]byte, error) {
 	buf := encoding.Encbuf{}
 
-	// If we're returning raw data, write the header to the buffer, and then return buffer directly.
 	if !useSnappy {
 		buf.PutString(codecHeaderRaw)
 	}

--- a/pkg/store/postings_codec.go
+++ b/pkg/store/postings_codec.go
@@ -3,10 +3,10 @@ package store
 import (
 	"bytes"
 	encoding_binary "encoding/binary"
-	"errors"
 	"fmt"
 
 	"github.com/golang/snappy"
+	"github.com/pkg/errors"
 	"github.com/prometheus/prometheus/tsdb/index"
 )
 

--- a/pkg/store/postings_codec.go
+++ b/pkg/store/postings_codec.go
@@ -22,7 +22,7 @@ import (
 // significantly (to about 20% of original), snappy then halves it to ~10% of the original.
 
 const (
-	codecHeaderSnappy = "diff+varint+snappy"
+	codecHeaderSnappy = "dvs" // as in "diff+varint+snappy"
 )
 
 // isDiffVarintSnappyEncodedPostings returns true, if input looks like it has been encoded by diff+varint(+snappy) codec.

--- a/pkg/store/postings_codec.go
+++ b/pkg/store/postings_codec.go
@@ -23,11 +23,6 @@ func isDiffVarintEncodedPostings(input []byte) bool {
 	return bytes.HasPrefix(input, []byte(codecHeaderRaw)) || bytes.HasPrefix(input, []byte(codecHeaderSnappy))
 }
 
-// diffVarintSnappyEncode encodes postings using diff+varint+snappy codec.
-func diffVarintSnappyEncode(p index.Postings) ([]byte, error) {
-	return diffVarintEncode(p, true)
-}
-
 // diffVarintEncode encodes postings into diff+varint representation and optional snappy compression.
 func diffVarintEncode(p index.Postings, useSnappy bool) ([]byte, error) {
 	buf := encoding.Encbuf{}

--- a/pkg/store/postings_codec.go
+++ b/pkg/store/postings_codec.go
@@ -69,7 +69,6 @@ func diffVarintDecode(input []byte) (index.Postings, error) {
 	switch {
 	case bytes.HasPrefix(input, []byte(codecHeaderRaw)):
 		headerLen = len(codecHeaderRaw)
-		break
 	case bytes.HasPrefix(input, []byte(codecHeaderSnappy)):
 		headerLen = len(codecHeaderSnappy)
 		compressed = true

--- a/pkg/store/postings_codec.go
+++ b/pkg/store/postings_codec.go
@@ -16,6 +16,10 @@ const (
 	codecHeaderSnappy = "diff+varint+snappy"
 )
 
+func isDiffVarintEncodedPostings(input []byte) bool {
+	return bytes.HasPrefix(input, []byte(codecHeaderRaw)) || bytes.HasPrefix(input, []byte(codecHeaderSnappy))
+}
+
 func diffVarintSnappyEncode(p index.Postings) ([]byte, error) {
 	return diffVarintEncode(p, true)
 }

--- a/pkg/store/postings_codec.go
+++ b/pkg/store/postings_codec.go
@@ -1,0 +1,133 @@
+package store
+
+import (
+	"bytes"
+	encoding_binary "encoding/binary"
+	"errors"
+	"fmt"
+
+	"github.com/golang/snappy"
+	"github.com/prometheus/prometheus/tsdb/index"
+)
+
+const (
+	// these headers should not be prefix of each other
+	codecHeaderRaw    = "diff+varint+raw"
+	codecHeaderSnappy = "diff+varint+snappy"
+)
+
+func diffVarintSnappyEncode(p index.Postings) ([]byte, error) {
+	return diffVarintEncode(p, true)
+}
+
+func diffVarintEncode(p index.Postings, useSnappy bool) ([]byte, error) {
+	varintBuf := make([]byte, encoding_binary.MaxVarintLen64)
+
+	buf := bytes.Buffer{}
+
+	// if we're returning raw data, write the header to the buffer, and then return buffer directly
+	if !useSnappy {
+		buf.WriteString(codecHeaderRaw)
+	}
+
+	prev := uint64(0)
+	for p.Next() {
+		v := p.At()
+		n := encoding_binary.PutUvarint(varintBuf, v-prev)
+		buf.Write(varintBuf[:n])
+
+		prev = v
+	}
+
+	if p.Err() != nil {
+		return nil, p.Err()
+	}
+
+	if !useSnappy {
+		// this already has the correct header
+		return buf.Bytes(), nil
+	}
+
+	// make result buffer large enough to hold our header and compressed block
+	resultBuf := make([]byte, len(codecHeaderSnappy)+snappy.MaxEncodedLen(buf.Len()))
+	copy(resultBuf, codecHeaderSnappy)
+
+	compressed := snappy.Encode(resultBuf[len(codecHeaderSnappy):], buf.Bytes())
+
+	// slice result buffer based on compressed size
+	resultBuf = resultBuf[:len(codecHeaderSnappy)+len(compressed)]
+	return resultBuf, nil
+}
+
+func diffVarintDecode(input []byte) (index.Postings, error) {
+	compressed := false
+	headerLen := 0
+	switch {
+	case bytes.HasPrefix(input, []byte(codecHeaderRaw)):
+		headerLen = len(codecHeaderRaw)
+		break
+	case bytes.HasPrefix(input, []byte(codecHeaderSnappy)):
+		headerLen = len(codecHeaderSnappy)
+		compressed = true
+	default:
+		return nil, errors.New("header not found")
+	}
+
+	raw := input[headerLen:]
+	if compressed {
+		var err error
+		raw, err = snappy.Decode(nil, raw)
+		if err != nil {
+			return nil, fmt.Errorf("snappy decode: %w", err)
+		}
+	}
+
+	return &diffVarintPostings{data: raw}, nil
+}
+
+type diffVarintPostings struct {
+	data []byte
+	cur  uint64
+	err  error
+}
+
+func (it *diffVarintPostings) At() uint64 {
+	return it.cur
+}
+
+func (it *diffVarintPostings) Next() bool {
+	if len(it.data) == 0 {
+		return false
+	}
+
+	val, n := encoding_binary.Uvarint(it.data)
+	if n == 0 {
+		it.err = errors.New("not enough data")
+		return false
+	}
+
+	it.data = it.data[n:]
+	it.cur = it.cur + val
+	it.err = nil
+	return true
+}
+
+func (it *diffVarintPostings) Seek(x uint64) bool {
+	if it.cur >= x {
+		return true
+	}
+
+	// we cannot do any search due to how values are stored,
+	// so we simply advance until we find the right value
+	for it.Next() {
+		if it.At() >= x {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (it *diffVarintPostings) Err() error {
+	return it.err
+}

--- a/pkg/store/postings_codec.go
+++ b/pkg/store/postings_codec.go
@@ -25,7 +25,7 @@ const (
 	codecHeaderSnappy = "dvs" // As in "diff+varint+snappy".
 )
 
-// isDiffVarintSnappyEncodedPostings returns true, if input looks like it has been encoded by diff+varint(+snappy) codec.
+// isDiffVarintSnappyEncodedPostings returns true, if input looks like it has been encoded by diff+varint+snappy codec.
 func isDiffVarintSnappyEncodedPostings(input []byte) bool {
 	return bytes.HasPrefix(input, []byte(codecHeaderSnappy))
 }

--- a/pkg/store/postings_codec_test.go
+++ b/pkg/store/postings_codec_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
 package store
 
 import (

--- a/pkg/store/postings_codec_test.go
+++ b/pkg/store/postings_codec_test.go
@@ -1,0 +1,178 @@
+package store
+
+import (
+	"testing"
+
+	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/prometheus/tsdb"
+	"github.com/prometheus/prometheus/tsdb/index"
+
+	"github.com/thanos-io/thanos/pkg/testutil"
+)
+
+func TestDiffVarintCodec(t *testing.T) {
+	h, err := tsdb.NewHead(nil, nil, nil, 1000)
+	testutil.Ok(t, err)
+	defer func() {
+		testutil.Ok(t, h.Close())
+	}()
+
+	appendTestData(t, h.Appender(), 1e6)
+
+	idx, err := h.Index()
+	testutil.Ok(t, err)
+	defer func() {
+		testutil.Ok(t, idx.Close())
+	}()
+
+	postingsMap := map[string]index.Postings{
+		"all":      allPostings(t, idx),
+		`n="1"`:    matchPostings(t, idx, labels.MustNewMatcher(labels.MatchEqual, "n", "1"+postingsBenchSuffix)),
+		`j="foo"`:  matchPostings(t, idx, labels.MustNewMatcher(labels.MatchEqual, "j", "foo")),
+		`j!="foo"`: matchPostings(t, idx, labels.MustNewMatcher(labels.MatchNotEqual, "j", "foo")),
+		`i=~".*"`:  matchPostings(t, idx, labels.MustNewMatcher(labels.MatchRegexp, "i", ".*")),
+		`i=~".+"`:  matchPostings(t, idx, labels.MustNewMatcher(labels.MatchRegexp, "i", ".+")),
+		`i=~"1.+"`: matchPostings(t, idx, labels.MustNewMatcher(labels.MatchRegexp, "i", "1.+")),
+		`i=~"^$"'`: matchPostings(t, idx, labels.MustNewMatcher(labels.MatchRegexp, "i", "^$")),
+		`i!~""`:    matchPostings(t, idx, labels.MustNewMatcher(labels.MatchNotEqual, "i", "")),
+		`n!="2"`:   matchPostings(t, idx, labels.MustNewMatcher(labels.MatchNotEqual, "n", "2"+postingsBenchSuffix)),
+		`i!~"2.*"`: matchPostings(t, idx, labels.MustNewMatcher(labels.MatchNotRegexp, "i", "^2.*$")),
+	}
+
+	for postingName, postings := range postingsMap {
+		p, err := toUint64Postings(postings)
+		testutil.Ok(t, err)
+
+		for _, snappy := range []bool{false, true} {
+			name := postingName + "/"
+			if snappy {
+				name = name + "snappy"
+			} else {
+				name = name + "raw"
+			}
+
+			t.Run(postingName+"/"+name, func(t *testing.T) {
+				t.Log("postings entries:", p.len())
+				t.Log("raw size (4*entries):", 4*p.len(), "bytes")
+				p.reset() // we reuse postings between runs, so we need to reset iterator
+
+				data, err := diffVarintEncode(p, snappy)
+				testutil.Ok(t, err)
+
+				t.Log("encoded size", len(data), "bytes")
+				t.Logf("ratio: %0.3f", (float64(len(data)) / float64(4*p.len())))
+
+				decodedPostings, err := diffVarintDecode(data)
+				testutil.Ok(t, err)
+
+				p.reset()
+				comparePostings(t, p, decodedPostings)
+			})
+		}
+	}
+}
+
+func comparePostings(t *testing.T, p1, p2 index.Postings) {
+	for p1.Next() {
+		if !p2.Next() {
+			t.Log("p1 has more values")
+			t.Fail()
+			return
+		}
+
+		if p1.At() != p2.At() {
+			t.Logf("values differ: %d, %d", p1.At(), p2.At())
+			t.Fail()
+			return
+		}
+	}
+
+	if p2.Next() {
+		t.Log("p2 has more values")
+		t.Fail()
+		return
+	}
+
+	testutil.Ok(t, p1.Err())
+	testutil.Ok(t, p2.Err())
+}
+
+func allPostings(t testing.TB, ix tsdb.IndexReader) index.Postings {
+	k, v := index.AllPostingsKey()
+	p, err := ix.Postings(k, v)
+	testutil.Ok(t, err)
+	return p
+}
+
+func matchPostings(t testing.TB, ix tsdb.IndexReader, m *labels.Matcher) index.Postings {
+	vals, err := ix.LabelValues(m.Name)
+	testutil.Ok(t, err)
+
+	matching := []string(nil)
+	for _, v := range vals {
+		if m.Matches(v) {
+			matching = append(matching, v)
+		}
+	}
+
+	p, err := ix.Postings(m.Name, matching...)
+	testutil.Ok(t, err)
+	return p
+}
+
+func toUint64Postings(p index.Postings) (*uint64Postings, error) {
+	var vals []uint64
+	for p.Next() {
+		vals = append(vals, p.At())
+	}
+	return &uint64Postings{vals: vals, ix: -1}, p.Err()
+}
+
+// postings with no decoding step
+type uint64Postings struct {
+	vals []uint64
+	ix   int
+}
+
+func (p *uint64Postings) At() uint64 {
+	if p.ix < 0 || p.ix >= len(p.vals) {
+		return 0
+	}
+	return p.vals[p.ix]
+}
+
+func (p *uint64Postings) Next() bool {
+	if p.ix < len(p.vals)-1 {
+		p.ix++
+		return true
+	}
+	return false
+}
+
+func (p *uint64Postings) Seek(x uint64) bool {
+	if p.At() >= x {
+		return true
+	}
+
+	// we cannot do any search due to how values are stored,
+	// so we simply advance until we find the right value
+	for p.Next() {
+		if p.At() >= x {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (p *uint64Postings) Err() error {
+	return nil
+}
+
+func (p *uint64Postings) reset() {
+	p.ix = -1
+}
+
+func (p *uint64Postings) len() int {
+	return len(p.vals)
+}

--- a/pkg/store/postings_codec_test.go
+++ b/pkg/store/postings_codec_test.go
@@ -57,7 +57,7 @@ func TestDiffVarintCodec(t *testing.T) {
 			t.Run(name, func(t *testing.T) {
 				t.Log("postings entries:", p.len())
 				t.Log("original size (4*entries):", 4*p.len(), "bytes")
-				p.reset() // we reuse postings between runs, so we need to reset iterator
+				p.reset() // We reuse postings between runs, so we need to reset iterator.
 
 				data, err := diffVarintEncode(p, snappy)
 				testutil.Ok(t, err)
@@ -131,7 +131,7 @@ func toUint64Postings(p index.Postings) (*uint64Postings, error) {
 	return &uint64Postings{vals: vals, ix: -1}, p.Err()
 }
 
-// postings with no decoding step
+// Postings with no decoding step.
 type uint64Postings struct {
 	vals []uint64
 	ix   int
@@ -157,8 +157,8 @@ func (p *uint64Postings) Seek(x uint64) bool {
 		return true
 	}
 
-	// we cannot do any search due to how values are stored,
-	// so we simply advance until we find the right value
+	// We cannot do any search due to how values are stored,
+	// so we simply advance until we find the right value.
 	for p.Next() {
 		if p.At() >= x {
 			return true

--- a/pkg/store/postings_codec_test.go
+++ b/pkg/store/postings_codec_test.go
@@ -47,16 +47,16 @@ func TestDiffVarintCodec(t *testing.T) {
 		testutil.Ok(t, err)
 
 		for _, snappy := range []bool{false, true} {
-			name := postingName + "/"
+			name := postingName
 			if snappy {
-				name = name + "snappy"
+				name = "snappy/" + name
 			} else {
-				name = name + "raw"
+				name = "raw/" + name
 			}
 
-			t.Run(postingName+"/"+name, func(t *testing.T) {
+			t.Run(name, func(t *testing.T) {
 				t.Log("postings entries:", p.len())
-				t.Log("raw size (4*entries):", 4*p.len(), "bytes")
+				t.Log("original size (4*entries):", 4*p.len(), "bytes")
 				p.reset() // we reuse postings between runs, so we need to reset iterator
 
 				data, err := diffVarintEncode(p, snappy)


### PR DESCRIPTION
* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

This PR introduces ability to compress postings before storing them into cache (in memory or shared cache). It reencodes postings to use more efficient encoding (diff + varint) and then uses snappy to compress it even more. It typically reduces original postings size to about 1/10th. New flag is disabled by default.

## Verification

- unit tests for encoding/decoding postings
- manual testing hitting the code paths in `fetchPostings` method, and stepping through it in debugger
