### PR TITLE
.*: Don't report "object not found" as error for Get/GetRange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 - [#2254](https://github.com/thanos-io/thanos/pull/2254) Bucket: Fix metrics registered multiple times in bucket replicate
 - [#2271](https://github.com/thanos-io/thanos/pull/2271) Bucket Web: Fixed Issue #2260 bucket passes null when storage is empty
 - [#2339](https://github.com/thanos-io/thanos/pull/2339) Query: fix a bug where `--store.unhealthy-timeout` was never respected
+- [#2365](https://github.com/thanos-io/thanos/pull/2365) .*: don't report "object not found" error as failure via `thanos_objstore_bucket_operation_failures_total` for `get` and `get_range` operations.
 
 ### Added
 

--- a/pkg/objstore/objstore.go
+++ b/pkg/objstore/objstore.go
@@ -276,7 +276,9 @@ func (b *metricBucket) Get(ctx context.Context, name string) (io.ReadCloser, err
 
 	rc, err := b.bkt.Get(ctx, name)
 	if err != nil {
-		b.opsFailures.WithLabelValues(getOp).Inc()
+		if !b.bkt.IsObjNotFoundErr(err) {
+			b.opsFailures.WithLabelValues(getOp).Inc()
+		}
 		return nil, err
 	}
 	return newTimingReadCloser(
@@ -292,7 +294,9 @@ func (b *metricBucket) GetRange(ctx context.Context, name string, off, length in
 
 	rc, err := b.bkt.GetRange(ctx, name, off, length)
 	if err != nil {
-		b.opsFailures.WithLabelValues(getRangeOp).Inc()
+		if !b.bkt.IsObjNotFoundErr(err) {
+			b.opsFailures.WithLabelValues(getRangeOp).Inc()
+		}
 		return nil, err
 	}
 	return newTimingReadCloser(


### PR DESCRIPTION
* [x] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

Don't treat "object not found" as failures when reporting metrics for Get/GetRange operations.

Recently introduced `IgnoreDeletionMarkFilter` uses Get operation to check if block is marked for deletion, and since many blocks are not, bucket store returns "object not found" error. Since `metricBucket` reports this as failed operation, it looks as if there were many failed operations. But this is expected outcome for Get/GetRange, so I don't think it should be reported as failure.

Alternatively, we can modify `IgnoreDeletionMarkFilter` to check for file first, but that would require two operations.

## Verification

See decreased number of reported failures `thanos_objstore_bucket_operation_failures_total` for `Get` operation.