### PR TITLE
Query: Add servername to grpc dial options for DNS stores (Fixes #1507)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 
 ## Unreleased
 
+- [#2407](https://github.com/thanos-io/thanos/pull/2407) Query: Add servername to grpc dial options for DNS stores (Fixes #1507)
+
 ### Fixed
 
 - [#2288](https://github.com/thanos-io/thanos/pull/2288) Ruler: Fixes issue #2281 bug in ruler with parsing query addr with path prefix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 
 ## Unreleased
 
-- [#2407](https://github.com/thanos-io/thanos/pull/2407) Query: Add servername to grpc dial options for DNS stores (Fixes #1507)
+- [#2407](https://github.com/thanos-io/thanos/pull/2407) Query: Add servername to gRPC dial options for DNS stores (Fixes #1507)
 
 ### Fixed
 

--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -56,7 +56,7 @@ func registerQuery(m map[string]setupFunc, app *kingpin.Application) {
 	key := cmd.Flag("grpc-client-tls-key", "TLS Key for the client's certificate").Default("").String()
 	caCert := cmd.Flag("grpc-client-tls-ca", "TLS CA Certificates to use to verify gRPC servers").Default("").String()
 	serverName := cmd.Flag("grpc-client-server-name", "Server name to verify the hostname on the returned gRPC certificates. See https://tools.ietf.org/html/rfc4366#section-3.1").Default("").String()
-	dnsServerName := cmd.Flag("grpc-client-dns-server-name", "For stores that are DNS, use the dns name as the server name for connection.  Needed when proxying through nginx, and only applicable if using the secure flag").Default("false").Bool()
+	dnsServerName := cmd.Flag("grpc-client-dns-server-name", "For stores that are DNS, use the dns name as the server name for connection. Only applicable if using the secure flag").Default("false").Bool()
 
 	webRoutePrefix := cmd.Flag("web.route-prefix", "Prefix for API and UI endpoints. This allows thanos UI to be served on a sub-path. This option is analogous to --web.route-prefix of Promethus.").Default("").String()
 	webExternalPrefix := cmd.Flag("web.external-prefix", "Static prefix for all HTML links and redirect URLs in the UI query web interface. Actual endpoints are still served on / or the web.route-prefix. This allows thanos UI to be served behind a reverse proxy that strips a URL sub-path.").Default("").String()

--- a/docs/components/query.md
+++ b/docs/components/query.md
@@ -290,9 +290,8 @@ Flags:
                                  https://tools.ietf.org/html/rfc4366#section-3.1
       --grpc-client-dns-server-name
                                  For stores that are DNS, use the dns name as
-                                 the server name for connection. Needed when
-                                 proxying through nginx, and only applicable if
-                                 using the secure flag
+                                 the server name for connection. Only applicable
+                                 if using the secure flag
       --web.route-prefix=""      Prefix for API and UI endpoints. This allows
                                  thanos UI to be served on a sub-path. This
                                  option is analogous to --web.route-prefix of

--- a/docs/components/query.md
+++ b/docs/components/query.md
@@ -288,6 +288,11 @@ Flags:
                                  Server name to verify the hostname on the
                                  returned gRPC certificates. See
                                  https://tools.ietf.org/html/rfc4366#section-3.1
+      --grpc-client-dns-server-name
+                                 For stores that are DNS, use the dns name as
+                                 the server name for connection. Needed when
+                                 proxying through nginx, and only applicable if
+                                 using the secure flag
       --web.route-prefix=""      Prefix for API and UI endpoints. This allows
                                  thanos UI to be served on a sub-path. This
                                  option is analogous to --web.route-prefix of

--- a/pkg/discovery/dns/provider.go
+++ b/pkg/discovery/dns/provider.go
@@ -150,3 +150,19 @@ func (p *Provider) Addresses() []string {
 	}
 	return result
 }
+
+// ServerName returns the server name for an address
+func (p *Provider) ServerName(addr string) string {
+	p.Lock()
+	defer p.Unlock()
+
+	for name, addrs := range p.resolved {
+		for _, a := range addrs {
+			if addr == a {
+				_, n := GetQTypeName(name)
+				return strings.SplitN(n, ":", 2)[0]
+			}
+		}
+	}
+	return ""
+}

--- a/pkg/discovery/dns/provider.go
+++ b/pkg/discovery/dns/provider.go
@@ -151,7 +151,7 @@ func (p *Provider) Addresses() []string {
 	return result
 }
 
-// ServerName returns the server name for an address
+// ServerName returns the server name for an address.
 func (p *Provider) ServerName(addr string) string {
 	p.Lock()
 	defer p.Unlock()

--- a/pkg/query/storeset.go
+++ b/pkg/query/storeset.go
@@ -40,8 +40,7 @@ type StoreSpec interface {
 	Metadata(ctx context.Context, client storepb.StoreClient) (labelSets []storepb.LabelSet, mint int64, maxt int64, storeType component.StoreAPI, err error)
 	// StrictStatic returns true if the StoreAPI has been statically defined and it is under a strict mode.
 	StrictStatic() bool
-	// ServerName returns StoreAPI ServerName for the store spec.
-	// It is needed to get to a StoreAPI behind an nginx proxy.
+	// ServerName returns the StoreAPI's server name for the store spec.
 	ServerName() string
 }
 
@@ -61,7 +60,7 @@ type grpcStoreSpec struct {
 	serverName   string
 }
 
-// NewGRPCStoreSpecServerName creates store pure gRPC spec with a Server Name.
+// NewGRPCStoreSpecServerName creates store pure gRPC spec with a server name.
 // It uses Info gRPC call to get Metadata.
 func NewGRPCStoreSpecServerName(addr string, strictstatic bool, serverName string) StoreSpec {
 	return &grpcStoreSpec{addr: addr, strictstatic: strictstatic, serverName: serverName}

--- a/pkg/query/storeset.go
+++ b/pkg/query/storeset.go
@@ -41,7 +41,7 @@ type StoreSpec interface {
 	// StrictStatic returns true if the StoreAPI has been statically defined and it is under a strict mode.
 	StrictStatic() bool
 	// ServerName returns StoreAPI ServerName for the store spec.
-	// It is needed to get to a StoreAPI behind an nginx proxy
+	// It is needed to get to a StoreAPI behind an nginx proxy.
 	ServerName() string
 }
 
@@ -449,7 +449,7 @@ func (s *StoreSet) getActiveStores(ctx context.Context, stores map[string]*store
 			if !seenAlready {
 				// New store or was unactive and was removed in the past - create new one.
 				dialOpts := s.dialOpts
-				// Update the dialOpts if we are asked to add dnsServerName
+				// Update the dialOpts if we are asked to add dnsServerName.
 				if s.dnsServerName {
 					tlsCfg, err := tls.NewClientConfig(s.logger, s.cert, s.key, s.caCert, spec.ServerName())
 					if err != nil {

--- a/pkg/query/storeset_test.go
+++ b/pkg/query/storeset_test.go
@@ -184,7 +184,7 @@ func TestStoreSet_Update(t *testing.T) {
 			specs = append(specs, NewGRPCStoreSpec(addr, false))
 		}
 		return specs
-	}, testGRPCOpts, time.Minute)
+	}, testGRPCOpts, time.Minute, false, "", "", "")
 	storeSet.gRPCInfoCallTimeout = 2 * time.Second
 	defer storeSet.Close()
 
@@ -532,7 +532,7 @@ func TestStoreSet_Update_NoneAvailable(t *testing.T) {
 			specs = append(specs, NewGRPCStoreSpec(addr, false))
 		}
 		return specs
-	}, testGRPCOpts, time.Minute)
+	}, testGRPCOpts, time.Minute, false, "", "", "")
 	storeSet.gRPCInfoCallTimeout = 2 * time.Second
 
 	// Should not matter how many of these we run.
@@ -596,7 +596,7 @@ func TestQuerierStrict(t *testing.T) {
 			NewGRPCStoreSpec(st.StoreAddresses()[0], true),
 			NewGRPCStoreSpec(st.StoreAddresses()[1], false),
 		}
-	}, testGRPCOpts, time.Minute)
+	}, testGRPCOpts, time.Minute, false, "", "", "")
 	defer storeSet.Close()
 	storeSet.gRPCInfoCallTimeout = 1 * time.Second
 


### PR DESCRIPTION
Closes #1507 
<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [X] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

To avoid needing a query per remote cluster, get the name to add to
the dial options from the dns provider when making the grpc connection.

## Verification

Building via make docker and running a query against multiple remote query services through nginx proxies.