### PR TITLE
store: proxy: fix queries never timing out bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 - [#2254](https://github.com/thanos-io/thanos/pull/2254) Bucket: Fix metrics registered multiple times in bucket replicate
 - [#2271](https://github.com/thanos-io/thanos/pull/2271) Bucket Web: Fixed Issue #2260 bucket passes null when storage is empty
 - [#2339](https://github.com/thanos-io/thanos/pull/2339) Query: fix a bug where `--store.unhealthy-timeout` was never respected
+- [#2411](https://github.com/thanos-io/thanos/pull/2411) Query: fix a bug where queries might not time out sometimes due to issues with one or more StoreAPIs
 
 ### Added
 

--- a/pkg/store/proxy_test.go
+++ b/pkg/store/proxy_test.go
@@ -463,6 +463,60 @@ func TestProxyStore_SeriesSlowStores(t *testing.T) {
 		expectedWarningsLen int
 	}{
 		{
+			title: "partial response disabled; 1st errors out after some delay; 2nd store is fast",
+			storeAPIs: []Client{
+				&testClient{
+					StoreClient: &mockedStoreAPI{
+						RespSeries: []*storepb.SeriesResponse{
+							storepb.NewWarnSeriesResponse(errors.New("warning")),
+							storeSeriesResponse(t, labels.FromStrings("a", "b"), []sample{{1, 1}, {2, 2}, {3, 3}}),
+						},
+						RespDuration:       2 * time.Second,
+						SlowSeriesIndex:    1,
+						injectedError:      errors.New("test"),
+						injectedErrorIndex: 1,
+					},
+					labelSets: []storepb.LabelSet{{Labels: []storepb.Label{{Name: "ext", Value: "1"}}}},
+					minTime:   1,
+					maxTime:   300,
+				},
+				&testClient{
+					StoreClient: &mockedStoreAPI{
+						RespSeries: []*storepb.SeriesResponse{
+							storepb.NewWarnSeriesResponse(errors.New("warning")),
+							storeSeriesResponse(t, labels.FromStrings("b", "a"), []sample{{4, 1}, {5, 2}, {6, 3}}),
+							storeSeriesResponse(t, labels.FromStrings("b", "a"), []sample{{4, 1}, {5, 2}, {6, 3}}),
+							storeSeriesResponse(t, labels.FromStrings("b", "a"), []sample{{4, 1}, {5, 2}, {6, 3}}),
+							storeSeriesResponse(t, labels.FromStrings("b", "a"), []sample{{4, 1}, {5, 2}, {6, 3}}),
+							storeSeriesResponse(t, labels.FromStrings("b", "a"), []sample{{4, 1}, {5, 2}, {6, 3}}),
+
+							storeSeriesResponse(t, labels.FromStrings("b", "a"), []sample{{4, 1}, {5, 2}, {6, 3}}),
+							storeSeriesResponse(t, labels.FromStrings("b", "a"), []sample{{4, 1}, {5, 2}, {6, 3}}),
+							storeSeriesResponse(t, labels.FromStrings("b", "a"), []sample{{4, 1}, {5, 2}, {6, 3}}),
+							storeSeriesResponse(t, labels.FromStrings("b", "a"), []sample{{4, 1}, {5, 2}, {6, 3}}),
+							storeSeriesResponse(t, labels.FromStrings("b", "a"), []sample{{4, 1}, {5, 2}, {6, 3}}),
+
+							storeSeriesResponse(t, labels.FromStrings("b", "a"), []sample{{4, 1}, {5, 2}, {6, 3}}),
+							storeSeriesResponse(t, labels.FromStrings("b", "a"), []sample{{4, 1}, {5, 2}, {6, 3}}),
+							storeSeriesResponse(t, labels.FromStrings("b", "a"), []sample{{4, 1}, {5, 2}, {6, 3}}),
+							storeSeriesResponse(t, labels.FromStrings("b", "a"), []sample{{4, 1}, {5, 2}, {6, 3}}),
+							storeSeriesResponse(t, labels.FromStrings("b", "a"), []sample{{4, 1}, {5, 2}, {6, 3}}),
+						},
+					},
+					labelSets: []storepb.LabelSet{{Labels: []storepb.Label{{Name: "ext", Value: "1"}}}},
+					minTime:   1,
+					maxTime:   300,
+				},
+			},
+			req: &storepb.SeriesRequest{
+				MinTime:                 1,
+				MaxTime:                 300,
+				Matchers:                []storepb.LabelMatcher{{Name: "ext", Value: "1", Type: storepb.LabelMatcher_EQ}},
+				PartialResponseDisabled: true,
+			},
+			expectedErr: errors.New("test: receive series from test: test"),
+		},
+		{
 			title: "partial response disabled; 1st store is slow, 2nd store is fast;",
 			storeAPIs: []Client{
 				&testClient{
@@ -1349,6 +1403,10 @@ type mockedStoreAPI struct {
 	LastSeriesReq      *storepb.SeriesRequest
 	LastLabelValuesReq *storepb.LabelValuesRequest
 	LastLabelNamesReq  *storepb.LabelNamesRequest
+
+	// injectedError will be injected into Recv() if not nil.
+	injectedError      error
+	injectedErrorIndex int
 }
 
 func (s *mockedStoreAPI) Info(ctx context.Context, req *storepb.InfoRequest, _ ...grpc.CallOption) (*storepb.InfoResponse, error) {
@@ -1358,7 +1416,7 @@ func (s *mockedStoreAPI) Info(ctx context.Context, req *storepb.InfoRequest, _ .
 func (s *mockedStoreAPI) Series(ctx context.Context, req *storepb.SeriesRequest, _ ...grpc.CallOption) (storepb.Store_SeriesClient, error) {
 	s.LastSeriesReq = req
 
-	return &StoreSeriesClient{ctx: ctx, respSet: s.RespSeries, respDur: s.RespDuration, slowSeriesIndex: s.SlowSeriesIndex}, s.RespError
+	return &StoreSeriesClient{injectedErrorIndex: s.injectedErrorIndex, injectedError: s.injectedError, ctx: ctx, respSet: s.RespSeries, respDur: s.RespDuration, slowSeriesIndex: s.SlowSeriesIndex}, s.RespError
 }
 
 func (s *mockedStoreAPI) LabelNames(ctx context.Context, req *storepb.LabelNamesRequest, _ ...grpc.CallOption) (*storepb.LabelNamesResponse, error) {
@@ -1382,11 +1440,17 @@ type StoreSeriesClient struct {
 	respSet         []*storepb.SeriesResponse
 	respDur         time.Duration
 	slowSeriesIndex int
+
+	injectedError      error
+	injectedErrorIndex int
 }
 
 func (c *StoreSeriesClient) Recv() (*storepb.SeriesResponse, error) {
 	if c.respDur != 0 && (c.slowSeriesIndex == c.i || c.slowSeriesIndex == 0) {
 		time.Sleep(c.respDur)
+	}
+	if c.injectedError != nil && (c.injectedErrorIndex == c.i || c.injectedErrorIndex == 0) {
+		return nil, c.injectedError
 	}
 
 	if c.i >= len(c.respSet) {


### PR DESCRIPTION
Closes: https://github.com/thanos-io/thanos/issues/2314

Running `THANOS_ENABLE_STORE_READ_TIMEOUT_TESTS=1 /usr/local/go/bin/go test -v -timeout 60s github.com/thanos-io/thanos/pkg/store -run '^(TestProxyStore_SeriesSlowStores)$'` gives us:

```
=== RUN   TestProxyStore_SeriesSlowStores
=== RUN   TestProxyStore_SeriesSlowStores/partial_response_disabled;_1st_errors_out_after_some_delay;_2nd_store_is_fast
panic: test timed out after 1m0s

goroutine 29 [running]:
testing.(*M).startAlarm.func1()
	/usr/local/go/src/testing/testing.go:1377 +0xdf
created by time.goFunc
	/usr/local/go/src/time/sleep.go:168 +0x44

goroutine 1 [chan receive, 1 minutes]:
testing.(*T).Run(0xc000262400, 0x1a2dff4, 0x1f, 0x1ac4b80, 0x48c301)
	/usr/local/go/src/testing/testing.go:961 +0x377
testing.runTests.func1(0xc000262300)
	/usr/local/go/src/testing/testing.go:1202 +0x78
testing.tRunner(0xc000262300, 0xc000557dc0)
	/usr/local/go/src/testing/testing.go:909 +0xc9
testing.runTests(0xc00000ff40, 0x2a15fc0, 0x26, 0x26, 0x0)
	/usr/local/go/src/testing/testing.go:1200 +0x2a7
testing.(*M).Run(0xc000298780, 0x0)
	/usr/local/go/src/testing/testing.go:1117 +0x176
main.main()
	_testmain.go:122 +0x135

goroutine 19 [syscall, 1 minutes]:
os/signal.signal_recv(0x4612d6)
	/usr/local/go/src/runtime/sigqueue.go:147 +0x9c
os/signal.loop()
	/usr/local/go/src/os/signal/signal_unix.go:23 +0x22
created by os/signal.init.0
	/usr/local/go/src/os/signal/signal_unix.go:29 +0x41

goroutine 41 [select]:
go.opencensus.io/stats/view.(*worker).start(0xc000202500)
	/home/gstatkevicius/go/pkg/mod/go.opencensus.io@v0.22.2/stats/view/worker.go:154 +0x100
created by go.opencensus.io/stats/view.init.0
	/home/gstatkevicius/go/pkg/mod/go.opencensus.io@v0.22.2/stats/view/worker.go:32 +0x57

goroutine 42 [chan receive]:
k8s.io/klog.(*loggingT).flushDaemon(0x2a275e0)
	/home/gstatkevicius/go/pkg/mod/k8s.io/klog@v0.3.1/klog.go:990 +0x8b
created by k8s.io/klog.init.0
	/home/gstatkevicius/go/pkg/mod/k8s.io/klog@v0.3.1/klog.go:404 +0x6c

goroutine 62 [chan receive]:
testing.(*T).Run(0xc000142000, 0x1a74de8, 0x4d, 0xc0001d08e0, 0x1)
	/usr/local/go/src/testing/testing.go:961 +0x377
github.com/thanos-io/thanos/pkg/store.TestProxyStore_SeriesSlowStores(0xc000262400)
	/home/gstatkevicius/dev/thanos/pkg/store/proxy_test.go:938 +0x8990
testing.tRunner(0xc000262400, 0x1ac4b80)
	/usr/local/go/src/testing/testing.go:909 +0xc9
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:960 +0x350

goroutine 63 [chan receive]:
github.com/thanos-io/thanos/pkg/store.(*ProxyStore).Series(0xc00017a050, 0xc0001537a0, 0x1dc1ec0, 0xc000153da0, 0xc000153d40, 0xc0001d0980)
	/home/gstatkevicius/dev/thanos/pkg/store/proxy.go:305 +0x3d0
github.com/thanos-io/thanos/pkg/store.TestProxyStore_SeriesSlowStores.func1(0xc000142000)
	/home/gstatkevicius/dev/thanos/pkg/store/proxy_test.go:952 +0x21f
testing.tRunner(0xc000142000, 0xc0001d08e0)
	/usr/local/go/src/testing/testing.go:909 +0xc9
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:960 +0x350

goroutine 64 [semacquire]:
sync.runtime_Semacquire(0xc00016a048)
	/usr/local/go/src/runtime/sema.go:56 +0x42
sync.(*WaitGroup).Wait(0xc00016a040)
	/usr/local/go/src/sync/waitgroup.go:130 +0x64
github.com/thanos-io/thanos/pkg/store.(*ProxyStore).Series.func1.1(0xc00016a040, 0xc0001d09a0)
	/home/gstatkevicius/dev/thanos/pkg/store/proxy.go:240 +0x2b
github.com/thanos-io/thanos/pkg/store.(*ProxyStore).Series.func1(0x1d64860, 0xc000160660)
	/home/gstatkevicius/dev/thanos/pkg/store/proxy.go:302 +0x7c3
golang.org/x/sync/errgroup.(*Group).Go.func1(0xc0001df200, 0xc00017a140)
	/home/gstatkevicius/go/pkg/mod/golang.org/x/sync@v0.0.0-20190911185100-cd5d95a43a6e/errgroup/errgroup.go:57 +0x64
created by golang.org/x/sync/errgroup.(*Group).Go
	/home/gstatkevicius/go/pkg/mod/golang.org/x/sync@v0.0.0-20190911185100-cd5d95a43a6e/errgroup/errgroup.go:54 +0x66

goroutine 98 [chan send]:
github.com/thanos-io/thanos/pkg/store.startStreamSeriesSet.func1(0xc00016a040, 0xc0003399e0, 0x1dbd4e0, 0xc000153ce0, 0x1da8de0, 0xc0001df380)
	/home/gstatkevicius/dev/thanos/pkg/store/proxy.go:437 +0x3d9
created by github.com/thanos-io/thanos/pkg/store.startStreamSeriesSet
	/home/gstatkevicius/dev/thanos/pkg/store/proxy.go:384 +0x1b3

goroutine 99 [select]:
github.com/thanos-io/thanos/pkg/store.startStreamSeriesSet.func1.2(0xc0003399e0, 0xc0000564e0, 0xc000056480)
	/home/gstatkevicius/dev/thanos/pkg/store/proxy.go:400 +0x138
created by github.com/thanos-io/thanos/pkg/store.startStreamSeriesSet.func1
	/home/gstatkevicius/dev/thanos/pkg/store/proxy.go:397 +0x1a8
FAIL	github.com/thanos-io/thanos/pkg/store	60.022s
FAIL
```

Leading to queries which never time out since the deadlock happens in a separate goroutine. 

Situation: partial response is disabled. There are more than 10 responses from one StoreAPI which means that channel operations become blocking. One StoreAPI errors out due to some reason. The goroutine which gets responses from it ends its work, and no one is reading from the channel anymore but the goroutine which handles responses from the "normal" StoreAPI gets stuck forever because no one is reading the messages coming through the channel anymore.

Kudos to @roastiek for the fix here: https://github.com/thanos-io/thanos/issues/2314#issuecomment-611007768. I have spent some time thinking whether this is the right fix and indeed seems like it is. You can find the rationale here: https://github.com/thanos-io/thanos/pull/2411/commits/20bd2aa05c261d0bbeba6a59ca8f4176fa8e4e7e.