### PR TITLE
use bytes unit where appropriate on grafana dashboards

### DIFF
--- a/examples/dashboards/compact.json
+++ b/examples/dashboards/compact.json
@@ -1215,7 +1215,7 @@
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "Memory Used (Bytes)",
+               "title": "Memory Used",
                "tooltip": {
                   "shared": false,
                   "sort": 0,
@@ -1231,7 +1231,7 @@
                },
                "yaxes": [
                   {
-                     "format": "short",
+                     "format": "bytes",
                      "label": null,
                      "logBase": 1,
                      "max": null,

--- a/examples/dashboards/query.json
+++ b/examples/dashboards/query.json
@@ -2147,7 +2147,7 @@
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "Memory Used (Bytes)",
+               "title": "Memory Used",
                "tooltip": {
                   "shared": false,
                   "sort": 0,
@@ -2163,7 +2163,7 @@
                },
                "yaxes": [
                   {
-                     "format": "short",
+                     "format": "bytes",
                      "label": null,
                      "logBase": 1,
                      "max": null,

--- a/examples/dashboards/receive.json
+++ b/examples/dashboards/receive.json
@@ -2002,7 +2002,7 @@
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "Memory Used (Bytes)",
+               "title": "Memory Used",
                "tooltip": {
                   "shared": false,
                   "sort": 0,
@@ -2018,7 +2018,7 @@
                },
                "yaxes": [
                   {
-                     "format": "short",
+                     "format": "bytes",
                      "label": null,
                      "logBase": 1,
                      "max": null,

--- a/examples/dashboards/rule.json
+++ b/examples/dashboards/rule.json
@@ -1680,7 +1680,7 @@
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "Memory Used (Bytes)",
+               "title": "Memory Used",
                "tooltip": {
                   "shared": false,
                   "sort": 0,
@@ -1696,7 +1696,7 @@
                },
                "yaxes": [
                   {
-                     "format": "short",
+                     "format": "bytes",
                      "label": null,
                      "logBase": 1,
                      "max": null,

--- a/examples/dashboards/sidecar.json
+++ b/examples/dashboards/sidecar.json
@@ -1555,7 +1555,7 @@
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "Memory Used (Bytes)",
+               "title": "Memory Used",
                "tooltip": {
                   "shared": false,
                   "sort": 0,
@@ -1571,7 +1571,7 @@
                },
                "yaxes": [
                   {
-                     "format": "short",
+                     "format": "bytes",
                      "label": null,
                      "logBase": 1,
                      "max": null,

--- a/examples/dashboards/store.json
+++ b/examples/dashboards/store.json
@@ -2002,7 +2002,7 @@
                "dashLength": 10,
                "dashes": false,
                "datasource": "$datasource",
-               "description": "Shows size of chunks that have sent to the bucket, in bytes.",
+               "description": "Shows size of chunks that have sent to the bucket.",
                "fill": 1,
                "id": 24,
                "legend": {
@@ -2056,7 +2056,7 @@
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "Chunk Size (bytes)",
+               "title": "Chunk Size",
                "tooltip": {
                   "shared": false,
                   "sort": 0,
@@ -2072,7 +2072,7 @@
                },
                "yaxes": [
                   {
-                     "format": "short",
+                     "format": "bytes",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -2095,25 +2095,7 @@
          "repeatRowId": null,
          "showTitle": true,
          "title": "Store Sent",
-         "titleSize": "h6",
-         "yaxes": [
-            {
-               "format": "decbytes",
-               "label": null,
-               "logBase": 1,
-               "max": null,
-               "min": 0,
-               "show": true
-            },
-            {
-               "format": "short",
-               "label": null,
-               "logBase": 1,
-               "max": null,
-               "min": null,
-               "show": false
-            }
-         ]
+         "titleSize": "h6"
       },
       {
          "collapse": false,
@@ -2217,7 +2199,7 @@
                "dashLength": 10,
                "dashes": false,
                "datasource": "$datasource",
-               "description": "Show the size of data fetched, in bytes",
+               "description": "Show the size of data fetched",
                "fill": 1,
                "id": 26,
                "legend": {
@@ -2271,7 +2253,7 @@
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "Data Fetched (bytes)",
+               "title": "Data Fetched",
                "tooltip": {
                   "shared": false,
                   "sort": 0,
@@ -2287,7 +2269,7 @@
                },
                "yaxes": [
                   {
-                     "format": "short",
+                     "format": "bytes",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -2782,7 +2764,7 @@
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "Memory Used (Bytes)",
+               "title": "Memory Used",
                "tooltip": {
                   "shared": false,
                   "sort": 0,
@@ -2798,7 +2780,7 @@
                },
                "yaxes": [
                   {
-                     "format": "short",
+                     "format": "bytes",
                      "label": null,
                      "logBase": 1,
                      "max": null,

--- a/mixin/thanos/dashboards/store.libsonnet
+++ b/mixin/thanos/dashboards/store.libsonnet
@@ -165,7 +165,7 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
       .addRow(
         g.row('Store Sent')
         .addPanel(
-          g.panel('Chunk Size (bytes)', 'Shows size of chunks that have sent to the bucket, in bytes.') +
+          g.panel('Chunk Size', 'Shows size of chunks that have sent to the bucket.') +
           g.queryPanel(
             [
               'histogram_quantile(0.99, sum(rate(thanos_bucket_store_sent_chunk_size_bytes_bucket{namespace="$namespace",job=~"$job"}[$interval])) by (job, le))',
@@ -177,9 +177,9 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
               'mean',
               'P50',
             ],
-          )
-        ) +
-        { yaxes: g.yaxes('decbytes') },
+          ) +
+          { yaxes: g.yaxes('bytes') }
+        ),
       )
       .addRow(
         g.row('Series Operations')
@@ -198,7 +198,7 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
           )
         )
         .addPanel(
-          g.panel('Data Fetched (bytes)', 'Show the size of data fetched, in bytes') +
+          g.panel('Data Fetched', 'Show the size of data fetched') +
           g.queryPanel(
             [
               'thanos_bucket_store_series_data_fetched{namespace="$namespace",job=~"$job",quantile="0.99"}',
@@ -209,7 +209,8 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
               'mean {{job}}',
               'P50',
             ],
-          )
+          ) +
+          { yaxes: g.yaxes('bytes') }
         )
         .addPanel(
           g.panel('Result series') +

--- a/mixin/thanos/lib/thanos-grafana-builder/builder.libsonnet
+++ b/mixin/thanos/lib/thanos-grafana-builder/builder.libsonnet
@@ -150,7 +150,7 @@ local template = grafana.template;
   resourceUtilizationRow()::
     $.row('Resources')
     .addPanel(
-      $.panel('Memory Used (Bytes)') +
+      $.panel('Memory Used') +
       $.queryPanel(
         [
           'go_memstats_alloc_bytes{namespace="$namespace",job=~"$job",kubernetes_pod_name=~"$pod"}',
@@ -168,7 +168,8 @@ local template = grafana.template;
           'inuse stack {{pod}}',
           'inuse heap {{pod}}',
         ]
-      ),
+      ) +
+      { yaxes: $.yaxes('bytes') },
     )
     .addPanel(
       $.panel('Goroutines') +


### PR DESCRIPTION
Signed-off-by: John Belmonte <john@neggie.net>

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

Use bytes unit in grafana dashboards

Fixes #2392 

## Verification

dashboard json files were regenerated with `make examples`

CI has coverage with `make check-examples`