### PR TITLE
storetestutil: Added shared series helpers on BucketSeries; added ProxySeries and MultiTSDB Series benchmarks.  

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,13 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 
 ### Fixed
 
-* [#2665](https://github.com/thanos-io/thanos/pull/2665) Swift: fix issue with missing Content-Type HTTP headers.
+- [#2665](https://github.com/thanos-io/thanos/pull/2665) Swift: fix issue with missing Content-Type HTTP headers.
 - [#2800](https://github.com/thanos-io/thanos/pull/2800) Query: Fix handling of `--web.external-prefix` and `--web.route-prefix`
 - [#2834](https://github.com/thanos-io/thanos/pull/2834) Query: Fix rendered JSON state value for rules and alerts should be in lowercase
 
 ### Changed
+
+- [#2305](https://github.com/thanos-io/thanos/pull/2305) Receive,Sidecar,Ruler: Propagate correct (stricter) MinTime for no-block TSDBs.
 
 ## [v0.14.0](https://github.com/thanos-io/thanos/releases) - IN PROGRESS
 

--- a/pkg/store/multitsdb.go
+++ b/pkg/store/multitsdb.go
@@ -121,7 +121,7 @@ func (s *tenantSeriesSetServer) Series(store *TSDBStore, r *storepb.SeriesReques
 	})
 
 	if err != nil {
-		if r.PartialResponseDisabled {
+		if r.PartialResponseDisabled || r.PartialResponseStrategy == storepb.PartialResponseStrategy_ABORT {
 			s.err = errors.Wrapf(err, "get series for tenant %s", s.tenant)
 		} else {
 			// Consistently prefix tenant specific warnings as done in various other places.

--- a/pkg/store/multitsdb_test.go
+++ b/pkg/store/multitsdb_test.go
@@ -1,0 +1,156 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package store
+
+import (
+	"fmt"
+	"io/ioutil"
+	"math"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/go-kit/kit/log"
+	"github.com/prometheus/prometheus/tsdb"
+	"github.com/thanos-io/thanos/pkg/component"
+	"github.com/thanos-io/thanos/pkg/store/storepb"
+	storetestutil "github.com/thanos-io/thanos/pkg/store/storepb/testutil"
+	"github.com/thanos-io/thanos/pkg/testutil"
+)
+
+func TestMultiTSDBSeries(t *testing.T) {
+	tb := testutil.NewTB(t)
+	storetestutil.RunSeriesInterestingCases(tb, 200e3, 200e3, func(t testutil.TB, samplesPerSeries, series int) {
+		if ok := t.Run("headOnly", func(t testutil.TB) {
+			benchMultiTSDBSeries(t, samplesPerSeries, series, false)
+		}); !ok {
+			return
+		}
+		t.Run("blocksOnly", func(t testutil.TB) {
+			benchMultiTSDBSeries(t, samplesPerSeries, series, true)
+		})
+	})
+}
+
+func BenchmarkMultiTSDBSeries(b *testing.B) {
+	tb := testutil.NewTB(b)
+	storetestutil.RunSeriesInterestingCases(tb, 10e6, 10e5, func(t testutil.TB, samplesPerSeries, series int) {
+		if ok := t.Run("headOnly", func(t testutil.TB) {
+			benchMultiTSDBSeries(t, samplesPerSeries, series, false)
+		}); !ok {
+			return
+		}
+		t.Run("blocksOnly", func(t testutil.TB) {
+			benchMultiTSDBSeries(t, samplesPerSeries, series, true)
+		})
+	})
+}
+
+type mockedStartTimeDB struct {
+	*tsdb.DBReadOnly
+	startTime int64
+}
+
+func (db *mockedStartTimeDB) StartTime() (int64, error) { return db.startTime, nil }
+
+func benchMultiTSDBSeries(t testutil.TB, totalSamples, totalSeries int, flushToBlocks bool) {
+	tmpDir, err := ioutil.TempDir("", "testorbench-multitsdbseries")
+	testutil.Ok(t, err)
+	defer func() { testutil.Ok(t, os.RemoveAll(tmpDir)) }()
+
+	const numOfTSDBs = 4
+
+	samplesPerSeriesPerTSDB := totalSamples / numOfTSDBs
+	if samplesPerSeriesPerTSDB == 0 {
+		samplesPerSeriesPerTSDB = 1
+	}
+	seriesPerTSDB := totalSeries / numOfTSDBs
+	if seriesPerTSDB == 0 {
+		seriesPerTSDB = 1
+	}
+
+	var (
+		dbs    = make([]*mockedStartTimeDB, numOfTSDBs)
+		resps  = make([][]*storepb.SeriesResponse, 4)
+		random = rand.New(rand.NewSource(120))
+		logger = log.NewNopLogger()
+	)
+
+	defer func() {
+		for _, db := range dbs {
+			if db != nil {
+				testutil.Ok(t, db.Close())
+			}
+		}
+	}()
+	for j := range dbs {
+		head, created := storetestutil.CreateHeadWithSeries(t, j, storetestutil.HeadGenOptions{
+			Dir:              tmpDir,
+			SamplesPerSeries: samplesPerSeriesPerTSDB,
+			Series:           seriesPerTSDB,
+			WithWAL:          true,
+			Random:           random,
+			SkipChunks:       t.IsBenchmark(),
+		})
+		testutil.Ok(t, head.Close())
+
+		tsdbDir := filepath.Join(tmpDir, fmt.Sprintf("%d", j))
+
+		for i := 0; i < len(created); i++ {
+			resps[j] = append(resps[j], storepb.NewSeriesResponse(&created[i]))
+		}
+
+		if flushToBlocks {
+			db, err := tsdb.OpenDBReadOnly(tsdbDir, logger)
+			testutil.Ok(t, err)
+
+			testutil.Ok(t, db.FlushWAL(tmpDir))
+			testutil.Ok(t, db.Close())
+		}
+
+		db, err := tsdb.OpenDBReadOnly(tsdbDir, logger)
+		testutil.Ok(t, err)
+
+		dbs[j] = &mockedStartTimeDB{DBReadOnly: db, startTime: int64(j * samplesPerSeriesPerTSDB * seriesPerTSDB)}
+	}
+
+	tsdbs := map[string]*TSDBStore{}
+	for i, db := range dbs {
+		tsdbs[fmt.Sprintf("%v", i)] = &TSDBStore{db: db, logger: logger, maxSamplesPerChunk: 120} // On production we have math.MaxInt64
+	}
+
+	store := NewMultiTSDBStore(logger, nil, component.Receive, func() map[string]*TSDBStore { return tsdbs })
+
+	var expected []storepb.Series
+	lastLabels := storepb.Series{}
+	for _, resp := range resps {
+		for _, r := range resp {
+			// MultiTSDB same as Proxy will merge all series with same labels without limit (https://github.com/thanos-io/thanos/issues/2332).
+			// Let's do this here as well.
+			x := storepb.Series{Labels: r.GetSeries().Labels}
+			if x.String() == lastLabels.String() {
+				expected[len(expected)-1].Chunks = append(expected[len(expected)-1].Chunks, r.GetSeries().Chunks...)
+				continue
+			}
+			lastLabels = x
+			expected = append(expected, *r.GetSeries())
+		}
+	}
+
+	storetestutil.TestServerSeries(t, store,
+		&storetestutil.SeriesCase{
+			Name: fmt.Sprintf("%d TSDBs with %d samples, %d series each", numOfTSDBs, samplesPerSeriesPerTSDB, seriesPerTSDB),
+			Req: &storepb.SeriesRequest{
+				MinTime: 0,
+				MaxTime: math.MaxInt64,
+				Matchers: []storepb.LabelMatcher{
+					{Type: storepb.LabelMatcher_EQ, Name: "foo", Value: "bar"},
+				},
+				PartialResponseStrategy: storepb.PartialResponseStrategy_ABORT,
+			},
+			ExpectedSeries: expected,
+		},
+	)
+}

--- a/pkg/store/postings_codec_test.go
+++ b/pkg/store/postings_codec_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/tsdb"
 	"github.com/prometheus/prometheus/tsdb/index"
-
+	storetestutil "github.com/thanos-io/thanos/pkg/store/storepb/testutil"
 	"github.com/thanos-io/thanos/pkg/testutil"
 )
 
@@ -39,7 +39,7 @@ func TestDiffVarintCodec(t *testing.T) {
 
 	postingsMap := map[string]index.Postings{
 		"all":      allPostings(t, idx),
-		`n="1"`:    matchPostings(t, idx, labels.MustNewMatcher(labels.MatchEqual, "n", "1"+postingsBenchSuffix)),
+		`n="1"`:    matchPostings(t, idx, labels.MustNewMatcher(labels.MatchEqual, "n", "1"+storetestutil.LabelLongSuffix)),
 		`j="foo"`:  matchPostings(t, idx, labels.MustNewMatcher(labels.MatchEqual, "j", "foo")),
 		`j!="foo"`: matchPostings(t, idx, labels.MustNewMatcher(labels.MatchNotEqual, "j", "foo")),
 		`i=~".*"`:  matchPostings(t, idx, labels.MustNewMatcher(labels.MatchRegexp, "i", ".*")),
@@ -47,7 +47,7 @@ func TestDiffVarintCodec(t *testing.T) {
 		`i=~"1.+"`: matchPostings(t, idx, labels.MustNewMatcher(labels.MatchRegexp, "i", "1.+")),
 		`i=~"^$"'`: matchPostings(t, idx, labels.MustNewMatcher(labels.MatchRegexp, "i", "^$")),
 		`i!~""`:    matchPostings(t, idx, labels.MustNewMatcher(labels.MatchNotEqual, "i", "")),
-		`n!="2"`:   matchPostings(t, idx, labels.MustNewMatcher(labels.MatchNotEqual, "n", "2"+postingsBenchSuffix)),
+		`n!="2"`:   matchPostings(t, idx, labels.MustNewMatcher(labels.MatchNotEqual, "n", "2"+storetestutil.LabelLongSuffix)),
 		`i!~"2.*"`: matchPostings(t, idx, labels.MustNewMatcher(labels.MatchNotRegexp, "i", "^2.*$")),
 	}
 

--- a/pkg/store/proxy.go
+++ b/pkg/store/proxy.go
@@ -294,6 +294,10 @@ func (s *ProxyStore) Series(r *storepb.SeriesRequest, srv storepb.Store_SeriesSe
 			return nil
 		}
 
+		// TODO(bwplotka): Currently we stream into big frames. Consider ensuring 1MB maximum.
+		// This however does not matter much when used with QueryAPI. Matters for federated Queries a lot.
+		// https://github.com/thanos-io/thanos/issues/2332
+		// Series are not necessarily merged across themselves.
 		mergedSet := storepb.MergeSeriesSets(seriesSet...)
 		for mergedSet.Next() {
 			var series storepb.Series

--- a/pkg/store/proxy_test.go
+++ b/pkg/store/proxy_test.go
@@ -7,12 +7,16 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"io/ioutil"
+	"math"
+	"math/rand"
 	"os"
 	"sort"
 	"testing"
 	"time"
 
 	"github.com/fortytw2/leaktest"
+	"github.com/go-kit/kit/log"
 	"github.com/gogo/protobuf/proto"
 	"github.com/gogo/protobuf/types"
 	"github.com/pkg/errors"
@@ -20,6 +24,7 @@ import (
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
 	"github.com/thanos-io/thanos/pkg/component"
 	"github.com/thanos-io/thanos/pkg/store/storepb"
+	storetestutil "github.com/thanos-io/thanos/pkg/store/storepb/testutil"
 	"github.com/thanos-io/thanos/pkg/testutil"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -1510,4 +1515,141 @@ func TestMergeLabels(t *testing.T) {
 	sort.Sort(resLabels)
 
 	testutil.Equals(t, expected, resLabels)
+}
+
+func TestProxySeries(t *testing.T) {
+	tb := testutil.NewTB(t)
+	storetestutil.RunSeriesInterestingCases(tb, 200e3, 200e3, func(t testutil.TB, samplesPerSeries, series int) {
+		benchProxySeries(t, samplesPerSeries, series)
+	})
+}
+
+func BenchmarkProxySeries(b *testing.B) {
+	tb := testutil.NewTB(b)
+	storetestutil.RunSeriesInterestingCases(tb, 10e6, 10e5, func(t testutil.TB, samplesPerSeries, series int) {
+		benchProxySeries(t, samplesPerSeries, series)
+	})
+}
+
+func benchProxySeries(t testutil.TB, totalSamples, totalSeries int) {
+	tmpDir, err := ioutil.TempDir("", "testorbench-proxyseries")
+	testutil.Ok(t, err)
+	defer func() { testutil.Ok(t, os.RemoveAll(tmpDir)) }()
+
+	const numOfClients = 4
+
+	samplesPerSeriesPerClient := totalSamples / numOfClients
+	if samplesPerSeriesPerClient == 0 {
+		samplesPerSeriesPerClient = 1
+	}
+	seriesPerClient := totalSeries / numOfClients
+	if seriesPerClient == 0 {
+		seriesPerClient = 1
+	}
+
+	random := rand.New(rand.NewSource(120))
+	clients := make([]Client, numOfClients)
+	for j := range clients {
+		var resps []*storepb.SeriesResponse
+
+		head, created := storetestutil.CreateHeadWithSeries(t, j, storetestutil.HeadGenOptions{
+			Dir:              tmpDir,
+			SamplesPerSeries: samplesPerSeriesPerClient,
+			Series:           seriesPerClient,
+			MaxFrameBytes:    storetestutil.RemoteReadFrameLimit,
+			Random:           random,
+			SkipChunks:       t.IsBenchmark(),
+		})
+		testutil.Ok(t, head.Close())
+
+		for i := 0; i < len(created); i++ {
+			resps = append(resps, storepb.NewSeriesResponse(&created[i]))
+		}
+
+		clients[j] = &testClient{
+			StoreClient: &mockedStoreAPI{
+				RespSeries: resps,
+			},
+			minTime: math.MinInt64,
+			maxTime: math.MaxInt64,
+		}
+	}
+
+	logger := log.NewNopLogger()
+	store := &ProxyStore{
+		logger:          logger,
+		stores:          func() []Client { return clients },
+		metrics:         newProxyStoreMetrics(nil),
+		responseTimeout: 0,
+	}
+
+	var allResps []*storepb.SeriesResponse
+	var expected []storepb.Series
+	lastLabels := storepb.Series{}
+	for _, c := range clients {
+		m := c.(*testClient).StoreClient.(*mockedStoreAPI)
+
+		for _, r := range m.RespSeries {
+			allResps = append(allResps, r)
+
+			// Proxy will merge all series with same labels without limit (https://github.com/thanos-io/thanos/issues/2332).
+			// Let's do this here as well.
+			x := storepb.Series{Labels: r.GetSeries().Labels}
+			if x.String() == lastLabels.String() {
+				expected[len(expected)-1].Chunks = append(expected[len(expected)-1].Chunks, r.GetSeries().Chunks...)
+				continue
+			}
+			lastLabels = x
+			expected = append(expected, *r.GetSeries())
+		}
+
+	}
+
+	chunkLen := len(allResps[len(allResps)-1].GetSeries().Chunks)
+	maxTime := allResps[len(allResps)-1].GetSeries().Chunks[chunkLen-1].MaxTime
+	storetestutil.TestServerSeries(t, store,
+		&storetestutil.SeriesCase{
+			Name: fmt.Sprintf("%d client with %d samples, %d series each", numOfClients, samplesPerSeriesPerClient, seriesPerClient),
+			Req: &storepb.SeriesRequest{
+				MinTime: 0,
+				MaxTime: maxTime,
+				Matchers: []storepb.LabelMatcher{
+					{Type: storepb.LabelMatcher_EQ, Name: "foo", Value: "bar"},
+				},
+			},
+			ExpectedSeries: expected,
+		},
+	)
+
+	// Change client to just one.
+	store.stores = func() []Client {
+		return []Client{&testClient{
+			StoreClient: &mockedStoreAPI{
+				// All responses.
+				RespSeries: allResps,
+			},
+			labelSets: []storepb.LabelSet{{Labels: []storepb.Label{{Name: "ext1", Value: "1"}}}},
+			minTime:   math.MinInt64,
+			maxTime:   math.MaxInt64,
+		}}
+	}
+
+	// In this we expect exactly the same response as input.
+	expected = expected[:0]
+	for _, r := range allResps {
+		expected = append(expected, *r.GetSeries())
+	}
+	storetestutil.TestServerSeries(t, store,
+		&storetestutil.SeriesCase{
+			Name: fmt.Sprintf("single client with %d samples, %d series", totalSamples, totalSeries),
+			Req: &storepb.SeriesRequest{
+				MinTime: 0,
+				MaxTime: maxTime,
+				Matchers: []storepb.LabelMatcher{
+					{Type: storepb.LabelMatcher_EQ, Name: "foo", Value: "bar"},
+				},
+			},
+			ExpectedSeries: expected,
+		},
+	)
 }

--- a/pkg/store/storepb/testutil/series.go
+++ b/pkg/store/storepb/testutil/series.go
@@ -1,0 +1,271 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package storetestutil
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"math/rand"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"testing"
+
+	"github.com/gogo/protobuf/types"
+	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/prometheus/tsdb"
+	"github.com/prometheus/prometheus/tsdb/chunks"
+	"github.com/prometheus/prometheus/tsdb/index"
+	"github.com/prometheus/prometheus/tsdb/wal"
+	"github.com/thanos-io/thanos/pkg/store/hintspb"
+	"github.com/thanos-io/thanos/pkg/store/storepb"
+	"github.com/thanos-io/thanos/pkg/testutil"
+)
+
+const (
+	// LabelLongSuffix is a label with ~50B in size, to emulate real-world high cardinality.
+	LabelLongSuffix = "aaaaaaaaaabbbbbbbbbbccccccccccdddddddddd"
+)
+
+func allPostings(t testing.TB, ix tsdb.IndexReader) index.Postings {
+	k, v := index.AllPostingsKey()
+	p, err := ix.Postings(k, v)
+	testutil.Ok(t, err)
+	return p
+}
+
+const RemoteReadFrameLimit = 1048576
+
+type HeadGenOptions struct {
+	Dir                      string
+	SamplesPerSeries, Series int
+
+	MaxFrameBytes int // No limit by default.
+	WithWAL       bool
+	PrependLabels labels.Labels
+	SkipChunks    bool
+
+	Random *rand.Rand
+}
+
+// CreateHeadWithSeries returns head filled with given samples and same series returned in separate list for assertion purposes.
+// Returned series list has "ext1"="1" prepended. Each series looks as follows:
+// {foo=bar,i=000001aaaaaaaaaabbbbbbbbbbccccccccccdddddddddd} <random value> where number indicate sample number from 0.
+// Returned series are frame in same way as remote read would frame them.
+func CreateHeadWithSeries(t testing.TB, j int, opts HeadGenOptions) (*tsdb.Head, []storepb.Series) {
+	if opts.SamplesPerSeries < 1 || opts.Series < 1 {
+		t.Fatal("samples and series has to be 1 or more")
+	}
+
+	tsdbDir := filepath.Join(opts.Dir, fmt.Sprintf("%d", j))
+	fmt.Printf("Creating %d %d-sample series in %s\n", opts.Series, opts.SamplesPerSeries, tsdbDir)
+
+	var w *wal.WAL
+	var err error
+	if opts.WithWAL {
+		w, err = wal.New(nil, nil, filepath.Join(tsdbDir, "wal"), true)
+		testutil.Ok(t, err)
+	}
+
+	h, err := tsdb.NewHead(nil, nil, w, 10000000, tsdbDir, nil, tsdb.DefaultStripeSize, nil)
+	testutil.Ok(t, err)
+
+	app := h.Appender()
+	for i := 0; i < opts.Series; i++ {
+		ts := int64(j*opts.Series*opts.SamplesPerSeries + i*opts.SamplesPerSeries)
+		ref, err := app.Add(labels.FromStrings("foo", "bar", "i", fmt.Sprintf("%07d%s", ts, LabelLongSuffix)), ts, opts.Random.Float64())
+		testutil.Ok(t, err)
+
+		for is := 1; is < opts.SamplesPerSeries; is++ {
+			testutil.Ok(t, app.AddFast(ref, ts+int64(is), opts.Random.Float64()))
+		}
+	}
+	testutil.Ok(t, app.Commit())
+
+	// Use TSDB and get all series for assertion.
+	chks, err := h.Chunks()
+	testutil.Ok(t, err)
+	defer func() { testutil.Ok(t, chks.Close()) }()
+
+	ir, err := h.Index()
+	testutil.Ok(t, err)
+	defer func() { testutil.Ok(t, ir.Close()) }()
+
+	var (
+		lset       labels.Labels
+		chunkMetas []chunks.Meta
+		expected   = make([]storepb.Series, 0, opts.Series)
+		sBytes     int
+	)
+
+	all := allPostings(t, ir)
+	for all.Next() {
+		testutil.Ok(t, ir.Series(all.At(), &lset, &chunkMetas))
+		i := 0
+		sLset := storepb.PromLabelsToLabels(lset)
+		expected = append(expected, storepb.Series{Labels: append(storepb.PromLabelsToLabels(opts.PrependLabels), sLset...)})
+
+		if opts.SkipChunks {
+			continue
+		}
+
+		lBytes := 0
+		for _, l := range sLset {
+			lBytes += l.Size()
+		}
+		sBytes = lBytes
+
+		for {
+			c := chunkMetas[i]
+			i++
+
+			chEnc, err := chks.Chunk(c.Ref)
+			testutil.Ok(t, err)
+
+			// Open Chunk.
+			if c.MaxTime == math.MaxInt64 {
+				c.MaxTime = c.MinTime + int64(chEnc.NumSamples()) - 1
+			}
+
+			sBytes += len(chEnc.Bytes())
+
+			expected[len(expected)-1].Chunks = append(expected[len(expected)-1].Chunks, storepb.AggrChunk{
+				MinTime: c.MinTime,
+				MaxTime: c.MaxTime,
+				Raw:     &storepb.Chunk{Type: storepb.Chunk_XOR, Data: chEnc.Bytes()},
+			})
+			if i >= len(chunkMetas) {
+				break
+			}
+
+			// Compose many frames as remote read (so sidecar StoreAPI) would do if requested by  maxFrameBytes.
+			if opts.MaxFrameBytes > 0 && sBytes >= opts.MaxFrameBytes {
+				expected = append(expected, storepb.Series{Labels: sLset})
+				sBytes = lBytes
+			}
+		}
+	}
+	testutil.Ok(t, all.Err())
+	return h, expected
+}
+
+// SeriesServer is test gRPC storeAPI series server.
+type SeriesServer struct {
+	// This field just exist to pseudo-implement the unused methods of the interface.
+	storepb.Store_SeriesServer
+
+	ctx context.Context
+
+	SeriesSet []storepb.Series
+	Warnings  []string
+	HintsSet  []*types.Any
+
+	Size int64
+}
+
+func NewSeriesServer(ctx context.Context) *SeriesServer {
+	return &SeriesServer{ctx: ctx}
+}
+
+func (s *SeriesServer) Send(r *storepb.SeriesResponse) error {
+	s.Size += int64(r.Size())
+
+	if r.GetWarning() != "" {
+		s.Warnings = append(s.Warnings, r.GetWarning())
+		return nil
+	}
+
+	if r.GetSeries() != nil {
+		s.SeriesSet = append(s.SeriesSet, *r.GetSeries())
+		return nil
+	}
+
+	if r.GetHints() != nil {
+		s.HintsSet = append(s.HintsSet, r.GetHints())
+		return nil
+	}
+	// Unsupported field, skip.
+	return nil
+}
+
+func (s *SeriesServer) Context() context.Context {
+	return s.ctx
+}
+
+func RunSeriesInterestingCases(t testutil.TB, maxSamples, maxSeries int, f func(t testutil.TB, samplesPerSeries, series int)) {
+	for _, tc := range []struct {
+		samplesPerSeries int
+		series           int
+	}{
+		{
+			samplesPerSeries: 1,
+			series:           maxSeries,
+		},
+		{
+			samplesPerSeries: maxSamples / (maxSeries / 10),
+			series:           maxSeries / 10,
+		},
+		{
+			samplesPerSeries: maxSamples,
+			series:           1,
+		},
+	} {
+		if ok := t.Run(fmt.Sprintf("%dSeriesWith%dSamples", tc.series, tc.samplesPerSeries), func(t testutil.TB) {
+			f(t, tc.samplesPerSeries, tc.series)
+		}); !ok {
+			return
+		}
+		runtime.GC()
+	}
+}
+
+// SeriesCase represents single test/benchmark case for testing storepb series.
+type SeriesCase struct {
+	Name string
+	Req  *storepb.SeriesRequest
+
+	// Exact expectations are checked only for tests. For benchmarks only length is assured.
+	ExpectedSeries   []storepb.Series
+	ExpectedWarnings []string
+	ExpectedHints    []hintspb.SeriesResponseHints
+}
+
+// TestServerSeries runs tests against given cases.
+func TestServerSeries(t testutil.TB, store storepb.StoreServer, cases ...*SeriesCase) {
+	for _, c := range cases {
+		t.Run(c.Name, func(t testutil.TB) {
+			t.ResetTimer()
+			for i := 0; i < t.N(); i++ {
+				srv := NewSeriesServer(context.Background())
+				testutil.Ok(t, store.Series(c.Req, srv))
+				testutil.Equals(t, len(c.ExpectedWarnings), len(srv.Warnings), "%v", srv.Warnings)
+				testutil.Equals(t, len(c.ExpectedSeries), len(srv.SeriesSet))
+				testutil.Equals(t, len(c.ExpectedHints), len(srv.HintsSet))
+
+				if !t.IsBenchmark() {
+					if len(c.ExpectedSeries) == 1 {
+						// For bucketStoreAPI chunks are not sorted within response. TODO: Investigate: Is this fine?
+						sort.Slice(srv.SeriesSet[0].Chunks, func(i, j int) bool {
+							return srv.SeriesSet[0].Chunks[i].MinTime < srv.SeriesSet[0].Chunks[j].MinTime
+						})
+					}
+
+					testutil.Equals(t, c.ExpectedSeries[0].Chunks[0], srv.SeriesSet[0].Chunks[0])
+
+					// This might give unreadable output for millions of series on fail..
+					testutil.Equals(t, c.ExpectedSeries, srv.SeriesSet)
+
+					var actualHints []hintspb.SeriesResponseHints
+					for _, anyHints := range srv.HintsSet {
+						hints := hintspb.SeriesResponseHints{}
+						testutil.Ok(t, types.UnmarshalAny(anyHints, &hints))
+						actualHints = append(actualHints, hints)
+					}
+					testutil.Equals(t, c.ExpectedHints, actualHints)
+				}
+			}
+		})
+	}
+}

--- a/pkg/store/tsdb.go
+++ b/pkg/store/tsdb.go
@@ -12,7 +12,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/pkg/labels"
-	"github.com/prometheus/prometheus/tsdb"
+	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -23,14 +23,20 @@ import (
 	"github.com/thanos-io/thanos/pkg/store/storepb"
 )
 
+type TSDBReader interface {
+	storage.Queryable
+	StartTime() (int64, error)
+}
+
 // TSDBStore implements the store API against a local TSDB instance.
 // It attaches the provided external labels to all results. It only responds with raw data
 // and does not support downsampling.
 type TSDBStore struct {
-	logger         log.Logger
-	db             *tsdb.DB
-	component      component.StoreAPI
-	externalLabels labels.Labels
+	logger             log.Logger
+	db                 TSDBReader
+	component          component.StoreAPI
+	externalLabels     labels.Labels
+	maxSamplesPerChunk int
 }
 
 // ReadWriteTSDBStore is a TSDBStore that can also be written to.
@@ -40,7 +46,7 @@ type ReadWriteTSDBStore struct {
 }
 
 // NewTSDBStore creates a new TSDBStore.
-func NewTSDBStore(logger log.Logger, _ prometheus.Registerer, db *tsdb.DB, component component.StoreAPI, externalLabels labels.Labels) *TSDBStore {
+func NewTSDBStore(logger log.Logger, _ prometheus.Registerer, db TSDBReader, component component.StoreAPI, externalLabels labels.Labels) *TSDBStore {
 	if logger == nil {
 		logger = log.NewNopLogger()
 	}
@@ -49,19 +55,26 @@ func NewTSDBStore(logger log.Logger, _ prometheus.Registerer, db *tsdb.DB, compo
 		db:             db,
 		component:      component,
 		externalLabels: externalLabels,
+		// NOTE: XOR encoding supports a max size of 2^16 - 1 samples, so we need
+		// to chunk all samples into groups of no more than 2^16 - 1
+		// See: https://github.com/thanos-io/thanos/pull/1038.
+		// TODO(bwplotka): Consider 120 samples?
+		maxSamplesPerChunk: math.MaxUint16,
 	}
 }
 
 // Info returns store information about the Prometheus instance.
 func (s *TSDBStore) Info(_ context.Context, _ *storepb.InfoRequest) (*storepb.InfoResponse, error) {
+	minTime, err := s.db.StartTime()
+	if err != nil {
+		return nil, errors.Wrap(err, "TSDB min Time")
+	}
+
 	res := &storepb.InfoResponse{
 		Labels:    make([]storepb.Label, 0, len(s.externalLabels)),
 		StoreType: s.component.ToProto(),
-		MinTime:   0,
+		MinTime:   minTime,
 		MaxTime:   math.MaxInt64,
-	}
-	if blocks := s.db.Blocks(); len(blocks) > 0 {
-		res.MinTime = blocks[0].Meta().MinTime
 	}
 	for _, l := range s.externalLabels {
 		res.Labels = append(res.Labels, storepb.Label{
@@ -120,12 +133,7 @@ func (s *TSDBStore) Series(r *storepb.SeriesRequest, srv storepb.Store_SeriesSer
 		if !r.SkipChunks {
 			// TODO(fabxc): An improvement over this trivial approach would be to directly
 			// use the chunks provided by TSDB in the response.
-			// But since the sidecar has a similar approach, optimizing here has only
-			// limited benefit for now.
-			// NOTE: XOR encoding supports a max size of 2^16 - 1 samples, so we need
-			// to chunk all samples into groups of no more than 2^16 - 1
-			// See: https://github.com/thanos-io/thanos/pull/1038.
-			c, err := s.encodeChunks(series.Iterator(), math.MaxUint16)
+			c, err := s.encodeChunks(series.Iterator(), s.maxSamplesPerChunk)
 			if err != nil {
 				return status.Errorf(codes.Internal, "encode chunk: %s", err)
 			}

--- a/pkg/store/tsdb_test.go
+++ b/pkg/store/tsdb_test.go
@@ -34,7 +34,20 @@ func TestTSDBStore_Info(t *testing.T) {
 
 	testutil.Equals(t, []storepb.Label{{Name: "region", Value: "eu-west"}}, resp.Labels)
 	testutil.Equals(t, storepb.StoreType_RULE, resp.StoreType)
-	testutil.Equals(t, int64(0), resp.MinTime)
+	testutil.Equals(t, int64(math.MaxInt64), resp.MinTime)
+	testutil.Equals(t, int64(math.MaxInt64), resp.MaxTime)
+
+	app := db.Appender()
+	_, err = app.Add(labels.FromStrings("a", "a"), 12, 0.1)
+	testutil.Ok(t, err)
+	testutil.Ok(t, app.Commit())
+
+	resp, err = tsdbStore.Info(ctx, &storepb.InfoRequest{})
+	testutil.Ok(t, err)
+
+	testutil.Equals(t, []storepb.Label{{Name: "region", Value: "eu-west"}}, resp.Labels)
+	testutil.Equals(t, storepb.StoreType_RULE, resp.StoreType)
+	testutil.Equals(t, int64(12), resp.MinTime)
 	testutil.Equals(t, int64(math.MaxInt64), resp.MaxTime)
 }
 


### PR DESCRIPTION
Similar to store GW Series but for proxy.

Also: * Fixed minTime for TSDB and Receiver. Now checks head block min Time as well. 

Signed-off-by: Bartlomiej Plotka <bwplotka@gmail.com>