### PR TITLE
query/storeset: do not close the connection if strict mode enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 
 - [#2536](https://github.com/thanos-io/thanos/pull/2536) minio-go: Fixed AWS STS endpoint url to https for Web Identity providers on AWS EKS
 - [#2501](https://github.com/thanos-io/thanos/pull/2501) Query: gracefully handle additional fields in `SeriesResponse` protobuf message that may be added in the future.
+- [#2568](https://github.com/thanos-io/thanos/pull/2568) Query: does not close the connection of strict, static nodes if establishing a connection had succeeded but Info() call failed
 
 ### Added
 

--- a/pkg/query/storeset.go
+++ b/pkg/query/storeset.go
@@ -414,14 +414,14 @@ func (s *StoreSet) getActiveStores(ctx context.Context, stores map[string]*store
 					level.Warn(s.logger).Log("msg", "update of store node failed", "err", errors.Wrap(err, "dialing connection"), "address", addr)
 					return
 				}
-				st = &storeRef{StoreClient: storepb.NewStoreClient(conn), cc: conn, addr: addr, logger: s.logger}
+				st = &storeRef{StoreClient: storepb.NewStoreClient(conn), storeType: component.UnknownStoreAPI, cc: conn, addr: addr, logger: s.logger}
 			}
 
 			// Check existing or new store. Is it healthy? What are current metadata?
 			labelSets, minTime, maxTime, storeType, err := spec.Metadata(ctx, st.StoreClient)
 			if err != nil {
 				if !seenAlready && !spec.StrictStatic() {
-					// Close only if new and not static.
+					// Close only if new and not a strict static node.
 					// Unactive `s.stores` will be closed later on.
 					st.Close()
 				}

--- a/pkg/query/storeset.go
+++ b/pkg/query/storeset.go
@@ -420,8 +420,9 @@ func (s *StoreSet) getActiveStores(ctx context.Context, stores map[string]*store
 			// Check existing or new store. Is it healthy? What are current metadata?
 			labelSets, minTime, maxTime, storeType, err := spec.Metadata(ctx, st.StoreClient)
 			if err != nil {
-				if !seenAlready {
-					// Close only if new. Unactive `s.stores` will be closed later on.
+				if !seenAlready && !spec.StrictStatic() {
+					// Close only if new and not static.
+					// Unactive `s.stores` will be closed later on.
 					st.Close()
 				}
 				s.updateStoreStatus(st, err)


### PR DESCRIPTION
Do not close the gRPC connection if establishing a connection has
succeeded but we have failed to get a response to a Info() call. Without
this and with strict mode in such a case, we will always keep around a
closed connection that won't work anymore unless the whole Thanos Query
process will be restarted.

Signed-off-by: Giedrius Statkevičius <giedriuswork@gmail.com>

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

It does not close the gRPC connection of strict nodes if the Info() call fails. Without it the `grpc.ClientConn` variables are kept around forever in this state and Thanos Query never tries to establish that connection again.

## Verification

Updated unit tests to cover this case. Without these changes they fail.