### PR TITLE
docs: Update S3 endpoint mapping link

### DIFF
--- a/docs/storage.md
+++ b/docs/storage.md
@@ -97,7 +97,7 @@ config:
 
 At a minimum, you will need to provide a value for the `bucket`, `endpoint`, `access_key`, and `secret_key` keys. The rest of the keys are optional.
 
-The AWS region to endpoint mapping can be found in this [link](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region).
+The AWS region to endpoint mapping can be found in this [link](https://docs.aws.amazon.com/general/latest/gr/s3.html).
 
 Make sure you use a correct signature version. Currently AWS requires signature v4, so it needs `signature-version2: false`. If you don't specify it, you will get an `Access Denied` error. On the other hand, several S3 compatible APIs use `signature-version2: true`.
 


### PR DESCRIPTION
The link for the AWS Region Endpoint Mappings for S3 was out of date, this PR updates it to point to the new location.

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

Updated S3 Endpoint Mapping link in the documentation.

## Verification

Link is rendered correctly in https://deploy-preview-2377--thanos-io.netlify.com/storage.md/#s3.
