### PR TITLE
Improve ThanosReceiveNoUpload to only alert on current instances

### DIFF
--- a/examples/alerts/alerts.md
+++ b/examples/alerts/alerts.md
@@ -459,7 +459,10 @@ rules:
   annotations:
     message: Thanos Receive {{$labels.job}} has not uploaded latest data to object
       storage.
-  expr: increase(thanos_shipper_uploads_total{job=~"thanos-receive.*"}[2h]) == 0
+  expr: |
+    (up{job=~"thanos-receive.*"} - 1)
+    + on (instance) # filters to only alert on current instance last 2h
+    sum by (instance) (increase(thanos_shipper_uploads_total{job=~"thanos-receive.*"}[2h]) == 0)
   for: 2h
   labels:
     severity: critical

--- a/examples/alerts/alerts.yaml
+++ b/examples/alerts/alerts.yaml
@@ -221,7 +221,10 @@ groups:
     annotations:
       message: Thanos Receive {{$labels.job}} has not uploaded latest data to object
         storage.
-    expr: increase(thanos_shipper_uploads_total{job=~"thanos-receive.*"}[2h]) == 0
+    expr: |
+      (up{job=~"thanos-receive.*"} - 1)
+      + on (instance) # filters to only alert on current instance last 2h
+      sum by (instance) (increase(thanos_shipper_uploads_total{job=~"thanos-receive.*"}[2h]) == 0)
     for: 2h
     labels:
       severity: critical

--- a/mixin/alerts/receive.libsonnet
+++ b/mixin/alerts/receive.libsonnet
@@ -104,7 +104,11 @@
             annotations: {
               message: 'Thanos Receive {{$labels.job}} has not uploaded latest data to object storage.',
             },
-            expr: 'increase(thanos_shipper_uploads_total{%(selector)s}[2h]) == 0' % thanos.receive,
+            expr: |||
+              (up{%(selector)s} - 1)
+              + on (instance) # filters to only alert on current instance last 2h
+              sum by (instance) (increase(thanos_shipper_uploads_total{%(selector)s}[2h]) == 0)
+            ||| % thanos.receive,
             'for': '2h',
             labels: {
               severity: 'critical',


### PR DESCRIPTION

* [ ] I added CHANGELOG entry for this change.
* [x] We don't have a CHANGELOG entry for mixin.

## Changes

![Screenshot from 2020-06-26 17-51-22-blurred](https://user-images.githubusercontent.com/872251/85877710-dce3f500-b7d7-11ea-9e45-e38d40f29c8c.png)

## Verification

Old query on the left and new query on the right. One can clearly see how the old query is still alerting on the long gone Pods, while we filter those on the right side and the number of NoUpload instances decreases while restarting Pods.