### PR TITLE
Chunks caching at bucket level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 
 - [#2502](https://github.com/thanos-io/thanos/pull/2502) Added `hints` field to `SeriesResponse`. Hints in an opaque data structure that can be used to carry additional information from the store and its content is implementation specific.
 - [#2521](https://github.com/thanos-io/thanos/pull/2521) Sidecar: add `thanos_sidecar_reloader_reloads_failed_total`, `thanos_sidecar_reloader_reloads_total`, `thanos_sidecar_reloader_watch_errors_total`, `thanos_sidecar_reloader_watch_events_total` and `thanos_sidecar_reloader_watches` metrics.
+- [#2532](https://github.com/thanos-io/thanos/pull/2532) Store: Added caching bucket, that can cache chunks into shared memcached. This can speed up querying and reduce number of requests to object storage.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 
 - [#2502](https://github.com/thanos-io/thanos/pull/2502) Added `hints` field to `SeriesResponse`. Hints in an opaque data structure that can be used to carry additional information from the store and its content is implementation specific.
 - [#2521](https://github.com/thanos-io/thanos/pull/2521) Sidecar: add `thanos_sidecar_reloader_reloads_failed_total`, `thanos_sidecar_reloader_reloads_total`, `thanos_sidecar_reloader_watch_errors_total`, `thanos_sidecar_reloader_watch_events_total` and `thanos_sidecar_reloader_watches` metrics.
-- [#2532](https://github.com/thanos-io/thanos/pull/2532) Store: Added caching bucket, that can cache chunks into shared memcached. This can speed up querying and reduce number of requests to object storage.
+- [#2532](https://github.com/thanos-io/thanos/pull/2532) Store: Added hidden option for experimental caching bucket, that can cache chunks into shared memcached. This can speed up querying and reduce number of requests to object storage.
 
 ### Changed
 

--- a/cmd/thanos/store.go
+++ b/cmd/thanos/store.go
@@ -225,11 +225,10 @@ func runStore(
 		return errors.Wrap(err, "get caching bucket configuration")
 	}
 	if len(cachingBucketConfigYaml) > 0 {
-		newbkt, err := storecache.NewCachingBucketFromYaml(cachingBucketConfigYaml, bkt, logger, reg)
+		bkt, err = storecache.NewCachingBucketFromYaml(cachingBucketConfigYaml, bkt, logger, reg)
 		if err != nil {
 			return errors.Wrap(err, "create caching bucket")
 		}
-		bkt = newbkt
 	}
 
 	relabelContentYaml, err := selectorRelabelConf.Content()

--- a/cmd/thanos/store.go
+++ b/cmd/thanos/store.go
@@ -55,7 +55,7 @@ func registerStore(m map[string]setupFunc, app *kingpin.Application) {
 		"YAML file that contains index cache configuration. See format details: https://thanos.io/components/store.md/#index-cache",
 		false)
 
-	cachingBucketConfig := extflag.RegisterPathOrContent(cmd, "store.caching-bucket.config",
+	cachingBucketConfig := extflag.RegisterPathOrContent(extflag.HiddenCmdClause(cmd), "store.caching-bucket.config",
 		"YAML that contains configuration for caching bucket. Experimental feature, with high risk of changes. See format details: https://thanos.io/components/store.md/#caching-bucket",
 		false)
 

--- a/cmd/thanos/store.go
+++ b/cmd/thanos/store.go
@@ -55,8 +55,8 @@ func registerStore(m map[string]setupFunc, app *kingpin.Application) {
 		"YAML file that contains index cache configuration. See format details: https://thanos.io/components/store.md/#index-cache",
 		false)
 
-	cachingBucketConfig := extflag.RegisterPathOrContent(cmd, "experimental.caching-bucket.config",
-		"YAML file that contains configuration for caching bucket. Experimental feature, with high risk of changes. See format details: https://thanos.io/components/store.md/#caching-bucket",
+	cachingBucketConfig := extflag.RegisterPathOrContent(cmd, "caching-bucket.config",
+		"YAML that contains configuration for caching bucket. Experimental feature, with high risk of changes. See format details: https://thanos.io/components/store.md/#caching-bucket",
 		false)
 
 	chunkPoolSize := cmd.Flag("chunk-pool-size", "Maximum size of concurrently allocatable bytes reserved strictly to reuse for chunks in memory.").

--- a/cmd/thanos/store.go
+++ b/cmd/thanos/store.go
@@ -56,7 +56,7 @@ func registerStore(m map[string]setupFunc, app *kingpin.Application) {
 		false)
 
 	cachingBucketConfig := extflag.RegisterPathOrContent(cmd, "experimental.caching-bucket.config",
-		"YAML file that contains configuration for caching bucket. Experimental feature, with high risk of changes. See format details: https://thanos.io/components/store.md/#TBD",
+		"YAML file that contains configuration for caching bucket. Experimental feature, with high risk of changes. See format details: https://thanos.io/components/store.md/#caching-bucket",
 		false)
 
 	chunkPoolSize := cmd.Flag("chunk-pool-size", "Maximum size of concurrently allocatable bytes reserved strictly to reuse for chunks in memory.").

--- a/cmd/thanos/store.go
+++ b/cmd/thanos/store.go
@@ -55,7 +55,7 @@ func registerStore(m map[string]setupFunc, app *kingpin.Application) {
 		"YAML file that contains index cache configuration. See format details: https://thanos.io/components/store.md/#index-cache",
 		false)
 
-	cachingBucketConfig := extflag.RegisterPathOrContent(cmd, "caching-bucket.config",
+	cachingBucketConfig := extflag.RegisterPathOrContent(cmd, "store.caching-bucket.config",
 		"YAML that contains configuration for caching bucket. Experimental feature, with high risk of changes. See format details: https://thanos.io/components/store.md/#caching-bucket",
 		false)
 

--- a/docs/components/store.md
+++ b/docs/components/store.md
@@ -232,6 +232,34 @@ While the remaining settings are **optional**:
 - `max_item_size`: maximum size of an item to be stored in memcached. This option should be set to the same value of memcached `-I` flag (defaults to 1MB) in order to avoid wasting network round trips to store items larger than the max item size allowed in memcached. If set to `0`, the item size is unlimited.
 - `dns_provider_update_interval`: the DNS discovery update interval.
 
+## Caching Bucket
+
+Thanos Store Gateway supports a "caching bucket" with chunks caching to speed up loading of chunks from TSDB blocks. Currently only memcached "backend" is supported:
+
+```yaml
+backend: memcached
+backend_config:
+  addresses:
+    - localhost:11211
+
+caching_config:
+  chunk_block_size: 16000
+  max_chunks_get_range_requests: 3
+  chunk_object_size_ttl: 24h
+  chunk_block_ttl: 24h
+```
+
+`backend_config` field for memcached supports all the same configuration as memcached for [index cache](#memcached-index-cache).
+
+`caching_config` is a configuration for chunks cache.
+
+- `chunk_block_size`: size of segment of chunks object that is stored to the cache. This is the smallest unit that chunks cache is working with.
+- `max_chunks_get_range_requests`: how many "get range" sub-requests may cache perform to fetch missing blocks.
+- `chunk_object_size_ttl`: how long to keep information about chunk file length in the cache.
+- `chunk_block_ttl`: how long to keep individual blocks in the cache.
+
+Note that chunks cache is an experimental feature, and these fields may be renamed or removed completely in the future.
+
 ## Index Header
 
 In order to query series inside blocks from object storage, Store Gateway has to know certain initial info about each block such as:

--- a/docs/components/store.md
+++ b/docs/components/store.md
@@ -251,7 +251,7 @@ caching_config:
 
 `backend_config` field for memcached supports all the same configuration as memcached for [index cache](#memcached-index-cache).
 
-`caching_config` is a configuration for chunks cache.
+`caching_config` is a configuration for chunks cache and supports the following optional settings:
 
 - `chunk_block_size`: size of segment of chunks object that is stored to the cache. This is the smallest unit that chunks cache is working with.
 - `max_chunks_get_range_requests`: how many "get range" sub-requests may cache perform to fetch missing blocks.

--- a/docs/components/store.md
+++ b/docs/components/store.md
@@ -243,20 +243,20 @@ backend_config:
     - localhost:11211
 
 caching_config:
-  chunk_block_size: 16000
+  chunk_subrange_size: 16000
   max_chunks_get_range_requests: 3
   chunk_object_size_ttl: 24h
-  chunk_block_ttl: 24h
+  chunk_subrange_ttl: 24h
 ```
 
 `backend_config` field for memcached supports all the same configuration as memcached for [index cache](#memcached-index-cache).
 
 `caching_config` is a configuration for chunks cache and supports the following optional settings:
 
-- `chunk_block_size`: size of segment of chunks object that is stored to the cache. This is the smallest unit that chunks cache is working with.
-- `max_chunks_get_range_requests`: how many "get range" sub-requests may cache perform to fetch missing blocks.
+- `chunk_subrange_size`: size of segment of chunks object that is stored to the cache. This is the smallest unit that chunks cache is working with.
+- `max_chunks_get_range_requests`: how many "get range" sub-requests may cache perform to fetch missing subranges.
 - `chunk_object_size_ttl`: how long to keep information about chunk file length in the cache.
-- `chunk_block_ttl`: how long to keep individual blocks in the cache.
+- `chunk_subrange_ttl`: how long to keep individual subranges in the cache.
 
 Note that chunks cache is an experimental feature, and these fields may be renamed or removed completely in the future.
 

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -15,6 +15,7 @@ type Cache interface {
 	// Note that individual byte buffers may be retained by the cache!
 	Store(ctx context.Context, data map[string][]byte, ttl time.Duration)
 
-	// Fetch multiple keys from cache.
-	Fetch(ctx context.Context, keys []string) (found map[string][]byte, missing []string)
+	// Fetch multiple keys from cache. Returns map of input keys to data.
+	// If key isn't in the map, data for given key was not found.
+	Fetch(ctx context.Context, keys []string) map[string][]byte
 }

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -1,0 +1,16 @@
+package cache
+
+import (
+	"context"
+	"time"
+)
+
+// Generic cache
+type Cache interface {
+	// Store data into the cache. If data for given key is nil, data is removed from cache instead.
+	// Only positive ttl values are used.
+	Store(ctx context.Context, data map[string][]byte, ttl time.Duration)
+
+	// Fetch multiple keys from cache.
+	Fetch(ctx context.Context, keys []string) (found map[string][]byte, missing []string)
+}

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -1,3 +1,6 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
 package cache
 
 import (
@@ -7,8 +10,9 @@ import (
 
 // Generic cache
 type Cache interface {
-	// Store data into the cache. If data for given key is nil, data is removed from cache instead.
-	// Only positive ttl values are used.
+	// Store data into the cache.
+	//
+	// Note that individual byte buffers may be retained by the cache!
 	Store(ctx context.Context, data map[string][]byte, ttl time.Duration)
 
 	// Fetch multiple keys from cache.

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -8,7 +8,7 @@ import (
 	"time"
 )
 
-// Generic cache
+// Generic best-effort cache.
 type Cache interface {
 	// Store data into the cache.
 	//

--- a/pkg/cache/memcached.go
+++ b/pkg/cache/memcached.go
@@ -1,0 +1,85 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package cache
+
+import (
+	"context"
+	"time"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+
+	"github.com/thanos-io/thanos/pkg/cacheutil"
+)
+
+// MemcachedCache is a memcached-based cache.
+type MemcachedCache struct {
+	logger    log.Logger
+	memcached cacheutil.MemcachedClient
+
+	// Metrics.
+	requests prometheus.Counter
+	hits     prometheus.Counter
+}
+
+// NewMemcachedCache makes a new MemcachedCache.
+func NewMemcachedCache(logger log.Logger, memcached cacheutil.MemcachedClient, reg prometheus.Registerer) *MemcachedCache {
+	c := &MemcachedCache{
+		logger:    logger,
+		memcached: memcached,
+	}
+
+	c.requests = promauto.With(reg).NewCounter(prometheus.CounterOpts{
+		Name: "thanos_store_memcached_requests_total",
+		Help: "Total number of items requests to the memcached.",
+	})
+
+	c.hits = promauto.With(reg).NewCounter(prometheus.CounterOpts{
+		Name: "thanos_store_memcached_hits_total",
+		Help: "Total number of items requests to the cache that were a hit.",
+	})
+
+	level.Info(logger).Log("msg", "created memcached cache")
+
+	return c
+}
+
+// Store data identified by keys.
+// The function enqueues the request and returns immediately: the entry will be
+// asynchronously stored in the cache.
+func (c *MemcachedCache) Store(ctx context.Context, data map[string][]byte, ttl time.Duration) {
+	for key, val := range data {
+		if err := c.memcached.SetAsync(ctx, key, val, ttl); err != nil {
+			level.Error(c.logger).Log("msg", "failed to cache postings in memcached", "err", err)
+		}
+	}
+}
+
+// FetchMultiPostings fetches multiple postings - each identified by a label -
+// and returns a map containing cache hits, along with a list of missing keys.
+// In case of error, it logs and return an empty cache hits map.
+func (c *MemcachedCache) Fetch(ctx context.Context, keys []string) (map[string][]byte, []string) {
+	// Fetch the keys from memcached in a single request.
+	c.requests.Add(float64(len(keys)))
+	results := c.memcached.GetMulti(ctx, keys)
+	if len(results) == 0 {
+		return nil, keys
+	}
+
+	// Construct the resulting hits map and list of missing keys. We iterate on the input
+	// list of labels to be able to easily create the list of ones in a single iteration.
+	var misses []string
+	for _, key := range keys {
+		_, ok := results[key]
+		if !ok {
+			misses = append(misses, key)
+			continue
+		}
+	}
+
+	c.hits.Add(float64(len(results)))
+	return results, misses
+}

--- a/pkg/cache/memcached.go
+++ b/pkg/cache/memcached.go
@@ -26,20 +26,22 @@ type MemcachedCache struct {
 }
 
 // NewMemcachedCache makes a new MemcachedCache.
-func NewMemcachedCache(logger log.Logger, memcached cacheutil.MemcachedClient, reg prometheus.Registerer) *MemcachedCache {
+func NewMemcachedCache(name string, logger log.Logger, memcached cacheutil.MemcachedClient, reg prometheus.Registerer) *MemcachedCache {
 	c := &MemcachedCache{
 		logger:    logger,
 		memcached: memcached,
 	}
 
 	c.requests = promauto.With(reg).NewCounter(prometheus.CounterOpts{
-		Name: "thanos_cache_memcached_requests_total",
-		Help: "Total number of items requests to the memcached.",
+		Name:        "thanos_cache_memcached_requests_total",
+		Help:        "Total number of items requests to memcached.",
+		ConstLabels: prometheus.Labels{"name": name},
 	})
 
 	c.hits = promauto.With(reg).NewCounter(prometheus.CounterOpts{
-		Name: "thanos_cache_memcached_hits_total",
-		Help: "Total number of items requests to the cache that were a hit.",
+		Name:        "thanos_cache_memcached_hits_total",
+		Help:        "Total number of items requests to the cache that were a hit.",
+		ConstLabels: prometheus.Labels{"name": name},
 	})
 
 	level.Info(logger).Log("msg", "created memcached cache")
@@ -51,34 +53,31 @@ func NewMemcachedCache(logger log.Logger, memcached cacheutil.MemcachedClient, r
 // The function enqueues the request and returns immediately: the entry will be
 // asynchronously stored in the cache.
 func (c *MemcachedCache) Store(ctx context.Context, data map[string][]byte, ttl time.Duration) {
+	var (
+		firstErr error
+		failed   int
+	)
+
 	for key, val := range data {
 		if err := c.memcached.SetAsync(ctx, key, val, ttl); err != nil {
-			level.Error(c.logger).Log("msg", "failed to store data into memcached", "err", err)
+			failed++
+			if firstErr == nil {
+				firstErr = err
+			}
 		}
+	}
+
+	if firstErr != nil {
+		level.Warn(c.logger).Log("msg", "failed to store one or more items into memcached", "failed", failed, "firstErr", firstErr)
 	}
 }
 
 // Fetch fetches multiple keys and returns a map containing cache hits, along with a list of missing keys.
 // In case of error, it logs and return an empty cache hits map.
-func (c *MemcachedCache) Fetch(ctx context.Context, keys []string) (map[string][]byte, []string) {
+func (c *MemcachedCache) Fetch(ctx context.Context, keys []string) map[string][]byte {
 	// Fetch the keys from memcached in a single request.
 	c.requests.Add(float64(len(keys)))
 	results := c.memcached.GetMulti(ctx, keys)
-	if len(results) == 0 {
-		return nil, keys
-	}
-
-	// Construct the resulting hits map and list of missing keys. We iterate on the input
-	// list of labels to be able to easily create the list of ones in a single iteration.
-	var misses []string
-	for _, key := range keys {
-		_, ok := results[key]
-		if !ok {
-			misses = append(misses, key)
-			continue
-		}
-	}
-
 	c.hits.Add(float64(len(results)))
-	return results, misses
+	return results
 }

--- a/pkg/cache/memcached.go
+++ b/pkg/cache/memcached.go
@@ -33,12 +33,12 @@ func NewMemcachedCache(logger log.Logger, memcached cacheutil.MemcachedClient, r
 	}
 
 	c.requests = promauto.With(reg).NewCounter(prometheus.CounterOpts{
-		Name: "thanos_store_memcached_requests_total",
+		Name: "thanos_cache_memcached_requests_total",
 		Help: "Total number of items requests to the memcached.",
 	})
 
 	c.hits = promauto.With(reg).NewCounter(prometheus.CounterOpts{
-		Name: "thanos_store_memcached_hits_total",
+		Name: "thanos_cache_memcached_hits_total",
 		Help: "Total number of items requests to the cache that were a hit.",
 	})
 
@@ -53,13 +53,12 @@ func NewMemcachedCache(logger log.Logger, memcached cacheutil.MemcachedClient, r
 func (c *MemcachedCache) Store(ctx context.Context, data map[string][]byte, ttl time.Duration) {
 	for key, val := range data {
 		if err := c.memcached.SetAsync(ctx, key, val, ttl); err != nil {
-			level.Error(c.logger).Log("msg", "failed to cache postings in memcached", "err", err)
+			level.Error(c.logger).Log("msg", "failed to store data into memcached", "err", err)
 		}
 	}
 }
 
-// FetchMultiPostings fetches multiple postings - each identified by a label -
-// and returns a map containing cache hits, along with a list of missing keys.
+// Fetch fetches multiple keys and returns a map containing cache hits, along with a list of missing keys.
 // In case of error, it logs and return an empty cache hits map.
 func (c *MemcachedCache) Fetch(ctx context.Context, keys []string) (map[string][]byte, []string) {
 	// Fetch the keys from memcached in a single request.

--- a/pkg/cache/memcached_test.go
+++ b/pkg/cache/memcached_test.go
@@ -27,17 +27,15 @@ func TestMemcachedIndexCache(t *testing.T) {
 	value3 := []byte{3}
 
 	tests := map[string]struct {
-		setup          map[string][]byte
-		mockedErr      error
-		fetchKeys      []string
-		expectedHits   map[string][]byte
-		expectedMisses []string
+		setup        map[string][]byte
+		mockedErr    error
+		fetchKeys    []string
+		expectedHits map[string][]byte
 	}{
 		"should return no hits on empty cache": {
-			setup:          nil,
-			fetchKeys:      []string{key1, key2},
-			expectedHits:   nil,
-			expectedMisses: []string{key1, key2},
+			setup:        nil,
+			fetchKeys:    []string{key1, key2},
+			expectedHits: nil,
 		},
 		"should return no misses on 100% hit ratio": {
 			setup: map[string][]byte{
@@ -49,16 +47,14 @@ func TestMemcachedIndexCache(t *testing.T) {
 			expectedHits: map[string][]byte{
 				key1: value1,
 			},
-			expectedMisses: nil,
 		},
 		"should return hits and misses on partial hits": {
 			setup: map[string][]byte{
 				key1: value1,
 				key2: value2,
 			},
-			fetchKeys:      []string{key1, key3},
-			expectedHits:   map[string][]byte{key1: value1},
-			expectedMisses: []string{key3},
+			fetchKeys:    []string{key1, key3},
+			expectedHits: map[string][]byte{key1: value1},
 		},
 		"should return no hits on memcached error": {
 			setup: map[string][]byte{
@@ -66,10 +62,9 @@ func TestMemcachedIndexCache(t *testing.T) {
 				key2: value2,
 				key3: value3,
 			},
-			mockedErr:      errors.New("mocked error"),
-			fetchKeys:      []string{key1},
-			expectedHits:   nil,
-			expectedMisses: []string{key1},
+			mockedErr:    errors.New("mocked error"),
+			fetchKeys:    []string{key1},
+			expectedHits: nil,
 		},
 	}
 
@@ -83,9 +78,8 @@ func TestMemcachedIndexCache(t *testing.T) {
 			c.Store(ctx, testData.setup, time.Hour)
 
 			// Fetch postings from cached and assert on it.
-			hits, misses := c.Fetch(ctx, testData.fetchKeys)
+			hits := c.Fetch(ctx, testData.fetchKeys)
 			testutil.Equals(t, testData.expectedHits, hits)
-			testutil.Equals(t, testData.expectedMisses, misses)
 
 			// Assert on metrics.
 			testutil.Equals(t, float64(len(testData.fetchKeys)), prom_testutil.ToFloat64(c.requests))

--- a/pkg/cache/memcached_test.go
+++ b/pkg/cache/memcached_test.go
@@ -1,0 +1,132 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package cache
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-kit/kit/log"
+	"github.com/pkg/errors"
+	prom_testutil "github.com/prometheus/client_golang/prometheus/testutil"
+
+	"github.com/thanos-io/thanos/pkg/testutil"
+)
+
+func TestMemcachedIndexCache(t *testing.T) {
+	t.Parallel()
+
+	// Init some data to conveniently define test cases later one.
+	key1 := "key1"
+	key2 := "key2"
+	key3 := "key3"
+	value1 := []byte{1}
+	value2 := []byte{2}
+	value3 := []byte{3}
+
+	tests := map[string]struct {
+		setup          map[string][]byte
+		mockedErr      error
+		fetchKeys      []string
+		expectedHits   map[string][]byte
+		expectedMisses []string
+	}{
+		"should return no hits on empty cache": {
+			setup:          nil,
+			fetchKeys:      []string{key1, key2},
+			expectedHits:   nil,
+			expectedMisses: []string{key1, key2},
+		},
+		"should return no misses on 100% hit ratio": {
+			setup: map[string][]byte{
+				key1: value1,
+				key2: value2,
+				key3: value3,
+			},
+			fetchKeys: []string{key1},
+			expectedHits: map[string][]byte{
+				key1: value1,
+			},
+			expectedMisses: nil,
+		},
+		"should return hits and misses on partial hits": {
+			setup: map[string][]byte{
+				key1: value1,
+				key2: value2,
+			},
+			fetchKeys:      []string{key1, key3},
+			expectedHits:   map[string][]byte{key1: value1},
+			expectedMisses: []string{key3},
+		},
+		"should return no hits on memcached error": {
+			setup: map[string][]byte{
+				key1: value1,
+				key2: value2,
+				key3: value3,
+			},
+			mockedErr:      errors.New("mocked error"),
+			fetchKeys:      []string{key1},
+			expectedHits:   nil,
+			expectedMisses: []string{key1},
+		},
+	}
+
+	for testName, testData := range tests {
+		t.Run(testName, func(t *testing.T) {
+			memcached := newMockedMemcachedClient(testData.mockedErr)
+			c := NewMemcachedCache(log.NewNopLogger(), memcached, nil)
+
+			// Store the postings expected before running the test.
+			ctx := context.Background()
+			c.Store(ctx, testData.setup, time.Hour)
+
+			// Fetch postings from cached and assert on it.
+			hits, misses := c.Fetch(ctx, testData.fetchKeys)
+			testutil.Equals(t, testData.expectedHits, hits)
+			testutil.Equals(t, testData.expectedMisses, misses)
+
+			// Assert on metrics.
+			testutil.Equals(t, float64(len(testData.fetchKeys)), prom_testutil.ToFloat64(c.requests))
+			testutil.Equals(t, float64(len(testData.expectedHits)), prom_testutil.ToFloat64(c.hits))
+		})
+	}
+}
+
+type mockedMemcachedClient struct {
+	cache             map[string][]byte
+	mockedGetMultiErr error
+}
+
+func newMockedMemcachedClient(mockedGetMultiErr error) *mockedMemcachedClient {
+	return &mockedMemcachedClient{
+		cache:             map[string][]byte{},
+		mockedGetMultiErr: mockedGetMultiErr,
+	}
+}
+
+func (c *mockedMemcachedClient) GetMulti(_ context.Context, keys []string) map[string][]byte {
+	if c.mockedGetMultiErr != nil {
+		return nil
+	}
+
+	hits := map[string][]byte{}
+
+	for _, key := range keys {
+		if value, ok := c.cache[key]; ok {
+			hits[key] = value
+		}
+	}
+
+	return hits
+}
+
+func (c *mockedMemcachedClient) SetAsync(_ context.Context, key string, value []byte, _ time.Duration) error {
+	c.cache[key] = value
+	return nil
+}
+
+func (c *mockedMemcachedClient) Stop() {
+	// Nothing to do.
+}

--- a/pkg/cache/memcached_test.go
+++ b/pkg/cache/memcached_test.go
@@ -35,7 +35,7 @@ func TestMemcachedIndexCache(t *testing.T) {
 		"should return no hits on empty cache": {
 			setup:        nil,
 			fetchKeys:    []string{key1, key2},
-			expectedHits: nil,
+			expectedHits: map[string][]byte{},
 		},
 		"should return no misses on 100% hit ratio": {
 			setup: map[string][]byte{

--- a/pkg/cache/memcached_test.go
+++ b/pkg/cache/memcached_test.go
@@ -76,7 +76,7 @@ func TestMemcachedIndexCache(t *testing.T) {
 	for testName, testData := range tests {
 		t.Run(testName, func(t *testing.T) {
 			memcached := newMockedMemcachedClient(testData.mockedErr)
-			c := NewMemcachedCache(log.NewNopLogger(), memcached, nil)
+			c := NewMemcachedCache("test", log.NewNopLogger(), memcached, nil)
 
 			// Store the postings expected before running the test.
 			ctx := context.Background()

--- a/pkg/extflag/hidden.go
+++ b/pkg/extflag/hidden.go
@@ -1,3 +1,6 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
 package extflag
 
 import (

--- a/pkg/extflag/hidden.go
+++ b/pkg/extflag/hidden.go
@@ -1,0 +1,18 @@
+package extflag
+
+import (
+	"gopkg.in/alecthomas/kingpin.v2"
+)
+
+// HiddenCmdClause returns CmdClause that hides created flags.
+func HiddenCmdClause(c CmdClause) CmdClause {
+	return hidden{c: c}
+}
+
+type hidden struct {
+	c CmdClause
+}
+
+func (h hidden) Flag(name, help string) *kingpin.FlagClause {
+	return h.c.Flag(name, help).Hidden()
+}

--- a/pkg/store/cache/caching_bucket.go
+++ b/pkg/store/cache/caching_bucket.go
@@ -1,0 +1,389 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package storecache
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"regexp"
+	"sync"
+	"time"
+
+	"github.com/go-kit/kit/log"
+	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/thanos-io/thanos/pkg/cache"
+	"github.com/thanos-io/thanos/pkg/objstore"
+	"github.com/thanos-io/thanos/pkg/runutil"
+)
+
+type ChunksCachingConfig struct {
+	// Basic unit used to cache chunks.
+	ChunkBlockSize int64 `yaml:"chunk_block_size"`
+
+	// Maximum number of GetRange requests issued by this bucket for single GetRange call. Zero or negative value = unlimited.
+	MaxChunksGetRangeRequests int `yaml:"max_chunks_get_range_requests"`
+
+	// TTLs for various cache items.
+	ChunkObjectSizeTTL time.Duration `yaml:"chunk_object_size_ttl"`
+	ChunkBlockTTL      time.Duration `yaml:"chunk_block_ttl"`
+}
+
+func DefaultChunksCachingConfig() ChunksCachingConfig {
+	return ChunksCachingConfig{
+		ChunkBlockSize:            16000, // equal to max chunk size
+		ChunkObjectSizeTTL:        24 * time.Hour,
+		ChunkBlockTTL:             24 * time.Hour,
+		MaxChunksGetRangeRequests: 1,
+	}
+}
+
+// Bucket implementation that provides some caching features, using knowledge about how Thanos accesses data.
+type CachingBucket struct {
+	bucket objstore.Bucket
+	cache  cache.Cache
+
+	chunks ChunksCachingConfig
+
+	logger            log.Logger
+	cachedChunkBytes  prometheus.Counter
+	fetchedChunkBytes prometheus.Counter
+}
+
+func NewCachingBucket(b objstore.Bucket, c cache.Cache, chunks ChunksCachingConfig, logger log.Logger, reg prometheus.Registerer) (*CachingBucket, error) {
+	if b == nil {
+		return nil, errors.New("bucket is nil")
+	}
+	if c == nil {
+		return nil, errors.New("cache is nil")
+	}
+
+	return &CachingBucket{
+		chunks: chunks,
+		bucket: b,
+		cache:  c,
+		logger: logger,
+
+		cachedChunkBytes: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Name: "thanos_store_caching_bucket_cached_chunk_bytes_total",
+			Help: "Total number of chunk bytes used from cache",
+		}),
+		fetchedChunkBytes: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Name: "thanos_store_caching_bucket_fetched_chunk_bytes_total",
+			Help: "Total number of chunk bytes fetched from storage",
+		}),
+	}, nil
+}
+
+func (cb *CachingBucket) Close() error {
+	return cb.bucket.Close()
+}
+
+func (cb *CachingBucket) Upload(ctx context.Context, name string, r io.Reader) error {
+	return cb.bucket.Upload(ctx, name, r)
+}
+
+func (cb *CachingBucket) Delete(ctx context.Context, name string) error {
+	return cb.bucket.Delete(ctx, name)
+}
+
+func (cb *CachingBucket) Name() string {
+	return "caching: " + cb.bucket.Name()
+}
+
+func (cb *CachingBucket) WithExpectedErrs(expectedFunc objstore.IsOpFailureExpectedFunc) objstore.Bucket {
+	if ib, ok := cb.bucket.(objstore.InstrumentedBucket); ok {
+		// make a copy, but replace bucket
+		res := &CachingBucket{}
+		*res = *cb
+		res.bucket = ib.WithExpectedErrs(expectedFunc)
+		return res
+	}
+
+	// nothing else to do (?)
+	return cb
+}
+
+func (cb *CachingBucket) ReaderWithExpectedErrs(expectedFunc objstore.IsOpFailureExpectedFunc) objstore.BucketReader {
+	return cb.WithExpectedErrs(expectedFunc)
+}
+
+func (cb *CachingBucket) Iter(ctx context.Context, dir string, f func(string) error) error {
+	return cb.bucket.Iter(ctx, dir, f)
+}
+
+func (cb *CachingBucket) Get(ctx context.Context, name string) (io.ReadCloser, error) {
+	return cb.bucket.Get(ctx, name)
+}
+
+var chunksMatcher = regexp.MustCompile(`^.*/chunks/\d+$`)
+
+func isTSDBChunkFile(name string) bool {
+	return chunksMatcher.MatchString(name)
+}
+
+func (cb *CachingBucket) GetRange(ctx context.Context, name string, off, length int64) (io.ReadCloser, error) {
+	if isTSDBChunkFile(name) && off >= 0 && length > 0 {
+		return cb.getRangeChunkFile(ctx, name, off, length)
+	}
+
+	return cb.bucket.GetRange(ctx, name, off, length)
+}
+
+func (cb *CachingBucket) Exists(ctx context.Context, name string) (bool, error) {
+	return cb.bucket.Exists(ctx, name)
+}
+
+func (cb *CachingBucket) IsObjNotFoundErr(err error) bool {
+	return cb.bucket.IsObjNotFoundErr(err)
+}
+
+func (cb *CachingBucket) ObjectSize(ctx context.Context, name string) (uint64, error) {
+	return cb.bucket.ObjectSize(ctx, name)
+}
+
+func (cb *CachingBucket) cachedObjectSize(ctx context.Context, name string, ttl time.Duration) (uint64, error) {
+	key := cachingKeyObjectSize(name)
+
+	hits, _ := cb.cache.Fetch(ctx, []string{key})
+	if s := hits[key]; len(s) == 8 {
+		return binary.BigEndian.Uint64(s), nil
+	}
+
+	size, err := cb.bucket.ObjectSize(ctx, name)
+	if err != nil {
+		return 0, err
+	}
+
+	var buf [8]byte
+	binary.BigEndian.PutUint64(buf[:], size)
+	cb.cache.Store(ctx, map[string][]byte{key: buf[:]}, ttl)
+
+	return size, nil
+}
+
+func (cb *CachingBucket) getRangeChunkFile(ctx context.Context, name string, offset, length int64) (io.ReadCloser, error) {
+	size, err := cb.cachedObjectSize(ctx, name, cb.chunks.ChunkObjectSizeTTL)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get size of chunk file: %s", name)
+	}
+
+	// If length goes over object size, adjust length. We use it later to limit number of read bytes.
+	if uint64(offset+length) > size {
+		length = int64(size - uint64(offset))
+	}
+
+	startOffset := (offset / cb.chunks.ChunkBlockSize) * cb.chunks.ChunkBlockSize
+	endOffset := ((offset + length) / cb.chunks.ChunkBlockSize) * cb.chunks.ChunkBlockSize
+	if (offset+length)%cb.chunks.ChunkBlockSize > 0 {
+		endOffset += cb.chunks.ChunkBlockSize
+	}
+
+	blocks := (endOffset - startOffset) / cb.chunks.ChunkBlockSize
+
+	offsetKeys := make(map[int64]string, blocks)
+	keys := make([]string, 0, blocks)
+	lastBlockLength := 0
+
+	for o := startOffset; o < endOffset; o += cb.chunks.ChunkBlockSize {
+		end := o + cb.chunks.ChunkBlockSize
+		if end > int64(size) {
+			end = int64(size)
+		}
+
+		lastBlockLength = int(end - o)
+
+		k := cachingKeyObjectBlock(name, o, end)
+		keys = append(keys, k)
+		offsetKeys[o] = k
+	}
+
+	// Try to get all blocks from the cache.
+	hits, _ := cb.cache.Fetch(ctx, keys)
+
+	for _, b := range hits {
+		cb.cachedChunkBytes.Add(float64(len(b)))
+	}
+
+	if len(hits) < len(keys) {
+		if hits == nil {
+			hits = map[string][]byte{}
+		}
+
+		err := cb.fetchMissingChunkBlocks(ctx, name, startOffset, endOffset, offsetKeys, hits, lastBlockLength)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return newBlocksReader(cb.chunks.ChunkBlockSize, offsetKeys, hits, offset, length), nil
+}
+
+type rng struct {
+	start, end int64
+}
+
+// Fetches missing blocks and stores them into "hits" map.
+func (cb *CachingBucket) fetchMissingChunkBlocks(ctx context.Context, name string, startOffset, endOffset int64, cacheKeys map[int64]string, hits map[string][]byte, lastBlockLength int) error {
+	// Ordered list of missing sub-ranges.
+	var missing []rng
+
+	for off := startOffset; off < endOffset; off += cb.chunks.ChunkBlockSize {
+		if hits[cacheKeys[off]] == nil {
+			missing = append(missing, rng{start: off, end: off + cb.chunks.ChunkBlockSize})
+		}
+	}
+
+	missing = mergeRanges(missing, 0) // Merge adjacent ranges.
+	// Keep merging until we have only max number of ranges (= requests).
+	for limit := cb.chunks.ChunkBlockSize; cb.chunks.MaxChunksGetRangeRequests > 0 && len(missing) > cb.chunks.MaxChunksGetRangeRequests; limit = limit * 2 {
+		missing = mergeRanges(missing, limit)
+	}
+
+	var hitsMutex sync.Mutex
+
+	// Run parallel queries for each missing range. Fetched data is stored into 'hits' map, protected by hitsMutex.
+	eg, nctx := errgroup.WithContext(ctx)
+	for _, m := range missing {
+		m := m
+		eg.Go(func() error {
+			r, err := cb.bucket.GetRange(nctx, name, m.start, m.end-m.start)
+			if err != nil {
+				return errors.Wrapf(err, "fetching range [%d, %d]", m.start, m.end)
+			}
+			defer runutil.CloseWithLogOnErr(cb.logger, r, "fetching range [%d, %d]", m.start, m.end)
+
+			for off := m.start; off < m.end && nctx.Err() == nil; off += cb.chunks.ChunkBlockSize {
+				key := cacheKeys[off]
+				if key == "" {
+					return errors.Errorf("fetching range [%d, %d]: caching key for offset %d not found", m.start, m.end, off)
+				}
+
+				// We need a new buffer for each block, both for storing into hits, and also for caching.
+				blockData := make([]byte, cb.chunks.ChunkBlockSize)
+				n, err := io.ReadFull(r, blockData)
+				if err == io.ErrUnexpectedEOF && (off+cb.chunks.ChunkBlockSize) == endOffset && n == lastBlockLength {
+					// Last block can be shorter.
+					err = nil
+					blockData = blockData[:n]
+				}
+				if err != nil {
+					return errors.Wrapf(err, "fetching range [%d, %d]", m.start, m.end)
+				}
+
+				hitsMutex.Lock()
+				hits[key] = blockData
+				hitsMutex.Unlock()
+
+				cb.fetchedChunkBytes.Add(float64(len(blockData)))
+				cb.cache.Store(nctx, map[string][]byte{key: blockData}, cb.chunks.ChunkBlockTTL)
+			}
+
+			return nctx.Err()
+		})
+	}
+
+	return eg.Wait()
+}
+
+// Merges ranges that are close to each other. Modifies input.
+func mergeRanges(input []rng, limit int64) []rng {
+	if len(input) == 0 {
+		return input
+	}
+
+	last := 0
+	for ix := 1; ix < len(input); ix++ {
+		if (input[ix].start - input[last].end) <= limit {
+			input[last].end = input[ix].end
+		} else {
+			last++
+			input[last] = input[ix]
+		}
+	}
+	return input[:last+1]
+}
+
+func cachingKeyObjectSize(name string) string {
+	return fmt.Sprintf("size:%s", name)
+}
+
+func cachingKeyObjectBlock(name string, start int64, end int64) string {
+	return fmt.Sprintf("block:%s:%d:%d", name, start, end)
+}
+
+// io.ReadCloser implementation that uses in-memory blocks.
+type blocksReader struct {
+	blockSize int64
+
+	// Mapping of blockSize-aligned offsets to keys in hits.
+	offsetsKeys map[int64]string
+	blocks      map[string][]byte
+
+	// Offset for next read, used to find correct block to return data from.
+	readOffset int64
+
+	// Remaining data to return from this reader. Once zero, this reader reports EOF.
+	remaining int64
+}
+
+func newBlocksReader(blockSize int64, offsetsKeys map[int64]string, blocks map[string][]byte, readOffset, remaining int64) *blocksReader {
+	return &blocksReader{
+		blockSize:   blockSize,
+		offsetsKeys: offsetsKeys,
+		blocks:      blocks,
+
+		readOffset: readOffset,
+		remaining:  remaining,
+	}
+}
+
+func (c *blocksReader) Close() error {
+	return nil
+}
+
+func (c *blocksReader) Read(p []byte) (n int, err error) {
+	if c.remaining <= 0 {
+		return 0, io.EOF
+	}
+
+	currentBlockOffset := (c.readOffset / c.blockSize) * c.blockSize
+	currentBlock, err := c.blockAt(currentBlockOffset)
+	if err != nil {
+		return 0, errors.Wrapf(err, "read position: %d", c.readOffset)
+	}
+
+	offsetInBlock := int(c.readOffset - currentBlockOffset)
+	toCopy := len(currentBlock) - offsetInBlock
+	if toCopy <= 0 {
+		// This can only happen if block's length is not blockSize, and reader is told to read more data.
+		return 0, errors.Errorf("no more data left in block at position %d, block length %d, reading position %d", currentBlockOffset, len(currentBlock), c.readOffset)
+	}
+
+	if len(p) < toCopy {
+		toCopy = len(p)
+	}
+	if c.remaining < int64(toCopy) {
+		toCopy = int(c.remaining) // Conversion is safe, c.remaining is small enough.
+	}
+
+	copy(p, currentBlock[offsetInBlock:offsetInBlock+toCopy])
+	c.readOffset += int64(toCopy)
+	c.remaining -= int64(toCopy)
+
+	return toCopy, nil
+}
+
+func (c *blocksReader) blockAt(offset int64) ([]byte, error) {
+	b := c.blocks[c.offsetsKeys[offset]]
+	if b == nil {
+		return nil, errors.Errorf("block for offset %d not found", offset)
+	}
+	return b, nil
+}

--- a/pkg/store/cache/caching_bucket.go
+++ b/pkg/store/cache/caching_bucket.go
@@ -78,15 +78,15 @@ func NewCachingBucket(b objstore.Bucket, c cache.Cache, chunks CachingBucketConf
 
 		requestedChunkBytes: promauto.With(reg).NewCounter(prometheus.CounterOpts{
 			Name: "thanos_store_bucket_cache_requested_chunk_bytes_total",
-			Help: "Total number of requested bytes for chunk data",
+			Help: "Total number of requested bytes for chunk data.",
 		}),
 		cachedChunkBytes: promauto.With(reg).NewCounter(prometheus.CounterOpts{
 			Name: "thanos_store_bucket_cache_cached_chunk_bytes_total",
-			Help: "Total number of chunk bytes used from cache",
+			Help: "Total number of chunk bytes used from cache.",
 		}),
 		fetchedChunkBytes: promauto.With(reg).NewCounter(prometheus.CounterOpts{
 			Name: "thanos_store_bucket_cache_fetched_chunk_bytes_total",
-			Help: "Total number of chunk bytes fetched from storage because missing from cache",
+			Help: "Total number of chunk bytes fetched from storage because missing from cache.",
 		}),
 		refetchedChunkBytes: promauto.With(reg).NewCounter(prometheus.CounterOpts{
 			Name: "thanos_store_bucket_cache_refetched_chunk_bytes_total",
@@ -94,11 +94,11 @@ func NewCachingBucket(b objstore.Bucket, c cache.Cache, chunks CachingBucketConf
 		}),
 		objectSizeRequests: promauto.With(reg).NewCounter(prometheus.CounterOpts{
 			Name: "thanos_store_bucket_cache_objectsize_requests_total",
-			Help: "Number of object size requests for objects",
+			Help: "Number of object size requests for objects.",
 		}),
 		objectSizeHits: promauto.With(reg).NewCounter(prometheus.CounterOpts{
 			Name: "thanos_store_bucket_cache_objectsize_hits_total",
-			Help: "Number of object size hits for objects",
+			Help: "Number of object size hits for objects.",
 		}),
 	}, nil
 }

--- a/pkg/store/cache/caching_bucket.go
+++ b/pkg/store/cache/caching_bucket.go
@@ -8,6 +8,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"regexp"
 	"sync"
 	"time"
@@ -236,7 +237,7 @@ func (cb *CachingBucket) getRangeChunkFile(ctx context.Context, name string, off
 		}
 	}
 
-	return newSubrangesReader(cb.config.ChunkSubrangeSize, offsetKeys, hits, offset, length), nil
+	return ioutil.NopCloser(newSubrangesReader(cb.config.ChunkSubrangeSize, offsetKeys, hits, offset, length)), nil
 }
 
 type rng struct {
@@ -343,7 +344,7 @@ func cachingKeyObjectSubrange(name string, start int64, end int64) string {
 	return fmt.Sprintf("subrange:%s:%d:%d", name, start, end)
 }
 
-// io.ReadCloser implementation that uses in-memory subranges.
+// Reader implementation that uses in-memory subranges.
 type subrangesReader struct {
 	subrangeSize int64
 
@@ -367,10 +368,6 @@ func newSubrangesReader(subrangeSize int64, offsetsKeys map[int64]string, subran
 		readOffset: readOffset,
 		remaining:  remaining,
 	}
-}
-
-func (c *subrangesReader) Close() error {
-	return nil
 }
 
 func (c *subrangesReader) Read(p []byte) (n int, err error) {

--- a/pkg/store/cache/caching_bucket.go
+++ b/pkg/store/cache/caching_bucket.go
@@ -86,7 +86,7 @@ func NewCachingBucket(b objstore.Bucket, c cache.Cache, chunks CachingBucketConf
 		}),
 		fetchedChunkBytes: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 			Name: "thanos_store_bucket_cache_fetched_chunk_bytes_total",
-			Help: "Total number of chunk bytes fetched from storage because missing from cache.",
+			Help: "Total number of fetched chunk bytes. Data from bucket is then stored to cache.",
 		}, []string{"origin"}),
 		refetchedChunkBytes: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 			Name: "thanos_store_bucket_cache_refetched_chunk_bytes_total",

--- a/pkg/store/cache/caching_bucket.go
+++ b/pkg/store/cache/caching_bucket.go
@@ -78,7 +78,7 @@ func NewCachingBucket(b objstore.Bucket, c cache.Cache, chunks CachingBucketConf
 
 		requestedChunkBytes: promauto.With(reg).NewCounter(prometheus.CounterOpts{
 			Name: "thanos_store_bucket_cache_requested_chunk_bytes_total",
-			Help: "Total number of requested bytes for chunk data ",
+			Help: "Total number of requested bytes for chunk data",
 		}),
 		cachedChunkBytes: promauto.With(reg).NewCounter(prometheus.CounterOpts{
 			Name: "thanos_store_bucket_cache_cached_chunk_bytes_total",
@@ -86,7 +86,7 @@ func NewCachingBucket(b objstore.Bucket, c cache.Cache, chunks CachingBucketConf
 		}),
 		fetchedChunkBytes: promauto.With(reg).NewCounter(prometheus.CounterOpts{
 			Name: "thanos_store_bucket_cache_fetched_chunk_bytes_total",
-			Help: "Total number of chunk bytes fetched from storage",
+			Help: "Total number of chunk bytes fetched from storage because missing from cache",
 		}),
 		refetchedChunkBytes: promauto.With(reg).NewCounter(prometheus.CounterOpts{
 			Name: "thanos_store_bucket_cache_refetched_chunk_bytes_total",

--- a/pkg/store/cache/caching_bucket.go
+++ b/pkg/store/cache/caching_bucket.go
@@ -213,7 +213,7 @@ func (cb *CachingBucket) getRangeChunkFile(ctx context.Context, name string, off
 	}
 
 	// The very last block in the object may have length that is not divisible by block size.
-	lastBlockOffset := int64(-1)
+	lastBlockOffset := endRange - cb.config.ChunkBlockSize
 	lastBlockLength := int(cb.config.ChunkBlockSize)
 	if uint64(endRange) > size {
 		lastBlockOffset = (int64(size) / cb.config.ChunkBlockSize) * cb.config.ChunkBlockSize

--- a/pkg/store/cache/caching_bucket.go
+++ b/pkg/store/cache/caching_bucket.go
@@ -243,7 +243,8 @@ type rng struct {
 	start, end int64
 }
 
-// Fetches missing blocks and stores them into "hits" map.
+// fetchMissingChunkBlocks fetches missing blocks, stores them into "hits" map
+// and into cache as well (using provided cacheKeys).
 func (cb *CachingBucket) fetchMissingChunkBlocks(ctx context.Context, name string, startRange, endRange int64, cacheKeys map[int64]string, hits map[string][]byte, lastBlockOffset int64, lastBlockLength int) error {
 	// Ordered list of missing sub-ranges.
 	var missing []rng

--- a/pkg/store/cache/caching_bucket.go
+++ b/pkg/store/cache/caching_bucket.go
@@ -37,7 +37,7 @@ type ChunksCachingConfig struct {
 
 func DefaultChunksCachingConfig() ChunksCachingConfig {
 	return ChunksCachingConfig{
-		ChunkBlockSize:            16000, // equal to max chunk size
+		ChunkBlockSize:            16000, // Equal to max chunk size.
 		ChunkObjectSizeTTL:        24 * time.Hour,
 		ChunkBlockTTL:             24 * time.Hour,
 		MaxChunksGetRangeRequests: 1,
@@ -99,7 +99,7 @@ func (cb *CachingBucket) Name() string {
 
 func (cb *CachingBucket) WithExpectedErrs(expectedFunc objstore.IsOpFailureExpectedFunc) objstore.Bucket {
 	if ib, ok := cb.bucket.(objstore.InstrumentedBucket); ok {
-		// make a copy, but replace bucket
+		// Make a copy, but replace bucket with instrumented one.
 		res := &CachingBucket{}
 		*res = *cb
 		res.bucket = ib.WithExpectedErrs(expectedFunc)

--- a/pkg/store/cache/caching_bucket_factory.go
+++ b/pkg/store/cache/caching_bucket_factory.go
@@ -15,10 +15,14 @@ import (
 	"github.com/thanos-io/thanos/pkg/objstore"
 )
 
+// BucketCacheProvider is a type used to evaluate all bucket cache providers.
 type BucketCacheProvider string
 
-const MemcachedBucketCacheProvider BucketCacheProvider = "memcached"
+const (
+	MemcachedBucketCacheProvider BucketCacheProvider = "memcached" // Memcached cache-provider for caching bucket.
+)
 
+// CachingBucketWithBackendConfig is a configuration of caching bucket used by Store component.
 type CachingBucketWithBackendConfig struct {
 	Type          BucketCacheProvider `yaml:"backend"`
 	BackendConfig interface{}         `yaml:"backend_config"`
@@ -26,6 +30,7 @@ type CachingBucketWithBackendConfig struct {
 	CachingBucketConfig CachingBucketConfig `yaml:"caching_config"`
 }
 
+// NewCachingBucketFromYaml uses YAML configuration to create new caching bucket.
 func NewCachingBucketFromYaml(yamlContent []byte, bucket objstore.Bucket, logger log.Logger, reg prometheus.Registerer) (objstore.InstrumentedBucket, error) {
 	level.Info(logger).Log("msg", "loading caching bucket configuration")
 

--- a/pkg/store/cache/caching_bucket_factory.go
+++ b/pkg/store/cache/caching_bucket_factory.go
@@ -1,0 +1,59 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package storecache
+
+import (
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
+	"gopkg.in/yaml.v2"
+
+	cache "github.com/thanos-io/thanos/pkg/cache"
+	"github.com/thanos-io/thanos/pkg/cacheutil"
+	"github.com/thanos-io/thanos/pkg/objstore"
+)
+
+type BucketCacheProvider string
+
+const MemcachedBucketCacheProvider BucketCacheProvider = "memcached"
+
+type CachingBucketConfig struct {
+	Type        BucketCacheProvider `yaml:"backend"`
+	CacheConfig interface{}         `yaml:"backend_config"`
+
+	ChunksCachingConfig ChunksCachingConfig `yaml:"chunks_caching_config"`
+}
+
+func NewCachingBucketFromYaml(yamlContent []byte, bucket objstore.Bucket, logger log.Logger, reg prometheus.Registerer) (objstore.InstrumentedBucket, error) {
+	level.Info(logger).Log("msg", "loading caching bucket configuration")
+
+	config := &CachingBucketConfig{}
+	config.ChunksCachingConfig = DefaultChunksCachingConfig()
+
+	if err := yaml.UnmarshalStrict(yamlContent, config); err != nil {
+		return nil, errors.Wrap(err, "parsing config YAML file")
+	}
+
+	backendConfig, err := yaml.Marshal(config.CacheConfig)
+	if err != nil {
+		return nil, errors.Wrap(err, "marshal content of cache backend configuration")
+	}
+
+	var c cache.Cache
+
+	switch config.Type {
+	case MemcachedBucketCacheProvider:
+		var memcached cacheutil.MemcachedClient
+		memcached, err := cacheutil.NewMemcachedClient(logger, "cache-bucket", backendConfig, reg)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to create memcached client")
+		}
+		c = cache.NewMemcachedCache(logger, memcached, reg)
+	default:
+		return nil, errors.Errorf("unsupported cache type: %s", config.Type)
+	}
+
+	return NewCachingBucket(bucket, c, config.ChunksCachingConfig, logger, reg)
+}

--- a/pkg/store/cache/caching_bucket_factory.go
+++ b/pkg/store/cache/caching_bucket_factory.go
@@ -46,11 +46,11 @@ func NewCachingBucketFromYaml(yamlContent []byte, bucket objstore.Bucket, logger
 	switch config.Type {
 	case MemcachedBucketCacheProvider:
 		var memcached cacheutil.MemcachedClient
-		memcached, err := cacheutil.NewMemcachedClient(logger, "cache-bucket", backendConfig, reg)
+		memcached, err := cacheutil.NewMemcachedClient(logger, "caching-bucket", backendConfig, reg)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to create memcached client")
 		}
-		c = cache.NewMemcachedCache(logger, memcached, reg)
+		c = cache.NewMemcachedCache("caching-bucket", logger, memcached, reg)
 	default:
 		return nil, errors.Errorf("unsupported cache type: %s", config.Type)
 	}

--- a/pkg/store/cache/caching_bucket_test.go
+++ b/pkg/store/cache/caching_bucket_test.go
@@ -107,7 +107,7 @@ func TestCachingBucket(t *testing.T) {
 			expectedFetchedBytes: length,
 			expectedCachedBytes:  0, // Cache is flushed.
 			init: func() {
-				cache.cache = map[string][]byte{} // flush cache
+				cache.cache = map[string][]byte{} // Flush cache.
 			},
 		},
 

--- a/pkg/store/cache/caching_bucket_test.go
+++ b/pkg/store/cache/caching_bucket_test.go
@@ -225,9 +225,9 @@ func TestCachingBucket(t *testing.T) {
 			testutil.Ok(t, err)
 
 			verifyGetRange(t, cachingBucket, name, tc.offset, tc.length, tc.expectedLength)
-			testutil.Equals(t, tc.expectedCachedBytes, int64(promtest.ToFloat64(cachingBucket.cachedChunkBytes)))
-			testutil.Equals(t, tc.expectedFetchedBytes, int64(promtest.ToFloat64(cachingBucket.fetchedChunkBytes)))
-			testutil.Equals(t, tc.expectedRefetchedBytes, int64(promtest.ToFloat64(cachingBucket.refetchedChunkBytes)))
+			testutil.Equals(t, tc.expectedCachedBytes, int64(promtest.ToFloat64(cachingBucket.fetchedChunkBytes.WithLabelValues(originCache))))
+			testutil.Equals(t, tc.expectedFetchedBytes, int64(promtest.ToFloat64(cachingBucket.fetchedChunkBytes.WithLabelValues(originBucket))))
+			testutil.Equals(t, tc.expectedRefetchedBytes, int64(promtest.ToFloat64(cachingBucket.refetchedChunkBytes.WithLabelValues(originCache))))
 		})
 	}
 }

--- a/pkg/store/cache/caching_bucket_test.go
+++ b/pkg/store/cache/caching_bucket_test.go
@@ -21,7 +21,7 @@ import (
 
 func TestCachingBucket(t *testing.T) {
 	length := int64(1024 * 1024)
-	blockSize := int64(16000) // all tests are based on this value
+	blockSize := int64(16000) // All tests are based on this value.
 
 	data := make([]byte, length)
 	for ix := 0; ix < len(data); ix++ {
@@ -71,7 +71,7 @@ func TestCachingBucket(t *testing.T) {
 			offset:               length - 10,
 			length:               3000,
 			expectedLength:       10,
-			expectedFetchedBytes: 8576, // last block is fetched
+			expectedFetchedBytes: 8576, // Last (incomplete) block is fetched.
 		},
 
 		{
@@ -87,7 +87,7 @@ func TestCachingBucket(t *testing.T) {
 			offset:               0,
 			length:               length,
 			expectedLength:       length,
-			expectedCachedBytes:  5*blockSize + 8576, // 5 block cached from first test, plus last incomplete block
+			expectedCachedBytes:  5*blockSize + 8576, // 5 block cached from first test, plus last incomplete block.
 			expectedFetchedBytes: 60 * blockSize,
 		},
 
@@ -96,7 +96,7 @@ func TestCachingBucket(t *testing.T) {
 			offset:              0,
 			length:              length,
 			expectedLength:      length,
-			expectedCachedBytes: length, // entire file is now cached
+			expectedCachedBytes: length, // Entire file is now cached.
 		},
 
 		{
@@ -104,7 +104,8 @@ func TestCachingBucket(t *testing.T) {
 			offset:               0,
 			length:               length,
 			expectedLength:       length,
-			expectedFetchedBytes: length, // cache is flushed
+			expectedFetchedBytes: length,
+			expectedCachedBytes:  0, // Cache is flushed.
 			init: func() {
 				cache.cache = map[string][]byte{} // flush cache
 			},
@@ -118,7 +119,7 @@ func TestCachingBucket(t *testing.T) {
 			expectedFetchedBytes: 3 * blockSize,
 			expectedCachedBytes:  7 * blockSize,
 			init: func() {
-				// delete first 3 blocks
+				// Delete first 3 blocks.
 				delete(cache.cache, cachingKeyObjectBlock(name, 0*blockSize, 1*blockSize))
 				delete(cache.cache, cachingKeyObjectBlock(name, 1*blockSize, 2*blockSize))
 				delete(cache.cache, cachingKeyObjectBlock(name, 2*blockSize, 3*blockSize))
@@ -133,7 +134,7 @@ func TestCachingBucket(t *testing.T) {
 			expectedFetchedBytes: 3 * blockSize,
 			expectedCachedBytes:  7 * blockSize,
 			init: func() {
-				// delete last 3 blocks
+				// Delete last 3 blocks.
 				delete(cache.cache, cachingKeyObjectBlock(name, 7*blockSize, 8*blockSize))
 				delete(cache.cache, cachingKeyObjectBlock(name, 8*blockSize, 9*blockSize))
 				delete(cache.cache, cachingKeyObjectBlock(name, 9*blockSize, 10*blockSize))

--- a/pkg/store/cache/caching_bucket_test.go
+++ b/pkg/store/cache/caching_bucket_test.go
@@ -1,0 +1,336 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package storecache
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io/ioutil"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+
+	"github.com/thanos-io/thanos/pkg/objstore"
+	"github.com/thanos-io/thanos/pkg/testutil"
+)
+
+func TestCachingBucket(t *testing.T) {
+	length := int64(1024 * 1024)
+	blockSize := int64(16000) // all tests are based on this value
+
+	data := make([]byte, length)
+	for ix := 0; ix < len(data); ix++ {
+		data[ix] = byte(ix)
+	}
+
+	name := "/test/chunks/000001"
+
+	inmem := objstore.NewInMemBucket()
+	testutil.Ok(t, inmem.Upload(context.Background(), name, bytes.NewReader(data)))
+
+	cache := &mockCache{cache: make(map[string][]byte)}
+
+	cachingBucket, err := NewCachingBucket(inmem, cache, DefaultChunksCachingConfig(), nil, nil)
+	testutil.Ok(t, err)
+	cachingBucket.chunks.ChunkBlockSize = blockSize
+
+	// Warning, these tests must be run in order, they depend cache state from previous test.
+	for _, tc := range []struct {
+		name                 string
+		init                 func()
+		offset               int64
+		length               int64
+		maxGetRangeRequests  int
+		expectedLength       int64
+		expectedFetchedBytes int64
+		expectedCachedBytes  int64
+	}{
+		{
+			name:                 "basic test",
+			offset:               555555,
+			length:               55555,
+			expectedLength:       55555,
+			expectedFetchedBytes: 5 * blockSize,
+		},
+
+		{
+			name:                "same request will hit all blocks in the cache",
+			offset:              555555,
+			length:              55555,
+			expectedLength:      55555,
+			expectedCachedBytes: 5 * blockSize,
+		},
+
+		{
+			name:                 "request data close to the end of object",
+			offset:               length - 10,
+			length:               3000,
+			expectedLength:       10,
+			expectedFetchedBytes: 8576, // last block is fetched
+		},
+
+		{
+			name:                "another request data close to the end of object, cached by previous test",
+			offset:              1040100,
+			length:              blockSize,
+			expectedLength:      8476,
+			expectedCachedBytes: 8576,
+		},
+
+		{
+			name:                 "entire object, combination of cached and uncached blocks",
+			offset:               0,
+			length:               length,
+			expectedLength:       length,
+			expectedCachedBytes:  5*blockSize + 8576, // 5 block cached from first test, plus last incomplete block
+			expectedFetchedBytes: 60 * blockSize,
+		},
+
+		{
+			name:                "entire object again, everything is cached",
+			offset:              0,
+			length:              length,
+			expectedLength:      length,
+			expectedCachedBytes: length, // entire file is now cached
+		},
+
+		{
+			name:                 "entire object again, nothing is cached",
+			offset:               0,
+			length:               length,
+			expectedLength:       length,
+			expectedFetchedBytes: length, // cache is flushed
+			init: func() {
+				cache.cache = map[string][]byte{} // flush cache
+			},
+		},
+
+		{
+			name:                 "missing first blocks",
+			offset:               0,
+			length:               10 * blockSize,
+			expectedLength:       10 * blockSize,
+			expectedFetchedBytes: 3 * blockSize,
+			expectedCachedBytes:  7 * blockSize,
+			init: func() {
+				// delete first 3 blocks
+				delete(cache.cache, cachingKeyObjectBlock(name, 0*blockSize, 1*blockSize))
+				delete(cache.cache, cachingKeyObjectBlock(name, 1*blockSize, 2*blockSize))
+				delete(cache.cache, cachingKeyObjectBlock(name, 2*blockSize, 3*blockSize))
+			},
+		},
+
+		{
+			name:                 "missing last blocks",
+			offset:               0,
+			length:               10 * blockSize,
+			expectedLength:       10 * blockSize,
+			expectedFetchedBytes: 3 * blockSize,
+			expectedCachedBytes:  7 * blockSize,
+			init: func() {
+				// delete last 3 blocks
+				delete(cache.cache, cachingKeyObjectBlock(name, 7*blockSize, 8*blockSize))
+				delete(cache.cache, cachingKeyObjectBlock(name, 8*blockSize, 9*blockSize))
+				delete(cache.cache, cachingKeyObjectBlock(name, 9*blockSize, 10*blockSize))
+			},
+		},
+
+		{
+			name:                 "missing middle blocks",
+			offset:               0,
+			length:               10 * blockSize,
+			expectedLength:       10 * blockSize,
+			expectedFetchedBytes: 3 * blockSize,
+			expectedCachedBytes:  7 * blockSize,
+			init: func() {
+				// Delete 3 blocks in the middle.
+				delete(cache.cache, cachingKeyObjectBlock(name, 3*blockSize, 4*blockSize))
+				delete(cache.cache, cachingKeyObjectBlock(name, 4*blockSize, 5*blockSize))
+				delete(cache.cache, cachingKeyObjectBlock(name, 5*blockSize, 6*blockSize))
+			},
+		},
+
+		{
+			name:                 "missing everything except middle blocks",
+			offset:               0,
+			length:               10 * blockSize,
+			expectedLength:       10 * blockSize,
+			expectedFetchedBytes: 7 * blockSize,
+			expectedCachedBytes:  3 * blockSize,
+			init: func() {
+				// Delete all but 3 blocks in the middle, and keep unlimited number of ranged subrequests.
+				for i := int64(0); i < 10; i++ {
+					if i > 0 && i%3 == 0 {
+						continue
+					}
+					delete(cache.cache, cachingKeyObjectBlock(name, i*blockSize, (i+1)*blockSize))
+				}
+			},
+		},
+
+		{
+			name:                 "missing everything except middle blocks, one subrequest only",
+			offset:               0,
+			length:               10 * blockSize,
+			expectedLength:       10 * blockSize,
+			expectedFetchedBytes: 10 * blockSize, // We need to fetch beginning and end in single request.
+			expectedCachedBytes:  3 * blockSize,
+			maxGetRangeRequests:  1,
+			init: func() {
+				// Delete all but 3 blocks in the middle, but only allow 1 subrequest.
+				for i := int64(0); i < 10; i++ {
+					if i == 3 || i == 5 || i == 7 {
+						continue
+					}
+					delete(cache.cache, cachingKeyObjectBlock(name, i*blockSize, (i+1)*blockSize))
+				}
+			},
+		},
+
+		{
+			name:                 "missing everything except middle blocks, two subrequests",
+			offset:               0,
+			length:               10 * blockSize,
+			expectedLength:       10 * blockSize,
+			expectedFetchedBytes: 7 * blockSize,
+			expectedCachedBytes:  3 * blockSize,
+			maxGetRangeRequests:  2,
+			init: func() {
+				// Delete all but one blocks in the middle, and allow 2 subrequests. They will be: 0-80000, 128000-160000.
+				for i := int64(0); i < 10; i++ {
+					if i == 5 || i == 6 || i == 7 {
+						continue
+					}
+					delete(cache.cache, cachingKeyObjectBlock(name, i*blockSize, (i+1)*blockSize))
+				}
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.init != nil {
+				tc.init()
+			}
+			cachedBytes, fetchedBytes := &counter{}, &counter{}
+			cachingBucket.cachedChunkBytes = cachedBytes
+			cachingBucket.fetchedChunkBytes = fetchedBytes
+			cachingBucket.chunks.MaxChunksGetRangeRequests = tc.maxGetRangeRequests
+
+			verifyGetRange(t, cachingBucket, name, tc.offset, tc.length, tc.expectedLength)
+			testutil.Equals(t, tc.expectedCachedBytes, int64(cachedBytes.Get()))
+			testutil.Equals(t, tc.expectedFetchedBytes, int64(fetchedBytes.Get()))
+		})
+	}
+}
+
+func verifyGetRange(t *testing.T, cachingBucket *CachingBucket, name string, offset, length int64, expectedLength int64) {
+	t.Helper()
+
+	r, err := cachingBucket.GetRange(context.Background(), name, offset, length)
+	testutil.Ok(t, err)
+
+	read, err := ioutil.ReadAll(r)
+	testutil.Ok(t, err)
+	testutil.Equals(t, expectedLength, int64(len(read)))
+
+	for ix := 0; ix < len(read); ix++ {
+		if byte(ix)+byte(offset) != read[ix] {
+			t.Fatalf("bytes differ at position %d", ix)
+		}
+	}
+}
+
+type mockCache struct {
+	mu    sync.Mutex
+	cache map[string][]byte
+}
+
+func (m *mockCache) Store(_ context.Context, data map[string][]byte, _ time.Duration) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for key, val := range data {
+		m.cache[key] = val
+	}
+}
+
+func (m *mockCache) Fetch(_ context.Context, keys []string) (found map[string][]byte, missing []string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	found = make(map[string][]byte)
+
+	for _, k := range keys {
+		v, ok := m.cache[k]
+		if ok {
+			found[k] = v
+		} else {
+			missing = append(missing, k)
+		}
+	}
+
+	return
+}
+
+func TestMergeRanges(t *testing.T) {
+	for ix, tc := range []struct {
+		input    []rng
+		limit    int64
+		expected []rng
+	}{
+		{
+			input:    nil,
+			limit:    0,
+			expected: nil,
+		},
+
+		{
+			input:    []rng{{start: 0, end: 100}, {start: 100, end: 200}},
+			limit:    0,
+			expected: []rng{{start: 0, end: 200}},
+		},
+
+		{
+			input:    []rng{{start: 0, end: 100}, {start: 500, end: 1000}},
+			limit:    300,
+			expected: []rng{{start: 0, end: 100}, {start: 500, end: 1000}},
+		},
+		{
+			input:    []rng{{start: 0, end: 100}, {start: 500, end: 1000}},
+			limit:    400,
+			expected: []rng{{start: 0, end: 1000}},
+		},
+	} {
+		t.Run(fmt.Sprintf("%d", ix), func(t *testing.T) {
+			testutil.Equals(t, tc.expected, mergeRanges(tc.input, tc.limit))
+		})
+	}
+}
+
+type counter struct {
+	mu    sync.Mutex
+	count float64
+}
+
+func (c *counter) Desc() *prometheus.Desc             { return nil }
+func (c *counter) Write(_ *dto.Metric) error          { return nil }
+func (c *counter) Describe(_ chan<- *prometheus.Desc) {}
+func (c *counter) Collect(_ chan<- prometheus.Metric) {}
+func (c *counter) Inc() {
+	c.mu.Lock()
+	c.count++
+	c.mu.Unlock()
+}
+func (c *counter) Add(f float64) {
+	c.mu.Lock()
+	c.count += f
+	c.mu.Unlock()
+}
+func (c *counter) Get() float64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.count
+}

--- a/pkg/store/cache/caching_bucket_test.go
+++ b/pkg/store/cache/caching_bucket_test.go
@@ -35,9 +35,9 @@ func TestCachingBucket(t *testing.T) {
 
 	cache := &mockCache{cache: make(map[string][]byte)}
 
-	cachingBucket, err := NewCachingBucket(inmem, cache, DefaultChunksCachingConfig(), nil, nil)
+	cachingBucket, err := NewCachingBucket(inmem, cache, DefaultCachingBucketConfig(), nil, nil)
 	testutil.Ok(t, err)
-	cachingBucket.chunks.ChunkBlockSize = blockSize
+	cachingBucket.config.ChunkBlockSize = blockSize
 
 	// Warning, these tests must be run in order, they depend cache state from previous test.
 	for _, tc := range []struct {
@@ -219,7 +219,7 @@ func TestCachingBucket(t *testing.T) {
 			cachedBytes, fetchedBytes := &counter{}, &counter{}
 			cachingBucket.cachedChunkBytes = cachedBytes
 			cachingBucket.fetchedChunkBytes = fetchedBytes
-			cachingBucket.chunks.MaxChunksGetRangeRequests = tc.maxGetRangeRequests
+			cachingBucket.config.MaxChunksGetRangeRequests = tc.maxGetRangeRequests
 
 			verifyGetRange(t, cachingBucket, name, tc.offset, tc.length, tc.expectedLength)
 			testutil.Equals(t, tc.expectedCachedBytes, int64(cachedBytes.Get()))

--- a/pkg/store/cache/factory.go
+++ b/pkg/store/cache/factory.go
@@ -24,6 +24,7 @@ const (
 
 // IndexCacheConfig specifies the index cache config.
 type IndexCacheConfig struct {
+	// TODO: rename to backend and backend_config.
 	Type   IndexCacheProvider `yaml:"type"`
 	Config interface{}        `yaml:"config"`
 }

--- a/pkg/store/cache/factory.go
+++ b/pkg/store/cache/factory.go
@@ -24,7 +24,6 @@ const (
 
 // IndexCacheConfig specifies the index cache config.
 type IndexCacheConfig struct {
-	// TODO: rename to backend and backend_config.
 	Type   IndexCacheProvider `yaml:"type"`
 	Config interface{}        `yaml:"config"`
 }


### PR DESCRIPTION
This PR implements chunks caching as described in ["Caching in Thanos"](https://docs.google.com/document/d/1knNXQfDJlQDA9Dr9R9OVFvdWS83sXd0kLEFdv21IxCM/edit#) document.

Chunks caching is done at Bucket level. Since bucket doesn't really know about chunks, and Thanos simply uses GetRange call on Bucket to fetch chunks, this implementation splits such requests into smaller "blocks" (with size of 16000 bytes), and stores each block into cache individually.

To enable chunks caching, one needs to configure `store` to use caching bucket using `--experimental.caching-bucket.config=store_cache.yaml` option. File looks like this:

```yaml
backend: memcached
backend_config:
  addresses:
    - localhost:11211

caching_config:
  chunk_block_size: 16000
  max_chunks_get_range_requests: 3
```

Only memcached client is supported at the moment. If `--caching-bucket.config-file` is not passed to the store (default), no chunks caching is done. (Index cache is unaffected by this)

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Verification

Tested manually (running queries against store with caching bucket) and using unit tests.
