### PR TITLE
*: add metrics to the reloader package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 ### Added
 
 - [#2502](https://github.com/thanos-io/thanos/pull/2502) Added `hints` field to `SeriesResponse`. Hints in an opaque data structure that can be used to carry additional information from the store and its content is implementation specific.
+- [#2521](https://github.com/thanos-io/thanos/pull/2521) Sidecar: add `thanos_sidecar_reloader_reloads_failed_total`, `thanos_sidecar_reloader_reloads_total`, `thanos_sidecar_reloader_watch_errors_total`, `thanos_sidecar_reloader_watch_events_total` and `thanos_sidecar_reloader_watches` metrics.
 
 ### Changed
 

--- a/cmd/thanos/sidecar.go
+++ b/cmd/thanos/sidecar.go
@@ -80,6 +80,7 @@ func registerSidecar(m map[string]setupFunc, app *kingpin.Application) {
 	m[component.Sidecar.String()] = func(g *run.Group, logger log.Logger, reg *prometheus.Registry, tracer opentracing.Tracer, _ <-chan struct{}, _ bool) error {
 		rl := reloader.New(
 			log.With(logger, "component", "reloader"),
+			extprom.WrapRegistererWithPrefix("thanos_sidecar_", reg),
 			reloader.ReloadURLFromBase(*promURL),
 			*reloaderCfgFile,
 			*reloaderCfgOutputFile,

--- a/pkg/reloader/example_test.go
+++ b/pkg/reloader/example_test.go
@@ -21,6 +21,7 @@ func ExampleReloader() {
 	}
 	rl := reloader.New(
 		nil,
+		nil,
 		reloader.ReloadURLFromBase(u),
 		"/path/to/cfg",
 		"/path/to/cfg.out",

--- a/pkg/reloader/reloader_test.go
+++ b/pkg/reloader/reloader_test.go
@@ -62,7 +62,7 @@ func TestReloader_ConfigApply(t *testing.T) {
 		input  = path.Join(dir, "in", "cfg.yaml.tmpl")
 		output = path.Join(dir, "out", "cfg.yaml")
 	)
-	reloader := New(nil, reloadURL, input, output, nil)
+	reloader := New(nil, nil, reloadURL, input, output, nil)
 	reloader.watchInterval = 9999 * time.Hour // Disable interval to test watch logic only.
 	reloader.retryInterval = 100 * time.Millisecond
 
@@ -205,7 +205,7 @@ func TestReloader_RuleApply(t *testing.T) {
 	testutil.Ok(t, os.Mkdir(path.Join(dir2, "rule-dir"), os.ModePerm))
 	testutil.Ok(t, os.Symlink(path.Join(dir2, "rule-dir"), path.Join(dir, "rule-dir")))
 
-	reloader := New(nil, reloadURL, "", "", []string{dir, path.Join(dir, "rule-dir")})
+	reloader := New(nil, nil, reloadURL, "", "", []string{dir, path.Join(dir, "rule-dir")})
 	reloader.watchInterval = 100 * time.Millisecond
 	reloader.retryInterval = 100 * time.Millisecond
 


### PR DESCRIPTION
* [X] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

The reloader package didn't expose any metrics. This PR adds a few:
* `thanos_sidecar_reloader_reloads_failed_total`
* `thanos_sidecar_reloader_reloads_total`
* `thanos_sidecar_reloader_watch_errors_total`
* `thanos_sidecar_reloader_watch_events_total`
* `thanos_sidecar_reloader_watches`

## Verification

Tested locally.
