### PR TITLE
Metadata caching in bucket

### DIFF
--- a/pkg/store/cache/caching_bucket.go
+++ b/pkg/store/cache/caching_bucket.go
@@ -345,7 +345,7 @@ func (cb *CachingBucket) cachedObjectSize(ctx context.Context, name string, cfgN
 }
 
 func (cb *CachingBucket) cachedGetRange(ctx context.Context, name string, offset, length int64, cfgName string, cfg *getRangeConfig) (io.ReadCloser, error) {
-	cb.operationRequests.WithLabelValues(opGetRange, cfgName)
+	cb.operationRequests.WithLabelValues(opGetRange, cfgName).Inc()
 	cb.requestedGetRangeBytes.WithLabelValues(cfgName).Add(float64(length))
 
 	size, err := cb.cachedObjectSize(ctx, name, cfgName, cfg.cache, cfg.objectSizeTTL)
@@ -398,7 +398,7 @@ func (cb *CachingBucket) cachedGetRange(ctx context.Context, name string, offset
 		totalCachedBytes += int64(len(b))
 	}
 	cb.fetchedGetRangeBytes.WithLabelValues(originCache, cfgName).Add(float64(totalCachedBytes))
-	cb.operationHits.WithLabelValues(opGetRange, cfgName).Add(float64(totalCachedBytes) / float64(totalRequestedBytes))
+	cb.operationHits.WithLabelValues(opGetRange, cfgName).Add(float64(len(hits)) / float64(len(keys)))
 
 	if len(hits) < len(keys) {
 		if hits == nil {

--- a/pkg/store/cache/caching_bucket_config.go
+++ b/pkg/store/cache/caching_bucket_config.go
@@ -1,3 +1,6 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
 package storecache
 
 import (

--- a/pkg/store/cache/caching_bucket_config.go
+++ b/pkg/store/cache/caching_bucket_config.go
@@ -1,0 +1,195 @@
+package storecache
+
+import (
+	"time"
+
+	"github.com/thanos-io/thanos/pkg/cache"
+)
+
+// CachingBucketConfig contains low-level configuration for individual bucket operations.
+// This is not exposed to the user, but it is expected that code sets up individual
+// operations based on user-provided configuration.
+type CachingBucketConfig struct {
+	get        map[string]*getConfig
+	iter       map[string]*iterConfig
+	exists     map[string]*existsConfig
+	getRange   map[string]*getRangeConfig
+	objectSize map[string]*objectSizeConfig
+}
+
+func NewCachingBucketConfig() *CachingBucketConfig {
+	return &CachingBucketConfig{
+		get:        map[string]*getConfig{},
+		iter:       map[string]*iterConfig{},
+		exists:     map[string]*existsConfig{},
+		getRange:   map[string]*getRangeConfig{},
+		objectSize: map[string]*objectSizeConfig{},
+	}
+}
+
+// Generic config for single operation.
+type operationConfig struct {
+	matcher func(name string) bool
+	cache   cache.Cache
+}
+
+// Operation-specific configs.
+type iterConfig struct {
+	operationConfig
+	ttl time.Duration
+}
+
+type existsConfig struct {
+	operationConfig
+	existsTTL      time.Duration
+	doesntExistTTL time.Duration
+}
+
+type getConfig struct {
+	existsConfig
+	contentTTL time.Duration
+}
+
+type getRangeConfig struct {
+	operationConfig
+	subrangeSize   int64
+	maxSubRequests int
+	objectSizeTTL  time.Duration
+	subrangeTTL    time.Duration
+}
+
+type objectSizeConfig struct {
+	operationConfig
+	ttl time.Duration
+}
+
+func newOperationConfig(cache cache.Cache, matcher func(string) bool) operationConfig {
+	if cache == nil {
+		panic("cache")
+	}
+	if matcher == nil {
+		panic("matcher")
+	}
+
+	return operationConfig{
+		matcher: matcher,
+		cache:   cache,
+	}
+}
+
+// CacheIter configures caching of "Iter" operation for matching directories.
+func (cfg *CachingBucketConfig) CacheIter(configName string, cache cache.Cache, matcher func(string) bool, ttl time.Duration) {
+	cfg.iter[configName] = &iterConfig{
+		operationConfig: newOperationConfig(cache, matcher),
+		ttl:             ttl,
+	}
+}
+
+// CacheGet configures caching of "Get" operation for matching files. Content of the object is cached, as well as whether object exists or not.
+func (cfg *CachingBucketConfig) CacheGet(configName string, cache cache.Cache, matcher func(string) bool, contentTTL, existsTTL, doesntExistTTL time.Duration) {
+	cfg.get[configName] = &getConfig{
+		existsConfig: existsConfig{
+			operationConfig: newOperationConfig(cache, matcher),
+			existsTTL:       existsTTL,
+			doesntExistTTL:  doesntExistTTL,
+		},
+		contentTTL: contentTTL,
+	}
+}
+
+// CacheExists configures caching of "Exists" operation for matching files. Negative values are cached as well.
+func (cfg *CachingBucketConfig) CacheExists(configName string, cache cache.Cache, matcher func(string) bool, existsTTL, doesntExistTTL time.Duration) {
+	cfg.exists[configName] = &existsConfig{
+		operationConfig: newOperationConfig(cache, matcher),
+		existsTTL:       existsTTL,
+		doesntExistTTL:  doesntExistTTL,
+	}
+}
+
+// CacheGetRange configures caching of "GetRange" operation. Subranges (aligned on subrange size) are cached individually.
+// Since caching operation needs to know the object size to compute correct subranges, object size is cached as well.
+// Single "GetRange" requests can result in multiple smaller GetRange sub-requests issued on the underlying bucket.
+// MaxSubRequests specifies how many such subrequests may be issued. Values <= 0 mean there is no limit (requests
+// for adjacent missing subranges are still merged).
+func (cfg *CachingBucketConfig) CacheGetRange(configName string, cache cache.Cache, matcher func(string) bool, subrangeSize int64, objectSizeTTL, subrangeTTL time.Duration, maxSubRequests int) {
+	cfg.getRange[configName] = &getRangeConfig{
+		operationConfig: newOperationConfig(cache, matcher),
+		subrangeSize:    subrangeSize,
+		objectSizeTTL:   objectSizeTTL,
+		subrangeTTL:     subrangeTTL,
+		maxSubRequests:  maxSubRequests,
+	}
+}
+
+// CacheObjectSize configures caching of "ObjectSize" operation for matching files.
+func (cfg *CachingBucketConfig) CacheObjectSize(configName string, cache cache.Cache, matcher func(name string) bool, ttl time.Duration) {
+	cfg.objectSize[configName] = &objectSizeConfig{
+		operationConfig: newOperationConfig(cache, matcher),
+		ttl:             ttl,
+	}
+}
+
+func (cfg *CachingBucketConfig) allConfigNames() map[string][]string {
+	result := map[string][]string{}
+	for n := range cfg.get {
+		result[opGet] = append(result[opGet], n)
+	}
+	for n := range cfg.iter {
+		result[opIter] = append(result[opIter], n)
+	}
+	for n := range cfg.exists {
+		result[opExists] = append(result[opExists], n)
+	}
+	for n := range cfg.getRange {
+		result[opGetRange] = append(result[opGetRange], n)
+	}
+	for n := range cfg.objectSize {
+		result[opObjectSize] = append(result[opObjectSize], n)
+	}
+	return result
+}
+
+func (cfg *CachingBucketConfig) findIterConfig(dir string) (string, *iterConfig) {
+	for n, cfg := range cfg.iter {
+		if cfg.matcher(dir) {
+			return n, cfg
+		}
+	}
+	return "", nil
+}
+
+func (cfg *CachingBucketConfig) findExistConfig(name string) (string, *existsConfig) {
+	for n, cfg := range cfg.exists {
+		if cfg.matcher(name) {
+			return n, cfg
+		}
+	}
+	return "", nil
+}
+
+func (cfg *CachingBucketConfig) findGetConfig(name string) (string, *getConfig) {
+	for n, cfg := range cfg.get {
+		if cfg.matcher(name) {
+			return n, cfg
+		}
+	}
+	return "", nil
+}
+
+func (cfg *CachingBucketConfig) findGetRangeConfig(name string) (string, *getRangeConfig) {
+	for n, cfg := range cfg.getRange {
+		if cfg.matcher(name) {
+			return n, cfg
+		}
+	}
+	return "", nil
+}
+
+func (cfg *CachingBucketConfig) findObjectSizeConfig(name string) (string, *objectSizeConfig) {
+	for n, cfg := range cfg.objectSize {
+		if cfg.matcher(name) {
+			return n, cfg
+		}
+	}
+	return "", nil
+}

--- a/pkg/store/cache/caching_bucket_config.go
+++ b/pkg/store/cache/caching_bucket_config.go
@@ -57,7 +57,8 @@ type existsConfig struct {
 
 type getConfig struct {
 	existsConfig
-	contentTTL time.Duration
+	contentTTL       time.Duration
+	maxCacheableSize int
 }
 
 type getRangeConfig struct {
@@ -97,14 +98,15 @@ func (cfg *CachingBucketConfig) CacheIter(configName string, cache cache.Cache, 
 }
 
 // CacheGet configures caching of "Get" operation for matching files. Content of the object is cached, as well as whether object exists or not.
-func (cfg *CachingBucketConfig) CacheGet(configName string, cache cache.Cache, matcher func(string) bool, contentTTL, existsTTL, doesntExistTTL time.Duration) {
+func (cfg *CachingBucketConfig) CacheGet(configName string, cache cache.Cache, matcher func(string) bool, maxCacheableSize int, contentTTL, existsTTL, doesntExistTTL time.Duration) {
 	cfg.get[configName] = &getConfig{
 		existsConfig: existsConfig{
 			operationConfig: newOperationConfig(cache, matcher),
 			existsTTL:       existsTTL,
 			doesntExistTTL:  doesntExistTTL,
 		},
-		contentTTL: contentTTL,
+		contentTTL:       contentTTL,
+		maxCacheableSize: maxCacheableSize,
 	}
 }
 

--- a/pkg/store/cache/caching_bucket_config.go
+++ b/pkg/store/cache/caching_bucket_config.go
@@ -6,6 +6,12 @@ import (
 	"github.com/thanos-io/thanos/pkg/cache"
 )
 
+// Codec for encoding and decoding results of Iter call.
+type IterCodec interface {
+	Encode(files []string) ([]byte, error)
+	Decode(cachedData []byte) ([]string, error)
+}
+
 // CachingBucketConfig contains low-level configuration for individual bucket operations.
 // This is not exposed to the user, but it is expected that code sets up individual
 // operations based on user-provided configuration.
@@ -36,7 +42,8 @@ type operationConfig struct {
 // Operation-specific configs.
 type iterConfig struct {
 	operationConfig
-	ttl time.Duration
+	ttl   time.Duration
+	codec IterCodec
 }
 
 type existsConfig struct {
@@ -78,10 +85,11 @@ func newOperationConfig(cache cache.Cache, matcher func(string) bool) operationC
 }
 
 // CacheIter configures caching of "Iter" operation for matching directories.
-func (cfg *CachingBucketConfig) CacheIter(configName string, cache cache.Cache, matcher func(string) bool, ttl time.Duration) {
+func (cfg *CachingBucketConfig) CacheIter(configName string, cache cache.Cache, matcher func(string) bool, ttl time.Duration, codec IterCodec) {
 	cfg.iter[configName] = &iterConfig{
 		operationConfig: newOperationConfig(cache, matcher),
 		ttl:             ttl,
+		codec:           codec,
 	}
 }
 

--- a/pkg/store/cache/caching_bucket_factory.go
+++ b/pkg/store/cache/caching_bucket_factory.go
@@ -60,8 +60,8 @@ func (cfg *CachingWithBackendConfig) Defaults() {
 	cfg.ChunkSubrangeTTL = 24 * time.Hour
 	cfg.MaxChunksGetRangeRequests = 3
 	cfg.BlocksIterTTL = 5 * time.Minute
-	cfg.MetafileExistsTTL = 10 * time.Minute
-	cfg.MetafileDoesntExistTTL = 3 * time.Minute
+	cfg.MetafileExistsTTL = 2 * time.Hour
+	cfg.MetafileDoesntExistTTL = 15 * time.Minute
 	cfg.MetafileContentTTL = 24 * time.Hour
 }
 

--- a/pkg/store/cache/caching_bucket_factory.go
+++ b/pkg/store/cache/caching_bucket_factory.go
@@ -76,7 +76,13 @@ func NewCachingBucketFromYaml(yamlContent []byte, bucket objstore.Bucket, logger
 	cb.CacheGetRange("chunks", c, isTSDBChunkFile, config.CachingBucketConfig)
 	cb.CacheExists("metafile", c, isMetaFile, config.CachingBucketConfig)
 	cb.CacheGet("metafile", c, isMetaFile, config.CachingBucketConfig)
-	cb.CacheIter("dir", c, func(dir string) bool { return dir == "" }, config.CachingBucketConfig) // Cache Iter requests for root.
+
+	// Cache Iter requests for root.
+	cb.CacheIter("dir", c, func(dir string) bool { return dir == "" }, config.CachingBucketConfig)
+
+	// Enabling index caching.
+	cb.CacheObjectSize("index", c, isIndexFile, config.CachingBucketConfig)
+	cb.CacheGetRange("index", c, isIndexFile, config.CachingBucketConfig)
 
 	return cb, nil
 }
@@ -87,4 +93,8 @@ func isTSDBChunkFile(name string) bool { return chunksMatcher.MatchString(name) 
 
 func isMetaFile(name string) bool {
 	return strings.HasSuffix(name, metaFilenameSuffix) || strings.HasSuffix(name, deletionMarkFilenameSuffix)
+}
+
+func isIndexFile(name string) bool {
+	return strings.HasSuffix(name, "/index")
 }

--- a/pkg/store/cache/caching_bucket_factory.go
+++ b/pkg/store/cache/caching_bucket_factory.go
@@ -119,10 +119,6 @@ func isMetaFile(name string) bool {
 	return strings.HasSuffix(name, "/"+metadata.MetaFilename) || strings.HasSuffix(name, "/"+metadata.DeletionMarkFilename)
 }
 
-func isIndexFile(name string) bool {
-	return strings.HasSuffix(name, "/index")
-}
-
 func isBlocksRootDir(name string) bool {
 	return name == ""
 }

--- a/pkg/store/cache/caching_bucket_factory.go
+++ b/pkg/store/cache/caching_bucket_factory.go
@@ -105,10 +105,6 @@ func NewCachingBucketFromYaml(yamlContent []byte, bucket objstore.Bucket, logger
 	// Cache Iter requests for root.
 	cfg.CacheIter("blocks-iter", c, isBlocksRootDir, config.BlocksIterTTL, JsonIterCodec{})
 
-	// Enabling index caching (example).
-	cfg.CacheObjectSize("index", c, isIndexFile, time.Hour)
-	cfg.CacheGetRange("index", c, isIndexFile, 32000, time.Hour, 24*time.Hour, 3)
-
 	cb, err := NewCachingBucket(bucket, cfg, logger, reg)
 	if err != nil {
 		return nil, err

--- a/pkg/store/cache/caching_bucket_factory.go
+++ b/pkg/store/cache/caching_bucket_factory.go
@@ -46,7 +46,7 @@ type CachingWithBackendConfig struct {
 	ChunkSubrangeTTL   time.Duration `yaml:"chunk_subrange_ttl"`
 
 	// How long to cache result of Iter call in root directory.
-	RootIterTTL time.Duration `yaml:"root_iter_ttl"`
+	BlocksIterTTL time.Duration `yaml:"blocks_iter_ttl"`
 
 	// Config for Exists and Get operations for metadata files.
 	MetafileExistsTTL      time.Duration `yaml:"metafile_exists_ttl"`
@@ -59,10 +59,10 @@ func (cfg *CachingWithBackendConfig) Defaults() {
 	cfg.ChunkObjectSizeTTL = 24 * time.Hour
 	cfg.ChunkSubrangeTTL = 24 * time.Hour
 	cfg.MaxChunksGetRangeRequests = 3
-	cfg.RootIterTTL = 5 * time.Minute
+	cfg.BlocksIterTTL = 5 * time.Minute
 	cfg.MetafileExistsTTL = 10 * time.Minute
 	cfg.MetafileDoesntExistTTL = 3 * time.Minute
-	cfg.MetafileContentTTL = 1 * time.Hour
+	cfg.MetafileContentTTL = 24 * time.Hour
 }
 
 // NewCachingBucketFromYaml uses YAML configuration to create new caching bucket.
@@ -103,7 +103,7 @@ func NewCachingBucketFromYaml(yamlContent []byte, bucket objstore.Bucket, logger
 	cfg.CacheGet("metafile", c, isMetaFile, config.MetafileContentTTL, config.MetafileExistsTTL, config.MetafileDoesntExistTTL)
 
 	// Cache Iter requests for root.
-	cfg.CacheIter("dir", c, func(dir string) bool { return dir == "" }, config.RootIterTTL)
+	cfg.CacheIter("dir", c, isBlocksRootDir, config.BlocksIterTTL)
 
 	// Enabling index caching (example).
 	cfg.CacheObjectSize("index", c, isIndexFile, time.Hour)
@@ -127,4 +127,8 @@ func isMetaFile(name string) bool {
 
 func isIndexFile(name string) bool {
 	return strings.HasSuffix(name, "/index")
+}
+
+func isBlocksRootDir(name string) bool {
+	return name == ""
 }

--- a/pkg/store/cache/caching_bucket_factory.go
+++ b/pkg/store/cache/caching_bucket_factory.go
@@ -23,12 +23,7 @@ import (
 // BucketCacheProvider is a type used to evaluate all bucket cache providers.
 type BucketCacheProvider string
 
-const (
-	MemcachedBucketCacheProvider BucketCacheProvider = "memcached" // Memcached cache-provider for caching bucket.
-
-	metaFilenameSuffix         = "/" + metadata.MetaFilename
-	deletionMarkFilenameSuffix = "/" + metadata.DeletionMarkFilename
-)
+const MemcachedBucketCacheProvider BucketCacheProvider = "memcached" // Memcached cache-provider for caching bucket.
 
 // CachingWithBackendConfig is a configuration of caching bucket used by Store component.
 type CachingWithBackendConfig struct {
@@ -99,11 +94,11 @@ func NewCachingBucketFromYaml(yamlContent []byte, bucket objstore.Bucket, logger
 
 	// Configure cache.
 	cfg.CacheGetRange("chunks", c, isTSDBChunkFile, config.ChunkSubrangeSize, config.ChunkObjectSizeTTL, config.ChunkSubrangeTTL, config.MaxChunksGetRangeRequests)
-	cfg.CacheExists("metafile", c, isMetaFile, config.MetafileExistsTTL, config.MetafileDoesntExistTTL)
-	cfg.CacheGet("metafile", c, isMetaFile, config.MetafileContentTTL, config.MetafileExistsTTL, config.MetafileDoesntExistTTL)
+	cfg.CacheExists("meta.jsons", c, isMetaFile, config.MetafileExistsTTL, config.MetafileDoesntExistTTL)
+	cfg.CacheGet("meta.jsons", c, isMetaFile, config.MetafileContentTTL, config.MetafileExistsTTL, config.MetafileDoesntExistTTL)
 
 	// Cache Iter requests for root.
-	cfg.CacheIter("blocks-iter", c, isBlocksRootDir, config.BlocksIterTTL, JsonIterCodec{})
+	cfg.CacheIter("blocks-iter", c, isBlocksRootDir, config.BlocksIterTTL, JSONIterCodec{})
 
 	cb, err := NewCachingBucket(bucket, cfg, logger, reg)
 	if err != nil {
@@ -118,7 +113,7 @@ var chunksMatcher = regexp.MustCompile(`^.*/chunks/\d+$`)
 func isTSDBChunkFile(name string) bool { return chunksMatcher.MatchString(name) }
 
 func isMetaFile(name string) bool {
-	return strings.HasSuffix(name, metaFilenameSuffix) || strings.HasSuffix(name, deletionMarkFilenameSuffix)
+	return strings.HasSuffix(name, "/"+metadata.MetaFilename) || strings.HasSuffix(name, "/"+metadata.DeletionMarkFilename)
 }
 
 func isIndexFile(name string) bool {

--- a/pkg/store/cache/caching_bucket_factory.go
+++ b/pkg/store/cache/caching_bucket_factory.go
@@ -103,7 +103,7 @@ func NewCachingBucketFromYaml(yamlContent []byte, bucket objstore.Bucket, logger
 	cfg.CacheGet("metafile", c, isMetaFile, config.MetafileContentTTL, config.MetafileExistsTTL, config.MetafileDoesntExistTTL)
 
 	// Cache Iter requests for root.
-	cfg.CacheIter("dir", c, isBlocksRootDir, config.BlocksIterTTL, JsonIterCodec{})
+	cfg.CacheIter("blocks-iter", c, isBlocksRootDir, config.BlocksIterTTL, JsonIterCodec{})
 
 	// Enabling index caching (example).
 	cfg.CacheObjectSize("index", c, isIndexFile, time.Hour)

--- a/pkg/store/cache/caching_bucket_factory.go
+++ b/pkg/store/cache/caching_bucket_factory.go
@@ -103,7 +103,7 @@ func NewCachingBucketFromYaml(yamlContent []byte, bucket objstore.Bucket, logger
 	cfg.CacheGet("metafile", c, isMetaFile, config.MetafileContentTTL, config.MetafileExistsTTL, config.MetafileDoesntExistTTL)
 
 	// Cache Iter requests for root.
-	cfg.CacheIter("dir", c, isBlocksRootDir, config.BlocksIterTTL)
+	cfg.CacheIter("dir", c, isBlocksRootDir, config.BlocksIterTTL, JsonIterCodec{})
 
 	// Enabling index caching (example).
 	cfg.CacheObjectSize("index", c, isIndexFile, time.Hour)

--- a/pkg/store/cache/caching_bucket_test.go
+++ b/pkg/store/cache/caching_bucket_test.go
@@ -381,7 +381,7 @@ func TestCachedIter(t *testing.T) {
 
 	const cfgName = "dirs"
 	cfg := NewCachingBucketConfig()
-	cfg.CacheIter(cfgName, cache, func(string) bool { return true }, 5*time.Minute, JsonIterCodec{})
+	cfg.CacheIter(cfgName, cache, func(string) bool { return true }, 5*time.Minute, JSONIterCodec{})
 
 	cb, err := NewCachingBucket(inmem, cfg, nil, nil)
 	testutil.Ok(t, err)

--- a/pkg/store/cache/caching_bucket_test.go
+++ b/pkg/store/cache/caching_bucket_test.go
@@ -221,8 +221,8 @@ func TestChunksCaching(t *testing.T) {
 			}
 
 			cfg := DefaultCachingBucketConfig()
-			cfg.ChunkSubrangeSize = subrangeSize
-			cfg.MaxChunksGetRangeRequests = tc.maxGetRangeRequests
+			cfg.SubrangeSize = subrangeSize
+			cfg.MaxGetRangeRequests = tc.maxGetRangeRequests
 
 			cachingBucket, err := NewCachingBucket(inmem, cache, cfg, nil, nil)
 			testutil.Ok(t, err)

--- a/pkg/store/cache/caching_bucket_test.go
+++ b/pkg/store/cache/caching_bucket_test.go
@@ -381,7 +381,7 @@ func TestCachedIter(t *testing.T) {
 
 	const cfgName = "dirs"
 	cfg := NewCachingBucketConfig()
-	cfg.CacheIter(cfgName, cache, func(string) bool { return true }, 5*time.Minute)
+	cfg.CacheIter(cfgName, cache, func(string) bool { return true }, 5*time.Minute, JsonIterCodec{})
 
 	cb, err := NewCachingBucket(inmem, cfg, nil, nil)
 	testutil.Ok(t, err)

--- a/pkg/store/cache/caching_bucket_test.go
+++ b/pkg/store/cache/caching_bucket_test.go
@@ -562,7 +562,7 @@ func TestObjectSize(t *testing.T) {
 	cb.CacheObjectSize(cfgName, cache, matchAll, time.Minute)
 
 	verifyObjectSize(t, cb, testFilename, -1, false, cfgName)
-	verifyObjectSize(t, cb, testFilename, -1, false, cfgName) // ObjectSize doesn't cache non-existant files.
+	verifyObjectSize(t, cb, testFilename, -1, false, cfgName) // ObjectSize doesn't cache non-existent files.
 
 	data := []byte("hello world")
 	testutil.Ok(t, inmem.Upload(context.Background(), testFilename, bytes.NewBuffer(data)))

--- a/pkg/store/cache/caching_bucket_test.go
+++ b/pkg/store/cache/caching_bucket_test.go
@@ -23,6 +23,8 @@ import (
 	"github.com/thanos-io/thanos/pkg/testutil"
 )
 
+const testFilename = "/random_object"
+
 func TestChunksCaching(t *testing.T) {
 	length := int64(1024 * 1024)
 	subrangeSize := int64(16000) // All tests are based on this value.
@@ -444,18 +446,17 @@ func TestExists(t *testing.T) {
 	testutil.Ok(t, err)
 	cb.CacheExists("test", cache, matchAll, config)
 
-	file := "/random_object"
-	verifyExists(t, cb, file, false, false, "test")
+	verifyExists(t, cb, testFilename, false, false, "test")
 
-	testutil.Ok(t, inmem.Upload(context.Background(), file, strings.NewReader("hej")))
-	verifyExists(t, cb, file, false, true, "test") // Reused cache result.
+	testutil.Ok(t, inmem.Upload(context.Background(), testFilename, strings.NewReader("hej")))
+	verifyExists(t, cb, testFilename, false, true, "test") // Reused cache result.
 	cache.flush()
-	verifyExists(t, cb, file, true, false, "test")
+	verifyExists(t, cb, testFilename, true, false, "test")
 
-	testutil.Ok(t, inmem.Delete(context.Background(), file))
-	verifyExists(t, cb, file, true, true, "test") // Reused cache result.
+	testutil.Ok(t, inmem.Delete(context.Background(), testFilename))
+	verifyExists(t, cb, testFilename, true, true, "test") // Reused cache result.
 	cache.flush()
-	verifyExists(t, cb, file, false, false, "test")
+	verifyExists(t, cb, testFilename, false, false, "test")
 }
 
 func TestExistsCachingDisabled(t *testing.T) {
@@ -468,14 +469,13 @@ func TestExistsCachingDisabled(t *testing.T) {
 	testutil.Ok(t, err)
 	cb.CacheExists("test", cache, func(string) bool { return false }, DefaultCachingBucketConfig())
 
-	file := "/random_object"
-	verifyExists(t, cb, file, false, false, "test")
+	verifyExists(t, cb, testFilename, false, false, "test")
 
-	testutil.Ok(t, inmem.Upload(context.Background(), file, strings.NewReader("hej")))
-	verifyExists(t, cb, file, true, false, "test")
+	testutil.Ok(t, inmem.Upload(context.Background(), testFilename, strings.NewReader("hej")))
+	verifyExists(t, cb, testFilename, true, false, "test")
 
-	testutil.Ok(t, inmem.Delete(context.Background(), file))
-	verifyExists(t, cb, file, false, false, "test")
+	testutil.Ok(t, inmem.Delete(context.Background(), testFilename))
+	verifyExists(t, cb, testFilename, false, false, "test")
 }
 
 func verifyExists(t *testing.T, cb *CachingBucket, file string, exists bool, fromCache bool, label string) {
@@ -504,22 +504,21 @@ func TestGet(t *testing.T) {
 	cb.CacheGet("metafile", cache, matchAll, DefaultCachingBucketConfig())
 	cb.CacheExists("metafile", cache, matchAll, DefaultCachingBucketConfig())
 
-	file := "/random_object"
-	verifyGet(t, cb, file, nil, false, "metafile")
-	verifyExists(t, cb, file, false, true, "metafile")
+	verifyGet(t, cb, testFilename, nil, false, "metafile")
+	verifyExists(t, cb, testFilename, false, true, "metafile")
 
 	data := []byte("hello world")
-	testutil.Ok(t, inmem.Upload(context.Background(), file, bytes.NewBuffer(data)))
+	testutil.Ok(t, inmem.Upload(context.Background(), testFilename, bytes.NewBuffer(data)))
 
 	// Even if file is now uploaded, old data is served from cache.
-	verifyGet(t, cb, file, nil, true, "metafile")
-	verifyExists(t, cb, file, false, true, "metafile")
+	verifyGet(t, cb, testFilename, nil, true, "metafile")
+	verifyExists(t, cb, testFilename, false, true, "metafile")
 
 	cache.flush()
 
-	verifyGet(t, cb, file, data, false, "metafile")
-	verifyGet(t, cb, file, data, true, "metafile")
-	verifyExists(t, cb, file, true, true, "metafile")
+	verifyGet(t, cb, testFilename, data, false, "metafile")
+	verifyGet(t, cb, testFilename, data, true, "metafile")
+	verifyExists(t, cb, testFilename, true, true, "metafile")
 }
 
 func verifyGet(t *testing.T, cb *CachingBucket, file string, expectedData []byte, cacheUsed bool, label string) {
@@ -561,15 +560,14 @@ func TestObjectSize(t *testing.T) {
 	testutil.Ok(t, err)
 	cb.CacheObjectSize("test", cache, matchAll, DefaultCachingBucketConfig())
 
-	file := "/random_object"
-	verifyObjectSize(t, cb, file, -1, false, "test")
-	verifyObjectSize(t, cb, file, -1, false, "test") // ObjectSize doesn't cache non-existant files.
+	verifyObjectSize(t, cb, testFilename, -1, false, "test")
+	verifyObjectSize(t, cb, testFilename, -1, false, "test") // ObjectSize doesn't cache non-existant files.
 
 	data := []byte("hello world")
-	testutil.Ok(t, inmem.Upload(context.Background(), file, bytes.NewBuffer(data)))
+	testutil.Ok(t, inmem.Upload(context.Background(), testFilename, bytes.NewBuffer(data)))
 
-	verifyObjectSize(t, cb, file, len(data), false, "test")
-	verifyObjectSize(t, cb, file, len(data), true, "test")
+	verifyObjectSize(t, cb, testFilename, len(data), false, "test")
+	verifyObjectSize(t, cb, testFilename, len(data), true, "test")
 }
 
 func verifyObjectSize(t *testing.T, cb *CachingBucket, file string, expectedLength int, cacheUsed bool, label string) {

--- a/pkg/store/cache/caching_bucket_test.go
+++ b/pkg/store/cache/caching_bucket_test.go
@@ -402,12 +402,12 @@ func TestCachedIter(t *testing.T) {
 }
 
 func verifyIter(t *testing.T, cb *CachingBucket, expectedFiles []string, expectedCache bool, cfgName string) {
-	hitsBefore := int(promtest.ToFloat64(cb.operationHits.WithLabelValues(operationIter, cfgName)))
+	hitsBefore := int(promtest.ToFloat64(cb.operationHits.WithLabelValues(opIter, cfgName)))
 
 	col := iterCollector{}
 	testutil.Ok(t, cb.Iter(context.Background(), "/", col.collect))
 
-	hitsAfter := int(promtest.ToFloat64(cb.operationHits.WithLabelValues(operationIter, cfgName)))
+	hitsAfter := int(promtest.ToFloat64(cb.operationHits.WithLabelValues(opIter, cfgName)))
 
 	sort.Strings(col.items)
 	testutil.Equals(t, expectedFiles, col.items)
@@ -477,11 +477,11 @@ func TestExistsCachingDisabled(t *testing.T) {
 
 func verifyExists(t *testing.T, cb *CachingBucket, file string, exists bool, fromCache bool, cfgName string) {
 	t.Helper()
-	hitsBefore := int(promtest.ToFloat64(cb.operationHits.WithLabelValues(operationExists, cfgName)))
+	hitsBefore := int(promtest.ToFloat64(cb.operationHits.WithLabelValues(opExists, cfgName)))
 	ok, err := cb.Exists(context.Background(), file)
 	testutil.Ok(t, err)
 	testutil.Equals(t, exists, ok)
-	hitsAfter := int(promtest.ToFloat64(cb.operationHits.WithLabelValues(operationExists, cfgName)))
+	hitsAfter := int(promtest.ToFloat64(cb.operationHits.WithLabelValues(opExists, cfgName)))
 
 	if fromCache {
 		testutil.Equals(t, 1, hitsAfter-hitsBefore)
@@ -521,13 +521,13 @@ func TestGet(t *testing.T) {
 }
 
 func verifyGet(t *testing.T, cb *CachingBucket, file string, expectedData []byte, cacheUsed bool, cfgName string) {
-	hitsBefore := int(promtest.ToFloat64(cb.operationHits.WithLabelValues(operationGet, cfgName)))
+	hitsBefore := int(promtest.ToFloat64(cb.operationHits.WithLabelValues(opGet, cfgName)))
 
 	r, err := cb.Get(context.Background(), file)
 	if expectedData == nil {
 		testutil.Assert(t, cb.IsObjNotFoundErr(err))
 
-		hitsAfter := int(promtest.ToFloat64(cb.operationHits.WithLabelValues(operationGet, cfgName)))
+		hitsAfter := int(promtest.ToFloat64(cb.operationHits.WithLabelValues(opGet, cfgName)))
 		if cacheUsed {
 			testutil.Equals(t, 1, hitsAfter-hitsBefore)
 		} else {
@@ -540,7 +540,7 @@ func verifyGet(t *testing.T, cb *CachingBucket, file string, expectedData []byte
 		testutil.Ok(t, err)
 		testutil.Equals(t, expectedData, data)
 
-		hitsAfter := int(promtest.ToFloat64(cb.operationHits.WithLabelValues(operationGet, cfgName)))
+		hitsAfter := int(promtest.ToFloat64(cb.operationHits.WithLabelValues(opGet, cfgName)))
 		if cacheUsed {
 			testutil.Equals(t, 1, hitsAfter-hitsBefore)
 		} else {
@@ -573,7 +573,7 @@ func TestObjectSize(t *testing.T) {
 
 func verifyObjectSize(t *testing.T, cb *CachingBucket, file string, expectedLength int, cacheUsed bool, cfgName string) {
 	t.Helper()
-	hitsBefore := int(promtest.ToFloat64(cb.operationHits.WithLabelValues(operationObjectSize, cfgName)))
+	hitsBefore := int(promtest.ToFloat64(cb.operationHits.WithLabelValues(opObjectSize, cfgName)))
 
 	length, err := cb.ObjectSize(context.Background(), file)
 	if expectedLength < 0 {
@@ -582,7 +582,7 @@ func verifyObjectSize(t *testing.T, cb *CachingBucket, file string, expectedLeng
 		testutil.Ok(t, err)
 		testutil.Equals(t, uint64(expectedLength), length)
 
-		hitsAfter := int(promtest.ToFloat64(cb.operationHits.WithLabelValues(operationObjectSize, cfgName)))
+		hitsAfter := int(promtest.ToFloat64(cb.operationHits.WithLabelValues(opObjectSize, cfgName)))
 		if cacheUsed {
 			testutil.Equals(t, 1, hitsAfter-hitsBefore)
 		} else {


### PR DESCRIPTION
This PR does several things at once:

- Adds caching to more methods in `CachingBucket` (Get, Exists, Iter, ObjectSize)
- Makes caching bucket fully configurable: caching for each operation is configured via `Cache<OperationName>` method. This takes config name (used as label in metrics), cache, matcher function that is used to match object names, and configuration used for matching objects.
- Factory configures caching bucket to support:
    - Chunks caching: via `GetRange` method
    - Meta files caching (meta.json, deletion mark) via `Get` and `Exists` method
    - Caching of `Iter` for root directory
    - Caching of index files via `GetRange` and `ObjectSize` (this is mostly an example how to do it. We can discuss whether to do it now, or we wait)

Factory uses user-supplied configuration to configure operations based on how Thanos works.
Notice that factory uses single cache object for all of these, but cache is still passed as extra argument since we plan to pass different caches for different configurations in Cortex.

Opening PR to get feedback on design. I think code is also ready for review, but documentation hasn't been updated yet. Note that existing metrics have been modified, but configuration has been preserved and extended (there is no config for index cache, those values are just hardcoded. We can discuss whether to provide index cache config now, or in another PR which will also document situation around two different approaches to index cache).

/cc @pracucci @bwplotka 

* [ ] I added CHANGELOG entry for this change.
* [ ] I have updated documentation.

## Verification

Unit tests for now. I have also tested earlier version of the code integrated into Cortex in our dev cluster, but will retest again.
