### PR TITLE
ui: Add error boundary in the React UI

### DIFF
--- a/pkg/query/api/v1.go
+++ b/pkg/query/api/v1.go
@@ -485,6 +485,10 @@ func (api *API) labelValues(r *http.Request) (interface{}, []error, *ApiError) {
 		return nil, nil, &ApiError{errorExec, err}
 	}
 
+	if vals == nil {
+		vals = make([]string, 0)
+	}
+
 	return vals, warnings, nil
 }
 

--- a/pkg/ui/react-app/src/App.tsx
+++ b/pkg/ui/react-app/src/App.tsx
@@ -6,12 +6,13 @@ import { Alerts, Config, Flags, Rules, ServiceDiscovery, Status, Targets, TSDBSt
 import PathPrefixProps from './types/PathPrefixProps';
 import ThanosComponentProps from './thanos/types/ThanosComponentProps';
 import Navigation from './thanos/Navbar';
+import { ErrorBoundary } from './thanos/pages';
 
 import './App.css';
 
 const App: FC<PathPrefixProps & ThanosComponentProps> = ({ pathPrefix, thanosComponent }) => {
   return (
-    <>
+    <ErrorBoundary>
       <Navigation pathPrefix={pathPrefix} thanosComponent={thanosComponent} />
       <Container fluid style={{ paddingTop: 70 }}>
         <Router basepath={`${pathPrefix}/new`}>
@@ -32,7 +33,7 @@ const App: FC<PathPrefixProps & ThanosComponentProps> = ({ pathPrefix, thanosCom
           <Targets path="/targets" pathPrefix={pathPrefix} />
         </Router>
       </Container>
-    </>
+    </ErrorBoundary>
   );
 };
 

--- a/pkg/ui/react-app/src/thanos/pages/errorBoundary/ErrorBoundary.module.css
+++ b/pkg/ui/react-app/src/thanos/pages/errorBoundary/ErrorBoundary.module.css
@@ -6,7 +6,8 @@
   align-items: center;
 }
 
-.detailsBtn {
+button.detailsBtn {
+  font-size: 1.2em;
   margin: 2em 0;
 }
 

--- a/pkg/ui/react-app/src/thanos/pages/errorBoundary/ErrorBoundary.module.css
+++ b/pkg/ui/react-app/src/thanos/pages/errorBoundary/ErrorBoundary.module.css
@@ -1,0 +1,16 @@
+.container {
+  display: flex;
+  min-height: 100vh;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}
+
+.detailsBtn {
+  margin: 2em 0;
+}
+
+.errorDiv {
+  white-space: pre-wrap;
+  font-family: monospace;
+}

--- a/pkg/ui/react-app/src/thanos/pages/errorBoundary/ErrorBoundary.tsx
+++ b/pkg/ui/react-app/src/thanos/pages/errorBoundary/ErrorBoundary.tsx
@@ -28,15 +28,15 @@ class ErrorBoundary extends React.Component<{}, ErrorState> {
         <Container fluid className={styles.container}>
           <h1>Aaaah! Something went wrong.</h1>
           <h3>
-            Please file an issue at&nbsp;
+            Please file an issue in the&nbsp;
             <a href="https://github.com/thanos-io/thanos/issues" target="_blank" rel="noreferrer noopener">
               Thanos issue tracker.
             </a>
           </h3>
-          <Button color="link" id="toggler" className={styles.detailsBtn} style={{ fontSize: '1.2em' }}>
+          <Button color="link" id="error-details-toggler" className={styles.detailsBtn}>
             View error details.
           </Button>
-          <UncontrolledCollapse toggler="#toggler" className={styles.errorDiv}>
+          <UncontrolledCollapse toggler="#error-details-toggler" className={styles.errorDiv}>
             <span>{this.state.error && this.state.error.toString()}</span>
             {this.state.errorInfo.componentStack}
           </UncontrolledCollapse>

--- a/pkg/ui/react-app/src/thanos/pages/errorBoundary/ErrorBoundary.tsx
+++ b/pkg/ui/react-app/src/thanos/pages/errorBoundary/ErrorBoundary.tsx
@@ -1,0 +1,50 @@
+import React, { ErrorInfo } from 'react';
+import { Container, UncontrolledCollapse, Button } from 'reactstrap';
+import styles from './ErrorBoundary.module.css';
+
+interface ErrorState {
+  error: Error | null;
+  errorInfo: ErrorInfo | null;
+}
+
+class ErrorBoundary extends React.Component<{}, ErrorState> {
+  constructor(props: {}) {
+    super(props);
+    this.state = {
+      error: null,
+      errorInfo: null,
+    };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
+    this.setState({
+      error,
+      errorInfo,
+    });
+  }
+  render(): React.ReactNode {
+    if (this.state.errorInfo) {
+      return (
+        <Container fluid className={styles.container}>
+          <h1>Aaaah! Something went wrong.</h1>
+          <h3>
+            Please file an issue at&nbsp;
+            <a href="https://github.com/thanos-io/thanos/issues" target="_blank" rel="noreferrer noopener">
+              Thanos issue tracker.
+            </a>
+          </h3>
+          <Button color="link" id="toggler" className={styles.detailsBtn} style={{ fontSize: '1.2em' }}>
+            View error details.
+          </Button>
+          <UncontrolledCollapse toggler="#toggler" className={styles.errorDiv}>
+            <span>{this.state.error && this.state.error.toString()}</span>
+            {this.state.errorInfo.componentStack}
+          </UncontrolledCollapse>
+        </Container>
+      );
+    }
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/pkg/ui/react-app/src/thanos/pages/index.tsx
+++ b/pkg/ui/react-app/src/thanos/pages/index.tsx
@@ -1,1 +1,3 @@
-export {};
+import ErrorBoundary from './errorBoundary/ErrorBoundary';
+
+export { ErrorBoundary };


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes
- Add a error boundary to the React UI. Now in case of an irrecoverable error, users would see a "Something went wrong" page instead of a blank screen.
- Fix the crash when there is no store connected to the Querier. The crash was because the API response for `/api/v1/label/__name__/values` was
```json
{
  "status": "success",
  "data": null
}
```
Here, the UI expects `data` to be an array.
Fixed this by sending an empty array (`[]`) instead of `null`

## Verification
Tested locally by emulating error conditions.

## Screenshot
![Error Boundary](https://user-images.githubusercontent.com/29674758/84884868-e078cd00-b0af-11ea-88a0-048fe68bba4e.png)


