### PR TITLE
bucket verify: document that compactor should be disabled

### DIFF
--- a/docs/components/bucket.md
+++ b/docs/components/bucket.md
@@ -172,6 +172,8 @@ Example:
 $ thanos bucket verify --objstore.config-file="..."
 ```
 
+When using the `--repair` option, make sure that the compactor job is disabled first.
+
 [embedmd]: # "flags/bucket_verify.txt"
 
 ```txt


### PR DESCRIPTION
* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

added note to `bucket verify` docs about disabling the compactor when using `--repair`