### PR TITLE
 Revert "Let forward requests run until timeout (#2679) + style fixes.

### DIFF
--- a/pkg/receive/handler.go
+++ b/pkg/receive/handler.go
@@ -230,7 +230,7 @@ func (h *Handler) handleRequest(ctx context.Context, rep uint64, tenant string, 
 		replicated: rep != 0,
 	}
 
-	// on-the-wire format is 1-indexed and in-code is 0-indexed so we decrement the value if it was already replicated.
+	// On-the-wire format is 1-indexed and in-code is 0-indexed so we decrement the value if it was already replicated.
 	if r.replicated {
 		r.n--
 	}
@@ -450,7 +450,7 @@ func (h *Handler) fanoutForward(ctx context.Context, tenant string, replicas map
 		close(ec)
 	}()
 
-	// At the end, make sure to exhaust the channel, letting remaining unnecessary requests finish asnychronously.
+	// At the end, make sure to exhaust the channel, letting remaining unnecessary requests finish asynchronously.
 	// This is needed if context is cancelled or if we reached success of fail quorum faster.
 	defer func() {
 		go func() {

--- a/pkg/receive/handler.go
+++ b/pkg/receive/handler.go
@@ -517,17 +517,11 @@ func (h *Handler) replicate(ctx context.Context, tenant string, wreq *prompb.Wri
 	}
 	h.mtx.RUnlock()
 
-	var err error
 	ctx, cancel := context.WithTimeout(ctx, h.options.ForwardTimeout)
-	defer func() {
-		// If there is no error, let forward requests optimistically run until timeout.
-		if err != nil {
-			cancel()
-		}
-	}()
+	defer cancel()
 
 	quorum := h.writeQuorum()
-	err = h.fanoutForward(ctx, tenant, replicas, wreqs, quorum)
+	err := h.fanoutForward(ctx, tenant, replicas, wreqs, quorum)
 	if countCause(err, isNotReady) >= quorum {
 		return tsdb.ErrNotReady
 	}


### PR DESCRIPTION
Let's revert the commit in the path of the problematic handler we saw on production.

I think the PR https://github.com/thanos-io/thanos/pull/2679 made sense, we want to replicate 3x, just 2x strictly and 3rd one best effort.
While it makes sense logically, there are some reasons why the receive could be saturated because of this change e.g

* If there is single slow writer, we would have to start new connections and eventually run out of connections.
* We still use extra bandwidth, because of requests left running behind.
* We put more pressure on TSDBs (have more concurrent appends)

Essentially with this change indeed we have "leaking" rate-limiting (if there is any;p), because we claim request end, despite things are still processing.

Anyway, let's build an image from this branch & deploy it and let's see if we can repro. There are solid reasons why this might attribute for potential saturation