### PR TITLE
Added thanos-block.jq script and mention in troubleshooting doc.

### DIFF
--- a/docs/operating/troubleshooting.md
+++ b/docs/operating/troubleshooting.md
@@ -25,7 +25,7 @@ In this halted example, we can read that compactor detected 2 overlapped blocks.
 * Duplicated upload with different ULID (non-persistent storage for Prometheus can cause this)
 * 2 Prometheus instances are misconfigured and they are uploading the data with exactly the same external labels. This is wrong, they should be unique.
 
-Checking producers log for such ULID, and checking meta.json (e.g if sample stats are the same or not) helps. Checksum the index and chunks files as well to reveal if data is exactly the same, thus ok to be removed manually.
+Checking producers log for such ULID, and checking meta.json (e.g if sample stats are the same or not) helps. Checksum the index and chunks files as well to reveal if data is exactly the same, thus ok to be removed manually. You may find `scripts/thanos-block.jq` script useful when inspecting `meta.json` files, as it translated timestamps to human-readable form.
 
 ### Reasons
 

--- a/docs/operating/troubleshooting.md
+++ b/docs/operating/troubleshooting.md
@@ -25,7 +25,7 @@ In this halted example, we can read that compactor detected 2 overlapped blocks.
 * Duplicated upload with different ULID (non-persistent storage for Prometheus can cause this)
 * 2 Prometheus instances are misconfigured and they are uploading the data with exactly the same external labels. This is wrong, they should be unique.
 
-Checking producers log for such ULID, and checking meta.json (e.g if sample stats are the same or not) helps. Checksum the index and chunks files as well to reveal if data is exactly the same, thus ok to be removed manually. You may find `scripts/thanos-block.jq` script useful when inspecting `meta.json` files, as it translated timestamps to human-readable form.
+Checking producers log for such ULID, and checking meta.json (e.g if sample stats are the same or not) helps. Checksum the index and chunks files as well to reveal if data is exactly the same, thus ok to be removed manually. You may find `scripts/thanos-block.jq` script useful when inspecting `meta.json` files, as it translates timestamps to human-readable form.
 
 ### Reasons
 

--- a/scripts/thanos-block.jq
+++ b/scripts/thanos-block.jq
@@ -1,0 +1,22 @@
+#!/usr/bin/env jq -f
+
+{
+  "ulid": .ulid,
+  "minTime": (.minTime / 1000 | todateiso8601),
+  "maxTime": (.maxTime / 1000 | todateiso8601),
+  "stats": .stats,
+  "thanos": .thanos,
+  "compaction": {
+    "level": .compaction.level,
+    "sources": .compaction.sources,
+    "sourcesCount": .compaction.sources | length,
+    "parents": (if .compaction.parents? then [
+      .compaction.parents[] | {
+        "ulid": .ulid,
+	"minTime": (.minTime / 1000 | todateiso8601),
+	"maxTime": (.maxTime / 1000 | todateiso8601),
+      }
+    ] else null end)
+  },
+}
+


### PR DESCRIPTION
This PR adds `scripts/thanos-block.jq` script that I find useful when inspecting `meta.json` files. It mostly just translates timestamps to human-readable form. Example:

```
$ cat ./thanos-tsdb/01E6K1KY8N748AE90M68TZGSEP/meta.json | thanos-block.jq 
{
  "ulid": "01E6K1KY8N748AE90M68TZGSEP",
  "minTime": "2020-03-19T00:00:00Z",
  "maxTime": "2020-03-28T20:00:00Z",
  "stats": {
    "numSamples": 18417487,
    "numSeries": 2455,
    "numChunks": 227913
  },
  "thanos": {
    "labels": {
      "prometheus_instance": "localhost"
    },
    "downsample": {
      "resolution": 0
    },
    "source": "compactor"
  },
  "compaction": {
    "level": 4,
    "sources": [
      "01E3RE3Y560AH99QJEV2D7D0KH",
      # cut for brevity ...
      "01E4NRW2PEVMRXEDDD046CDEBX"
    ],
    "sourcesCount": 113, # not found in original meta.json, but I find it useful
    "parents": [
      {
        "ulid": "01E45Z17PVM72TDGF19WC5ZV02",
        "minTime": "2020-03-19T00:00:00Z",
        "maxTime": "2020-03-21T00:00:00Z"
      },
      {
        "ulid": "01E45Z19C17KVVZSJZT54G4VX9",
        "minTime": "2020-03-21T00:00:00Z",
        "maxTime": "2020-03-23T00:00:00Z"
      },
      {
        "ulid": "01E4WY01C1DC5XWVG474JVA3H4",
        "minTime": "2020-03-23T00:00:00Z",
        "maxTime": "2020-03-25T00:00:00Z"
      },
      {
        "ulid": "01E4WY02W2NN0EW66C4R58GW7W",
        "minTime": "2020-03-25T00:00:00Z",
        "maxTime": "2020-03-27T00:00:00Z"
      },
      {
        "ulid": "01E6K1KWA05BS2XJBSKCEY4NEK",
        "minTime": "2020-03-27T00:00:00Z",
        "maxTime": "2020-03-28T20:00:00Z"
      }
    ]
  }
}
```