### PR TITLE
cmd/thanos/receive: Serve TLS when TLSConfig is given

### DIFF
--- a/pkg/receive/handler.go
+++ b/pkg/receive/handler.go
@@ -192,6 +192,13 @@ func (h *Handler) Run() error {
 		TLSConfig: h.options.TLSConfig,
 	}
 
+	if h.options.TLSConfig != nil {
+		level.Info(h.logger).Log("msg", "Serving HTTPS", "address", h.options.ListenAddress)
+		// Cert & Key are already being passed in via TLSConfig.
+		return httpSrv.ServeTLS(h.listener, "", "")
+	}
+
+	level.Info(h.logger).Log("msg", "Serving plain HTTP", "address", h.options.ListenAddress)
 	return httpSrv.Serve(h.listener)
 }
 


### PR DESCRIPTION
Re-opening #2298

## Changes

Invoke `httpSrv.ListenTLS` when a `TLSConfig` was specified.

## Verification

### Running upstream receiver
```
# Receiver flags
# --remote-write.address=0.0.0.0:19291
# --remote-write.server-tls-cert=/etc/mtls-server/tls.crt
# --remote-write.server-tls-key=/etc/mtls-server/tls.key
# --remote-write.server-tls-client-ca=/etc/mtls-server/ca.crt

curl -v -d {} http://127.0.0.1:19291/api/v1/receive
*   Trying 127.0.0.1:19291...
* Connected to 127.0.0.1 (127.0.0.1) port 19291 (#0)
> POST /api/v1/receive HTTP/1.1
> Host: 127.0.0.1:19291
> User-Agent: curl/7.69.0
> Accept: */*
> Content-Length: 2
> Content-Type: application/x-www-form-urlencoded
> 
* upload completely sent off: 2 out of 2 bytes
* Mark bundle as not supporting multiuse
< HTTP/1.1 400 Bad Request
< Content-Type: text/plain; charset=utf-8
< X-Content-Type-Options: nosniff
< Date: Sat, 21 Mar 2020 13:01:34 GMT
< Content-Length: 22
< 
snappy: corrupt input
* Connection #0 to host 127.0.0.1 left intact
```

### Running change
```
# Receiver flags
# --remote-write.address=0.0.0.0:19291
# --remote-write.server-tls-cert=/etc/mtls-server/tls.crt
# --remote-write.server-tls-key=/etc/mtls-server/tls.key
# --remote-write.server-tls-client-ca=/etc/mtls-server/ca.crt

curl --insecure -v -d {} http://127.0.0.1:19291/api/v1/receive
*   Trying 127.0.0.1:19291...
* Connected to 127.0.0.1 (127.0.0.1) port 19291 (#0)
> POST /api/v1/receive HTTP/1.1
> Host: 127.0.0.1:19291
> User-Agent: curl/7.69.0
> Accept: */*
> Content-Length: 2
> Content-Type: application/x-www-form-urlencoded
> 
* upload completely sent off: 2 out of 2 bytes
* Mark bundle as not supporting multiuse
* HTTP 1.0, assume close after body
< HTTP/1.0 400 Bad Request
< 
Client sent an HTTP request to an HTTPS server.
* Closing connection 0


curl --insecure -v -d {} https://127.0.0.1:19291/api/v1/receive
*   Trying 127.0.0.1:19291...
* Connected to 127.0.0.1 (127.0.0.1) port 19291 (#0)
* ALPN, offering h2
* ALPN, offering http/1.1
* successfully set certificate verify locations:
*   CAfile: /etc/ssl/certs/ca-certificates.crt
  CApath: none
* TLSv1.3 (OUT), TLS handshake, Client hello (1):
* TLSv1.3 (IN), TLS handshake, Server hello (2):
* TLSv1.3 (IN), TLS handshake, Encrypted Extensions (8):
* TLSv1.3 (IN), TLS handshake, Request CERT (13):
* TLSv1.3 (IN), TLS handshake, Certificate (11):
* TLSv1.3 (IN), TLS handshake, CERT verify (15):
* TLSv1.3 (IN), TLS handshake, Finished (20):
* TLSv1.3 (OUT), TLS change cipher, Change cipher spec (1):
* TLSv1.3 (OUT), TLS handshake, Certificate (11):
* TLSv1.3 (OUT), TLS handshake, Finished (20):
* SSL connection using TLSv1.3 / TLS_AES_128_GCM_SHA256
* ALPN, server accepted to use h2
* Server certificate:
*  subject: O=some-org
*  start date: Mar 21 10:20:01 2020 GMT
*  expire date: Jun 19 10:20:01 2020 GMT
*  issuer: O=some-org
*  SSL certificate verify result: self signed certificate (18), continuing anyway.
* Using HTTP2, server supports multi-use
* Connection state changed (HTTP/2 confirmed)
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
* Using Stream ID: 1 (easy handle 0x55e5a035a830)
> POST /api/v1/receive HTTP/2
> Host: 127.0.0.1:19291
> user-agent: curl/7.69.0
> accept: */*
> content-length: 2
> content-type: application/x-www-form-urlencoded
> 
* We are completely uploaded and fine
* TLSv1.3 (IN), TLS alert, bad certificate (554):
* OpenSSL SSL_read: error:14094412:SSL routines:ssl3_read_bytes:sslv3 alert bad certificate, errno 0
* Failed receiving HTTP2 data
* OpenSSL SSL_write: SSL_ERROR_ZERO_RETURN, errno 0
* Failed sending HTTP2 data
* Connection #0 to host 127.0.0.1 left intact
curl: (56) OpenSSL SSL_read: error:14094412:SSL routines:ssl3_read_bytes:sslv3 alert bad certificate, errno 0

```