### PR TITLE
store: Binary index header is now production ready and enabled by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Since there are no consistency guarantees provided by some Object Storage provid
 - [#2294](https://github.com/thanos-io/thanos/pull/2294) store: optimizations for fetching postings. Queries using `=~".*"` matchers or negation matchers (`!=...` or `!~...`) benefit the most.
 - [#2301](https://github.com/thanos-io/thanos/pull/2301) Ruler: initlialization fails with filepath bad pattern error and rule manager update error.
 - [#2310](https://github.com/thanos-io/thanos/pull/2310) query: Report timespan 0 to 0 when discovering no stores.
+- [#2330](https://github.com/thanos-io/thanos/pull/2330) store: index-header is no longer experimental. It is enabled by default for store Gateway. You can disable it with new hidden flag: `--store.disable-index-header`. `--experimental.enable-index-header` flag was removed.
 
 ## [v0.11.0](https://github.com/thanos-io/thanos/releases/tag/v0.11.0) - 2020.03.02
 

--- a/cmd/thanos/store.go
+++ b/cmd/thanos/store.go
@@ -79,7 +79,7 @@ func registerStore(m map[string]setupFunc, app *kingpin.Application) {
 	selectorRelabelConf := regSelectorRelabelFlags(cmd)
 
 	// TODO(bwplotka): Remove in v0.13.0 if no issues.
-	disableIndexHeader := cmd.Flag("store.disable-index-header", "If specified, Store Gateway will user index-cache.json for each block instead of recreating binary index-header").
+	disableIndexHeader := cmd.Flag("store.disable-index-header", "If specified, Store Gateway will use index-cache.json for each block instead of recreating binary index-header").
 		Hidden().Default("false").Bool()
 
 	enablePostingsCompression := cmd.Flag("experimental.enable-index-cache-postings-compression", "If true, Store Gateway will reencode and compress postings before storing them into cache. Compressed postings take about 10% of the original size.").

--- a/cmd/thanos/store.go
+++ b/cmd/thanos/store.go
@@ -78,7 +78,8 @@ func registerStore(m map[string]setupFunc, app *kingpin.Application) {
 
 	selectorRelabelConf := regSelectorRelabelFlags(cmd)
 
-	enableIndexHeader := cmd.Flag("experimental.enable-index-header", "If true, Store Gateway will recreate index-header instead of index-cache.json for each block. This will replace index-cache.json permanently once it will be out of experimental stage.").
+	// TODO(bwplotka): Remove in v0.13.0 if no issues.
+	disableIndexHeader := cmd.Flag("store.disable-index-header", "If specified, Store Gateway will user index-cache.json for each block instead of recreating binary index-header").
 		Hidden().Default("false").Bool()
 
 	enablePostingsCompression := cmd.Flag("experimental.enable-index-cache-postings-compression", "If true, Store Gateway will reencode and compress postings before storing them into cache. Compressed postings take about 10% of the original size.").
@@ -117,7 +118,7 @@ func registerStore(m map[string]setupFunc, app *kingpin.Application) {
 			uint64(*indexCacheSize),
 			uint64(*chunkPoolSize),
 			uint64(*maxSampleCount),
-			int(*maxConcurrent),
+			*maxConcurrent,
 			component.Store,
 			debugLogging,
 			*syncInterval,
@@ -128,7 +129,7 @@ func registerStore(m map[string]setupFunc, app *kingpin.Application) {
 			},
 			selectorRelabelConf,
 			*advertiseCompatibilityLabel,
-			*enableIndexHeader,
+			*disableIndexHeader,
 			*enablePostingsCompression,
 			time.Duration(*consistencyDelay),
 			time.Duration(*ignoreDeletionMarksDelay),
@@ -163,7 +164,7 @@ func runStore(
 	filterConf *store.FilterConfig,
 	selectorRelabelConf *extflag.PathOrContent,
 	advertiseCompatibilityLabel bool,
-	enableIndexHeader bool,
+	disableIndexHeader bool,
 	enablePostingsCompression bool,
 	consistencyDelay time.Duration,
 	ignoreDeletionMarksDelay time.Duration,
@@ -252,7 +253,7 @@ func runStore(
 		return errors.Wrap(err, "meta fetcher")
 	}
 
-	if enableIndexHeader {
+	if !disableIndexHeader {
 		level.Info(logger).Log("msg", "index-header instead of index-cache.json enabled")
 	}
 	bs, err := store.NewBucketStore(
@@ -269,7 +270,7 @@ func runStore(
 		blockSyncConcurrency,
 		filterConf,
 		advertiseCompatibilityLabel,
-		enableIndexHeader,
+		!disableIndexHeader,
 		enablePostingsCompression,
 	)
 	if err != nil {

--- a/test/e2e/e2ethanos/services.go
+++ b/test/e2e/e2ethanos/services.go
@@ -322,7 +322,7 @@ func NewStoreGW(sharedDir string, name string, bucketConfig client.BucketConfig,
 	store := NewService(
 		fmt.Sprintf("store-gw-%v", name),
 		DefaultImage(),
-		e2e.NewCommand("store", append(e2e.BuildArgs(map[string]string{
+		e2e.NewCommand("store", e2e.BuildArgs(map[string]string{
 			"--debug.name":        fmt.Sprintf("store-gw-%v", name),
 			"--grpc-address":      ":9091",
 			"--grpc-grace-period": "0s",
@@ -336,7 +336,7 @@ func NewStoreGW(sharedDir string, name string, bucketConfig client.BucketConfig,
 			"--store.grpc.series-max-concurrency": "1",
 			"--selector.relabel-config":           string(relabelConfigBytes),
 			"--consistency-delay":                 "30m",
-		}), "--experimental.enable-index-header")...),
+		})...),
 		e2e.NewReadinessProbe(80, "/-/ready", 200),
 		80,
 		9091,


### PR DESCRIPTION
Based on the feedback we got binary header is outperforming old method in almost everything and it's stable for few months now. It has been running on Production on many setups we are aware of. Also, see offline discussion: https://cloud-native.slack.com/archives/CL25937SP/p1585297836078500

Let's claim production readiness:+1: 

Signed-off-by: Bartlomiej Plotka <bwplotka@gmail.com>

