### PR TITLE
Allow more connection reuse than the default of 2

### DIFF
--- a/pkg/objstore/s3/s3.go
+++ b/pkg/objstore/s3/s3.go
@@ -149,6 +149,7 @@ func NewBucketWithConfig(logger log.Logger, config Config, component string) (*B
 			DualStack: true,
 		}).DialContext,
 		MaxIdleConns:          100,
+		MaxIdleConnsPerHost:   100,
 		IdleConnTimeout:       time.Duration(config.HTTPConfig.IdleConnTimeout),
 		TLSHandshakeTimeout:   10 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,


### PR DESCRIPTION
* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

Due to https://github.com/golang/go/issues/13801 Connection reuse currently seems not to work as expected. This also got fixed for Prometheus in https://github.com/prometheus/prometheus/pull/3592 and for Cortex in https://github.com/cortexproject/cortex/pull/2268, since Cortex is now using the implementation of object store of thanos i may hit this behaviour.

I am not sure how to test this, if someone could help to test, this would be great.

## Verification

See above