### PR TITLE
Makefile: remove --coverage from test run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -166,7 +166,7 @@ react-app-lint-fix:
 .PHONY: react-app-test
 react-app-test: | $(REACT_APP_NODE_MODULES_PATH) react-app-lint
 	@echo ">> running React app tests"
-	cd $(REACT_APP_PATH) && export CI=true && yarn test --no-watch --coverage
+	cd $(REACT_APP_PATH) && export CI=true && yarn test --no-watch
 
 .PHONY: react-app-start
 react-app-start: $(REACT_APP_NODE_MODULES_PATH)


### PR DESCRIPTION
## Changes

Found out that there is some weird interaction between `jest --coverage`
and `babel-plugin-istanbul`. Maybe related to:
https://github.com/facebook/jest/issues/6827.

From my testing, removing `--coverage` makes this work again. Probably
worth investigating in the future why that happens.

Also, this is really not needed during CI because we do not use the
coverage data anywhere anyway.

Signed-off-by: Giedrius Statkevičius <giedriuswork@gmail.com>

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.


## Verification

`docker run --user 1000 -v "$(pwd):/src" -it --rm quay.io/thanos/thanos-ci:go1.14.2-node` and then:

```bash
cd /src
make react-app-test
```

Passes the tests as it is supposed to.