### PR TITLE
Cleanup flags for compact component

### DIFF
--- a/cmd/thanos/config.go
+++ b/cmd/thanos/config.go
@@ -125,3 +125,17 @@ func (sc *shipperConfig) registerFlag(cmd *kingpin.CmdClause) *shipperConfig {
 		Default("false").Hidden().BoolVar(&sc.ignoreBlockSize)
 	return sc
 }
+
+type webConfig struct {
+	externalPrefix   string
+	prefixHeaderName string
+}
+
+func (wc *webConfig) registerFlag(cmd *kingpin.CmdClause) *webConfig {
+	cmd.Flag("web.external-prefix",
+		"Static prefix for all HTML links and redirect URLs in the bucket web UI interface. Actual endpoints are still served on / or the web.route-prefix. This allows thanos bucket web UI to be served behind a reverse proxy that strips a URL sub-path.").
+		Default("").StringVar(&wc.externalPrefix)
+	cmd.Flag("web.prefix-header", "Name of HTTP request header used for dynamic prefixing of UI links and redirects. This option is ignored if web.external-prefix argument is set. Security risk: enable this option only if a reverse proxy in front of thanos is resetting the header. The --web.prefix-header=X-Forwarded-Prefix option can be useful, for example, if Thanos UI is served via Traefik reverse proxy with PathPrefixStrip option enabled, which sends the stripped prefix value in X-Forwarded-Prefix header. This allows thanos UI to be served on a sub-path.").
+		Default("").StringVar(&wc.externalPrefix)
+	return wc
+}


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->
Introduce config structs for sidecar component.
<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] Change is not relevant to the end user.

## Changes

As per #2248  - this change parses flags into structs before passing into the compact run func
