### PR TITLE
continue compact group even if occur a error

### DIFF
--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -958,16 +958,18 @@ func (c *BucketCompactor) Compact(ctx context.Context) (rerr error) {
 		}
 
 		level.Info(c.logger).Log("msg", "start of compactions")
+		st := time.Now()
+		compactCount := 0
 
 		// Send all groups found during this pass to the compaction workers.
 		var groupErrs terrors.MultiError
-	groupLoop:
 		for _, g := range groups {
 			select {
 			case groupErr := <-errChan:
 				groupErrs.Add(groupErr)
-				break groupLoop
 			case groupChan <- g:
+				compactCount++
+				level.Info(c.logger).Log("msg", "start compact group", "group", g.Key(), "compactRatio", fmt.Sprintf("%d/%d", compactCount, len(groups)), "duration", time.Since(st))
 			}
 		}
 		close(groupChan)


### PR DESCRIPTION
compact group is independent of each other, even if one error does not affect other compression, this is very necessary for massive data, and is very effective for my company's scenario

Signed-off-by: joelei <thezero12@hotmail.com>

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

- continue compact group even if occur a error
- show compact ratio, useful for a long compact

## Verification

Tested it on prod environment, 20T data, 60K blocks, with continue compact, successfully reduced to 6k blocks