### PR TITLE
remove redundant promauto

### DIFF
--- a/pkg/extprom/tx_gauge.go
+++ b/pkg/extprom/tx_gauge.go
@@ -7,7 +7,6 @@ import (
 	"sync"
 
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
 type TxGaugeVec struct {
@@ -26,9 +25,8 @@ type TxGaugeVec struct {
 // Additionally it allows to init LabelValues on each transaction.
 // NOTE: This is quite naive implementation creating new prometheus.GaugeVec on each `ResetTx`, use wisely.
 func NewTxGaugeVec(reg prometheus.Registerer, opts prometheus.GaugeOpts, labelNames []string, initLabelValues ...[]string) *TxGaugeVec {
-	// Nil as we will register it on our own later.
 	f := func() *prometheus.GaugeVec {
-		g := promauto.With(nil).NewGaugeVec(opts, labelNames)
+		g := prometheus.NewGaugeVec(opts, labelNames)
 		for _, vals := range initLabelValues {
 			g.WithLabelValues(vals...)
 		}


### PR DESCRIPTION
*promauto.With(nil).NewGaugeVec(opts, labelNames)* equals *prometheus.NewGaugeVec(opts, labelNames)*

According to source code:
https://github.com/prometheus/client_golang/blob/aa9238db679fc02bf22cf4f2c27a980edcb5ada0/prometheus/promauto/auto.go#L303