### PR TITLE
Fix markdown docs style and link in the sharding doc

### DIFF
--- a/docs/sharding.md
+++ b/docs/sharding.md
@@ -22,14 +22,18 @@ This means that with time you might want to scale out certain components e.g:
 
 # Relabelling
 
-Similar to [promtail](https://github.com/grafana/loki/blob/master/docs/promtail.md#scrape-configs) this config will follow native
+Similar to [promtail](https://github.com/grafana/loki/blob/master/docs/clients/promtail/configuration.md#relabel_config) this config will follow native
 [Prometheus relabel-config](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config) syntax.
 
 Now, thanos only support following relabel actions:
+
 * keep
+
 * drop
+
 * hashmod
     * `external labels` for all components
+
     * `__block_id` for store gateway, see this [example](https://github.com/observatorium/configuration/blob/bf1304b0d7bce2ae3fefa80412bb358f9aa176fb/environments/openshift/manifests/observatorium-template.yaml#L1514-L1521)
 
 The relabel config defines filtering process done on **every** synchronization with object storage.


### PR DESCRIPTION
Signed-off-by: yeya24 <yb532204897@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [X] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->
- Update the promtail link
- We also support the default `replace` relabel action
- Fix the markdown style issue in the website


## Verification

<!-- How you tested it? How do you know it works? -->

Before: https://thanos.io/sharding.md/

After: https://deploy-preview-2379--thanos-io.netlify.com/sharding.md/
