### PR TITLE
pkge/receive: trace TSDB ingestion

### DIFF
--- a/pkg/receive/writer.go
+++ b/pkg/receive/writer.go
@@ -12,6 +12,7 @@ import (
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/storage"
 	terrors "github.com/prometheus/prometheus/tsdb/errors"
+
 	"github.com/thanos-io/thanos/pkg/store/storepb/prompb"
 )
 


### PR DESCRIPTION
This commit adds a tracing span around the writing of remote-write
requests into TSDB. This will help us differentiate between the
latencies in the forwarding of requests around the hashring and the
latencies of appending to the database.

This commit also removes the `thanos_` prefix from the forwarding span
to better align with the span naming in the rest of the project.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>

* [x] Change is not relevant to the end user.