### PR TITLE
ui: react: Add runtime and build info page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 - [#2800](https://github.com/thanos-io/thanos/pull/2800) Query: Fix handling of `--web.external-prefix` and `--web.route-prefix`
 
 ### Changed
+- [#2832](https://github.com/thanos-io/thanos/pull/2832) ui: React: Add runtime and build info page
 
 ## [v0.14.0](https://github.com/thanos-io/thanos/releases) - IN PROGRESS
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 * [#2665](https://github.com/thanos-io/thanos/pull/2665) Swift: fix issue with missing Content-Type HTTP headers.
 - [#2800](https://github.com/thanos-io/thanos/pull/2800) Query: Fix handling of `--web.external-prefix` and `--web.route-prefix`
 
-### Changed
+### Added
 - [#2832](https://github.com/thanos-io/thanos/pull/2832) ui: React: Add runtime and build info page
 
 ## [v0.14.0](https://github.com/thanos-io/thanos/releases) - IN PROGRESS

--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -492,10 +492,11 @@ func runQuery(
 	return nil
 }
 
-func runtimeInfo() v1.RuntimeInfo {
+func runtimeInfo(logger log.Logger) v1.RuntimeInfo {
 	cwd, err := os.Getwd()
 	if err != nil {
 		cwd = "<error retrieving current working directory>"
+		level.Warn(logger).Log("msg", "failed to retrieve current working directory", "err", err)
 	}
 
 	status := v1.RuntimeInfo{

--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -429,10 +429,10 @@ func runQuery(
 			CWD = "<error retrieving current working directory>"
 			level.Warn(logger).Log("msg", "failed to retrieve current working directory", "err", err)
 		}
-		
+
 		birth := time.Now()
 
-		var runtimeInfo v1.RuntimeInfoFn = func (logger log.Logger) v1.RuntimeInfo {
+		var runtimeInfo v1.RuntimeInfoFn = func(logger log.Logger) v1.RuntimeInfo {
 			status := v1.RuntimeInfo{
 				StartTime:      birth,
 				CWD:            CWD,

--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -432,7 +432,7 @@ func runQuery(
 
 		birth := time.Now()
 
-		var runtimeInfo v1.RuntimeInfoFn = func(logger log.Logger) v1.RuntimeInfo {
+		var runtimeInfo v1.RuntimeInfoFn = func() v1.RuntimeInfo {
 			status := v1.RuntimeInfo{
 				StartTime:      birth,
 				CWD:            CWD,

--- a/pkg/query/api/v1.go
+++ b/pkg/query/api/v1.go
@@ -107,6 +107,9 @@ type RuntimeInfo struct {
 	GODEBUG        string    `json:"GODEBUG"`
 }
 
+// RuntimeInfoFn returns updated runtime information about Thanos.
+type RuntimeInfoFn func(log.Logger) RuntimeInfo
+
 type response struct {
 	Status    status      `json:"status"`
 	Data      interface{} `json:"data,omitempty"`

--- a/pkg/query/api/v1.go
+++ b/pkg/query/api/v1.go
@@ -87,6 +87,26 @@ func (e *ApiError) Error() string {
 	return fmt.Sprintf("%s: %s", e.Typ, e.Err)
 }
 
+// ThanosVersion contains build information about Thanos.
+type ThanosVersion struct {
+	Version   string `json:"version"`
+	Revision  string `json:"revision"`
+	Branch    string `json:"branch"`
+	BuildUser string `json:"buildUser"`
+	BuildDate string `json:"buildDate"`
+	GoVersion string `json:"goVersion"`
+}
+
+// RuntimeInfo contains runtime information about Thanos.
+type RuntimeInfo struct {
+	StartTime      time.Time `json:"startTime"`
+	CWD            string    `json:"CWD"`
+	GoroutineCount int       `json:"goroutineCount"`
+	GOMAXPROCS     int       `json:"GOMAXPROCS"`
+	GOGC           string    `json:"GOGC"`
+	GODEBUG        string    `json:"GODEBUG"`
+}
+
 type response struct {
 	Status    status      `json:"status"`
 	Data      interface{} `json:"data,omitempty"`
@@ -119,6 +139,8 @@ type API struct {
 	enableRulePartialResponse  bool
 	replicaLabels              []string
 	flagsMap                   map[string]string
+	runtimeInfo                func() RuntimeInfo
+	buildInfo                  *ThanosVersion
 
 	storeSet                               *query.StoreSet
 	defaultInstantQueryMaxSourceResolution time.Duration
@@ -141,6 +163,8 @@ func NewAPI(
 	flagsMap map[string]string,
 	defaultInstantQueryMaxSourceResolution time.Duration,
 	maxConcurrentQueries int,
+	runtimeInfo func() RuntimeInfo,
+	buildInfo *ThanosVersion,
 ) *API {
 	return &API{
 		logger:          logger,
@@ -157,6 +181,8 @@ func NewAPI(
 		flagsMap:                               flagsMap,
 		storeSet:                               storeSet,
 		defaultInstantQueryMaxSourceResolution: defaultInstantQueryMaxSourceResolution,
+		runtimeInfo:                            runtimeInfo,
+		buildInfo:                              buildInfo,
 
 		now: time.Now,
 	}
@@ -195,6 +221,8 @@ func (api *API) Register(r *route.Router, tracer opentracing.Tracer, logger log.
 	r.Post("/labels", instr("label_names", api.labelNames))
 
 	r.Get("/status/flags", instr("status_flags", api.flags))
+	r.Get("/status/runtimeinfo", instr("status_runtime", api.serveRuntimeInfo))
+	r.Get("/status/buildinfo", instr("status_build", api.serveBuildInfo))
 
 	r.Get("/stores", instr("stores", api.stores))
 
@@ -681,6 +709,14 @@ func (api *API) stores(r *http.Request) (interface{}, []error, *ApiError) {
 
 func (api *API) flags(r *http.Request) (interface{}, []error, *ApiError) {
 	return api.flagsMap, nil, nil
+}
+
+func (api *API) serveRuntimeInfo(r *http.Request) (interface{}, []error, *ApiError) {
+	return api.runtimeInfo(), nil, nil
+}
+
+func (api *API) serveBuildInfo(r *http.Request) (interface{}, []error, *ApiError) {
+	return api.buildInfo, nil, nil
 }
 
 // NewRulesHandler created handler compatible with HTTP /api/v1/rules https://prometheus.io/docs/prometheus/latest/querying/api/#rules

--- a/pkg/query/api/v1.go
+++ b/pkg/query/api/v1.go
@@ -139,7 +139,7 @@ type API struct {
 	enableRulePartialResponse  bool
 	replicaLabels              []string
 	flagsMap                   map[string]string
-	runtimeInfo                func() RuntimeInfo
+	runtimeInfo                func(log.Logger) RuntimeInfo
 	buildInfo                  *ThanosVersion
 
 	storeSet                               *query.StoreSet
@@ -163,7 +163,7 @@ func NewAPI(
 	flagsMap map[string]string,
 	defaultInstantQueryMaxSourceResolution time.Duration,
 	maxConcurrentQueries int,
-	runtimeInfo func() RuntimeInfo,
+	runtimeInfo func(log.Logger) RuntimeInfo,
 	buildInfo *ThanosVersion,
 ) *API {
 	return &API{
@@ -712,7 +712,7 @@ func (api *API) flags(r *http.Request) (interface{}, []error, *ApiError) {
 }
 
 func (api *API) serveRuntimeInfo(r *http.Request) (interface{}, []error, *ApiError) {
-	return api.runtimeInfo(), nil, nil
+	return api.runtimeInfo(api.logger), nil, nil
 }
 
 func (api *API) serveBuildInfo(r *http.Request) (interface{}, []error, *ApiError) {

--- a/pkg/query/api/v1.go
+++ b/pkg/query/api/v1.go
@@ -108,7 +108,7 @@ type RuntimeInfo struct {
 }
 
 // RuntimeInfoFn returns updated runtime information about Thanos.
-type RuntimeInfoFn func(log.Logger) RuntimeInfo
+type RuntimeInfoFn func() RuntimeInfo
 
 type response struct {
 	Status    status      `json:"status"`
@@ -142,7 +142,7 @@ type API struct {
 	enableRulePartialResponse  bool
 	replicaLabels              []string
 	flagsMap                   map[string]string
-	runtimeInfo                func(log.Logger) RuntimeInfo
+	runtimeInfo                RuntimeInfoFn
 	buildInfo                  *ThanosVersion
 
 	storeSet                               *query.StoreSet
@@ -166,7 +166,7 @@ func NewAPI(
 	flagsMap map[string]string,
 	defaultInstantQueryMaxSourceResolution time.Duration,
 	maxConcurrentQueries int,
-	runtimeInfo func(log.Logger) RuntimeInfo,
+	runtimeInfo RuntimeInfoFn,
 	buildInfo *ThanosVersion,
 ) *API {
 	return &API{
@@ -715,7 +715,7 @@ func (api *API) flags(r *http.Request) (interface{}, []error, *ApiError) {
 }
 
 func (api *API) serveRuntimeInfo(r *http.Request) (interface{}, []error, *ApiError) {
-	return api.runtimeInfo(api.logger), nil, nil
+	return api.runtimeInfo(), nil, nil
 }
 
 func (api *API) serveBuildInfo(r *http.Request) (interface{}, []error, *ApiError) {

--- a/pkg/ui/query.go
+++ b/pkg/ui/query.go
@@ -34,15 +34,6 @@ type Query struct {
 	now     func() model.Time
 }
 
-type thanosVersion struct {
-	Version   string `json:"version"`
-	Revision  string `json:"revision"`
-	Branch    string `json:"branch"`
-	BuildUser string `json:"buildUser"`
-	BuildDate string `json:"buildDate"`
-	GoVersion string `json:"goVersion"`
-}
-
 func NewQueryUI(logger log.Logger, reg prometheus.Registerer, storeSet *query.StoreSet, externalPrefix, prefixHeader string, runtimeInfo func(log.Logger) v1.RuntimeInfo, buildInfo v1.ThanosVersion) *Query {
 	return &Query{
 		BaseUI:         NewBaseUI(logger, "query_menu.html", queryTmplFuncs(), externalPrefix, prefixHeader, component.Query),

--- a/pkg/ui/query.go
+++ b/pkg/ui/query.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/common/route"
@@ -47,6 +48,7 @@ func NewQueryUI(logger log.Logger, reg prometheus.Registerer, storeSet *query.St
 	cwd, err := os.Getwd()
 	if err != nil {
 		cwd = "<error retrieving current working directory>"
+		level.Warn(logger).Log("msg", "failed to retrieve current working directory", "err", err)
 	}
 	return &Query{
 		BaseUI:         NewBaseUI(logger, "query_menu.html", queryTmplFuncs(), externalPrefix, prefixHeader, component.Query),

--- a/pkg/ui/query.go
+++ b/pkg/ui/query.go
@@ -34,14 +34,14 @@ type Query struct {
 	now     func() model.Time
 }
 
-func NewQueryUI(logger log.Logger, reg prometheus.Registerer, storeSet *query.StoreSet, externalPrefix, prefixHeader string, runtimeInfo func(log.Logger) v1.RuntimeInfo, buildInfo v1.ThanosVersion) *Query {
+func NewQueryUI(logger log.Logger, reg prometheus.Registerer, storeSet *query.StoreSet, externalPrefix, prefixHeader string, runtimeInfo v1.RuntimeInfoFn, buildInfo v1.ThanosVersion) *Query {
 	return &Query{
 		BaseUI:         NewBaseUI(logger, "query_menu.html", queryTmplFuncs(), externalPrefix, prefixHeader, component.Query),
 		storeSet:       storeSet,
 		externalPrefix: externalPrefix,
 		prefixHeader:   prefixHeader,
-		cwd:            runtimeInfo(logger).CWD,
-		birth:          runtimeInfo(logger).StartTime,
+		cwd:            runtimeInfo().CWD,
+		birth:          runtimeInfo().StartTime,
 		version:        buildInfo,
 		reg:            reg,
 		now:            model.Now,

--- a/pkg/ui/react-app/src/pages/status/Status.tsx
+++ b/pkg/ui/react-app/src/pages/status/Status.tsx
@@ -92,7 +92,6 @@ const Status: FC<RouteComponentProps & PathPrefixProps> = ({ pathPrefix = '' }) 
       {[
         { fetchResult: useFetch<Record<string, string>>(`${path}/status/runtimeinfo`), title: 'Runtime Information' },
         { fetchResult: useFetch<Record<string, string>>(`${path}/status/buildinfo`), title: 'Build Information' },
-        { fetchResult: useFetch<Record<string, string>>(`${path}/alertmanagers`), title: 'Alertmanagers' },
       ].map(({ fetchResult, title }) => {
         const { response, isLoading, error } = fetchResult;
         return (

--- a/pkg/ui/react-app/src/thanos/Navbar.tsx
+++ b/pkg/ui/react-app/src/thanos/Navbar.tsx
@@ -29,7 +29,13 @@ const navConfig: { [component: string]: (NavConfig | NavDropDown)[] } = {
   query: [
     { name: 'Graph', uri: '/new/graph' },
     { name: 'Stores', uri: '/new/stores' },
-    { name: 'Status', children: [{ name: 'Command-Line Flags', uri: '/new/flags' }] },
+    {
+      name: 'Status',
+      children: [
+        { name: 'Runtime & Build Information', uri: '/new/status' },
+        { name: 'Command-Line Flags', uri: '/new/flags' },
+      ],
+    },
   ],
 };
 


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end-user.

## Changes
- Implement API endpoints `/status/runtimeinfo` and `/api/buildinfo`
- Enable the `Runtime & Build Information` page in react UI

## Verification
Tested locally using both production and development build.

## Screenshot
![Runtime & Build Info page](https://user-images.githubusercontent.com/29674758/86342691-95e17e00-bc75-11ea-9897-04305ee13378.png)

