### PR TITLE
objstore: Added WithExpectedErrs which allows to control instrumentation (e.g not increment failures for expected not found).

### DIFF
--- a/cmd/thanos/main_test.go
+++ b/cmd/thanos/main_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/thanos-io/thanos/pkg/block/metadata"
 	"github.com/thanos-io/thanos/pkg/compact"
 	"github.com/thanos-io/thanos/pkg/compact/downsample"
-	"github.com/thanos-io/thanos/pkg/objstore/inmem"
+	"github.com/thanos-io/thanos/pkg/objstore"
 	"github.com/thanos-io/thanos/pkg/testutil"
 	"github.com/thanos-io/thanos/pkg/testutil/e2eutil"
 )
@@ -36,7 +36,7 @@ func TestCleanupIndexCacheFolder(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	bkt := inmem.NewBucket()
+	bkt := objstore.WithNoopInstr(objstore.NewInMemBucket())
 
 	// Upload one compaction lvl = 2 block, one compaction lvl = 1.
 	// We generate index cache files only for lvl > 1 blocks.
@@ -97,7 +97,7 @@ func TestCleanupDownsampleCacheFolder(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	bkt := inmem.NewBucket()
+	bkt := objstore.WithNoopInstr(objstore.NewInMemBucket())
 	var id ulid.ULID
 	{
 		id, err = e2eutil.CreateBlock(

--- a/pkg/block/block_test.go
+++ b/pkg/block/block_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/go-kit/kit/log"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/thanos-io/thanos/pkg/block/metadata"
-	"github.com/thanos-io/thanos/pkg/objstore/inmem"
+	"github.com/thanos-io/thanos/pkg/objstore"
 	"github.com/thanos-io/thanos/pkg/testutil"
 	"github.com/thanos-io/thanos/pkg/testutil/e2eutil"
 
@@ -81,7 +81,7 @@ func TestUpload(t *testing.T) {
 	testutil.Ok(t, err)
 	defer func() { testutil.Ok(t, os.RemoveAll(tmpDir)) }()
 
-	bkt := inmem.NewBucket()
+	bkt := objstore.NewInMemBucket()
 	b1, err := e2eutil.CreateBlock(ctx, tmpDir, []labels.Labels{
 		{{Name: "a", Value: "1"}},
 		{{Name: "a", Value: "2"}},
@@ -185,7 +185,7 @@ func TestDelete(t *testing.T) {
 	testutil.Ok(t, err)
 	defer func() { testutil.Ok(t, os.RemoveAll(tmpDir)) }()
 
-	bkt := inmem.NewBucket()
+	bkt := objstore.NewInMemBucket()
 	{
 		b1, err := e2eutil.CreateBlock(ctx, tmpDir, []labels.Labels{
 			{{Name: "a", Value: "1"}},
@@ -232,7 +232,7 @@ func TestMarkForDeletion(t *testing.T) {
 	testutil.Ok(t, err)
 	defer func() { testutil.Ok(t, os.RemoveAll(tmpDir)) }()
 
-	bkt := inmem.NewBucket()
+	bkt := objstore.NewInMemBucket()
 	{
 		blockWithoutDeletionMark, err := e2eutil.CreateBlock(ctx, tmpDir, []labels.Labels{
 			{{Name: "a", Value: "1"}},

--- a/pkg/block/fetcher_test.go
+++ b/pkg/block/fetcher_test.go
@@ -75,7 +75,7 @@ func TestMetaFetcher_Fetch(t *testing.T) {
 
 		var ulidToDelete ulid.ULID
 		r := prometheus.NewRegistry()
-		baseFetcher, err := NewBaseFetcher(log.NewNopLogger(), 20, bkt, dir, r)
+		baseFetcher, err := NewBaseFetcher(log.NewNopLogger(), 20, objstore.WithNoopInstr(bkt), dir, r)
 		testutil.Ok(t, err)
 
 		fetcher := baseFetcher.NewMetaFetcher(r, []MetadataFilter{
@@ -1065,7 +1065,7 @@ func TestIgnoreDeletionMarkFilter_Filter(t *testing.T) {
 		now := time.Now()
 		f := &IgnoreDeletionMarkFilter{
 			logger: log.NewNopLogger(),
-			bkt:    bkt,
+			bkt:    objstore.WithNoopInstr(bkt),
 			delay:  48 * time.Hour,
 		}
 

--- a/pkg/block/indexheader/json_reader.go
+++ b/pkg/block/indexheader/json_reader.go
@@ -199,7 +199,7 @@ type JSONReader struct {
 }
 
 // NewJSONReader loads or builds new index-cache.json if not present on disk or object storage.
-func NewJSONReader(ctx context.Context, logger log.Logger, bkt objstore.BucketReader, dir string, id ulid.ULID) (*JSONReader, error) {
+func NewJSONReader(ctx context.Context, logger log.Logger, bkt objstore.InstrumentedBucketReader, dir string, id ulid.ULID) (*JSONReader, error) {
 	cachefn := filepath.Join(dir, id.String(), block.IndexCacheFilename)
 	jr, err := newFileJSONReader(logger, cachefn)
 	if err == nil {
@@ -216,7 +216,7 @@ func NewJSONReader(ctx context.Context, logger log.Logger, bkt objstore.BucketRe
 	}
 
 	// Try to download index cache file from object store.
-	if err = objstore.DownloadFile(ctx, logger, bkt, filepath.Join(id.String(), block.IndexCacheFilename), cachefn); err == nil {
+	if err = objstore.DownloadFile(ctx, logger, bkt.ReaderWithExpectedErrs(bkt.IsObjNotFoundErr), filepath.Join(id.String(), block.IndexCacheFilename), cachefn); err == nil {
 		return newFileJSONReader(logger, cachefn)
 	}
 

--- a/pkg/block/metadata/deletionmark.go
+++ b/pkg/block/metadata/deletionmark.go
@@ -45,10 +45,10 @@ type DeletionMark struct {
 }
 
 // ReadDeletionMark reads the given deletion mark file from <dir>/deletion-mark.json in bucket.
-func ReadDeletionMark(ctx context.Context, bkt objstore.BucketReader, logger log.Logger, dir string) (*DeletionMark, error) {
+func ReadDeletionMark(ctx context.Context, bkt objstore.InstrumentedBucketReader, logger log.Logger, dir string) (*DeletionMark, error) {
 	deletionMarkFile := path.Join(dir, DeletionMarkFilename)
 
-	r, err := bkt.Get(ctx, deletionMarkFile)
+	r, err := bkt.ReaderWithExpectedErrs(bkt.IsObjNotFoundErr).Get(ctx, deletionMarkFile)
 	if err != nil {
 		if bkt.IsObjNotFoundErr(err) {
 			return nil, ErrorDeletionMarkNotFound

--- a/pkg/block/metadata/deletionmark_test.go
+++ b/pkg/block/metadata/deletionmark_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/fortytw2/leaktest"
 	"github.com/oklog/ulid"
 	"github.com/pkg/errors"
-	"github.com/thanos-io/thanos/pkg/objstore/inmem"
+	"github.com/thanos-io/thanos/pkg/objstore"
 	"github.com/thanos-io/thanos/pkg/testutil"
 )
 
@@ -29,7 +29,7 @@ func TestReadDeletionMark(t *testing.T) {
 	testutil.Ok(t, err)
 	defer func() { testutil.Ok(t, os.RemoveAll(tmpDir)) }()
 
-	bkt := inmem.NewBucket()
+	bkt := objstore.WithNoopInstr(objstore.NewInMemBucket())
 	{
 		blockWithoutDeletionMark := ulid.MustNew(uint64(1), nil)
 		_, err := ReadDeletionMark(ctx, bkt, nil, path.Join(tmpDir, blockWithoutDeletionMark.String()))

--- a/pkg/compact/clean_test.go
+++ b/pkg/compact/clean_test.go
@@ -18,7 +18,7 @@ import (
 	promtest "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/thanos-io/thanos/pkg/block"
 	"github.com/thanos-io/thanos/pkg/block/metadata"
-	"github.com/thanos-io/thanos/pkg/objstore/inmem"
+	"github.com/thanos-io/thanos/pkg/objstore"
 	"github.com/thanos-io/thanos/pkg/testutil"
 )
 
@@ -26,7 +26,7 @@ func TestBestEffortCleanAbortedPartialUploads(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	bkt := inmem.NewBucket()
+	bkt := objstore.WithNoopInstr(objstore.NewInMemBucket())
 	logger := log.NewNopLogger()
 
 	metaFetcher, err := block.NewMetaFetcher(nil, 32, bkt, "", nil, nil, nil)

--- a/pkg/compact/compact_e2e_test.go
+++ b/pkg/compact/compact_e2e_test.go
@@ -90,7 +90,7 @@ func TestSyncer_GarbageCollect_e2e(t *testing.T) {
 		}
 
 		duplicateBlocksFilter := block.NewDeduplicateFilter()
-		metaFetcher, err := block.NewMetaFetcher(nil, 32, bkt, "", nil, []block.MetadataFilter{
+		metaFetcher, err := block.NewMetaFetcher(nil, 32, objstore.WithNoopInstr(bkt), "", nil, []block.MetadataFilter{
 			duplicateBlocksFilter,
 		}, nil)
 		testutil.Ok(t, err)
@@ -176,9 +176,9 @@ func TestGroup_Compact_e2e(t *testing.T) {
 
 		reg := prometheus.NewRegistry()
 
-		ignoreDeletionMarkFilter := block.NewIgnoreDeletionMarkFilter(logger, bkt, 48*time.Hour)
+		ignoreDeletionMarkFilter := block.NewIgnoreDeletionMarkFilter(logger, objstore.WithNoopInstr(bkt), 48*time.Hour)
 		duplicateBlocksFilter := block.NewDeduplicateFilter()
-		metaFetcher, err := block.NewMetaFetcher(nil, 32, bkt, "", nil, []block.MetadataFilter{
+		metaFetcher, err := block.NewMetaFetcher(nil, 32, objstore.WithNoopInstr(bkt), "", nil, []block.MetadataFilter{
 			ignoreDeletionMarkFilter,
 			duplicateBlocksFilter,
 		}, nil)

--- a/pkg/compact/retention_test.go
+++ b/pkg/compact/retention_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/thanos-io/thanos/pkg/block/metadata"
 	"github.com/thanos-io/thanos/pkg/compact"
 	"github.com/thanos-io/thanos/pkg/objstore"
-	"github.com/thanos-io/thanos/pkg/objstore/inmem"
 	"github.com/thanos-io/thanos/pkg/testutil"
 )
 
@@ -240,7 +239,7 @@ func TestApplyRetentionPolicyByResolution(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			bkt := inmem.NewBucket()
+			bkt := objstore.WithNoopInstr(objstore.NewInMemBucket())
 			for _, b := range tt.blocks {
 				uploadMockBlock(t, bkt, b.id, b.minTime, b.maxTime, int64(b.resolution))
 			}

--- a/pkg/objstore/azure/azure.go
+++ b/pkg/objstore/azure/azure.go
@@ -64,7 +64,7 @@ func (conf *Config) validate() error {
 	return nil
 }
 
-// NewBucket returns a new Bucket using the provided Azure config.
+// NewInMemBucket returns a new Bucket using the provided Azure config.
 func NewBucket(logger log.Logger, azureConfig []byte, component string) (*Bucket, error) {
 	level.Debug(logger).Log("msg", "creating new Azure bucket connection", "component", component)
 

--- a/pkg/objstore/client/factory.go
+++ b/pkg/objstore/client/factory.go
@@ -40,9 +40,9 @@ type BucketConfig struct {
 	Config interface{} `yaml:"config"`
 }
 
-// NewBucket initializes and returns new object storage clients.
+// NewInMemBucket initializes and returns new object storage clients.
 // NOTE: confContentYaml can contain secrets.
-func NewBucket(logger log.Logger, confContentYaml []byte, reg prometheus.Registerer, component string) (objstore.Bucket, error) {
+func NewBucket(logger log.Logger, confContentYaml []byte, reg prometheus.Registerer, component string) (objstore.InstrumentedBucket, error) {
 	level.Info(logger).Log("msg", "loading bucket configuration")
 	bucketConf := &BucketConfig{}
 	if err := yaml.UnmarshalStrict(confContentYaml, bucketConf); err != nil {

--- a/pkg/objstore/filesystem/filesystem.go
+++ b/pkg/objstore/filesystem/filesystem.go
@@ -43,7 +43,7 @@ func NewBucketFromConfig(conf []byte) (*Bucket, error) {
 	return NewBucket(c.Directory)
 }
 
-// NewBucket returns a new filesystem.Bucket.
+// NewInMemBucket returns a new filesystem.Bucket.
 func NewBucket(rootDir string) (*Bucket, error) {
 	absDir, err := filepath.Abs(rootDir)
 	if err != nil {

--- a/pkg/objstore/gcs/gcs.go
+++ b/pkg/objstore/gcs/gcs.go
@@ -41,7 +41,7 @@ type Bucket struct {
 	closer io.Closer
 }
 
-// NewBucket returns a new Bucket against the given bucket handle.
+// NewInMemBucket returns a new Bucket against the given bucket handle.
 func NewBucket(ctx context.Context, logger log.Logger, conf []byte, component string) (*Bucket, error) {
 	var gc Config
 	if err := yaml.Unmarshal(conf, &gc); err != nil {

--- a/pkg/objstore/inmem.go
+++ b/pkg/objstore/inmem.go
@@ -1,7 +1,7 @@
 // Copyright (c) The Thanos Authors.
 // Licensed under the Apache License 2.0.
 
-package inmem
+package objstore
 
 import (
 	"bytes"
@@ -13,37 +13,36 @@ import (
 	"sync"
 
 	"github.com/pkg/errors"
-	"github.com/thanos-io/thanos/pkg/objstore"
 )
 
 var errNotFound = errors.New("inmem: object not found")
 
 // Bucket implements the objstore.Bucket interfaces against local memory.
 // Methods from Bucket interface are thread-safe. Objects are assumed to be immutable.
-type Bucket struct {
+type InMemBucket struct {
 	mtx     sync.RWMutex
 	objects map[string][]byte
 }
 
-// NewBucket returns a new in memory Bucket.
+// NewInMemBucket returns a new in memory Bucket.
 // NOTE: Returned bucket is just a naive in memory bucket implementation. For test use cases only.
-func NewBucket() *Bucket {
-	return &Bucket{objects: map[string][]byte{}}
+func NewInMemBucket() *InMemBucket {
+	return &InMemBucket{objects: map[string][]byte{}}
 }
 
 // Objects returns internally stored objects.
 // NOTE: For assert purposes.
-func (b *Bucket) Objects() map[string][]byte {
+func (b *InMemBucket) Objects() map[string][]byte {
 	return b.objects
 }
 
 // Iter calls f for each entry in the given directory. The argument to f is the full
 // object name including the prefix of the inspected directory.
-func (b *Bucket) Iter(_ context.Context, dir string, f func(string) error) error {
+func (b *InMemBucket) Iter(_ context.Context, dir string, f func(string) error) error {
 	unique := map[string]struct{}{}
 
 	var dirPartsCount int
-	dirParts := strings.SplitAfter(dir, objstore.DirDelim)
+	dirParts := strings.SplitAfter(dir, DirDelim)
 	for _, p := range dirParts {
 		if p == "" {
 			continue
@@ -57,7 +56,7 @@ func (b *Bucket) Iter(_ context.Context, dir string, f func(string) error) error
 			continue
 		}
 
-		parts := strings.SplitAfter(filename, objstore.DirDelim)
+		parts := strings.SplitAfter(filename, DirDelim)
 		unique[strings.Join(parts[:dirPartsCount+1], "")] = struct{}{}
 	}
 	b.mtx.RUnlock()
@@ -67,13 +66,13 @@ func (b *Bucket) Iter(_ context.Context, dir string, f func(string) error) error
 		keys = append(keys, n)
 	}
 	sort.Slice(keys, func(i, j int) bool {
-		if strings.HasSuffix(keys[i], objstore.DirDelim) && strings.HasSuffix(keys[j], objstore.DirDelim) {
+		if strings.HasSuffix(keys[i], DirDelim) && strings.HasSuffix(keys[j], DirDelim) {
 			return strings.Compare(keys[i], keys[j]) < 0
 		}
-		if strings.HasSuffix(keys[i], objstore.DirDelim) {
+		if strings.HasSuffix(keys[i], DirDelim) {
 			return false
 		}
-		if strings.HasSuffix(keys[j], objstore.DirDelim) {
+		if strings.HasSuffix(keys[j], DirDelim) {
 			return true
 		}
 
@@ -89,7 +88,7 @@ func (b *Bucket) Iter(_ context.Context, dir string, f func(string) error) error
 }
 
 // Get returns a reader for the given object name.
-func (b *Bucket) Get(_ context.Context, name string) (io.ReadCloser, error) {
+func (b *InMemBucket) Get(_ context.Context, name string) (io.ReadCloser, error) {
 	if name == "" {
 		return nil, errors.New("inmem: object name is empty")
 	}
@@ -105,7 +104,7 @@ func (b *Bucket) Get(_ context.Context, name string) (io.ReadCloser, error) {
 }
 
 // GetRange returns a new range reader for the given object name and range.
-func (b *Bucket) GetRange(_ context.Context, name string, off, length int64) (io.ReadCloser, error) {
+func (b *InMemBucket) GetRange(_ context.Context, name string, off, length int64) (io.ReadCloser, error) {
 	if name == "" {
 		return nil, errors.New("inmem: object name is empty")
 	}
@@ -138,7 +137,7 @@ func (b *Bucket) GetRange(_ context.Context, name string, off, length int64) (io
 }
 
 // Exists checks if the given directory exists in memory.
-func (b *Bucket) Exists(_ context.Context, name string) (bool, error) {
+func (b *InMemBucket) Exists(_ context.Context, name string) (bool, error) {
 	b.mtx.RLock()
 	defer b.mtx.RUnlock()
 	_, ok := b.objects[name]
@@ -146,7 +145,7 @@ func (b *Bucket) Exists(_ context.Context, name string) (bool, error) {
 }
 
 // ObjectSize returns the size of the specified object.
-func (b *Bucket) ObjectSize(_ context.Context, name string) (uint64, error) {
+func (b *InMemBucket) ObjectSize(_ context.Context, name string) (uint64, error) {
 	b.mtx.RLock()
 	file, ok := b.objects[name]
 	b.mtx.RUnlock()
@@ -157,7 +156,7 @@ func (b *Bucket) ObjectSize(_ context.Context, name string) (uint64, error) {
 }
 
 // Upload writes the file specified in src to into the memory.
-func (b *Bucket) Upload(_ context.Context, name string, r io.Reader) error {
+func (b *InMemBucket) Upload(_ context.Context, name string, r io.Reader) error {
 	b.mtx.Lock()
 	defer b.mtx.Unlock()
 	body, err := ioutil.ReadAll(r)
@@ -169,7 +168,7 @@ func (b *Bucket) Upload(_ context.Context, name string, r io.Reader) error {
 }
 
 // Delete removes all data prefixed with the dir.
-func (b *Bucket) Delete(_ context.Context, name string) error {
+func (b *InMemBucket) Delete(_ context.Context, name string) error {
 	b.mtx.Lock()
 	defer b.mtx.Unlock()
 	if _, ok := b.objects[name]; !ok {
@@ -180,13 +179,13 @@ func (b *Bucket) Delete(_ context.Context, name string) error {
 }
 
 // IsObjNotFoundErr returns true if error means that object is not found. Relevant to Get operations.
-func (b *Bucket) IsObjNotFoundErr(err error) bool {
-	return err == errNotFound
+func (b *InMemBucket) IsObjNotFoundErr(err error) bool {
+	return errors.Cause(err) == errNotFound
 }
 
-func (b *Bucket) Close() error { return nil }
+func (b *InMemBucket) Close() error { return nil }
 
 // Name returns the bucket name.
-func (b *Bucket) Name() string {
+func (b *InMemBucket) Name() string {
 	return "inmem"
 }

--- a/pkg/objstore/objstore_test.go
+++ b/pkg/objstore/objstore_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
 package objstore
 
 import (

--- a/pkg/objstore/objstore_test.go
+++ b/pkg/objstore/objstore_test.go
@@ -1,0 +1,61 @@
+package objstore
+
+import (
+	"testing"
+
+	promtest "github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/thanos-io/thanos/pkg/testutil"
+)
+
+func TestMetricBucket_Close(t *testing.T) {
+	bkt := BucketWithMetrics("abc", NewInMemBucket(), nil)
+	// Expected initialized metrics.
+	testutil.Equals(t, 7, promtest.CollectAndCount(bkt.ops))
+	testutil.Equals(t, 7, promtest.CollectAndCount(bkt.opsFailures))
+	testutil.Equals(t, 7, promtest.CollectAndCount(bkt.opsDuration))
+
+	AcceptanceTest(t, bkt.WithExpectedErrs(bkt.IsObjNotFoundErr))
+	testutil.Equals(t, float64(6), promtest.ToFloat64(bkt.ops.WithLabelValues(iterOp)))
+	testutil.Equals(t, float64(2), promtest.ToFloat64(bkt.ops.WithLabelValues(sizeOp)))
+	testutil.Equals(t, float64(3), promtest.ToFloat64(bkt.ops.WithLabelValues(getOp)))
+	testutil.Equals(t, float64(3), promtest.ToFloat64(bkt.ops.WithLabelValues(getRangeOp)))
+	testutil.Equals(t, float64(2), promtest.ToFloat64(bkt.ops.WithLabelValues(existsOp)))
+	testutil.Equals(t, float64(6), promtest.ToFloat64(bkt.ops.WithLabelValues(uploadOp)))
+	testutil.Equals(t, float64(2), promtest.ToFloat64(bkt.ops.WithLabelValues(deleteOp)))
+	testutil.Equals(t, 7, promtest.CollectAndCount(bkt.ops))
+	testutil.Equals(t, float64(0), promtest.ToFloat64(bkt.opsFailures.WithLabelValues(iterOp)))
+	testutil.Equals(t, float64(0), promtest.ToFloat64(bkt.opsFailures.WithLabelValues(sizeOp)))
+	testutil.Equals(t, float64(1), promtest.ToFloat64(bkt.opsFailures.WithLabelValues(getOp)))
+	testutil.Equals(t, float64(0), promtest.ToFloat64(bkt.opsFailures.WithLabelValues(getRangeOp)))
+	testutil.Equals(t, float64(0), promtest.ToFloat64(bkt.opsFailures.WithLabelValues(existsOp)))
+	testutil.Equals(t, float64(0), promtest.ToFloat64(bkt.opsFailures.WithLabelValues(uploadOp)))
+	testutil.Equals(t, float64(0), promtest.ToFloat64(bkt.opsFailures.WithLabelValues(deleteOp)))
+	testutil.Equals(t, 7, promtest.CollectAndCount(bkt.opsFailures))
+	testutil.Equals(t, 7, promtest.CollectAndCount(bkt.opsDuration))
+	lastUpload := promtest.ToFloat64(bkt.lastSuccessfulUploadTime)
+	testutil.Assert(t, lastUpload > 0, "last upload not greater than 0, val: %f", lastUpload)
+
+	// Clear bucket, but don't clear metrics to ensure we use same.
+	bkt.bkt = NewInMemBucket()
+	AcceptanceTest(t, bkt)
+	testutil.Equals(t, float64(12), promtest.ToFloat64(bkt.ops.WithLabelValues(iterOp)))
+	testutil.Equals(t, float64(4), promtest.ToFloat64(bkt.ops.WithLabelValues(sizeOp)))
+	testutil.Equals(t, float64(6), promtest.ToFloat64(bkt.ops.WithLabelValues(getOp)))
+	testutil.Equals(t, float64(6), promtest.ToFloat64(bkt.ops.WithLabelValues(getRangeOp)))
+	testutil.Equals(t, float64(4), promtest.ToFloat64(bkt.ops.WithLabelValues(existsOp)))
+	testutil.Equals(t, float64(12), promtest.ToFloat64(bkt.ops.WithLabelValues(uploadOp)))
+	testutil.Equals(t, float64(4), promtest.ToFloat64(bkt.ops.WithLabelValues(deleteOp)))
+	testutil.Equals(t, 7, promtest.CollectAndCount(bkt.ops))
+	testutil.Equals(t, float64(0), promtest.ToFloat64(bkt.opsFailures.WithLabelValues(iterOp)))
+	// Not expected not found error here.
+	testutil.Equals(t, float64(1), promtest.ToFloat64(bkt.opsFailures.WithLabelValues(sizeOp)))
+	// Not expected not found errors, this should increment failure metric on get for not found as well, so +2.
+	testutil.Equals(t, float64(3), promtest.ToFloat64(bkt.opsFailures.WithLabelValues(getOp)))
+	testutil.Equals(t, float64(0), promtest.ToFloat64(bkt.opsFailures.WithLabelValues(getRangeOp)))
+	testutil.Equals(t, float64(0), promtest.ToFloat64(bkt.opsFailures.WithLabelValues(existsOp)))
+	testutil.Equals(t, float64(0), promtest.ToFloat64(bkt.opsFailures.WithLabelValues(uploadOp)))
+	testutil.Equals(t, float64(0), promtest.ToFloat64(bkt.opsFailures.WithLabelValues(deleteOp)))
+	testutil.Equals(t, 7, promtest.CollectAndCount(bkt.opsFailures))
+	testutil.Equals(t, 7, promtest.CollectAndCount(bkt.opsDuration))
+	testutil.Assert(t, promtest.ToFloat64(bkt.lastSuccessfulUploadTime) > lastUpload)
+}

--- a/pkg/objstore/objtesting/acceptance_e2e_test.go
+++ b/pkg/objstore/objtesting/acceptance_e2e_test.go
@@ -4,14 +4,9 @@
 package objtesting
 
 import (
-	"context"
-	"io/ioutil"
-	"sort"
-	"strings"
 	"testing"
 
 	"github.com/thanos-io/thanos/pkg/objstore"
-	"github.com/thanos-io/thanos/pkg/testutil"
 )
 
 // TestObjStoreAcceptanceTest_e2e tests all known implementation against interface behaviour contract we agreed on.
@@ -19,142 +14,5 @@ import (
 // NOTE: This test assumes strong consistency, but in the same way it does not guarantee that if it passes, the
 // used object store is strongly consistent.
 func TestObjStore_AcceptanceTest_e2e(t *testing.T) {
-	ForeachStore(t, func(t *testing.T, bkt objstore.Bucket) {
-		ctx := context.Background()
-
-		_, err := bkt.Get(ctx, "")
-		testutil.NotOk(t, err)
-		testutil.Assert(t, !bkt.IsObjNotFoundErr(err), "expected user error got not found %s", err)
-
-		_, err = bkt.Get(ctx, "id1/obj_1.some")
-		testutil.NotOk(t, err)
-		testutil.Assert(t, bkt.IsObjNotFoundErr(err), "expected not found error got %s", err)
-
-		ok, err := bkt.Exists(ctx, "id1/obj_1.some")
-		testutil.Ok(t, err)
-		testutil.Assert(t, !ok, "expected not exits")
-
-		_, err = bkt.ObjectSize(ctx, "id1/obj_1.some")
-		testutil.NotOk(t, err)
-		testutil.Assert(t, bkt.IsObjNotFoundErr(err), "expected not found error but got %s", err)
-
-		// Upload first object.
-		testutil.Ok(t, bkt.Upload(ctx, "id1/obj_1.some", strings.NewReader("@test-data@")))
-
-		// Double check we can immediately read it.
-		rc1, err := bkt.Get(ctx, "id1/obj_1.some")
-		testutil.Ok(t, err)
-		defer func() { testutil.Ok(t, rc1.Close()) }()
-		content, err := ioutil.ReadAll(rc1)
-		testutil.Ok(t, err)
-		testutil.Equals(t, "@test-data@", string(content))
-
-		// Check if we can get the correct size.
-		sz, err := bkt.ObjectSize(ctx, "id1/obj_1.some")
-		testutil.Ok(t, err)
-		testutil.Assert(t, sz == 11, "expected size to be equal to 11")
-
-		rc2, err := bkt.GetRange(ctx, "id1/obj_1.some", 1, 3)
-		testutil.Ok(t, err)
-		defer func() { testutil.Ok(t, rc2.Close()) }()
-		content, err = ioutil.ReadAll(rc2)
-		testutil.Ok(t, err)
-		testutil.Equals(t, "tes", string(content))
-
-		// Unspecified range with offset.
-		rcUnspecifiedLen, err := bkt.GetRange(ctx, "id1/obj_1.some", 1, -1)
-		testutil.Ok(t, err)
-		defer func() { testutil.Ok(t, rcUnspecifiedLen.Close()) }()
-		content, err = ioutil.ReadAll(rcUnspecifiedLen)
-		testutil.Ok(t, err)
-		testutil.Equals(t, "test-data@", string(content))
-
-		// Out of band offset. Do not rely on outcome.
-		// NOTE: For various providers we have different outcome.
-		// * GCS is giving 416 status code
-		// * S3 errors immdiately with invalid range error.
-		// * inmem and filesystem are returning 0 bytes.
-		//rcOffset, err := bkt.GetRange(ctx, "id1/obj_1.some", 124141, 3)
-
-		// Out of band length. We expect to read file fully.
-		rcLength, err := bkt.GetRange(ctx, "id1/obj_1.some", 3, 9999)
-		testutil.Ok(t, err)
-		defer func() { testutil.Ok(t, rcLength.Close()) }()
-		content, err = ioutil.ReadAll(rcLength)
-		testutil.Ok(t, err)
-		testutil.Equals(t, "st-data@", string(content))
-
-		ok, err = bkt.Exists(ctx, "id1/obj_1.some")
-		testutil.Ok(t, err)
-		testutil.Assert(t, ok, "expected exits")
-
-		// Upload other objects.
-		testutil.Ok(t, bkt.Upload(ctx, "id1/obj_2.some", strings.NewReader("@test-data2@")))
-		// Upload should be idempotent.
-		testutil.Ok(t, bkt.Upload(ctx, "id1/obj_2.some", strings.NewReader("@test-data2@")))
-		testutil.Ok(t, bkt.Upload(ctx, "id1/obj_3.some", strings.NewReader("@test-data3@")))
-		testutil.Ok(t, bkt.Upload(ctx, "id2/obj_4.some", strings.NewReader("@test-data4@")))
-		testutil.Ok(t, bkt.Upload(ctx, "obj_5.some", strings.NewReader("@test-data5@")))
-
-		// Can we iter over items from top dir?
-		var seen []string
-		testutil.Ok(t, bkt.Iter(ctx, "", func(fn string) error {
-			seen = append(seen, fn)
-			return nil
-		}))
-		expected := []string{"obj_5.some", "id1/", "id2/"}
-		sort.Strings(expected)
-		sort.Strings(seen)
-		testutil.Equals(t, expected, seen)
-
-		// Can we iter over items from id1/ dir?
-		seen = []string{}
-		testutil.Ok(t, bkt.Iter(ctx, "id1/", func(fn string) error {
-			seen = append(seen, fn)
-			return nil
-		}))
-		testutil.Equals(t, []string{"id1/obj_1.some", "id1/obj_2.some", "id1/obj_3.some"}, seen)
-
-		// Can we iter over items from id1 dir?
-		seen = []string{}
-		testutil.Ok(t, bkt.Iter(ctx, "id1", func(fn string) error {
-			seen = append(seen, fn)
-			return nil
-		}))
-		testutil.Equals(t, []string{"id1/obj_1.some", "id1/obj_2.some", "id1/obj_3.some"}, seen)
-
-		// Can we iter over items from not existing dir?
-		testutil.Ok(t, bkt.Iter(ctx, "id0", func(fn string) error {
-			t.Error("Not expected to loop through not existing directory")
-			t.FailNow()
-
-			return nil
-		}))
-
-		testutil.Ok(t, bkt.Delete(ctx, "id1/obj_2.some"))
-
-		// Delete is expected to fail on non existing object.
-		// NOTE: Don't rely on this. S3 is not complying with this as GCS is.
-		// testutil.NotOk(t, bkt.Delete(ctx, "id1/obj_2.some"))
-
-		// Can we iter over items from id1/ dir and see obj2 being deleted?
-		seen = []string{}
-		testutil.Ok(t, bkt.Iter(ctx, "id1/", func(fn string) error {
-			seen = append(seen, fn)
-			return nil
-		}))
-		testutil.Equals(t, []string{"id1/obj_1.some", "id1/obj_3.some"}, seen)
-
-		testutil.Ok(t, bkt.Delete(ctx, "id2/obj_4.some"))
-
-		seen = []string{}
-		testutil.Ok(t, bkt.Iter(ctx, "", func(fn string) error {
-			seen = append(seen, fn)
-			return nil
-		}))
-		expected = []string{"obj_5.some", "id1/"}
-		sort.Strings(expected)
-		sort.Strings(seen)
-		testutil.Equals(t, expected, seen)
-	})
+	ForeachStore(t, objstore.AcceptanceTest)
 }

--- a/pkg/objstore/objtesting/foreach.go
+++ b/pkg/objstore/objtesting/foreach.go
@@ -16,7 +16,6 @@ import (
 	"github.com/thanos-io/thanos/pkg/objstore/azure"
 	"github.com/thanos-io/thanos/pkg/objstore/cos"
 	"github.com/thanos-io/thanos/pkg/objstore/gcs"
-	"github.com/thanos-io/thanos/pkg/objstore/inmem"
 	"github.com/thanos-io/thanos/pkg/objstore/oss"
 	"github.com/thanos-io/thanos/pkg/objstore/s3"
 	"github.com/thanos-io/thanos/pkg/objstore/swift"
@@ -48,7 +47,7 @@ func ForeachStore(t *testing.T, testFn func(t *testing.T, bkt objstore.Bucket)) 
 
 	// Mandatory Inmem. Not parallel, to detect problem early.
 	if ok := t.Run("inmem", func(t *testing.T) {
-		testFn(t, inmem.NewBucket())
+		testFn(t, objstore.NewInMemBucket())
 	}); !ok {
 		return
 	}

--- a/pkg/objstore/oss/oss.go
+++ b/pkg/objstore/oss/oss.go
@@ -150,7 +150,7 @@ func (b *Bucket) ObjectSize(ctx context.Context, name string) (uint64, error) {
 	return 0, errors.New("content-length header not found")
 }
 
-// NewBucket returns a new Bucket using the provided oss config values.
+// NewInMemBucket returns a new Bucket using the provided oss config values.
 func NewBucket(logger log.Logger, conf []byte, component string) (*Bucket, error) {
 	var config Config
 	if err := yaml.Unmarshal(conf, &config); err != nil {

--- a/pkg/objstore/s3/s3.go
+++ b/pkg/objstore/s3/s3.go
@@ -93,7 +93,7 @@ func parseConfig(conf []byte) (Config, error) {
 	return config, nil
 }
 
-// NewBucket returns a new Bucket using the provided s3 config values.
+// NewInMemBucket returns a new Bucket using the provided s3 config values.
 func NewBucket(logger log.Logger, conf []byte, component string) (*Bucket, error) {
 	config, err := parseConfig(conf)
 	if err != nil {

--- a/pkg/objstore/testing.go
+++ b/pkg/objstore/testing.go
@@ -5,10 +5,28 @@ package objstore
 
 import (
 	"context"
+	"fmt"
+	"io/ioutil"
+	"math/rand"
+	"sort"
 	"strings"
 	"sync"
 	"testing"
+	"time"
+
+	"github.com/thanos-io/thanos/pkg/testutil"
 )
+
+func CreateTemporaryTestBucketName(t testing.TB) string {
+	src := rand.NewSource(time.Now().UnixNano())
+
+	// Bucket name need to conform: https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-s3-bucket-naming-requirements.html.
+	name := strings.Replace(strings.Replace(fmt.Sprintf("test_%x_%s", src.Int63(), strings.ToLower(t.Name())), "_", "-", -1), "/", "-", -1)
+	if len(name) >= 63 {
+		name = name[:63]
+	}
+	return name
+}
 
 // EmptyBucket deletes all objects from bucket. This operation is required to properly delete bucket as a whole.
 // It is used for testing only.
@@ -43,4 +61,159 @@ func EmptyBucket(t testing.TB, ctx context.Context, bkt Bucket) {
 		}
 	}
 	wg.Wait()
+}
+
+func WithNoopInstr(bkt Bucket) InstrumentedBucket {
+	return noopInstrumentedBucket{Bucket: bkt}
+}
+
+type noopInstrumentedBucket struct {
+	Bucket
+}
+
+func (b noopInstrumentedBucket) WithExpectedErrs(IsOpFailureExpectedFunc) Bucket {
+	return b
+}
+
+func (b noopInstrumentedBucket) ReaderWithExpectedErrs(IsOpFailureExpectedFunc) BucketReader {
+	return b
+}
+
+func AcceptanceTest(t *testing.T, bkt Bucket) {
+	ctx := context.Background()
+
+	_, err := bkt.Get(ctx, "")
+	testutil.NotOk(t, err)
+	testutil.Assert(t, !bkt.IsObjNotFoundErr(err), "expected user error got not found %s", err)
+
+	_, err = bkt.Get(ctx, "id1/obj_1.some")
+	testutil.NotOk(t, err)
+	testutil.Assert(t, bkt.IsObjNotFoundErr(err), "expected not found error got %s", err)
+
+	ok, err := bkt.Exists(ctx, "id1/obj_1.some")
+	testutil.Ok(t, err)
+	testutil.Assert(t, !ok, "expected not exits")
+
+	_, err = bkt.ObjectSize(ctx, "id1/obj_1.some")
+	testutil.NotOk(t, err)
+	testutil.Assert(t, bkt.IsObjNotFoundErr(err), "expected not found error but got %s", err)
+
+	// Upload first object.
+	testutil.Ok(t, bkt.Upload(ctx, "id1/obj_1.some", strings.NewReader("@test-data@")))
+
+	// Double check we can immediately read it.
+	rc1, err := bkt.Get(ctx, "id1/obj_1.some")
+	testutil.Ok(t, err)
+	defer func() { testutil.Ok(t, rc1.Close()) }()
+	content, err := ioutil.ReadAll(rc1)
+	testutil.Ok(t, err)
+	testutil.Equals(t, "@test-data@", string(content))
+
+	// Check if we can get the correct size.
+	sz, err := bkt.ObjectSize(ctx, "id1/obj_1.some")
+	testutil.Ok(t, err)
+	testutil.Assert(t, sz == 11, "expected size to be equal to 11")
+
+	rc2, err := bkt.GetRange(ctx, "id1/obj_1.some", 1, 3)
+	testutil.Ok(t, err)
+	defer func() { testutil.Ok(t, rc2.Close()) }()
+	content, err = ioutil.ReadAll(rc2)
+	testutil.Ok(t, err)
+	testutil.Equals(t, "tes", string(content))
+
+	// Unspecified range with offset.
+	rcUnspecifiedLen, err := bkt.GetRange(ctx, "id1/obj_1.some", 1, -1)
+	testutil.Ok(t, err)
+	defer func() { testutil.Ok(t, rcUnspecifiedLen.Close()) }()
+	content, err = ioutil.ReadAll(rcUnspecifiedLen)
+	testutil.Ok(t, err)
+	testutil.Equals(t, "test-data@", string(content))
+
+	// Out of band offset. Do not rely on outcome.
+	// NOTE: For various providers we have different outcome.
+	// * GCS is giving 416 status code
+	// * S3 errors immdiately with invalid range error.
+	// * inmem and filesystem are returning 0 bytes.
+	//rcOffset, err := bkt.GetRange(ctx, "id1/obj_1.some", 124141, 3)
+
+	// Out of band length. We expect to read file fully.
+	rcLength, err := bkt.GetRange(ctx, "id1/obj_1.some", 3, 9999)
+	testutil.Ok(t, err)
+	defer func() { testutil.Ok(t, rcLength.Close()) }()
+	content, err = ioutil.ReadAll(rcLength)
+	testutil.Ok(t, err)
+	testutil.Equals(t, "st-data@", string(content))
+
+	ok, err = bkt.Exists(ctx, "id1/obj_1.some")
+	testutil.Ok(t, err)
+	testutil.Assert(t, ok, "expected exits")
+
+	// Upload other objects.
+	testutil.Ok(t, bkt.Upload(ctx, "id1/obj_2.some", strings.NewReader("@test-data2@")))
+	// Upload should be idempotent.
+	testutil.Ok(t, bkt.Upload(ctx, "id1/obj_2.some", strings.NewReader("@test-data2@")))
+	testutil.Ok(t, bkt.Upload(ctx, "id1/obj_3.some", strings.NewReader("@test-data3@")))
+	testutil.Ok(t, bkt.Upload(ctx, "id2/obj_4.some", strings.NewReader("@test-data4@")))
+	testutil.Ok(t, bkt.Upload(ctx, "obj_5.some", strings.NewReader("@test-data5@")))
+
+	// Can we iter over items from top dir?
+	var seen []string
+	testutil.Ok(t, bkt.Iter(ctx, "", func(fn string) error {
+		seen = append(seen, fn)
+		return nil
+	}))
+	expected := []string{"obj_5.some", "id1/", "id2/"}
+	sort.Strings(expected)
+	sort.Strings(seen)
+	testutil.Equals(t, expected, seen)
+
+	// Can we iter over items from id1/ dir?
+	seen = []string{}
+	testutil.Ok(t, bkt.Iter(ctx, "id1/", func(fn string) error {
+		seen = append(seen, fn)
+		return nil
+	}))
+	testutil.Equals(t, []string{"id1/obj_1.some", "id1/obj_2.some", "id1/obj_3.some"}, seen)
+
+	// Can we iter over items from id1 dir?
+	seen = []string{}
+	testutil.Ok(t, bkt.Iter(ctx, "id1", func(fn string) error {
+		seen = append(seen, fn)
+		return nil
+	}))
+	testutil.Equals(t, []string{"id1/obj_1.some", "id1/obj_2.some", "id1/obj_3.some"}, seen)
+
+	// Can we iter over items from not existing dir?
+	testutil.Ok(t, bkt.Iter(ctx, "id0", func(fn string) error {
+		t.Error("Not expected to loop through not existing directory")
+		t.FailNow()
+
+		return nil
+	}))
+
+	testutil.Ok(t, bkt.Delete(ctx, "id1/obj_2.some"))
+
+	// Delete is expected to fail on non existing object.
+	// NOTE: Don't rely on this. S3 is not complying with this as GCS is.
+	// testutil.NotOk(t, bkt.Delete(ctx, "id1/obj_2.some"))
+
+	// Can we iter over items from id1/ dir and see obj2 being deleted?
+	seen = []string{}
+	testutil.Ok(t, bkt.Iter(ctx, "id1/", func(fn string) error {
+		seen = append(seen, fn)
+		return nil
+	}))
+	testutil.Equals(t, []string{"id1/obj_1.some", "id1/obj_3.some"}, seen)
+
+	testutil.Ok(t, bkt.Delete(ctx, "id2/obj_4.some"))
+
+	seen = []string{}
+	testutil.Ok(t, bkt.Iter(ctx, "", func(fn string) error {
+		seen = append(seen, fn)
+		return nil
+	}))
+	expected = []string{"obj_5.some", "id1/"}
+	sort.Strings(expected)
+	sort.Strings(seen)
+	testutil.Equals(t, expected, seen)
 }

--- a/pkg/shipper/shipper_e2e_test.go
+++ b/pkg/shipper/shipper_e2e_test.go
@@ -15,7 +15,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/thanos-io/thanos/pkg/objstore/inmem"
 	"github.com/thanos-io/thanos/pkg/testutil/e2eutil"
 
 	"github.com/go-kit/kit/log"
@@ -180,7 +179,7 @@ func TestShipper_SyncBlocksWithMigrating_e2e(t *testing.T) {
 			testutil.Ok(t, os.RemoveAll(dir))
 		}()
 
-		bkt := inmem.NewBucket()
+		bkt := objstore.NewInMemBucket()
 
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -221,7 +221,7 @@ type FilterConfig struct {
 type BucketStore struct {
 	logger     log.Logger
 	metrics    *bucketStoreMetrics
-	bkt        objstore.BucketReader
+	bkt        objstore.InstrumentedBucketReader
 	fetcher    block.MetadataFetcher
 	dir        string
 	indexCache storecache.IndexCache
@@ -260,7 +260,7 @@ type BucketStore struct {
 func NewBucketStore(
 	logger log.Logger,
 	reg prometheus.Registerer,
-	bucket objstore.BucketReader,
+	bkt objstore.InstrumentedBucketReader,
 	fetcher block.MetadataFetcher,
 	dir string,
 	indexCache storecache.IndexCache,
@@ -290,7 +290,7 @@ func NewBucketStore(
 	metrics := newBucketStoreMetrics(reg)
 	s := &BucketStore{
 		logger:               logger,
-		bkt:                  bucket,
+		bkt:                  bkt,
 		fetcher:              fetcher,
 		dir:                  dir,
 		indexCache:           indexCache,

--- a/pkg/store/bucket_e2e_test.go
+++ b/pkg/store/bucket_e2e_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/thanos-io/thanos/pkg/block/metadata"
 	"github.com/thanos-io/thanos/pkg/model"
 	"github.com/thanos-io/thanos/pkg/objstore"
-	"github.com/thanos-io/thanos/pkg/objstore/inmem"
 	"github.com/thanos-io/thanos/pkg/objstore/objtesting"
 	storecache "github.com/thanos-io/thanos/pkg/store/cache"
 	"github.com/thanos-io/thanos/pkg/store/storepb"
@@ -147,7 +146,7 @@ func prepareStoreWithTestBlocks(t testing.TB, dir string, bkt objstore.Bucket, m
 		maxTime: maxTime,
 	}
 
-	metaFetcher, err := block.NewMetaFetcher(s.logger, 20, bkt, dir, nil, []block.MetadataFilter{
+	metaFetcher, err := block.NewMetaFetcher(s.logger, 20, objstore.WithNoopInstr(bkt), dir, nil, []block.MetadataFilter{
 		block.NewTimePartitionMetaFilter(filterConf.MinTime, filterConf.MaxTime),
 		block.NewLabelShardedMetaFilter(relabelConfig),
 	}, nil)
@@ -156,7 +155,7 @@ func prepareStoreWithTestBlocks(t testing.TB, dir string, bkt objstore.Bucket, m
 	store, err := NewBucketStore(
 		s.logger,
 		nil,
-		bkt,
+		objstore.WithNoopInstr(bkt),
 		metaFetcher,
 		dir,
 		s.cache,
@@ -497,7 +496,7 @@ func TestBucketStore_ManyParts_e2e(t *testing.T) {
 func TestBucketStore_TimePartitioning_e2e(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	bkt := inmem.NewBucket()
+	bkt := objstore.NewInMemBucket()
 
 	dir, err := ioutil.TempDir("", "test_bucket_time_part_e2e")
 	testutil.Ok(t, err)

--- a/pkg/store/bucket_test.go
+++ b/pkg/store/bucket_test.go
@@ -43,7 +43,6 @@ import (
 	"github.com/thanos-io/thanos/pkg/compact/downsample"
 	"github.com/thanos-io/thanos/pkg/objstore"
 	"github.com/thanos-io/thanos/pkg/objstore/filesystem"
-	"github.com/thanos-io/thanos/pkg/objstore/inmem"
 	"github.com/thanos-io/thanos/pkg/pool"
 	storecache "github.com/thanos-io/thanos/pkg/store/cache"
 	"github.com/thanos-io/thanos/pkg/store/storepb"
@@ -526,7 +525,7 @@ func TestBucketStore_Sharding(t *testing.T) {
 	testutil.Ok(t, err)
 	defer func() { testutil.Ok(t, os.RemoveAll(dir)) }()
 
-	bkt := inmem.NewBucket()
+	bkt := objstore.NewInMemBucket()
 	series := []labels.Labels{labels.FromStrings("a", "1", "b", "1")}
 
 	id1, err := e2eutil.CreateBlock(ctx, dir, series, 10, 0, 1000, labels.Labels{{Name: "cluster", Value: "a"}, {Name: "region", Value: "r1"}}, 0)
@@ -711,7 +710,7 @@ func testSharding(t *testing.T, reuseDisk string, bkt objstore.Bucket, all ...ul
 			testutil.Ok(t, yaml.Unmarshal([]byte(sc.relabel), &relabelConf))
 
 			rec := &recorder{Bucket: bkt}
-			metaFetcher, err := block.NewMetaFetcher(logger, 20, bkt, dir, nil, []block.MetadataFilter{
+			metaFetcher, err := block.NewMetaFetcher(logger, 20, objstore.WithNoopInstr(bkt), dir, nil, []block.MetadataFilter{
 				block.NewTimePartitionMetaFilter(allowAllFilterConf.MinTime, allowAllFilterConf.MaxTime),
 				block.NewLabelShardedMetaFilter(relabelConf),
 			}, nil)
@@ -720,7 +719,7 @@ func testSharding(t *testing.T, reuseDisk string, bkt objstore.Bucket, all ...ul
 			bucketStore, err := NewBucketStore(
 				logger,
 				nil,
-				rec,
+				objstore.WithNoopInstr(rec),
 				metaFetcher,
 				dir,
 				noopCache{},
@@ -813,7 +812,7 @@ func expectedTouchedBlockOps(all []ulid.ULID, expected []ulid.ULID, cached []uli
 
 // Regression tests against: https://github.com/thanos-io/thanos/issues/1983.
 func TestReadIndexCache_LoadSeries(t *testing.T) {
-	bkt := inmem.NewBucket()
+	bkt := objstore.NewInMemBucket()
 
 	s := newBucketStoreMetrics(nil)
 	b := &bucketBlock{
@@ -1310,7 +1309,7 @@ func benchSeries(t testutil.TB, number int, dimension Dimension, cases ...int) {
 	}
 
 	store := &BucketStore{
-		bkt:        bkt,
+		bkt:        objstore.WithNoopInstr(bkt),
 		logger:     logger,
 		indexCache: noopCache{},
 		metrics:    newBucketStoreMetrics(nil),
@@ -1551,7 +1550,7 @@ func TestSeries_OneBlock_InMemIndexCacheSegfault(t *testing.T) {
 	}
 
 	store := &BucketStore{
-		bkt:        bkt,
+		bkt:        objstore.WithNoopInstr(bkt),
 		logger:     logger,
 		indexCache: indexCache,
 		metrics:    newBucketStoreMetrics(nil),

--- a/pkg/testutil/testutil.go
+++ b/pkg/testutil/testutil.go
@@ -18,6 +18,7 @@ import (
 
 // Assert fails the test if the condition is false.
 func Assert(tb testing.TB, condition bool, v ...interface{}) {
+	tb.Helper()
 	if condition {
 		return
 	}
@@ -27,11 +28,12 @@ func Assert(tb testing.TB, condition bool, v ...interface{}) {
 	if len(v) > 0 {
 		msg = fmt.Sprintf(v[0].(string), v[1:]...)
 	}
-	tb.Fatalf("\033[31m%s:%d: "+msg+"\033[39m\n\n", append([]interface{}{filepath.Base(file), line}, v...)...)
+	tb.Fatalf("\033[31m%s:%d: "+msg+"\033[39m\n\n", filepath.Base(file), line)
 }
 
 // Ok fails the test if an err is not nil.
 func Ok(tb testing.TB, err error, v ...interface{}) {
+	tb.Helper()
 	if err == nil {
 		return
 	}
@@ -46,6 +48,7 @@ func Ok(tb testing.TB, err error, v ...interface{}) {
 
 // NotOk fails the test if an err is nil.
 func NotOk(tb testing.TB, err error, v ...interface{}) {
+	tb.Helper()
 	if err != nil {
 		return
 	}
@@ -60,6 +63,7 @@ func NotOk(tb testing.TB, err error, v ...interface{}) {
 
 // Equals fails the test if exp is not equal to act.
 func Equals(tb testing.TB, exp, act interface{}, v ...interface{}) {
+	tb.Helper()
 	if reflect.DeepEqual(exp, act) {
 		return
 	}


### PR DESCRIPTION
This 3rd alternative to below PRs that was discussed offline: https://cloud-native.slack.com/archives/CL25937SP/p1585903230146500

Closes https://github.com/thanos-io/thanos/pull/2365 and https://github.com/thanos-io/thanos/pull/2369

This allows to not wake up on-call in the middle of the night, because of the expected, properly handled case (:

Thanks @pracucci and @pstibrany for starting this work and discussion. We were aware of this for like 12 months, but only with your discussions, we clarified what is expected here :hugs:  Your input was super valuable.

## Changes

Added new interface:

```go
type InstrumentedBucket interface {
	Bucket

	// WithExpectedErrs allows to specify a filter that marks certain errors as expected, so it will not wake up
	// on-call engineer (:
	WithExpectedErrs(IsOpFailureExpectedFunc) Bucket
```

Also: Has to move inmem to objstore for testing.

Signed-off-by: Bartlomiej Plotka <bwplotka@gmail.com>
