### PR TITLE
fetcher: Made metaFetcher go routine safe; Fixed multiple bucket UI +fetcher issues.

### DIFF
--- a/cmd/thanos/downsample.go
+++ b/cmd/thanos/downsample.go
@@ -72,7 +72,9 @@ func RunDownsample(
 		return err
 	}
 
-	metaFetcher, err := block.NewMetaFetcher(logger, 32, bkt, "", extprom.WrapRegistererWithPrefix("thanos_", reg), nil)
+	metaFetcher, err := block.NewMetaFetcher(logger, 32, bkt, "", extprom.WrapRegistererWithPrefix("thanos_", reg), []block.MetadataFilter{
+		block.NewDeduplicateFilter(),
+	}, nil)
 	if err != nil {
 		return errors.Wrap(err, "create meta fetcher")
 	}

--- a/cmd/thanos/main_test.go
+++ b/cmd/thanos/main_test.go
@@ -76,7 +76,7 @@ func TestCleanupIndexCacheFolder(t *testing.T) {
 		Name: metricIndexGenerateName,
 		Help: metricIndexGenerateHelp,
 	})
-	metaFetcher, err := block.NewMetaFetcher(nil, 32, bkt, "", nil, nil)
+	metaFetcher, err := block.NewMetaFetcher(nil, 32, bkt, "", nil, nil, nil)
 	testutil.Ok(t, err)
 
 	testutil.Ok(t, genMissingIndexCacheFiles(ctx, logger, reg, bkt, metaFetcher, dir))
@@ -116,7 +116,7 @@ func TestCleanupDownsampleCacheFolder(t *testing.T) {
 
 	metrics := newDownsampleMetrics(prometheus.NewRegistry())
 	testutil.Equals(t, 0.0, promtest.ToFloat64(metrics.downsamples.WithLabelValues(compact.GroupKey(meta.Thanos))))
-	metaFetcher, err := block.NewMetaFetcher(nil, 32, bkt, "", nil, nil)
+	metaFetcher, err := block.NewMetaFetcher(nil, 32, bkt, "", nil, nil, nil)
 	testutil.Ok(t, err)
 
 	testutil.Ok(t, downsampleBucket(ctx, logger, metrics, bkt, metaFetcher, dir))

--- a/cmd/thanos/store.go
+++ b/cmd/thanos/store.go
@@ -241,14 +241,14 @@ func runStore(
 	}
 
 	ignoreDeletionMarkFilter := block.NewIgnoreDeletionMarkFilter(logger, bkt, ignoreDeletionMarksDelay)
-	prometheusRegisterer := extprom.WrapRegistererWithPrefix("thanos_", reg)
-	metaFetcher, err := block.NewMetaFetcher(logger, fetcherConcurrency, bkt, dataDir, prometheusRegisterer, []block.MetadataFilter{
-		block.NewTimePartitionMetaFilter(filterConf.MinTime, filterConf.MaxTime),
-		block.NewLabelShardedMetaFilter(relabelConfig),
-		block.NewConsistencyDelayMetaFilter(logger, consistencyDelay, prometheusRegisterer),
-		ignoreDeletionMarkFilter,
-		block.NewDeduplicateFilter(),
-	})
+	metaFetcher, err := block.NewMetaFetcher(logger, fetcherConcurrency, bkt, dataDir, extprom.WrapRegistererWithPrefix("thanos_", reg),
+		[]block.MetadataFilter{
+			block.NewTimePartitionMetaFilter(filterConf.MinTime, filterConf.MaxTime),
+			block.NewLabelShardedMetaFilter(relabelConfig),
+			block.NewConsistencyDelayMetaFilter(logger, consistencyDelay, extprom.WrapRegistererWithPrefix("thanos_", reg)),
+			ignoreDeletionMarkFilter,
+			block.NewDeduplicateFilter(),
+		}, nil)
 	if err != nil {
 		return errors.Wrap(err, "meta fetcher")
 	}

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/go-kit/kit v0.9.0
 	github.com/go-openapi/strfmt v0.19.2
 	github.com/gogo/protobuf v1.3.1
+	github.com/golang/groupcache v0.0.0-20191027212112-611e8accdfc9
 	github.com/golang/snappy v0.0.1
 	github.com/googleapis/gax-go v2.0.2+incompatible
 	github.com/gophercloud/gophercloud v0.6.0

--- a/pkg/compact/clean_test.go
+++ b/pkg/compact/clean_test.go
@@ -29,7 +29,7 @@ func TestBestEffortCleanAbortedPartialUploads(t *testing.T) {
 	bkt := inmem.NewBucket()
 	logger := log.NewNopLogger()
 
-	metaFetcher, err := block.NewMetaFetcher(nil, 32, bkt, "", nil, nil)
+	metaFetcher, err := block.NewMetaFetcher(nil, 32, bkt, "", nil, nil, nil)
 	testutil.Ok(t, err)
 
 	// 1. No meta, old block, should be removed.

--- a/pkg/compact/compact_e2e_test.go
+++ b/pkg/compact/compact_e2e_test.go
@@ -92,7 +92,7 @@ func TestSyncer_GarbageCollect_e2e(t *testing.T) {
 		duplicateBlocksFilter := block.NewDeduplicateFilter()
 		metaFetcher, err := block.NewMetaFetcher(nil, 32, bkt, "", nil, []block.MetadataFilter{
 			duplicateBlocksFilter,
-		})
+		}, nil)
 		testutil.Ok(t, err)
 
 		blocksMarkedForDeletion := promauto.With(nil).NewCounter(prometheus.CounterOpts{})
@@ -181,7 +181,7 @@ func TestGroup_Compact_e2e(t *testing.T) {
 		metaFetcher, err := block.NewMetaFetcher(nil, 32, bkt, "", nil, []block.MetadataFilter{
 			ignoreDeletionMarkFilter,
 			duplicateBlocksFilter,
-		})
+		}, nil)
 		testutil.Ok(t, err)
 
 		blocksMarkedForDeletion := promauto.With(nil).NewCounter(prometheus.CounterOpts{})

--- a/pkg/compact/retention_test.go
+++ b/pkg/compact/retention_test.go
@@ -245,7 +245,7 @@ func TestApplyRetentionPolicyByResolution(t *testing.T) {
 				uploadMockBlock(t, bkt, b.id, b.minTime, b.maxTime, int64(b.resolution))
 			}
 
-			metaFetcher, err := block.NewMetaFetcher(logger, 32, bkt, "", nil, nil)
+			metaFetcher, err := block.NewMetaFetcher(logger, 32, bkt, "", nil, nil, nil)
 			testutil.Ok(t, err)
 
 			blocksMarkedForDeletion := promauto.With(nil).NewCounter(prometheus.CounterOpts{})

--- a/pkg/replicate/replicator.go
+++ b/pkg/replicate/replicator.go
@@ -151,7 +151,7 @@ func RunReplicate(
 		Help: "The Duration of replication runs split by success and error.",
 	}, []string{"result"})
 
-	fetcher, err := thanosblock.NewMetaFetcher(logger, 32, fromBkt, "", reg, nil)
+	fetcher, err := thanosblock.NewMetaFetcher(logger, 32, fromBkt, "", reg, nil, nil)
 	if err != nil {
 		return errors.Wrapf(err, "create meta fetcher with bucket %v", fromBkt)
 	}

--- a/pkg/replicate/scheme_test.go
+++ b/pkg/replicate/scheme_test.go
@@ -313,7 +313,7 @@ func TestReplicationSchemeAll(t *testing.T) {
 		}
 
 		filter := NewBlockFilter(logger, selector, compact.ResolutionLevelRaw, 1).Filter
-		fetcher, err := block.NewMetaFetcher(logger, 32, originBucket, "", nil, nil)
+		fetcher, err := block.NewMetaFetcher(logger, 32, originBucket, "", nil, nil, nil)
 		testutil.Ok(t, err)
 
 		r := newReplicationScheme(

--- a/pkg/store/bucket_e2e_test.go
+++ b/pkg/store/bucket_e2e_test.go
@@ -150,7 +150,7 @@ func prepareStoreWithTestBlocks(t testing.TB, dir string, bkt objstore.Bucket, m
 	metaFetcher, err := block.NewMetaFetcher(s.logger, 20, bkt, dir, nil, []block.MetadataFilter{
 		block.NewTimePartitionMetaFilter(filterConf.MinTime, filterConf.MaxTime),
 		block.NewLabelShardedMetaFilter(relabelConfig),
-	})
+	}, nil)
 	testutil.Ok(t, err)
 
 	store, err := NewBucketStore(

--- a/pkg/store/bucket_test.go
+++ b/pkg/store/bucket_test.go
@@ -714,7 +714,7 @@ func testSharding(t *testing.T, reuseDisk string, bkt objstore.Bucket, all ...ul
 			metaFetcher, err := block.NewMetaFetcher(logger, 20, bkt, dir, nil, []block.MetadataFilter{
 				block.NewTimePartitionMetaFilter(allowAllFilterConf.MinTime, allowAllFilterConf.MaxTime),
 				block.NewLabelShardedMetaFilter(relabelConf),
-			})
+			}, nil)
 			testutil.Ok(t, err)
 
 			bucketStore, err := NewBucketStore(

--- a/pkg/ui/bucket.go
+++ b/pkg/ui/bucket.go
@@ -4,13 +4,19 @@
 package ui
 
 import (
+	"context"
+	"encoding/json"
 	"html/template"
 	"net/http"
 	"time"
 
 	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/common/route"
+	"github.com/thanos-io/thanos/pkg/block"
+	"github.com/thanos-io/thanos/pkg/block/metadata"
 	extpromhttp "github.com/thanos-io/thanos/pkg/extprom/http"
+	"github.com/thanos-io/thanos/pkg/runutil"
 )
 
 // Bucket is a web UI representing state of buckets as a timeline.
@@ -27,7 +33,7 @@ type Bucket struct {
 
 func NewBucketUI(logger log.Logger, label string, flagsMap map[string]string) *Bucket {
 	return &Bucket{
-		BaseUI:   NewBaseUI(logger, "bucket_menu.html", queryTmplFuncs()),
+		BaseUI:   NewBaseUI(log.With(logger, "component", "bucketUI"), "bucket_menu.html", queryTmplFuncs()),
 		Blocks:   "[]",
 		Label:    label,
 		flagsMap: flagsMap,
@@ -52,6 +58,38 @@ func (b *Bucket) root(w http.ResponseWriter, r *http.Request) {
 
 func (b *Bucket) Set(data string, err error) {
 	b.RefreshedAt = time.Now()
-	b.Blocks = template.JS(string(data))
+	b.Blocks = template.JS(data)
 	b.Err = err
+}
+
+// RunRefreshLoop refreshes periodically metadata from remote storage periodically and update the UI.
+func (b *Bucket) RunRefreshLoop(ctx context.Context, fetcher block.MetadataFetcher, interval time.Duration, loopTimeout time.Duration) error {
+	return runutil.Repeat(interval, ctx.Done(), func() error {
+		return runutil.RetryWithLog(b.logger, time.Minute, ctx.Done(), func() error {
+			iterCtx, iterCancel := context.WithTimeout(ctx, loopTimeout)
+			defer iterCancel()
+
+			level.Debug(b.logger).Log("msg", "synchronizing block metadata")
+			metas, _, err := fetcher.Fetch(iterCtx)
+			if err != nil {
+				level.Error(b.logger).Log("msg", "failed to sync metas", "err", err)
+				b.Set("[]", err)
+				return err
+			}
+			blocks := make([]metadata.Meta, 0, len(metas))
+			for _, meta := range metas {
+				blocks = append(blocks, *meta)
+			}
+			level.Debug(b.logger).Log("msg", "downloaded blocks meta.json", "num", len(blocks))
+
+			data, err := json.Marshal(blocks)
+			if err != nil {
+				b.Set("[]", err)
+				return err
+			}
+			// TODO(bwplotka): Allow setting info about partial blocks as well.
+			b.Set(string(data), nil)
+			return nil
+		})
+	})
 }

--- a/pkg/verifier/duplicated_compaction.go
+++ b/pkg/verifier/duplicated_compaction.go
@@ -27,14 +27,14 @@ const DuplicatedCompactionIssueID = "duplicated_compaction"
 // until sync-delay passes.
 // The expected print of this are same overlapped blocks with exactly the same sources, time ranges and stats.
 // If repair is enabled, all but one duplicates are safely deleted.
-func DuplicatedCompactionIssue(ctx context.Context, logger log.Logger, bkt objstore.Bucket, backupBkt objstore.Bucket, repair bool, idMatcher func(ulid.ULID) bool, fetcher *block.MetaFetcher, deleteDelay time.Duration, metrics *verifierMetrics) error {
+func DuplicatedCompactionIssue(ctx context.Context, logger log.Logger, bkt objstore.Bucket, backupBkt objstore.Bucket, repair bool, idMatcher func(ulid.ULID) bool, fetcher block.MetadataFetcher, deleteDelay time.Duration, metrics *verifierMetrics) error {
 	if idMatcher != nil {
 		return errors.Errorf("id matching is not supported by issue %s verifier", DuplicatedCompactionIssueID)
 	}
 
 	level.Info(logger).Log("msg", "started verifying issue", "with-repair", repair, "issue", DuplicatedCompactionIssueID)
 
-	overlaps, err := fetchOverlaps(ctx, logger, bkt, fetcher)
+	overlaps, err := fetchOverlaps(ctx, fetcher)
 	if err != nil {
 		return errors.Wrap(err, DuplicatedCompactionIssueID)
 	}

--- a/pkg/verifier/index_issue.go
+++ b/pkg/verifier/index_issue.go
@@ -29,7 +29,7 @@ const IndexIssueID = "index_issue"
 // If the replacement was created successfully it is uploaded to the bucket and the input
 // block is deleted.
 // NOTE: This also verifies all indexes against chunks mismatches and duplicates.
-func IndexIssue(ctx context.Context, logger log.Logger, bkt objstore.Bucket, backupBkt objstore.Bucket, repair bool, idMatcher func(ulid.ULID) bool, fetcher *block.MetaFetcher, deleteDelay time.Duration, metrics *verifierMetrics) error {
+func IndexIssue(ctx context.Context, logger log.Logger, bkt objstore.Bucket, backupBkt objstore.Bucket, repair bool, idMatcher func(ulid.ULID) bool, fetcher block.MetadataFetcher, deleteDelay time.Duration, metrics *verifierMetrics) error {
 	level.Info(logger).Log("msg", "started verifying issue", "with-repair", repair, "issue", IndexIssueID)
 
 	metas, _, err := fetcher.Fetch(ctx)

--- a/pkg/verifier/overlapped_blocks.go
+++ b/pkg/verifier/overlapped_blocks.go
@@ -22,14 +22,14 @@ const OverlappedBlocksIssueID = "overlapped_blocks"
 
 // OverlappedBlocksIssue checks bucket for blocks with overlapped time ranges.
 // No repair is available for this issue.
-func OverlappedBlocksIssue(ctx context.Context, logger log.Logger, bkt objstore.Bucket, _ objstore.Bucket, repair bool, idMatcher func(ulid.ULID) bool, fetcher *block.MetaFetcher, deleteDelay time.Duration, metrics *verifierMetrics) error {
+func OverlappedBlocksIssue(ctx context.Context, logger log.Logger, _ objstore.Bucket, _ objstore.Bucket, repair bool, idMatcher func(ulid.ULID) bool, fetcher block.MetadataFetcher, _ time.Duration, _ *verifierMetrics) error {
 	if idMatcher != nil {
 		return errors.Errorf("id matching is not supported by issue %s verifier", OverlappedBlocksIssueID)
 	}
 
 	level.Info(logger).Log("msg", "started verifying issue", "with-repair", repair, "issue", OverlappedBlocksIssueID)
 
-	overlaps, err := fetchOverlaps(ctx, logger, bkt, fetcher)
+	overlaps, err := fetchOverlaps(ctx, fetcher)
 	if err != nil {
 		return errors.Wrap(err, OverlappedBlocksIssueID)
 	}
@@ -49,7 +49,7 @@ func OverlappedBlocksIssue(ctx context.Context, logger log.Logger, bkt objstore.
 	return nil
 }
 
-func fetchOverlaps(ctx context.Context, logger log.Logger, bkt objstore.Bucket, fetcher *block.MetaFetcher) (map[string]tsdb.Overlaps, error) {
+func fetchOverlaps(ctx context.Context, fetcher block.MetadataFetcher) (map[string]tsdb.Overlaps, error) {
 	metas, _, err := fetcher.Fetch(ctx)
 	if err != nil {
 		return nil, err

--- a/pkg/verifier/verify.go
+++ b/pkg/verifier/verify.go
@@ -35,7 +35,7 @@ func newVerifierMetrics(reg prometheus.Registerer) *verifierMetrics {
 
 // Issue is an function that does verification and repair only if repair arg is true.
 // It should log affected blocks using warn level logs. It should be safe for issue to run on healthy bucket.
-type Issue func(ctx context.Context, logger log.Logger, bkt objstore.Bucket, backupBkt objstore.Bucket, repair bool, idMatcher func(ulid.ULID) bool, fetcher *block.MetaFetcher, deleteDelay time.Duration, metrics *verifierMetrics) error
+type Issue func(ctx context.Context, logger log.Logger, bkt objstore.Bucket, backupBkt objstore.Bucket, repair bool, idMatcher func(ulid.ULID) bool, fetcher block.MetadataFetcher, deleteDelay time.Duration, metrics *verifierMetrics) error
 
 // Verifier runs given issues to verify if bucket is healthy.
 type Verifier struct {
@@ -44,13 +44,13 @@ type Verifier struct {
 	backupBkt   objstore.Bucket
 	issues      []Issue
 	repair      bool
-	fetcher     *block.MetaFetcher
+	fetcher     block.MetadataFetcher
 	deleteDelay time.Duration
 	metrics     *verifierMetrics
 }
 
 // New returns verifier that only logs affected blocks.
-func New(logger log.Logger, reg prometheus.Registerer, bkt objstore.Bucket, fetcher *block.MetaFetcher, deleteDelay time.Duration, issues []Issue) *Verifier {
+func New(logger log.Logger, reg prometheus.Registerer, bkt objstore.Bucket, fetcher block.MetadataFetcher, deleteDelay time.Duration, issues []Issue) *Verifier {
 	return &Verifier{
 		logger:      logger,
 		bkt:         bkt,
@@ -63,7 +63,7 @@ func New(logger log.Logger, reg prometheus.Registerer, bkt objstore.Bucket, fetc
 }
 
 // NewWithRepair returns verifier that logs affected blocks and attempts to repair them.
-func NewWithRepair(logger log.Logger, reg prometheus.Registerer, bkt objstore.Bucket, backupBkt objstore.Bucket, fetcher *block.MetaFetcher, deleteDelay time.Duration, issues []Issue) *Verifier {
+func NewWithRepair(logger log.Logger, reg prometheus.Registerer, bkt objstore.Bucket, backupBkt objstore.Bucket, fetcher block.MetadataFetcher, deleteDelay time.Duration, issues []Issue) *Verifier {
 	return &Verifier{
 		logger:      logger,
 		bkt:         bkt,


### PR DESCRIPTION

Fixed https://github.com/thanos-io/thanos/issues/2349
Fixed races (we were reusing fetcher by both bucket UI and compaction syncs...
Fixed logging
Added singleflight to ensure we don't synchronize too often.

Signed-off-by: Bartlomiej Plotka <bwplotka@gmail.com>

cc @squat Would be awesome to merge this before release as it's a major race :/ That might interact with what compact sees.