### PR TITLE
compact: unwrap the original error as well

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 
 ## Unreleased
 
+### Fixed
+
+* [#2637](https://github.com/thanos-io/thanos/pull/2637) Compact: detect retryable errors that are inside of a wrapped `tsdb.MultiError`
+
 ## [v0.13.0](https://github.com/thanos-io/thanos/releases) - IN PROGRESS
 
 ### Fixed

--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -487,7 +487,7 @@ func (e RetryError) Error() string {
 // IsRetryError returns true if the base error is a RetryError.
 // If a multierror is passed, all errors must be retriable.
 func IsRetryError(err error) bool {
-	if multiErr, ok := err.(terrors.MultiError); ok {
+	if multiErr, ok := errors.Cause(err).(terrors.MultiError); ok {
 		for _, err := range multiErr {
 			if _, ok := errors.Cause(err).(RetryError); !ok {
 				return false

--- a/pkg/compact/compact_test.go
+++ b/pkg/compact/compact_test.go
@@ -50,6 +50,8 @@ func TestRetryMultiError(t *testing.T) {
 	errs = terrors.MultiError{retryErr}
 	testutil.Assert(t, IsRetryError(errs), "if all errors are retriable this should return true")
 
+	testutil.Assert(t, IsRetryError(errors.Wrap(errs, "wrap")), "retry error with wrap")
+
 	errs = terrors.MultiError{nonRetryErr, retryErr}
 	testutil.Assert(t, !IsRetryError(errs), "mixed errors should return false")
 }


### PR DESCRIPTION
Just like in IsHaltError(), let's unwrap the given error to see if is
`terrors.MultiError`. This lets us detect the retryable errors as well:

* `BucketCompactor.Compact` returns `terrors.MultiError` of wrapped
errors;
* `compactMainFn` wraps the previously returned error again.

So, we need to unwrap it at the beginning, iterate over it, and then
unwrap again which is what the code does with this change.

Signed-off-by: Giedrius Statkevičius <giedriuswork@gmail.com>

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

`IsRetryError()` now detects wrapped `terrors.MultiError` which is what happens in some (if not all) cases.

## Verification

Amended unit tests.