### PR TITLE
mixin: Default dashboards to UTC

### DIFF
--- a/examples/dashboards/bucket_replicate.json
+++ b/examples/dashboards/bucket_replicate.json
@@ -508,7 +508,7 @@
          "30d"
       ]
    },
-   "timezone": "",
+   "timezone": "UTC",
    "title": "Thanos / BucketReplicate",
    "uid": "49f644ecf8e31dd1a5084ae2a5f10e80",
    "version": 0

--- a/examples/dashboards/compact.json
+++ b/examples/dashboards/compact.json
@@ -1542,7 +1542,7 @@
          "30d"
       ]
    },
-   "timezone": "",
+   "timezone": "UTC",
    "title": "Thanos / Compact",
    "uid": "651943d05a8123e32867b4673963f42b",
    "version": 0

--- a/examples/dashboards/overview.json
+++ b/examples/dashboards/overview.json
@@ -2059,7 +2059,7 @@
          "30d"
       ]
    },
-   "timezone": "",
+   "timezone": "UTC",
    "title": "Thanos / Overview",
    "uid": "0cb8830a6e957978796729870f560cda",
    "version": 0

--- a/examples/dashboards/query.json
+++ b/examples/dashboards/query.json
@@ -2474,7 +2474,7 @@
          "30d"
       ]
    },
-   "timezone": "",
+   "timezone": "UTC",
    "title": "Thanos / Query",
    "uid": "af36c91291a603f1d9fbdabdd127ac4a",
    "version": 0

--- a/examples/dashboards/receive.json
+++ b/examples/dashboards/receive.json
@@ -2329,7 +2329,7 @@
          "30d"
       ]
    },
-   "timezone": "",
+   "timezone": "UTC",
    "title": "Thanos / Receive",
    "uid": "916a852b00ccc5ed81056644718fa4fb",
    "version": 0

--- a/examples/dashboards/rule.json
+++ b/examples/dashboards/rule.json
@@ -2007,7 +2007,7 @@
          "30d"
       ]
    },
-   "timezone": "",
+   "timezone": "UTC",
    "title": "Thanos / Rule",
    "uid": "35da848f5f92b2dc612e0c3a0577b8a1",
    "version": 0

--- a/examples/dashboards/sidecar.json
+++ b/examples/dashboards/sidecar.json
@@ -1882,7 +1882,7 @@
          "30d"
       ]
    },
-   "timezone": "",
+   "timezone": "UTC",
    "title": "Thanos / Sidecar",
    "uid": "b19644bfbf0ec1e108027cce268d99f7",
    "version": 0

--- a/examples/dashboards/store.json
+++ b/examples/dashboards/store.json
@@ -3091,7 +3091,7 @@
          "30d"
       ]
    },
-   "timezone": "",
+   "timezone": "UTC",
    "title": "Thanos / Store",
    "uid": "e832e8f26403d95fac0ea1c59837588b",
    "version": 0

--- a/mixin/dashboards/defaults.libsonnet
+++ b/mixin/dashboards/defaults.libsonnet
@@ -15,7 +15,7 @@
   grafanaDashboards:: {
     [filename]: grafanaDashboards[filename] {
       uid: std.md5(filename),
-      timezone: '',
+      timezone: 'UTC',
       tags: thanos.dashboard.tags,
 
       // Modify tooltip to only show a single value


### PR DESCRIPTION
Various tools in the SRE space use UTC as the default to make it
effortless during incidents to not have to calculate between timezones.
The Thanos query UI also defaults to this just like Prometheus.

Signed-off-by: Frederic Branczyk <fbranczyk@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

Changed the default timezone to UTC to follow best practices.

## Verification

Re-generated the examples and the values changed.

@thanos-io/thanos-maintainers 