### PR TITLE
Fixed the timezone url of Community page in docs

### DIFF
--- a/docs/community.md
+++ b/docs/community.md
@@ -16,7 +16,7 @@ Thanos Community Meeting is a **public** and **recorded** monthly meeting every 
 Thanos maintainers & the community meet to discuss open issues, features and other Thanos related things.
 Everyone is welcome to join & add items to the agenda. The meeting happens in Zoom. Right now meeting is in a Webinar format, where only small amount of people will have ability to speak and video share, due to recent [Zoombombing](https://en.wikipedia.org/wiki/Zoombombing) issues.
 
-* When: Monthly, every second Wednesday 12:00 UTC ([Time zone converter](https://      www.thetimezoneconverter.com/?t=12%3A00%20pm&tz=UTC%20(Coordinated%20Universal%20Time)&)).
+* When: Monthly, every second Wednesday 12:00 UTC ([Time zone converter](https://www.thetimezoneconverter.com/?t=12%3A00%20pm&tz=UTC%20(Coordinated%20Universal%20Time)&)).
 * Google Calendar: [Google Calendar](https://calendar.google.com/calendar/embed?src=go39q7eu71vvu3gfrkbup6b254%40group.calendar.google.com)
 * Agenda: [https://bit.ly/thanos-community-agenda](https://bit.ly/thanos-community-agenda)
 * Link to join zoom webinar: [https://zoom.us/j/96476403386](https://zoom.us/j/96476403386)


### PR DESCRIPTION
Signed-off-by: Yash <yashrsharma44@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Fixed the URL for the timezone in `docs/community.md`.

## Verification
The timezone entry of the [community](https://thanos.io/community.md/#thanos-community-meeting) page contains an invalid URL, so I have fixed it. 