### PR TITLE
pkg/server/grpc: Fix Unregister gRPC prometheus middleware metrics

### DIFF
--- a/pkg/server/grpc/grpc.go
+++ b/pkg/server/grpc/grpc.go
@@ -83,6 +83,7 @@ func New(logger log.Logger, reg prometheus.Registerer, tracer opentracing.Tracer
 
 	storepb.RegisterStoreServer(s, storeSrv)
 	met.InitializeMetrics(s)
+	reg.MustRegister(met)
 
 	grpc_health.RegisterHealthServer(s, probe.HealthServer())
 


### PR DESCRIPTION
This PR fixes unregistered gRPC metrics issues that accidentally introduced with https://github.com/thanos-io/thanos/pull/2228.

Signed-off-by: Kemal Akkoyun <kakkoyun@gmail.com>

cc @bwplotka 

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->


* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

* Register metrics.

## Verification

* `MINIO_ENABLED=1 ./scripts/quickstart.sh`
* Check local prometheus
