### PR TITLE
make, ci: Check example alerts and rules in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,7 @@ jobs:
       - run: make deps
       - run: make lint
       - run: make check-docs
+      - run: make check-examples
       - run: make format
       - run:
           name: "Run unit tests."

--- a/Makefile
+++ b/Makefile
@@ -406,7 +406,7 @@ example-rules-lint: $(PROMTOOL) examples/alerts/alerts.yaml examples/alerts/rule
 
 .PHONY: check-examples
 check-examples: examples example-rules-lint
-	git diff --exit-code
+	$(call require_clean_work_tree,'all generated files should be committed,check examples')
 
 .PHONY: examples-clean
 examples-clean:

--- a/Makefile
+++ b/Makefile
@@ -361,7 +361,7 @@ examples-in-container:
 		examples
 
 .PHONY: examples
-examples: jsonnet-format $(EMBEDMD) ${THANOS_MIXIN}/README.md examples/alerts/alerts.md examples/alerts/alerts.yaml examples/alerts/rules.yaml examples/dashboards examples/tmp
+examples: jsonnet-vendor jsonnet-format $(EMBEDMD) ${THANOS_MIXIN}/README.md examples/alerts/alerts.md examples/alerts/alerts.yaml examples/alerts/rules.yaml examples/dashboards examples/tmp
 	$(EMBEDMD) -w examples/alerts/alerts.md
 	$(EMBEDMD) -w ${THANOS_MIXIN}/README.md
 
@@ -403,6 +403,10 @@ jsonnet-format-in-container:
 example-rules-lint: $(PROMTOOL) examples/alerts/alerts.yaml examples/alerts/rules.yaml
 	$(PROMTOOL) check rules examples/alerts/alerts.yaml examples/alerts/rules.yaml
 	$(PROMTOOL) test rules examples/alerts/tests.yaml
+
+.PHONY: check-examples
+check-examples: examples example-rules-lint
+	git diff --exit-code
 
 .PHONY: examples-clean
 examples-clean:


### PR DESCRIPTION
This PR adds a new make task and CI step to check if example alert and rules properly generated and error-free.

Signed-off-by: Kemal Akkoyun <kakkoyun@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

* Add check-examples make task
* Add CI step

## Verification

* `make check-examples`
