### PR TITLE
store: Preallocate output buffer when encoding postings.

### DIFF
--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -1705,7 +1705,8 @@ func (r *bucketIndexReader) fetchPostings(keys []labels.Label) ([]index.Postings
 					// Errors from corrupted postings will be reported when postings are used.
 					compressions++
 					s := time.Now()
-					data, err := diffVarintSnappyEncode(newBigEndianPostings(pBytes[4:]))
+					bep := newBigEndianPostings(pBytes[4:])
+					data, err := diffVarintSnappyEncode(bep, bep.count())
 					compressionTime = time.Since(s)
 					if err == nil {
 						dataToCache = data
@@ -1801,6 +1802,11 @@ func (it *bigEndianPostings) Seek(x uint64) bool {
 
 func (it *bigEndianPostings) Err() error {
 	return nil
+}
+
+// Returns number of remaining postings values.
+func (it *bigEndianPostings) count() int {
+	return len(it.list) / 4
 }
 
 func (r *bucketIndexReader) PreloadSeries(ids []uint64) error {

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -1706,7 +1706,7 @@ func (r *bucketIndexReader) fetchPostings(keys []labels.Label) ([]index.Postings
 					compressions++
 					s := time.Now()
 					bep := newBigEndianPostings(pBytes[4:])
-					data, err := diffVarintSnappyEncode(bep, bep.count())
+					data, err := diffVarintSnappyEncode(bep, bep.length())
 					compressionTime = time.Since(s)
 					if err == nil {
 						dataToCache = data
@@ -1805,7 +1805,7 @@ func (it *bigEndianPostings) Err() error {
 }
 
 // Returns number of remaining postings values.
-func (it *bigEndianPostings) count() int {
+func (it *bigEndianPostings) length() int {
 	return len(it.list) / 4
 }
 

--- a/pkg/store/bucket_test.go
+++ b/pkg/store/bucket_test.go
@@ -1933,7 +1933,7 @@ func TestBigEndianPostingsCount(t *testing.T) {
 	}
 
 	p := newBigEndianPostings(raw)
-	testutil.Equals(t, count, p.count())
+	testutil.Equals(t, count, p.length())
 
 	c := 0
 	for p.Next() {

--- a/pkg/store/bucket_test.go
+++ b/pkg/store/bucket_test.go
@@ -6,6 +6,7 @@ package store
 import (
 	"bytes"
 	"context"
+	"encoding/binary"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -1921,4 +1922,22 @@ func mustMarshalAny(pb proto.Message) *types.Any {
 		panic(err)
 	}
 	return out
+}
+
+func TestBigEndianPostingsCount(t *testing.T) {
+	const count = 1000
+	raw := make([]byte, count*4)
+
+	for ix := 0; ix < count; ix++ {
+		binary.BigEndian.PutUint32(raw[4*ix:], rand.Uint32())
+	}
+
+	p := newBigEndianPostings(raw)
+	testutil.Equals(t, count, p.count())
+
+	c := 0
+	for p.Next() {
+		c++
+	}
+	testutil.Equals(t, count, c)
 }

--- a/pkg/store/postings_codec.go
+++ b/pkg/store/postings_codec.go
@@ -33,9 +33,9 @@ func isDiffVarintSnappyEncodedPostings(input []byte) bool {
 // diffVarintSnappyEncode encodes postings into diff+varint representation,
 // and applies snappy compression on the result.
 // Returned byte slice starts with codecHeaderSnappy header.
-// Values argument is expected number of postings, used for preallocating buffer.
-func diffVarintSnappyEncode(p index.Postings, values int) ([]byte, error) {
-	buf, err := diffVarintEncodeNoHeader(p, values)
+// Length argument is expected number of postings, used for preallocating buffer.
+func diffVarintSnappyEncode(p index.Postings, length int) ([]byte, error) {
+	buf, err := diffVarintEncodeNoHeader(p, length)
 	if err != nil {
 		return nil, err
 	}
@@ -53,14 +53,14 @@ func diffVarintSnappyEncode(p index.Postings, values int) ([]byte, error) {
 
 // diffVarintEncodeNoHeader encodes postings into diff+varint representation.
 // It doesn't add any header to the output bytes.
-// Values argument is expected number of postings, used for preallocating buffer.
-func diffVarintEncodeNoHeader(p index.Postings, values int) ([]byte, error) {
+// Length argument is expected number of postings, used for preallocating buffer.
+func diffVarintEncodeNoHeader(p index.Postings, length int) ([]byte, error) {
 	buf := encoding.Encbuf{}
 
 	// This encoding uses around ~1 bytes per posting, but let's use
 	// conservative 1.25 bytes per posting to avoid extra allocations.
-	if values > 0 {
-		buf.B = make([]byte, 0, 5*values/4)
+	if length > 0 {
+		buf.B = make([]byte, 0, 5*length/4)
 	}
 
 	prev := uint64(0)

--- a/pkg/store/postings_codec.go
+++ b/pkg/store/postings_codec.go
@@ -33,8 +33,9 @@ func isDiffVarintSnappyEncodedPostings(input []byte) bool {
 // diffVarintSnappyEncode encodes postings into diff+varint representation,
 // and applies snappy compression on the result.
 // Returned byte slice starts with codecHeaderSnappy header.
-func diffVarintSnappyEncode(p index.Postings) ([]byte, error) {
-	buf, err := diffVarintEncodeNoHeader(p)
+// Values argument is expected number of postings, used for preallocating buffer.
+func diffVarintSnappyEncode(p index.Postings, values int) ([]byte, error) {
+	buf, err := diffVarintEncodeNoHeader(p, values)
 	if err != nil {
 		return nil, err
 	}
@@ -52,8 +53,15 @@ func diffVarintSnappyEncode(p index.Postings) ([]byte, error) {
 
 // diffVarintEncodeNoHeader encodes postings into diff+varint representation.
 // It doesn't add any header to the output bytes.
-func diffVarintEncodeNoHeader(p index.Postings) ([]byte, error) {
+// Values argument is expected number of postings, used for preallocating buffer.
+func diffVarintEncodeNoHeader(p index.Postings, values int) ([]byte, error) {
 	buf := encoding.Encbuf{}
+
+	// This encoding uses around ~1 bytes per posting, but let's use
+	// conservative 1.25 bytes per posting to avoid extra allocations.
+	if values > 0 {
+		buf.B = make([]byte, 0, 5*values/4)
+	}
 
 	prev := uint64(0)
 	for p.Next() {


### PR DESCRIPTION
This PR modifies `diffVarintSnappyEncode` method to preallocate output buffer based on number of passed postings. This helps to avoid reallocations.

```
name                      old time/op    new time/op    delta
EncodePostings/10000-4       114µs ± 1%     106µs ± 1%   -6.55%  (p=0.009 n=3+9)
EncodePostings/100000-4     1.11ms ± 1%    1.05ms ± 0%   -5.39%  (p=0.007 n=3+10)
EncodePostings/1000000-4    11.6ms ± 2%    10.7ms ± 0%   -7.21%  (p=0.009 n=3+9)

name                      old alloc/op   new alloc/op   delta
EncodePostings/10000-4      48.5kB ± 0%    13.6kB ± 0%  -71.98%  (p=0.000 n=3+10)
EncodePostings/100000-4      506kB ± 0%     131kB ± 0%  -74.08%  (p=0.000 n=3+10)
EncodePostings/1000000-4    5.86MB ± 0%    1.25MB ± 0%  -78.62%  (p=0.000 n=3+10)

name                      old allocs/op  new allocs/op  delta
EncodePostings/10000-4        18.0 ± 0%       2.0 ± 0%  -88.89%  (p=0.000 n=3+10)
EncodePostings/100000-4       26.0 ± 0%       2.0 ± 0%  -92.31%  (p=0.000 n=3+10)
EncodePostings/1000000-4      36.0 ± 0%       2.0 ± 0%  -94.44%  (p=0.000 n=3+10)
```

Notes for reviewers: I chose to pass expected number of postings as another parameter. Alternative I considered was introducing an interface with `PostingsCount` method, which may look nicer, but would add hidden dependency into `diffVarintSnappyEncode` -- for postings implementing the interface, it would be faster (use less allocs) than for postings not implementing it. Passing extra parameter is more explicit.

* [NA] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Verification

Added benchmark.
