### PR TITLE
test/e2e: Add timestamp to e2e test log output

### DIFF
--- a/test/e2e/query_test.go
+++ b/test/e2e/query_test.go
@@ -166,7 +166,9 @@ func instantQuery(t *testing.T, ctx context.Context, addr string, q string, opts
 
 	fmt.Println("queryAndAssert: Waiting for", expectedSeriesLen, "results for query", q)
 	var result model.Vector
-	testutil.Ok(t, runutil.RetryWithLog(log.NewLogfmtLogger(os.Stdout), time.Second, ctx.Done(), func() error {
+	logger := log.NewLogfmtLogger(os.Stdout)
+	logger = log.With(logger, "ts", log.DefaultTimestampUTC)
+	testutil.Ok(t, runutil.RetryWithLog(logger, time.Second, ctx.Done(), func() error {
 		res, warnings, err := promclient.QueryInstant(ctx, nil, urlParse(t, "http://"+addr), q, time.Now(), opts)
 		if err != nil {
 			return err


### PR DESCRIPTION

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

Add timestamps to e2e log output. I found this helpful a couple of times while debugging e2e tests, so I thought I may as well not just have it in a local branch as it's probably helpful for others.

## Verification

Checked that e2e tests print timestamps.