### PR TITLE
ui: Fix UI state being shared

### DIFF
--- a/pkg/ui/static/js/graph.js
+++ b/pkg/ui/static/js/graph.js
@@ -207,48 +207,48 @@ Prometheus.Graph.prototype.initialize = function() {
   // Deduplication.
   let dedup_icon = self.dedupBtn.find('.glyphicon');
   self.isDedupEnabled = function() {
-    let v = localStorage.getItem('enable-dedup');
+    let v = localStorage.getItem(`enable-dedup-${self.id}`);
 
     // If not set in localstorage, make it enabled.
     return v === '1' || v === null;
   };
 
   if (self.isDedupEnabled()) {
-    self.toggleOn(dedup_icon, 'enable-dedup');
+    self.toggleOn(dedup_icon, `enable-dedup-${self.id}`);
   } else {
-    self.toggleOff(dedup_icon, 'enable-dedup');
+    self.toggleOff(dedup_icon, `enable-dedup-${self.id}`);
   }
 
   self.dedupBtn.click(function() {
     self.enableDedup.val(self.isDedupEnabled() ? '0' : '1');
     if (dedup_icon.hasClass('glyphicon-unchecked')) {
-      self.toggleOn(dedup_icon, 'enable-dedup');
+      self.toggleOn(dedup_icon, `enable-dedup-${self.id}`);
     } else if (dedup_icon.hasClass('glyphicon-check')) {
-      self.toggleOff(dedup_icon, 'enable-dedup');
+      self.toggleOff(dedup_icon, `enable-dedup-${self.id}`);
     }
   });
 
   // Partial response.
   let partial_response_icon = self.partialResponseBtn.find('.glyphicon');
   self.isPartialResponseEnabled = function() {
-    let v = localStorage.getItem('enable-partial-response');
+    let v = localStorage.getItem(`enable-partial-response-${self.id}`);
 
     // If not set in localstorage, make it enabled.
     return v === '1' || v === null;
   };
 
   if (self.isPartialResponseEnabled()) {
-    self.toggleOn(partial_response_icon, 'enable-partial-response');
+    self.toggleOn(partial_response_icon, `enable-partial-response-${self.id}`);
   } else {
-    self.toggleOff(partial_response_icon, 'enable-partial-response');
+    self.toggleOff(partial_response_icon, `enable-partial-response-${self.id}`);
   }
 
   self.partialResponseBtn.click(function() {
     self.partialResponse.val(self.isPartialResponseEnabled() ? '0' : '1');
     if (partial_response_icon.hasClass('glyphicon-unchecked')) {
-      self.toggleOn(partial_response_icon, 'enable-partial-response');
+      self.toggleOn(partial_response_icon, `enable-partial-response-${self.id}`);
     } else if (partial_response_icon.hasClass('glyphicon-check')) {
-      self.toggleOff(partial_response_icon, 'enable-partial-response');
+      self.toggleOff(partial_response_icon, `enable-partial-response-${self.id}`);
     }
   });
 


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes
Fixes #2578 
We now use per panel `key` to store the state in `localStorage`. This keeps the states separate and provides a more consistent experience.

## Verification
Tested locally by inspecting requests and localStorage.
