### PR TITLE
Revert "Makefile: ignore GCS in CI (#2368)"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -231,7 +231,7 @@ test: check-git install-deps
 
 .PHONY: test-ci
 test-ci: ## Runs test for CI, so excluding object storage integrations that we don't have configured yet.
-test-ci: export THANOS_TEST_OBJSTORE_SKIP=AZURE,SWIFT,COS,ALIYUNOSS,GCS
+test-ci: export THANOS_TEST_OBJSTORE_SKIP=AZURE,SWIFT,COS,ALIYUNOSS
 test-ci:
 	@echo ">> Skipping ${THANOS_TEST_OBJSTORE_SKIP} tests"
 	$(MAKE) test


### PR DESCRIPTION
This reverts commit 8591434856ced5803e399b4d9d1bf2d1459c0ee0.

No need, I updated the GCS project, should work now against new account.

