### PR TITLE
Query: Fix rendered JSON state value for rules and alerts should be in lowercase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 
 * [#2665](https://github.com/thanos-io/thanos/pull/2665) Swift: fix issue with missing Content-Type HTTP headers.
 - [#2800](https://github.com/thanos-io/thanos/pull/2800) Query: Fix handling of `--web.external-prefix` and `--web.route-prefix`
+- [#2834](https://github.com/thanos-io/thanos/pull/2834) Query: Fix rendered JSON state value for rules and alerts should be in lowercase
 
 ### Changed
 

--- a/pkg/query/api/v1_test.go
+++ b/pkg/query/api/v1_test.go
@@ -1318,7 +1318,7 @@ func TestRulesHandler(t *testing.T) {
 			Type:           "recording",
 		},
 		testpromcompatibility.AlertingRule{
-			State:          all[2].GetAlert().State.String(),
+			State:          strings.ToLower(all[2].GetAlert().State.String()),
 			Name:           all[2].GetAlert().Name,
 			Query:          all[2].GetAlert().Query,
 			Labels:         storepb.LabelsToPromLabels(all[2].GetAlert().Labels.Labels),
@@ -1332,7 +1332,7 @@ func TestRulesHandler(t *testing.T) {
 				{
 					Labels:                  storepb.LabelsToPromLabels(all[2].GetAlert().Alerts[0].Labels.Labels),
 					Annotations:             storepb.LabelsToPromLabels(all[2].GetAlert().Alerts[0].Annotations.Labels),
-					State:                   all[2].GetAlert().Alerts[0].State.String(),
+					State:                   strings.ToLower(all[2].GetAlert().Alerts[0].State.String()),
 					ActiveAt:                all[2].GetAlert().Alerts[0].ActiveAt,
 					Value:                   all[2].GetAlert().Alerts[0].Value,
 					PartialResponseStrategy: all[2].GetAlert().Alerts[0].PartialResponseStrategy.String(),
@@ -1340,7 +1340,7 @@ func TestRulesHandler(t *testing.T) {
 				{
 					Labels:                  storepb.LabelsToPromLabels(all[2].GetAlert().Alerts[1].Labels.Labels),
 					Annotations:             storepb.LabelsToPromLabels(all[2].GetAlert().Alerts[1].Annotations.Labels),
-					State:                   all[2].GetAlert().Alerts[1].State.String(),
+					State:                   strings.ToLower(all[2].GetAlert().Alerts[1].State.String()),
 					ActiveAt:                all[2].GetAlert().Alerts[1].ActiveAt,
 					Value:                   all[2].GetAlert().Alerts[1].Value,
 					PartialResponseStrategy: all[2].GetAlert().Alerts[1].PartialResponseStrategy.String(),
@@ -1349,7 +1349,7 @@ func TestRulesHandler(t *testing.T) {
 			Type: "alerting",
 		},
 		testpromcompatibility.AlertingRule{
-			State:          all[3].GetAlert().State.String(),
+			State:          strings.ToLower(all[3].GetAlert().State.String()),
 			Name:           all[3].GetAlert().Name,
 			Query:          all[3].GetAlert().Query,
 			Labels:         storepb.LabelsToPromLabels(all[3].GetAlert().Labels.Labels),

--- a/pkg/rules/rulespb/custom.go
+++ b/pkg/rules/rulespb/custom.go
@@ -247,7 +247,7 @@ func (x *AlertState) UnmarshalJSON(entry []byte) error {
 }
 
 func (x *AlertState) MarshalJSON() ([]byte, error) {
-	return []byte(strconv.Quote(x.String())), nil
+	return []byte(strconv.Quote(strings.ToLower(x.String()))), nil
 }
 
 // Compare compares alert state x and y and returns:

--- a/pkg/rules/rulespb/custom_test.go
+++ b/pkg/rules/rulespb/custom_test.go
@@ -207,7 +207,7 @@ func TestJSONUnmarshalMarshal(t *testing.T) {
 										Annotations: labels.Labels{
 											{Name: "annotation1", Value: "2"},
 										},
-										State:                   "INACTIVE",
+										State:                   "inactive",
 										ActiveAt:                nil,
 										Value:                   "1",
 										PartialResponseStrategy: "WARN",
@@ -215,7 +215,7 @@ func TestJSONUnmarshalMarshal(t *testing.T) {
 									{
 										Labels:                  nil,
 										Annotations:             nil,
-										State:                   "FIRING",
+										State:                   "firing",
 										ActiveAt:                &twoHoursAgo,
 										Value:                   "2143",
 										PartialResponseStrategy: "ABORT",
@@ -223,7 +223,7 @@ func TestJSONUnmarshalMarshal(t *testing.T) {
 								},
 								LastError:      "1",
 								Duration:       60,
-								State:          "PENDING",
+								State:          "pending",
 								LastEvaluation: now.Add(-1 * time.Minute),
 								EvaluationTime: 1.1,
 							},


### PR DESCRIPTION
Currently, alert state is rendered as upper case.
In Prometheus it is lower case.
This fixes it.

Signed-off-by: Sergiusz Urbaniak <sergiusz.urbaniak@gmail.com>

Fixes #2830

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

- the web /apiv1/rules endpoint renders alert states now in lowercase to retain compatibility with the Prometheus API.

## Verification

- Changed unit tests
- Verified manually in a local setup:

```
$ curl -s localhost:32775/api/v1/rules | jq .
{
  "status": "success",
  "data": {
    "groups": [
      {
        "name": "example_abort",
        "file": "/shared/rules/rules-0.yaml",
        "rules": [
          {
            "state": "inactive",
            "name": "TestAlert_AbortOnPartialResponse",
            "query": "absent(some_metric)",
            "duration": 0,
            "labels": {
              "replica": "rule1",
              "severity": "page"
            },
            "annotations": {
              "summary": "I always complain, but I don't allow partial response in query."
            },
            "alerts": [],
            "health": "err",
            "lastError": "no query API server reachable",
            "evaluationTime": 0.00042013,
            "lastEvaluation": "2020-07-02T11:36:10.20089108Z",
            "type": "alerting"
          }
        ],
        "interval": 3,
        "evaluationTime": 0,
        "lastEvaluation": "0001-01-01T00:00:00Z",
        "partial_response_strategy": "WARN",
        "partialResponseStrategy": "ABORT"
      },
      {
        "name": "example_warn",
        "file": "/shared/rules/rules-1.yaml",
        "rules": [
          {
            "state": "inactive",
            "name": "TestAlert_WarnOnPartialResponse",
            "query": "absent(some_metric)",
            "duration": 0,
            "labels": {
              "replica": "rule1",
              "severity": "page"
            },
            "annotations": {
              "summary": "I always complain and allow partial response in query."
            },
            "alerts": [],
            "health": "err",
            "lastError": "no query API server reachable",
            "evaluationTime": 0.000391637,
            "lastEvaluation": "2020-07-02T11:36:11.856795352Z",
            "type": "alerting"
          }
        ],
        "interval": 3,
        "evaluationTime": 0,
        "lastEvaluation": "0001-01-01T00:00:00Z",
        "partial_response_strategy": "WARN",
        "partialResponseStrategy": "WARN"
      }
    ]
  }
}
```