### PR TITLE
Fix race condition on err variable.

### DIFF
--- a/pkg/cacheutil/memcached_client.go
+++ b/pkg/cacheutil/memcached_client.go
@@ -273,7 +273,7 @@ func (c *memcachedClient) Stop() {
 	c.workers.Wait()
 }
 
-func (c *memcachedClient) SetAsync(ctx context.Context, key string, value []byte, ttl time.Duration) (err error) {
+func (c *memcachedClient) SetAsync(ctx context.Context, key string, value []byte, ttl time.Duration) error {
 	// Skip hitting memcached at all if the item is bigger than the max allowed size.
 	if c.config.MaxItemSize > 0 && uint64(len(value)) > uint64(c.config.MaxItemSize) {
 		c.skipped.WithLabelValues(opSet, reasonMaxItemSize).Inc()
@@ -284,6 +284,7 @@ func (c *memcachedClient) SetAsync(ctx context.Context, key string, value []byte
 		start := time.Now()
 		c.operations.WithLabelValues(opSet).Inc()
 
+		var err error
 		tracing.DoInSpan(ctx, "memcached_set", func(ctx context.Context) {
 			err = c.client.Set(&memcache.Item{
 				Key:        key,


### PR DESCRIPTION
This PR fixes race on `err` variable. It was set by `return` statement as well as by function run by different goroutine via async queue.

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Verification

Running with `-race` no longer produces warning. Previous warning:

```
=================
WARNING: DATA RACE
Write at 0x00c000280310 by goroutine 83:
  github.com/thanos-io/thanos/pkg/cacheutil.(*memcachedClient).SetAsync.func1.1()
      /Users/peter/Grafana/cortex/vendor/github.com/thanos-io/thanos/pkg/cacheutil/memcached_client.go:287 +0x3a2
  github.com/thanos-io/thanos/pkg/tracing.DoInSpan()
      /Users/peter/Grafana/cortex/vendor/github.com/thanos-io/thanos/pkg/tracing/tracing.go:63 +0x252
  github.com/thanos-io/thanos/pkg/cacheutil.(*memcachedClient).SetAsync.func1()
      /Users/peter/Grafana/cortex/vendor/github.com/thanos-io/thanos/pkg/cacheutil/memcached_client.go:286 +0x55e
  github.com/thanos-io/thanos/pkg/cacheutil.(*memcachedClient).asyncQueueProcessLoop()
      /Users/peter/Grafana/cortex/vendor/github.com/thanos-io/thanos/pkg/cacheutil/memcached_client.go:434 +0x245

Previous write at 0x00c000280310 by goroutine 320:
  github.com/thanos-io/thanos/pkg/cacheutil.(*memcachedClient).SetAsync()
      /Users/peter/Grafana/cortex/vendor/github.com/thanos-io/thanos/pkg/cacheutil/memcached_client.go:282 +0x645
  github.com/thanos-io/thanos/pkg/cache.(*MemcachedCache).Store()
      /Users/peter/Grafana/cortex/vendor/github.com/thanos-io/thanos/pkg/cache/memcached.go:62 +0x2be
  github.com/thanos-io/thanos/pkg/store/cache.(*CachingBucket).Iter()
      /Users/peter/Grafana/cortex/vendor/github.com/thanos-io/thanos/pkg/store/cache/caching_bucket.go:171 +0x158f
  github.com/cortexproject/cortex/pkg/storegateway.(*BucketStores).syncUsersBlocks()
      /Users/peter/Grafana/cortex/pkg/storegateway/bucket_stores.go:155 +0x6c6
  github.com/cortexproject/cortex/pkg/storegateway.(*BucketStores).InitialSync()
      /Users/peter/Grafana/cortex/pkg/storegateway/bucket_stores.go:99 +0x253
  github.com/cortexproject/cortex/pkg/querier.(*BucketStoresService).starting()
      /Users/peter/Grafana/cortex/pkg/querier/blocks_bucket_stores_service.go:58 +0xcd
  github.com/cortexproject/cortex/pkg/querier.(*BucketStoresService).starting-fm()
      /Users/peter/Grafana/cortex/pkg/querier/blocks_bucket_stores_service.go:55 +0x85
  github.com/cortexproject/cortex/pkg/util/services.(*BasicService).main()
      /Users/peter/Grafana/cortex/pkg/util/services/basic_service.go:134 +0x151
```