### PR TITLE
store: Added regex-set optimization to ExpandedPostings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 ### Added
 
 ### Changed
+- [#2450](https://github.com/thanos-io/thanos/pull/2450) Store: regex-set optimization for `label=~"a|b|c"` matchers. 
 
 ## [v0.12.0](https://github.com/thanos-io/thanos/releases/tag/v0.12.0) - 2020.04.15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 ### Added
 
 ### Changed
-- [#2450](https://github.com/thanos-io/thanos/pull/2450) Store: regex-set optimization for `label=~"a|b|c"` matchers. 
+- [#2450](https://github.com/thanos-io/thanos/pull/2450) Store: regex-set optimization for `label=~"a|b|c"` matchers.
 
 ## [v0.12.0](https://github.com/thanos-io/thanos/releases/tag/v0.12.0) - 2020.04.15
 

--- a/go.mod
+++ b/go.mod
@@ -45,6 +45,7 @@ require (
 	github.com/prometheus/client_model v0.2.0
 	github.com/prometheus/common v0.9.1
 	github.com/prometheus/prometheus v1.8.2-0.20200213233353-b90be6f32a33
+	github.com/stretchr/testify v1.4.0
 	github.com/uber/jaeger-client-go v2.20.1+incompatible
 	github.com/uber/jaeger-lib v2.2.0+incompatible
 	go.elastic.co/apm v1.5.0

--- a/go.mod
+++ b/go.mod
@@ -45,7 +45,6 @@ require (
 	github.com/prometheus/client_model v0.2.0
 	github.com/prometheus/common v0.9.1
 	github.com/prometheus/prometheus v1.8.2-0.20200213233353-b90be6f32a33
-	github.com/stretchr/testify v1.4.0
 	github.com/uber/jaeger-client-go v2.20.1+incompatible
 	github.com/uber/jaeger-lib v2.2.0+incompatible
 	go.elastic.co/apm v1.5.0

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -1502,6 +1502,15 @@ func toPostingGroup(lvalsFn func(name string) ([]string, error), m *labels.Match
 		return emptyPostingsGroup, nil
 	}
 
+	if m.Type == labels.MatchRegexp && len(findSetMatches(m.Value)) > 0 {
+		vals := findSetMatches(m.Value)
+		toAdd := make([]labels.Label, 0, len(vals))
+		for _, val := range vals {
+			toAdd = append(toAdd, labels.Label{Name: m.Name, Value: val})
+		}
+		return newPostingGroup(false, toAdd, nil), nil
+	}
+
 	// If the matcher selects an empty value, it selects all the series which don't
 	// have the label name set too. See: https://github.com/prometheus/prometheus/issues/3575
 	// and https://github.com/prometheus/prometheus/pull/3578#issuecomment-351653555.

--- a/pkg/store/bucket_test.go
+++ b/pkg/store/bucket_test.go
@@ -1030,7 +1030,7 @@ func benchmarkExpandedPostings(
 		{`n="1",i=~"1.+",j="foo"`, []*labels.Matcher{n1, i1Plus, jFoo}, int(float64(series) * 0.011111)},
 		{`n="1",i=~".+",i!="2",j="foo"`, []*labels.Matcher{n1, iPlus, iNot2, jFoo}, int(float64(series) * 0.1)},
 		{`n="1",i=~".+",i!~"2.*",j="foo"`, []*labels.Matcher{n1, iPlus, iNot2Star, jFoo}, int(1 + float64(series)*0.088888)},
-		{`i=~"0|1|2"`, []*labels.Matcher{iRegexSet}, 150}, // 50 series for "1", 50 for "2" and 50 for "3"
+		{`i=~"0|1|2"`, []*labels.Matcher{iRegexSet}, 150}, // 50 series for "1", 50 for "2" and 50 for "3".
 	}
 
 	for _, c := range cases {

--- a/pkg/store/bucket_test.go
+++ b/pkg/store/bucket_test.go
@@ -1005,6 +1005,7 @@ func benchmarkExpandedPostings(
 	iNotEmpty := labels.MustNewMatcher(labels.MatchNotEqual, "i", "")
 	iNot2 := labels.MustNewMatcher(labels.MatchNotEqual, "n", "2"+postingsBenchSuffix)
 	iNot2Star := labels.MustNewMatcher(labels.MatchNotRegexp, "i", "^2.*$")
+	iRegexSet := labels.MustNewMatcher(labels.MatchRegexp, "i", "0"+postingsBenchSuffix+"|1"+postingsBenchSuffix+"|2"+postingsBenchSuffix)
 
 	series = series / 5
 	cases := []struct {
@@ -1029,6 +1030,7 @@ func benchmarkExpandedPostings(
 		{`n="1",i=~"1.+",j="foo"`, []*labels.Matcher{n1, i1Plus, jFoo}, int(float64(series) * 0.011111)},
 		{`n="1",i=~".+",i!="2",j="foo"`, []*labels.Matcher{n1, iPlus, iNot2, jFoo}, int(float64(series) * 0.1)},
 		{`n="1",i=~".+",i!~"2.*",j="foo"`, []*labels.Matcher{n1, iPlus, iNot2Star, jFoo}, int(1 + float64(series)*0.088888)},
+		{`i=~"0|1|2"`, []*labels.Matcher{iRegexSet}, 150}, // 50 series for "1", 50 for "2" and 50 for "3"
 	}
 
 	for _, c := range cases {

--- a/pkg/store/opts.go
+++ b/pkg/store/opts.go
@@ -1,0 +1,60 @@
+package store
+
+import (
+	"strings"
+	"unicode/utf8"
+)
+
+// Bitmap used by func isRegexMetaCharacter to check whether a character needs to be escaped.
+var regexMetaCharacterBytes [16]byte
+
+// isRegexMetaCharacter reports whether byte b needs to be escaped.
+func isRegexMetaCharacter(b byte) bool {
+	return b < utf8.RuneSelf && regexMetaCharacterBytes[b%16]&(1<<(b/16)) != 0
+}
+
+func init() {
+	for _, b := range []byte(`.+*?()|[]{}^$`) {
+		regexMetaCharacterBytes[b%16] |= 1 << (b / 16)
+	}
+}
+
+// copied from Prometheus querier.go, removed check for Prometheus wrapper.
+// Returns list of values that can regex matches.
+func findSetMatches(pattern string) []string {
+	escaped := false
+	sets := []*strings.Builder{{}}
+	for i := 0; i < len(pattern); i++ {
+		if escaped {
+			switch {
+			case isRegexMetaCharacter(pattern[i]):
+				sets[len(sets)-1].WriteByte(pattern[i])
+			case pattern[i] == '\\':
+				sets[len(sets)-1].WriteByte('\\')
+			default:
+				return nil
+			}
+			escaped = false
+		} else {
+			switch {
+			case isRegexMetaCharacter(pattern[i]):
+				if pattern[i] == '|' {
+					sets = append(sets, &strings.Builder{})
+				} else {
+					return nil
+				}
+			case pattern[i] == '\\':
+				escaped = true
+			default:
+				sets[len(sets)-1].WriteByte(pattern[i])
+			}
+		}
+	}
+	matches := make([]string, 0, len(sets))
+	for _, s := range sets {
+		if s.Len() > 0 {
+			matches = append(matches, s.String())
+		}
+	}
+	return matches
+}

--- a/pkg/store/opts.go
+++ b/pkg/store/opts.go
@@ -19,7 +19,7 @@ func init() {
 	}
 }
 
-// copied from Prometheus querier.go, removed check for Prometheus wrapper.
+// Copied from Prometheus querier.go, removed check for Prometheus wrapper.
 // Returns list of values that can regex matches.
 func findSetMatches(pattern string) []string {
 	escaped := false

--- a/pkg/store/opts.go
+++ b/pkg/store/opts.go
@@ -1,3 +1,6 @@
+// Copyright 2017 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+
 package store
 
 import (

--- a/pkg/store/opts.go
+++ b/pkg/store/opts.go
@@ -1,5 +1,5 @@
-// Copyright 2017 The Prometheus Authors
-// Licensed under the Apache License, Version 2.0 (the "License");
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
 
 package store
 

--- a/pkg/store/opts_test.go
+++ b/pkg/store/opts_test.go
@@ -1,0 +1,50 @@
+package store
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Refer to https://github.com/prometheus/prometheus/issues/2651.
+func TestFindSetMatches(t *testing.T) {
+	cases := []struct {
+		pattern string
+		exp     []string
+	}{
+		// Simple sets.
+		{
+			pattern: "foo|bar|baz",
+			exp: []string{
+				"foo",
+				"bar",
+				"baz",
+			},
+		},
+		// Simple sets containing escaped characters.
+		{
+			pattern: "fo\\.o|bar\\?|\\^baz",
+			exp: []string{
+				"fo.o",
+				"bar?",
+				"^baz",
+			},
+		},
+		// Simple sets containing special characters without escaping.
+		{
+			pattern: "fo.o|bar?|^baz",
+			exp:     nil,
+		},
+		{
+			pattern: "foo\\|bar\\|baz",
+			exp: []string{
+				"foo|bar|baz",
+			},
+		},
+	}
+
+	for _, c := range cases {
+		matches := findSetMatches(c.pattern)
+		require.Equal(t, c.exp, matches)
+	}
+}

--- a/pkg/store/opts_test.go
+++ b/pkg/store/opts_test.go
@@ -1,3 +1,6 @@
+// Copyright 2017 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+
 package store
 
 import (

--- a/pkg/store/opts_test.go
+++ b/pkg/store/opts_test.go
@@ -1,5 +1,5 @@
-// Copyright 2017 The Prometheus Authors
-// Licensed under the Apache License, Version 2.0 (the "License");
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
 
 package store
 

--- a/pkg/store/opts_test.go
+++ b/pkg/store/opts_test.go
@@ -3,7 +3,7 @@ package store
 import (
 	"testing"
 
-	"github.com/stretchr/testify/require"
+	"github.com/thanos-io/thanos/pkg/testutil"
 )
 
 // Refer to https://github.com/prometheus/prometheus/issues/2651.
@@ -45,6 +45,6 @@ func TestFindSetMatches(t *testing.T) {
 
 	for _, c := range cases {
 		matches := findSetMatches(c.pattern)
-		require.Equal(t, c.exp, matches)
+		testutil.Equals(t, c.exp, matches)
 	}
 }


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

This PR adds "regex set" optimization that's already available in Prometheus to Thanos. If label matcher is in form label=~"a|b", then we can simply get postings for label=a and label=b. This is especially useful for labels with high cardinality (as used in benchmark).

## Verification

Extended unit test and benchmark to cover this case.

```
name                                                                 old time/op    new time/op    delta
BucketIndexReader_ExpandedPostings/n="1"-4                             4.14ms ± 3%    4.15ms ± 2%     ~     (p=0.853 n=10+10)
BucketIndexReader_ExpandedPostings/n="1",j="foo"-4                     32.7ms ± 1%    33.6ms ± 1%   +2.75%  (p=0.000 n=9+8)
BucketIndexReader_ExpandedPostings/j="foo",n="1"-4                     44.6ms ±56%    34.2ms ± 2%     ~     (p=0.165 n=10+10)
BucketIndexReader_ExpandedPostings/n="1",j!="foo"-4                    24.3ms ± 2%    25.0ms ± 1%   +2.59%  (p=0.000 n=10+9)
BucketIndexReader_ExpandedPostings/i=~".*"-4                           71.1ms ± 4%    70.9ms ± 2%     ~     (p=0.971 n=10+10)
BucketIndexReader_ExpandedPostings/i=~".+"-4                            479ms ± 2%     482ms ± 2%     ~     (p=0.113 n=9+10)
BucketIndexReader_ExpandedPostings/i=~""-4                              544ms ± 0%     551ms ± 1%   +1.31%  (p=0.000 n=7+9)
BucketIndexReader_ExpandedPostings/i!=""-4                              397ms ± 2%     398ms ± 2%     ~     (p=0.529 n=10+10)
BucketIndexReader_ExpandedPostings/n="1",i=~".*",j="foo"-4             32.6ms ± 2%    33.8ms ± 2%   +3.69%  (p=0.000 n=10+10)
BucketIndexReader_ExpandedPostings/n="1",i=~".*",i!="2",j="foo"-4      41.1ms ± 2%    43.0ms ± 1%   +4.63%  (p=0.000 n=10+7)
BucketIndexReader_ExpandedPostings/n="1",i!=""-4                        183ms ± 2%     182ms ± 1%     ~     (p=0.190 n=9+9)
BucketIndexReader_ExpandedPostings/n="1",i!="",j="foo"-4                207ms ± 2%     207ms ± 2%     ~     (p=0.393 n=10+10)
BucketIndexReader_ExpandedPostings/n="1",i=~".+",j="foo"-4              289ms ± 2%     291ms ± 2%     ~     (p=0.218 n=10+10)
BucketIndexReader_ExpandedPostings/n="1",i=~"1.+",j="foo"-4            49.3ms ± 2%    48.9ms ± 2%     ~     (p=0.063 n=10+10)
BucketIndexReader_ExpandedPostings/n="1",i=~".+",i!="2",j="foo"-4       300ms ± 2%     299ms ± 2%     ~     (p=0.842 n=10+9)
BucketIndexReader_ExpandedPostings/n="1",i=~".+",i!~"2.*",j="foo"-4     334ms ± 2%     337ms ± 1%   +0.95%  (p=0.043 n=10+10)
BucketIndexReader_ExpandedPostings/i=~"0|1|2"-4                        17.8ms ± 4%     0.1ms ± 2%  -99.56%  (p=0.000 n=10+9)

name                                                                 old alloc/op   new alloc/op   delta
BucketIndexReader_ExpandedPostings/n="1"-4                             11.4MB ± 0%    11.4MB ± 0%     ~     (p=0.344 n=10+9)
BucketIndexReader_ExpandedPostings/n="1",j="foo"-4                     23.5MB ± 0%    23.5MB ± 0%     ~     (p=0.305 n=8+10)
BucketIndexReader_ExpandedPostings/j="foo",n="1"-4                     23.5MB ± 0%    23.5MB ± 0%     ~     (p=0.372 n=9+10)
BucketIndexReader_ExpandedPostings/n="1",j!="foo"-4                    23.5MB ± 0%    23.5MB ± 0%     ~     (p=0.645 n=9+9)
BucketIndexReader_ExpandedPostings/i=~".*"-4                            284MB ± 0%     284MB ± 0%     ~     (p=0.195 n=10+10)
BucketIndexReader_ExpandedPostings/i=~".+"-4                            382MB ± 0%     382MB ± 0%     ~     (p=0.081 n=10+10)
BucketIndexReader_ExpandedPostings/i=~""-4                              240MB ± 0%     240MB ± 0%   +0.00%  (p=0.002 n=9+10)
BucketIndexReader_ExpandedPostings/i!=""-4                              382MB ± 0%     382MB ± 0%     ~     (p=0.891 n=8+10)
BucketIndexReader_ExpandedPostings/n="1",i=~".*",j="foo"-4             23.5MB ± 0%    23.5MB ± 0%   +0.00%  (p=0.026 n=10+9)
BucketIndexReader_ExpandedPostings/n="1",i=~".*",i!="2",j="foo"-4      25.6MB ± 0%    25.6MB ± 0%     ~     (p=0.740 n=9+10)
BucketIndexReader_ExpandedPostings/n="1",i!=""-4                        177MB ± 0%     177MB ± 0%     ~     (all equal)
BucketIndexReader_ExpandedPostings/n="1",i!="",j="foo"-4                189MB ± 0%     189MB ± 0%     ~     (all equal)
BucketIndexReader_ExpandedPostings/n="1",i=~".+",j="foo"-4              189MB ± 0%     189MB ± 0%     ~     (p=0.083 n=9+8)
BucketIndexReader_ExpandedPostings/n="1",i=~"1.+",j="foo"-4            83.6MB ± 0%    83.6MB ± 0%   +0.00%  (p=0.014 n=10+10)
BucketIndexReader_ExpandedPostings/n="1",i=~".+",i!="2",j="foo"-4       191MB ± 0%     191MB ± 0%     ~     (p=0.698 n=9+10)
BucketIndexReader_ExpandedPostings/n="1",i=~".+",i!~"2.*",j="foo"-4     247MB ± 0%     247MB ± 0%   +0.00%  (p=0.040 n=10+10)
BucketIndexReader_ExpandedPostings/i=~"0|1|2"-4                        51.2MB ± 0%     0.0MB ± 0%  -99.97%  (p=0.000 n=10+10)

name                                                                 old allocs/op  new allocs/op  delta
BucketIndexReader_ExpandedPostings/n="1"-4                               76.0 ± 0%      76.0 ± 0%     ~     (all equal)
BucketIndexReader_ExpandedPostings/n="1",j="foo"-4                        112 ± 0%       112 ± 0%     ~     (all equal)
BucketIndexReader_ExpandedPostings/j="foo",n="1"-4                        112 ± 0%       112 ± 0%     ~     (all equal)
BucketIndexReader_ExpandedPostings/n="1",j!="foo"-4                       111 ± 0%       111 ± 0%     ~     (all equal)
BucketIndexReader_ExpandedPostings/i=~".*"-4                             96.0 ± 0%      96.0 ± 0%     ~     (all equal)
BucketIndexReader_ExpandedPostings/i=~".+"-4                             300k ± 0%      300k ± 0%   +0.00%  (p=0.000 n=9+8)
BucketIndexReader_ExpandedPostings/i=~""-4                               300k ± 0%      300k ± 0%   +0.00%  (p=0.001 n=10+10)
BucketIndexReader_ExpandedPostings/i!=""-4                               300k ± 0%      300k ± 0%     ~     (all equal)
BucketIndexReader_ExpandedPostings/n="1",i=~".*",j="foo"-4                113 ± 0%       113 ± 0%     ~     (all equal)
BucketIndexReader_ExpandedPostings/n="1",i=~".*",i!="2",j="foo"-4         145 ± 0%       145 ± 0%     ~     (all equal)
BucketIndexReader_ExpandedPostings/n="1",i!=""-4                         300k ± 0%      300k ± 0%     ~     (all equal)
BucketIndexReader_ExpandedPostings/n="1",i!="",j="foo"-4                 300k ± 0%      300k ± 0%     ~     (all equal)
BucketIndexReader_ExpandedPostings/n="1",i=~".+",j="foo"-4               300k ± 0%      300k ± 0%   +0.00%  (p=0.000 n=9+9)
BucketIndexReader_ExpandedPostings/n="1",i=~"1.+",j="foo"-4             33.5k ± 0%     33.5k ± 0%   +0.00%  (p=0.001 n=10+10)
BucketIndexReader_ExpandedPostings/n="1",i=~".+",i!="2",j="foo"-4        300k ± 0%      300k ± 0%   +0.00%  (p=0.005 n=10+9)
BucketIndexReader_ExpandedPostings/n="1",i=~".+",i!~"2.*",j="foo"-4      334k ± 0%      334k ± 0%   +0.00%  (p=0.008 n=8+10)
BucketIndexReader_ExpandedPostings/i=~"0|1|2"-4                          87.5 ± 1%     119.0 ± 0%  +36.00%  (p=0.000 n=10+10)
````
