### PR TITLE
change code of conduct to CNCF

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,53 +1,11 @@
-# Contributor Covenant Code of Conduct
+# Thanos Community Code of Conduct
 
-## Our Pledge
+Thanos follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md). Additionally our team members can be contacted directly for code of conduct abuse, as described below.
 
-In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to
-making participation in our project and our community a harassment-free experience for everyone,
-regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience,
-nationality, personal appearance, race, religion, or sexual identity and orientation.
-
-## Our Standards
-
-Examples of behavior that contributes to creating a positive environment include:
-
-* Using welcoming and inclusive language
-* Being respectful of differing viewpoints and experiences
-* Gracefully accepting constructive criticism
-* Focusing on what is best for the community
-* Showing empathy towards other community members
-
-Examples of unacceptable behavior by participants include:
-
-* The use of sexualized language or imagery and unwelcome sexual attention or advances
-* Trolling, insulting/derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or electronic address, without explicit permission
-* Other conduct which could reasonably be considered inappropriate in a professional setting
-
-## Our Responsibilities
-
-Project maintainers are responsible for clarifying the standards of acceptable behavior and
-are expected to take appropriate and fair corrective action in response to any instances of
-unacceptable behavior.
-
-Project maintainers have the right and responsibility to remove, edit, or reject comments,
-commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct,
-or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate,
-threatening, offensive, or harmful.
-
-## Scope
-
-This Code of Conduct applies both within project spaces and in public spaces when an individual
-is representing the project or its community. Examples of representing a project or community
-include using an official project e-mail address, posting via an official social media account,
-or acting as an appointed representative at an online or offline event. Representation of a project
-may be further defined and clarified by project maintainers.
-
-## Enforcement
+# Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting
-the project team members (e.g @bplotka @domgreen, @Fabian Reinartz) at Thanos slack workspace.
+the project team members (e.g @bwplotka, @povilasv) at [CNCF slack workspace](https://slack.cncf.io/).
 The project team will review and investigate all complaints,
 and will respond in a way that it deems appropriate to the circumstances.
 The project team is obligated to maintain confidentiality with regard to the


### PR DESCRIPTION
There is nothing wrong with current code of conduct a part from being a bit outdated. So I propose instead of having our own code of conduct, we "import" CNCF and add additional information about enforcement.

I believe it's easier for our users to learn/read one Code of Conduct.

This is similar to what other has done (Prometheus, Cortex).

 https://github.com/prometheus/prometheus/blob/master/code-of-conduct.md
https://github.com/cortexproject/cortex/blob/master/code-of-conduct.md