### PR TITLE
test/e2e: Use new testing.Cleanup

### DIFF
--- a/test/e2e/compact_test.go
+++ b/test/e2e/compact_test.go
@@ -271,7 +271,7 @@ func TestCompactWithStoreGateway(t *testing.T) {
 
 	s, err := e2e.NewScenario("e2e_test_compact")
 	testutil.Ok(t, err)
-	defer s.Close() // TODO(kakkoyun): Change with t.CleanUp after go 1.14 update.
+	t.Cleanup(s.Close)
 
 	dir := filepath.Join(s.SharedDir(), "tmp")
 	testutil.Ok(t, os.MkdirAll(dir, os.ModePerm))
@@ -290,7 +290,7 @@ func TestCompactWithStoreGateway(t *testing.T) {
 	testutil.Ok(t, err)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
-	defer cancel() // TODO(kakkoyun): Change with t.CleanUp after go 1.14 update.
+	t.Cleanup(cancel)
 
 	rawBlockIDs := map[ulid.ULID]struct{}{}
 	for _, b := range blocks {
@@ -384,7 +384,7 @@ func TestCompactWithStoreGateway(t *testing.T) {
 	testutil.Ok(t, s.StartAndWaitReady(q))
 
 	ctx, cancel = context.WithTimeout(context.Background(), 3*time.Minute)
-	defer cancel()
+	t.Cleanup(cancel)
 
 	// Check if query detects current series, even if overlapped.
 	queryAndAssert(t, ctx, q.HTTPEndpoint(),
@@ -530,7 +530,7 @@ func TestCompactWithStoreGateway(t *testing.T) {
 		testutil.Ok(t, s.Stop(c))
 
 		ctx, cancel = context.WithTimeout(context.Background(), 3*time.Minute)
-		defer cancel()
+		t.Cleanup(cancel)
 
 		// Check if query detects new blocks.
 		queryAndAssert(t, ctx, q.HTTPEndpoint(),
@@ -575,7 +575,7 @@ func TestCompactWithStoreGateway(t *testing.T) {
 		testutil.Ok(t, s.Stop(c))
 
 		ctx, cancel = context.WithTimeout(context.Background(), 3*time.Minute)
-		defer cancel()
+		t.Cleanup(cancel)
 
 		// Check if query detects new blocks.
 		queryAndAssert(t, ctx, q.HTTPEndpoint(),

--- a/test/e2e/query_test.go
+++ b/test/e2e/query_test.go
@@ -82,7 +82,7 @@ func TestQuery(t *testing.T) {
 
 	s, err := e2e.NewScenario("e2e_test_query")
 	testutil.Ok(t, err)
-	defer s.Close()
+	t.Cleanup(s.Close)
 
 	receiver, err := e2ethanos.NewReceiver(s.SharedDir(), s.NetworkName(), "1", 1)
 	testutil.Ok(t, err)
@@ -104,7 +104,7 @@ func TestQuery(t *testing.T) {
 	testutil.Ok(t, s.StartAndWaitReady(q))
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
-	defer cancel()
+	t.Cleanup(cancel)
 
 	testutil.Ok(t, q.WaitSumMetrics(e2e.Equals(5), "thanos_store_nodes_grpc_connections"))
 
@@ -170,7 +170,7 @@ func TestQueryRoutePrefix(t *testing.T) {
 
 	s, err := e2e.NewScenario("e2e_test_query_route_prefix")
 	testutil.Ok(t, err)
-	defer s.Close()
+	t.Cleanup(s.Close)
 
 	q, err := e2ethanos.NewQuerier(
 		s.SharedDir(), "1",
@@ -183,7 +183,7 @@ func TestQueryRoutePrefix(t *testing.T) {
 	testutil.Ok(t, s.StartAndWaitReady(q))
 
 	ctx, cancel := chromedp.NewContext(context.Background())
-	defer cancel()
+	t.Cleanup(cancel)
 
 	var networkErrors []string
 

--- a/test/e2e/receive_test.go
+++ b/test/e2e/receive_test.go
@@ -24,7 +24,7 @@ func TestReceive(t *testing.T) {
 
 		s, err := e2e.NewScenario("e2e_test_receive_hashring")
 		testutil.Ok(t, err)
-		defer s.Close()
+		t.Cleanup(s.Close)
 
 		// The hashring suite creates three receivers, each with a Prometheus
 		// remote-writing data to it. However, due to the hashing of the labels,
@@ -69,7 +69,7 @@ func TestReceive(t *testing.T) {
 		testutil.Ok(t, s.StartAndWaitReady(q))
 
 		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
-		defer cancel()
+		t.Cleanup(cancel)
 
 		testutil.Ok(t, q.WaitSumMetrics(e2e.Equals(3), "thanos_store_nodes_grpc_connections"))
 
@@ -105,7 +105,7 @@ func TestReceive(t *testing.T) {
 
 		s, err := e2e.NewScenario("e2e_test_receive_replication")
 		testutil.Ok(t, err)
-		defer s.Close()
+		t.Cleanup(s.Close)
 
 		// The replication suite creates three receivers but only one
 		// receives Prometheus remote-written data. The querier queries all
@@ -144,7 +144,7 @@ func TestReceive(t *testing.T) {
 		testutil.Ok(t, s.StartAndWaitReady(q))
 
 		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
-		defer cancel()
+		t.Cleanup(cancel)
 
 		testutil.Ok(t, q.WaitSumMetrics(e2e.Equals(3), "thanos_store_nodes_grpc_connections"))
 
@@ -180,7 +180,7 @@ func TestReceive(t *testing.T) {
 
 		s, err := e2e.NewScenario("e2e_test_receive_replication_with_outage")
 		testutil.Ok(t, err)
-		defer s.Close()
+		t.Cleanup(s.Close)
 
 		// The replication suite creates a three-node hashring but one of the
 		// receivers is dead. In this case, replication should still
@@ -216,7 +216,7 @@ func TestReceive(t *testing.T) {
 		testutil.Ok(t, s.StartAndWaitReady(q))
 
 		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
-		defer cancel()
+		t.Cleanup(cancel)
 
 		testutil.Ok(t, q.WaitSumMetrics(e2e.Equals(2), "thanos_store_nodes_grpc_connections"))
 

--- a/test/e2e/rule_test.go
+++ b/test/e2e/rule_test.go
@@ -207,7 +207,7 @@ func TestRule_AlertmanagerHTTPClient(t *testing.T) {
 
 	s, err := e2e.NewScenario("e2e_test_rule_am_http_client")
 	testutil.Ok(t, err)
-	defer s.Close()
+	t.Cleanup(s.Close)
 
 	tlsSubDir := filepath.Join("tls")
 	testutil.Ok(t, os.MkdirAll(filepath.Join(s.SharedDir(), tlsSubDir), os.ModePerm))
@@ -215,12 +215,12 @@ func TestRule_AlertmanagerHTTPClient(t *testing.T) {
 	// API v1 with plain HTTP and a prefix.
 	handler1 := newMockAlertmanager("/prefix/api/v1/alerts", "")
 	srv1 := httptest.NewServer(handler1)
-	defer srv1.Close()
+	t.Cleanup(srv1.Close)
 
 	// API v2 with HTTPS and authentication.
 	handler2 := newMockAlertmanager("/api/v2/alerts", "secret")
 	srv2 := httptest.NewTLSServer(handler2)
-	defer srv2.Close()
+	t.Cleanup(srv2.Close)
 
 	var out bytes.Buffer
 	testutil.Ok(t, pem.Encode(&out, &pem.Block{Type: "CERTIFICATE", Bytes: srv2.TLS.Certificates[0].Certificate[0]}))
@@ -275,7 +275,7 @@ func TestRule_AlertmanagerHTTPClient(t *testing.T) {
 	testutil.Ok(t, s.StartAndWaitReady(q))
 
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
-	defer cancel()
+	t.Cleanup(cancel)
 
 	testutil.Ok(t, runutil.Retry(5*time.Second, ctx.Done(), func() (err error) {
 		for i, am := range []*mockAlertmanager{handler1, handler2} {
@@ -293,10 +293,10 @@ func TestRule(t *testing.T) {
 
 	s, err := e2e.NewScenario("e2e_test_rule")
 	testutil.Ok(t, err)
-	defer s.Close()
+	t.Cleanup(s.Close)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
-	defer cancel()
+	t.Cleanup(cancel)
 
 	// Prepare work dirs.
 	rulesSubDir := filepath.Join("rules")

--- a/test/e2e/rules_api_test.go
+++ b/test/e2e/rules_api_test.go
@@ -31,7 +31,7 @@ func TestRulesAPI_Fanout(t *testing.T) {
 
 	s, err := e2e.NewScenario(netName)
 	testutil.Ok(t, err)
-	defer s.Close()
+	t.Cleanup(s.Close)
 
 	rulesSubDir := filepath.Join("rules")
 	testutil.Ok(t, os.MkdirAll(filepath.Join(s.SharedDir(), rulesSubDir), os.ModePerm))
@@ -76,7 +76,7 @@ func TestRulesAPI_Fanout(t *testing.T) {
 	testutil.Ok(t, s.StartAndWaitReady(q))
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
-	defer cancel()
+	t.Cleanup(cancel)
 
 	testutil.Ok(t, q.WaitSumMetrics(e2e.Equals(4), "thanos_store_nodes_grpc_connections"))
 

--- a/test/e2e/store_gateway_test.go
+++ b/test/e2e/store_gateway_test.go
@@ -36,7 +36,7 @@ func TestStoreGateway(t *testing.T) {
 
 	s, err := e2e.NewScenario("e2e_test_store_gateway")
 	testutil.Ok(t, err)
-	defer s.Close()
+	t.Cleanup(s.Close)
 
 	m := e2edb.NewMinio(80, "thanos")
 	testutil.Ok(t, s.StartAndWaitReady(m))
@@ -74,7 +74,7 @@ func TestStoreGateway(t *testing.T) {
 	extLset4 := labels.FromStrings("ext1", "value1", "replica", "3")
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
-	defer cancel()
+	t.Cleanup(cancel)
 
 	now := time.Now()
 	id1, err := e2eutil.CreateBlockWithBlockDelay(ctx, dir, series, 10, timestamp.FromTime(now), timestamp.FromTime(now.Add(2*time.Hour)), 30*time.Minute, extLset, 0)


### PR DESCRIPTION
Signed-off-by: Kemal Akkoyun <kakkoyun@gmail.com>

* [X] Change is not relevant to the end user.

## Changes

* Clean up TODOs
* Use new testing.Cleanup for end-to-end tests

## Verification

* `make test-local`
* `make test-e2e`
