### PR TITLE
receive: Add more tracing spans for the life-cycle of requests

### DIFF
--- a/pkg/store/tsdb.go
+++ b/pkg/store/tsdb.go
@@ -14,12 +14,13 @@ import (
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/tsdb"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
 	"github.com/thanos-io/thanos/pkg/component"
 	"github.com/thanos-io/thanos/pkg/promclient"
 	"github.com/thanos-io/thanos/pkg/runutil"
 	"github.com/thanos-io/thanos/pkg/store/storepb"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 // TSDBStore implements the store API against a local TSDB instance.
@@ -211,7 +212,7 @@ func (s *TSDBStore) translateAndExtendLabels(m, extend labels.Labels) []storepb.
 }
 
 // LabelNames returns all known label names.
-func (s *TSDBStore) LabelNames(ctx context.Context, _ *storepb.LabelNamesRequest) (
+func (s *TSDBStore) LabelNames(_ context.Context, _ *storepb.LabelNamesRequest) (
 	*storepb.LabelNamesResponse, error,
 ) {
 	q, err := s.db.Querier(context.Background(), math.MinInt64, math.MaxInt64)
@@ -228,7 +229,7 @@ func (s *TSDBStore) LabelNames(ctx context.Context, _ *storepb.LabelNamesRequest
 }
 
 // LabelValues returns all known label values for a given label name.
-func (s *TSDBStore) LabelValues(ctx context.Context, r *storepb.LabelValuesRequest) (
+func (s *TSDBStore) LabelValues(_ context.Context, r *storepb.LabelValuesRequest) (
 	*storepb.LabelValuesResponse, error,
 ) {
 	q, err := s.db.Querier(context.Background(), math.MinInt64, math.MaxInt64)

--- a/pkg/store/tsdb.go
+++ b/pkg/store/tsdb.go
@@ -212,10 +212,10 @@ func (s *TSDBStore) translateAndExtendLabels(m, extend labels.Labels) []storepb.
 }
 
 // LabelNames returns all known label names.
-func (s *TSDBStore) LabelNames(_ context.Context, _ *storepb.LabelNamesRequest) (
+func (s *TSDBStore) LabelNames(ctx context.Context, _ *storepb.LabelNamesRequest) (
 	*storepb.LabelNamesResponse, error,
 ) {
-	q, err := s.db.Querier(context.Background(), math.MinInt64, math.MaxInt64)
+	q, err := s.db.Querier(ctx, math.MinInt64, math.MaxInt64)
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}
@@ -229,10 +229,10 @@ func (s *TSDBStore) LabelNames(_ context.Context, _ *storepb.LabelNamesRequest) 
 }
 
 // LabelValues returns all known label values for a given label name.
-func (s *TSDBStore) LabelValues(_ context.Context, r *storepb.LabelValuesRequest) (
+func (s *TSDBStore) LabelValues(ctx context.Context, r *storepb.LabelValuesRequest) (
 	*storepb.LabelValuesResponse, error,
 ) {
-	q, err := s.db.Querier(context.Background(), math.MinInt64, math.MaxInt64)
+	q, err := s.db.Querier(ctx, math.MinInt64, math.MaxInt64)
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}


### PR DESCRIPTION
Signed-off-by: Kemal Akkoyun <kakkoyun@gmail.com>

* [x] Change is not relevant to the end user.

### Spans

#### Write
```
.
└── "receive_http"
    └── "receive_fanout_forward"
        ├── "receive_replicate"
        │   ├── "receive_replicate"
        │   ├── "receive_tsdb_write"
        │   └── "receive_forward"
        ├── "receive_tsdb_write"
        └── "receive_forward"
```

```
.
└── "receive_grpc"
    └── "receive_fanout_forward"
        ├── "receive_replicate"
        │   ├── "receive_replicate"
        │   ├── "receive_tsdb_write"
        │   └── "receive_forward"
        ├── "receive_tsdb_write"
        └── "receive_forward"
```
#### Read
```
.
├── "multitsdb_series"
│   └── "multitsdb_tenant_series"
├── "multitsdb_label_names"
└── "multitsdb_label_values"
```


## Changes

* Add more tracing spans for the life-cycle of a receive request.
* Add tracing spans for storeAPI read path.

## Verification

* `make build`
* `make test-local`
