### PR TITLE
querier: Execute Selects concurrently per query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 ### Added
 
 - [#2671](https://github.com/thanos-io/thanos/pull/2671) Tools: bucket replicate now allows passing repeated `--compaction` and `--resolution` flags.
+- [#2657](https://github.com/thanos-io/thanos/pull/2657) Querier: Now, has the ability to perform concurrent select request per query.
 
 ## [v0.13.0](https://github.com/thanos-io/thanos/releases) - IN PROGRESS
 

--- a/docs/components/query.md
+++ b/docs/components/query.md
@@ -216,6 +216,12 @@ type queryData struct {
 Additional field is `Warnings` that contains every error that occurred that is assumed non critical. `partial_response`
 option controls if storeAPI unavailability is considered critical.
 
+### Concurrent Selects
+
+Thanos Querier has the ability to perform concurrent select request per query. It dissects given PromQL statement and executes selectors concurrently against the discovered StoreAPIs.
+The maximum number of concurrent requests are being made per query is controller by `query.max-concurrent-select` flag.
+Keep in mind that the maximum number of concurrent queries that are handled by querier is controlled by `query.max-concurrent`. Please consider implications of combined value while tuning the querier.
+
 ## Expose UI on a sub-path
 
 It is possible to expose thanos-query UI and optionally API on a sub-path.

--- a/docs/components/query.md
+++ b/docs/components/query.md
@@ -333,6 +333,9 @@ Flags:
       --query.timeout=2m         Maximum time to process query by query node.
       --query.max-concurrent=20  Maximum number of queries processed
                                  concurrently by query node.
+      --query.max-concurrent-select=4
+                                 Maximum number of select requests made
+                                 concurrently per a query.
       --query.replica-label=QUERY.REPLICA-LABEL ...
                                  Labels to treat as a replica indicator along
                                  which data is deduplicated. Still you will be

--- a/pkg/query/api/v1_test.go
+++ b/pkg/query/api/v1_test.go
@@ -108,13 +108,14 @@ func TestEndpoints(t *testing.T) {
 	testutil.Ok(t, app.Commit())
 
 	now := time.Now()
+	timeout := 100 * time.Second
 	api := &API{
-		queryableCreate: query.NewQueryableCreator(nil, store.NewTSDBStore(nil, nil, db, component.Query, nil)),
+		queryableCreate: query.NewQueryableCreator(nil, nil, store.NewTSDBStore(nil, nil, db, component.Query, nil), 2, timeout),
 		queryEngine: promql.NewEngine(promql.EngineOpts{
 			Logger:     nil,
 			Reg:        nil,
 			MaxSamples: 10000,
-			Timeout:    100 * time.Second,
+			Timeout:    timeout,
 		}),
 		now:  func() time.Time { return now },
 		gate: gate.NewKeeper(nil).NewGate(4),

--- a/pkg/query/iter.go
+++ b/pkg/query/iter.go
@@ -670,3 +670,40 @@ func (it *dedupSeriesIterator) Err() error {
 	}
 	return it.b.Err()
 }
+
+type lazySeriesSet struct {
+	create func() (s storage.SeriesSet, ok bool)
+
+	set storage.SeriesSet
+}
+
+func (c *lazySeriesSet) Next() bool {
+	if c.set != nil {
+		return c.set.Next()
+	}
+
+	var ok bool
+	c.set, ok = c.create()
+	return ok
+}
+
+func (c *lazySeriesSet) Err() error {
+	if c.set != nil {
+		return c.set.Err()
+	}
+	return nil
+}
+
+func (c *lazySeriesSet) At() storage.Series {
+	if c.set != nil {
+		return c.set.At()
+	}
+	return nil
+}
+
+func (c *lazySeriesSet) Warnings() storage.Warnings {
+	if c.set != nil {
+		return c.set.Warnings()
+	}
+	return nil
+}

--- a/pkg/query/querier.go
+++ b/pkg/query/querier.go
@@ -7,13 +7,17 @@ import (
 	"context"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/go-kit/kit/log"
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/storage"
 
+	"github.com/thanos-io/thanos/pkg/extprom"
+	"github.com/thanos-io/thanos/pkg/gate"
 	"github.com/thanos-io/thanos/pkg/store/storepb"
 	"github.com/thanos-io/thanos/pkg/tracing"
 )
@@ -27,38 +31,45 @@ import (
 type QueryableCreator func(deduplicate bool, replicaLabels []string, maxResolutionMillis int64, partialResponse, skipChunks bool) storage.Queryable
 
 // NewQueryableCreator creates QueryableCreator.
-func NewQueryableCreator(logger log.Logger, proxy storepb.StoreServer) QueryableCreator {
+func NewQueryableCreator(logger log.Logger, reg prometheus.Registerer, proxy storepb.StoreServer, maxConcurrentSelects int, selectTimeout time.Duration) QueryableCreator {
 	return func(deduplicate bool, replicaLabels []string, maxResolutionMillis int64, partialResponse, skipChunks bool) storage.Queryable {
 		return &queryable{
-			logger:              logger,
-			replicaLabels:       replicaLabels,
-			proxy:               proxy,
-			deduplicate:         deduplicate,
-			maxResolutionMillis: maxResolutionMillis,
-			partialResponse:     partialResponse,
-			skipChunks:          skipChunks,
+			logger:               logger,
+			reg:                  reg,
+			replicaLabels:        replicaLabels,
+			proxy:                proxy,
+			deduplicate:          deduplicate,
+			maxResolutionMillis:  maxResolutionMillis,
+			partialResponse:      partialResponse,
+			skipChunks:           skipChunks,
+			maxConcurrentSelects: maxConcurrentSelects,
+			selectTimeout:        selectTimeout,
 		}
 	}
 }
 
 type queryable struct {
-	logger              log.Logger
-	replicaLabels       []string
-	proxy               storepb.StoreServer
-	deduplicate         bool
-	maxResolutionMillis int64
-	partialResponse     bool
-	skipChunks          bool
+	logger               log.Logger
+	reg                  prometheus.Registerer
+	replicaLabels        []string
+	proxy                storepb.StoreServer
+	deduplicate          bool
+	maxResolutionMillis  int64
+	partialResponse      bool
+	skipChunks           bool
+	maxConcurrentSelects int
+	selectTimeout        time.Duration
 }
 
 // Querier returns a new storage querier against the underlying proxy store API.
 func (q *queryable) Querier(ctx context.Context, mint, maxt int64) (storage.Querier, error) {
-	return newQuerier(ctx, q.logger, mint, maxt, q.replicaLabels, q.proxy, q.deduplicate, q.maxResolutionMillis, q.partialResponse, q.skipChunks), nil
+	return newQuerier(ctx, q.logger, q.reg, mint, maxt, q.replicaLabels, q.proxy, q.deduplicate, q.maxResolutionMillis, q.partialResponse, q.skipChunks, q.maxConcurrentSelects, q.selectTimeout), nil
 }
 
 type querier struct {
 	ctx                 context.Context
 	logger              log.Logger
+	reg                 prometheus.Registerer
 	cancel              func()
 	mint, maxt          int64
 	replicaLabels       map[string]struct{}
@@ -67,6 +78,8 @@ type querier struct {
 	maxResolutionMillis int64
 	partialResponse     bool
 	skipChunks          bool
+	gate                *gate.Gate
+	selectTimeout       time.Duration
 }
 
 // newQuerier creates implementation of storage.Querier that fetches data from the proxy
@@ -74,13 +87,15 @@ type querier struct {
 func newQuerier(
 	ctx context.Context,
 	logger log.Logger,
+	reg prometheus.Registerer,
 	mint, maxt int64,
 	replicaLabels []string,
 	proxy storepb.StoreServer,
 	deduplicate bool,
 	maxResolutionMillis int64,
-	partialResponse bool,
-	skipChunks bool,
+	partialResponse, skipChunks bool,
+	maxConcurrentSelects int,
+	selectTimeout time.Duration,
 ) *querier {
 	if logger == nil {
 		logger = log.NewNopLogger()
@@ -92,9 +107,16 @@ func newQuerier(
 		rl[replicaLabel] = struct{}{}
 	}
 	return &querier{
-		ctx:                 ctx,
-		logger:              logger,
-		cancel:              cancel,
+		ctx:    ctx,
+		logger: logger,
+		reg:    reg,
+		cancel: cancel,
+		gate: gate.NewGate(
+			maxConcurrentSelects,
+			extprom.WrapRegistererWithPrefix("thanos_concurrent_select", reg),
+		),
+		selectTimeout: selectTimeout,
+
 		mint:                mint,
 		maxt:                maxt,
 		replicaLabels:       rl,
@@ -173,16 +195,58 @@ func (q *querier) Select(_ bool, hints *storage.SelectHints, ms ...*labels.Match
 	for i, m := range ms {
 		matchers[i] = m.String()
 	}
-	span, ctx := tracing.StartSpan(q.ctx, "querier_select", opentracing.Tags{
+
+	// querier has a context but it gets cancelled, as soon as query evaluation is completed, by the engine.
+	ctx, cancel := context.WithTimeout(context.Background(), q.selectTimeout)
+	span, ctx := tracing.StartSpan(ctx, "querier_select", opentracing.Tags{
 		"minTime":  hints.Start,
 		"maxTime":  hints.End,
 		"matchers": "{" + strings.Join(matchers, ",") + "}",
 	})
-	defer span.Finish()
 
+	promise := make(chan storage.SeriesSet, 1)
+	go func() {
+		defer close(promise)
+
+		var err error
+		tracing.DoInSpan(ctx, "querier_select_ismyturn", func(ctx context.Context) {
+			err = q.gate.IsMyTurn(ctx)
+		})
+		if err != nil {
+			promise <- storage.ErrSeriesSet(errors.Wrap(err, "failed to wait for turn"))
+			return
+		}
+		defer q.gate.Done()
+
+		span, ctx := tracing.StartSpan(ctx, "querier_select_select_fn")
+		defer span.Finish()
+
+		set, err := q.selectFn(ctx, hints, ms...)
+		if err != nil {
+			promise <- storage.ErrSeriesSet(err)
+			return
+		}
+
+		promise <- set
+	}()
+
+	return &lazySeriesSet{create: func() (storage.SeriesSet, bool) {
+		defer cancel()
+		defer span.Finish()
+
+		// Only gets called once, for the first Next() call of the series set.
+		set, ok := <-promise
+		if !ok {
+			return storage.ErrSeriesSet(errors.New("channel closed before a value received")), false
+		}
+		return set, set.Next()
+	}}
+}
+
+func (q *querier) selectFn(ctx context.Context, hints *storage.SelectHints, ms ...*labels.Matcher) (storage.SeriesSet, error) {
 	sms, err := storepb.TranslatePromMatchers(ms...)
 	if err != nil {
-		return storage.ErrSeriesSet(errors.Wrap(err, "convert matchers"))
+		return nil, errors.Wrap(err, "convert matchers")
 	}
 
 	aggrs := aggrsFromFunc(hints.Func)
@@ -197,7 +261,7 @@ func (q *querier) Select(_ bool, hints *storage.SelectHints, ms ...*labels.Match
 		PartialResponseDisabled: !q.partialResponse,
 		SkipChunks:              q.skipChunks,
 	}, resp); err != nil {
-		return storage.ErrSeriesSet(errors.Wrap(err, "proxy Series()"))
+		return nil, errors.Wrap(err, "proxy Series()")
 	}
 
 	var warns storage.Warnings
@@ -213,7 +277,7 @@ func (q *querier) Select(_ bool, hints *storage.SelectHints, ms ...*labels.Match
 			set:   newStoreSeriesSet(resp.seriesSet),
 			aggrs: aggrs,
 			warns: warns,
-		}
+		}, nil
 	}
 
 	// TODO(fabxc): this could potentially pushed further down into the store API to make true streaming possible.
@@ -228,7 +292,7 @@ func (q *querier) Select(_ bool, hints *storage.SelectHints, ms ...*labels.Match
 
 	// The merged series set assembles all potentially-overlapping time ranges of the same series into a single one.
 	// TODO(bwplotka): We could potentially dedup on chunk level, use chunk iterator for that when available.
-	return newDedupSeriesSet(set, q.replicaLabels, len(aggrs) == 1 && aggrs[0] == storepb.Aggr_COUNTER)
+	return newDedupSeriesSet(set, q.replicaLabels, len(aggrs) == 1 && aggrs[0] == storepb.Aggr_COUNTER), nil
 }
 
 // sortDedupLabels re-sorts the set so that the same series with different replica

--- a/pkg/query/querier_test.go
+++ b/pkg/query/querier_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/fortytw2/leaktest"
 	"github.com/go-kit/kit/log"
 	"github.com/pkg/errors"
+	"github.com/prometheus/prometheus/pkg/gate"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/pkg/timestamp"
 	"github.com/prometheus/prometheus/pkg/value"
@@ -508,7 +509,8 @@ func TestQuerier_Select(t *testing.T) {
 				{dedup: false, expected: tcase.expected},
 				{dedup: true, expected: []series{tcase.expectedAfterDedup}},
 			} {
-				q := newQuerier(context.Background(), nil, nil, tcase.mint, tcase.maxt, tcase.replicaLabels, tcase.storeAPI, sc.dedup, 0, true, false, 2, timeout)
+				g := gate.New(2)
+				q := newQuerier(context.Background(), nil, nil, tcase.mint, tcase.maxt, tcase.replicaLabels, tcase.storeAPI, sc.dedup, 0, true, false, g, timeout)
 				t.Cleanup(func() { testutil.Ok(t, q.Close()) })
 
 				t.Run(fmt.Sprintf("dedup=%v", sc.dedup), func(t *testing.T) {
@@ -677,8 +679,8 @@ func TestQuerierWithDedupUnderstoodByPromQL_Rate(t *testing.T) {
 		)
 
 		timeout := 100 * time.Second
-
-		q := newQuerier(context.Background(), logger, nil, realSeriesWithStaleMarkerMint, realSeriesWithStaleMarkerMaxt, []string{"replica"}, s, false, 0, true, false, 2, timeout)
+		g := gate.New(2)
+		q := newQuerier(context.Background(), logger, nil, realSeriesWithStaleMarkerMint, realSeriesWithStaleMarkerMaxt, []string{"replica"}, s, false, 0, true, false, g, timeout)
 		t.Cleanup(func() {
 			testutil.Ok(t, q.Close())
 		})
@@ -751,7 +753,8 @@ func TestQuerierWithDedupUnderstoodByPromQL_Rate(t *testing.T) {
 		)
 
 		timeout := 5 * time.Second
-		q := newQuerier(context.Background(), logger, nil, realSeriesWithStaleMarkerMint, realSeriesWithStaleMarkerMaxt, []string{"replica"}, s, true, 0, true, false, 2, timeout)
+		g := gate.New(2)
+		q := newQuerier(context.Background(), logger, nil, realSeriesWithStaleMarkerMint, realSeriesWithStaleMarkerMaxt, []string{"replica"}, s, true, 0, true, false, g, timeout)
 		t.Cleanup(func() {
 			testutil.Ok(t, q.Close())
 		})

--- a/pkg/query/querier_test.go
+++ b/pkg/query/querier_test.go
@@ -38,16 +38,16 @@ type sample struct {
 }
 
 func TestQueryableCreator_MaxResolution(t *testing.T) {
-	defer leaktest.CheckTimeout(t, 10*time.Second)()
+	t.Cleanup(leaktest.CheckTimeout(t, 10*time.Second))
 	testProxy := &storeServer{resps: []*storepb.SeriesResponse{}}
-	queryableCreator := NewQueryableCreator(nil, testProxy)
+	queryableCreator := NewQueryableCreator(nil, nil, testProxy, 2, 5*time.Second)
 
 	oneHourMillis := int64(1*time.Hour) / int64(time.Millisecond)
 	queryable := queryableCreator(false, nil, oneHourMillis, false, false)
 
 	q, err := queryable.Querier(context.Background(), 0, 42)
 	testutil.Ok(t, err)
-	defer func() { testutil.Ok(t, q.Close()) }()
+	t.Cleanup(func() { testutil.Ok(t, q.Close()) })
 
 	querierActual, ok := q.(*querier)
 
@@ -58,7 +58,7 @@ func TestQueryableCreator_MaxResolution(t *testing.T) {
 
 // Tests E2E how PromQL works with downsampled data.
 func TestQuerier_DownsampledData(t *testing.T) {
-	defer leaktest.CheckTimeout(t, 10*time.Second)()
+	t.Cleanup(leaktest.CheckTimeout(t, 10*time.Second))
 	testProxy := &storeServer{
 		resps: []*storepb.SeriesResponse{
 			storeSeriesResponse(t, labels.FromStrings("__name__", "a", "zzz", "a", "aaa", "bbb"), []sample{{99, 1}, {199, 5}}),                   // Downsampled chunk from Store.
@@ -70,12 +70,12 @@ func TestQuerier_DownsampledData(t *testing.T) {
 		},
 	}
 
-	q := NewQueryableCreator(nil, testProxy)(false, nil, 9999999, false, false)
-
+	timeout := 10 * time.Second
+	q := NewQueryableCreator(nil, nil, testProxy, 2, timeout)(false, nil, 9999999, false, false)
 	engine := promql.NewEngine(
 		promql.EngineOpts{
 			MaxSamples: math.MaxInt32,
-			Timeout:    10 * time.Second,
+			Timeout:    timeout,
 		},
 	)
 
@@ -493,9 +493,10 @@ func TestQuerier_Select(t *testing.T) {
 			},
 		},
 	} {
+		timeout := 5 * time.Second
 		e := promql.NewEngine(promql.EngineOpts{
 			Logger:     logger,
-			Timeout:    5 * time.Second,
+			Timeout:    timeout,
 			MaxSamples: math.MaxInt64,
 		})
 
@@ -507,16 +508,14 @@ func TestQuerier_Select(t *testing.T) {
 				{dedup: false, expected: tcase.expected},
 				{dedup: true, expected: []series{tcase.expectedAfterDedup}},
 			} {
-				q := newQuerier(context.Background(), nil, tcase.mint, tcase.maxt, tcase.replicaLabels, tcase.storeAPI, sc.dedup, 0, true, false)
-				defer testutil.Ok(t, q.Close())
+				q := newQuerier(context.Background(), nil, nil, tcase.mint, tcase.maxt, tcase.replicaLabels, tcase.storeAPI, sc.dedup, 0, true, false, 2, timeout)
+				t.Cleanup(func() { testutil.Ok(t, q.Close()) })
 
 				t.Run(fmt.Sprintf("dedup=%v", sc.dedup), func(t *testing.T) {
 					t.Run("querier.Select", func(t *testing.T) {
-						defer leaktest.CheckTimeout(t, 10*time.Second)()
-						defer testutil.Ok(t, q.Close())
+						t.Cleanup(leaktest.CheckTimeout(t, 10*time.Second))
 
 						res := q.Select(false, tcase.hints, tcase.matchers...)
-
 						testSelectResponse(t, sc.expected, res)
 
 						if tcase.expectedWarning != "" {
@@ -527,12 +526,12 @@ func TestQuerier_Select(t *testing.T) {
 					})
 					// Integration test: Make sure the PromQL would select exactly the same.
 					t.Run("through PromQL with 100s step", func(t *testing.T) {
-						defer leaktest.CheckTimeout(t, 10*time.Second)()
+						t.Cleanup(leaktest.CheckTimeout(t, 10*time.Second))
 
 						catcher := &querierResponseCatcher{t: t, Querier: q}
 						q, err := e.NewRangeQuery(&mockedQueryable{catcher}, tcase.equivalentQuery, timestamp.Time(tcase.mint), timestamp.Time(tcase.maxt), 100*time.Second)
 						testutil.Ok(t, err)
-						defer q.Close()
+						t.Cleanup(q.Close)
 
 						r := q.Exec(context.Background())
 						testutil.Ok(t, r.Err)
@@ -676,18 +675,24 @@ func TestQuerierWithDedupUnderstoodByPromQL_Rate(t *testing.T) {
 			"gprd", "fqdn", "web-08-sv-gprd.c.gitlab-production.internal", "instance", "web-08-sv-gprd.c.gitlab-production.internal:8083", "job", "gitlab-rails", "monitor", "app", "provider",
 			"gcp", "region", "us-east", "replica", "02", "shard", "default", "stage", "main", "tier", "sv", "type", "web",
 		)
-		q := newQuerier(context.Background(), logger, realSeriesWithStaleMarkerMint, realSeriesWithStaleMarkerMaxt, []string{"replica"}, s, false, 0, true, false)
-		defer func() { testutil.Ok(t, q.Close()) }()
+
+		timeout := 100 * time.Second
+
+		q := newQuerier(context.Background(), logger, nil, realSeriesWithStaleMarkerMint, realSeriesWithStaleMarkerMaxt, []string{"replica"}, s, false, 0, true, false, 2, timeout)
+		t.Cleanup(func() {
+			testutil.Ok(t, q.Close())
+		})
 
 		e := promql.NewEngine(promql.EngineOpts{
 			Logger:     logger,
-			Timeout:    5 * time.Second,
+			Timeout:    timeout,
 			MaxSamples: math.MaxInt64,
 		})
 		t.Run("Rate=5mStep=100s", func(t *testing.T) {
+			t.Cleanup(leaktest.CheckTimeout(t, 10*time.Second))
+
 			q, err := e.NewRangeQuery(&mockedQueryable{q}, `rate(gitlab_transaction_cache_read_hit_count_total[5m])`, timestamp.Time(realSeriesWithStaleMarkerMint).Add(5*time.Minute), timestamp.Time(realSeriesWithStaleMarkerMaxt), 100*time.Second)
 			testutil.Ok(t, err)
-			defer q.Close()
 
 			r := q.Exec(context.Background())
 			testutil.Ok(t, r.Err)
@@ -715,9 +720,10 @@ func TestQuerierWithDedupUnderstoodByPromQL_Rate(t *testing.T) {
 			}, vec)
 		})
 		t.Run("Rate=30mStep=500s", func(t *testing.T) {
+			t.Cleanup(leaktest.CheckTimeout(t, 10*time.Second))
+
 			q, err := e.NewRangeQuery(&mockedQueryable{q}, `rate(gitlab_transaction_cache_read_hit_count_total[30m])`, timestamp.Time(realSeriesWithStaleMarkerMint).Add(30*time.Minute), timestamp.Time(realSeriesWithStaleMarkerMaxt), 500*time.Second)
 			testutil.Ok(t, err)
-			defer q.Close()
 
 			r := q.Exec(context.Background())
 			testutil.Ok(t, r.Err)
@@ -743,18 +749,23 @@ func TestQuerierWithDedupUnderstoodByPromQL_Rate(t *testing.T) {
 			"gprd", "fqdn", "web-08-sv-gprd.c.gitlab-production.internal", "instance", "web-08-sv-gprd.c.gitlab-production.internal:8083", "job", "gitlab-rails", "monitor", "app", "provider",
 			"gcp", "region", "us-east", "shard", "default", "stage", "main", "tier", "sv", "type", "web",
 		)
-		q := newQuerier(context.Background(), logger, realSeriesWithStaleMarkerMint, realSeriesWithStaleMarkerMaxt, []string{"replica"}, s, true, 0, true, false)
-		defer func() { testutil.Ok(t, q.Close()) }()
+
+		timeout := 5 * time.Second
+		q := newQuerier(context.Background(), logger, nil, realSeriesWithStaleMarkerMint, realSeriesWithStaleMarkerMaxt, []string{"replica"}, s, true, 0, true, false, 2, timeout)
+		t.Cleanup(func() {
+			testutil.Ok(t, q.Close())
+		})
 
 		e := promql.NewEngine(promql.EngineOpts{
 			Logger:     logger,
-			Timeout:    5 * time.Second,
+			Timeout:    timeout,
 			MaxSamples: math.MaxInt64,
 		})
 		t.Run("Rate=5mStep=100s", func(t *testing.T) {
+			t.Cleanup(leaktest.CheckTimeout(t, 10*time.Second))
+
 			q, err := e.NewRangeQuery(&mockedQueryable{q}, `rate(gitlab_transaction_cache_read_hit_count_total[5m])`, timestamp.Time(realSeriesWithStaleMarkerMint).Add(5*time.Minute), timestamp.Time(realSeriesWithStaleMarkerMaxt), 100*time.Second)
 			testutil.Ok(t, err)
-			defer q.Close()
 
 			r := q.Exec(context.Background())
 			testutil.Ok(t, r.Err)
@@ -777,9 +788,10 @@ func TestQuerierWithDedupUnderstoodByPromQL_Rate(t *testing.T) {
 			}, vec)
 		})
 		t.Run("Rate=30mStep=500s", func(t *testing.T) {
+			t.Cleanup(leaktest.CheckTimeout(t, 10*time.Second))
+
 			q, err := e.NewRangeQuery(&mockedQueryable{q}, `rate(gitlab_transaction_cache_read_hit_count_total[30m])`, timestamp.Time(realSeriesWithStaleMarkerMint).Add(30*time.Minute), timestamp.Time(realSeriesWithStaleMarkerMaxt), 500*time.Second)
 			testutil.Ok(t, err)
-			defer q.Close()
 
 			r := q.Exec(context.Background())
 			testutil.Ok(t, r.Err)
@@ -800,7 +812,7 @@ func TestQuerierWithDedupUnderstoodByPromQL_Rate(t *testing.T) {
 }
 
 func TestSortReplicaLabel(t *testing.T) {
-	defer leaktest.CheckTimeout(t, 10*time.Second)()
+	t.Cleanup(leaktest.CheckTimeout(t, 10*time.Second))
 
 	tests := []struct {
 		input       []storepb.Series
@@ -867,7 +879,7 @@ func expandSeries(t testing.TB, it chunkenc.Iterator) (res []sample) {
 }
 
 func TestDedupSeriesSet(t *testing.T) {
-	defer leaktest.CheckTimeout(t, 10*time.Second)()
+	t.Cleanup(leaktest.CheckTimeout(t, 10*time.Second))
 
 	tests := []struct {
 		input       []series
@@ -1198,7 +1210,7 @@ func TestDedupSeriesSet(t *testing.T) {
 }
 
 func TestDedupSeriesIterator(t *testing.T) {
-	defer leaktest.CheckTimeout(t, 10*time.Second)()
+	t.Cleanup(leaktest.CheckTimeout(t, 10*time.Second))
 
 	// The deltas between timestamps should be at least 10000 to not be affected
 	// by the initial penalty of 5000, that will cause the second iterator to seek
@@ -1300,7 +1312,7 @@ type storeServer struct {
 	resps []*storepb.SeriesResponse
 }
 
-func (s *storeServer) Series(r *storepb.SeriesRequest, srv storepb.Store_SeriesServer) error {
+func (s *storeServer) Series(_ *storepb.SeriesRequest, srv storepb.Store_SeriesServer) error {
 	for _, resp := range s.resps {
 		err := srv.Send(resp)
 		if err != nil {

--- a/pkg/tracing/tracing.go
+++ b/pkg/tracing/tracing.go
@@ -29,12 +29,22 @@ func ContextWithTracer(ctx context.Context, tracer opentracing.Tracer) context.C
 	return context.WithValue(ctx, tracerKey, tracer)
 }
 
+// tracerFromContext extracts opentracing.Tracer from the given context.
 func tracerFromContext(ctx context.Context) opentracing.Tracer {
 	val := ctx.Value(tracerKey)
 	if sp, ok := val.(opentracing.Tracer); ok {
 		return sp
 	}
 	return nil
+}
+
+// CopyTraceContext copies the necessary trace context from given source context to target context.
+func CopyTraceContext(trgt, src context.Context) context.Context {
+	ctx := ContextWithTracer(trgt, tracerFromContext(src))
+	if parentSpan := opentracing.SpanFromContext(src); parentSpan != nil {
+		ctx = opentracing.ContextWithSpan(ctx, parentSpan)
+	}
+	return ctx
 }
 
 // StartSpan starts and returns span with `operationName` and hooking as child to a span found within given context if any.


### PR DESCRIPTION
Enable Querier to dissect a query into pieces and execute concurrently.

xref: https://github.com/prometheus/prometheus/pull/7251
depends: https://github.com/thanos-io/thanos/pull/2748

Signed-off-by: Kemal Akkoyun <kakkoyun@gmail.com>

* [x] I added CHANGELOG entry for this change.

## Changes

* [x] Implement async select for Querier

## Verification

* `maka test-local`
* `make test-e2e`

### Tracing 
<img width="1910" alt="Screenshot 2020-06-17 09 11 47" src="https://user-images.githubusercontent.com/536449/84867242-1e0f3300-b07b-11ea-8269-b8d66c95d93e.png">