### PR TITLE
website: Collapsible menu sections

### DIFF
--- a/website/layouts/partials/_default/sidemenu.html
+++ b/website/layouts/partials/_default/sidemenu.html
@@ -6,7 +6,7 @@
 
 <nav class="docs-menu collapse d-lg-block">
     <div class="sidemenu-thanos">
-        <input type="checkbox" id="menuinput-thanos" class="menuinput" checked />
+        <input type="checkbox" id="menuinput-thanos" class="menuinput"{{if eq .Section ""}} checked{{end}} />
         <label for="menuinput-thanos" class="menulabel-thanos">
             <h5>Thanos</h5>
             <img class="caret-expand" src="/expand.svg" alt="expand" />
@@ -18,7 +18,7 @@
         </div>
     </div>
     <div class="sidemenu-thanos">
-        <input type="checkbox" id="menuinput-components" class="menuinput" />
+        <input type="checkbox" id="menuinput-components" class="menuinput"{{if eq .Section "components"}} checked{{end}} />
         <label for="menuinput-components" class="menulabel-thanos">
             <h5 class="mt-3">Components</h5>
             <img class="caret-expand mt-3" src="/expand.svg" alt="expand" />
@@ -30,7 +30,7 @@
         </div>
     </div>
     <div class="sidemenu-thanos">
-        <input type="checkbox" id="menuinput-operating" class="menuinput" />
+        <input type="checkbox" id="menuinput-operating" class="menuinput"{{if eq .Section "operating"}} checked{{end}} />
         <label for="menuinput-operating" class="menulabel-thanos">
             <h5 class="mt-3">Operating</h5>
             <img class="caret-expand mt-3" src="/expand.svg" alt="expand" />
@@ -42,7 +42,7 @@
         </div>
     </div>
     <div class="sidemenu-thanos">
-        <input type="checkbox" id="menuinput-contributing" class="menuinput" />
+        <input type="checkbox" id="menuinput-contributing" class="menuinput"{{if eq .Section "contributing"}} checked{{end}} />
         <label for="menuinput-contributing" class="menulabel-thanos">
             <h5 class="mt-3">Contributing</h5>
             <img class="caret-expand mt-3" src="/expand.svg" alt="expand" />
@@ -54,7 +54,7 @@
         </div>
     </div>
     <div class="sidemenu-thanos">
-        <input type="checkbox" id="menuinput-proposals" class="menuinput" />
+        <input type="checkbox" id="menuinput-proposals" class="menuinput"{{if eq .Section "proposals"}} checked{{end}} />
         <label for="menuinput-proposals" class="menulabel-thanos">
             <h5 class="mt-3">Proposals</h5>
             <img class="caret-expand mt-3" src="/expand.svg" alt="expand" />

--- a/website/layouts/partials/_default/sidemenu.html
+++ b/website/layouts/partials/_default/sidemenu.html
@@ -5,34 +5,59 @@
 </button>
 
 <nav class="docs-menu collapse d-lg-block">
-    <h5>Thanos</h5>
-    <div class="list-group list-group-flush">
-        {{ range .Site.Menus.thanos }}
-            <a class="list-group-item list-group-item-action list-group-item-thanos py-1" href="{{ .URL }}">{{ .Title }}</a>
-        {{ end }}
+    <div class="sidemenu-thanos">
+        <input type="checkbox" id="menuinput-thanos" class="menuinput" checked />
+        <label for="menuinput-thanos" class="menulabel-thanos">
+            <h5>Thanos</h5>
+        </label>
+        <div class="list-group list-group-flush">
+            {{ range .Site.Menus.thanos }}
+                <a class="list-group-item list-group-item-action list-group-item-thanos py-1" href="{{ .URL }}">{{ .Title }}</a>
+            {{ end }}
+        </div>
     </div>
-    <h5 class="mt-3">Components</h5>
-    <div class="list-group list-group-flush">
-        {{ range .Site.Menus.components }}
-            <a class="list-group-item list-group-item-action list-group-item-thanos py-1" href="{{ .URL }}">{{ .Title }}</a>
-        {{ end }}
+    <div class="sidemenu-thanos">
+        <input type="checkbox" id="menuinput-components" class="menuinput" />
+        <label for="menuinput-components" class="menulabel-thanos">
+            <h5 class="mt-3">Components</h5>
+        </label>
+        <div class="list-group list-group-flush">
+            {{ range .Site.Menus.components }}
+                <a class="list-group-item list-group-item-action list-group-item-thanos py-1" href="{{ .URL }}">{{ .Title }}</a>
+            {{ end }}
+        </div>
     </div>
-    <h5 class="mt-3">Operating</h5>
-    <div class="list-group list-group-flush">
-        {{ range .Site.Menus.operating }}
-            <a class="list-group-item list-group-item-action list-group-item-thanos py-1" href="{{ .URL }}">{{ .Title }}</a>
-        {{ end }}
+    <div class="sidemenu-thanos">
+        <input type="checkbox" id="menuinput-operating" class="menuinput" />
+        <label for="menuinput-operating" class="menulabel-thanos">
+            <h5 class="mt-3">Operating</h5>
+        </label>
+        <div class="list-group list-group-flush">
+            {{ range .Site.Menus.operating }}
+                <a class="list-group-item list-group-item-action list-group-item-thanos py-1" href="{{ .URL }}">{{ .Title }}</a>
+            {{ end }}
+        </div>
     </div>
-    <h5 class="mt-3">Contributing</h5>
-    <div class="list-group list-group-flush">
-        {{ range .Site.Menus.contributing }}
-            <a class="list-group-item list-group-item-action list-group-item-thanos py-1" href="{{ .URL }}">{{ .Title }}</a>
-        {{ end }}
+    <div class="sidemenu-thanos">
+        <input type="checkbox" id="menuinput-contributing" class="menuinput" />
+        <label for="menuinput-contributing" class="menulabel-thanos">
+            <h5 class="mt-3">Contributing</h5>
+        </label>
+        <div class="list-group list-group-flush">
+            {{ range .Site.Menus.contributing }}
+                <a class="list-group-item list-group-item-action list-group-item-thanos py-1" href="{{ .URL }}">{{ .Title }}</a>
+            {{ end }}
+        </div>
     </div>
-    <h5 class="mt-3">Proposals</h5>
-    <div class="list-group list-group-flush">
-        {{ range .Site.Menus.proposals }}
-            <a class="list-group-item list-group-item-action list-group-item-thanos py-1" href="{{ .URL }}">{{ .Title }}</a>
-        {{ end }}
+    <div class="sidemenu-thanos">
+        <input type="checkbox" id="menuinput-proposals" class="menuinput" />
+        <label for="menuinput-proposals" class="menulabel-thanos">
+            <h5 class="mt-3">Proposals</h5>
+        </label>
+        <div class="list-group list-group-flush">
+            {{ range .Site.Menus.proposals }}
+                <a class="list-group-item list-group-item-action list-group-item-thanos py-1" href="{{ .URL }}">{{ .Title }}</a>
+            {{ end }}
+        </div>
     </div>
 </nav>

--- a/website/layouts/partials/_default/sidemenu.html
+++ b/website/layouts/partials/_default/sidemenu.html
@@ -9,6 +9,7 @@
         <input type="checkbox" id="menuinput-thanos" class="menuinput" checked />
         <label for="menuinput-thanos" class="menulabel-thanos">
             <h5>Thanos</h5>
+            <img class="caret-expand" src="/expand.svg" alt="expand" />
         </label>
         <div class="list-group list-group-flush">
             {{ range .Site.Menus.thanos }}
@@ -20,6 +21,7 @@
         <input type="checkbox" id="menuinput-components" class="menuinput" />
         <label for="menuinput-components" class="menulabel-thanos">
             <h5 class="mt-3">Components</h5>
+            <img class="caret-expand mt-3" src="/expand.svg" alt="expand" />
         </label>
         <div class="list-group list-group-flush">
             {{ range .Site.Menus.components }}
@@ -31,6 +33,7 @@
         <input type="checkbox" id="menuinput-operating" class="menuinput" />
         <label for="menuinput-operating" class="menulabel-thanos">
             <h5 class="mt-3">Operating</h5>
+            <img class="caret-expand mt-3" src="/expand.svg" alt="expand" />
         </label>
         <div class="list-group list-group-flush">
             {{ range .Site.Menus.operating }}
@@ -42,6 +45,7 @@
         <input type="checkbox" id="menuinput-contributing" class="menuinput" />
         <label for="menuinput-contributing" class="menulabel-thanos">
             <h5 class="mt-3">Contributing</h5>
+            <img class="caret-expand mt-3" src="/expand.svg" alt="expand" />
         </label>
         <div class="list-group list-group-flush">
             {{ range .Site.Menus.contributing }}
@@ -53,6 +57,7 @@
         <input type="checkbox" id="menuinput-proposals" class="menuinput" />
         <label for="menuinput-proposals" class="menulabel-thanos">
             <h5 class="mt-3">Proposals</h5>
+            <img class="caret-expand mt-3" src="/expand.svg" alt="expand" />
         </label>
         <div class="list-group list-group-flush">
             {{ range .Site.Menus.proposals }}

--- a/website/static/expand.svg
+++ b/website/static/expand.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="24.28" height="15.14" fill="#000000" version="1.1" viewBox="0 0 12.14 7.57" xmlns="http://www.w3.org/2000/svg">
+	<path d="m12.14 1.5-1.5-1.5-4.57 4.57-4.57-4.57-1.5 1.5 6.07 6.07z"/>
+</svg>

--- a/website/static/main.css
+++ b/website/static/main.css
@@ -71,3 +71,22 @@ pre {
 
 .header-anchor { font-size: 100%; visibility: hidden;}
 h1:hover a, h2:hover a, h3:hover a, h4:hover a { visibility: visible}
+
+/* SideMenu Collapse */
+.menuinput {
+    display: none;
+}
+
+.menulabel-thanos {
+    cursor: pointer;
+}
+
+.sidemenu-thanos .list-group {
+    transform: scaleY(0);
+    height: 0;
+}
+
+.menuinput:checked ~ .list-group {
+    transform: scaleY(1);
+    height: auto;
+}

--- a/website/static/main.css
+++ b/website/static/main.css
@@ -79,6 +79,19 @@ h1:hover a, h2:hover a, h3:hover a, h4:hover a { visibility: visible}
 
 .menulabel-thanos {
     cursor: pointer;
+    display: flex;
+    align-items: center;
+}
+
+.caret-expand {
+    width: 16px;
+    margin-left: 8px;
+    margin-bottom: 0.2rem;
+    transition: transform 0.2s ease-out;
+}
+
+.menuinput:checked + label .caret-expand {
+    transform: rotateX(180deg);
 }
 
 .sidemenu-thanos .list-group {


### PR DESCRIPTION
Made the Side menu sections collapsible. This was done using CSS only so the website remains functional without JS :smile: 

Preview: https://deploy-preview-2336--thanos-io.netlify.com/getting-started.md/

Fixes #2335 

* [ ] ~~I added CHANGELOG entry for this change.~~
* [x] Change is not relevant to the end user.

## Changes
- Made the side menu collapsible
- Current section stays open by default, achieved using Hugo's page variables

## Verification
I tested the website build manually and verified everything's working as expected.
