### PR TITLE
objstore/swift: use ncw/swift and support large files for OpenStack Swift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -196,9 +196,10 @@ sse_config:
 - [#2739](https://github.com/thanos-io/thanos/pull/2739) Changed `bucket tool bucket verify` `--id-whitelist` flag to `--id`.
 - [#2748](https://github.com/thanos-io/thanos/pull/2748) Upgrade Prometheus to [@66dfb951c4ca](https://github.com/prometheus/prometheus/commit/66dfb951c4ca2c1dd3f266172a48a925403b13a5) which is after v2.19.0.
   - PromQL now allow us to executed concurrent selects.
-- [#2732](https://github.com/thanos-io/thanos/pull/2732) Swift: Switched to a new library [ncw/swift]() providing large objects support.
+- [#2732](https://github.com/thanos-io/thanos/pull/2732) Swift: Switched to a new library [ncw/swift](https://github.com/ncw/swift) providing large objects support.
    By default, segments will be uploaded to the same container directory `segments/` if the file is bigger than `1GB`.
    To change the defaults see [the docs](./docs/storage.md#openstack-swift).
+
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ We use _breaking :warning:_ to mark changes that are not backward compatible (re
 ### Changed
 
 - [#3496](https://github.com/thanos-io/thanos/pull/3496) s3: Respect SignatureV2 flag for all credential providers.
+- [#2732](https://github.com/thanos-io/thanos/pull/2732) Swift: Switched to a new library [ncw/swift](https://github.com/ncw/swift) providing large objects support.
+   By default, segments will be uploaded to the same container directory `segments/` if the file is bigger than `1GB`.
+   To change the defaults see [the docs](./docs/storage.md#openstack-swift).
 
 ## [v0.17.0](https://github.com/thanos-io/thanos/releases/tag/v0.17.0) - 2020.11.18
 
@@ -68,9 +71,6 @@ We use _breaking :warning:_ to mark changes that are not backward compatible (re
   - `thanos_replicate_origin_meta_loads_total` can be replaced by `blocks_meta_synced{state="loaded"}`.
   - `thanos_replicate_origin_partial_meta_reads_total` can be replaced by `blocks_meta_synced{state="failed"}`.
 - [#3309](https://github.com/thanos-io/thanos/pull/3309) Compact: _breaking :warning:_ Rename metrics to match naming convention. This includes metrics starting with `thanos_compactor` to `thanos_compact`, `thanos_querier` to `thanos_query` and `thanos_ruler` to `thanos_rule`.
-- [#2732](https://github.com/thanos-io/thanos/pull/2732) Swift: Switched to a new library [ncw/swift](https://github.com/ncw/swift) providing large objects support.
-   By default, segments will be uploaded to the same container directory `segments/` if the file is bigger than `1GB`.
-   To change the defaults see [the docs](./docs/storage.md#openstack-swift).
 
 ## [v0.16.0](https://github.com/thanos-io/thanos/releases) - 2020.10.26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,9 @@ We use _breaking :warning:_ to mark changes that are not backward compatible (re
   - `thanos_replicate_origin_meta_loads_total` can be replaced by `blocks_meta_synced{state="loaded"}`.
   - `thanos_replicate_origin_partial_meta_reads_total` can be replaced by `blocks_meta_synced{state="failed"}`.
 - [#3309](https://github.com/thanos-io/thanos/pull/3309) Compact: _breaking :warning:_ Rename metrics to match naming convention. This includes metrics starting with `thanos_compactor` to `thanos_compact`, `thanos_querier` to `thanos_query` and `thanos_ruler` to `thanos_rule`.
+- [#2732](https://github.com/thanos-io/thanos/pull/2732) Swift: Switched to a new library [ncw/swift](https://github.com/ncw/swift) providing large objects support.
+   By default, segments will be uploaded to the same container directory `segments/` if the file is bigger than `1GB`.
+   To change the defaults see [the docs](./docs/storage.md#openstack-swift).
 
 ## [v0.16.0](https://github.com/thanos-io/thanos/releases) - 2020.10.26
 
@@ -196,10 +199,6 @@ sse_config:
 - [#2739](https://github.com/thanos-io/thanos/pull/2739) Changed `bucket tool bucket verify` `--id-whitelist` flag to `--id`.
 - [#2748](https://github.com/thanos-io/thanos/pull/2748) Upgrade Prometheus to [@66dfb951c4ca](https://github.com/prometheus/prometheus/commit/66dfb951c4ca2c1dd3f266172a48a925403b13a5) which is after v2.19.0.
   - PromQL now allow us to executed concurrent selects.
-- [#2732](https://github.com/thanos-io/thanos/pull/2732) Swift: Switched to a new library [ncw/swift](https://github.com/ncw/swift) providing large objects support.
-   By default, segments will be uploaded to the same container directory `segments/` if the file is bigger than `1GB`.
-   To change the defaults see [the docs](./docs/storage.md#openstack-swift).
-
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -196,6 +196,9 @@ sse_config:
 - [#2739](https://github.com/thanos-io/thanos/pull/2739) Changed `bucket tool bucket verify` `--id-whitelist` flag to `--id`.
 - [#2748](https://github.com/thanos-io/thanos/pull/2748) Upgrade Prometheus to [@66dfb951c4ca](https://github.com/prometheus/prometheus/commit/66dfb951c4ca2c1dd3f266172a48a925403b13a5) which is after v2.19.0.
   - PromQL now allow us to executed concurrent selects.
+- [#TBA](https://github.com/thanos-io/thanos/pull/TBA) Swift: Switched to a new library [ncw/swift]() providing large objects support.
+   By default, segments will be uploaded to the same container directory `segments/` if the file is bigger than `1GB`.
+   To change the defaults see [the docs](./docs/storage.md#openstack-swift).
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -196,7 +196,7 @@ sse_config:
 - [#2739](https://github.com/thanos-io/thanos/pull/2739) Changed `bucket tool bucket verify` `--id-whitelist` flag to `--id`.
 - [#2748](https://github.com/thanos-io/thanos/pull/2748) Upgrade Prometheus to [@66dfb951c4ca](https://github.com/prometheus/prometheus/commit/66dfb951c4ca2c1dd3f266172a48a925403b13a5) which is after v2.19.0.
   - PromQL now allow us to executed concurrent selects.
-- [#TBA](https://github.com/thanos-io/thanos/pull/TBA) Swift: Switched to a new library [ncw/swift]() providing large objects support.
+- [#2732](https://github.com/thanos-io/thanos/pull/2732) Swift: Switched to a new library [ncw/swift]() providing large objects support.
    By default, segments will be uploaded to the same container directory `segments/` if the file is bigger than `1GB`.
    To change the defaults see [the docs](./docs/storage.md#openstack-swift).
 

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -340,7 +340,7 @@ Various examples for OpenStack authentication can be found in the [official docu
 By default, OpenStack Swift has a limit for maximum file size of 5 GiB. Thanos index files are often larger than that.
 To resolve this issue, Thanos uses [Static Large Objects (SLO)](https://docs.openstack.org/swift/latest/overview_large_objects.html)
 which are uploaded as segments. These are by default put into the `segments` directory of the same container.
-Default limit for using SLO is 1 GiB which is also maximal size of the segment.
+The default limit for using SLO is 1 GiB which is also the maximum size of the segment.
 If you don't want to use the same container for the segments
 (best practise is to use `<container_name>_segments` to avoid polluting listing of the container objects)
 you can use the `large_file_segments_container_name` option to override the default and put the segments to other container.

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -344,6 +344,8 @@ The default limit for using SLO is 1 GiB which is also the maximum size of the 
 If you don't want to use the same container for the segments
 (best practise is to use `<container_name>_segments` to avoid polluting listing of the container objects)
 you can use the `large_file_segments_container_name` option to override the default and put the segments to other container.
+_In rare cases you can switch to [Dynamic Large Objects (DLO)](https://docs.openstack.org/swift/latest/overview_large_objects.html)
+by setting the `use_dynamic_large_objects` to true, but use it with caution since it even more relies on eventual consistency._
 
 [embedmd]:# (flags/config_bucket_swift.txt yaml)
 ```yaml
@@ -369,6 +371,7 @@ config:
   retries: 3
   connect_timeout: 10s
   timeout: 5m
+  use_dynamic_large_objects: false
 ```
 
 #### Tencent COS

--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,7 @@ require (
 	github.com/minio/minio-go/v7 v7.0.2
 	github.com/mozillazg/go-cos v0.13.0
 	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f
+	github.com/ncw/swift v1.0.52
 	github.com/oklog/run v1.1.0
 	github.com/oklog/ulid v1.3.1
 	github.com/olekukonko/tablewriter v0.0.2

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,6 @@ require (
 	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e
 	github.com/golang/snappy v0.0.2
 	github.com/googleapis/gax-go v2.0.2+incompatible
-	github.com/gophercloud/gophercloud v0.14.0
 	github.com/grpc-ecosystem/go-grpc-middleware v1.1.0
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 	github.com/hashicorp/golang-lru v0.5.4

--- a/go.sum
+++ b/go.sum
@@ -893,6 +893,8 @@ github.com/nats-io/nkeys v0.1.0/go.mod h1:xpnFELMwJABBLVhffcfd1MZx6VsNRFpEugbxzi
 github.com/nats-io/nkeys v0.1.3/go.mod h1:xpnFELMwJABBLVhffcfd1MZx6VsNRFpEugbxziKVo7w=
 github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OSON2c=
 github.com/ncw/swift v1.0.50/go.mod h1:23YIA4yWVnGwv2dQlN4bB7egfYX6YLn0Yo/S6zZO/ZM=
+github.com/ncw/swift v1.0.52 h1:ACF3JufDGgeKp/9mrDgQlEgS8kRYC4XKcuzj/8EJjQU=
+github.com/ncw/swift v1.0.52/go.mod h1:23YIA4yWVnGwv2dQlN4bB7egfYX6YLn0Yo/S6zZO/ZM=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nxadm/tail v1.4.4 h1:DQuhQpB1tVlglWS2hLQ5OV6B5r8aGxSrPc5Qo6uTN78=

--- a/pkg/objstore/swift/swift.go
+++ b/pkg/objstore/swift/swift.go
@@ -203,7 +203,7 @@ func (c *Container) Name() string {
 
 // Iter calls f for each entry in the given directory. The argument to f is the full
 // object name including the prefix of the inspected directory.
-func (c *Container) Iter(ctx context.Context, dir string, f func(string) error) error {
+func (c *Container) Iter(_ context.Context, dir string, f func(string) error) error {
 	if dir != "" {
 		dir = strings.TrimSuffix(dir, string(DirDelim)) + string(DirDelim)
 	}
@@ -233,11 +233,11 @@ func (c *Container) get(name string, headers swift.Headers, checkHash bool) (io.
 }
 
 // Get returns a reader for the given object name.
-func (c *Container) Get(ctx context.Context, name string) (io.ReadCloser, error) {
+func (c *Container) Get(_ context.Context, name string) (io.ReadCloser, error) {
 	return c.get(name, swift.Headers{}, true)
 }
 
-func (c *Container) GetRange(ctx context.Context, name string, off, length int64) (io.ReadCloser, error) {
+func (c *Container) GetRange(_ context.Context, name string, off, length int64) (io.ReadCloser, error) {
 	// Set Range HTTP header, see the docs https://docs.openstack.org/api-ref/object-store/?expanded=show-container-details-and-list-objects-detail,get-object-content-and-metadata-detail#id76.
 	bytesRange := fmt.Sprintf("bytes=%d-", off)
 	if length != -1 {
@@ -247,7 +247,7 @@ func (c *Container) GetRange(ctx context.Context, name string, off, length int64
 }
 
 // Attributes returns information about the specified object.
-func (c *Container) Attributes(ctx context.Context, name string) (objstore.ObjectAttributes, error) {
+func (c *Container) Attributes(_ context.Context, name string) (objstore.ObjectAttributes, error) {
 	if name == "" {
 		return objstore.ObjectAttributes{}, errors.New("Object name cannot be empty")
 	}
@@ -262,7 +262,7 @@ func (c *Container) Attributes(ctx context.Context, name string) (objstore.Objec
 }
 
 // Exists checks if the given object exists.
-func (c *Container) Exists(ctx context.Context, name string) (bool, error) {
+func (c *Container) Exists(_ context.Context, name string) (bool, error) {
 	_, _, err := c.connection.Object(c.name, name)
 	if c.IsObjNotFoundErr(err) {
 		err = nil
@@ -279,7 +279,7 @@ func (c *Container) IsObjNotFoundErr(err error) bool {
 }
 
 // Upload writes the contents of the reader as an object into the container.
-func (c *Container) Upload(ctx context.Context, name string, r io.Reader) error {
+func (c *Container) Upload(_ context.Context, name string, r io.Reader) error {
 	size, err := objstore.TryToGetSize(r)
 	if err != nil {
 		level.Warn(c.logger).Log("msg", "could not guess file size, using large object to avoid issues if the file is larger than limit", "name", name, "err", err)
@@ -320,7 +320,7 @@ func (c *Container) Upload(ctx context.Context, name string, r io.Reader) error 
 }
 
 // Delete removes the object with the given name.
-func (c *Container) Delete(ctx context.Context, name string) error {
+func (c *Container) Delete(_ context.Context, name string) error {
 	return errors.Wrap(c.connection.LargeObjectDelete(c.name, name), "swift delete object")
 }
 

--- a/pkg/objstore/swift/swift.go
+++ b/pkg/objstore/swift/swift.go
@@ -8,16 +8,19 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
+	"strconv"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/go-kit/kit/log/level"
+
+	"github.com/thanos-io/thanos/pkg/runutil"
 
 	"github.com/go-kit/kit/log"
-	"github.com/gophercloud/gophercloud"
-	"github.com/gophercloud/gophercloud/openstack"
-	"github.com/gophercloud/gophercloud/openstack/objectstorage/v1/containers"
-	"github.com/gophercloud/gophercloud/openstack/objectstorage/v1/objects"
-	"github.com/gophercloud/gophercloud/pagination"
+	"github.com/ncw/swift"
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v2"
 
@@ -25,54 +28,174 @@ import (
 )
 
 // DirDelim is the delimiter used to model a directory structure in an object store bucket.
-const DirDelim = "/"
+const DirDelim = '/'
 
-type SwiftConfig struct {
-	AuthUrl           string `yaml:"auth_url"`
-	Username          string `yaml:"username"`
-	UserDomainName    string `yaml:"user_domain_name"`
-	UserDomainID      string `yaml:"user_domain_id"`
-	UserId            string `yaml:"user_id"`
-	Password          string `yaml:"password"`
-	DomainId          string `yaml:"domain_id"`
-	DomainName        string `yaml:"domain_name"`
-	ProjectID         string `yaml:"project_id"`
-	ProjectName       string `yaml:"project_name"`
-	ProjectDomainID   string `yaml:"project_domain_id"`
-	ProjectDomainName string `yaml:"project_domain_name"`
-	RegionName        string `yaml:"region_name"`
-	ContainerName     string `yaml:"container_name"`
+var DefaultConfig = Config{
+	ChunkSize:      1024 * 1024 * 1024,
+	Retries:        3,
+	ConnectTimeout: "10s",
+	Timeout:        "5m",
+}
+
+type Config struct {
+	AuthVersion          int    `yaml:"auth_version"`
+	AuthUrl              string `yaml:"auth_url"`
+	Username             string `yaml:"username"`
+	UserDomainName       string `yaml:"user_domain_name"`
+	UserDomainID         string `yaml:"user_domain_id"`
+	UserId               string `yaml:"user_id"`
+	Password             string `yaml:"password"`
+	DomainId             string `yaml:"domain_id"`
+	DomainName           string `yaml:"domain_name"`
+	ProjectID            string `yaml:"project_id"`
+	ProjectName          string `yaml:"project_name"`
+	ProjectDomainID      string `yaml:"project_domain_id"`
+	ProjectDomainName    string `yaml:"project_domain_name"`
+	RegionName           string `yaml:"region_name"`
+	ContainerName        string `yaml:"container_name"`
+	ChunkSize            int64  `yaml:"large_object_chunk_size"`
+	SegmentContainerName string `yaml:"large_object_segments_container_name"`
+	Retries              int    `yaml:"retries"`
+	ConnectTimeout       string `yaml:"connect_timeout"`
+	Timeout              string `yaml:"timeout"`
+}
+
+func parseConfig(conf []byte) (*Config, error) {
+	sc := DefaultConfig
+	err := yaml.UnmarshalStrict(conf, &sc)
+	return &sc, err
+}
+
+func configFromEnv() (*Config, error) {
+	c := swift.Connection{}
+	if err := c.ApplyEnvironment(); err != nil {
+		return nil, err
+	}
+
+	config := Config{
+		AuthVersion:          c.AuthVersion,
+		AuthUrl:              c.AuthUrl,
+		Password:             c.ApiKey,
+		Username:             c.UserName,
+		UserId:               c.UserId,
+		DomainId:             c.DomainId,
+		DomainName:           c.Domain,
+		ProjectID:            c.TenantId,
+		ProjectName:          c.Tenant,
+		ProjectDomainID:      c.TenantDomainId,
+		ProjectDomainName:    c.TenantDomain,
+		RegionName:           c.Region,
+		ContainerName:        os.Getenv("OS_CONTAINER_NAME"),
+		SegmentContainerName: os.Getenv("SWIFT_SEGMENTS_CONTAINER_NAME"),
+		Retries:              c.Retries,
+		ConnectTimeout:       c.ConnectTimeout.String(),
+		Timeout:              c.Timeout.String(),
+	}
+	if os.Getenv("SWIFT_CHUNK_SIZE") != "" {
+		var err error
+		config.ChunkSize, err = strconv.ParseInt(os.Getenv("SWIFT_CHUNK_SIZE"), 10, 64)
+		if err != nil {
+			return nil, errors.Wrap(err, "swift parsing chunk size")
+		}
+	}
+	return &config, nil
+}
+
+func connectionFromConfig(sc *Config) (*swift.Connection, error) {
+	connection := swift.Connection{
+		Domain:         sc.DomainName,
+		DomainId:       sc.DomainId,
+		UserName:       sc.Username,
+		UserId:         sc.UserId,
+		ApiKey:         sc.Password,
+		AuthUrl:        sc.AuthUrl,
+		Retries:        sc.Retries,
+		Region:         sc.RegionName,
+		AuthVersion:    sc.AuthVersion,
+		Tenant:         sc.ProjectName,
+		TenantId:       sc.ProjectID,
+		TenantDomain:   sc.ProjectDomainName,
+		TenantDomainId: sc.ProjectDomainID,
+	}
+	if sc.ConnectTimeout != "" {
+		connectTimeout, err := time.ParseDuration(sc.ConnectTimeout)
+		if err != nil {
+			return nil, errors.Wrap(err, "swift parsing connectionTimeout")
+		}
+		connection.ConnectTimeout = connectTimeout
+	}
+	if sc.Timeout != "" {
+		timeout, err := time.ParseDuration(sc.Timeout)
+		if err != nil {
+			return nil, errors.Wrap(err, "swift parsing timeout")
+		}
+		connection.Timeout = timeout
+	}
+	return &connection, nil
 }
 
 type Container struct {
-	logger log.Logger
-	client *gophercloud.ServiceClient
-	name   string
+	logger            log.Logger
+	name              string
+	connection        *swift.Connection
+	chunkSize         int64
+	segmentsContainer string
 }
 
 func NewContainer(logger log.Logger, conf []byte) (*Container, error) {
 	sc, err := parseConfig(conf)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "swift parse configs")
 	}
+	return NewContainerFromConfig(logger, sc, false)
+}
 
-	provider, err := openstack.AuthenticatedClient(authOptsFromConfig(sc))
+func ensureContainer(connection *swift.Connection, name string, createIfNotExist bool) (string, error) {
+	if _, _, err := connection.Container(name); err != nil {
+		if err != swift.ContainerNotFound {
+			return "", errors.Wrapf(err, "swift verify container %s", name)
+		}
+		if !createIfNotExist {
+			return "", fmt.Errorf("unable to find the expected container %s", name)
+		}
+		var newContainer swift.Container
+		if err = connection.ContainerCreate(name, swift.Headers{}); err != nil {
+			return "", errors.Wrapf(err, "create container %s", name)
+		}
+		return newContainer.Name, nil
+	}
+	return "", nil
+}
+
+func NewContainerFromConfig(logger log.Logger, sc *Config, createContainer bool) (*Container, error) {
+	connection, err := connectionFromConfig(sc)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "swift load config")
 	}
 
-	client, err := openstack.NewObjectStorageV1(provider, gophercloud.EndpointOpts{
-		Region: sc.RegionName,
-	})
-	if err != nil {
-		return nil, err
+	if err := connection.Authenticate(); err != nil {
+		return nil, errors.Wrap(err, "swift authentication")
 	}
 
-	return &Container{
-		logger: logger,
-		client: client,
-		name:   sc.ContainerName,
-	}, nil
+	if _, err := ensureContainer(connection, sc.ContainerName, createContainer); err != nil {
+		return nil, err
+	}
+	if sc.SegmentContainerName == "" {
+		sc.SegmentContainerName = sc.ContainerName
+	} else {
+		if _, err := ensureContainer(connection, sc.SegmentContainerName, createContainer); err != nil {
+			return nil, err
+		}
+	}
+
+	container := Container{
+		logger:            logger,
+		name:              sc.ContainerName,
+		connection:        connection,
+		chunkSize:         sc.ChunkSize,
+		segmentsContainer: sc.SegmentContainerName,
+	}
+	return &container, nil
 }
 
 // Name returns the container name for swift.
@@ -83,99 +206,124 @@ func (c *Container) Name() string {
 // Iter calls f for each entry in the given directory. The argument to f is the full
 // object name including the prefix of the inspected directory.
 func (c *Container) Iter(ctx context.Context, dir string, f func(string) error) error {
-	// Ensure the object name actually ends with a dir suffix. Otherwise we'll just iterate the
-	// object itself as one prefix item.
 	if dir != "" {
-		dir = strings.TrimSuffix(dir, DirDelim) + DirDelim
+		dir = strings.TrimSuffix(dir, string(DirDelim)) + string(DirDelim)
 	}
-
-	options := &objects.ListOpts{Full: true, Prefix: dir, Delimiter: DirDelim}
-	return objects.List(c.client, c.name, options).EachPage(func(page pagination.Page) (bool, error) {
-		objectNames, err := objects.ExtractNames(page)
+	return c.connection.ObjectsWalk(c.name, &swift.ObjectsOpts{Prefix: dir, Delimiter: DirDelim}, func(opts *swift.ObjectsOpts) (interface{}, error) {
+		objects, err := c.connection.ObjectNames(c.name, opts)
 		if err != nil {
-			return false, err
+			return objects, errors.Wrap(err, "swift list object names")
 		}
-		for _, objectName := range objectNames {
-			if err := f(objectName); err != nil {
-				return false, err
+		for _, object := range objects {
+			if err := f(object); err != nil {
+				return objects, errors.Wrap(err, "swift iteration over objects")
 			}
 		}
-
-		return true, nil
+		return objects, nil
 	})
+}
+
+func (c *Container) get(name string, headers swift.Headers, checkHash bool) (io.ReadCloser, error) {
+	if name == "" {
+		return nil, errors.New("Object name cannot be empty")
+	}
+	file, _, err := c.connection.ObjectOpen(c.name, name, checkHash, headers)
+	if err != nil {
+		return nil, errors.Wrap(err, "swift open object")
+	}
+	return file, err
 }
 
 // Get returns a reader for the given object name.
 func (c *Container) Get(ctx context.Context, name string) (io.ReadCloser, error) {
-	if name == "" {
-		return nil, errors.New("error, empty container name passed")
-	}
-	response := objects.Download(c.client, c.name, name, nil)
-	return response.Body, response.Err
+	return c.get(name, swift.Headers{}, true)
 }
 
-// GetRange returns a new range reader for the given object name and range.
 func (c *Container) GetRange(ctx context.Context, name string, off, length int64) (io.ReadCloser, error) {
-	lowerLimit := ""
-	upperLimit := ""
-	if off >= 0 {
-		lowerLimit = fmt.Sprintf("%d", off)
+	// Set Range HTTP header, see the docs https://docs.openstack.org/api-ref/object-store/?expanded=show-container-details-and-list-objects-detail,get-object-content-and-metadata-detail#id76.
+	bytesRange := fmt.Sprintf("bytes=%d-", off)
+	if length != -1 {
+		bytesRange = fmt.Sprintf("%s%d", bytesRange, off+length-1)
 	}
-	if length > 0 {
-		upperLimit = fmt.Sprintf("%d", off+length-1)
-	}
-	options := objects.DownloadOpts{
-		Newest: true,
-		Range:  fmt.Sprintf("bytes=%s-%s", lowerLimit, upperLimit),
-	}
-	response := objects.Download(c.client, c.name, name, options)
-	return response.Body, response.Err
+	return c.get(name, swift.Headers{"Range": bytesRange}, false)
 }
 
 // Attributes returns information about the specified object.
 func (c *Container) Attributes(ctx context.Context, name string) (objstore.ObjectAttributes, error) {
-	response := objects.Get(c.client, c.name, name, nil)
-	headers, err := response.Extract()
-	if err != nil {
-		return objstore.ObjectAttributes{}, err
+	if name == "" {
+		return objstore.ObjectAttributes{}, errors.New("Object name cannot be empty")
 	}
-
+	info, _, err := c.connection.Object(c.name, name)
+	if err != nil {
+		return objstore.ObjectAttributes{}, errors.Wrap(err, "swift get object attributes")
+	}
 	return objstore.ObjectAttributes{
-		Size:         headers.ContentLength,
-		LastModified: headers.LastModified,
+		Size:         info.Bytes,
+		LastModified: info.LastModified,
 	}, nil
 }
 
 // Exists checks if the given object exists.
 func (c *Container) Exists(ctx context.Context, name string) (bool, error) {
-	err := objects.Get(c.client, c.name, name, nil).Err
-	if err == nil {
-		return true, nil
+	_, _, err := c.connection.Object(c.name, name)
+	if err != nil {
+		if c.IsObjNotFoundErr(err) {
+			err = nil
+		}
+		return false, errors.Wrap(err, "swift check if file exists")
 	}
-
-	if _, ok := err.(gophercloud.ErrDefault404); ok {
-		return false, nil
-	}
-
-	return false, err
+	return true, nil
 }
 
 // IsObjNotFoundErr returns true if error means that object is not found. Relevant to Get operations.
 func (c *Container) IsObjNotFoundErr(err error) bool {
-	_, ok := err.(gophercloud.ErrDefault404)
-	return ok
+	return errors.Is(err, swift.ObjectNotFound)
 }
 
 // Upload writes the contents of the reader as an object into the container.
 func (c *Container) Upload(ctx context.Context, name string, r io.Reader) error {
-	options := &objects.CreateOpts{Content: r}
-	res := objects.Create(c.client, c.name, name, options)
-	return res.Err
+	size, err := objstore.TryToGetSize(r)
+	if err != nil {
+		level.Warn(c.logger).Log("msg", "could not guess file size, using large object to avoid issues if the file is larger than limit", "name", name, "err", err)
+		// Anything higher or equal to chunk size so the SLO is used.
+		size = c.chunkSize
+	}
+	var file io.WriteCloser
+	if size >= c.chunkSize {
+		file, err = c.connection.StaticLargeObjectCreateFile(&swift.LargeObjectOpts{
+			Container:        c.name,
+			ObjectName:       name,
+			ChunkSize:        c.chunkSize,
+			SegmentContainer: c.segmentsContainer,
+			CheckHash:        true,
+		})
+	} else {
+		file, err = c.connection.ObjectCreate(c.name, name, true, "", "", swift.Headers{})
+	}
+	if err != nil {
+		return errors.Wrap(err, "swift failed to create file")
+	}
+	defer runutil.CloseWithLogOnErr(c.logger, file, "swift upload obj close")
+	switch f := file.(type) {
+	case io.ReaderFrom:
+		if _, err := f.ReadFrom(r); err != nil {
+			return errors.Wrap(err, "swift failed to write uploaded file")
+		}
+	default:
+		buf, err := ioutil.ReadAll(r)
+		if err != nil {
+			return errors.Wrap(err, "swift failed to read uploaded file")
+		}
+		if _, err = file.Write(buf); err != nil {
+			return errors.Wrap(err, "swift failed to write uploaded file")
+		}
+	}
+	return nil
 }
 
 // Delete removes the object with the given name.
 func (c *Container) Delete(ctx context.Context, name string) error {
-	return objects.Delete(c.client, c.name, name, nil).Err
+	return errors.Wrap(c.connection.LargeObjectDelete(c.name, name), "swift delete object")
 }
 
 func (*Container) Close() error {
@@ -183,114 +331,13 @@ func (*Container) Close() error {
 	return nil
 }
 
-func parseConfig(conf []byte) (*SwiftConfig, error) {
-	var sc SwiftConfig
-	err := yaml.UnmarshalStrict(conf, &sc)
-	return &sc, err
-}
-
-func authOptsFromConfig(sc *SwiftConfig) gophercloud.AuthOptions {
-	authOpts := gophercloud.AuthOptions{
-		IdentityEndpoint: sc.AuthUrl,
-		Username:         sc.Username,
-		UserID:           sc.UserId,
-		Password:         sc.Password,
-		DomainID:         sc.DomainId,
-		DomainName:       sc.DomainName,
-		TenantID:         sc.ProjectID,
-		TenantName:       sc.ProjectName,
-
-		// Allow Gophercloud to re-authenticate automatically.
-		AllowReauth: true,
-	}
-
-	// Support for cross-domain scoping (user in different domain than project).
-	// If a userDomainName or userDomainID is given, the user is scoped to this domain.
-	switch {
-	case sc.UserDomainName != "":
-		authOpts.DomainName = sc.UserDomainName
-	case sc.UserDomainID != "":
-		authOpts.DomainID = sc.UserDomainID
-	}
-
-	// A token can be scoped to a domain or project.
-	// The project can be in another domain than the user, which is indicated by setting either projectDomainName or projectDomainID.
-	switch {
-	case sc.ProjectDomainName != "":
-		authOpts.Scope = &gophercloud.AuthScope{
-			DomainName: sc.ProjectDomainName,
-		}
-	case sc.ProjectDomainID != "":
-		authOpts.Scope = &gophercloud.AuthScope{
-			DomainID: sc.ProjectDomainID,
-		}
-	}
-	if authOpts.Scope != nil {
-		switch {
-		case sc.ProjectName != "":
-			authOpts.Scope.ProjectName = sc.ProjectName
-		case sc.ProjectID != "":
-			authOpts.Scope.ProjectID = sc.ProjectID
-		}
-	}
-	return authOpts
-}
-
-func (c *Container) createContainer(name string) error {
-	return containers.Create(c.client, name, nil).Err
-}
-
-func (c *Container) deleteContainer(name string) error {
-	return containers.Delete(c.client, name).Err
-}
-
-func configFromEnv() SwiftConfig {
-	c := SwiftConfig{
-		AuthUrl:           os.Getenv("OS_AUTH_URL"),
-		Username:          os.Getenv("OS_USERNAME"),
-		Password:          os.Getenv("OS_PASSWORD"),
-		RegionName:        os.Getenv("OS_REGION_NAME"),
-		ContainerName:     os.Getenv("OS_CONTAINER_NAME"),
-		ProjectID:         os.Getenv("OS_PROJECT_ID"),
-		ProjectName:       os.Getenv("OS_PROJECT_NAME"),
-		UserDomainID:      os.Getenv("OS_USER_DOMAIN_ID"),
-		UserDomainName:    os.Getenv("OS_USER_DOMAIN_NAME"),
-		ProjectDomainID:   os.Getenv("OS_PROJECT_DOMAIN_ID"),
-		ProjectDomainName: os.Getenv("OS_PROJECT_DOMAIN_NAME"),
-	}
-
-	return c
-}
-
-// validateForTests checks to see the config options for tests are set.
-func validateForTests(conf SwiftConfig) error {
-	if conf.AuthUrl == "" ||
-		conf.Username == "" ||
-		conf.Password == "" ||
-		(conf.ProjectName == "" && conf.ProjectID == "") ||
-		conf.RegionName == "" {
-		return errors.New("insufficient swift test configuration information")
-	}
-	return nil
-}
-
 // NewTestContainer creates test objStore client that before returning creates temporary container.
 // In a close function it empties and deletes the container.
 func NewTestContainer(t testing.TB) (objstore.Bucket, func(), error) {
-	config := configFromEnv()
-	if err := validateForTests(config); err != nil {
-		return nil, nil, err
-	}
-	containerConfig, err := yaml.Marshal(config)
+	config, err := configFromEnv()
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, errors.Wrap(err, "swift loading config from ENV")
 	}
-
-	c, err := NewContainer(log.NewNopLogger(), containerConfig)
-	if err != nil {
-		return nil, nil, err
-	}
-
 	if config.ContainerName != "" {
 		if os.Getenv("THANOS_ALLOW_EXISTING_BUCKET_USE") == "" {
 			return nil, nil, errors.New("OS_CONTAINER_NAME is defined. Normally this tests will create temporary container " +
@@ -299,30 +346,34 @@ func NewTestContainer(t testing.TB) (objstore.Bucket, func(), error) {
 				"needs to be manually cleared. This means that it is only useful to run one test in a time. This is due " +
 				"to safety (accidentally pointing prod container for test) as well as swift not being fully strong consistent.")
 		}
-
-		if err := c.Iter(context.Background(), "", func(f string) error {
-			return errors.Errorf("container %s is not empty", config.ContainerName)
-		}); err != nil {
-			return nil, nil, errors.Wrapf(err, "swift check container %s", config.ContainerName)
+		c, err := NewContainerFromConfig(log.NewNopLogger(), config, false)
+		if err != nil {
+			return nil, nil, errors.Wrap(err, "swift initializing new container")
 		}
-
-		t.Log("WARNING. Reusing", config.ContainerName, "container for Swift tests. Manual cleanup afterwards is required")
+		if err := c.Iter(context.Background(), "", func(f string) error {
+			return errors.Errorf("container %s is not empty", c.Name())
+		}); err != nil {
+			return nil, nil, errors.Wrapf(err, "swift check container %s", c.Name())
+		}
+		t.Log("WARNING. Reusing", c.Name(), "container for Swift tests. Manual cleanup afterwards is required")
 		return c, func() {}, nil
 	}
-
-	tmpContainerName := objstore.CreateTemporaryTestBucketName(t)
-
-	if err := c.createContainer(tmpContainerName); err != nil {
-		return nil, nil, err
+	config.ContainerName = objstore.CreateTemporaryTestBucketName(t)
+	config.SegmentContainerName = config.ContainerName
+	c, err := NewContainerFromConfig(log.NewNopLogger(), config, true)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "swift initializing new container")
 	}
-
-	c.name = tmpContainerName
-	t.Log("created temporary container for swift tests with name", tmpContainerName)
+	t.Log("created temporary container for swift tests with name", c.Name())
 
 	return c, func() {
 		objstore.EmptyBucket(t, context.Background(), c)
-		if err := c.deleteContainer(tmpContainerName); err != nil {
-			t.Logf("deleting container %s failed: %s", tmpContainerName, err)
+		time.Sleep(time.Second)
+		if err := c.connection.ContainerDelete(c.name); err != nil {
+			t.Logf("deleting container %s failed: %s", c.Name(), err)
+		}
+		if err := c.connection.ContainerDelete(c.segmentsContainer); err != nil {
+			t.Logf("deleting segments container %s failed: %s", c.segmentsContainer, err)
 		}
 	}, nil
 }

--- a/pkg/objstore/swift/swift.go
+++ b/pkg/objstore/swift/swift.go
@@ -360,7 +360,6 @@ func NewTestContainer(t testing.TB) (objstore.Bucket, func(), error) {
 
 	return c, func() {
 		objstore.EmptyBucket(t, context.Background(), c)
-		time.Sleep(time.Second)
 		if err := c.connection.ContainerDelete(c.name); err != nil {
 			t.Logf("deleting container %s failed: %s", c.Name(), err)
 		}

--- a/pkg/objstore/swift/swift.go
+++ b/pkg/objstore/swift/swift.go
@@ -31,6 +31,7 @@ import (
 const DirDelim = '/'
 
 var DefaultConfig = Config{
+	AuthVersion:    0, // Means autodetect of the auth API version by the library
 	ChunkSize:      1024 * 1024 * 1024,
 	Retries:        3,
 	ConnectTimeout: "10s",

--- a/pkg/objstore/swift/swift.go
+++ b/pkg/objstore/swift/swift.go
@@ -31,7 +31,7 @@ import (
 const DirDelim = '/'
 
 var DefaultConfig = Config{
-	AuthVersion:    0, // Means autodetect of the auth API version by the library
+	AuthVersion:    0, // Means autodetect of the auth API version by the library.
 	ChunkSize:      1024 * 1024 * 1024,
 	Retries:        3,
 	ConnectTimeout: "10s",

--- a/pkg/objstore/swift/swift.go
+++ b/pkg/objstore/swift/swift.go
@@ -185,16 +185,15 @@ func NewContainerFromConfig(logger log.Logger, sc *Config, createContainer bool)
 	} else if _, err := ensureContainer(connection, sc.SegmentContainerName, createContainer); err != nil {
 		return nil, err
 	}
-}
 
-container := Container{
-logger:            logger,
-name:              sc.ContainerName,
-connection:        connection,
-chunkSize:         sc.ChunkSize,
-segmentsContainer: sc.SegmentContainerName,
-}
-return &container, nil
+	container := Container{
+		logger:            logger,
+		name:              sc.ContainerName,
+		connection:        connection,
+		chunkSize:         sc.ChunkSize,
+		segmentsContainer: sc.SegmentContainerName,
+	}
+	return &container, nil
 }
 
 // Name returns the container name for swift.

--- a/pkg/objstore/swift/swift.go
+++ b/pkg/objstore/swift/swift.go
@@ -183,18 +183,18 @@ func NewContainerFromConfig(logger log.Logger, sc *Config, createContainer bool)
 	if sc.SegmentContainerName == "" {
 		sc.SegmentContainerName = sc.ContainerName
 	} else if _, err := ensureContainer(connection, sc.SegmentContainerName, createContainer); err != nil {
-			return nil, err
-		}
+		return nil, err
 	}
+}
 
-	container := Container{
-		logger:            logger,
-		name:              sc.ContainerName,
-		connection:        connection,
-		chunkSize:         sc.ChunkSize,
-		segmentsContainer: sc.SegmentContainerName,
-	}
-	return &container, nil
+container := Container{
+logger:            logger,
+name:              sc.ContainerName,
+connection:        connection,
+chunkSize:         sc.ChunkSize,
+segmentsContainer: sc.SegmentContainerName,
+}
+return &container, nil
 }
 
 // Name returns the container name for swift.
@@ -265,10 +265,10 @@ func (c *Container) Attributes(ctx context.Context, name string) (objstore.Objec
 // Exists checks if the given object exists.
 func (c *Container) Exists(ctx context.Context, name string) (bool, error) {
 	_, _, err := c.connection.Object(c.name, name)
+	if c.IsObjNotFoundErr(err) {
+		err = nil
+	}
 	if err != nil {
-		if c.IsObjNotFoundErr(err) {
-			err = nil
-		}
 		return false, errors.Wrap(err, "swift check if file exists")
 	}
 	return true, nil

--- a/pkg/objstore/swift/swift.go
+++ b/pkg/objstore/swift/swift.go
@@ -182,8 +182,7 @@ func NewContainerFromConfig(logger log.Logger, sc *Config, createContainer bool)
 	}
 	if sc.SegmentContainerName == "" {
 		sc.SegmentContainerName = sc.ContainerName
-	} else {
-		if _, err := ensureContainer(connection, sc.SegmentContainerName, createContainer); err != nil {
+	} else if _, err := ensureContainer(connection, sc.SegmentContainerName, createContainer); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/objstore/swift/swift.go
+++ b/pkg/objstore/swift/swift.go
@@ -106,7 +106,7 @@ func configFromEnv() (*Config, error) {
 	return &config, nil
 }
 
-func connectionFromConfig(sc *Config) (*swift.Connection, error) {
+func connectionFromConfig(sc *Config) *swift.Connection {
 	connection := swift.Connection{
 		Domain:         sc.DomainName,
 		DomainId:       sc.DomainId,
@@ -124,7 +124,7 @@ func connectionFromConfig(sc *Config) (*swift.Connection, error) {
 		ConnectTimeout: time.Duration(sc.ConnectTimeout),
 		Timeout:        time.Duration(sc.Timeout),
 	}
-	return &connection, nil
+	return &connection
 }
 
 type Container struct {
@@ -160,11 +160,7 @@ func ensureContainer(connection *swift.Connection, name string, createIfNotExist
 }
 
 func NewContainerFromConfig(logger log.Logger, sc *Config, createContainer bool) (*Container, error) {
-	connection, err := connectionFromConfig(sc)
-	if err != nil {
-		return nil, errors.Wrap(err, "swift load config")
-	}
-
+	connection := connectionFromConfig(sc)
 	if err := connection.Authenticate(); err != nil {
 		return nil, errors.Wrap(err, "swift authentication")
 	}

--- a/pkg/objstore/swift/swift.go
+++ b/pkg/objstore/swift/swift.go
@@ -42,27 +42,31 @@ var DefaultConfig = Config{
 	Timeout:        model.Duration(5 * time.Minute),
 }
 
+// TODO(FUSAKLA): Added to avoid breaking dependency of Cortex which uses the original struct name SwiftConfig.
+type SwiftConfig Config
+
 type Config struct {
-	AuthVersion          int            `yaml:"auth_version"`
-	AuthUrl              string         `yaml:"auth_url"`
-	Username             string         `yaml:"username"`
-	UserDomainName       string         `yaml:"user_domain_name"`
-	UserDomainID         string         `yaml:"user_domain_id"`
-	UserId               string         `yaml:"user_id"`
-	Password             string         `yaml:"password"`
-	DomainId             string         `yaml:"domain_id"`
-	DomainName           string         `yaml:"domain_name"`
-	ProjectID            string         `yaml:"project_id"`
-	ProjectName          string         `yaml:"project_name"`
-	ProjectDomainID      string         `yaml:"project_domain_id"`
-	ProjectDomainName    string         `yaml:"project_domain_name"`
-	RegionName           string         `yaml:"region_name"`
-	ContainerName        string         `yaml:"container_name"`
-	ChunkSize            int64          `yaml:"large_object_chunk_size"`
-	SegmentContainerName string         `yaml:"large_object_segments_container_name"`
-	Retries              int            `yaml:"retries"`
-	ConnectTimeout       model.Duration `yaml:"connect_timeout"`
-	Timeout              model.Duration `yaml:"timeout"`
+	AuthVersion            int            `yaml:"auth_version"`
+	AuthUrl                string         `yaml:"auth_url"`
+	Username               string         `yaml:"username"`
+	UserDomainName         string         `yaml:"user_domain_name"`
+	UserDomainID           string         `yaml:"user_domain_id"`
+	UserId                 string         `yaml:"user_id"`
+	Password               string         `yaml:"password"`
+	DomainId               string         `yaml:"domain_id"`
+	DomainName             string         `yaml:"domain_name"`
+	ProjectID              string         `yaml:"project_id"`
+	ProjectName            string         `yaml:"project_name"`
+	ProjectDomainID        string         `yaml:"project_domain_id"`
+	ProjectDomainName      string         `yaml:"project_domain_name"`
+	RegionName             string         `yaml:"region_name"`
+	ContainerName          string         `yaml:"container_name"`
+	ChunkSize              int64          `yaml:"large_object_chunk_size"`
+	SegmentContainerName   string         `yaml:"large_object_segments_container_name"`
+	Retries                int            `yaml:"retries"`
+	ConnectTimeout         model.Duration `yaml:"connect_timeout"`
+	Timeout                model.Duration `yaml:"timeout"`
+	UseDynamicLargeObjects bool           `yaml:"use_dynamic_large_objects"`
 }
 
 func parseConfig(conf []byte) (*Config, error) {
@@ -78,23 +82,25 @@ func configFromEnv() (*Config, error) {
 	}
 
 	config := Config{
-		AuthVersion:          c.AuthVersion,
-		AuthUrl:              c.AuthUrl,
-		Password:             c.ApiKey,
-		Username:             c.UserName,
-		UserId:               c.UserId,
-		DomainId:             c.DomainId,
-		DomainName:           c.Domain,
-		ProjectID:            c.TenantId,
-		ProjectName:          c.Tenant,
-		ProjectDomainID:      c.TenantDomainId,
-		ProjectDomainName:    c.TenantDomain,
-		RegionName:           c.Region,
-		ContainerName:        os.Getenv("OS_CONTAINER_NAME"),
-		SegmentContainerName: os.Getenv("SWIFT_SEGMENTS_CONTAINER_NAME"),
-		Retries:              c.Retries,
-		ConnectTimeout:       model.Duration(c.ConnectTimeout),
-		Timeout:              model.Duration(c.Timeout),
+		AuthVersion:            c.AuthVersion,
+		AuthUrl:                c.AuthUrl,
+		Password:               c.ApiKey,
+		Username:               c.UserName,
+		UserId:                 c.UserId,
+		DomainId:               c.DomainId,
+		DomainName:             c.Domain,
+		ProjectID:              c.TenantId,
+		ProjectName:            c.Tenant,
+		ProjectDomainID:        c.TenantDomainId,
+		ProjectDomainName:      c.TenantDomain,
+		RegionName:             c.Region,
+		ContainerName:          os.Getenv("OS_CONTAINER_NAME"),
+		ChunkSize:              DefaultConfig.ChunkSize,
+		SegmentContainerName:   os.Getenv("SWIFT_SEGMENTS_CONTAINER_NAME"),
+		Retries:                c.Retries,
+		ConnectTimeout:         model.Duration(c.ConnectTimeout),
+		Timeout:                model.Duration(c.Timeout),
+		UseDynamicLargeObjects: false,
 	}
 	if os.Getenv("SWIFT_CHUNK_SIZE") != "" {
 		var err error
@@ -102,6 +108,9 @@ func configFromEnv() (*Config, error) {
 		if err != nil {
 			return nil, errors.Wrap(err, "swift parsing chunk size")
 		}
+	}
+	if strings.ToLower(os.Getenv("SWIFT_USE_DYNAMIC_LARGE_OBJECTS")) == "true" {
+		config.UseDynamicLargeObjects = true
 	}
 	return &config, nil
 }
@@ -128,17 +137,18 @@ func connectionFromConfig(sc *Config) *swift.Connection {
 }
 
 type Container struct {
-	logger            log.Logger
-	name              string
-	connection        *swift.Connection
-	chunkSize         int64
-	segmentsContainer string
+	logger                 log.Logger
+	name                   string
+	connection             *swift.Connection
+	chunkSize              int64
+	useDynamicLargeObjects bool
+	segmentsContainer      string
 }
 
 func NewContainer(logger log.Logger, conf []byte) (*Container, error) {
 	sc, err := parseConfig(conf)
 	if err != nil {
-		return nil, errors.Wrap(err, "swift parse configs")
+		return nil, errors.Wrap(err, "swift parse config")
 	}
 	return NewContainerFromConfig(logger, sc, false)
 }
@@ -175,11 +185,12 @@ func NewContainerFromConfig(logger log.Logger, sc *Config, createContainer bool)
 	}
 
 	return &Container{
-		logger:            logger,
-		name:              sc.ContainerName,
-		connection:        connection,
-		chunkSize:         sc.ChunkSize,
-		segmentsContainer: sc.SegmentContainerName,
+		logger:                 logger,
+		name:                   sc.ContainerName,
+		connection:             connection,
+		chunkSize:              sc.ChunkSize,
+		useDynamicLargeObjects: sc.UseDynamicLargeObjects,
+		segmentsContainer:      sc.SegmentContainerName,
 	}, nil
 }
 
@@ -213,7 +224,7 @@ func (c *Container) Iter(_ context.Context, dir string, f func(string) error) er
 
 func (c *Container) get(name string, headers swift.Headers, checkHash bool) (io.ReadCloser, error) {
 	if name == "" {
-		return nil, errors.New("Object name cannot be empty")
+		return nil, errors.New("object name cannot be empty")
 	}
 	file, _, err := c.connection.ObjectOpen(c.name, name, checkHash, headers)
 	if err != nil {
@@ -239,7 +250,7 @@ func (c *Container) GetRange(_ context.Context, name string, off, length int64) 
 // Attributes returns information about the specified object.
 func (c *Container) Attributes(_ context.Context, name string) (objstore.ObjectAttributes, error) {
 	if name == "" {
-		return objstore.ObjectAttributes{}, errors.New("Object name cannot be empty")
+		return objstore.ObjectAttributes{}, errors.New("object name cannot be empty")
 	}
 	info, _, err := c.connection.Object(c.name, name)
 	if err != nil {
@@ -277,13 +288,18 @@ func (c *Container) Upload(_ context.Context, name string, r io.Reader) error {
 	}
 	var file io.WriteCloser
 	if size >= c.chunkSize {
-		file, err = c.connection.StaticLargeObjectCreateFile(&swift.LargeObjectOpts{
+		opts := swift.LargeObjectOpts{
 			Container:        c.name,
 			ObjectName:       name,
 			ChunkSize:        c.chunkSize,
 			SegmentContainer: c.segmentsContainer,
 			CheckHash:        true,
-		})
+		}
+		if c.useDynamicLargeObjects {
+			file, err = c.connection.DynamicLargeObjectCreateFile(&opts)
+		} else {
+			file, err = c.connection.StaticLargeObjectCreateFile(&opts)
+		}
 	} else {
 		file, err = c.connection.ObjectCreate(c.name, name, true, "", "", swift.Headers{})
 	}

--- a/pkg/objstore/swift/swift_test.go
+++ b/pkg/objstore/swift/swift_test.go
@@ -34,20 +34,3 @@ tenant_name: something`)
 	// Must result in unmarshal error as there's no `tenant_name` in SwiftConfig.
 	testutil.NotOk(t, err)
 }
-
-func TestAuthOptsFromConfig(t *testing.T) {
-	input := &SwiftConfig{
-		AuthUrl:           "http://identity.something.com/v3",
-		Username:          "thanos",
-		UserDomainName:    "userDomain",
-		ProjectName:       "thanosProject",
-		ProjectDomainName: "projectDomain",
-	}
-
-	authOpts := authOptsFromConfig(input)
-	testutil.Equals(t, "http://identity.something.com/v3", authOpts.IdentityEndpoint)
-	testutil.Equals(t, "thanos", authOpts.Username)
-	testutil.Equals(t, "userDomain", authOpts.DomainName)
-	testutil.Equals(t, "projectDomain", authOpts.Scope.DomainName)
-	testutil.Equals(t, "thanosProject", authOpts.Scope.ProjectName)
-}

--- a/scripts/cfggen/main.go
+++ b/scripts/cfggen/main.go
@@ -43,7 +43,7 @@ var (
 		client.AZURE:      azure.Config{},
 		client.GCS:        gcs.Config{},
 		client.S3:         s3.DefaultConfig,
-		client.SWIFT:      swift.SwiftConfig{},
+		client.SWIFT:      swift.DefaultConfig,
 		client.COS:        cos.Config{},
 		client.ALIYUNOSS:  oss.Config{},
 		client.FILESYSTEM: filesystem.Config{},


### PR DESCRIPTION
Resolves #2678 
Closes #2665 

As described in the issue, switch to new library to communicate with swift which supports large file types.

I also changed the maintainer of the swift integration to me since if this would be accepted, there would be not much of the old codebase left so it felt fair not to leave the burden on @sudhi-vm.

It supports also working with the large objects which was limit of the previous library.

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes
- switched to new library for Swift API
- added support for large files (description in docs)
- added timeouts for Swift API 

## Verification

All tests are passing, tried running it as a sidecar, compactor and store for now on real workload.
Works well but will continue testing it with higher load and  bigger blocks. 

Eventually would like to migrate production on it.