### PR TITLE
Upgrade Prometheus to fix merge adapter bug

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -47,7 +47,7 @@ require (
 	github.com/prometheus/client_golang v1.6.0
 	github.com/prometheus/client_model v0.2.0
 	github.com/prometheus/common v0.10.0
-	github.com/prometheus/prometheus v1.8.2-0.20200601152113-3268eac2ddda
+	github.com/prometheus/prometheus v1.8.2-0.20200609165731-66dfb951c4ca
 	github.com/sercand/kuberesolver v2.4.0+incompatible // indirect
 	github.com/uber/jaeger-client-go v2.23.0+incompatible
 	github.com/uber/jaeger-lib v2.2.0+incompatible


### PR DESCRIPTION
* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

Upgrade Prometheus to include the merge adapter bug fix https://github.com/prometheus/prometheus/pull/7369, introduced in Thanos by https://github.com/thanos-io/thanos/pull/2596.

This bug shouldn't affect Thanos (reason why I haven't opened a PR against the `0.13` branch) but it's safer to upgrade the vendored Prometheus. The reason why this bug shouldn't affect Thanos is because `storage.NewMergeSeriesSet()` is only used by the series API, but the resulting `SeriesSet` is iterated sequentially (the bug is triggered when the result of an iteration is retained).

## Verification

_Existing tests_
