### PR TITLE
(release branch) query: `irate` and `resets` use now counter downsampling aggregations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 - [#2525](https://github.com/thanos-io/thanos/pull/2525) Query: Fixed logging for dns resolution error in the `Query` component.
 - [#2484](https://github.com/thanos-io/thanos/pull/2484) Query/Ruler: Fixed issue #2483, when web.route-prefix is set, it is added twice in HTTP router prefix.
 - [#2416](https://github.com/thanos-io/thanos/pull/2416) Bucket: Fixed issue #2416 bug in `inspect --sort-by` doesn't work correctly in all cases
+- [#2719](https://github.com/thanos-io/thanos/pull/2719) Store: `irate` and `resets` use now counter downsampling aggregations.
 
 ### Added
 

--- a/pkg/query/querier.go
+++ b/pkg/query/querier.go
@@ -153,7 +153,7 @@ func aggrsFromFunc(f string) []storepb.Aggr {
 	if strings.HasPrefix(f, "sum_") {
 		return []storepb.Aggr{storepb.Aggr_SUM}
 	}
-	if f == "increase" || f == "rate" {
+	if f == "increase" || f == "rate" || f == "irate" || f == "resets" {
 		return []storepb.Aggr{storepb.Aggr_COUNTER}
 	}
 	// In the default case, we retrieve count and sum to compute an average.


### PR DESCRIPTION
See related discussion: https://cloud-native.slack.com/archives/CL25937SP/p1590408991325100

cc @SuperQ 

Signed-off-by: Bartlomiej Plotka <bwplotka@gmail.com>

