### PR TITLE
Update README with new badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,6 @@
 [![CI](https://circleci.com/gh/thanos-io/thanos.svg?style=svg)](https://circleci.com/gh/thanos-io/thanos)
 [![go](https://github.com/thanos-io/thanos/workflows/go/badge.svg)](https://github.com/thanos-io/thanos/actions?query=workflow%3Ago)
 [![react](https://github.com/thanos-io/thanos/workflows/react/badge.svg)](https://github.com/thanos-io/thanos/actions?query=workflow%3Areact)
-[![benchmark](https://github.com/thanos-io/thanos/workflows/benchmark/badge.svg)](https://github.com/thanos-io/thanos/actions?query=workflow%3Abenchmark)
-[![fuzzy-test-on-master](https://github.com/thanos-io/thanos/workflows/fuzzy-test-on-master/badge.svg)](https://github.com/thanos-io/thanos/actions?query=workflow%3Afuzzy-test-on-master)
 [![docs](https://github.com/thanos-io/thanos/workflows/docs/badge.svg)](https://github.com/thanos-io/thanos/actions?query=workflow%3Adocs)
 
 ## Overview

--- a/README.md
+++ b/README.md
@@ -1,14 +1,19 @@
 <p align="center"><img src="docs/img/Thanos-logo_fullmedium.png" alt="Thanos Logo"></p>
 
 [![Latest Release](https://img.shields.io/github/release/thanos-io/thanos.svg?style=flat-square)](https://github.com/thanos-io/thanos/releases/latest)
-[![CI](https://circleci.com/gh/thanos-io/thanos.svg?style=svg)](https://circleci.com/gh/thanos-io/thanos)
-[![Cross Build](https://github.com/thanos-io/thanos/workflows/cross-build/badge.svg)](https://github.com/thanos-io/thanos/actions?query=workflow%3Across-build)
-[![End-to-End Tests](https://github.com/thanos-io/thanos/workflows/e2e/badge.svg)](https://github.com/thanos-io/thanos/actions?query=workflow%3Ae2e)
 [![Go Report Card](https://goreportcard.com/badge/github.com/thanos-io/thanos)](https://goreportcard.com/report/github.com/thanos-io/thanos)
 [![Go Code reference](https://img.shields.io/badge/code%20reference-go.dev-darkblue.svg)](https://pkg.go.dev/github.com/thanos-io/thanos?tab=subdirectories)
 [![Slack](https://img.shields.io/badge/join%20slack-%23thanos-brightgreen.svg)](https://slack.cncf.io/)
 [![Netlify Status](https://api.netlify.com/api/v1/badges/664a5091-934c-4b0e-a7b6-bc12f822a590/deploy-status)](https://app.netlify.com/sites/thanos-io/deploys)
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/3048/badge)](https://bestpractices.coreinfrastructure.org/projects/3048)
+
+[![CI](https://github.com/thanos-io/thanos/workflows/CI/badge.svg)](https://github.com/thanos-io/thanos/actions?query=workflow%3ACI)
+[![CI](https://circleci.com/gh/thanos-io/thanos.svg?style=svg)](https://circleci.com/gh/thanos-io/thanos)
+[![go](https://github.com/thanos-io/thanos/workflows/go/badge.svg)](https://github.com/thanos-io/thanos/actions?query=workflow%3Ago)
+[![react](https://github.com/thanos-io/thanos/workflows/react/badge.svg)](https://github.com/thanos-io/thanos/actions?query=workflow%3Areact)
+[![benchmark](https://github.com/thanos-io/thanos/workflows/benchmark/badge.svg)](https://github.com/thanos-io/thanos/actions?query=workflow%3Abenchmark)
+[![fuzzy-test-on-master](https://github.com/thanos-io/thanos/workflows/fuzzy-test-on-master/badge.svg)](https://github.com/thanos-io/thanos/actions?query=workflow%3Afuzzy-test-on-master)
+[![docs](https://github.com/thanos-io/thanos/workflows/docs/badge.svg)](https://github.com/thanos-io/thanos/actions?query=workflow%3Adocs)
 
 ## Overview
 


### PR DESCRIPTION
Signed-off-by: Spencer Gilbert <spencer.gilbert@gmail.com>

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

Removed cross-build and e2e action badges
Added: react, go, docs, benchmark, fuzzy-test-on-master, CI
Grouped all CI badges on newline (wasn't entirely sure if there was a preferred order)

## Verification

Viewed local markdown rendering and on my fork
