### PR TITLE
ui: fix store never removed from /stores page bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 - [#2231](https://github.com/thanos-io/thanos/pull/2231) Bucket Web - Sort chunks by thanos.downsample.resolution for better grouping
 - [#2254](https://github.com/thanos-io/thanos/pull/2254) Bucket: Fix metrics registered multiple times in bucket replicate
 - [#2271](https://github.com/thanos-io/thanos/pull/2271) Bucket Web: Fixed Issue #2260 bucket passes null when storage is empty
+- [#2339](https://github.com/thanos-io/thanos/pull/2339) Query: fix a bug where `--store.unhealthy-timeout` was never respected
 
 ### Added
 

--- a/pkg/query/storeset.go
+++ b/pkg/query/storeset.go
@@ -457,10 +457,9 @@ func (s *StoreSet) updateStoreStatus(store *storeRef, err error) {
 	}
 
 	status.LastError = err
-	status.LastCheck = time.Now()
 
 	if err == nil {
-
+		status.LastCheck = time.Now()
 		mint, maxt := store.TimeRange()
 		status.LabelSets = store.LabelSets()
 		status.StoreType = store.StoreType()

--- a/pkg/query/storeset_test.go
+++ b/pkg/query/storeset_test.go
@@ -174,9 +174,6 @@ func TestStoreSet_Update(t *testing.T) {
 
 	discoveredStoreAddr := stores.StoreAddresses()
 
-	// Start with one not available.
-	stores.CloseOne(discoveredStoreAddr[2])
-
 	// Testing if duplicates can cause weird results.
 	discoveredStoreAddr = append(discoveredStoreAddr, discoveredStoreAddr[0])
 	storeSet := NewStoreSet(nil, nil, func() (specs []StoreSpec) {
@@ -187,6 +184,12 @@ func TestStoreSet_Update(t *testing.T) {
 	}, testGRPCOpts, time.Minute)
 	storeSet.gRPCInfoCallTimeout = 2 * time.Second
 	defer storeSet.Close()
+
+	// Initial update.
+	storeSet.Update(context.Background())
+
+	// Start with one not available.
+	stores.CloseOne(discoveredStoreAddr[2])
 
 	// Should not matter how many of these we run.
 	storeSet.Update(context.Background())

--- a/pkg/ui/templates/stores.html
+++ b/pkg/ui/templates/stores.html
@@ -18,7 +18,7 @@
             <th>Announced LabelSets</th>
             <th>Min Time</th>
             <th>Max Time</th>
-            <th>Last Health Check</th>
+            <th>Last Successful Health Check</th>
             <th>Last Message</th>
         </tr>
         </thead>


### PR DESCRIPTION
We need to update `LastCheck` only if the error is non-nil. That field
is used in the cleanup function to know when to remove the StoreAPI from
the UI. If we always update it, even if an error has happened, that
means that `--store.unhealthy-timeout` is never respected.
*But* this only affects the UI part.

Signed-off-by: Giedrius Statkevičius <giedriuswork@gmail.com>

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Verification

* Local testing;
* Amended unit tests

## Note

Funnily enough, https://github.com/thanos-io/thanos/pull/2337 will have to probably be modified a bit because the UI AFAICT will continuously remove/add nodes specified via `--store-strict` if they go down.