### PR TITLE
sidecar: document caveat of --shipper.upload_compacted

### DIFF
--- a/docs/components/sidecar.md
+++ b/docs/components/sidecar.md
@@ -79,6 +79,9 @@ To use this, the Prometheus compaction needs to be disabled. This can be done by
 - `--storage.tsdb.min-block-duration=2h`
 - `--storage.tsdb.max-block-duration=2h`
 
+A known issue is that Prometheus and Thanos use different compaction schedules, so Compact may
+get confused when trying to further compact or downsample compacted blocks from Prometheus.
+
 ## Flags
 
 [embedmd]:# (flags/sidecar.txt $)


### PR DESCRIPTION
Document a known issue of the experimental `--shipper.upload_compacted` flag, where the different compaction schedules of Prometheus and Thanos is not accounted for and may affect higher-order compaction and downsampling.

See #2413 

Signed-off-by: John Belmonte <john@neggie.net>