### PR TITLE
feat tools: bucket replicate allows to filter multiple compaction and…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 - [#2667](https://github.com/thanos-io/thanos/pull/2667) Compact: the deprecated flag `--index.generate-missing-cache-file` and the metric `thanos_compact_generated_index_total` were removed.
 - [2603](https://github.com/thanos-io/thanos/pull/2603) Store/Querier: Significantly optimize cases where StoreAPIs or blocks returns exact overlapping chunks (e.g Store GW and sidecar or brute force Store Gateway HA).
 
+### Added
+- [#TBA](https://github.com/thanos-io/thanos/pull/TBA) Tools: bucket replicate now allows passing repeated `--compaction` and `--resolution` flags.
+
 ## [v0.13.0](https://github.com/thanos-io/thanos/releases) - IN PROGRESS
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 - [2603](https://github.com/thanos-io/thanos/pull/2603) Store/Querier: Significantly optimize cases where StoreAPIs or blocks returns exact overlapping chunks (e.g Store GW and sidecar or brute force Store Gateway HA).
 
 ### Added
-- [#TBA](https://github.com/thanos-io/thanos/pull/TBA) Tools: bucket replicate now allows passing repeated `--compaction` and `--resolution` flags.
+- [#2671](https://github.com/thanos-io/thanos/pull/2671) Tools: bucket replicate now allows passing repeated `--compaction` and `--resolution` flags.
 
 ## [v0.13.0](https://github.com/thanos-io/thanos/releases) - IN PROGRESS
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,12 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 - [#2667](https://github.com/thanos-io/thanos/pull/2667) Store: removed support to the legacy `index.cache.json`. The hidden flag `--store.disable-index-header` was removed.
 - [#2667](https://github.com/thanos-io/thanos/pull/2667) Compact: the deprecated flag `--index.generate-missing-cache-file` and the metric `thanos_compact_generated_index_total` were removed.
 - [2603](https://github.com/thanos-io/thanos/pull/2603) Store/Querier: Significantly optimize cases where StoreAPIs or blocks returns exact overlapping chunks (e.g Store GW and sidecar or brute force Store Gateway HA).
+- [#2671](https://github.com/thanos-io/thanos/pull/2671) *breaking* Tools: bucket replicate flag `--resolution` is now in Go duration format.
+- [#2671](https://github.com/thanos-io/thanos/pull/2671) Tools: bucket replicate now replicates by default all blocks.
+
 
 ### Added
+
 - [#2671](https://github.com/thanos-io/thanos/pull/2671) Tools: bucket replicate now allows passing repeated `--compaction` and `--resolution` flags.
 
 ## [v0.13.0](https://github.com/thanos-io/thanos/releases) - IN PROGRESS

--- a/cmd/thanos/tools_bucket.go
+++ b/cmd/thanos/tools_bucket.go
@@ -424,7 +424,7 @@ func registerBucketReplicate(m map[string]setupFunc, root *kingpin.CmdClause, na
 	httpBindAddr, httpGracePeriod := regHTTPFlags(cmd)
 	toObjStoreConfig := regCommonObjStoreFlags(cmd, "-to", false, "The object storage which replicate data to.")
 	resolutions := cmd.Flag("resolution", "Only blocks with this resolution will be replicated. (Resolution in ms)").Default(strconv.FormatInt(downsample.ResLevel0, 10)).HintAction(listResLevel).Int64List()
-	compactions := cmd.Flag("compaction", "Only blocks with this compaction level will be replicated.").Default("1").Ints()
+	compactions := cmd.Flag("compaction", "Only blocks with those compaction levels will be replicated. Repeated flag.").Default("1").Ints()
 	matcherStrs := cmd.Flag("matcher", "Only blocks whose external labels exactly match this matcher will be replicated.").PlaceHolder("key=\"value\"").Strings()
 	singleRun := cmd.Flag("single-run", "Run replication only one time, then exit.").Default("false").Bool()
 

--- a/cmd/thanos/tools_bucket.go
+++ b/cmd/thanos/tools_bucket.go
@@ -423,7 +423,7 @@ func registerBucketReplicate(m map[string]setupFunc, root *kingpin.CmdClause, na
 	cmd := root.Command("replicate", fmt.Sprintf("Replicate data from one object storage to another. NOTE: Currently it works only with Thanos blocks (%v has to have Thanos metadata).", block.MetaFilename))
 	httpBindAddr, httpGracePeriod := regHTTPFlags(cmd)
 	toObjStoreConfig := regCommonObjStoreFlags(cmd, "-to", false, "The object storage which replicate data to.")
-	resolutions := cmd.Flag("resolution", "Only blocks with this resolution will be replicated. (Resolution in ms)").Default(strconv.FormatInt(downsample.ResLevel0, 10)).HintAction(listResLevel).Int64List()
+	resolutions := cmd.Flag("resolution", "Only blocks with those resolutions will be replicated. (Resolution in ms). Repeated flag.").Default(strconv.FormatInt(downsample.ResLevel0, 10)).HintAction(listResLevel).Int64List()
 	compactions := cmd.Flag("compaction", "Only blocks with those compaction levels will be replicated. Repeated flag.").Default("1").Ints()
 	matcherStrs := cmd.Flag("matcher", "Only blocks whose external labels exactly match this matcher will be replicated.").PlaceHolder("key=\"value\"").Strings()
 	singleRun := cmd.Flag("single-run", "Run replication only one time, then exit.").Default("false").Bool()

--- a/docs/components/tools.md
+++ b/docs/components/tools.md
@@ -451,9 +451,9 @@ Flags:
                                  format details:
                                  https://thanos.io/storage.md/#configuration The
                                  object storage which replicate data to.
-      --resolution=0             Only blocks with this resolution will be
-                                 replicated.
-      --compaction=1             Only blocks with this compaction level will be
+      --resolution=0 ...         Only blocks with this resolution will be
+                                 replicated. (Resolution in ms)
+      --compaction=1 ...         Only blocks with this compaction level will be
                                  replicated.
       --matcher=key="value" ...  Only blocks whose external labels exactly match
                                  this matcher will be replicated.

--- a/docs/components/tools.md
+++ b/docs/components/tools.md
@@ -451,10 +451,10 @@ Flags:
                                  format details:
                                  https://thanos.io/storage.md/#configuration The
                                  object storage which replicate data to.
-      --resolution=0 ...         Only blocks with this resolution will be
-                                 replicated. (Resolution in ms)
-      --compaction=1 ...         Only blocks with this compaction level will be
-                                 replicated.
+      --resolution=0 ...         Only blocks with those resolutions will be
+                                 replicated. (Resolution in ms). Repeated flag.
+      --compaction=1 ...         Only blocks with those compaction levels will
+                                 be replicated. Repeated flag.
       --matcher=key="value" ...  Only blocks whose external labels exactly match
                                  this matcher will be replicated.
       --single-run               Run replication only one time, then exit.

--- a/docs/components/tools.md
+++ b/docs/components/tools.md
@@ -451,9 +451,9 @@ Flags:
                                  format details:
                                  https://thanos.io/storage.md/#configuration The
                                  object storage which replicate data to.
-      --resolution=0 ...         Only blocks with those resolutions will be
-                                 replicated. (Resolution in ms). Repeated flag.
-      --compaction=1 ...         Only blocks with those compaction levels will
+      --resolution=0s... ...     Only blocks with these resolutions will be
+                                 replicated. Repeated flag.
+      --compaction=1... ...      Only blocks with these compaction levels will
                                  be replicated. Repeated flag.
       --matcher=key="value" ...  Only blocks whose external labels exactly match
                                  this matcher will be replicated.

--- a/pkg/objstore/swift/swift.go
+++ b/pkg/objstore/swift/swift.go
@@ -251,7 +251,7 @@ func configFromEnv() SwiftConfig {
 		ProjectName:       os.Getenv("OS_PROJECT_NAME"),
 		UserDomainID:      os.Getenv("OS_USER_DOMAIN_ID"),
 		UserDomainName:    os.Getenv("OS_USER_DOMAIN_NAME"),
-		ProjectDomainID:   os.Getenv("OS_PROJET_DOMAIN_ID"),
+		ProjectDomainID:   os.Getenv("OS_PROJECT_DOMAIN_ID"),
 		ProjectDomainName: os.Getenv("OS_PROJECT_DOMAIN_NAME"),
 	}
 

--- a/pkg/objstore/swift/swift.go
+++ b/pkg/objstore/swift/swift.go
@@ -251,7 +251,7 @@ func configFromEnv() SwiftConfig {
 		ProjectName:       os.Getenv("OS_PROJECT_NAME"),
 		UserDomainID:      os.Getenv("OS_USER_DOMAIN_ID"),
 		UserDomainName:    os.Getenv("OS_USER_DOMAIN_NAME"),
-		ProjectDomainID:   os.Getenv("OS_PROJECT_DOMAIN_ID"),
+		ProjectDomainID:   os.Getenv("OS_PROJET_DOMAIN_ID"),
 		ProjectDomainName: os.Getenv("OS_PROJECT_DOMAIN_NAME"),
 	}
 

--- a/pkg/replicate/replicator.go
+++ b/pkg/replicate/replicator.go
@@ -69,8 +69,8 @@ func RunReplicate(
 	httpBindAddr string,
 	httpGracePeriod time.Duration,
 	labelSelector labels.Selector,
-	resolution compact.ResolutionLevel,
-	compaction int,
+	resolutions []compact.ResolutionLevel,
+	compactions []int,
 	fromObjStoreConfig *extflag.PathOrContent,
 	toObjStoreConfig *extflag.PathOrContent,
 	singleRun bool,
@@ -159,8 +159,8 @@ func RunReplicate(
 	blockFilter := NewBlockFilter(
 		logger,
 		labelSelector,
-		resolution,
-		compaction,
+		resolutions,
+		compactions,
 	).Filter
 	metrics := newReplicationMetrics(reg)
 	ctx, cancel := context.WithCancel(context.Background())

--- a/pkg/replicate/scheme_test.go
+++ b/pkg/replicate/scheme_test.go
@@ -311,7 +311,7 @@ func TestReplicationSchemeAll(t *testing.T) {
 			selector = c.selector
 		}
 
-		filter := NewBlockFilter(logger, selector, compact.ResolutionLevelRaw, 1).Filter
+		filter := NewBlockFilter(logger, selector, []compact.ResolutionLevel{compact.ResolutionLevelRaw}, []int{1}).Filter
 		fetcher, err := block.NewMetaFetcher(logger, 32, objstore.WithNoopInstr(originBucket), "", nil, nil, nil)
 		testutil.Ok(t, err)
 


### PR DESCRIPTION
Just bumped into this when migrating from one S3 to Swift.
Is this how you imagined it @bwplotka ?

Didn't want to change the defaults even though I'd maybe prefer to replicate all the data by default and make the filtering as blacklist instead of whitelist. But maybe my use-case is different.

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

- thanos tools bucket replicate now allows repeated flags for compaction and resolution levels
- thanos tools bucket replicate resolution flag is now in duraion format
- thanos tools bucket replicate defaults now to migrate all blocks

## Verification

tested it locally
