### PR TITLE
docs: fixed typo in coding style guide

### DIFF
--- a/docs/contributing/coding-style-guide.md
+++ b/docs/contributing/coding-style-guide.md
@@ -1060,7 +1060,7 @@ No Grammarly plugin for this yet ): (We wish).
 
 Ensured [here](https://github.com/thanos-io/thanos/blob/40526f52f54d4501737e5246c0e71e56dd7e0b2d/Makefile#L317).
 
-#### Commentaries Should we a Full Sentence.
+#### Commentaries Should be a Full Sentence.
 
 All comments should be a full sentence. Should start with Uppercase letter and end with a period.
 


### PR DESCRIPTION
fixed typo