### PR TITLE
Ignore GCS in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -231,7 +231,7 @@ test: check-git install-deps
 
 .PHONY: test-ci
 test-ci: ## Runs test for CI, so excluding object storage integrations that we don't have configured yet.
-test-ci: export THANOS_TEST_OBJSTORE_SKIP=AZURE,SWIFT,COS,ALIYUNOSS
+test-ci: export THANOS_TEST_OBJSTORE_SKIP=AZURE,SWIFT,COS,ALIYUNOSS,GCS
 test-ci:
 	@echo ">> Skipping ${THANOS_TEST_OBJSTORE_SKIP} tests"
 	$(MAKE) test


### PR DESCRIPTION
We got booted from the GCS account, so skip this in CI for now.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>

cc @thanos-io/thanos-maintainers 