### PR TITLE
Add deleteSeries skeleton to return bad request

### DIFF
--- a/pkg/query/api/v1.go
+++ b/pkg/query/api/v1.go
@@ -166,6 +166,8 @@ func (api *API) Register(r *route.Router, tracer opentracing.Tracer, logger log.
 	r.Get("/series", instr("series", api.series))
 	r.Post("/series", instr("series", api.series))
 
+	r.Post("/delete_series", instr("delete_series", api.deleteSeries))
+
 	r.Get("/labels", instr("label_names", api.labelNames))
 	r.Post("/labels", instr("label_names", api.labelNames))
 }
@@ -534,6 +536,10 @@ func (api *API) series(r *http.Request) (interface{}, []error, *ApiError) {
 		return nil, nil, &ApiError{errorExec, set.Err()}
 	}
 	return metrics, warnings, nil
+}
+
+func (api *API) deleteSeries(r *http.Request) (interface{}, []error, *ApiError) {
+	return nil, nil, &ApiError{errorBadData, errors.New("delete_series is not implemented yet")}
 }
 
 func Respond(w http.ResponseWriter, data interface{}, warnings []error) {

--- a/pkg/query/api/v1_test.go
+++ b/pkg/query/api/v1_test.go
@@ -786,6 +786,13 @@ func TestEndpoints(t *testing.T) {
 			errType: errorBadData,
 			method:  http.MethodPost,
 		},
+		// deleteSeries should return bad request.
+		{
+			endpoint: api.deleteSeries,
+			query:    url.Values{},
+			method:   http.MethodPost,
+			errType:  errorBadData,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Signed-off-by: darshanime <deathbullet@gmail.com>

Thanos currently does not support `delete_series` api, see https://github.com/thanos-io/thanos/issues/415. This PR adds a skeleton endpoint explicitly mentioning the api is not supported yet as [suggested earlier](https://github.com/thanos-io/thanos/issues/415#issuecomment-403399284).
 
We will eventually implement the API by adding in functionality in the handler. 

### Changes
- return `400 Bad Request` on `delete_series` API
### Verification
```
curl -X POST "http://thanos_querier:10902/api/v1/delete_series?match[]=scrape_duration_seconds"  -v
*   Trying 172.24.0.5...
* TCP_NODELAY set
* Connected to thanos_querier (172.24.0.5) port 10902 (#0)
> POST /api/v1/delete_series?match[]=scrape_duration_seconds HTTP/1.1
> Host: thanos_querier:10902
> User-Agent: curl/7.60.0
> Accept: */*
>
< HTTP/1.1 400 Bad Request
< Access-Control-Allow-Headers: Accept, Accept-Encoding, Authorization, Content-Type, Origin
< Access-Control-Allow-Methods: GET, OPTIONS
< Access-Control-Allow-Origin: *
< Access-Control-Expose-Headers: Date
< Cache-Control: no-store
< Content-Type: application/json
< Vary: Accept-Encoding
< Date: Mon, 27 Apr 2020 17:06:40 GMT
< Content-Length: 89
<
{"status":"error","errorType":"bad_data","error":"delete_series is not implemented yet"}
* Connection #0 to host thanos_querier left intact
```

