### PR TITLE
mixin: Change critical rule alert to be symptom based

### DIFF
--- a/examples/alerts/alerts.md
+++ b/examples/alerts/alerts.md
@@ -181,13 +181,14 @@ rules:
   for: 5m
   labels:
     severity: info
-- alert: ThanosRuleTSDBNotIngestingSamples
+- alert: ThanosNoRuleEvaluations
   annotations:
-    message: Thanos Rule {{$labels.job}} did not ingest any samples for the last 15
-      minutes.
+    message: Thanos Rule {{$labels.job}} did not perform any rule evaluations in the
+      past 2 minutes.
   expr: |
-    sum by (job) (rate(prometheus_tsdb_head_samples_appended_total{job=~"thanos-rule.*"}[5m])) <= 0
-  for: 10m
+    sum(rate(prometheus_rule_evaluations_total{job=~"thanos-rule.*"}[2m])) <= 0
+      and
+    sum(thanos_rule_loaded_rules{job=~"thanos-rule.*"}) > 0
   labels:
     severity: critical
 ```

--- a/examples/alerts/alerts.yaml
+++ b/examples/alerts/alerts.yaml
@@ -400,13 +400,14 @@ groups:
     for: 5m
     labels:
       severity: info
-  - alert: ThanosRuleTSDBNotIngestingSamples
+  - alert: ThanosNoRuleEvaluations
     annotations:
-      message: Thanos Rule {{$labels.job}} did not ingest any samples for the last
-        15 minutes.
+      message: Thanos Rule {{$labels.job}} did not perform any rule evaluations in
+        the past 2 minutes.
     expr: |
-      sum by (job) (rate(prometheus_tsdb_head_samples_appended_total{job=~"thanos-rule.*"}[5m])) <= 0
-    for: 10m
+      sum(rate(prometheus_rule_evaluations_total{job=~"thanos-rule.*"}[2m])) <= 0
+        and
+      sum(thanos_rule_loaded_rules{job=~"thanos-rule.*"}) > 0
     labels:
       severity: critical
 - name: thanos-component-absent.rules

--- a/mixin/thanos/alerts/rule.libsonnet
+++ b/mixin/thanos/alerts/rule.libsonnet
@@ -171,15 +171,15 @@
             },
           },
           {
-            // NOTE: This alert will give false positive if no rules are configured.
-            alert: 'ThanosRuleTSDBNotIngestingSamples',
+            alert: 'ThanosNoRuleEvaluations',
             annotations: {
-              message: 'Thanos Rule {{$labels.job}} did not ingest any samples for the last 15 minutes.',
+              message: 'Thanos Rule {{$labels.job}} did not perform any rule evaluations in the past 2 minutes.',
             },
             expr: |||
-              sum by (job) (rate(prometheus_tsdb_head_samples_appended_total{%(selector)s}[5m])) <= 0
+              sum(rate(prometheus_rule_evaluations_total{%(selector)s}[2m])) <= 0
+                and
+              sum(thanos_rule_loaded_rules{%(selector)s}) > 0
             ||| % thanos.rule,
-            'for': '10m',
             labels: {
               severity: 'critical',
             },


### PR DESCRIPTION
* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

This change makes the critical (typically paging) alert more symptom
based, rather than observing data written to disk. Additionally after
this change the alert will only fire if there are actually rules loaded.

Additionally to no rules loaded the previous alert was also prone to rules that legitimately are not writing data.

Fixes https://github.com/thanos-io/thanos/issues/2391

## Verification

Verified against an incident we had, plus verified that this doesn't fire against a Thanos Rule instance that does not have any rules loaded.

@thanos-io/thanos-maintainers @lilic 