### PR TITLE
store: Fixed critical bug, when certain not-existing values queried was causing "invalid size" error inside binary index-header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 - [#2319](https://github.com/thanos-io/thanos/pull/2319) Query: fixed inconsistent naming of metrics.
 - [#2390](https://github.com/thanos-io/thanos/pull/2390) Store: Fixed bug which was causing all posting offsets to be used instead of 1/32 as it was meant.
 Added hidden flag to control this behavior.
+- [#2393](https://github.com/thanos-io/thanos/pull/2393) Store: Fixed bug causing certain not-existing label values queried to fail with "invalid-size" error from binary header.
 
 ### Added
 


### PR DESCRIPTION
The reason, why we could not reproduce it locally, was that for most of non-existing values, we were lucky that buffer was still long enough and we could read and decode some (malformed) variadic type. For certain rare cases, the buffer was not long enough or varint was failing.

Fixed and spotted thanks to amazing @mkabischev!

* Added more regression tests for the binary header.

Without the fix it fails with:
```
            header_test.go:154: header_test.go:154:

                	exp: range not found

                	got: get postings offset entry: invalid size
```

Signed-off-by: Bartlomiej Plotka <bwplotka@gmail.com>
