### PR TITLE
Refactoring to extract blocks grouping logic out of syncer

### DIFF
--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -132,6 +132,10 @@ func runCompact(
 		Name: "thanos_compactor_blocks_marked_for_deletion_total",
 		Help: "Total number of blocks marked for deletion in compactor.",
 	})
+	garbageCollectedBlocks := promauto.With(reg).NewCounter(prometheus.CounterOpts{
+		Name: "thanos_compact_garbage_collected_blocks_total",
+		Help: "Total number of blocks marked for deletion by compactor.",
+	})
 	_ = promauto.With(reg).NewGaugeFunc(prometheus.GaugeOpts{
 		Name: "thanos_delete_delay_seconds",
 		Help: "Configured delete delay in seconds.",
@@ -237,8 +241,8 @@ func runCompact(
 			duplicateBlocksFilter,
 			ignoreDeletionMarkFilter,
 			blocksMarkedForDeletion,
-			conf.blockSyncConcurrency,
-			conf.acceptMalformedIndex, enableVerticalCompaction)
+			garbageCollectedBlocks,
+			conf.blockSyncConcurrency)
 		if err != nil {
 			return errors.Wrap(err, "create syncer")
 		}
@@ -273,8 +277,9 @@ func runCompact(
 		return errors.Wrap(err, "clean working downsample directory")
 	}
 
+	grouper := compact.NewDefaultGrouper(logger, bkt, conf.acceptMalformedIndex, enableVerticalCompaction, reg, blocksMarkedForDeletion, garbageCollectedBlocks)
 	blocksCleaner := compact.NewBlocksCleaner(logger, bkt, ignoreDeletionMarkFilter, deleteDelay, blocksCleaned, blockCleanupFailures)
-	compactor, err := compact.NewBucketCompactor(logger, sy, comp, compactDir, bkt, conf.compactionConcurrency)
+	compactor, err := compact.NewBucketCompactor(logger, sy, grouper, comp, compactDir, bkt, conf.compactionConcurrency)
 	if err != nil {
 		cancel()
 		return errors.Wrap(err, "create bucket compactor")

--- a/cmd/thanos/downsample.go
+++ b/cmd/thanos/downsample.go
@@ -208,10 +208,10 @@ func downsampleBucket(
 				continue
 			}
 			if err := processDownsampling(ctx, logger, bkt, m, dir, downsample.ResLevel1); err != nil {
-				metrics.downsampleFailures.WithLabelValues(compact.GroupKey(m.Thanos)).Inc()
+				metrics.downsampleFailures.WithLabelValues(compact.DefaultGroupKey(m.Thanos)).Inc()
 				return errors.Wrap(err, "downsampling to 5 min")
 			}
-			metrics.downsamples.WithLabelValues(compact.GroupKey(m.Thanos)).Inc()
+			metrics.downsamples.WithLabelValues(compact.DefaultGroupKey(m.Thanos)).Inc()
 
 		case downsample.ResLevel1:
 			missing := false
@@ -231,10 +231,10 @@ func downsampleBucket(
 				continue
 			}
 			if err := processDownsampling(ctx, logger, bkt, m, dir, downsample.ResLevel2); err != nil {
-				metrics.downsampleFailures.WithLabelValues(compact.GroupKey(m.Thanos))
+				metrics.downsampleFailures.WithLabelValues(compact.DefaultGroupKey(m.Thanos))
 				return errors.Wrap(err, "downsampling to 60 min")
 			}
-			metrics.downsamples.WithLabelValues(compact.GroupKey(m.Thanos))
+			metrics.downsamples.WithLabelValues(compact.DefaultGroupKey(m.Thanos))
 		}
 	}
 	return nil

--- a/cmd/thanos/main_test.go
+++ b/cmd/thanos/main_test.go
@@ -117,14 +117,14 @@ func TestCleanupDownsampleCacheFolder(t *testing.T) {
 	testutil.Ok(t, err)
 
 	metrics := newDownsampleMetrics(prometheus.NewRegistry())
-	testutil.Equals(t, 0.0, promtest.ToFloat64(metrics.downsamples.WithLabelValues(compact.GroupKey(meta.Thanos))))
+	testutil.Equals(t, 0.0, promtest.ToFloat64(metrics.downsamples.WithLabelValues(compact.DefaultGroupKey(meta.Thanos))))
 	metaFetcher, err := block.NewMetaFetcher(nil, 32, bkt, "", nil, nil, nil)
 	testutil.Ok(t, err)
 
 	metas, _, err := metaFetcher.Fetch(ctx)
 	testutil.Ok(t, err)
 	testutil.Ok(t, downsampleBucket(ctx, logger, metrics, bkt, metas, dir))
-	testutil.Equals(t, 1.0, promtest.ToFloat64(metrics.downsamples.WithLabelValues(compact.GroupKey(meta.Thanos))))
+	testutil.Equals(t, 1.0, promtest.ToFloat64(metrics.downsamples.WithLabelValues(compact.DefaultGroupKey(meta.Thanos))))
 
 	_, err = os.Stat(dir)
 	testutil.Assert(t, os.IsNotExist(err), "index cache dir should not exist at the end of execution")

--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -49,8 +49,6 @@ type Syncer struct {
 	partial                  map[ulid.ULID]error
 	blockSyncConcurrency     int
 	metrics                  *syncerMetrics
-	acceptMalformedIndex     bool
-	enableVerticalCompaction bool
 	duplicateBlocksFilter    *block.DeduplicateFilter
 	ignoreDeletionMarkFilter *block.IgnoreDeletionMarkFilter
 }
@@ -60,21 +58,13 @@ type syncerMetrics struct {
 	garbageCollections        prometheus.Counter
 	garbageCollectionFailures prometheus.Counter
 	garbageCollectionDuration prometheus.Histogram
-	compactions               *prometheus.CounterVec
-	compactionRunsStarted     *prometheus.CounterVec
-	compactionRunsCompleted   *prometheus.CounterVec
-	compactionFailures        *prometheus.CounterVec
-	verticalCompactions       *prometheus.CounterVec
 	blocksMarkedForDeletion   prometheus.Counter
 }
 
-func newSyncerMetrics(reg prometheus.Registerer, blocksMarkedForDeletion prometheus.Counter) *syncerMetrics {
+func newSyncerMetrics(reg prometheus.Registerer, blocksMarkedForDeletion prometheus.Counter, garbageCollectedBlocks prometheus.Counter) *syncerMetrics {
 	var m syncerMetrics
 
-	m.garbageCollectedBlocks = promauto.With(reg).NewCounter(prometheus.CounterOpts{
-		Name: "thanos_compact_garbage_collected_blocks_total",
-		Help: "Total number of blocks marked for deletion by compactor.",
-	})
+	m.garbageCollectedBlocks = garbageCollectedBlocks
 	m.garbageCollections = promauto.With(reg).NewCounter(prometheus.CounterOpts{
 		Name: "thanos_compact_garbage_collection_total",
 		Help: "Total number of garbage collection operations.",
@@ -89,26 +79,6 @@ func newSyncerMetrics(reg prometheus.Registerer, blocksMarkedForDeletion prometh
 		Buckets: []float64{0.01, 0.1, 0.3, 0.6, 1, 3, 6, 9, 20, 30, 60, 90, 120, 240, 360, 720},
 	})
 
-	m.compactions = promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
-		Name: "thanos_compact_group_compactions_total",
-		Help: "Total number of group compaction attempts that resulted in a new block.",
-	}, []string{"group"})
-	m.compactionRunsStarted = promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
-		Name: "thanos_compact_group_compaction_runs_started_total",
-		Help: "Total number of group compaction attempts.",
-	}, []string{"group"})
-	m.compactionRunsCompleted = promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
-		Name: "thanos_compact_group_compaction_runs_completed_total",
-		Help: "Total number of group completed compaction runs. This also includes compactor group runs that resulted with no compaction.",
-	}, []string{"group"})
-	m.compactionFailures = promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
-		Name: "thanos_compact_group_compactions_failures_total",
-		Help: "Total number of failed group compactions.",
-	}, []string{"group"})
-	m.verticalCompactions = promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
-		Name: "thanos_compact_group_vertical_compactions_total",
-		Help: "Total number of group compaction attempts that resulted in a new block based on overlapping blocks.",
-	}, []string{"group"})
 	m.blocksMarkedForDeletion = blocksMarkedForDeletion
 
 	return &m
@@ -116,7 +86,7 @@ func newSyncerMetrics(reg prometheus.Registerer, blocksMarkedForDeletion prometh
 
 // NewMetaSyncer returns a new Syncer for the given Bucket and directory.
 // Blocks must be at least as old as the sync delay for being considered.
-func NewSyncer(logger log.Logger, reg prometheus.Registerer, bkt objstore.Bucket, fetcher block.MetadataFetcher, duplicateBlocksFilter *block.DeduplicateFilter, ignoreDeletionMarkFilter *block.IgnoreDeletionMarkFilter, blocksMarkedForDeletion prometheus.Counter, blockSyncConcurrency int, acceptMalformedIndex bool, enableVerticalCompaction bool) (*Syncer, error) {
+func NewSyncer(logger log.Logger, reg prometheus.Registerer, bkt objstore.Bucket, fetcher block.MetadataFetcher, duplicateBlocksFilter *block.DeduplicateFilter, ignoreDeletionMarkFilter *block.IgnoreDeletionMarkFilter, blocksMarkedForDeletion prometheus.Counter, garbageCollectedBlocks prometheus.Counter, blockSyncConcurrency int) (*Syncer, error) {
 	if logger == nil {
 		logger = log.NewNopLogger()
 	}
@@ -126,15 +96,10 @@ func NewSyncer(logger log.Logger, reg prometheus.Registerer, bkt objstore.Bucket
 		bkt:                      bkt,
 		fetcher:                  fetcher,
 		blocks:                   map[ulid.ULID]*metadata.Meta{},
-		metrics:                  newSyncerMetrics(reg, blocksMarkedForDeletion),
+		metrics:                  newSyncerMetrics(reg, blocksMarkedForDeletion, garbageCollectedBlocks),
 		duplicateBlocksFilter:    duplicateBlocksFilter,
 		ignoreDeletionMarkFilter: ignoreDeletionMarkFilter,
 		blockSyncConcurrency:     blockSyncConcurrency,
-		acceptMalformedIndex:     acceptMalformedIndex,
-		// The syncer offers an option to enable vertical compaction, even if it's
-		// not currently used by Thanos, because the compactor is also used by Cortex
-		// which needs vertical compaction.
-		enableVerticalCompaction: enableVerticalCompaction,
 	}, nil
 }
 
@@ -182,59 +147,6 @@ func (s *Syncer) Metas() map[ulid.ULID]*metadata.Meta {
 	defer s.mtx.Unlock()
 
 	return s.blocks
-}
-
-// GroupKey returns a unique identifier for the group the block belongs to. It considers
-// the downsampling resolution and the block's labels.
-func GroupKey(meta metadata.Thanos) string {
-	return groupKey(meta.Downsample.Resolution, labels.FromMap(meta.Labels))
-}
-
-func groupKey(res int64, lbls labels.Labels) string {
-	return fmt.Sprintf("%d@%v", res, lbls.Hash())
-}
-
-// Groups returns the compaction groups for all blocks currently known to the syncer.
-// It creates all groups from the scratch on every call.
-func (s *Syncer) Groups() (res []*Group, err error) {
-	s.mtx.Lock()
-	defer s.mtx.Unlock()
-
-	groups := map[string]*Group{}
-	for _, m := range s.blocks {
-		groupKey := GroupKey(m.Thanos)
-		g, ok := groups[groupKey]
-		if !ok {
-			lbls := labels.FromMap(m.Thanos.Labels)
-			g, err = newGroup(
-				log.With(s.logger, "group", fmt.Sprintf("%d@%v", m.Thanos.Downsample.Resolution, lbls.String()), "groupKey", groupKey),
-				s.bkt,
-				lbls,
-				m.Thanos.Downsample.Resolution,
-				s.acceptMalformedIndex,
-				s.enableVerticalCompaction,
-				s.metrics.compactions.WithLabelValues(groupKey),
-				s.metrics.compactionRunsStarted.WithLabelValues(groupKey),
-				s.metrics.compactionRunsCompleted.WithLabelValues(groupKey),
-				s.metrics.compactionFailures.WithLabelValues(groupKey),
-				s.metrics.verticalCompactions.WithLabelValues(groupKey),
-				s.metrics.garbageCollectedBlocks,
-				s.metrics.blocksMarkedForDeletion,
-			)
-			if err != nil {
-				return nil, errors.Wrap(err, "create compaction group")
-			}
-			groups[groupKey] = g
-			res = append(res, g)
-		}
-		if err := g.Add(m); err != nil {
-			return nil, errors.Wrap(err, "add compaction group")
-		}
-	}
-	sort.Slice(res, func(i, j int) bool {
-		return res[i].Key() < res[j].Key()
-	})
-	return res, nil
 }
 
 // GarbageCollect marks blocks for deletion from bucket if their data is available as part of a
@@ -286,11 +198,127 @@ func (s *Syncer) GarbageCollect(ctx context.Context) error {
 	return nil
 }
 
+// Grouper is responsible to group all known blocks into sub groups which are safe to be
+// compacted concurrently.
+type Grouper interface {
+	// Groups returns the compaction groups for all blocks currently known to the syncer.
+	// It creates all groups from the scratch on every call.
+	Groups(blocks map[ulid.ULID]*metadata.Meta) (res []*Group, err error)
+}
+
+// DefaultGroupKey returns a unique identifier for the group the block belongs to, based on
+// the DefaultGrouper logic. It considers the downsampling resolution and the block's labels.
+func DefaultGroupKey(meta metadata.Thanos) string {
+	return defaultGroupKey(meta.Downsample.Resolution, labels.FromMap(meta.Labels))
+}
+
+func defaultGroupKey(res int64, lbls labels.Labels) string {
+	return fmt.Sprintf("%d@%v", res, lbls.Hash())
+}
+
+// DefaultGrouper is the Thanos built-in grouper. It groups blocks based on downsample
+// resolution and block's labels.
+type DefaultGrouper struct {
+	bkt                      objstore.Bucket
+	logger                   log.Logger
+	acceptMalformedIndex     bool
+	enableVerticalCompaction bool
+	compactions              *prometheus.CounterVec
+	compactionRunsStarted    *prometheus.CounterVec
+	compactionRunsCompleted  *prometheus.CounterVec
+	compactionFailures       *prometheus.CounterVec
+	verticalCompactions      *prometheus.CounterVec
+	garbageCollectedBlocks   prometheus.Counter
+	blocksMarkedForDeletion  prometheus.Counter
+}
+
+// NewDefaultGrouper makes a new DefaultGrouper.
+func NewDefaultGrouper(
+	logger log.Logger,
+	bkt objstore.Bucket,
+	acceptMalformedIndex bool,
+	enableVerticalCompaction bool,
+	reg prometheus.Registerer,
+	blocksMarkedForDeletion prometheus.Counter,
+	garbageCollectedBlocks prometheus.Counter,
+) *DefaultGrouper {
+	return &DefaultGrouper{
+		bkt:                      bkt,
+		logger:                   logger,
+		acceptMalformedIndex:     acceptMalformedIndex,
+		enableVerticalCompaction: enableVerticalCompaction,
+		compactions: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "thanos_compact_group_compactions_total",
+			Help: "Total number of group compaction attempts that resulted in a new block.",
+		}, []string{"group"}),
+		compactionRunsStarted: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "thanos_compact_group_compaction_runs_started_total",
+			Help: "Total number of group compaction attempts.",
+		}, []string{"group"}),
+		compactionRunsCompleted: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "thanos_compact_group_compaction_runs_completed_total",
+			Help: "Total number of group completed compaction runs. This also includes compactor group runs that resulted with no compaction.",
+		}, []string{"group"}),
+		compactionFailures: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "thanos_compact_group_compactions_failures_total",
+			Help: "Total number of failed group compactions.",
+		}, []string{"group"}),
+		verticalCompactions: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "thanos_compact_group_vertical_compactions_total",
+			Help: "Total number of group compaction attempts that resulted in a new block based on overlapping blocks.",
+		}, []string{"group"}),
+		garbageCollectedBlocks:  garbageCollectedBlocks,
+		blocksMarkedForDeletion: blocksMarkedForDeletion,
+	}
+}
+
+// Groups returns the compaction groups for all blocks currently known to the syncer.
+// It creates all groups from the scratch on every call.
+func (g *DefaultGrouper) Groups(blocks map[ulid.ULID]*metadata.Meta) (res []*Group, err error) {
+	groups := map[string]*Group{}
+	for _, m := range blocks {
+		groupKey := DefaultGroupKey(m.Thanos)
+		group, ok := groups[groupKey]
+		if !ok {
+			lbls := labels.FromMap(m.Thanos.Labels)
+			group, err = NewGroup(
+				log.With(g.logger, "group", fmt.Sprintf("%d@%v", m.Thanos.Downsample.Resolution, lbls.String()), "groupKey", groupKey),
+				g.bkt,
+				groupKey,
+				lbls,
+				m.Thanos.Downsample.Resolution,
+				g.acceptMalformedIndex,
+				g.enableVerticalCompaction,
+				g.compactions.WithLabelValues(groupKey),
+				g.compactionRunsStarted.WithLabelValues(groupKey),
+				g.compactionRunsCompleted.WithLabelValues(groupKey),
+				g.compactionFailures.WithLabelValues(groupKey),
+				g.verticalCompactions.WithLabelValues(groupKey),
+				g.garbageCollectedBlocks,
+				g.blocksMarkedForDeletion,
+			)
+			if err != nil {
+				return nil, errors.Wrap(err, "create compaction group")
+			}
+			groups[groupKey] = group
+			res = append(res, group)
+		}
+		if err := group.Add(m); err != nil {
+			return nil, errors.Wrap(err, "add compaction group")
+		}
+	}
+	sort.Slice(res, func(i, j int) bool {
+		return res[i].Key() < res[j].Key()
+	})
+	return res, nil
+}
+
 // Group captures a set of blocks that have the same origin labels and downsampling resolution.
 // Those blocks generally contain the same series and can thus efficiently be compacted.
 type Group struct {
 	logger                      log.Logger
 	bkt                         objstore.Bucket
+	key                         string
 	labels                      labels.Labels
 	resolution                  int64
 	mtx                         sync.Mutex
@@ -306,10 +334,11 @@ type Group struct {
 	blocksMarkedForDeletion     prometheus.Counter
 }
 
-// newGroup returns a new compaction group.
-func newGroup(
+// NewGroup returns a new compaction group.
+func NewGroup(
 	logger log.Logger,
 	bkt objstore.Bucket,
+	key string,
 	lset labels.Labels,
 	resolution int64,
 	acceptMalformedIndex bool,
@@ -328,6 +357,7 @@ func newGroup(
 	g := &Group{
 		logger:                      logger,
 		bkt:                         bkt,
+		key:                         key,
 		labels:                      lset,
 		resolution:                  resolution,
 		blocks:                      map[ulid.ULID]*metadata.Meta{},
@@ -346,7 +376,7 @@ func newGroup(
 
 // Key returns an identifier for the group.
 func (cg *Group) Key() string {
-	return groupKey(cg.resolution, cg.labels)
+	return cg.key
 }
 
 // Add the block with the given meta to the group.
@@ -376,6 +406,34 @@ func (cg *Group) IDs() (ids []ulid.ULID) {
 		return ids[i].Compare(ids[j]) < 0
 	})
 	return ids
+}
+
+// MinTime returns the min time across all group's blocks.
+func (cg *Group) MinTime() int64 {
+	cg.mtx.Lock()
+	defer cg.mtx.Unlock()
+
+	min := int64(0)
+	for _, b := range cg.blocks {
+		if b.MinTime < min {
+			min = b.MinTime
+		}
+	}
+	return min
+}
+
+// MaxTime returns the max time across all group's blocks.
+func (cg *Group) MaxTime() int64 {
+	cg.mtx.Lock()
+	defer cg.mtx.Unlock()
+
+	max := int64(0)
+	for _, b := range cg.blocks {
+		if b.MaxTime < max {
+			max = b.MaxTime
+		}
+	}
+	return max
 }
 
 // Labels returns the labels that all blocks in the group share.
@@ -645,11 +703,6 @@ func (cg *Group) compact(ctx context.Context, dir string, comp tsdb.Compactor) (
 			return false, ulid.ULID{}, errors.Wrapf(err, "read meta from %s", pdir)
 		}
 
-		cgKey, groupKey := cg.Key(), GroupKey(meta.Thanos)
-		if cgKey != groupKey {
-			return false, ulid.ULID{}, halt(errors.Errorf("compact planned compaction for mixed groups. group: %s, planned block's group: %s", cgKey, groupKey))
-		}
-
 		for _, s := range meta.Compaction.Sources {
 			if _, ok := uniqueSources[s]; ok {
 				return false, ulid.ULID{}, halt(errors.Errorf("overlapping sources detected for plan %v", plan))
@@ -800,6 +853,7 @@ func (cg *Group) deleteBlock(b string) error {
 type BucketCompactor struct {
 	logger      log.Logger
 	sy          *Syncer
+	grouper     Grouper
 	comp        tsdb.Compactor
 	compactDir  string
 	bkt         objstore.Bucket
@@ -810,6 +864,7 @@ type BucketCompactor struct {
 func NewBucketCompactor(
 	logger log.Logger,
 	sy *Syncer,
+	grouper Grouper,
 	comp tsdb.Compactor,
 	compactDir string,
 	bkt objstore.Bucket,
@@ -821,6 +876,7 @@ func NewBucketCompactor(
 	return &BucketCompactor{
 		logger:      logger,
 		sy:          sy,
+		grouper:     grouper,
 		comp:        comp,
 		compactDir:  compactDir,
 		bkt:         bkt,
@@ -896,7 +952,7 @@ func (c *BucketCompactor) Compact(ctx context.Context) error {
 			return errors.Wrap(err, "garbage")
 		}
 
-		groups, err := c.sy.Groups()
+		groups, err := c.grouper.Groups(c.sy.Metas())
 		if err != nil {
 			return errors.Wrap(err, "build compaction groups")
 		}

--- a/pkg/compact/compact_test.go
+++ b/pkg/compact/compact_test.go
@@ -105,7 +105,7 @@ func TestGroupKey(t *testing.T) {
 		},
 	} {
 		if ok := t.Run("", func(t *testing.T) {
-			testutil.Equals(t, tcase.expected, GroupKey(tcase.input))
+			testutil.Equals(t, tcase.expected, DefaultGroupKey(tcase.input))
 		}); !ok {
 			return
 		}

--- a/pkg/verifier/overlapped_blocks.go
+++ b/pkg/verifier/overlapped_blocks.go
@@ -57,7 +57,7 @@ func fetchOverlaps(ctx context.Context, fetcher block.MetadataFetcher) (map[stri
 
 	groupMetasMap := map[string][]tsdb.BlockMeta{}
 	for _, meta := range metas {
-		groupKey := compact.GroupKey(meta.Thanos)
+		groupKey := compact.DefaultGroupKey(meta.Thanos)
 		groupMetasMap[groupKey] = append(groupMetasMap[groupKey], meta.BlockMeta)
 	}
 


### PR DESCRIPTION
* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

In Cortex we're experimenting a different grouping logic, in order to be able to concurrently compact blocks belonging to non-overlapping time ranges. So far we've got a good result and we would like to move it upstream.

In order to continue to use the great Thanos `BucketCompactor`, we would need to inject a custom blocks grouping logic.

In this PR I'm proposing to extract the syncer grouping logic into a dedicated component (`Grouper`), moving the syncer `Groups()` logic to a `DefaultGrouper` implementation. Logic and metrics haven't changed (if they did, it's a bug).

/cc @pstibrany 

## Verification

Existing tests.
