### PR TITLE
Query: correctly marshal errors to JSON and ignore if nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 * [#2665](https://github.com/thanos-io/thanos/pull/2665) Swift: fix issue with missing Content-Type HTTP headers.
 - [#2800](https://github.com/thanos-io/thanos/pull/2800) Query: Fix handling of `--web.external-prefix` and `--web.route-prefix`
 - [#2834](https://github.com/thanos-io/thanos/pull/2834) Query: Fix rendered JSON state value for rules and alerts should be in lowercase
+- [#2847](https://github.com/thanos-io/thanos/pull/2847) Query: Fix remove erroneos error when viewing stores.
 
 ### Changed
 

--- a/pkg/query/storeset.go
+++ b/pkg/query/storeset.go
@@ -527,7 +527,9 @@ func (s *StoreSet) updateStoreStatus(store *storeRef, err error) {
 		status = *prev
 	}
 
-	status.LastError = &stringError{originalErr: err}
+	if err != nil {
+		status.LastError = &stringError{originalErr: err}
+	}
 
 	if err == nil {
 		status.LastCheck = time.Now()

--- a/pkg/query/storeset_test.go
+++ b/pkg/query/storeset_test.go
@@ -781,27 +781,55 @@ func TestStoreSet_Update_Rules(t *testing.T) {
 	}
 }
 
-type weirdError struct {
-	originalErr error
+type errThatMarshalsToEmptyDict struct {
+	errMsg string
 }
 
 // MarshalJSON marshals the error and returns weird results.
-func (e *weirdError) MarshalJSON() ([]byte, error) {
+func (e *errThatMarshalsToEmptyDict) MarshalJSON() ([]byte, error) {
 	return json.Marshal(map[string]string{})
 }
 
 // Error returns the original, underlying string.
-func (e *weirdError) Error() string {
-	return e.originalErr.Error()
+func (e *errThatMarshalsToEmptyDict) Error() string {
+	return e.errMsg
 }
 
+// show that without wrapping the error, it is marshalled to {}, not its message
 func TestStringError(t *testing.T) {
-	weirdError := &weirdError{originalErr: errors.New("test")}
+	weirdError := &errThatMarshalsToEmptyDict{errMsg: "Error message"}
 	properErr := &stringError{originalErr: weirdError}
 	storestatusMock := map[string]error{}
 	storestatusMock["weird"] = weirdError
 	storestatusMock["proper"] = properErr
 	b, err := json.Marshal(storestatusMock)
 	testutil.Ok(t, err)
-	testutil.Equals(t, []byte(`{"proper":"test","weird":{}}`), b, "expected to get proper results")
+	testutil.Equals(t, []byte(`{"proper":"Error message","weird":{}}`), b, "expected to get proper results")
+}
+
+// Errors that marshal to empty dict should return the original error string
+func TestUpdateStoreStateLastError(t *testing.T) {
+	tcs := []struct{
+		InputError error
+		ExpectedLastErr string
+	}{
+		{errors.New("normal_err"), `"normal_err"`},
+		{nil, `null`},
+		{&errThatMarshalsToEmptyDict{"the error message"}, `"the error message"`},
+	}
+
+	for _, tc := range tcs {
+		mockStoreSet := &StoreSet{
+			storeStatuses:  map[string]*StoreStatus{},
+		}
+		mockStoreRef := &storeRef{
+			addr: "testStore",
+		}
+
+		mockStoreSet.updateStoreStatus(mockStoreRef, tc.InputError)
+
+		b, err := json.Marshal(mockStoreSet.storeStatuses["testStore"].LastError)
+		testutil.Ok(t, err)
+		testutil.Equals(t, tc.ExpectedLastErr, string(b))
+	}
 }


### PR DESCRIPTION
* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Fixes: https://github.com/thanos-io/thanos/issues/2846
Passing nil error to updateStoreStatus causes a panic. This is displayed to the user in the Stores ui when the Store is healthy


Added higher level unit test to catch this, and hopefully clarified existing test.
