### PR TITLE
Added some benchmarking tests for deduplicate filter

### DIFF
--- a/pkg/block/fetcher_test.go
+++ b/pkg/block/fetcher_test.go
@@ -1173,7 +1173,7 @@ func BenchmarkDeduplicateFilter_Filter(b *testing.B) {
 				b.ResetTimer()
 				b.Run("", func(b *testing.B) {
 					for n := 0; n <= b.N; n++ {
-						dedupFilter.Filter(ctx, tcase, synced, false)
+						_ = dedupFilter.Filter(ctx, tcase, synced, false)
 						testutil.Equals(b, 0, len(dedupFilter.DuplicateIDs()))
 					}
 				})

--- a/pkg/block/fetcher_test.go
+++ b/pkg/block/fetcher_test.go
@@ -1124,7 +1124,7 @@ func BenchmarkDeduplicateFilter_Filter(b *testing.B) {
 	for blocksNum := 10; blocksNum <= 10000; blocksNum *= 10 {
 
 		var ctx context.Context
-		// blocksNum number of blocks with all of them unique ULID and unique 100 sources
+		// blocksNum number of blocks with all of them unique ULID and unique 100 sources.
 		cases = append(cases, make(map[ulid.ULID]*metadata.Meta, blocksNum))
 		for i := 0; i < blocksNum; i++ {
 
@@ -1143,8 +1143,8 @@ func BenchmarkDeduplicateFilter_Filter(b *testing.B) {
 			}
 		}
 
-		// Case for running 3x resolution as they can be run concurrently
-		// blocksNum number of blocks. all of them with unique ULID and unique 100 cases
+		// Case for running 3x resolution as they can be run concurrently.
+		// blocksNum number of blocks. all of them with unique ULID and unique 100 cases.
 		cases = append(cases, make(map[ulid.ULID]*metadata.Meta, 3*blocksNum))
 
 		for i := 0; i < blocksNum; i++ {

--- a/pkg/block/fetcher_test.go
+++ b/pkg/block/fetcher_test.go
@@ -1109,3 +1109,76 @@ func TestIgnoreDeletionMarkFilter_Filter(t *testing.T) {
 		testutil.Equals(t, expected, input)
 	})
 }
+
+func BenchmarkDeduplicateFilter_Filter(b *testing.B){
+
+	var (
+		reg prometheus.Registerer
+		count uint64
+		cases []map[ulid.ULID]*metadata.Meta
+	)
+
+	dedupFilter := NewDeduplicateFilter()
+	synced := extprom.NewTxGaugeVec(reg, prometheus.GaugeOpts{}, []string{"state"})
+
+	for blocksNum := 10; blocksNum <= 10000; blocksNum *= 10 {
+
+		var ctx context.Context
+		// blocksNum number of blocks with all of them unique ULID and unique 100 sources
+		cases = append(cases, make(map[ulid.ULID]*metadata.Meta, blocksNum))
+		for i := 0; i < blocksNum; i++ {
+			
+			id := ulid.MustNew(count, nil)
+			count++
+
+			cases[0][id] = &metadata.Meta{
+				BlockMeta : tsdb.BlockMeta{
+					ULID: id,
+				},
+			}
+
+			for j := 0; j < 100; j++ {
+				cases[0][id].Compaction.Sources = append(cases[0][id].Compaction.Sources, ulid.MustNew(count, nil))
+				count++
+			}
+		}
+
+		// Case for running 3x resolution as they can be run concurrently
+		// blocksNum number of blocks. all of them with unique ULID and unique 100 cases
+		cases = append(cases, make(map[ulid.ULID]*metadata.Meta, 3*blocksNum))
+		
+		for i := 0; i < blocksNum;i++ {
+			for _, res := range[]int64{0, 5 * 60 * 1000, 60 * 60 * 1000} {
+
+				id := ulid.MustNew(count, nil)
+				count++
+				cases[1][id] = &metadata.Meta{
+					BlockMeta: tsdb.BlockMeta{
+						ULID: id,
+					},
+					Thanos: metadata.Thanos{
+						Downsample: metadata.ThanosDownsample{Resolution: res},
+					},
+				}
+				for j := 0; j < 100; j++ {
+					cases[1][id].Compaction.Sources = append(cases[1][id].Compaction.Sources, ulid.MustNew(count, nil),)
+					count++
+				}
+
+			}
+		}
+
+		b.Run(fmt.Sprintf("Block-%d",blocksNum),func(b *testing.B){
+			for _, tcase := range cases {
+				b.ResetTimer()
+				b.Run("", func(b *testing.B) {
+					for n := 0; n <= b.N; n++ {
+						dedupFilter.Filter(ctx, tcase, synced, false)
+						testutil.Equals(b, 0, len(dedupFilter.DuplicateIDs()))
+					}
+				})
+			}
+		})
+	}
+
+}

--- a/pkg/block/fetcher_test.go
+++ b/pkg/block/fetcher_test.go
@@ -1110,10 +1110,10 @@ func TestIgnoreDeletionMarkFilter_Filter(t *testing.T) {
 	})
 }
 
-func BenchmarkDeduplicateFilter_Filter(b *testing.B){
+func BenchmarkDeduplicateFilter_Filter(b *testing.B) {
 
 	var (
-		reg prometheus.Registerer
+		reg   prometheus.Registerer
 		count uint64
 		cases []map[ulid.ULID]*metadata.Meta
 	)
@@ -1127,12 +1127,12 @@ func BenchmarkDeduplicateFilter_Filter(b *testing.B){
 		// blocksNum number of blocks with all of them unique ULID and unique 100 sources
 		cases = append(cases, make(map[ulid.ULID]*metadata.Meta, blocksNum))
 		for i := 0; i < blocksNum; i++ {
-			
+
 			id := ulid.MustNew(count, nil)
 			count++
 
 			cases[0][id] = &metadata.Meta{
-				BlockMeta : tsdb.BlockMeta{
+				BlockMeta: tsdb.BlockMeta{
 					ULID: id,
 				},
 			}
@@ -1146,9 +1146,9 @@ func BenchmarkDeduplicateFilter_Filter(b *testing.B){
 		// Case for running 3x resolution as they can be run concurrently
 		// blocksNum number of blocks. all of them with unique ULID and unique 100 cases
 		cases = append(cases, make(map[ulid.ULID]*metadata.Meta, 3*blocksNum))
-		
-		for i := 0; i < blocksNum;i++ {
-			for _, res := range[]int64{0, 5 * 60 * 1000, 60 * 60 * 1000} {
+
+		for i := 0; i < blocksNum; i++ {
+			for _, res := range []int64{0, 5 * 60 * 1000, 60 * 60 * 1000} {
 
 				id := ulid.MustNew(count, nil)
 				count++
@@ -1161,14 +1161,14 @@ func BenchmarkDeduplicateFilter_Filter(b *testing.B){
 					},
 				}
 				for j := 0; j < 100; j++ {
-					cases[1][id].Compaction.Sources = append(cases[1][id].Compaction.Sources, ulid.MustNew(count, nil),)
+					cases[1][id].Compaction.Sources = append(cases[1][id].Compaction.Sources, ulid.MustNew(count, nil))
 					count++
 				}
 
 			}
 		}
 
-		b.Run(fmt.Sprintf("Block-%d",blocksNum),func(b *testing.B){
+		b.Run(fmt.Sprintf("Block-%d", blocksNum), func(b *testing.B) {
 			for _, tcase := range cases {
 				b.ResetTimer()
 				b.Run("", func(b *testing.B) {

--- a/pkg/block/fetcher_test.go
+++ b/pkg/block/fetcher_test.go
@@ -1173,7 +1173,7 @@ func BenchmarkDeduplicateFilter_Filter(b *testing.B) {
 				b.ResetTimer()
 				b.Run("", func(b *testing.B) {
 					for n := 0; n <= b.N; n++ {
-						_ = dedupFilter.Filter(ctx, tcase, synced, false)
+						_ = dedupFilter.Filter(ctx, tcase, synced)
 						testutil.Equals(b, 0, len(dedupFilter.DuplicateIDs()))
 					}
 				})


### PR DESCRIPTION
This WIP PR intends to add benchmarking tests to **Thanos** for the `deduplication filter`.
Currently, I have used some ideas from this PR #2118 

Fixes #2174 

Signed-off-by: Yash <yashrsharma44@gmail.com>

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes
* Added a benchmarking test in `fetcher_test.go`.
## Verification
Some details of the benchmarking result after I ran them - 
```
goos: linux
goarch: amd64
pkg: github.com/thanos-io/thanos/pkg/block
BenchmarkDeduplicateFilter_Filter/Block-10/#00-4     	   16364	     77193 ns/op	    3544 B/op	      48 allocs/op
BenchmarkDeduplicateFilter_Filter/Block-10/#01-4     	    8421	    155745 ns/op	    9502 B/op	     134 allocs/op
BenchmarkDeduplicateFilter_Filter/Block-100/#00-4    	     126	   8885819 ns/op	   31375 B/op	     356 allocs/op
BenchmarkDeduplicateFilter_Filter/Block-100/#01-4    	      74	  15998391 ns/op	   93495 B/op	    1066 allocs/op
BenchmarkDeduplicateFilter_Filter/Block-100/#02-4    	 1222910	      1051 ns/op	     280 B/op	       4 allocs/op
BenchmarkDeduplicateFilter_Filter/Block-100/#03-4    	 1000000	      1034 ns/op	     280 B/op	       4 allocs/op
BenchmarkDeduplicateFilter_Filter/Block-1000/#00-4   	       1	1777479341 ns/op	  640752 B/op	    6726 allocs/op
BenchmarkDeduplicateFilter_Filter/Block-1000/#01-4   	       1	3027688695 ns/op	 1919616 B/op	   20154 allocs/op
BenchmarkDeduplicateFilter_Filter/Block-1000/#02-4   	 1250241	       874 ns/op	     280 B/op	       4 allocs/op
BenchmarkDeduplicateFilter_Filter/Block-1000/#03-4   	 1343001	       888 ns/op	     280 B/op	       4 allocs/op
BenchmarkDeduplicateFilter_Filter/Block-1000/#04-4   	 1000000	      1016 ns/op	     280 B/op	       4 allocs/op
BenchmarkDeduplicateFilter_Filter/Block-1000/#05-4   	 1278493	       991 ns/op	     280 B/op	       4 allocs/op
BenchmarkDeduplicateFilter_Filter/Block-10000/#00-4  	       1	191091773100 ns/op	 6879488 B/op	   66758 allocs/op
BenchmarkDeduplicateFilter_Filter/Block-10000/#01-4  	       1	354931689492 ns/op	20635776 B/op	  200250 allocs/op
BenchmarkDeduplicateFilter_Filter/Block-10000/#02-4  	 1000000	      1036 ns/op	     280 B/op	       4 allocs/op
BenchmarkDeduplicateFilter_Filter/Block-10000/#03-4  	 1213599	      1014 ns/op	     280 B/op	       4 allocs/op
BenchmarkDeduplicateFilter_Filter/Block-10000/#04-4  	 1000000	      1005 ns/op	     280 B/op	       4 allocs/op
BenchmarkDeduplicateFilter_Filter/Block-10000/#05-4  	 1000000	      1009 ns/op	     280 B/op	       4 allocs/op
BenchmarkDeduplicateFilter_Filter/Block-10000/#06-4  	 1000000	      1003 ns/op	     280 B/op	       4 allocs/op
BenchmarkDeduplicateFilter_Filter/Block-10000/#07-4  	 1000000	      1053 ns/op	     280 B/op	       4 allocs/op
PASS
ok  	github.com/thanos-io/thanos/pkg/block	577.057s
```

## Post-Thoughts
I am currently thinking of various other test cases for the benchmarking, so this PR would be updated as time goes.
I would appreciate suggestions from the maintainers and contributors!