### PR TITLE
Cache deletion mark files together with meta files.

### DIFF
--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -293,7 +293,7 @@ func runCompact(
 	// While fetching blocks, we filter out blocks that were marked for deletion by using IgnoreDeletionMarkFilter.
 	// The delay of deleteDelay/2 is added to ensure we fetch blocks that are meant to be deleted but do not have a replacement yet.
 	// This is to make sure compactor will not accidentally perform compactions with gap instead.
-	ignoreDeletionMarkFilter := block.NewIgnoreDeletionMarkFilter(logger, bkt, deleteDelay/2)
+	ignoreDeletionMarkFilter := block.NewIgnoreDeletionMarkFilter(logger, deleteDelay/2)
 	duplicateBlocksFilter := block.NewDeduplicateFilter()
 
 	baseMetaFetcher, err := block.NewBaseFetcher(logger, 32, bkt, "", extprom.WrapRegistererWithPrefix("thanos_", reg))

--- a/cmd/thanos/store.go
+++ b/cmd/thanos/store.go
@@ -251,7 +251,7 @@ func runStore(
 		return errors.Wrap(err, "create index cache")
 	}
 
-	ignoreDeletionMarkFilter := block.NewIgnoreDeletionMarkFilter(logger, bkt, ignoreDeletionMarksDelay)
+	ignoreDeletionMarkFilter := block.NewIgnoreDeletionMarkFilter(logger, ignoreDeletionMarksDelay)
 	metaFetcher, err := block.NewMetaFetcher(logger, fetcherConcurrency, bkt, dataDir, extprom.WrapRegistererWithPrefix("thanos_", reg),
 		[]block.MetadataFilter{
 			block.NewTimePartitionMetaFilter(filterConf.MinTime, filterConf.MaxTime),

--- a/pkg/block/fetcher.go
+++ b/pkg/block/fetcher.go
@@ -75,7 +75,7 @@ const (
 	// Modified label values.
 	replicaRemovedMeta = "replica-label-removed"
 
-	// Default values for caching deletion marks in memory
+	// Default values for caching deletion marks in memory.
 	defaultDeletionMarkPositiveCacheEntryTTL = 1 * time.Hour
 	defaultDeletionMarkNegativeCacheEntryTTL = 5 * time.Minute
 )
@@ -156,8 +156,8 @@ type BaseFetcher struct {
 	concurrency int
 	bkt         objstore.InstrumentedBucketReader
 
-	// How long to cache deletion mark cache entries (positive -- when deletion mark exists, and negative -- when it doesn't exist)
-	// Note that real TTL is computed as: TTL/2 + random(TTL)
+	// How long to cache deletion mark cache entries (positive -- when deletion mark exists, and negative -- when it doesn't exist).
+	// Note that real TTL is computed as: TTL/2 + random(TTL).
 	deletionMarkPositiveCacheEntryTTL time.Duration
 	deletionMarkNegativeCacheEntryTTL time.Duration
 

--- a/pkg/block/fetcher.go
+++ b/pkg/block/fetcher.go
@@ -401,7 +401,8 @@ func (r response) metasCopy() map[ulid.ULID]*metadata.Meta {
 func (r response) filterMarksCopy() map[ulid.ULID]*metadata.DeletionMark {
 	marks := make(map[ulid.ULID]*metadata.DeletionMark, len(r.marks))
 	for id, m := range r.marks {
-		if m.mark != nil { // don't return cached non-existant marks
+		// Don't return cached non-existent marks.
+		if m.mark != nil {
 			marks[id] = m.mark
 		}
 	}

--- a/pkg/block/fetcher.go
+++ b/pkg/block/fetcher.go
@@ -302,7 +302,7 @@ func (f *BaseFetcher) newCachedDeletionMark(m metadata.DeletionMark, now time.Ti
 
 // loadDeletionMark returns (possibly cached) deletion mark from object storage or error.
 // Result is a entry that can be stored into a cache, or error.
-// Missing entry is not considered to be an error, and simply returns nil.
+// Missing deletion mark is not considered to be an error, and simply returns nil.
 func (f *BaseFetcher) loadDeletionMark(ctx context.Context, id ulid.ULID, now time.Time) (*cachedDeletionMark, error) {
 	var (
 		markFile       = path.Join(id.String(), metadata.DeletionMarkFilename)

--- a/pkg/block/fetcher_test.go
+++ b/pkg/block/fetcher_test.go
@@ -237,8 +237,11 @@ func TestMetaFetcher_Fetch(t *testing.T) {
 				expectedMetaErr:       errors.New("incomplete view: unexpected meta file: 00000000070000000000000000/meta.json version: 20"),
 			},
 			{
-				name: "markers",
+				name: "delete markers",
 				do: func() {
+					// Flush cache, because it also caches negative results.
+					baseFetcher.marks = map[ulid.ULID]*cachedDeletionMark{}
+
 					markBlock := func(id ulid.ULID, deletionTime time.Time) {
 						buf := bytes.Buffer{}
 

--- a/pkg/block/fetcher_test.go
+++ b/pkg/block/fetcher_test.go
@@ -1185,7 +1185,7 @@ func TestMetaFetcher_FetchDeletionMarkerCache(t *testing.T) {
 			resp, err := baseFetcher.fetchMetadata(ctx, now)
 			testutil.Ok(t, err)
 			testutil.Equals(t, meta, resp.metas[id])
-			testutil.Equals(t, (*metadata.DeletionMark)(nil), resp.marks[id].mark)
+			testutil.Equals(t, (*cachedDeletionMark)(nil), resp.marks[id])
 		}
 
 		// Write deletion mark.
@@ -1201,21 +1201,10 @@ func TestMetaFetcher_FetchDeletionMarkerCache(t *testing.T) {
 			testutil.Ok(t, bkt.Upload(ctx, path.Join(mark.ID.String(), metadata.DeletionMarkFilename), &buf))
 		}
 
-		// Even after writing deletion marker, if we ask again, cached negative result will be returned.
-		{
-			resp, err := baseFetcher.fetchMetadata(ctx, now)
-			testutil.Ok(t, err)
-			testutil.Equals(t, meta, resp.metas[id])
-			testutil.Equals(t, (*metadata.DeletionMark)(nil), resp.marks[id].mark)
-		}
-
-		// Ask again, this time in the future.
-		now = now.Add(2 * defaultDeletionMarkNegativeCacheEntryTTL)
-
 		resp, err := baseFetcher.fetchMetadata(ctx, now)
 		testutil.Ok(t, err)
 		testutil.Equals(t, meta, resp.metas[id])
-		testutil.Equals(t, mark, resp.marks[id].mark)
+		testutil.Equals(t, *mark, resp.marks[id].mark)
 
 		// Delete marker from bucket, and try to fetch metadata again, with the same timestamp.
 		// It should hit the cache, and keep using deletion marker.
@@ -1232,7 +1221,7 @@ func TestMetaFetcher_FetchDeletionMarkerCache(t *testing.T) {
 		{
 			resp3, err := baseFetcher.fetchMetadata(ctx, now)
 			testutil.Ok(t, err)
-			testutil.Equals(t, (*metadata.DeletionMark)(nil), resp3.marks[id].mark)
+			testutil.Equals(t, (*cachedDeletionMark)(nil), resp3.marks[id])
 		}
 	})
 }

--- a/pkg/block/fetcher_test.go
+++ b/pkg/block/fetcher_test.go
@@ -239,9 +239,6 @@ func TestMetaFetcher_Fetch(t *testing.T) {
 			{
 				name: "delete markers",
 				do: func() {
-					// Flush cache, because it also caches negative results.
-					baseFetcher.marks = map[ulid.ULID]*cachedDeletionMark{}
-
 					markBlock := func(id ulid.ULID, deletionTime time.Time) {
 						buf := bytes.Buffer{}
 

--- a/pkg/block/fetcher_test.go
+++ b/pkg/block/fetcher_test.go
@@ -1162,7 +1162,7 @@ func TestMetaFetcher_FetchDeletionMarkerCache(t *testing.T) {
 
 		id := ULID(1)
 
-		// prepare files
+		// Prepare files.
 		meta := &metadata.Meta{
 			BlockMeta: tsdb.BlockMeta{
 				Version: 1,
@@ -1185,7 +1185,7 @@ func TestMetaFetcher_FetchDeletionMarkerCache(t *testing.T) {
 			testutil.Equals(t, (*metadata.DeletionMark)(nil), resp.marks[id].mark)
 		}
 
-		// write deletion mark
+		// Write deletion mark.
 		mark := &metadata.DeletionMark{
 			ID:           id,
 			DeletionTime: time.Now().Unix(),
@@ -1198,7 +1198,7 @@ func TestMetaFetcher_FetchDeletionMarkerCache(t *testing.T) {
 			testutil.Ok(t, bkt.Upload(ctx, path.Join(mark.ID.String(), metadata.DeletionMarkFilename), &buf))
 		}
 
-		// Even after writing deletion marker, if we ask again, cached negative result will be returned
+		// Even after writing deletion marker, if we ask again, cached negative result will be returned.
 		{
 			resp, err := baseFetcher.fetchMetadata(ctx, now)
 			testutil.Ok(t, err)
@@ -1206,7 +1206,7 @@ func TestMetaFetcher_FetchDeletionMarkerCache(t *testing.T) {
 			testutil.Equals(t, (*metadata.DeletionMark)(nil), resp.marks[id].mark)
 		}
 
-		// Ask again, this time in the future
+		// Ask again, this time in the future.
 		now = now.Add(2 * defaultDeletionMarkNegativeCacheEntryTTL)
 
 		resp, err := baseFetcher.fetchMetadata(ctx, now)
@@ -1214,8 +1214,8 @@ func TestMetaFetcher_FetchDeletionMarkerCache(t *testing.T) {
 		testutil.Equals(t, meta, resp.metas[id])
 		testutil.Equals(t, mark, resp.marks[id].mark)
 
-		// delete from bucket, and try to fetch metadata again, with same timestamp...
-		// it should hit the cache, and keep using deletion marker
+		// Delete marker from bucket, and try to fetch metadata again, with the same timestamp.
+		// It should hit the cache, and keep using deletion marker.
 		testutil.Ok(t, bkt.Delete(ctx, path.Join(id.String(), metadata.DeletionMarkFilename)))
 
 		{

--- a/pkg/block/fetcher_test.go
+++ b/pkg/block/fetcher_test.go
@@ -275,7 +275,7 @@ func TestMetaFetcher_Fetch(t *testing.T) {
 				tcase.do()
 
 				ulidToDelete = tcase.filterULID
-				metas, marks, partial, err := fetcher.FetchWithMarks(ctx)
+				metas, marks, partial, err := fetcher.fetchWithDeletionMarks(ctx)
 				if tcase.expectedMetaErr != nil {
 					testutil.NotOk(t, err)
 					testutil.Equals(t, tcase.expectedMetaErr.Error(), err.Error())
@@ -1214,7 +1214,7 @@ func TestMetaFetcher_FetchDeletionMarkerCache(t *testing.T) {
 		}
 
 		// Try again, with time in the future -- mark is no longer available.
-		now = now.Add(3 * defaultDeletionMarkPositiveCacheEntryTTL)
+		now = now.Add(3 * defaultDeletionMarkCacheEntryTTL)
 		{
 			resp3, err := baseFetcher.fetchMetadata(ctx, now)
 			testutil.Ok(t, err)

--- a/pkg/block/fetcher_test.go
+++ b/pkg/block/fetcher_test.go
@@ -253,11 +253,11 @@ func TestMetaFetcher_Fetch(t *testing.T) {
 					}
 
 					markBlock(ULID(1), time.Now())
-					markBlock(ULID(2), time.Now()) // no meta, deletion marker will not be reported
-					markBlock(ULID(5), time.Now()) // corrupted meta, deletion marker will not be reported
+					markBlock(ULID(2), time.Now()) // No meta, deletion marker will not be reported.
+					markBlock(ULID(5), time.Now()) // Corrupted meta, deletion marker will not be reported.
 					markBlock(ULID(6), time.Now())
 
-					// this will be ignored
+					// This mark will be ignored.
 					testutil.Ok(t, bkt.Upload(ctx, path.Join(ULID(3).String(), metadata.DeletionMarkFilename), bytes.NewBufferString("not a valid deletion-mark.json")))
 				},
 
@@ -1114,13 +1114,13 @@ func TestIgnoreDeletionMarkFilter_Filter(t *testing.T) {
 	}
 
 	marks := map[ulid.ULID]*metadata.DeletionMark{
-		// should fetch
+		// Should fetch.
 		ULID(1): {
 			ID:           ULID(1),
 			DeletionTime: now.Add(-15 * time.Hour).Unix(),
 			Version:      1,
 		},
-		// should ignore
+		// Should ignore.
 		ULID(2): {
 			ID:           ULID(2),
 			DeletionTime: now.Add(-60 * time.Hour).Unix(),

--- a/pkg/block/metadata/deletionmark.go
+++ b/pkg/block/metadata/deletionmark.go
@@ -91,7 +91,7 @@ func WriteDeletionMarkToLocalDir(logger log.Logger, dir string, mark *DeletionMa
 	p := filepath.Join(dir, DeletionMarkFilename)
 	tmp := p + ".tmp"
 
-	err = ioutil.WriteFile(tmp, data, 0600)
+	err = ioutil.WriteFile(tmp, data, 0666)
 	if err != nil {
 		return err
 	}

--- a/pkg/block/metadata/deletionmark.go
+++ b/pkg/block/metadata/deletionmark.go
@@ -99,7 +99,7 @@ func WriteDeletionMarkToLocalDir(logger log.Logger, dir string, mark *DeletionMa
 }
 
 // ReadDeletionMarkFromLocalDir from <dir>/deletion-mark.json in the local filesystem.
-// Returns ErrorDeletionMarkNotFound if file doesn't exist, ErrorUnmarshalDeletionMark if file is corrupted
+// Returns ErrorDeletionMarkNotFound if file doesn't exist, ErrorUnmarshalDeletionMark if file is corrupted.
 func ReadDeletionMarkFromLocalDir(dir string) (*DeletionMark, error) {
 	deletionMarkFile := filepath.Join(dir, DeletionMarkFilename)
 

--- a/pkg/block/metadata/deletionmark.go
+++ b/pkg/block/metadata/deletionmark.go
@@ -113,3 +113,7 @@ func ReadDeletionMarkFromLocalDir(dir string) (*DeletionMark, error) {
 
 	return unmarshalDeletionMark(b, deletionMarkFile)
 }
+
+func DeleteDeletionMarkFromLocalDir(dir string) error {
+	return os.Remove(filepath.Join(dir, DeletionMarkFilename))
+}

--- a/pkg/compact/compact_e2e_test.go
+++ b/pkg/compact/compact_e2e_test.go
@@ -96,7 +96,7 @@ func TestSyncer_GarbageCollect_e2e(t *testing.T) {
 		testutil.Ok(t, err)
 
 		blocksMarkedForDeletion := promauto.With(nil).NewCounter(prometheus.CounterOpts{})
-		ignoreDeletionMarkFilter := block.NewIgnoreDeletionMarkFilter(nil, nil, 48*time.Hour)
+		ignoreDeletionMarkFilter := block.NewIgnoreDeletionMarkFilter(nil, 48*time.Hour)
 		sy, err := NewSyncer(nil, nil, bkt, metaFetcher, duplicateBlocksFilter, ignoreDeletionMarkFilter, blocksMarkedForDeletion, 1, false, false)
 		testutil.Ok(t, err)
 
@@ -176,7 +176,7 @@ func TestGroup_Compact_e2e(t *testing.T) {
 
 		reg := prometheus.NewRegistry()
 
-		ignoreDeletionMarkFilter := block.NewIgnoreDeletionMarkFilter(logger, objstore.WithNoopInstr(bkt), 48*time.Hour)
+		ignoreDeletionMarkFilter := block.NewIgnoreDeletionMarkFilter(logger, 48*time.Hour)
 		duplicateBlocksFilter := block.NewDeduplicateFilter()
 		metaFetcher, err := block.NewMetaFetcher(nil, 32, objstore.WithNoopInstr(bkt), "", nil, []block.MetadataFilter{
 			ignoreDeletionMarkFilter,


### PR DESCRIPTION
## Changes

This PR adds caching of deletion mark files, similar to how meta.json files are cached. Deletion mark files are stored at the same place.

In order to make this work, deletion mark files are fetched at the same time as `meta.json` files. They are fetched for each block, stored in a map and on the disk (if they exist), and then passed to filters.

Open questions:
- is this a viable approach? 
- do we want to avoid fetching deletion mark files, if no filter uses them? We can do that for example by adding `RequiresDeletionMarks() bool` function to `Filter` interface, to figure out if we need them, and passing the OR-ed result from all filters to `BaseFetcher`.

I personally think this idea can be extended so that Fetcher returns mark files as well. Compactor could use that information, instead of relying on `ignoreDeletionMarkFilter` like it does today. But that would be a different PR.

## Verification

Not tested yet, and unit tests are broken. I will continue working on tests once I know this is a valid approach.

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.
