### PR TITLE
store: Expose bucket index operation duration histogram

### DIFF
--- a/pkg/cacheutil/memcached_client.go
+++ b/pkg/cacheutil/memcached_client.go
@@ -466,7 +466,7 @@ func (c *memcachedClient) resolveAddrs() error {
 
 	// If some of the dns resolution fails, log the error.
 	if err := c.dnsProvider.Resolve(ctx, c.config.Addresses); err != nil {
-		level.Error(c.logger).Log("msg", "failed to resolve addresses for storeAPIs", "addresses", strings.Join(c.config.Addresses, ","), "err", err)
+		level.Error(c.logger).Log("msg", "failed to resolve addresses for memcached", "addresses", strings.Join(c.config.Addresses, ","), "err", err)
 	}
 	// Fail in case no server address is resolved.
 	servers := c.dnsProvider.Addresses()

--- a/pkg/objstore/objstore.go
+++ b/pkg/objstore/objstore.go
@@ -17,6 +17,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+
 	"github.com/thanos-io/thanos/pkg/runutil"
 )
 
@@ -257,6 +258,7 @@ func BucketWithMetrics(name string, b Bucket, reg prometheus.Registerer) *metric
 			ConstLabels: prometheus.Labels{"bucket": name},
 			Buckets:     []float64{0.001, 0.01, 0.1, 0.3, 0.6, 1, 3, 6, 9, 20, 30, 60, 90, 120},
 		}, []string{"operation"}),
+
 		lastSuccessfulUploadTime: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
 			Name: "thanos_objstore_bucket_last_successful_upload_time",
 			Help: "Second timestamp of the last successful upload to the bucket.",

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -1631,8 +1631,8 @@ type postingPtr struct {
 // It returns one postings for each key, in the same order.
 // If postings for given key is not fetched, entry at given index will be nil.
 func (r *bucketIndexReader) fetchPostings(keys []labels.Label) ([]index.Postings, error) {
-	start := time.Now()
-	defer r.block.metrics.postingsLookupDuration.Observe(time.Since(start).Seconds())
+	timer := prometheus.NewTimer(r.block.metrics.postingsLookupDuration)
+	defer timer.ObserveDuration()
 
 	var ptrs []postingPtr
 
@@ -1851,8 +1851,8 @@ func (it *bigEndianPostings) length() int {
 }
 
 func (r *bucketIndexReader) PreloadSeries(ids []uint64) error {
-	start := time.Now()
-	defer r.block.metrics.seriesLookupDuration.Observe(float64(time.Since(start)))
+	timer := prometheus.NewTimer(r.block.metrics.seriesLookupDuration)
+	defer timer.ObserveDuration()
 
 	// Load series from cache, overwriting the list of ids to preload
 	// with the missing ones.

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -226,13 +226,13 @@ func newBucketStoreMetrics(reg prometheus.Registerer) *bucketStoreMetrics {
 	})
 
 	m.postingsFetchDuration = promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
-		Name:    "thanos_bucket_store_series_fetch_duration_seconds",
+		Name:    "thanos_bucket_store_postings_fetch_duration_seconds",
 		Help:    "Time it takes to fetch postings to respond a query.",
 		Buckets: []float64{0.001, 0.01, 0.1, 0.3, 0.6, 1, 3, 6, 9, 20, 30, 60, 90, 120},
 	})
 	m.seriesFetchDuration = promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
-		Name:    "thanos_bucket_store_postings_fetch_duration_seconds",
-		Help:    "Time it takes to fetch sub-results to respond a query.",
+		Name:    "thanos_bucket_store_series_fetch_duration_seconds",
+		Help:    "Time it takes to fetch series to respond a query.",
 		Buckets: []float64{0.001, 0.01, 0.1, 0.3, 0.6, 1, 3, 6, 9, 20, 30, 60, 90, 120},
 	})
 	m.chunksFetchDuration = promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
@@ -987,7 +987,7 @@ func (s *BucketStore) Series(req *storepb.SeriesRequest, srv storepb.Store_Serie
 		s.metrics.cachedPostingsOriginalSizeBytes.Add(float64(stats.cachedPostingsOriginalSizeSum))
 		s.metrics.cachedPostingsCompressedSizeBytes.Add(float64(stats.cachedPostingsCompressedSizeSum))
 		s.metrics.postingsFetchDuration.Observe(stats.postingsFetchDurationSum.Seconds())
-		s.metrics.chunksFetchDuration.Observe(stats.postingsFetchDurationSum.Seconds())
+		s.metrics.chunksFetchDuration.Observe(stats.chunksFetchDurationSum.Seconds())
 		s.metrics.seriesFetchDuration.Observe(stats.seriesFetchDurationSum.Seconds())
 
 		level.Debug(s.logger).Log("msg", "stats query processed",

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -105,10 +105,7 @@ type bucketStoreMetrics struct {
 	chunkSizeBytes        prometheus.Histogram
 	queriesDropped        prometheus.Counter
 	seriesRefetches       prometheus.Counter
-
-	postingsFetchDuration prometheus.Histogram
-	seriesFetchDuration   prometheus.Histogram
-	chunksFetchDuration   prometheus.Histogram
+	fetchDuration         *prometheus.HistogramVec
 
 	cachedPostingsCompressions           *prometheus.CounterVec
 	cachedPostingsCompressionErrors      *prometheus.CounterVec
@@ -225,21 +222,11 @@ func newBucketStoreMetrics(reg prometheus.Registerer) *bucketStoreMetrics {
 		Help: "Compressed size of postings stored into cache.",
 	})
 
-	m.postingsFetchDuration = promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
-		Name:    "thanos_bucket_store_postings_fetch_duration_seconds",
-		Help:    "Time it takes to fetch postings to respond a query.",
+	m.fetchDuration = promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "thanos_bucket_store_fetch_duration_seconds",
+		Help:    "Time it takes to fetch an element from a bucket to respond a query (Any BucketReader can be used as source: objstore or caching bucket).",
 		Buckets: []float64{0.001, 0.01, 0.1, 0.3, 0.6, 1, 3, 6, 9, 20, 30, 60, 90, 120},
-	})
-	m.seriesFetchDuration = promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
-		Name:    "thanos_bucket_store_series_fetch_duration_seconds",
-		Help:    "Time it takes to fetch series to respond a query.",
-		Buckets: []float64{0.001, 0.01, 0.1, 0.3, 0.6, 1, 3, 6, 9, 20, 30, 60, 90, 120},
-	})
-	m.chunksFetchDuration = promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
-		Name:    "thanos_bucket_store_chunks_fetch_duration_seconds",
-		Help:    "Time it takes to fetch chunks to respond a query.",
-		Buckets: []float64{0.001, 0.01, 0.1, 0.3, 0.6, 1, 3, 6, 9, 20, 30, 60, 90, 120},
-	})
+	}, []string{"data_type"})
 
 	return &m
 }
@@ -986,9 +973,9 @@ func (s *BucketStore) Series(req *storepb.SeriesRequest, srv storepb.Store_Serie
 		s.metrics.cachedPostingsCompressionTimeSeconds.WithLabelValues(labelDecode).Add(stats.cachedPostingsDecompressionTimeSum.Seconds())
 		s.metrics.cachedPostingsOriginalSizeBytes.Add(float64(stats.cachedPostingsOriginalSizeSum))
 		s.metrics.cachedPostingsCompressedSizeBytes.Add(float64(stats.cachedPostingsCompressedSizeSum))
-		s.metrics.postingsFetchDuration.Observe(stats.postingsFetchDurationSum.Seconds())
-		s.metrics.chunksFetchDuration.Observe(stats.chunksFetchDurationSum.Seconds())
-		s.metrics.seriesFetchDuration.Observe(stats.seriesFetchDurationSum.Seconds())
+		s.metrics.fetchDuration.WithLabelValues("postings").Observe(stats.postingsFetchDurationSum.Seconds())
+		s.metrics.fetchDuration.WithLabelValues("series").Observe(stats.seriesFetchDurationSum.Seconds())
+		s.metrics.fetchDuration.WithLabelValues("chunks").Observe(stats.chunksFetchDurationSum.Seconds())
 
 		level.Debug(s.logger).Log("msg", "stats query processed",
 			"stats", fmt.Sprintf("%+v", stats), "err", err)

--- a/pkg/store/bucket_test.go
+++ b/pkg/store/bucket_test.go
@@ -30,14 +30,14 @@ import (
 	"github.com/leanovate/gopter/gen"
 	"github.com/leanovate/gopter/prop"
 	"github.com/oklog/ulid"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 	promtest "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/pkg/relabel"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb"
 	"github.com/prometheus/prometheus/tsdb/encoding"
+
+	"go.uber.org/atomic"
 
 	"github.com/thanos-io/thanos/pkg/block"
 	"github.com/thanos-io/thanos/pkg/block/indexheader"
@@ -52,7 +52,6 @@ import (
 	storetestutil "github.com/thanos-io/thanos/pkg/store/storepb/testutil"
 	"github.com/thanos-io/thanos/pkg/testutil"
 	"github.com/thanos-io/thanos/pkg/testutil/e2eutil"
-	"go.uber.org/atomic"
 )
 
 var emptyRelabelConfig = make([]*relabel.Config, 0)
@@ -209,7 +208,7 @@ func TestBucketBlock_matchLabels(t *testing.T) {
 		},
 	}
 
-	b, err := newBucketBlock(context.Background(), log.NewNopLogger(), meta, bkt, path.Join(dir, blockID.String()), nil, nil, nil, nil, nil, true)
+	b, err := newBucketBlock(context.Background(), log.NewNopLogger(), newBucketStoreMetrics(nil), meta, bkt, path.Join(dir, blockID.String()), nil, nil, nil, nil, true)
 	testutil.Ok(t, err)
 
 	cases := []struct {
@@ -921,10 +920,10 @@ func TestReadIndexCache_LoadSeries(t *testing.T) {
 				ULID: ulid.MustNew(1, nil),
 			},
 		},
-		bkt:             bkt,
-		seriesRefetches: s.seriesRefetches,
-		logger:          log.NewNopLogger(),
-		indexCache:      noopCache{},
+		bkt:        bkt,
+		logger:     log.NewNopLogger(),
+		metrics:    s,
+		indexCache: noopCache{},
 	}
 
 	buf := encoding.Encbuf{}
@@ -1130,6 +1129,7 @@ func benchmarkExpandedPostings(
 		t.Run(c.name, func(t testutil.TB) {
 			b := &bucketBlock{
 				logger:            log.NewNopLogger(),
+				metrics:           newBucketStoreMetrics(nil),
 				indexHeaderReader: r,
 				indexCache:        noopCache{},
 				bkt:               bkt,
@@ -1228,15 +1228,16 @@ func benchBucketSeries(t testutil.TB, samplesPerSeries, totalSeries int, request
 		testutil.Ok(t, err)
 		testutil.Ok(t, block.Upload(context.Background(), logger, bkt, filepath.Join(blockDir, id.String())))
 
+		m := newBucketStoreMetrics(nil)
 		b := &bucketBlock{
-			indexCache:      noopCache{},
-			logger:          logger,
-			bkt:             bkt,
-			meta:            meta,
-			partitioner:     gapBasedPartitioner{maxGapSize: partitionerMaxGapSize},
-			chunkObjs:       []string{filepath.Join(id.String(), "chunks", "000001")},
-			chunkPool:       chunkPool,
-			seriesRefetches: promauto.With(nil).NewCounter(prometheus.CounterOpts{}),
+			indexCache:  noopCache{},
+			logger:      logger,
+			metrics:     m,
+			bkt:         bkt,
+			meta:        meta,
+			partitioner: gapBasedPartitioner{maxGapSize: partitionerMaxGapSize},
+			chunkObjs:   []string{filepath.Join(id.String(), "chunks", "000001")},
+			chunkPool:   chunkPool,
 		}
 		blocks = append(blocks, b)
 	}
@@ -1289,7 +1290,7 @@ func benchBucketSeries(t testutil.TB, samplesPerSeries, totalSeries int, request
 
 		for _, b := range blocks {
 			// NOTE(bwplotka): It is 4 x 1.0 for 100mln samples. Kind of make sense: long series.
-			testutil.Equals(t, 0.0, promtest.ToFloat64(b.seriesRefetches))
+			testutil.Equals(t, 0.0, promtest.ToFloat64(b.metrics.seriesRefetches))
 		}
 	}
 }
@@ -1393,6 +1394,7 @@ func TestBucketSeries_OneBlock_InMemIndexCacheSegfault(t *testing.T) {
 		b1 = &bucketBlock{
 			indexCache:  indexCache,
 			logger:      logger,
+			metrics:     newBucketStoreMetrics(nil),
 			bkt:         bkt,
 			meta:        meta,
 			partitioner: gapBasedPartitioner{maxGapSize: partitionerMaxGapSize},
@@ -1431,6 +1433,7 @@ func TestBucketSeries_OneBlock_InMemIndexCacheSegfault(t *testing.T) {
 		b2 = &bucketBlock{
 			indexCache:  indexCache,
 			logger:      logger,
+			metrics:     newBucketStoreMetrics(nil),
 			bkt:         bkt,
 			meta:        meta,
 			partitioner: gapBasedPartitioner{maxGapSize: partitionerMaxGapSize},


### PR DESCRIPTION
I would like to expose bucket fetch operation durations to fine-tune caching layer for store.

Signed-off-by: Kemal Akkoyun <kakkoyun@gmail.com>

* [ ] I added CHANGELOG entry for this change.

## Changes

* Add metrics to expose already collected fetch durations.

## Verification

* `make build`
