### PR TITLE
receive: Use read locks where possible to read tenants

### DIFF
--- a/pkg/receive/multitsdb.go
+++ b/pkg/receive/multitsdb.go
@@ -143,8 +143,8 @@ func (t *MultiTSDB) Open() error {
 }
 
 func (t *MultiTSDB) Flush() error {
-	t.mtx.Lock()
-	defer t.mtx.Unlock()
+	t.mtx.RLock()
+	defer t.mtx.RUnlock()
 
 	errmtx := &sync.Mutex{}
 	merr := terrors.MultiError{}
@@ -171,8 +171,8 @@ func (t *MultiTSDB) Flush() error {
 }
 
 func (t *MultiTSDB) Sync(ctx context.Context) error {
-	t.mtx.Lock()
-	defer t.mtx.Unlock()
+	t.mtx.RLock()
+	defer t.mtx.RUnlock()
 
 	errmtx := &sync.Mutex{}
 	merr := terrors.MultiError{}


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

Use read locks where possible to read tenants in multitsdb.

## Verification

Ran tests.

@bwplotka @squat @metalmatze @kakkoyun @krasi-georgiev 