### PR TITLE
mixin: Improve receive alerts

### DIFF
--- a/examples/alerts/alerts.md
+++ b/examples/alerts/alerts.md
@@ -418,16 +418,19 @@ rules:
       }}% of requests.
   expr: |
     (
-      sum by (job) (rate(thanos_receive_forward_requests_total{result="error", job=~"thanos-receive.*"}[5m]))
-    /
-      sum by (job) (rate(thanos_receive_forward_requests_total{job=~"thanos-receive.*"}[5m]))
-    )
-    >
-    (
-      max by (job) (floor((thanos_receive_replication_factor{job=~"thanos-receive.*"}+1) / 2))
-    /
-      max by (job) (thanos_receive_hashring_nodes{job=~"thanos-receive.*"})
-    )
+      (
+        sum by (job) (rate(thanos_receive_forward_requests_total{result="error", job=~"thanos-receive.*"}[5m]))
+      /
+        sum by (job) (rate(thanos_receive_forward_requests_total{job=~"thanos-receive.*"}[5m]))
+      )
+      >
+      (
+        max by (job) (floor((thanos_receive_replication_factor{job=~"thanos-receive.*"}+1) / 2))
+      /
+        max by (job) (thanos_receive_hashring_nodes{job=~"thanos-receive.*"})
+      )
+    ) * 100
+  for: 5m
   labels:
     severity: warning
 - alert: ThanosReceiveHighHashringFileRefreshFailures
@@ -457,9 +460,9 @@ rules:
     message: Thanos Receive {{$labels.job}} has not uploaded latest data to object
       storage.
   expr: increase(thanos_shipper_uploads_total{job=~"thanos-receive.*"}[2h]) == 0
-  for: 30m
+  for: 2h
   labels:
-    severity: warning
+    severity: critical
 ```
 
 ## Replicate

--- a/examples/alerts/alerts.yaml
+++ b/examples/alerts/alerts.yaml
@@ -179,16 +179,19 @@ groups:
         }}% of requests.
     expr: |
       (
-        sum by (job) (rate(thanos_receive_forward_requests_total{result="error", job=~"thanos-receive.*"}[5m]))
-      /
-        sum by (job) (rate(thanos_receive_forward_requests_total{job=~"thanos-receive.*"}[5m]))
-      )
-      >
-      (
-        max by (job) (floor((thanos_receive_replication_factor{job=~"thanos-receive.*"}+1) / 2))
-      /
-        max by (job) (thanos_receive_hashring_nodes{job=~"thanos-receive.*"})
-      )
+        (
+          sum by (job) (rate(thanos_receive_forward_requests_total{result="error", job=~"thanos-receive.*"}[5m]))
+        /
+          sum by (job) (rate(thanos_receive_forward_requests_total{job=~"thanos-receive.*"}[5m]))
+        )
+        >
+        (
+          max by (job) (floor((thanos_receive_replication_factor{job=~"thanos-receive.*"}+1) / 2))
+        /
+          max by (job) (thanos_receive_hashring_nodes{job=~"thanos-receive.*"})
+        )
+      ) * 100
+    for: 5m
     labels:
       severity: warning
   - alert: ThanosReceiveHighHashringFileRefreshFailures
@@ -219,9 +222,9 @@ groups:
       message: Thanos Receive {{$labels.job}} has not uploaded latest data to object
         storage.
     expr: increase(thanos_shipper_uploads_total{job=~"thanos-receive.*"}[2h]) == 0
-    for: 30m
+    for: 2h
     labels:
-      severity: warning
+      severity: critical
 - name: thanos-sidecar.rules
   rules:
   - alert: ThanosSidecarPrometheusDown

--- a/mixin/alerts/receive.libsonnet
+++ b/mixin/alerts/receive.libsonnet
@@ -52,17 +52,20 @@
             },
             expr: |||
               (
-                sum by (job) (rate(thanos_receive_forward_requests_total{result="error", %(selector)s}[5m]))
-              /
-                sum by (job) (rate(thanos_receive_forward_requests_total{%(selector)s}[5m]))
-              )
-              >
-              (
-                max by (job) (floor((thanos_receive_replication_factor{%(selector)s}+1) / 2))
-              /
-                max by (job) (thanos_receive_hashring_nodes{%(selector)s})
-              )
+                (
+                  sum by (job) (rate(thanos_receive_forward_requests_total{result="error", %(selector)s}[5m]))
+                /
+                  sum by (job) (rate(thanos_receive_forward_requests_total{%(selector)s}[5m]))
+                )
+                >
+                (
+                  max by (job) (floor((thanos_receive_replication_factor{%(selector)s}+1) / 2))
+                /
+                  max by (job) (thanos_receive_hashring_nodes{%(selector)s})
+                )
+              ) * 100
             ||| % thanos.receive,
+            'for': '5m',
             labels: {
               severity: 'warning',
             },
@@ -102,9 +105,9 @@
               message: 'Thanos Receive {{$labels.job}} has not uploaded latest data to object storage.',
             },
             expr: 'increase(thanos_shipper_uploads_total{%(selector)s}[2h]) == 0' % thanos.receive,
-            'for': '30m',
+            'for': '2h',
             labels: {
-              severity: 'warning',
+              severity: 'critical',
             },
           },
         ],


### PR DESCRIPTION
Signed-off-by: Kemal Akkoyun <kakkoyun@gmail.com>

## Changes

* Improve readability for `ThanosReceiveHighForwardRequestFailures` while increasing `for` value to prevent flappy alerts.

<img width="563" alt="Screenshot 2020-06-15 10 12 50" src="https://user-images.githubusercontent.com/536449/84633647-ff7d3080-aef0-11ea-9943-3ad28873bc5c.png">

* Promote `ThanosReceiveNoUpload` to critical while increasing `for` value to prevent flappy alerts.

## Verification

* `make examples`
* `make example-rules-lint`

cc @brancz 
