### PR TITLE
Fixed panic in compactor

### DIFF
--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -647,7 +647,7 @@ func (cg *Group) compact(ctx context.Context, dir string, comp tsdb.Compactor) (
 
 		cgKey, groupKey := cg.Key(), GroupKey(meta.Thanos)
 		if cgKey != groupKey {
-			return false, ulid.ULID{}, halt(errors.Wrapf(err, "compact planned compaction for mixed groups. group: %s, planned block's group: %s", cgKey, groupKey))
+			return false, ulid.ULID{}, halt(errors.Errorf("compact planned compaction for mixed groups. group: %s, planned block's group: %s", cgKey, groupKey))
 		}
 
 		for _, s := range meta.Compaction.Sources {


### PR DESCRIPTION
* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

If the compactor group key check fails, it currently wraps an error which is actually `nil` and this causes a panic. This PR fixes it.

## Verification

Manual tests.
