### PR TITLE
.*: pkg/tracing: Disable Elastic APM default tracer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 - [#2501](https://github.com/thanos-io/thanos/pull/2501) Query: gracefully handle additional fields in `SeriesResponse` protobuf message that may be added in the future.
 - [#2568](https://github.com/thanos-io/thanos/pull/2568) Query: does not close the connection of strict, static nodes if establishing a connection had succeeded but Info() call failed
 - [#2615](https://github.com/thanos-io/thanos/pull/2615) Rule: Fix bugs where rules were out of sync.
+- [#2614](https://github.com/thanos-io/thanos/pull/2614) Tracing: Disable Elastic APM Go Agent default tracer on initialization to disable the default metric gatherer
 
 ### Added
 

--- a/pkg/tracing/elasticapm/elastic_apm.go
+++ b/pkg/tracing/elasticapm/elastic_apm.go
@@ -12,6 +12,10 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+func init() {
+	apm.DefaultTracer.Close()
+}
+
 type Config struct {
 	ServiceName        string  `yaml:"service_name"`
 	ServiceVersion     string  `yaml:"service_version"`


### PR DESCRIPTION
Disable Elastic APM Default Tracer that would otherwise gather metrics
and send them on localhost even if no tracing backend was specified.

Fix thanos-io/thanos#2610

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

I don't think the change is relevant as I don't see anyone using the default metric gatherer without enabling tracing. However feel free to edit it if you think the new behavior is considered breaking changes.
The worse case scenario is: someone is using the default gatherer to gather Go Metrics without having tracing enabled. As far as I understand it, this is undocumented and unsupported.

## Changes

Disable Elastic APM default tracer on initialization 
<!-- Enumerate changes you made -->

## Verification

Start `thanos` with `ELASTIC_APM_LOG_LEVEL=debug` and `ELASTIC_APM_LOG_FILE=stdout`. Elastic APM does not try to gather and send metrics anymore.
