### PR TITLE
quickstart: fix bucket web after recent changes

### DIFF
--- a/scripts/quickstart.sh
+++ b/scripts/quickstart.sh
@@ -250,7 +250,7 @@ done
 sleep 0.5
 
 if [ -n "${GCS_BUCKET}" -o -n "${S3_ENDPOINT}" ]; then
-  ${THANOS_EXECUTABLE} bucket web \
+  ${THANOS_EXECUTABLE} tools bucket web \
     --debug.name bucket-web \
     --log.level debug \
     --http-address 0.0.0.0:10933 \


### PR DESCRIPTION
The subcommand is called now `tools bucket web` after the recent
changes.

Without this, the quickstart script outputs:
```
Error parsing commandline arguments: expected command but got "bucket"
thanos: error: expected command but got "bucket"
```

Signed-off-by: Giedrius Statkevičius <giedriuswork@gmail.com>

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

Edited `./scripts/quickstart.sh` to include the "tools" prefix which is needed after the recent renames.

## Verification

`./scripts/quickstart.sh` brings up Thanos Bucket Viewer on `http://localhost:10933/`
