### PR TITLE
rule: Add metric exposing the amount of rules loaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 - [#2304](https://github.com/thanos-io/thanos/pull/2304) Store: Added `max_item_size` config option to memcached-based index cache. This should be set to the max item size configured in memcached (`-I` flag) in order to not waste network round-trips to cache items larger than the limit configured in memcached.
 - [#2297](https://github.com/thanos-io/thanos/pull/2297) Store Gateway: Add `--experimental.enable-index-cache-postings-compression` flag to enable reencoding and compressing postings before storing them into cache. Compressed postings take about 10% of the original size.
 - [#2357](https://github.com/thanos-io/thanos/pull/2357) Compactor and Store Gateway now have serve BucketUI on `:<http-port>/loaded` and shows exactly the blocks that are currently seen by compactor and store gateway. Compactor also serves different BucketUI on `:<http-port>/global` that shows the status of object storage without any filters.
+- [#2394](https://github.com/thanos-io/thanos/pull/2394) Rule: Add `thanos_rule_rules_loaded` metric exposing the amount of rules loaded.
 
 ### Changed
 

--- a/cmd/thanos/rule.go
+++ b/cmd/thanos/rule.go
@@ -401,7 +401,7 @@ func runRule(
 	// Run rule evaluation and alert notifications.
 	var (
 		alertQ  = alert.NewQueue(logger, reg, 10000, 100, labelsTSDBToProm(lset), alertExcludeLabels)
-		ruleMgr = thanosrule.NewManager(dataDir)
+		ruleMgr = thanosrule.NewManager(reg, dataDir)
 	)
 	{
 		notify := func(ctx context.Context, expr string, alerts ...*rules.Alert) {

--- a/pkg/rule/rule_test.go
+++ b/pkg/rule/rule_test.go
@@ -65,7 +65,7 @@ groups:
 		},
 		Appendable: nopAppendable{},
 	}
-	thanosRuleMgr := NewManager(dir)
+	thanosRuleMgr := NewManager(nil, dir)
 	ruleMgr := rules.NewManager(&opts)
 	thanosRuleMgr.SetRuleManager(storepb.PartialResponseStrategy_ABORT, ruleMgr)
 	thanosRuleMgr.SetRuleManager(storepb.PartialResponseStrategy_WARN, ruleMgr)
@@ -151,7 +151,7 @@ groups:
 	opts := rules.ManagerOptions{
 		Logger: log.NewLogfmtLogger(os.Stderr),
 	}
-	m := NewManager(dir)
+	m := NewManager(nil, dir)
 	m.SetRuleManager(storepb.PartialResponseStrategy_ABORT, rules.NewManager(&opts))
 	m.SetRuleManager(storepb.PartialResponseStrategy_WARN, rules.NewManager(&opts))
 


### PR DESCRIPTION
* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Add gauge metric that exposes the amount of rules loaded by the rule manager. I went with the gaugefunc strategy and actual rules as opposed to rule files as in theory there could be an empty rule file (or just empty rule group) and the alert would falsely fire in that case.

If people prefer I'm also happy to point this at the 0.12 release, but I'm also fine with waiting for 0.13.

Related to https://github.com/thanos-io/thanos/issues/2391. With this metric we could make the alert more stable as described in the issue.

## Verification

`curl`ed the metrics endpoint and the metric was there :) 

@thanos-io/thanos-maintainers 

cc @lilic 