### PR TITLE
store: Fix inconsistent cache backend types

### DIFF
--- a/docs/components/store.md
+++ b/docs/components/store.md
@@ -285,7 +285,7 @@ Thanos Store Gateway supports a "caching bucket" with chunks and metadata cachin
 Currently only memcached "backend" is supported:
 
 ```yaml
-type: memcached
+type: MEMCACHED # Case-insensitive
 config:
   addresses:
     - localhost:11211

--- a/pkg/store/cache/caching_bucket_factory.go
+++ b/pkg/store/cache/caching_bucket_factory.go
@@ -24,7 +24,7 @@ import (
 // BucketCacheProvider is a type used to evaluate all bucket cache providers.
 type BucketCacheProvider string
 
-const MemcachedBucketCacheProvider BucketCacheProvider = "memcached" // Memcached cache-provider for caching bucket.
+const MemcachedBucketCacheProvider BucketCacheProvider = "MEMCACHED" // Memcached cache-provider for caching bucket.
 
 // CachingWithBackendConfig is a configuration of caching bucket used by Store component.
 type CachingWithBackendConfig struct {
@@ -81,8 +81,8 @@ func NewCachingBucketFromYaml(yamlContent []byte, bucket objstore.Bucket, logger
 
 	var c cache.Cache
 
-	switch config.Type {
-	case MemcachedBucketCacheProvider:
+	switch strings.ToUpper(string(config.Type)) {
+	case string(MemcachedBucketCacheProvider):
 		var memcached cacheutil.MemcachedClient
 		memcached, err := cacheutil.NewMemcachedClient(logger, "caching-bucket", backendConfig, reg)
 		if err != nil {


### PR DESCRIPTION
Signed-off-by: Kemal Akkoyun <kakkoyun@gmail.com>

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

* Change memcached BucketCacheProvider constant type to `MEMCACHED` to be consistent with index cache backend.

https://github.com/thanos-io/thanos/blob/8bdd15e032c24fb98ed9ec69fa42f16376a9101e/pkg/store/cache/factory.go#L18-L23

* Make it case-insensitive to prevent future issues.

## Verification

* `make test-local`

cc @pstibrany 