### PR TITLE
Gracefully handle additional oneof fields in SeriesResponse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 
 We use *breaking* word for marking changes that are not backward compatible (relates only to v0.y.z releases.)
 
+## Unreleased
+
+### Fixed
+
+- [#2501](https://github.com/thanos-io/thanos/pull/2501) Query: gracefully handle additional fields in `SeriesResponse` protobuf message that may be added in the future.
+
 ## [v0.12.1](https://github.com/thanos-io/thanos/releases/tag/v0.12.1) - 2020.04.20
 
 ### Fixed

--- a/pkg/query/querier.go
+++ b/pkg/query/querier.go
@@ -124,10 +124,12 @@ func (s *seriesServer) Send(r *storepb.SeriesResponse) error {
 		return nil
 	}
 
-	if r.GetSeries() == nil {
-		return errors.New("no seriesSet")
+	if r.GetSeries() != nil {
+		s.seriesSet = append(s.seriesSet, *r.GetSeries())
+		return nil
 	}
-	s.seriesSet = append(s.seriesSet, *r.GetSeries())
+
+	// Unsupported field, skip.
 	return nil
 }
 

--- a/pkg/store/proxy.go
+++ b/pkg/store/proxy.go
@@ -434,11 +434,15 @@ func startStreamSeriesSet(
 				s.warnCh.send(storepb.NewWarnSeriesResponse(errors.New(w)))
 				continue
 			}
-			select {
-			case s.recvCh <- rr.r.GetSeries():
-			case <-ctx.Done():
-				s.handleErr(errors.Wrapf(ctx.Err(), "failed to receive any data from %s", s.name), done)
-				return
+
+			if series := rr.r.GetSeries(); series != nil {
+				select {
+				case s.recvCh <- series:
+				case <-ctx.Done():
+					s.handleErr(errors.Wrapf(ctx.Err(), "failed to receive any data from %s", s.name), done)
+					return
+				}
+				continue
 			}
 		}
 	}()

--- a/pkg/store/proxy.go
+++ b/pkg/store/proxy.go
@@ -432,7 +432,6 @@ func startStreamSeriesSet(
 
 			if w := rr.r.GetWarning(); w != "" {
 				s.warnCh.send(storepb.NewWarnSeriesResponse(errors.New(w)))
-				continue
 			}
 
 			if series := rr.r.GetSeries(); series != nil {
@@ -442,7 +441,6 @@ func startStreamSeriesSet(
 					s.handleErr(errors.Wrapf(ctx.Err(), "failed to receive any data from %s", s.name), done)
 					return
 				}
-				continue
 			}
 		}
 	}()

--- a/pkg/store/proxy_test.go
+++ b/pkg/store/proxy_test.go
@@ -1379,10 +1379,12 @@ func (s *storeSeriesServer) Send(r *storepb.SeriesResponse) error {
 		return nil
 	}
 
-	if r.GetSeries() == nil {
-		return errors.New("no seriesSet")
+	if r.GetSeries() != nil {
+		s.SeriesSet = append(s.SeriesSet, *r.GetSeries())
+		return nil
 	}
-	s.SeriesSet = append(s.SeriesSet, *r.GetSeries())
+
+	// Unsupported field, skip.
 	return nil
 }
 


### PR DESCRIPTION
* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

Following up the discussion we had in #2479, in this PR I'm proposing to gracefully handle additional `oneof` fields we may add in the future to `SeriesResponse`, without assuming that it either contains warnings or series (may also contain new fields an older client doesn't known).

## Verification

(Already existing)  tests.
