### PR TITLE
Add Rule Group Evaluations to Ruler dashboard in mixin

### DIFF
--- a/examples/dashboards/overview.json
+++ b/examples/dashboards/overview.json
@@ -1549,7 +1549,7 @@
                      "expr": "sum(rate(thanos_alert_sender_alerts_sent_total{namespace=\"$namespace\",job=~\"thanos-rule.*\"}[$interval])) by (job, alertmanager)",
                      "format": "time_series",
                      "intervalFactor": 2,
-                     "legendFormat": "{{job}} {{alertmanager}}",
+                     "legendFormat": "{{alertmanager}}",
                      "legendLink": null,
                      "step": 10
                   }

--- a/examples/dashboards/rule.json
+++ b/examples/dashboards/rule.json
@@ -19,9 +19,249 @@
                "dashLength": 10,
                "dashes": false,
                "datasource": "$datasource",
-               "description": "Shows rate of dropped alerts.",
                "fill": 1,
                "id": 1,
+               "legend": {
+                  "avg": false,
+                  "current": false,
+                  "max": false,
+                  "min": false,
+                  "show": true,
+                  "total": false,
+                  "values": false
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null as zero",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "span": 4,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "sum by (strategy) (rate(prometheus_rule_evaluations_total{namespace=\"$namespace\",job=\"$job\"}[$interval]))\n",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{ strategy }}",
+                     "legendLink": null,
+                     "step": 10
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Rule Group Evaluations",
+               "tooltip": {
+                  "shared": false,
+                  "sort": 0,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": false
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$datasource",
+               "fill": 1,
+               "id": 2,
+               "legend": {
+                  "avg": false,
+                  "current": false,
+                  "max": false,
+                  "min": false,
+                  "show": true,
+                  "total": false,
+                  "values": false
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null as zero",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "span": 4,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "sum by (strategy) (increase(prometheus_rule_group_iterations_missed_total{namespace=\"$namespace\",job=\"$job\"}[$interval]))\n",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{ strategy }}",
+                     "legendLink": null,
+                     "step": 10
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Rule Group Evaluations Missed",
+               "tooltip": {
+                  "shared": false,
+                  "sort": 0,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": false
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$datasource",
+               "fill": 1,
+               "id": 3,
+               "legend": {
+                  "avg": false,
+                  "current": false,
+                  "max": false,
+                  "min": false,
+                  "show": true,
+                  "total": false,
+                  "values": false
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null as zero",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "span": 4,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "(\n  max by(rule_group) (prometheus_rule_group_last_duration_seconds{namespace=\"$namespace\",job=\"$job\"})\n  >\n  sum by(rule_group) (prometheus_rule_group_interval_seconds{namespace=\"$namespace\",job=\"$job\"})\n)\n",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{ rule_group }}",
+                     "legendLink": null,
+                     "step": 10
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Rule Group Evlauations Too Slow",
+               "tooltip": {
+                  "shared": false,
+                  "sort": 0,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": false
+                  }
+               ]
+            }
+         ],
+         "repeat": null,
+         "repeatIteration": null,
+         "repeatRowId": null,
+         "showTitle": true,
+         "title": "Rule Group Evaluations",
+         "titleSize": "h6"
+      },
+      {
+         "collapse": false,
+         "height": "250px",
+         "panels": [
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$datasource",
+               "description": "Shows rate of dropped alerts.",
+               "fill": 1,
+               "id": 4,
                "legend": {
                   "avg": false,
                   "current": false,
@@ -49,7 +289,7 @@
                      "expr": "sum(rate(thanos_alert_sender_alerts_dropped_total{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job, alertmanager)",
                      "format": "time_series",
                      "intervalFactor": 2,
-                     "legendFormat": "{{job}} {{alertmanager}}",
+                     "legendFormat": "{{alertmanager}}",
                      "legendLink": null,
                      "step": 10
                   }
@@ -98,7 +338,7 @@
                "datasource": "$datasource",
                "description": "Shows rate of alerts that successfully sent to alert manager.",
                "fill": 10,
-               "id": 2,
+               "id": 5,
                "legend": {
                   "avg": false,
                   "current": false,
@@ -126,7 +366,7 @@
                      "expr": "sum(rate(thanos_alert_sender_alerts_sent_total{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job, alertmanager)",
                      "format": "time_series",
                      "intervalFactor": 2,
-                     "legendFormat": "{{job}} {{alertmanager}}",
+                     "legendFormat": "{{alertmanager}}",
                      "legendLink": null,
                      "step": 10
                   }
@@ -177,7 +417,7 @@
                "datasource": "$datasource",
                "description": "Shows ratio of errors compared to the total number of sent alerts.",
                "fill": 10,
-               "id": 3,
+               "id": 6,
                "legend": {
                   "avg": false,
                   "current": false,
@@ -254,7 +494,7 @@
                "datasource": "$datasource",
                "description": "Shows how long has it taken to send alerts to alert manager.",
                "fill": 1,
-               "id": 4,
+               "id": 7,
                "legend": {
                   "avg": false,
                   "current": false,
@@ -359,7 +599,7 @@
                "datasource": "$datasource",
                "description": "Shows rate of queued alerts.",
                "fill": 1,
-               "id": 5,
+               "id": 8,
                "legend": {
                   "avg": false,
                   "current": false,
@@ -387,7 +627,7 @@
                      "expr": "sum(rate(thanos_alert_queue_alerts_dropped_total{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job, pod)",
                      "format": "time_series",
                      "intervalFactor": 2,
-                     "legendFormat": "{{job}} {{pod}}",
+                     "legendFormat": "{{pod}}",
                      "legendLink": null,
                      "step": 10
                   }
@@ -438,7 +678,7 @@
                "datasource": "$datasource",
                "description": "Shows ratio of dropped alerts compared to the total number of queued alerts.",
                "fill": 10,
-               "id": 6,
+               "id": 9,
                "legend": {
                   "avg": false,
                   "current": false,
@@ -546,7 +786,7 @@
                "datasource": "$datasource",
                "description": "Shows rate of handled Unary gRPC requests.",
                "fill": 10,
-               "id": 7,
+               "id": 10,
                "legend": {
                   "avg": false,
                   "current": false,
@@ -625,7 +865,7 @@
                "datasource": "$datasource",
                "description": "Shows ratio of errors compared to the total number of handled requests.",
                "fill": 10,
-               "id": 8,
+               "id": 11,
                "legend": {
                   "avg": false,
                   "current": false,
@@ -702,7 +942,7 @@
                "datasource": "$datasource",
                "description": "Shows how long has it taken to handle requests, in quantiles.",
                "fill": 1,
-               "id": 9,
+               "id": 12,
                "legend": {
                   "avg": false,
                   "current": false,
@@ -826,7 +1066,7 @@
                "datasource": "$datasource",
                "description": "Shows rate of handled Streamed gRPC requests.",
                "fill": 10,
-               "id": 10,
+               "id": 13,
                "legend": {
                   "avg": false,
                   "current": false,
@@ -905,7 +1145,7 @@
                "datasource": "$datasource",
                "description": "Shows ratio of errors compared to the total number of handled requests.",
                "fill": 10,
-               "id": 11,
+               "id": 14,
                "legend": {
                   "avg": false,
                   "current": false,
@@ -982,7 +1222,7 @@
                "datasource": "$datasource",
                "description": "Shows how long has it taken to handle requests, in quantiles",
                "fill": 1,
-               "id": 12,
+               "id": 15,
                "legend": {
                   "avg": false,
                   "current": false,
@@ -1086,7 +1326,7 @@
                "dashes": false,
                "datasource": "$datasource",
                "fill": 1,
-               "id": 13,
+               "id": 16,
                "legend": {
                   "avg": false,
                   "current": false,
@@ -1202,7 +1442,7 @@
                "dashes": false,
                "datasource": "$datasource",
                "fill": 1,
-               "id": 14,
+               "id": 17,
                "legend": {
                   "avg": false,
                   "current": false,
@@ -1278,7 +1518,7 @@
                "dashes": false,
                "datasource": "$datasource",
                "fill": 1,
-               "id": 15,
+               "id": 18,
                "legend": {
                   "avg": false,
                   "current": false,

--- a/mixin/dashboards/rule.libsonnet
+++ b/mixin/dashboards/rule.libsonnet
@@ -11,19 +11,53 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
     'rule.json':
       g.dashboard(thanos.rule.title)
       .addRow(
+        g.row('Rule Group Evaluations')
+        .addPanel(
+          g.panel('Rule Group Evaluations') +
+          g.queryPanel(
+            |||
+              sum by (strategy) (rate(prometheus_rule_evaluations_total{namespace="$namespace",job="$job"}[$interval]))
+            |||,
+            '{{ strategy }}',
+          )
+        )
+        .addPanel(
+          g.panel('Rule Group Evaluations Missed') +
+          g.queryPanel(
+            |||
+              sum by (strategy) (increase(prometheus_rule_group_iterations_missed_total{namespace="$namespace",job="$job"}[$interval]))
+            |||,
+            '{{ strategy }}',
+          )
+        )
+        .addPanel(
+          g.panel('Rule Group Evlauations Too Slow') +
+          g.queryPanel(
+            |||
+              (
+                max by(rule_group) (prometheus_rule_group_last_duration_seconds{namespace="$namespace",job="$job"})
+                >
+                sum by(rule_group) (prometheus_rule_group_interval_seconds{namespace="$namespace",job="$job"})
+              )
+            |||,
+            '{{ rule_group }}',
+          )
+        )
+      )
+      .addRow(
         g.row('Alert Sent')
         .addPanel(
           g.panel('Dropped Rate', 'Shows rate of dropped alerts.') +
           g.queryPanel(
             'sum(rate(thanos_alert_sender_alerts_dropped_total{namespace="$namespace",job=~"$job"}[$interval])) by (job, alertmanager)',
-            '{{job}} {{alertmanager}}'
+            '{{alertmanager}}'
           )
         )
         .addPanel(
           g.panel('Sent Rate', 'Shows rate of alerts that successfully sent to alert manager.') +
           g.queryPanel(
             'sum(rate(thanos_alert_sender_alerts_sent_total{namespace="$namespace",job=~"$job"}[$interval])) by (job, alertmanager)',
-            '{{job}} {{alertmanager}}'
+            '{{alertmanager}}'
           ) +
           g.stack
         )
@@ -45,7 +79,7 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
           g.panel('Push Rate', 'Shows rate of queued alerts.') +
           g.queryPanel(
             'sum(rate(thanos_alert_queue_alerts_dropped_total{namespace="$namespace",job=~"$job"}[$interval])) by (job, pod)',
-            '{{job}} {{pod}}'
+            '{{pod}}'
           )
         )
         .addPanel(
@@ -99,7 +133,7 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
         g.panel('Alert Sent Rate', 'Shows rate of alerts that successfully sent to alert manager.') +
         g.queryPanel(
           'sum(rate(thanos_alert_sender_alerts_sent_total{namespace="$namespace",%(selector)s}[$interval])) by (job, alertmanager)' % thanos.rule,
-          '{{job}} {{alertmanager}}'
+          '{{alertmanager}}'
         ) +
         g.addDashboardLink(thanos.rule.title) +
         g.stack


### PR DESCRIPTION
In #2398 we added a ThanosNoRuleEvaluations alert which is really helpful and signaling a symptom of unavailability of the Thanos Ruler. Sadly we don't surface these underlying metrics on the Thanos Ruler dashboard.

![Screenshot from 2020-05-13 19-51-10](https://user-images.githubusercontent.com/872251/81847257-a4ec5f80-9553-11ea-9d66-f16ac7e45e3c.png)




* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

Add some panel to the Thanos Ruler dashboard.

## Verification

Deployed the new Thanos Ruler dashboard on Grafana and check against our datasource :)