### PR TITLE
rule: Fix bug when rules were out of sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 - [#2536](https://github.com/thanos-io/thanos/pull/2536) minio-go: Fixed AWS STS endpoint url to https for Web Identity providers on AWS EKS
 - [#2501](https://github.com/thanos-io/thanos/pull/2501) Query: gracefully handle additional fields in `SeriesResponse` protobuf message that may be added in the future.
 - [#2568](https://github.com/thanos-io/thanos/pull/2568) Query: does not close the connection of strict, static nodes if establishing a connection had succeeded but Info() call failed
+- [#2615](https://github.com/thanos-io/thanos/pull/2615) Rule: Fix bugs where rules were out of sync.
 
 ### Added
 

--- a/cmd/thanos/rule.go
+++ b/cmd/thanos/rule.go
@@ -763,8 +763,9 @@ func reloadRules(logger log.Logger,
 	metrics *RuleMetrics) error {
 	level.Debug(logger).Log("msg", "configured rule files", "files", strings.Join(ruleFiles, ","))
 	var (
-		errs  tsdberrors.MultiError
-		files []string
+		errs      tsdberrors.MultiError
+		files     []string
+		seenFiles = make(map[string]struct{})
 	)
 	for _, pat := range ruleFiles {
 		fs, err := filepath.Glob(pat)
@@ -774,7 +775,13 @@ func reloadRules(logger log.Logger,
 			continue
 		}
 
-		files = append(files, fs...)
+		for _, fp := range fs {
+			if _, ok := seenFiles[fp]; ok {
+				continue
+			}
+			files = append(files, fp)
+			seenFiles[fp] = struct{}{}
+		}
 	}
 
 	level.Info(logger).Log("msg", "reload rule files", "numFiles", len(files))

--- a/pkg/rule/rule_test.go
+++ b/pkg/rule/rule_test.go
@@ -66,14 +66,17 @@ groups:
 		Appendable: nopAppendable{},
 	}
 	thanosRuleMgr := NewManager(dir)
-	ruleMgr := rules.NewManager(&opts)
-	thanosRuleMgr.SetRuleManager(storepb.PartialResponseStrategy_ABORT, ruleMgr)
-	thanosRuleMgr.SetRuleManager(storepb.PartialResponseStrategy_WARN, ruleMgr)
+	ruleMgrAbort := rules.NewManager(&opts)
+	ruleMgrWarn := rules.NewManager(&opts)
+	thanosRuleMgr.SetRuleManager(storepb.PartialResponseStrategy_ABORT, ruleMgrAbort)
+	thanosRuleMgr.SetRuleManager(storepb.PartialResponseStrategy_WARN, ruleMgrWarn)
+
+	ruleMgrAbort.Run()
+	ruleMgrWarn.Run()
+	defer ruleMgrAbort.Stop()
+	defer ruleMgrWarn.Stop()
 
 	testutil.Ok(t, thanosRuleMgr.Update(10*time.Second, []string{filepath.Join(dir, "rule.yaml")}))
-
-	ruleMgr.Run()
-	defer ruleMgr.Stop()
 
 	select {
 	case <-time.After(2 * time.Minute):
@@ -223,6 +226,44 @@ groups:
 			testutil.Equals(t, exp[i].file, g[i].OriginalFile())
 		})
 	}
+}
+
+func TestUpdateAfterClear(t *testing.T) {
+	dir, err := ioutil.TempDir("", "test_rule_rule_groups")
+	testutil.Ok(t, err)
+	defer func() { testutil.Ok(t, os.RemoveAll(dir)) }()
+
+	testutil.Ok(t, ioutil.WriteFile(filepath.Join(dir, "no_strategy.yaml"), []byte(`
+groups:
+- name: "something1"
+  rules:
+  - alert: "some"
+    expr: "up"
+`), os.ModePerm))
+
+	opts := rules.ManagerOptions{
+		Logger: log.NewLogfmtLogger(os.Stderr),
+	}
+	m := NewManager(dir)
+	ruleMgrAbort := rules.NewManager(&opts)
+	ruleMgrWarn := rules.NewManager(&opts)
+	m.SetRuleManager(storepb.PartialResponseStrategy_ABORT, ruleMgrAbort)
+	m.SetRuleManager(storepb.PartialResponseStrategy_WARN, ruleMgrWarn)
+
+	ruleMgrAbort.Run()
+	ruleMgrWarn.Run()
+	defer ruleMgrAbort.Stop()
+	defer ruleMgrWarn.Stop()
+
+	err = m.Update(1*time.Second, []string{
+		filepath.Join(dir, "no_strategy.yaml"),
+	})
+	testutil.Ok(t, err)
+	testutil.Equals(t, 1, len(m.RuleGroups()))
+
+	err = m.Update(1*time.Second, []string{})
+	testutil.Ok(t, err)
+	testutil.Equals(t, 0, len(m.RuleGroups()))
 }
 
 func TestRuleGroupMarshalYAML(t *testing.T) {


### PR DESCRIPTION

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

Note: The commits were taken from this PR https://github.com/thanos-io/thanos/pull/1439, as that PR was closed too early but the bug still exists and we hit it in our setup. I added the original author as the co-commiter, as they were not responsive on the original PR.

## Changes

From original PR:
> Thanos rule loading alerts about out-of-sync rule files
Specifically, the following scenario:
Rule file rule. Yaml, which contains some rules, through the reload command, thanos rule load rules.
If you clear the contents of rule. Yaml, but leave the file in, the old rules in thanos rule will not be cleared.
This bug leads to a common situation (all rules in one file)
If thanos rule has 100 rules, it can only clear 99 rules at most.

Note this also fixes when you have one rule loaded only, and you delete that rule it doesn't get updated, the number or rules is not important, it's the last rule.

## Verification

There is a unit test added, I also tested this manually in our cluster setup by loading the rule via yaml file as the OP suggested and deleting the rule from the file, the rule was now cleared correctly.