### PR TITLE
ci: use GitHub Actions to test React UI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,6 @@ jobs:
               exit
             fi
             taskset 2 make test-ci
-            taskset 2 make react-app-test
 
   # Cross build is needed for publish_release but needs to be done outside of docker.
   cross_build:

--- a/.github/workflows/react-test.yml
+++ b/.github/workflows/react-test.yml
@@ -1,0 +1,33 @@
+name: react-test
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: [ '10', '12' ]
+    name: React UI test on Node ${{ matrix.node }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup node
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node }}
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - uses: actions/cache@v1
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('pkg/ui/react-app/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - run: make react-app-test


### PR DESCRIPTION

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes
Add a GH actions workflow to test the React UI on nodejs v10 and v12
Remove `react-app-test` from CircleCI config

## Verification
I tested it by creating a dummy PR on my clone and the GH action wrokflow seems to work as expected.
