### PR TITLE
Treating GCS EOF failures in the read path as IsObjNotFoundErr w/ logging

### DIFF
--- a/pkg/objstore/gcs/gcs.go
+++ b/pkg/objstore/gcs/gcs.go
@@ -167,7 +167,11 @@ func (b *Bucket) Delete(ctx context.Context, name string) error {
 
 // IsObjNotFoundErr returns true if error means that object is not found. Relevant to Get operations.
 func (b *Bucket) IsObjNotFoundErr(err error) bool {
-	return err == storage.ErrObjectNotExist
+	eof :=  errors.Is(err, io.ErrUnexpectedEOF)
+	if eof {
+		b.logger.Log("method", "IsObjNotFoundErr", "err", err, "stack", fmt.Sprintf("%+v", errors.WithStack(err)))
+	}
+	return err == storage.ErrObjectNotExist || eof
 }
 
 func (b *Bucket) Close() error {


### PR DESCRIPTION
Upon startup of thanos store on GCS it's common to see read failures on the deletion mark:

caller=grpc.go:137 service=gRPC/server component=store msg="internal server shutdown"
    err="bucket store initial sync: sync block: filter metas: get file: ***/deletion-mark.json: Get ***/deletion-mark.json: unexpected EOF"
caller=main.go:212
    err="Get ***/deletion-mark.json: unexpected EOF get file: ***/deletion-mark.json
thanos/pkg/block/metadata.ReadDeletionMark
thanos/pkg/block/metadata/deletionmark.go:56
thanos/pkg/block.(*IgnoreDeletionMarkFilter).Filter

These failures cause crash loops in our GKE clusters where storage will commonly need 20+ restarts before becoming available.

After this change we still see intermittent transient failures on startup (mostly due to rate limiting) but typically no more than 2.

Now treat eof (wrapped) as a not-found-error but log the stack trace for analysis

This is the underlying issue tracking the eof error in GCS:

https://github.com/googleapis/google-cloud-go/issues/1832

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
