### PR TITLE
website: fix 404 on root of sections

### DIFF
--- a/docs/components/_index.md
+++ b/docs/components/_index.md
@@ -1,0 +1,3 @@
+---
+title: "Components:"
+---

--- a/docs/operating/_index.md
+++ b/docs/operating/_index.md
@@ -1,0 +1,3 @@
+---
+title: "Operating Guides:"
+---

--- a/docs/proposals/_index.md
+++ b/docs/proposals/_index.md
@@ -1,0 +1,3 @@
+---
+title: "Proposals:"
+---

--- a/website/layouts/_default/list.html
+++ b/website/layouts/_default/list.html
@@ -1,0 +1,21 @@
+{{ define "main" }}
+    <div class="container">
+        <div class="row py-5">
+            <div class="col col-3">
+                {{ partial "_default/sidemenu.html" . }}
+            </div>
+            <div class="col col-9">
+                <h1>{{ .Title }}</h1>
+                <ul class="list-group list-group-flush">
+                  <!-- Ranges through docs-pre-processed/**/*.md -->
+                  {{ range .Pages }}
+                      <li class="list-group-item list-group-item-action list-group-item-thanos">
+                        <h4><a href="{{.Permalink}}">{{.Title}}</a></h4>
+                      </li>
+                  {{ end }}
+                </ul>
+                {{ replace .Content "<table>" "<table class='table table-striped'>" | safeHTML }}
+            </div>
+        </div>
+    </div>
+{{ end }}


### PR DESCRIPTION
Fix `404 Not Found` errors on various sections like `/proposals` and `/components`

Preview: https://deploy-preview-2328--thanos-io.netlify.com/proposals/
Fixes #2261 

* [ ] ~~I added CHANGELOG entry for this change.~~
* [x] Change is not relevant to the end user.

## Changes
- Add missing template `list.html` in `website/layouts/_default`. It is required to render the lists of items instead of giving a `404`
- Add `_index.md` to section folders inside /docs.
