### PR TITLE
bucket: "inspect --sort-by" doesn't work in all cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 ## Unreleased
 
 ### Fixed
-
+- [#2416](https://github.com/thanos-io/thanos/pull/2416) Bucket: Fixes issue #2416 bug in `inspect --sort-by` doesn't work correctly in all cases
 - [#2288](https://github.com/thanos-io/thanos/pull/2288) Ruler: Fixes issue #2281 bug in ruler with parsing query addr with path prefix
 - [#2238](https://github.com/thanos-io/thanos/pull/2238) Ruler: Fixed Issue #2204 bug in alert queue signalling filled up queue and alerts were dropped
 - [#2231](https://github.com/thanos-io/thanos/pull/2231) Bucket Web - Sort chunks by thanos.downsample.resolution for better grouping

--- a/cmd/thanos/bucket.go
+++ b/cmd/thanos/bucket.go
@@ -582,10 +582,21 @@ func (t Table) Less(i, j int) bool {
 }
 
 func compare(s1, s2 string) bool {
+	// Values can be either Time, Duration, comma-delimited integers or strings.
 	s1Time, s1Err := time.Parse("02-01-2006 15:04:05", s1)
 	s2Time, s2Err := time.Parse("02-01-2006 15:04:05", s2)
 	if s1Err != nil || s2Err != nil {
-		return s1 < s2
+		s1Duration, s1Err := time.ParseDuration(s1)
+		s2Duration, s2Err := time.ParseDuration(s2)
+		if s1Err != nil || s2Err != nil {
+			s1Int, s1Err := strconv.ParseUint(strings.Replace(s1, ",", "", -1), 10, 64)
+			s2Int, s2Err := strconv.ParseUint(strings.Replace(s2, ",", "", -1), 10, 64)
+			if s1Err != nil || s2Err != nil {
+				return s1 < s2
+			}
+			return s1Int < s2Int
+		}
+		return s1Duration < s2Duration
 	}
 	return s1Time.Before(s2Time)
 }


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->
Fixes #2414 
The compare function used for sorting only checks if the string is `Time` type which causes wrong sorting if the string is `TimeDuration` type.
<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [X] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->
Added extra check to compare `time Duration` type values.

## Verification

<!-- How you tested it? How do you know it works? -->

Manually tested the compare function with different type of strings