### PR TITLE
Fix failing docker multistage builds

### DIFF
--- a/Dockerfile.multi-stage
+++ b/Dockerfile.multi-stage
@@ -17,6 +17,6 @@ RUN git update-index --refresh; make build
 FROM quay.io/prometheus/busybox:latest
 LABEL maintainer="The Thanos Authors"
 
-COPY --from=builder /go/src/github.com/thanos-io/thanos/thanos /bin/thanos
+COPY --from=builder /go/bin/thanos /bin/thanos
 
 ENTRYPOINT [ "/bin/thanos" ]


### PR DESCRIPTION
Signed-off-by: Kemal Akkoyun <kakkoyun@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

* Fix multi-stage builds (reflect changes after modification to `make build`)

## Verification

* `make docker-multi-stage`