### PR TITLE
compact: reduce DownsampleRange1 to 6d

### DIFF
--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -345,10 +345,10 @@ func runCompact(
 	}
 
 	// Ensure the lowest resolution downsampling is triggered at the highest compaction level.
-	downsample_range1 := downsample.DownsampleRange1 * time.Millisecond
+	downsample_range1 := downsample.ResLevel2MinBlockRange * time.Millisecond
 	if downsample_range1 <= compactions[len(compactions)-2] ||
 		downsample_range1 >= compactions[len(compactions)-1] {
-		panic("DownsampleRange1 must be between the final two compaction levels")
+		panic("ResLevel2MinBlockRange must be between the final two compaction levels")
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -344,6 +344,13 @@ func runCompact(
 		level.Warn(logger).Log("msg", "Max compaction level is lower than should be", "current", maxCompactionLevel, "default", compactions.maxLevel())
 	}
 
+	// Ensure the lowest resolution downsampling is triggered at the highest compaction level.
+	downsample_range1 := downsample.DownsampleRange1 * time.Millisecond
+	if downsample_range1 <= compactions[len(compactions)-2] ||
+		downsample_range1 >= compactions[len(compactions)-1] {
+		panic("DownsampleRange1 must be between the final two compaction levels")
+	}
+
 	ctx, cancel := context.WithCancel(context.Background())
 	// Instantiate the compactor with different time slices. Timestamps in TSDB
 	// are in milliseconds.

--- a/cmd/thanos/downsample.go
+++ b/cmd/thanos/downsample.go
@@ -204,7 +204,7 @@ func downsampleBucket(
 			// Only downsample blocks once we are sure to get roughly 2 chunks out of it.
 			// NOTE(fabxc): this must match with at which block size the compactor creates downsampled
 			// blocks. Otherwise we may never downsample some data.
-			if m.MaxTime-m.MinTime < downsample.DownsampleRange0 {
+			if m.MaxTime-m.MinTime < downsample.ResLevel1MinBlockRange {
 				continue
 			}
 			if err := processDownsampling(ctx, logger, bkt, m, dir, downsample.ResLevel1); err != nil {
@@ -227,7 +227,7 @@ func downsampleBucket(
 			// Only downsample blocks once we are sure to get roughly 2 chunks out of it.
 			// NOTE(fabxc): this must match with at which block size the compactor creates downsampled
 			// blocks. Otherwise we may never downsample some data.
-			if m.MaxTime-m.MinTime < downsample.DownsampleRange1 {
+			if m.MaxTime-m.MinTime < downsample.ResLevel2MinBlockRange {
 				continue
 			}
 			if err := processDownsampling(ctx, logger, bkt, m, dir, downsample.ResLevel2); err != nil {

--- a/cmd/thanos/main_test.go
+++ b/cmd/thanos/main_test.go
@@ -45,7 +45,7 @@ func TestCleanupIndexCacheFolder(t *testing.T) {
 			ctx,
 			dir,
 			[]labels.Labels{{{Name: "a", Value: "1"}}},
-			1, 0, downsample.DownsampleRange0+1, // Pass the minimum DownsampleRange0 check.
+			1, 0, downsample.ResLevel1MinBlockRange+1, // Pass the minimum ResLevel1MinBlockRange check.
 			labels.Labels{{Name: "e1", Value: "1"}},
 			downsample.ResLevel0)
 		testutil.Ok(t, err)
@@ -63,7 +63,7 @@ func TestCleanupIndexCacheFolder(t *testing.T) {
 			ctx,
 			dir,
 			[]labels.Labels{{{Name: "a", Value: "1"}}},
-			1, 0, downsample.DownsampleRange0+1, // Pass the minimum DownsampleRange0 check.
+			1, 0, downsample.ResLevel1MinBlockRange+1, // Pass the minimum ResLevel1MinBlockRange check.
 			labels.Labels{{Name: "e1", Value: "1"}},
 			downsample.ResLevel0)
 		testutil.Ok(t, err)
@@ -106,7 +106,7 @@ func TestCleanupDownsampleCacheFolder(t *testing.T) {
 			ctx,
 			dir,
 			[]labels.Labels{{{Name: "a", Value: "1"}}},
-			1, 0, downsample.DownsampleRange0+1, // Pass the minimum DownsampleRange0 check.
+			1, 0, downsample.ResLevel1MinBlockRange+1, // Pass the minimum ResLevel1MinBlockRange check.
 			labels.Labels{{Name: "e1", Value: "1"}},
 			downsample.ResLevel0)
 		testutil.Ok(t, err)

--- a/docs/components/compact.md
+++ b/docs/components/compact.md
@@ -11,8 +11,8 @@ It is generally not semantically concurrency safe and must be deployed as a sing
 
 It is also responsible for downsampling of data:
 
-- creating 5m downsampling for blocks larger than **40 hours** (2d, 2w)
-- creating 1h downsampling for blocks larger than **3 days** (2w).
+- creating 5m downsampling for blocks larger than **40 hours** (Thanos 2d and 2w compactions)
+- creating 1h downsampling for blocks larger than **3 days** (Thanos 2w compactions).
 
 Example:
 

--- a/docs/components/compact.md
+++ b/docs/components/compact.md
@@ -12,7 +12,7 @@ It is generally not semantically concurrency safe and must be deployed as a sing
 It is also responsible for downsampling of data:
 
 - creating 5m downsampling for blocks larger than **40 hours** (2d, 2w)
-- creating 1h downsampling for blocks larger than **10 days** (2w).
+- creating 1h downsampling for blocks larger than **3 days** (2w).
 
 Example:
 

--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -146,9 +146,9 @@ func UntilNextDownsampling(m *metadata.Meta) (time.Duration, error) {
 	case downsample.ResLevel2:
 		return time.Duration(0), errors.New("no downsampling")
 	case downsample.ResLevel1:
-		return time.Duration(downsample.DownsampleRange1*time.Millisecond) - timeRange, nil
+		return time.Duration(downsample.ResLevel2MinBlockRange*time.Millisecond) - timeRange, nil
 	case downsample.ResLevel0:
-		return time.Duration(downsample.DownsampleRange0*time.Millisecond) - timeRange, nil
+		return time.Duration(downsample.ResLevel1MinBlockRange*time.Millisecond) - timeRange, nil
 	default:
 		panic(errors.Errorf("invalid resolution %v", m.Thanos.Downsample.Resolution))
 	}

--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -140,6 +140,8 @@ func NewSyncer(logger log.Logger, reg prometheus.Registerer, bkt objstore.Bucket
 
 // UntilNextDownsampling calculates how long it will take until the next downsampling operation.
 // Returns an error if there will be no downsampling.
+// TODO: This should take the compaction schedule into account.  Currenty it assumes that
+//   the downsample min ranges match the compaction schedule, which is not actually the case.
 func UntilNextDownsampling(m *metadata.Meta) (time.Duration, error) {
 	timeRange := time.Duration((m.MaxTime - m.MinTime) * int64(time.Millisecond))
 	switch m.Thanos.Downsample.Resolution {

--- a/pkg/compact/downsample/downsample.go
+++ b/pkg/compact/downsample/downsample.go
@@ -33,8 +33,11 @@ const (
 
 // Downsampling ranges i.e. minimum block size after which we start to downsample blocks (in seconds).
 const (
-	DownsampleRange0 = 40 * 60 * 60 * 1000      // 40 hours.
-	DownsampleRange1 = 10 * 24 * 60 * 60 * 1000 // 10 days.
+	// NOTE: although DownsampleRange1 can be as high as our last compaction level (14d),
+	//   we use just over the penultimate level to accommodate compacted blocks migrated
+	//   from other systems (e.g. Prometheus server, which maxes out at 6.75d).
+	DownsampleRange0 = 40 * 60 * 60 * 1000     // 40 hours.
+	DownsampleRange1 = 3 * 24 * 60 * 60 * 1000 // 3 days.
 )
 
 // Downsample downsamples the given block. It writes a new block into dir and returns its ID.

--- a/pkg/compact/downsample/downsample.go
+++ b/pkg/compact/downsample/downsample.go
@@ -33,11 +33,11 @@ const (
 
 // Downsampling ranges i.e. minimum block size after which we start to downsample blocks (in seconds).
 const (
-	// NOTE: although DownsampleRange1 can be as high as our last compaction level (14d),
-	//   we use just over the penultimate level to accommodate compacted blocks migrated
+	// NOTE: although ResLevel2MinBlockRange can be as high as our last compaction level (14d),
+	//   we use just over the 2nd-to-last level to accommodate compacted blocks migrated
 	//   from other systems (e.g. Prometheus server, which maxes out at 6.75d).
-	DownsampleRange0 = 40 * 60 * 60 * 1000     // 40 hours.
-	DownsampleRange1 = 3 * 24 * 60 * 60 * 1000 // 3 days.
+	ResLevel1MinBlockRange = 40 * 60 * 60 * 1000     // 40 hours.
+	ResLevel2MinBlockRange = 3 * 24 * 60 * 60 * 1000 // 3 days.
 )
 
 // Downsample downsamples the given block. It writes a new block into dir and returns its ID.


### PR DESCRIPTION
Signed-off-by: John Belmonte <john@neggie.net>

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Reduced DownsampleRange1 from 10d to 6d.

The intention is to accommodate blocks migrated from prometheus-server,
which has a different compaction schedule ending at 6.75 days.

Also rename `DownsampleRange{0,1}` to `ResLevel{1,2}MinBlockRange`.

Fixes #2413.
