### PR TITLE
mixin: Remove unused jobPrefix field

### DIFF
--- a/mixin/thanos/alerts/bucket_replicate.libsonnet
+++ b/mixin/thanos/alerts/bucket_replicate.libsonnet
@@ -1,7 +1,6 @@
 {
   local thanos = self,
   bucket_replicate+:: {
-    jobPrefix: error 'must provide job prefix for Thanos Bucket Replicate dashboard',
     selector: error 'must provide selector for Thanos Bucket Replicate dashboard',
     errorThreshold: 10,
     p99LatencyThreshold: 20,

--- a/mixin/thanos/alerts/compact.libsonnet
+++ b/mixin/thanos/alerts/compact.libsonnet
@@ -1,7 +1,6 @@
 {
   local thanos = self,
   compact+:: {
-    jobPrefix: error 'must provide job prefix for Thanos Compact alerts',
     selector: error 'must provide selector for Thanos Compact alerts',
     compactionErrorThreshold: 5,
     bucketOpsErrorThreshold: 5,

--- a/mixin/thanos/alerts/query.libsonnet
+++ b/mixin/thanos/alerts/query.libsonnet
@@ -1,7 +1,6 @@
 {
   local thanos = self,
   query+:: {
-    jobPrefix: error 'must provide job prefix for Thanos Query alerts',
     selector: error 'must provide selector for Thanos Query alerts',
     httpErrorThreshold: 5,
     grpcErrorThreshold: 5,

--- a/mixin/thanos/alerts/receive.libsonnet
+++ b/mixin/thanos/alerts/receive.libsonnet
@@ -1,7 +1,6 @@
 {
   local thanos = self,
   receive+:: {
-    jobPrefix: error 'must provide job prefix for Thanos Receive alerts',
     selector: error 'must provide selector for Thanos Receive alerts',
     httpErrorThreshold: 5,
     forwardErrorThreshold: 5,

--- a/mixin/thanos/alerts/rule.libsonnet
+++ b/mixin/thanos/alerts/rule.libsonnet
@@ -1,7 +1,6 @@
 {
   local thanos = self,
   rule+:: {
-    jobPrefix: error 'must provide job prefix for Thanos Rule alerts',
     selector: error 'must provide selector for Thanos Rule alerts',
     grpcErrorThreshold: 5,
     rulerDnsErrorThreshold: 1,

--- a/mixin/thanos/alerts/sidecar.libsonnet
+++ b/mixin/thanos/alerts/sidecar.libsonnet
@@ -1,7 +1,6 @@
 {
   local thanos = self,
   sidecar+:: {
-    jobPrefix: error 'must provide job prefix for Thanos Sidecar alerts',
     selector: error 'must provide selector for Thanos Sidecar alerts',
   },
   prometheusAlerts+:: {

--- a/mixin/thanos/alerts/store.libsonnet
+++ b/mixin/thanos/alerts/store.libsonnet
@@ -1,7 +1,6 @@
 {
   local thanos = self,
   store+:: {
-    jobPrefix: error 'must provide job prefix for Thanos Store alerts',
     selector: error 'must provide selector for Thanos Store alerts',
     grpcErrorThreshold: 5,
     compactionErrorThreshold: 5,


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

Remove jobPrefix from the thanos mixin, as it's not used anywhere.

## Verification

After removing the field from the libs I did a `grep -r 'jobPrefix' mixin/thanos/alerts` to confirm it's really not used anywhere.

---
Not sure if this needs a CHANELOG entry? 🤔 