### PR TITLE
Adjust memcached operation buckets

### DIFF
--- a/pkg/cacheutil/memcached_client.go
+++ b/pkg/cacheutil/memcached_client.go
@@ -240,7 +240,7 @@ func newMemcachedClient(
 		Name:        "thanos_memcached_operation_duration_seconds",
 		Help:        "Duration of operations against memcached.",
 		ConstLabels: prometheus.Labels{"name": name},
-		Buckets:     []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.2, 0.5, 1},
+		Buckets:     []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.2, 0.5, 1, 3, 6, 10},
 	}, []string{"operation"})
 	c.duration.WithLabelValues(opGetMulti)
 	c.duration.WithLabelValues(opSet)


### PR DESCRIPTION
Depending on the memcached client configuration, particularly `MaxGetMultiBatchSize` and `MaxItemSize`, Memcached operation duration varies; hence this PR adjusts buckets to cover more latency classes.

https://github.com/thanos-io/thanos/blob/45a6bc4ed39e7f7b14f99fedbc62ac414b745bb4/pkg/cacheutil/memcached_client.go#L35-L45

Signed-off-by: Kemal Akkoyun <kakkoyun@gmail.com>

cc @brancz @pracucci @pstibrany 

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

* Adjust `thanos_memcached_operation_duration_seconds ` metric histogram buckets.

## Verification

* `make build`
* `MINIO_ENABLED=1 ./scripts/quickstart.sh`
* Check `curl localhost:10906/metrics`
