### PR TITLE
compact: introduce flag --wait-sync-block-duration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 - [#2671](https://github.com/thanos-io/thanos/pull/2671) Tools: bucket replicate now allows passing repeated `--compaction` and `--resolution` flags.
 - [#2657](https://github.com/thanos-io/thanos/pull/2657) Querier: Now, has the ability to perform concurrent select request per query.
 - [#2754](https://github.com/thanos-io/thanos/pull/2671) UI: add stores page in the React UI.
+- [#2752](https://github.com/thanos-io/thanos/pull/2752) Compact: add flag `--block-viewer.global.sync-block-interval` to configure metadata sync interval for the bucket UI.
 
 ## [v0.13.0](https://github.com/thanos-io/thanos/releases/tag/v0.13.0) - 2020.06.22
 

--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -400,7 +400,7 @@ func runCompact(
 			iterCancel()
 
 			// For /global state make sure to fetch periodically.
-			return runutil.Repeat(time.Minute, ctx.Done(), func() error {
+			return runutil.Repeat(conf.blockViewerSyncBlockInterval, ctx.Done(), func() error {
 				return runutil.RetryWithLog(logger, time.Minute, ctx.Done(), func() error {
 					iterCtx, iterCancel := context.WithTimeout(ctx, conf.waitInterval)
 					defer iterCancel()
@@ -435,6 +435,7 @@ type compactConfig struct {
 	waitInterval                                   time.Duration
 	disableDownsampling                            bool
 	blockSyncConcurrency                           int
+	blockViewerSyncBlockInterval                   time.Duration
 	compactionConcurrency                          int
 	deleteDelay                                    model.Duration
 	dedupReplicaLabels                             []string
@@ -482,6 +483,8 @@ func (cc *compactConfig) registerFlag(cmd *kingpin.CmdClause) *compactConfig {
 
 	cmd.Flag("block-sync-concurrency", "Number of goroutines to use when syncing block metadata from object storage.").
 		Default("20").IntVar(&cc.blockSyncConcurrency)
+	cmd.Flag("block-viewer.global.sync-block-interval", "Repeat interval for syncing the blocks between local and remote view for /global Block Viewer UI.").
+		Default("1m").DurationVar(&cc.blockViewerSyncBlockInterval)
 
 	cmd.Flag("compact.concurrency", "Number of goroutines to use when compacting groups.").
 		Default("1").IntVar(&cc.compactionConcurrency)

--- a/docs/components/compact.md
+++ b/docs/components/compact.md
@@ -143,6 +143,10 @@ Flags:
       --block-sync-concurrency=20
                                 Number of goroutines to use when syncing block
                                 metadata from object storage.
+      --block-viewer.global.sync-block-interval=1m
+                                Repeat interval for syncing the blocks between
+                                local and remote view for /global Block Viewer
+                                UI.
       --compact.concurrency=1   Number of goroutines to use when compacting
                                 groups.
       --delete-delay=48h        Time before a block marked for deletion is


### PR DESCRIPTION
Thanos compact currently does metadata sync every minute if `--wait` is
active. Thanos store has a equivalent flag named `sync-block-duration`.
This commit introduces `--wait-sync-block-duration` to be able to
configure the interval via a flag.

Resolves #2642 

Signed-off-by: Schlotter, Christian <christi.schlotter@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.

## Changes

* added flag `--wait-sync-block-duration` to compact command
* used value of flag instead of hardcoded time.Minute

## Verification

Run it in production
