### PR TITLE
Update ThanosReceiveNoUpload to select sum == 0

### DIFF
--- a/examples/alerts/alerts.md
+++ b/examples/alerts/alerts.md
@@ -462,7 +462,7 @@ rules:
   expr: |
     (up{job=~"thanos-receive.*"} - 1)
     + on (instance) # filters to only alert on current instance last 2h
-    sum by (instance) (increase(thanos_shipper_uploads_total{job=~"thanos-receive.*"}[2h]) == 0)
+    (sum by (instance) (increase(thanos_shipper_uploads_total{job=~"thanos-receive.*"}[2h])) == 0)
   for: 2h
   labels:
     severity: critical

--- a/examples/alerts/alerts.yaml
+++ b/examples/alerts/alerts.yaml
@@ -224,7 +224,7 @@ groups:
     expr: |
       (up{job=~"thanos-receive.*"} - 1)
       + on (instance) # filters to only alert on current instance last 2h
-      sum by (instance) (increase(thanos_shipper_uploads_total{job=~"thanos-receive.*"}[2h]) == 0)
+      (sum by (instance) (increase(thanos_shipper_uploads_total{job=~"thanos-receive.*"}[2h])) == 0)
     for: 2h
     labels:
       severity: critical

--- a/mixin/alerts/receive.libsonnet
+++ b/mixin/alerts/receive.libsonnet
@@ -107,7 +107,7 @@
             expr: |||
               (up{%(selector)s} - 1)
               + on (instance) # filters to only alert on current instance last 2h
-              sum by (instance) (increase(thanos_shipper_uploads_total{%(selector)s}[2h]) == 0)
+              (sum by (instance) (increase(thanos_shipper_uploads_total{%(selector)s}[2h])) == 0)
             ||| % thanos.receive,
             'for': '2h',
             labels: {


### PR DESCRIPTION
Right now the alert actually fires in wrong conditions.
We select all sum(instances  == 0) which is always 0...
Instead we want to sum(instances) == 0

Thanks for finding this @krasi-georgiev 

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

