### PR TITLE
pkg/ui: simplify SanitizePrefix func

### DIFF
--- a/pkg/ui/ui.go
+++ b/pkg/ui/ui.go
@@ -183,10 +183,7 @@ func SanitizePrefix(prefix string) (string, error) {
 
 	// Remove double slashes, convert to absolute path.
 	sanitizedPrefix := strings.TrimPrefix(path.Clean(u.Path), ".")
-
-	if strings.HasSuffix(sanitizedPrefix, "/") {
-		sanitizedPrefix = strings.TrimSuffix(sanitizedPrefix, "/")
-	}
+	sanitizedPrefix = strings.TrimSuffix(sanitizedPrefix, "/")
 
 	return sanitizedPrefix, nil
 }


### PR DESCRIPTION
This commit simplifies the SanitizePrefix func to remove an unecessary
call to `strings.HasSuffix`. The `strings.TrimSuffix` func internally
calls `strings.HasSuffix`, so there is an unneeded, extra call.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>

* [x] Change is not relevant to the end user.

cc @prmsrswt @GiedriusS 
