### PR TITLE
cmd: rule: do not wrap reload endpoint with '/'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 ### Fixed
 
 - [#2501](https://github.com/thanos-io/thanos/pull/2501) Query: gracefully handle additional fields in `SeriesResponse` protobuf message that may be added in the future.
+- [#2515](https://github.com/thanos-io/thanos/pull/2515) Rule: do not wrap reload endpoint with `/`. Makes `/-/reload` accessible again when no prefix has been specified.
 
 ### Added
 

--- a/cmd/thanos/rule.go
+++ b/cmd/thanos/rule.go
@@ -561,7 +561,7 @@ func runRule(
 			router = router.WithPrefix(webRoutePrefix)
 		}
 
-		router.WithPrefix(webRoutePrefix).Post("/-/reload", func(w http.ResponseWriter, r *http.Request) {
+		router.Post("/-/reload", func(w http.ResponseWriter, r *http.Request) {
 			reloadMsg := make(chan error)
 			reloadWebhandler <- reloadMsg
 			if err := <-reloadMsg; err != nil {


### PR DESCRIPTION
Do not wrap the router with `/` on the `/-/reload` endpoint. Otherwise,
it is inaccessible when no prefix has been specified by the user.

Fixes #2514.

Signed-off-by: Giedrius Statkevičius <giedriuswork@gmail.com>