### PR TITLE
Allow using multiple memcached clients at the same time.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 ### Fixed
 
 * [#2637](https://github.com/thanos-io/thanos/pull/2637) Compact: detect retryable errors that are inside of a wrapped `tsdb.MultiError`
+* [#2648](https://github.com/thanos-io/thanos/pull/2648) Store: allow index cache and caching bucket to be configured at the same time.
 
 ## [v0.13.0](https://github.com/thanos-io/thanos/releases) - IN PROGRESS
 

--- a/pkg/cacheutil/memcached_client.go
+++ b/pkg/cacheutil/memcached_client.go
@@ -185,12 +185,11 @@ func NewMemcachedClientWithConfig(logger log.Logger, name string, config Memcach
 	if reg != nil {
 		reg = prometheus.WrapRegistererWith(prometheus.Labels{"name": name}, reg)
 	}
-	return newMemcachedClient(logger, name, client, selector, config, reg)
+	return newMemcachedClient(logger, client, selector, config, reg)
 }
 
 func newMemcachedClient(
 	logger log.Logger,
-	name string,
 	client memcachedClientBackend,
 	selector *MemcachedJumpHashSelector,
 	config MemcachedClientConfig,

--- a/pkg/cacheutil/memcached_client_test.go
+++ b/pkg/cacheutil/memcached_client_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/fortytw2/leaktest"
 	"github.com/go-kit/kit/log"
 	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
 	prom_testutil "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/thanos-io/thanos/pkg/model"
 	"github.com/thanos-io/thanos/pkg/testutil"
@@ -438,4 +439,19 @@ func (c *memcachedClientBackendMock) waitItems(expected int) error {
 	}
 
 	return errors.New("timeout expired while waiting for items in the memcached mock")
+}
+
+func TestMultipleClientsCanUseSameRegistry(t *testing.T) {
+	reg := prometheus.NewRegistry()
+
+	config := defaultMemcachedClientConfig
+	config.Addresses = []string{"127.0.0.1:11211"}
+
+	client1, err := NewMemcachedClientWithConfig(log.NewNopLogger(), "a", config, reg)
+	testutil.Ok(t, err)
+	defer client1.Stop()
+
+	client2, err := NewMemcachedClientWithConfig(log.NewNopLogger(), "b", config, reg)
+	testutil.Ok(t, err)
+	defer client2.Stop()
 }

--- a/pkg/cacheutil/memcached_client_test.go
+++ b/pkg/cacheutil/memcached_client_test.go
@@ -379,7 +379,7 @@ func TestMemcachedClient_GetMulti(t *testing.T) {
 func prepare(config MemcachedClientConfig, backendMock *memcachedClientBackendMock) (*memcachedClient, error) {
 	logger := log.NewNopLogger()
 	selector := &MemcachedJumpHashSelector{}
-	client, err := newMemcachedClient(logger, "test", backendMock, selector, config, nil)
+	client, err := newMemcachedClient(logger, backendMock, selector, config, nil)
 
 	return client, err
 }


### PR DESCRIPTION
This PR fixes issue when user tries to configure both caching bucket and index cache at the same time. That creates two independent memcached clients, which try to create same metrics into the same registry, which failed before. This PR fixes that.

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Verification

Unit test that fails on master. Also manually tested by configuring Thanos store to use both caches -- it fails with master build, but works with this patch.

/cc @kakkoyun (since you reported it to me)