### PR TITLE
Add reminder label to stale bot config

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -12,7 +12,9 @@ onlyLabels: []
 
 # Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable.
 # We want stale bot to notify us that something is stale so we can revisit it.
-exemptLabels: []
+# If one issue is marked as 'reminder' by the reminder bot, we don't mark it as 'stale' again.
+exemptLabels:
+  - reminder
 
 # Set to true to ignore issues in a project (defaults to false)
 exemptProjects: false


### PR DESCRIPTION
Signed-off-by: yeya24 <yb532204897@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

Based on the discussion in #2262, we want to add a [reminder bot](https://github.com/probot/reminders) to mark stale issues for a customized time period. 

This PR just adds a `reminder` label to stale bot config, after this is merged, we can install [reminder bot](https://github.com/probot/reminders) and see if it fulfills our requirements.

## Verification

<!-- How you tested it? How do you know it works? -->
