### PR TITLE
pkg/rules/manager: expose original file field in groups

### DIFF
--- a/pkg/rules/manager.go
+++ b/pkg/rules/manager.go
@@ -33,14 +33,14 @@ const tmpRuleDir = ".tmp-rules"
 
 type Group struct {
 	*rules.Group
-	originalFile            string
+	OriginalFile            string
 	PartialResponseStrategy storepb.PartialResponseStrategy
 }
 
 func (g Group) toProto() *rulespb.RuleGroup {
 	ret := &rulespb.RuleGroup{
 		Name:                    g.Name(),
-		File:                    g.originalFile,
+		File:                    g.OriginalFile,
 		Interval:                g.Interval().Seconds(),
 		PartialResponseStrategy: g.PartialResponseStrategy,
 	}
@@ -172,7 +172,7 @@ func (m *Manager) RuleGroups() []Group {
 		for _, group := range r.RuleGroups() {
 			res = append(res, Group{
 				Group:                   group,
-				originalFile:            m.ruleFiles[group.File()],
+				OriginalFile:            m.ruleFiles[group.File()],
 				PartialResponseStrategy: s,
 			})
 		}


### PR DESCRIPTION
Currently, the original file field is a private field.
This causes it to render in the Thanos Rules UI.
This fixes it by making that field public.

Signed-off-by: Sergiusz Urbaniak <sergiusz.urbaniak@gmail.com>

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

- Exposed original file field in `pkg/rules.Group` struct.

## Verification

Screenshot before this change shows that Rules are not being rendered:

![image](https://user-images.githubusercontent.com/375856/84660919-d91fbb00-af19-11ea-8549-c704345e5970.png)

Additionally the following warn error message is rendered in log files:

```
level=warn ts=2020-06-15T11:05:16.146463886Z caller=ui.go:152 component=rules msg="template expansion failed" err="template: :82:26: executing \"content\" at <.OriginalFile>: can't evaluate field OriginalFile in type rules.Group"
```

Screenshot with this change applied:

![image](https://user-images.githubusercontent.com/375856/84660989-f6548980-af19-11ea-8df6-378ebbd4767f.png)

/cc @bwplotka @brancz