### PR TITLE
compact: set unready if halted

### DIFF
--- a/.bingo/go.mod
+++ b/.bingo/go.mod
@@ -1,1 +1,3 @@
 module _ // Fake go.mod auto-created by 'bingo' for go -moddir compatibility with non-Go projects. Commit this file, together with other .mod files.
+
+go 1.13

--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -357,6 +357,7 @@ func runCompact(
 				if conf.haltOnError {
 					level.Error(logger).Log("msg", "critical error detected; halting", "err", err)
 					halted.Set(1)
+					httpProbe.NotHealthy(fmt.Errorf("critical error detected; halting: %v", err))
 					select {}
 				} else {
 					return errors.Wrap(err, "critical error detected")


### PR DESCRIPTION
If comapctor is halted, it should not report ready state any more.



<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->