### PR TITLE
2020 05 tracing bucket

### DIFF
--- a/cmd/thanos/store.go
+++ b/cmd/thanos/store.go
@@ -23,6 +23,7 @@ import (
 	"github.com/thanos-io/thanos/pkg/extprom"
 	extpromhttp "github.com/thanos-io/thanos/pkg/extprom/http"
 	"github.com/thanos-io/thanos/pkg/model"
+	"github.com/thanos-io/thanos/pkg/objstore"
 	"github.com/thanos-io/thanos/pkg/objstore/client"
 	"github.com/thanos-io/thanos/pkg/prober"
 	"github.com/thanos-io/thanos/pkg/runutil"
@@ -214,6 +215,9 @@ func runStore(
 	if err != nil {
 		return errors.Wrap(err, "create bucket client")
 	}
+
+	// Include interactions with bucket in the traces.
+	bkt = &objstore.TracingBucket{Bucket: bkt}
 
 	cachingBucketConfigYaml, err := cachingBucketConfig.Content()
 	if err != nil {

--- a/cmd/thanos/store.go
+++ b/cmd/thanos/store.go
@@ -23,7 +23,6 @@ import (
 	"github.com/thanos-io/thanos/pkg/extprom"
 	extpromhttp "github.com/thanos-io/thanos/pkg/extprom/http"
 	"github.com/thanos-io/thanos/pkg/model"
-	"github.com/thanos-io/thanos/pkg/objstore"
 	"github.com/thanos-io/thanos/pkg/objstore/client"
 	"github.com/thanos-io/thanos/pkg/prober"
 	"github.com/thanos-io/thanos/pkg/runutil"
@@ -215,9 +214,6 @@ func runStore(
 	if err != nil {
 		return errors.Wrap(err, "create bucket client")
 	}
-
-	// Include interactions with bucket in the traces.
-	bkt = &objstore.TracingBucket{Bucket: bkt}
 
 	cachingBucketConfigYaml, err := cachingBucketConfig.Content()
 	if err != nil {

--- a/pkg/cache/tracing_cache.go
+++ b/pkg/cache/tracing_cache.go
@@ -1,3 +1,6 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
 package cache
 
 import (
@@ -9,6 +12,7 @@ import (
 	"github.com/thanos-io/thanos/pkg/tracing"
 )
 
+// TracingCache includes Fetch operation in the traces.
 type TracingCache struct {
 	c Cache
 }

--- a/pkg/cache/tracing_cache.go
+++ b/pkg/cache/tracing_cache.go
@@ -2,6 +2,7 @@ package cache
 
 import (
 	"context"
+	"time"
 
 	"github.com/opentracing/opentracing-go"
 
@@ -9,14 +10,18 @@ import (
 )
 
 type TracingCache struct {
-	Cache
+	c Cache
+}
+
+func (t TracingCache) Store(ctx context.Context, data map[string][]byte, ttl time.Duration) {
+	t.c.Store(ctx, data, ttl)
 }
 
 func (t TracingCache) Fetch(ctx context.Context, keys []string) (result map[string][]byte) {
 	tracing.DoWithSpan(ctx, "cache_fetch", func(spanCtx context.Context, span opentracing.Span) {
 		span.LogKV("requested keys", len(keys))
 
-		result = t.Cache.Fetch(spanCtx, keys)
+		result = t.c.Fetch(spanCtx, keys)
 
 		bytes := 0
 		for _, v := range result {

--- a/pkg/cache/tracing_cache.go
+++ b/pkg/cache/tracing_cache.go
@@ -1,0 +1,21 @@
+package cache
+
+import (
+	"context"
+
+	"github.com/opentracing/opentracing-go"
+
+	"github.com/thanos-io/thanos/pkg/tracing"
+)
+
+type TracingCache struct {
+	Cache
+}
+
+func (t TracingCache) Fetch(ctx context.Context, keys []string) (result map[string][]byte) {
+	tracing.DoWithSpan(ctx, "cache_fetch", func(spanCtx context.Context, span opentracing.Span) {
+		result = t.Cache.Fetch(spanCtx, keys)
+		span.LogKV("requested", len(keys), "returned", len(result))
+	})
+	return
+}

--- a/pkg/cache/tracing_cache.go
+++ b/pkg/cache/tracing_cache.go
@@ -17,6 +17,10 @@ type TracingCache struct {
 	c Cache
 }
 
+func NewTracingCache(cache Cache) Cache {
+	return TracingCache{c: cache}
+}
+
 func (t TracingCache) Store(ctx context.Context, data map[string][]byte, ttl time.Duration) {
 	t.c.Store(ctx, data, ttl)
 }

--- a/pkg/cache/tracing_cache.go
+++ b/pkg/cache/tracing_cache.go
@@ -14,8 +14,15 @@ type TracingCache struct {
 
 func (t TracingCache) Fetch(ctx context.Context, keys []string) (result map[string][]byte) {
 	tracing.DoWithSpan(ctx, "cache_fetch", func(spanCtx context.Context, span opentracing.Span) {
+		span.LogKV("requested keys", len(keys))
+
 		result = t.Cache.Fetch(spanCtx, keys)
-		span.LogKV("requested", len(keys), "returned", len(result))
+
+		bytes := 0
+		for _, v := range result {
+			bytes += len(v)
+		}
+		span.LogKV("returned keys", len(result), "returned bytes", bytes)
 	})
 	return
 }

--- a/pkg/objstore/client/factory.go
+++ b/pkg/objstore/client/factory.go
@@ -76,5 +76,5 @@ func NewBucket(logger log.Logger, confContentYaml []byte, reg prometheus.Registe
 	if err != nil {
 		return nil, errors.Wrap(err, fmt.Sprintf("create %s client", bucketConf.Type))
 	}
-	return objstore.BucketWithMetrics(bucket.Name(), bucket, reg), nil
+	return objstore.NewTracingBucket(objstore.BucketWithMetrics(bucket.Name(), bucket, reg)), nil
 }

--- a/pkg/objstore/tracing.go
+++ b/pkg/objstore/tracing.go
@@ -1,3 +1,6 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
 package objstore
 
 import (
@@ -9,6 +12,7 @@ import (
 	"github.com/thanos-io/thanos/pkg/tracing"
 )
 
+// TracingBucket includes bucket operations in the traces.
 type TracingBucket struct {
 	bkt Bucket
 }

--- a/pkg/objstore/tracing.go
+++ b/pkg/objstore/tracing.go
@@ -1,0 +1,124 @@
+package objstore
+
+import (
+	"context"
+	"io"
+
+	"github.com/opentracing/opentracing-go"
+
+	"github.com/thanos-io/thanos/pkg/tracing"
+)
+
+type TracingBucket struct {
+	Bucket
+}
+
+func (t TracingBucket) WithExpectedErrs(expectedFunc IsOpFailureExpectedFunc) Bucket {
+	if ib, ok := t.Bucket.(InstrumentedBucket); ok {
+		return TracingBucket{ib.WithExpectedErrs(expectedFunc)}
+	}
+	return t
+}
+
+func (t TracingBucket) ReaderWithExpectedErrs(expectedFunc IsOpFailureExpectedFunc) BucketReader {
+	return t.WithExpectedErrs(expectedFunc)
+}
+
+func (t TracingBucket) Iter(ctx context.Context, dir string, f func(string) error) (err error) {
+	tracing.DoWithSpan(ctx, "bucket_iter", func(spanCtx context.Context, span opentracing.Span) {
+		span.LogKV("dir", dir)
+		err = t.Bucket.Iter(spanCtx, dir, f)
+	})
+	return
+}
+
+func (t TracingBucket) Get(ctx context.Context, name string) (io.ReadCloser, error) {
+	span, spanCtx := tracing.StartSpan(ctx, "bucket_get")
+	span.LogKV("name", name)
+
+	r, err := t.Bucket.Get(spanCtx, name)
+	if err != nil {
+		span.LogKV("err", err)
+		span.Finish()
+		return nil, err
+	}
+
+	return &tracingReadCloser{r: r, s: span}, nil
+}
+
+func (t TracingBucket) GetRange(ctx context.Context, name string, off, length int64) (io.ReadCloser, error) {
+	span, spanCtx := tracing.StartSpan(ctx, "bucket_getrange")
+	span.LogKV("name", name, "off", off, "length", length)
+
+	r, err := t.Bucket.GetRange(spanCtx, name, off, length)
+	if err != nil {
+		span.LogKV("err", err)
+		span.Finish()
+		return nil, err
+	}
+
+	return &tracingReadCloser{r: r, s: span}, nil
+}
+
+func (t TracingBucket) Exists(ctx context.Context, name string) (exists bool, err error) {
+	tracing.DoWithSpan(ctx, "bucket_exists", func(spanCtx context.Context, span opentracing.Span) {
+		span.LogKV("name", name)
+		exists, err = t.Bucket.Exists(spanCtx, name)
+	})
+	return
+}
+
+func (t TracingBucket) IsObjNotFoundErr(err error) bool {
+	return t.Bucket.IsObjNotFoundErr(err)
+}
+
+func (t TracingBucket) Attributes(ctx context.Context, name string) (attrs ObjectAttributes, err error) {
+	tracing.DoWithSpan(ctx, "bucket_attributes", func(spanCtx context.Context, span opentracing.Span) {
+		span.LogKV("name", name)
+		attrs, err = t.Bucket.Attributes(spanCtx, name)
+	})
+	return
+}
+
+func (t TracingBucket) Upload(ctx context.Context, name string, r io.Reader) (err error) {
+	tracing.DoWithSpan(ctx, "bucket_upload", func(spanCtx context.Context, span opentracing.Span) {
+		span.LogKV("name", name)
+		err = t.Bucket.Upload(spanCtx, name, r)
+	})
+	return
+}
+
+func (t TracingBucket) Delete(ctx context.Context, name string) (err error) {
+	tracing.DoWithSpan(ctx, "bucket_delete", func(spanCtx context.Context, span opentracing.Span) {
+		span.LogKV("name", name)
+		err = t.Bucket.Delete(spanCtx, name)
+	})
+	return
+}
+
+func (t TracingBucket) Name() string {
+	return "tracing: " + t.Bucket.Name()
+}
+
+type tracingReadCloser struct {
+	r    io.ReadCloser
+	s    opentracing.Span
+	read int
+}
+
+func (t *tracingReadCloser) Read(p []byte) (int, error) {
+	n, err := t.r.Read(p)
+	if n > 0 {
+		t.read += n
+	}
+	if err != nil {
+		t.s.LogKV("err", err)
+	}
+	return n, err
+}
+
+func (t *tracingReadCloser) Close() error {
+	err := t.Close()
+	t.s.LogKV("read", t.read)
+	return err
+}

--- a/pkg/objstore/tracing.go
+++ b/pkg/objstore/tracing.go
@@ -13,6 +13,10 @@ type TracingBucket struct {
 	Bucket
 }
 
+func NewTracingBucket(bkt Bucket) Bucket {
+	return &TracingBucket{Bucket: bkt}
+}
+
 func (t TracingBucket) WithExpectedErrs(expectedFunc IsOpFailureExpectedFunc) Bucket {
 	if ib, ok := t.Bucket.(InstrumentedBucket); ok {
 		return TracingBucket{ib.WithExpectedErrs(expectedFunc)}

--- a/pkg/store/cache/caching_bucket.go
+++ b/pkg/store/cache/caching_bucket.go
@@ -24,7 +24,6 @@ import (
 	"github.com/thanos-io/thanos/pkg/cache"
 	"github.com/thanos-io/thanos/pkg/objstore"
 	"github.com/thanos-io/thanos/pkg/runutil"
-	"github.com/thanos-io/thanos/pkg/tracing"
 )
 
 const (
@@ -280,14 +279,7 @@ func (cb *CachingBucket) GetRange(ctx context.Context, name string, off, length 
 		return cb.Bucket.GetRange(ctx, name, off, length)
 	}
 
-	var (
-		r   io.ReadCloser
-		err error
-	)
-	tracing.DoInSpan(ctx, "cachingbucket_getrange", func(ctx context.Context) {
-		r, err = cb.cachedGetRange(ctx, name, off, length, cfgName, cfg)
-	})
-	return r, err
+	return cb.cachedGetRange(ctx, name, off, length, cfgName, cfg)
 }
 
 func (cb *CachingBucket) Attributes(ctx context.Context, name string) (objstore.ObjectAttributes, error) {

--- a/pkg/store/cache/caching_bucket_factory.go
+++ b/pkg/store/cache/caching_bucket_factory.go
@@ -93,6 +93,8 @@ func NewCachingBucketFromYaml(yamlContent []byte, bucket objstore.Bucket, logger
 		return nil, errors.Errorf("unsupported cache type: %s", config.Type)
 	}
 
+	// Include interactions with cache in the traces.
+	c = &cache.TracingCache{Cache: c}
 	cfg := NewCachingBucketConfig()
 
 	// Configure cache.

--- a/pkg/store/cache/caching_bucket_factory.go
+++ b/pkg/store/cache/caching_bucket_factory.go
@@ -94,7 +94,7 @@ func NewCachingBucketFromYaml(yamlContent []byte, bucket objstore.Bucket, logger
 	}
 
 	// Include interactions with cache in the traces.
-	c = &cache.TracingCache{Cache: c}
+	c = cache.NewTracingCache(c)
 	cfg := NewCachingBucketConfig()
 
 	// Configure cache.

--- a/pkg/tracing/tracing.go
+++ b/pkg/tracing/tracing.go
@@ -61,3 +61,11 @@ func DoInSpan(ctx context.Context, operationName string, doFn func(context.Conte
 	defer doFn(newCtx)
 	defer span.Finish()
 }
+
+// DoWithSpan executes function doFn inside new span with `operationName` name and hooking as child to a span found within given context if any.
+// It uses opentracing.Tracer propagated in context. If no found, it uses noop tracer notification.
+func DoWithSpan(ctx context.Context, operationName string, doFn func(context.Context, opentracing.Span), opts ...opentracing.StartSpanOption) {
+	span, newCtx := StartSpan(ctx, operationName, opts...)
+	defer doFn(newCtx, span)
+	defer span.Finish()
+}

--- a/pkg/tracing/tracing.go
+++ b/pkg/tracing/tracing.go
@@ -58,14 +58,14 @@ func StartSpan(ctx context.Context, operationName string, opts ...opentracing.St
 // It uses opentracing.Tracer propagated in context. If no found, it uses noop tracer notification.
 func DoInSpan(ctx context.Context, operationName string, doFn func(context.Context), opts ...opentracing.StartSpanOption) {
 	span, newCtx := StartSpan(ctx, operationName, opts...)
-	defer doFn(newCtx)
 	defer span.Finish()
+	doFn(newCtx)
 }
 
 // DoWithSpan executes function doFn inside new span with `operationName` name and hooking as child to a span found within given context if any.
 // It uses opentracing.Tracer propagated in context. If no found, it uses noop tracer notification.
 func DoWithSpan(ctx context.Context, operationName string, doFn func(context.Context, opentracing.Span), opts ...opentracing.StartSpanOption) {
 	span, newCtx := StartSpan(ctx, operationName, opts...)
-	defer doFn(newCtx, span)
 	defer span.Finish()
+	doFn(newCtx, span)
 }


### PR DESCRIPTION
This PR adds bucket and cache interactions to the traces.

This PR also fixes bug in Thanos tracing code, which first finished the span and only then called the function with given span.

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Verification

Tested manually, see screenshot with small part of example trace.

<img width="2027" alt="Screenshot 2020-05-28 at 15 40 09" src="https://user-images.githubusercontent.com/895919/83148691-90829800-a0f9-11ea-9976-86dd21dc308d.png">
