### PR TITLE
chore: enable Swift CI tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,10 +4,13 @@ version: 2
 defaults: &defaults
   docker:
     # Built by Thanos make docker-ci
-    - image: quay.io/thanos/thanos-ci:v1.2-go1.14.2-node
+    - image: &default-docker-image quay.io/thanos/thanos-ci:v1.2-go1.14.2-node
+
 jobs:
   test:
-    <<: *defaults
+    docker:
+      - image: *default-docker-image
+      - image: beaukode/docker-swift-onlyone-authv2-keystone
     working_directory: /go/src/github.com/thanos-io/thanos
     environment:
       GO111MODULE: 'on'
@@ -26,13 +29,21 @@ jobs:
             fi
       - run:
           name: "Run unit tests."
+          environment:
+            THANOS_TEST_OBJSTORE_SKIP: AZURE,COS,ALIYUNOSS
+            # Variables for Sift testing.
+            OS_AUTH_URL: http://127.0.0.1:5000/v2.0
+            OS_PASSWORD: s3cr3t
+            OS_PROJECT_NAME: admin
+            OS_REGION_NAME: RegionOne
+            OS_USERNAME: admin
           # taskset sets CPU affinity to 2 (current CPU limit).
           command: |
             if [ -z ${GCP_PROJECT} ]; then
-              taskset 2 make test-local
-              exit
+              export THANOS_TEST_OBJSTORE_SKIP=${THANOS_TEST_OBJSTORE_SKIP},GCS,S3
             fi
-            taskset 2 make test-ci
+            echo "Skipping tests for object storages: ${THANOS_TEST_OBJSTORE_SKIP}"
+            taskset 2 make test
 
   # Cross build is needed for publish_release but needs to be done outside of docker.
   cross_build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
           name: "Run unit tests."
           environment:
             THANOS_TEST_OBJSTORE_SKIP: AZURE,COS,ALIYUNOSS
-            # Variables for Sift testing.
+            # Variables for Swift testing.
             OS_AUTH_URL: http://127.0.0.1:5000/v2.0
             OS_PASSWORD: s3cr3t
             OS_PROJECT_NAME: admin

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,8 +133,7 @@ $ git push origin <your_branch_for_new_pr>
 1. If you don't have a live object store ready, you can use the `make test-local` command.
 
 NOTE: this command skips tests against live object storage systems by specifying environment variables; this causes the
-store-specific tests to be run against memory and filesystem object storages only. The CI tests run `make test-ci` instead
-(uses GCS, AWS).
+store-specific tests to be run against memory and filesystem object storage types only. The CI tests run uses GCS, AWS and Swift.
 
 Not specifying these variables will result in auth errors against GCS, AWS, Azure, COS etc.
 

--- a/Makefile
+++ b/Makefile
@@ -196,13 +196,6 @@ test: check-git install-deps
 	@echo ">> running unit tests (without /test/e2e). Do export THANOS_TEST_OBJSTORE_SKIP=GCS,S3,AZURE,SWIFT,COS,ALIYUNOSS if you want to skip e2e tests against all real store buckets. Current value: ${THANOS_TEST_OBJSTORE_SKIP}"
 	@go test $(shell go list ./... | grep -v /vendor/ | grep -v /test/e2e);
 
-.PHONY: test-ci
-test-ci: ## Runs test for CI, so excluding object storage integrations that we don't have configured yet.
-test-ci: export THANOS_TEST_OBJSTORE_SKIP=AZURE,SWIFT,COS,ALIYUNOSS
-test-ci:
-	@echo ">> Skipping ${THANOS_TEST_OBJSTORE_SKIP} tests"
-	$(MAKE) test
-
 .PHONY: test-local
 test-local: ## Runs test excluding tests for ALL  object storage integrations.
 test-local: export THANOS_TEST_OBJSTORE_SKIP=GCS,S3,AZURE,SWIFT,COS,ALIYUNOSS


### PR DESCRIPTION
Signed-off-by: Martin Chodur <m.chodur@seznam.cz>

Added Swift CI tests as suggested in https://github.com/thanos-io/thanos/issues/2829

I'm not sure if it should run for every test? I'm not sure if we are somehow limited in the CircleCI usage.
From time perspective it does not significantly prolong the test stage in CI. 


