### PR TITLE
Document series labels sorting in SeriesResponse

### DIFF
--- a/pkg/store/storepb/rpc.proto
+++ b/pkg/store/storepb/rpc.proto
@@ -115,6 +115,7 @@ enum Aggr {
 
 message SeriesResponse {
   oneof result {
+    /// series contains 1 response series. The series labels are sorted by name.
     Series series = 1;
 
     /// warning is considered an information piece in place of series for warning purposes.


### PR DESCRIPTION
* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

After a brief [discussion on public Slack](https://cloud-native.slack.com/archives/CL25937SP/p1590491672334400) and after a look at the `Series()` implementation, I think we can safely document that response series labels are guaranteed to be sorted by name.

## Verification

N/A
