### PR TITLE
cmd/thanos/receive: Remove unused TLSClientConfig from Options

### DIFF
--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -190,10 +190,6 @@ func runReceive(
 	if err != nil {
 		return err
 	}
-	rwTLSClientConfig, err := tls.NewClientConfig(logger, rwClientCert, rwClientKey, rwClientServerCA, rwClientServerName)
-	if err != nil {
-		return err
-	}
 	dialOpts, err := extgrpc.StoreClientGRPCOpts(logger, reg, tracer, rwServerCert != "", rwClientCert, rwClientKey, rwClientServerCA, rwClientServerName)
 	if err != nil {
 		return err
@@ -208,7 +204,6 @@ func runReceive(
 		ReplicationFactor: replicationFactor,
 		Tracer:            tracer,
 		TLSConfig:         rwTLSConfig,
-		TLSClientConfig:   rwTLSClientConfig,
 		DialOpts:          dialOpts,
 	})
 

--- a/pkg/receive/handler.go
+++ b/pkg/receive/handler.go
@@ -60,7 +60,6 @@ type Options struct {
 	ReplicationFactor uint64
 	Tracer            opentracing.Tracer
 	TLSConfig         *tls.Config
-	TLSClientConfig   *tls.Config
 	DialOpts          []grpc.DialOption
 }
 


### PR DESCRIPTION
## Changes

Remove unused TLSClientConfig from receiver Options.

Its not used anymore since the [forwarding got moved to GRPC](https://github.com/thanos-io/thanos/pull/1970).
The TLS client settings for the GRPC client are being passed as DialOpts:

https://github.com/thanos-io/thanos/blob/master/cmd/thanos/receive.go#L197

https://github.com/thanos-io/thanos/blob/a7aa2986678309790d3fd2cc6810e42cd81603ab/pkg/extgrpc/client.go#L56

## Verification

It compiles