### PR TITLE
pkg/block/fetcher: fix concurrent map usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 ### Fixed
 
 - [#2411](https://github.com/thanos-io/thanos/pull/2411) Query: fix a bug where queries might not time out sometimes due to issues with one or more StoreAPIs
+- [#2474](https://github.com/thanos-io/thanos/pull/2474) Store: fix a panic caused by concurrent memory access during block filtering.
 
 ## [v0.12.0](https://github.com/thanos-io/thanos/releases/tag/v0.12.0) - 2020.04.15
 

--- a/pkg/block/fetcher.go
+++ b/pkg/block/fetcher.go
@@ -550,6 +550,7 @@ var _ MetadataFilter = &DeduplicateFilter{}
 // Not go-routine safe.
 type DeduplicateFilter struct {
 	duplicateIDs []ulid.ULID
+	mu           sync.Mutex
 }
 
 // NewDeduplicateFilter creates DeduplicateFilter.
@@ -603,11 +604,13 @@ func (f *DeduplicateFilter) filterForResolution(root *Node, metaSlice []*metadat
 
 	duplicateULIDs := getNonRootIDs(root)
 	for _, id := range duplicateULIDs {
+		f.mu.Lock()
 		if metas[id] != nil {
 			f.duplicateIDs = append(f.duplicateIDs, id)
 		}
 		synced.WithLabelValues(duplicateMeta).Inc()
 		delete(metas, id)
+		f.mu.Unlock()
 	}
 }
 


### PR DESCRIPTION
Fixes: #2471

This commit fixes an issue where multiple goroutines in the block
fetcher filtering were concurrently accessing the same map. The
goroutines were concurrently writing AND reading to the shared metas
map. This commit guards this concurrent access by giving the
DeduplicateFilter struct a mutex.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>

* [x] I added CHANGELOG entry for this change.