### PR TITLE
Fixed thanos_compact_garbage_collected_blocks_total metric help

### DIFF
--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -73,7 +73,7 @@ func newSyncerMetrics(reg prometheus.Registerer, blocksMarkedForDeletion prometh
 
 	m.garbageCollectedBlocks = promauto.With(reg).NewCounter(prometheus.CounterOpts{
 		Name: "thanos_compact_garbage_collected_blocks_total",
-		Help: "Total number of deleted blocks by compactor.",
+		Help: "Total number of blocks marked for deletion by compactor.",
 	})
 	m.garbageCollections = promauto.With(reg).NewCounter(prometheus.CounterOpts{
 		Name: "thanos_compact_garbage_collection_total",


### PR DESCRIPTION
* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Since when we introduced the deletion marker, the `thanos_compact_garbage_collected_blocks_total` metric tracks the number of blocks marked for deletion and not the ones effectively deleted.

## Verification

N/A
