### PR TITLE
Rename caching_bucket yaml fields

### DIFF
--- a/docs/components/store.md
+++ b/docs/components/store.md
@@ -285,8 +285,8 @@ Thanos Store Gateway supports a "caching bucket" with chunks and metadata cachin
 Currently only memcached "backend" is supported:
 
 ```yaml
-backend: memcached
-backend_config:
+type: memcached
+config:
   addresses:
     - localhost:11211
 
@@ -301,7 +301,7 @@ metafile_content_ttl: 24h
 metafile_max_size: 1MiB
 ```
 
-`backend_config` field for memcached supports all the same configuration as memcached for [index cache](#memcached-index-cache).
+`config` field for memcached supports all the same configuration as memcached for [index cache](#memcached-index-cache).
 
 Additional options to configure various aspects of chunks cache are available:
 

--- a/pkg/store/cache/caching_bucket_factory.go
+++ b/pkg/store/cache/caching_bucket_factory.go
@@ -28,8 +28,8 @@ const MemcachedBucketCacheProvider BucketCacheProvider = "memcached" // Memcache
 
 // CachingWithBackendConfig is a configuration of caching bucket used by Store component.
 type CachingWithBackendConfig struct {
-	Type          BucketCacheProvider `yaml:"backend"`
-	BackendConfig interface{}         `yaml:"backend_config"`
+	Type          BucketCacheProvider `yaml:"type"`
+	BackendConfig interface{}         `yaml:"config"`
 
 	// Basic unit used to cache chunks.
 	ChunkSubrangeSize int64 `yaml:"chunk_subrange_size"`


### PR DESCRIPTION
Relevant discussion #2575 

Signed-off-by: Ranjith Kumar <ranjith.dakshana2015@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes
1. Rename caching bucket YAML fields from backend to type, backend_config to config 
2. Update docs to reflect the change in YAML fields

<!-- Enumerate changes you made -->

## Verification
Verified documentation using `make web-serve` .
<!-- How you tested it? How do you know it works? -->

Caching at bucket level was not part of an earlier release. So, this shouldn't update changelog, right? 
