### PR TITLE
docs: fixed broken links in documentation

### DIFF
--- a/docs/components/query.md
+++ b/docs/components/query.md
@@ -228,7 +228,7 @@ Additionally, Thanos supports dynamic prefix configuration, which
 [is not yet implemented by Prometheus](https://github.com/prometheus/prometheus/issues/3156).
 Dynamic prefixing simplifies setup when `thanos query` is exposed on a sub-path behind
 a reverse proxy, for example, via a Kubernetes ingress controller
-[Traefik](https://docs.traefik.io/basics/#frontends)
+[Traefik](https://docs.traefik.io/routing/routers/)
 or [nginx](https://github.com/kubernetes/ingress-nginx/pull/1805).
 If `PathPrefixStrip: /some-path` option or `traefik.frontend.rule.type: PathPrefixStrip`
 Kubernetes Ingress annotation is set, then `Traefik` writes the stripped prefix into X-Forwarded-Prefix header.

--- a/docs/components/store.md
+++ b/docs/components/store.md
@@ -6,7 +6,7 @@ menu: components
 
 # Store
 
-The `thanost store` command (also known as Store Gateway) implements the Store API on top of historical data in an object storage bucket. It acts primarily as an API gateway and therefore does not need significant amounts of local disk space. It joins a Thanos cluster on startup and advertises the data it can access.
+The `thanos store` command (also known as Store Gateway) implements the Store API on top of historical data in an object storage bucket. It acts primarily as an API gateway and therefore does not need significant amounts of local disk space. It joins a Thanos cluster on startup and advertises the data it can access.
 It keeps a small amount of information about all remote blocks on local disk and keeps it in sync with the bucket. This data is generally safe to delete across restarts at the cost of increased startup times.
 
 ```bash

--- a/docs/proposals/201909_thanos_sharding.md
+++ b/docs/proposals/201909_thanos_sharding.md
@@ -95,7 +95,7 @@ On each component that works on the object storage (e.g Store GW and Compactor),
 
 ### Relabelling
 
-Similar to [promtail](https://github.com/grafana/loki/blob/master/docs/promtail.md#scrape-configs) this config will follow native
+Similar to [promtail](https://github.com/grafana/loki/blob/master/docs/clients/promtail/scraping.md#relabeling) this config will follow native
 [Prometheus relabel-config](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config) syntax.
 
 The relabel config will define filtering process done on **every** synchronization with object storage.

--- a/docs/quick-tutorial.md
+++ b/docs/quick-tutorial.md
@@ -221,7 +221,7 @@ The compactor is not in the critical path of querying or data backup. It can eit
 
 _NOTE: The compactor must be run as a **singleton** and must not run when manually modifying data in the bucket._
 
-* _[Example Kubernetes manifest](https://github.com/thanos-io/kube-thanos/blob/master/examples/all/manifests/thanos-compactor-statefulSet.yaml)_
+* _[Example Kubernetes manifest](https://github.com/thanos-io/kube-thanos/blob/master/examples/all/manifests/thanos-compact-statefulSet.yaml)_
 
 ### [Ruler/Rule](components/rule.md)
 


### PR DESCRIPTION
currently setting up Thanos and came across a couple of broken links. also ran the docs/ dir through link checker and updated any broken ones while at it.

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes
N/A 

## Verification
N/A
