### PR TITLE
test/e2e: Make sure clean test files cleaned

### DIFF
--- a/test/e2e/compact_test.go
+++ b/test/e2e/compact_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/pkg/timestamp"
+
 	"github.com/thanos-io/thanos/pkg/block"
 	"github.com/thanos-io/thanos/pkg/block/metadata"
 	"github.com/thanos-io/thanos/pkg/objstore"
@@ -286,7 +287,7 @@ func TestCompactWithStoreGateway(t *testing.T) {
 
 	s, err := e2e.NewScenario("e2e_test_compact")
 	testutil.Ok(t, err)
-	t.Cleanup(s.Close)
+	t.Cleanup(e2ethanos.CleanScenario(t, s))
 
 	dir := filepath.Join(s.SharedDir(), "tmp")
 	testutil.Ok(t, os.MkdirAll(dir, os.ModePerm))

--- a/test/e2e/e2ethanos/helpers.go
+++ b/test/e2e/e2ethanos/helpers.go
@@ -14,10 +14,8 @@ import (
 
 func CleanScenario(t *testing.T, s *e2e.Scenario) func() {
 	return func() {
-		// Otherwise close will fail.
-		out, err := exec.Command("chmod", "-R", "777", s.SharedDir()).CombinedOutput()
-		t.Log("command out", string(out))
-		testutil.Ok(t, err)
+		// Make sure Clean can properly delete everything.
+		testutil.Ok(t, exec.Command("chmod", "-R", "777", s.SharedDir()).Run())
 		s.Close()
 	}
 }

--- a/test/e2e/e2ethanos/helpers.go
+++ b/test/e2e/e2ethanos/helpers.go
@@ -1,0 +1,23 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package e2ethanos
+
+import (
+	"os/exec"
+	"testing"
+
+	"github.com/cortexproject/cortex/integration/e2e"
+
+	"github.com/thanos-io/thanos/pkg/testutil"
+)
+
+func CleanScenario(t *testing.T, s *e2e.Scenario) func() {
+	return func() {
+		// Otherwise close will fail.
+		out, err := exec.Command("chmod", "-R", "777", s.SharedDir()).CombinedOutput()
+		t.Log("command out", string(out))
+		testutil.Ok(t, err)
+		s.Close()
+	}
+}

--- a/test/e2e/query_test.go
+++ b/test/e2e/query_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/go-kit/kit/log"
 	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
+
 	"github.com/thanos-io/thanos/pkg/promclient"
 	"github.com/thanos-io/thanos/pkg/runutil"
 	"github.com/thanos-io/thanos/pkg/testutil"
@@ -82,7 +83,7 @@ func TestQuery(t *testing.T) {
 
 	s, err := e2e.NewScenario("e2e_test_query")
 	testutil.Ok(t, err)
-	t.Cleanup(s.Close)
+	t.Cleanup(e2ethanos.CleanScenario(t, s))
 
 	receiver, err := e2ethanos.NewReceiver(s.SharedDir(), s.NetworkName(), "1", 1)
 	testutil.Ok(t, err)
@@ -170,7 +171,7 @@ func TestQueryRoutePrefix(t *testing.T) {
 
 	s, err := e2e.NewScenario("e2e_test_query_route_prefix")
 	testutil.Ok(t, err)
-	t.Cleanup(s.Close)
+	t.Cleanup(e2ethanos.CleanScenario(t, s))
 
 	q, err := e2ethanos.NewQuerier(
 		s.SharedDir(), "1",

--- a/test/e2e/query_test.go
+++ b/test/e2e/query_test.go
@@ -91,7 +91,7 @@ func TestQuery(t *testing.T) {
 
 	prom1, sidecar1, err := e2ethanos.NewPrometheusWithSidecar(s.SharedDir(), "e2e_test_query", "alone", defaultPromConfig("prom-alone", 0, "", ""), e2ethanos.DefaultPrometheusImage())
 	testutil.Ok(t, err)
-	prom2, sidecar2, err := e2ethanos.NewPrometheusWithSidecar(s.SharedDir(), "e2e_test_query", "remote-and-sidecar", defaultPromConfig("prom-both-remote-write-and-sidecar", 1234, e2ethanos.RemoteWriteEndpoint(receiver.NetworkEndpoint(81)), ""), e2ethanos.DefaultPrometheusImage())
+	prom2, sidecar2, err := e2ethanos.NewPrometheusWithSidecar(s.SharedDir(), "e2e_test_query", "remote-and-sidecar", defaultPromConfig("prom-both-remote-write-and-sidecar", 1234, e2ethanos.RemoteWriteEndpoint(receiver.NetworkEndpoint(8081)), ""), e2ethanos.DefaultPrometheusImage())
 	testutil.Ok(t, err)
 	prom3, sidecar3, err := e2ethanos.NewPrometheusWithSidecar(s.SharedDir(), "e2e_test_query", "ha1", defaultPromConfig("prom-ha", 0, "", filepath.Join(e2e.ContainerSharedDir, "", "*.yaml")), e2ethanos.DefaultPrometheusImage())
 	testutil.Ok(t, err)

--- a/test/e2e/receive_test.go
+++ b/test/e2e/receive_test.go
@@ -57,11 +57,11 @@ func TestReceive(t *testing.T) {
 		testutil.Ok(t, err)
 		testutil.Ok(t, s.StartAndWaitReady(r1, r2, r3))
 
-		prom1, _, err := e2ethanos.NewPrometheus(s.SharedDir(), "1", defaultPromConfig("prom1", 0, e2ethanos.RemoteWriteEndpoint(r1.NetworkEndpoint(81)), ""), e2ethanos.DefaultPrometheusImage())
+		prom1, _, err := e2ethanos.NewPrometheus(s.SharedDir(), "1", defaultPromConfig("prom1", 0, e2ethanos.RemoteWriteEndpoint(r1.NetworkEndpoint(8081)), ""), e2ethanos.DefaultPrometheusImage())
 		testutil.Ok(t, err)
-		prom2, _, err := e2ethanos.NewPrometheus(s.SharedDir(), "2", defaultPromConfig("prom2", 0, e2ethanos.RemoteWriteEndpoint(r2.NetworkEndpoint(81)), ""), e2ethanos.DefaultPrometheusImage())
+		prom2, _, err := e2ethanos.NewPrometheus(s.SharedDir(), "2", defaultPromConfig("prom2", 0, e2ethanos.RemoteWriteEndpoint(r2.NetworkEndpoint(8081)), ""), e2ethanos.DefaultPrometheusImage())
 		testutil.Ok(t, err)
-		prom3, _, err := e2ethanos.NewPrometheus(s.SharedDir(), "3", defaultPromConfig("prom3", 0, e2ethanos.RemoteWriteEndpoint(r3.NetworkEndpoint(81)), ""), e2ethanos.DefaultPrometheusImage())
+		prom3, _, err := e2ethanos.NewPrometheus(s.SharedDir(), "3", defaultPromConfig("prom3", 0, e2ethanos.RemoteWriteEndpoint(r3.NetworkEndpoint(8081)), ""), e2ethanos.DefaultPrometheusImage())
 		testutil.Ok(t, err)
 		testutil.Ok(t, s.StartAndWaitReady(prom1, prom2, prom3))
 
@@ -136,7 +136,7 @@ func TestReceive(t *testing.T) {
 		testutil.Ok(t, err)
 		testutil.Ok(t, s.StartAndWaitReady(r1, r2, r3))
 
-		prom1, _, err := e2ethanos.NewPrometheus(s.SharedDir(), "1", defaultPromConfig("prom1", 0, e2ethanos.RemoteWriteEndpoint(r1.NetworkEndpoint(81)), ""), e2ethanos.DefaultPrometheusImage())
+		prom1, _, err := e2ethanos.NewPrometheus(s.SharedDir(), "1", defaultPromConfig("prom1", 0, e2ethanos.RemoteWriteEndpoint(r1.NetworkEndpoint(8081)), ""), e2ethanos.DefaultPrometheusImage())
 		testutil.Ok(t, err)
 		testutil.Ok(t, s.StartAndWaitReady(prom1))
 
@@ -208,7 +208,7 @@ func TestReceive(t *testing.T) {
 		testutil.Ok(t, err)
 		testutil.Ok(t, s.StartAndWaitReady(r1, r2))
 
-		prom1, _, err := e2ethanos.NewPrometheus(s.SharedDir(), "1", defaultPromConfig("prom1", 0, e2ethanos.RemoteWriteEndpoint(r1.NetworkEndpoint(81)), ""), e2ethanos.DefaultPrometheusImage())
+		prom1, _, err := e2ethanos.NewPrometheus(s.SharedDir(), "1", defaultPromConfig("prom1", 0, e2ethanos.RemoteWriteEndpoint(r1.NetworkEndpoint(8081)), ""), e2ethanos.DefaultPrometheusImage())
 		testutil.Ok(t, err)
 		testutil.Ok(t, s.StartAndWaitReady(prom1))
 

--- a/test/e2e/receive_test.go
+++ b/test/e2e/receive_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/cortexproject/cortex/integration/e2e"
 	"github.com/prometheus/common/model"
+
 	"github.com/thanos-io/thanos/pkg/promclient"
 	"github.com/thanos-io/thanos/pkg/receive"
 	"github.com/thanos-io/thanos/pkg/testutil"
@@ -24,7 +25,7 @@ func TestReceive(t *testing.T) {
 
 		s, err := e2e.NewScenario("e2e_test_receive_hashring")
 		testutil.Ok(t, err)
-		t.Cleanup(s.Close)
+		t.Cleanup(e2ethanos.CleanScenario(t, s))
 
 		// The hashring suite creates three receivers, each with a Prometheus
 		// remote-writing data to it. However, due to the hashing of the labels,
@@ -105,7 +106,7 @@ func TestReceive(t *testing.T) {
 
 		s, err := e2e.NewScenario("e2e_test_receive_replication")
 		testutil.Ok(t, err)
-		t.Cleanup(s.Close)
+		t.Cleanup(e2ethanos.CleanScenario(t, s))
 
 		// The replication suite creates three receivers but only one
 		// receives Prometheus remote-written data. The querier queries all
@@ -180,7 +181,7 @@ func TestReceive(t *testing.T) {
 
 		s, err := e2e.NewScenario("e2e_test_receive_replication_with_outage")
 		testutil.Ok(t, err)
-		t.Cleanup(s.Close)
+		t.Cleanup(e2ethanos.CleanScenario(t, s))
 
 		// The replication suite creates a three-node hashring but one of the
 		// receivers is dead. In this case, replication should still

--- a/test/e2e/rule_test.go
+++ b/test/e2e/rule_test.go
@@ -23,6 +23,8 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/discovery/targetgroup"
+	"gopkg.in/yaml.v2"
+
 	"github.com/thanos-io/thanos/pkg/alert"
 	http_util "github.com/thanos-io/thanos/pkg/http"
 	"github.com/thanos-io/thanos/pkg/promclient"
@@ -30,7 +32,6 @@ import (
 	"github.com/thanos-io/thanos/pkg/runutil"
 	"github.com/thanos-io/thanos/pkg/testutil"
 	"github.com/thanos-io/thanos/test/e2e/e2ethanos"
-	yaml "gopkg.in/yaml.v2"
 )
 
 const (
@@ -207,7 +208,7 @@ func TestRule_AlertmanagerHTTPClient(t *testing.T) {
 
 	s, err := e2e.NewScenario("e2e_test_rule_am_http_client")
 	testutil.Ok(t, err)
-	t.Cleanup(s.Close)
+	t.Cleanup(e2ethanos.CleanScenario(t, s))
 
 	tlsSubDir := filepath.Join("tls")
 	testutil.Ok(t, os.MkdirAll(filepath.Join(s.SharedDir(), tlsSubDir), os.ModePerm))
@@ -293,7 +294,7 @@ func TestRule(t *testing.T) {
 
 	s, err := e2e.NewScenario("e2e_test_rule")
 	testutil.Ok(t, err)
-	t.Cleanup(s.Close)
+	t.Cleanup(e2ethanos.CleanScenario(t, s))
 
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
 	t.Cleanup(cancel)

--- a/test/e2e/rules_api_test.go
+++ b/test/e2e/rules_api_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/cortexproject/cortex/integration/e2e"
 	"github.com/pkg/errors"
+
 	"github.com/thanos-io/thanos/pkg/promclient"
 	"github.com/thanos-io/thanos/pkg/rules/rulespb"
 	"github.com/thanos-io/thanos/pkg/runutil"
@@ -31,7 +32,7 @@ func TestRulesAPI_Fanout(t *testing.T) {
 
 	s, err := e2e.NewScenario(netName)
 	testutil.Ok(t, err)
-	t.Cleanup(s.Close)
+	t.Cleanup(e2ethanos.CleanScenario(t, s))
 
 	rulesSubDir := filepath.Join("rules")
 	testutil.Ok(t, os.MkdirAll(filepath.Join(s.SharedDir(), rulesSubDir), os.ModePerm))

--- a/test/e2e/store_gateway_test.go
+++ b/test/e2e/store_gateway_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/pkg/relabel"
 	"github.com/prometheus/prometheus/pkg/timestamp"
+
 	"github.com/thanos-io/thanos/pkg/block"
 	"github.com/thanos-io/thanos/pkg/objstore"
 	"github.com/thanos-io/thanos/pkg/objstore/client"
@@ -36,7 +37,7 @@ func TestStoreGateway(t *testing.T) {
 
 	s, err := e2e.NewScenario("e2e_test_store_gateway")
 	testutil.Ok(t, err)
-	t.Cleanup(s.Close)
+	t.Cleanup(e2ethanos.CleanScenario(t, s))
 
 	m := e2edb.NewMinio(80, "thanos")
 	testutil.Ok(t, s.StartAndWaitReady(m))

--- a/test/e2e/store_gateway_test.go
+++ b/test/e2e/store_gateway_test.go
@@ -39,7 +39,7 @@ func TestStoreGateway(t *testing.T) {
 	testutil.Ok(t, err)
 	t.Cleanup(e2ethanos.CleanScenario(t, s))
 
-	m := e2edb.NewMinio(80, "thanos")
+	m := e2edb.NewMinio(8080, "thanos")
 	testutil.Ok(t, s.StartAndWaitReady(m))
 
 	s1, err := e2ethanos.NewStoreGW(s.SharedDir(), "1", client.BucketConfig{


### PR DESCRIPTION
Signed-off-by: Kemal Akkoyun <kakkoyun@gmail.com>

As it pointed out, https://github.com/thanos-io/thanos/pull/2742#issuecomment-642172122,
cleaning up e2e test files.

Fixes `2587`.

* [x] Change is not relevant to the end user.

## Changes

* Introduce a new e2e test helper to clean up the files after scenario is done.

## Verification

* `make test-e2e`
