### PR TITLE
Dockerfile: Leveraging docker layer caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 ### Changed
 
 - [#2505](https://github.com/thanos.io/thanos/pull/2505) Store: remove obsolete `thanos_store_node_info` metric.
+- [#2508](https://github.com/thanos.io/thanos/pull/2508) Dockerfile: Leveraging docker layer caching.
 
 ## [v0.12.1](https://github.com/thanos-io/thanos/releases/tag/v0.12.1) - 2020.04.20
 

--- a/Dockerfile.multi-stage
+++ b/Dockerfile.multi-stage
@@ -1,9 +1,14 @@
 FROM golang:1.13.6-alpine3.11 as builder
 
-ADD . $GOPATH/src/github.com/thanos-io/thanos
 WORKDIR $GOPATH/src/github.com/thanos-io/thanos
-
+# Change in the docker context invalidates the cache so to leverage docker
+# layer caching, moving update and installing apk packages above COPY cmd
+# More info https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#leverage-build-cache
 RUN apk update && apk upgrade && apk add --no-cache alpine-sdk
+# Replaced ADD with COPY as add is generally to download content form link or tar files
+# while COPY supports the basic copying of local files into the container.
+# https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#add-or-copy
+COPY . $GOPATH/src/github.com/thanos-io/thanos
 
 RUN git update-index --refresh; make build
 


### PR DESCRIPTION
Reformatting `Dockerfile.muti-stage` to leverage the Docker Layer Caching, it reduces the build time up to 30% for recurring builds. First-time build will take the same time.

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end-user.
