### PR TITLE
Rename index cache YAML fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ anymore.
 - [#2596](https://github.com/thanos-io/thanos/pull/2596) Update to Prometheus [@cd73b3d33e064bbd846fc7a26dc8c313d46af382](https://github.com/prometheus/prometheus/commit/cd73b3d33e064bbd846fc7a26dc8c313d46af382) which falls in between v2.17.0 and v2.18.0.
     - TSDB now supports isolation of append and queries.
     - TSDB now holds less WAL files after Head Truncation.
+- [#2575](https://github.com/thanos-io/thanos/pull/2575) Store: Rename index cache YAML fields from `type` to `backend`, `config` to `backend_config`.
 
 ## [v0.12.2](https://github.com/thanos-io/thanos/releases/tag/v0.12.2) - 2020.04.30
 

--- a/docs/components/store.md
+++ b/docs/components/store.md
@@ -232,8 +232,8 @@ Alternatively, the `in-memory` index cache can also by configured using `--index
 [embedmd]: # "../flags/config_index_cache_in_memory.txt yaml"
 
 ```yaml
-type: IN-MEMORY
-config:
+backend: IN-MEMORY
+backend_config:
   max_size: 0
   max_item_size: 0
 ```
@@ -250,8 +250,8 @@ The `memcached` index cache allows to use [Memcached](https://memcached.org) as 
 [embedmd]: # "../flags/config_index_cache_memcached.txt yaml"
 
 ```yaml
-type: MEMCACHED
-config:
+backend: MEMCACHED
+backend_config:
   addresses: []
   timeout: 0s
   max_idle_connections: 0

--- a/pkg/store/cache/factory.go
+++ b/pkg/store/cache/factory.go
@@ -24,8 +24,8 @@ const (
 
 // IndexCacheConfig specifies the index cache config.
 type IndexCacheConfig struct {
-	Type   IndexCacheProvider `yaml:"type"`
-	Config interface{}        `yaml:"config"`
+	Type   IndexCacheProvider `yaml:"backend"`
+	Config interface{}        `yaml:"backend_config"`
 }
 
 // NewIndexCache initializes and returns new index cache.


### PR DESCRIPTION
Fixes #2570 
Signed-off-by: Ranjith Kumar <ranjith.dakshana2015@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->
* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes
1. Rename index cache YAML fields from `type` to `backend`, `config` to `backend_config`
2. Update docs to reflect the change in YAML fields

<!-- Enumerate changes you made -->

## Verification
for Change 1, Not required may be?
for Change 2. I checked using `make web-serve`.
<!-- How you tested it? How do you know it works? -->



cc @pstibrany 
