### PR TITLE
Remove optimizations for label=~".*" and label!~".*".

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 
 ### Changed
 - [#2450](https://github.com/thanos-io/thanos/pull/2450) Store: regex-set optimization for `label=~"a|b|c"` matchers.
+- [#2475](https://github.com/thanos-io/thanos/pull/2475) Store: remove incorrect optimizations for queries with `=~".*"` and `!=~".*"` matchers.
 
 ## [v0.12.0](https://github.com/thanos-io/thanos/releases/tag/v0.12.0) - 2020.04.15
 

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -1485,23 +1485,8 @@ func checkNilPosting(l labels.Label, p index.Postings) index.Postings {
 	return p
 }
 
-var (
-	allPostingsGroup   = newPostingGroup(true, nil, nil)
-	emptyPostingsGroup = newPostingGroup(false, nil, nil)
-)
-
 // NOTE: Derived from tsdb.postingsForMatcher. index.Merge is equivalent to map duplication.
 func toPostingGroup(lvalsFn func(name string) ([]string, error), m *labels.Matcher) (*postingGroup, error) {
-	// This matches any label value, and also series that don't have this label at all.
-	if m.Type == labels.MatchRegexp && (m.Value == ".*" || m.Value == "^.*$") {
-		return allPostingsGroup, nil
-	}
-
-	// NOT matching any value = match nothing. We can shortcut this easily.
-	if m.Type == labels.MatchNotRegexp && (m.Value == ".*" || m.Value == "^.*$") {
-		return emptyPostingsGroup, nil
-	}
-
 	if m.Type == labels.MatchRegexp && len(findSetMatches(m.Value)) > 0 {
 		vals := findSetMatches(m.Value)
 		toAdd := make([]labels.Label, 0, len(vals))


### PR DESCRIPTION
* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

This PR removes shortcuts for `label=~".*"` and `label!~".*"` matchers. Unless default in Prometheus changes such that `.` matches newline as well, these optimizations are not correct. See https://github.com/prometheus/prometheus/pull/6996#issuecomment-616473253

## Verification

Only removes shortcuts for specific matchers. Nothing else is changed.
