### PR TITLE
Add a placeholder for devdocs

### DIFF
--- a/docs/contributing/onboarding-dev.md
+++ b/docs/contributing/onboarding-dev.md
@@ -1,0 +1,37 @@
+---
+title: Onboarding Dev Docs
+type: docs
+menu: contributing
+---
+
+- [Onboarding Dev Docs](#onboarding-dev-docs)
+- [Getting up and running with Thanos](#getting-up-and-running-with-thanos)
+- [Resources for the design and internal working for Thanos](#resources-for-the-design-and-internal-working-for-thanos)
+- [Prometheus TSDB Blocks](#prometheus-tsdb-blocks)
+- [Step by step flow of command for Thanos](#step-by-step-flow-of-command-for-thanos)
+- [Sidecar](#sidecar)
+- [Compact](#compact)
+- [Bucket](#bucket)
+- [Store Gateway](#store-gateway)
+- [Querier](#querier)
+- [Ruler](#ruler)
+
+<small><i><a href='http://ecotrust-canada.github.io/markdown-toc/'>Table of contents generated with markdown-toc</a></i></small>
+
+
+
+# Onboarding Dev Docs
+This document would help new developers who want to get up and running with Thanos for contributing a technical PR. It contains explanation of different components of Thanos and how they work internally. Each of the components are explained thoroughly and it is expected that after reading this document, the user would be equipped with conceptual clarity to understand and question the internal working of Thanos.
+
+Since this is a live document, please feel free to submit a PR for a component whose detailed explanation is missing / or could be improved.
+
+# Getting up and running with Thanos
+# Resources for the design and internal working for Thanos
+# Prometheus TSDB Blocks
+# Step by step flow of command for Thanos
+# Sidecar
+# Compact
+# Bucket
+# Store Gateway
+# Querier
+# Ruler

--- a/docs/contributing/onboarding-dev.md
+++ b/docs/contributing/onboarding-dev.md
@@ -1,10 +1,9 @@
 ---
-title: Onboarding Dev Docs
+title: Developer Onboarding
 type: docs
 menu: contributing
 ---
-
-- [Onboarding Dev Docs](#onboarding-dev-docs)
+- [Developer Onboarding](#developer-onboarding)
 - [Getting up and running with Thanos](#getting-up-and-running-with-thanos)
 - [Resources for the design and internal working for Thanos](#resources-for-the-design-and-internal-working-for-thanos)
 - [Prometheus TSDB Blocks](#prometheus-tsdb-blocks)
@@ -18,9 +17,8 @@ menu: contributing
 
 <small><i><a href='http://ecotrust-canada.github.io/markdown-toc/'>Table of contents generated with markdown-toc</a></i></small>
 
+# Developer Onboarding
 
-
-# Onboarding Dev Docs
 This document would help new developers who want to get up and running with Thanos for contributing a technical PR. It contains explanation of different components of Thanos and how they work internally. Each of the components are explained thoroughly and it is expected that after reading this document, the user would be equipped with conceptual clarity to understand and question the internal working of Thanos.
 
 Since this is a live document, please feel free to submit a PR for a component whose detailed explanation is missing / or could be improved.


### PR DESCRIPTION
Signed-off-by: Yash <yashrsharma44@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

This PR adds a placeholder for writing up a dev-docs from scratch. Some content has been written up here in a [doc](https://docs.google.com/document/d/1hluKPDKsSdOqcCpOnzr7-4PxLnUtrCl5d4-TVGch_D4/edit)

## Verification

<!-- How you tested it? How do you know it works? -->
