### PR TITLE
pkg/gate: Refactor gate to enable to track metrics for multiple gates

### DIFF
--- a/pkg/gate/gate.go
+++ b/pkg/gate/gate.go
@@ -9,56 +9,70 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-	"github.com/prometheus/prometheus/pkg/gate"
+	promgate "github.com/prometheus/prometheus/pkg/gate"
 )
 
-type Gater interface {
-	IsMyTurn(ctx context.Context) error
+// Gate is an interface that mimics prometheus/pkg/gate behaviour.
+type Gate interface {
+	Start(ctx context.Context) error
 	Done()
 }
 
 // Gate wraps the Prometheus gate with extra metrics.
-type Gate struct {
-	g               *gate.Gate
+type gate struct {
+	g *promgate.Gate
+	m *metrics
+}
+
+type metrics struct {
 	inflightQueries prometheus.Gauge
 	gateTiming      prometheus.Histogram
 }
 
-// NewGate returns a new query gate.
-func NewGate(maxConcurrent int, reg prometheus.Registerer) *Gate {
-	g := &Gate{
-		g: gate.New(maxConcurrent),
-		inflightQueries: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
-			Name: "gate_queries_in_flight",
-			Help: "Number of queries that are currently in flight.",
-		}),
-		gateTiming: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
-			Name:    "gate_duration_seconds",
-			Help:    "How many seconds it took for queries to wait at the gate.",
-			Buckets: []float64{0.01, 0.1, 0.3, 0.6, 1, 3, 6, 9, 20, 30, 60, 90, 120, 240, 360, 720},
-		}),
-	}
-
-	return g
+// Keeper is used to create multiple gates sharing the same metrics.
+type Keeper struct {
+	m *metrics
 }
 
-// IsMyTurn iniates a new query and waits until it's our turn to fulfill a query request.
-func (g *Gate) IsMyTurn(ctx context.Context) error {
+// NewKeeper creates a new Keeper.
+func NewKeeper(reg prometheus.Registerer) *Keeper {
+	return &Keeper{
+		m: &metrics{
+			inflightQueries: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
+				Name: "gate_queries_in_flight",
+				Help: "Number of queries that are currently in flight.",
+			}),
+			gateTiming: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
+				Name:    "gate_duration_seconds",
+				Help:    "How many seconds it took for queries to wait at the gate.",
+				Buckets: []float64{0.01, 0.1, 0.3, 0.6, 1, 3, 6, 9, 20, 30, 60, 90, 120, 240, 360, 720},
+			}),
+		},
+	}
+}
+
+// NewGate returns a new Gate that collects metrics.
+func (k *Keeper) NewGate(maxConcurrent int) Gate {
+	return &gate{g: promgate.New(maxConcurrent), m: k.m}
+}
+
+// Start initiates a new request and waits until it's our turn to fulfill a request.
+func (g *gate) Start(ctx context.Context) error {
 	start := time.Now()
 	defer func() {
-		g.gateTiming.Observe(time.Since(start).Seconds())
+		g.m.gateTiming.Observe(time.Since(start).Seconds())
 	}()
 
 	if err := g.g.Start(ctx); err != nil {
 		return err
 	}
 
-	g.inflightQueries.Inc()
+	g.m.inflightQueries.Inc()
 	return nil
 }
 
 // Done finishes a query.
-func (g *Gate) Done() {
-	g.inflightQueries.Dec()
+func (g *gate) Done() {
+	g.m.inflightQueries.Dec()
 	g.g.Done()
 }

--- a/pkg/query/api/v1_test.go
+++ b/pkg/query/api/v1_test.go
@@ -117,7 +117,7 @@ func TestEndpoints(t *testing.T) {
 			Timeout:    100 * time.Second,
 		}),
 		now:  func() time.Time { return now },
-		gate: gate.NewGate(4, nil),
+		gate: gate.NewKeeper(nil).NewGate(4),
 	}
 
 	start := time.Unix(0, 0)
@@ -1032,7 +1032,7 @@ func TestParseDuration(t *testing.T) {
 func TestOptionsMethod(t *testing.T) {
 	r := route.New()
 	api := &API{
-		gate: gate.NewGate(4, nil),
+		gate: gate.NewKeeper(nil).NewGate(4),
 	}
 	api.Register(r, &opentracing.NoopTracer{}, log.NewNopLogger(), extpromhttp.NewNopInstrumentationMiddleware())
 
@@ -1149,7 +1149,7 @@ func TestParseDownsamplingParamMillis(t *testing.T) {
 	for i, test := range tests {
 		api := API{
 			enableAutodownsampling: test.enableAutodownsampling,
-			gate:                   gate.NewGate(4, nil),
+			gate:                   gate.NewKeeper(nil).NewGate(4),
 		}
 		v := url.Values{}
 		v.Set("max_source_resolution", test.maxSourceResolutionParam)

--- a/pkg/store/bucket_test.go
+++ b/pkg/store/bucket_test.go
@@ -41,6 +41,8 @@ import (
 	"github.com/prometheus/prometheus/tsdb/chunks"
 	"github.com/prometheus/prometheus/tsdb/encoding"
 	"github.com/prometheus/prometheus/tsdb/index"
+	"gopkg.in/yaml.v2"
+
 	"github.com/thanos-io/thanos/pkg/block"
 	"github.com/thanos-io/thanos/pkg/block/indexheader"
 	"github.com/thanos-io/thanos/pkg/block/metadata"
@@ -53,7 +55,6 @@ import (
 	"github.com/thanos-io/thanos/pkg/store/storepb"
 	"github.com/thanos-io/thanos/pkg/testutil"
 	"github.com/thanos-io/thanos/pkg/testutil/e2eutil"
-	"gopkg.in/yaml.v2"
 )
 
 var emptyRelabelConfig = make([]*relabel.Config, 0)
@@ -1420,7 +1421,7 @@ func benchSeries(t testutil.TB, number int, dimension Dimension, cases ...int) {
 		blockSets: map[uint64]*bucketBlockSet{
 			labels.Labels{{Name: "ext1", Value: "1"}}.Hash(): {blocks: [][]*bucketBlock{blocks}},
 		},
-		queryGate:      noopGater{},
+		queryGate:      noopGate{},
 		samplesLimiter: noopLimiter{},
 	}
 
@@ -1502,10 +1503,10 @@ func (m *mockedPool) Put(b *[]byte) {
 	m.parent.Put(b)
 }
 
-type noopGater struct{}
+type noopGate struct{}
 
-func (noopGater) IsMyTurn(context.Context) error { return nil }
-func (noopGater) Done()                          {}
+func (noopGate) Start(context.Context) error { return nil }
+func (noopGate) Done()                       {}
 
 type noopLimiter struct{}
 
@@ -1675,7 +1676,7 @@ func TestSeries_OneBlock_InMemIndexCacheSegfault(t *testing.T) {
 			b1.meta.ULID: b1,
 			b2.meta.ULID: b2,
 		},
-		queryGate:      noopGater{},
+		queryGate:      noopGate{},
 		samplesLimiter: noopLimiter{},
 	}
 


### PR DESCRIPTION
Signed-off-by: Kemal Akkoyun <kakkoyun@gmail.com>

Changes will be useful for https://github.com/thanos-io/thanos/pull/2657 to track gate metrics for queries that has multiple selects.

* [x] Change is not relevant to the end user.

## Changes

* Refactor gate to enable to track metrics for multiple gates
* Add an interface that conforms prometheus/gate as well to use interchangeably 

## Verification

* `make test`
