### PR TITLE
Allow blocks to be retained after compaction

### DIFF
--- a/docs/components/compact.md
+++ b/docs/components/compact.md
@@ -49,6 +49,8 @@ Ideally, you will have equal retention set (or no retention at all) to all resol
 
 Not setting this flag, or setting it to `0d`, i.e. `--retention.resolution-X=0d`, will mean that samples at the `X` resolution level will be kept forever.
 
+Optionally, you can also retain blocks which are compacted into larger blocks. You can supply `--objstore-retain-compacted-blocks-to-bucket.config` and Thanos will move compacted blocks to the specified bucket. This can be useful if you do not want to lose blocks during rewrites, which can happen in compaction, delete series etc.
+
 ## Storage space consumption
 
 In fact, downsampling doesn't save you any space but instead it adds 2 more blocks for each raw block which are only slightly smaller or relatively similar size to raw block. This is required by internal downsampling implementation which to be mathematically correct holds various aggregations. This means that downsampling can increase the size of your storage a bit (~3x), but it gives massive advantage on querying long ranges.

--- a/pkg/block/block.go
+++ b/pkg/block/block.go
@@ -69,6 +69,14 @@ func Download(ctx context.Context, logger log.Logger, bucket objstore.Bucket, id
 // It also verifies basic features of Thanos block.
 // TODO(bplotka): Ensure bucket operations have reasonable backoff retries.
 func Upload(ctx context.Context, logger log.Logger, bkt objstore.Bucket, bdir string) error {
+	return UploadTo(ctx, logger, bkt, bdir, ".")
+}
+
+// UploadTo uploads block from given block dir that ends with block id.
+// It makes sure cleanup is done on error to avoid partial block uploads.
+// It also verifies basic features of Thanos block.
+// TODO(bplotka): Ensure bucket operations have reasonable backoff retries.
+func UploadTo(ctx context.Context, logger log.Logger, bkt objstore.Bucket, bdir, dstDir string) error {
 	df, err := os.Stat(bdir)
 	if err != nil {
 		return err
@@ -93,27 +101,27 @@ func Upload(ctx context.Context, logger log.Logger, bkt objstore.Bucket, bdir st
 		return errors.New("empty external labels are not allowed for Thanos block.")
 	}
 
-	if err := objstore.UploadFile(ctx, logger, bkt, path.Join(bdir, MetaFilename), path.Join(DebugMetas, fmt.Sprintf("%s.json", id))); err != nil {
+	if err := objstore.UploadFile(ctx, logger, bkt, path.Join(bdir, MetaFilename), path.Join(dstDir, DebugMetas, fmt.Sprintf("%s.json", id))); err != nil {
 		return errors.Wrap(err, "upload meta file to debug dir")
 	}
 
-	if err := objstore.UploadDir(ctx, logger, bkt, path.Join(bdir, ChunksDirname), path.Join(id.String(), ChunksDirname)); err != nil {
+	if err := objstore.UploadDir(ctx, logger, bkt, path.Join(bdir, ChunksDirname), path.Join(dstDir, id.String(), ChunksDirname)); err != nil {
 		return cleanUp(logger, bkt, id, errors.Wrap(err, "upload chunks"))
 	}
 
-	if err := objstore.UploadFile(ctx, logger, bkt, path.Join(bdir, IndexFilename), path.Join(id.String(), IndexFilename)); err != nil {
+	if err := objstore.UploadFile(ctx, logger, bkt, path.Join(bdir, IndexFilename), path.Join(dstDir, id.String(), IndexFilename)); err != nil {
 		return cleanUp(logger, bkt, id, errors.Wrap(err, "upload index"))
 	}
 
 	if meta.Thanos.Source == metadata.CompactorSource {
-		if err := objstore.UploadFile(ctx, logger, bkt, path.Join(bdir, IndexCacheFilename), path.Join(id.String(), IndexCacheFilename)); err != nil {
+		if err := objstore.UploadFile(ctx, logger, bkt, path.Join(bdir, IndexCacheFilename), path.Join(dstDir, id.String(), IndexCacheFilename)); err != nil {
 			return cleanUp(logger, bkt, id, errors.Wrap(err, "upload index cache"))
 		}
 	}
 
 	// Meta.json always need to be uploaded as a last item. This will allow to assume block directories without meta file
 	// to be pending uploads.
-	if err := objstore.UploadFile(ctx, logger, bkt, path.Join(bdir, MetaFilename), path.Join(id.String(), MetaFilename)); err != nil {
+	if err := objstore.UploadFile(ctx, logger, bkt, path.Join(bdir, MetaFilename), path.Join(dstDir, id.String(), MetaFilename)); err != nil {
 		return cleanUp(logger, bkt, id, errors.Wrap(err, "upload meta file"))
 	}
 

--- a/pkg/block/fetcher_test.go
+++ b/pkg/block/fetcher_test.go
@@ -65,7 +65,8 @@ func ULIDs(is ...int) []ulid.ULID {
 }
 
 func TestMetaFetcher_Fetch(t *testing.T) {
-	objtesting.ForeachStore(t, func(t *testing.T, bkt objstore.Bucket) {
+	objtesting.ForeachStore(t, 1, func(t *testing.T, bkts ...objstore.Bucket) {
+		bkt := bkts[0]
 		ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 		defer cancel()
 
@@ -1058,7 +1059,8 @@ func TestConsistencyDelayMetaFilter_Filter_0(t *testing.T) {
 }
 
 func TestIgnoreDeletionMarkFilter_Filter(t *testing.T) {
-	objtesting.ForeachStore(t, func(t *testing.T, bkt objstore.Bucket) {
+	objtesting.ForeachStore(t, 1, func(t *testing.T, bkts ...objstore.Bucket) {
+		bkt := bkts[0]
 		ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 		defer cancel()
 

--- a/pkg/objstore/objtesting/acceptance_e2e_test.go
+++ b/pkg/objstore/objtesting/acceptance_e2e_test.go
@@ -14,5 +14,5 @@ import (
 // NOTE: This test assumes strong consistency, but in the same way it does not guarantee that if it passes, the
 // used object store is strongly consistent.
 func TestObjStore_AcceptanceTest_e2e(t *testing.T) {
-	ForeachStore(t, objstore.AcceptanceTest)
+	ForeachStore(t, 1, objstore.AcceptanceTest)
 }

--- a/pkg/objstore/testing.go
+++ b/pkg/objstore/testing.go
@@ -79,7 +79,8 @@ func (b noopInstrumentedBucket) ReaderWithExpectedErrs(IsOpFailureExpectedFunc) 
 	return b
 }
 
-func AcceptanceTest(t *testing.T, bkt Bucket) {
+func AcceptanceTest(t *testing.T, bkts ...Bucket) {
+	bkt := bkts[0]
 	ctx := context.Background()
 
 	_, err := bkt.Get(ctx, "")

--- a/pkg/shipper/shipper_e2e_test.go
+++ b/pkg/shipper/shipper_e2e_test.go
@@ -30,7 +30,8 @@ import (
 )
 
 func TestShipper_SyncBlocks_e2e(t *testing.T) {
-	objtesting.ForeachStore(t, func(t *testing.T, bkt objstore.Bucket) {
+	objtesting.ForeachStore(t, 1, func(t *testing.T, bkts ...objstore.Bucket) {
+		bkt := bkts[0]
 		dir, err := ioutil.TempDir("", "shipper-e2e-test")
 		testutil.Ok(t, err)
 		defer func() {

--- a/pkg/store/bucket_e2e_test.go
+++ b/pkg/store/bucket_e2e_test.go
@@ -417,7 +417,8 @@ func testBucketStore_e2e(t *testing.T, ctx context.Context, s *storeSuite) {
 }
 
 func TestBucketStore_e2e(t *testing.T) {
-	objtesting.ForeachStore(t, func(t *testing.T, bkt objstore.Bucket) {
+	objtesting.ForeachStore(t, 1, func(t *testing.T, bkts ...objstore.Bucket) {
+		bkt := bkts[0]
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
@@ -474,7 +475,8 @@ func (g naivePartitioner) Partition(length int, rng func(int) (uint64, uint64)) 
 // This tests if our, sometimes concurrent, fetches for different parts works.
 // Regression test against: https://github.com/thanos-io/thanos/issues/829.
 func TestBucketStore_ManyParts_e2e(t *testing.T) {
-	objtesting.ForeachStore(t, func(t *testing.T, bkt objstore.Bucket) {
+	objtesting.ForeachStore(t, 1, func(t *testing.T, bkts ...objstore.Bucket) {
+		bkt := bkts[0]
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 


### PR DESCRIPTION
Signed-off-by: darshanime <deathbullet@gmail.com>

Add ability to retain blocks after compaction. 
Fixes https://github.com/thanos-io/thanos/issues/2344

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.