### PR TITLE
Initial setup for Request Logging in HTTP in the server side

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,8 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 
 ### Added
 
-- [#2832](https://github.com/thanos-io/thanos/pull/2832) ui: React: Add runtime and build info page.
+- [#2849](https://github.com/thanos-io/thanos/pull/2849) Query, Ruler : Added request logging for HTTP server side.
+- [#2832](https://github.com/thanos-io/thanos/pull/2832) ui: React: Add runtime and build info page
 - [#2305](https://github.com/thanos-io/thanos/pull/2305) Receive,Sidecar,Ruler: Propagate correct (stricter) MinTime for no-block TSDBs.
 - [#2926](https://github.com/thanos-io/thanos/pull/2926) API: Add new blocks HTTP API to serve blocks metadata. The status endpoints (`/api/v1/status/flags`, `/api/v1/status/runtimeinfo` and `/api/v1/status/buildinfo`) are now available on all components with a HTTP API.
 - [#2892](https://github.com/thanos-io/thanos/pull/2892) Receive: Receiver fails when the initial upload fails.

--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -402,7 +402,7 @@ func runCompact(
 
 		api := blocksAPI.NewBlocksAPI(logger, conf.label, flagsMap)
 		// Configure Request Logging for HTTP calls.
-		opts := []logging.Option{logging.WithDecider(func(_ string) logging.Decision {
+		opts := []logging.Option{logging.WithDecider(func() logging.Decision {
 			return logging.NoLogCall
 		})}
 		logMiddleware := logging.NewHTTPServerMiddleware(logger, opts...)

--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -31,6 +31,7 @@ import (
 	"github.com/thanos-io/thanos/pkg/extflag"
 	"github.com/thanos-io/thanos/pkg/extprom"
 	extpromhttp "github.com/thanos-io/thanos/pkg/extprom/http"
+	"github.com/thanos-io/thanos/pkg/logging"
 	"github.com/thanos-io/thanos/pkg/objstore/client"
 	"github.com/thanos-io/thanos/pkg/prober"
 	"github.com/thanos-io/thanos/pkg/runutil"
@@ -400,7 +401,12 @@ func runCompact(
 		global.Register(r, ins)
 
 		api := blocksAPI.NewBlocksAPI(logger, conf.label, flagsMap)
-		api.Register(r.WithPrefix("/api/v1"), tracer, logger, ins)
+		// Configure Request Logging for HTTP calls.
+		opts := []logging.Option{logging.WithDecider(func(_ string) logging.Decision {
+			return logging.NoLogCall
+		})}
+		logMiddleware := logging.NewHTTPServerMiddleware(logger, opts...)
+		api.Register(r.WithPrefix("/api/v1"), tracer, logger, ins, logMiddleware)
 
 		// Separate fetcher for global view.
 		// TODO(bwplotka): Allow Bucket UI to visualize the state of the block as well.

--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -407,7 +407,7 @@ func runQuery(
 		}
 
 		// Configure Request Logging for HTTP calls.
-		opts := []logging.Option{logging.WithDecider(func(_ string) logging.Decision {
+		opts := []logging.Option{logging.WithDecider(func() logging.Decision {
 			return logging.LogDecision[requestLoggingDecision]
 		})}
 		logMiddleware := logging.NewHTTPServerMiddleware(logger, opts...)

--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -32,6 +32,7 @@ import (
 	"github.com/thanos-io/thanos/pkg/extgrpc"
 	"github.com/thanos-io/thanos/pkg/extprom"
 	extpromhttp "github.com/thanos-io/thanos/pkg/extprom/http"
+	"github.com/thanos-io/thanos/pkg/logging"
 	"github.com/thanos-io/thanos/pkg/prober"
 	"github.com/thanos-io/thanos/pkg/query"
 	"github.com/thanos-io/thanos/pkg/rules"
@@ -60,6 +61,8 @@ func registerQuery(m map[string]setupFunc, app *kingpin.Application) {
 	webRoutePrefix := cmd.Flag("web.route-prefix", "Prefix for API and UI endpoints. This allows thanos UI to be served on a sub-path. Defaults to the value of --web.external-prefix. This option is analogous to --web.route-prefix of Promethus.").Default("").String()
 	webExternalPrefix := cmd.Flag("web.external-prefix", "Static prefix for all HTML links and redirect URLs in the UI query web interface. Actual endpoints are still served on / or the web.route-prefix. This allows thanos UI to be served behind a reverse proxy that strips a URL sub-path.").Default("").String()
 	webPrefixHeaderName := cmd.Flag("web.prefix-header", "Name of HTTP request header used for dynamic prefixing of UI links and redirects. This option is ignored if web.external-prefix argument is set. Security risk: enable this option only if a reverse proxy in front of thanos is resetting the header. The --web.prefix-header=X-Forwarded-Prefix option can be useful, for example, if Thanos UI is served via Traefik reverse proxy with PathPrefixStrip option enabled, which sends the stripped prefix value in X-Forwarded-Prefix header. This allows thanos UI to be served on a sub-path.").Default("").String()
+
+	requestLoggingDecision := cmd.Flag("log.request.decision", "Request Logging for logging the start and end of requests. LogFinishCall is enabled by default. LogFinishCall : Logs the finish call of the requests. LogStartAndFinishCall : Logs the start and finish call of the requests. NoLogCall : Disable request logging.").Default("LogFinishCall").Enum("NoLogCall", "LogFinishCall", "LogStartAndFinishCall")
 
 	queryTimeout := modelDuration(cmd.Flag("query.timeout", "Maximum time to process query by query node.").
 		Default("2m"))
@@ -156,6 +159,7 @@ func registerQuery(m map[string]setupFunc, app *kingpin.Application) {
 			logger,
 			reg,
 			tracer,
+			*requestLoggingDecision,
 			*grpcBindAddr,
 			time.Duration(*grpcGracePeriod),
 			*grpcCert,
@@ -201,6 +205,7 @@ func runQuery(
 	logger log.Logger,
 	reg *prometheus.Registry,
 	tracer opentracing.Tracer,
+	requestLoggingDecision string,
 	grpcBindAddr string,
 	grpcGracePeriod time.Duration,
 	grpcCert string,
@@ -401,6 +406,12 @@ func runQuery(
 			router = router.WithPrefix(webRoutePrefix)
 		}
 
+		// Configure Request Logging for HTTP calls.
+		opts := []logging.Option{logging.WithDecider(func(_ string) logging.Decision {
+			return logging.LogDecision[requestLoggingDecision]
+		})}
+		logMiddleware := logging.NewHTTPServerMiddleware(logger, opts...)
+
 		ins := extpromhttp.NewInstrumentationMiddleware(reg)
 		// TODO(bplotka in PR #513 review): pass all flags, not only the flags needed by prefix rewriting.
 		ui.NewQueryUI(logger, reg, stores, webExternalPrefix, webPrefixHeaderName).Register(router, ins)
@@ -422,7 +433,7 @@ func runQuery(
 			maxConcurrentQueries,
 		)
 
-		api.Register(router.WithPrefix("/api/v1"), tracer, logger, ins)
+		api.Register(router.WithPrefix("/api/v1"), tracer, logger, ins, logMiddleware)
 
 		srv := httpserver.New(logger, reg, comp, httpProbe,
 			httpserver.WithListen(httpBindAddr),

--- a/cmd/thanos/rule.go
+++ b/cmd/thanos/rule.go
@@ -592,7 +592,7 @@ func runRule(
 		ins := extpromhttp.NewInstrumentationMiddleware(reg)
 
 		// Configure Request Logging for HTTP calls.
-		opts := []logging.Option{logging.WithDecider(func(_ string) logging.Decision {
+		opts := []logging.Option{logging.WithDecider(func() logging.Decision {
 			return logging.LogDecision[requestLoggingDecision]
 		})}
 		logMiddleware := logging.NewHTTPServerMiddleware(logger, opts...)

--- a/cmd/thanos/rule.go
+++ b/cmd/thanos/rule.go
@@ -98,6 +98,8 @@ func registerRule(m map[string]setupFunc, app *kingpin.Application) {
 	webExternalPrefix := cmd.Flag("web.external-prefix", "Static prefix for all HTML links and redirect URLs in the UI query web interface. Actual endpoints are still served on / or the web.route-prefix. This allows thanos UI to be served behind a reverse proxy that strips a URL sub-path.").Default("").String()
 	webPrefixHeaderName := cmd.Flag("web.prefix-header", "Name of HTTP request header used for dynamic prefixing of UI links and redirects. This option is ignored if web.external-prefix argument is set. Security risk: enable this option only if a reverse proxy in front of thanos is resetting the header. The --web.prefix-header=X-Forwarded-Prefix option can be useful, for example, if Thanos UI is served via Traefik reverse proxy with PathPrefixStrip option enabled, which sends the stripped prefix value in X-Forwarded-Prefix header. This allows thanos UI to be served on a sub-path.").Default("").String()
 
+	requestLoggingDecision := cmd.Flag("log.request.decision", "Request Logging for logging the start and end of requests. LogFinishCall is enabled by default. LogFinishCall : Logs the finish call of the requests. LogStartAndFinishCall : Logs the start and finish call of the requests. NoLogCall : Disable request logging.").Default("LogFinishCall").Enum("NoLogCall", "LogFinishCall", "LogStartAndFinishCall")
+
 	objStoreConfig := regCommonObjStoreFlags(cmd, "", false)
 
 	queries := cmd.Flag("query", "Addresses of statically configured query API servers (repeatable). The scheme may be prefixed with 'dns+' or 'dnssrv+' to detect query API servers through respective DNS lookups.").
@@ -177,6 +179,7 @@ func registerRule(m map[string]setupFunc, app *kingpin.Application) {
 			logger,
 			reg,
 			tracer,
+			*requestLoggingDecision,
 			reload,
 			lset,
 			*alertmgrs,
@@ -265,6 +268,7 @@ func runRule(
 	logger log.Logger,
 	reg *prometheus.Registry,
 	tracer opentracing.Tracer,
+	requestLoggingDecision string,
 	reloadSignal <-chan struct{},
 	lset labels.Labels,
 	alertmgrURLs []string,
@@ -589,7 +593,7 @@ func runRule(
 
 		// Configure Request Logging for HTTP calls.
 		opts := []logging.Option{logging.WithDecider(func(_ string) logging.Decision {
-			return logging.NoLogCall
+			return logging.LogDecision[requestLoggingDecision]
 		})}
 		logMiddleware := logging.NewHTTPServerMiddleware(logger, opts...)
 

--- a/cmd/thanos/tools_bucket.go
+++ b/cmd/thanos/tools_bucket.go
@@ -33,6 +33,7 @@ import (
 	"github.com/thanos-io/thanos/pkg/extflag"
 	"github.com/thanos-io/thanos/pkg/extprom"
 	extpromhttp "github.com/thanos-io/thanos/pkg/extprom/http"
+	"github.com/thanos-io/thanos/pkg/logging"
 	"github.com/thanos-io/thanos/pkg/objstore"
 	"github.com/thanos-io/thanos/pkg/objstore/client"
 	"github.com/thanos-io/thanos/pkg/prober"
@@ -351,7 +352,14 @@ func registerBucketWeb(m map[string]setupFunc, root *kingpin.CmdClause, name str
 		flagsMap := getFlagsMap(cmd.Model().Flags)
 
 		api := v1.NewBlocksAPI(logger, *label, flagsMap)
-		api.Register(router.WithPrefix("/api/v1"), tracer, logger, ins)
+
+		// Configure Request Logging for HTTP calls.
+		opts := []logging.Option{logging.WithDecider(func(_ string) logging.Decision {
+			return logging.NoLogCall
+		})}
+		logMiddleware := logging.NewHTTPServerMiddleware(logger, opts...)
+
+		api.Register(router.WithPrefix("/api/v1"), tracer, logger, ins, logMiddleware)
 
 		srv.Handle("/", router)
 

--- a/cmd/thanos/tools_bucket.go
+++ b/cmd/thanos/tools_bucket.go
@@ -354,7 +354,7 @@ func registerBucketWeb(m map[string]setupFunc, root *kingpin.CmdClause, name str
 		api := v1.NewBlocksAPI(logger, *label, flagsMap)
 
 		// Configure Request Logging for HTTP calls.
-		opts := []logging.Option{logging.WithDecider(func(_ string) logging.Decision {
+		opts := []logging.Option{logging.WithDecider(func() logging.Decision {
 			return logging.NoLogCall
 		})}
 		logMiddleware := logging.NewHTTPServerMiddleware(logger, opts...)

--- a/docs/components/query.md
+++ b/docs/components/query.md
@@ -357,6 +357,13 @@ Flags:
                                  stripped prefix value in X-Forwarded-Prefix
                                  header. This allows thanos UI to be served on a
                                  sub-path.
+      --log.request.decision=LogFinishCall
+                                 Request Logging for logging the start and end
+                                 of requests. LogFinishCall is enabled by
+                                 default. LogFinishCall : Logs the finish call
+                                 of the requests. LogStartAndFinishCall : Logs
+                                 the start and finish call of the requests.
+                                 NoLogCall : Disable request logging.
       --query.timeout=2m         Maximum time to process query by query node.
       --query.max-concurrent=20  Maximum number of queries processed
                                  concurrently by query node.

--- a/docs/components/rule.md
+++ b/docs/components/rule.md
@@ -349,6 +349,13 @@ Flags:
                                  stripped prefix value in X-Forwarded-Prefix
                                  header. This allows thanos UI to be served on a
                                  sub-path.
+      --log.request.decision=LogFinishCall
+                                 Request Logging for logging the start and end
+                                 of requests. LogFinishCall is enabled by
+                                 default. LogFinishCall : Logs the finish call
+                                 of the requests. LogStartAndFinishCall : Logs
+                                 the start and finish call of the requests.
+                                 NoLogCall : Disable request logging.
       --objstore.config-file=<file-path>
                                  Path to YAML file that contains object store
                                  configuration. See format details:

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/prometheus/common/route"
 
 	extpromhttp "github.com/thanos-io/thanos/pkg/extprom/http"
+	"github.com/thanos-io/thanos/pkg/logging"
 	"github.com/thanos-io/thanos/pkg/testutil"
 )
 
@@ -112,7 +113,8 @@ func TestRespondError(t *testing.T) {
 func TestOptionsMethod(t *testing.T) {
 	r := route.New()
 	api := &BaseAPI{}
-	api.Register(r, &opentracing.NoopTracer{}, log.NewNopLogger(), extpromhttp.NewNopInstrumentationMiddleware())
+	logMiddleware := logging.NewHTTPServerMiddleware(log.NewNopLogger())
+	api.Register(r, &opentracing.NoopTracer{}, log.NewNopLogger(), extpromhttp.NewNopInstrumentationMiddleware(), logMiddleware)
 
 	s := httptest.NewServer(r)
 	defer s.Close()

--- a/pkg/api/blocks/v1.go
+++ b/pkg/api/blocks/v1.go
@@ -13,6 +13,7 @@ import (
 	"github.com/thanos-io/thanos/pkg/api"
 	"github.com/thanos-io/thanos/pkg/block/metadata"
 	extpromhttp "github.com/thanos-io/thanos/pkg/extprom/http"
+	"github.com/thanos-io/thanos/pkg/logging"
 )
 
 // BlocksAPI is a very simple API used by Thanos Block Viewer.
@@ -41,10 +42,10 @@ func NewBlocksAPI(logger log.Logger, label string, flagsMap map[string]string) *
 	}
 }
 
-func (bapi *BlocksAPI) Register(r *route.Router, tracer opentracing.Tracer, logger log.Logger, ins extpromhttp.InstrumentationMiddleware) {
-	bapi.baseAPI.Register(r, tracer, logger, ins)
+func (bapi *BlocksAPI) Register(r *route.Router, tracer opentracing.Tracer, logger log.Logger, ins extpromhttp.InstrumentationMiddleware, logMiddleware *logging.HTTPServerMiddleware) {
+	bapi.baseAPI.Register(r, tracer, logger, ins, logMiddleware)
 
-	instr := api.GetInstr(tracer, logger, ins)
+	instr := api.GetInstr(tracer, logger, ins, logMiddleware)
 
 	r.Get("/blocks", instr("blocks", bapi.blocks))
 }

--- a/pkg/api/query/v1.go
+++ b/pkg/api/query/v1.go
@@ -43,6 +43,7 @@ import (
 	"github.com/thanos-io/thanos/pkg/extprom"
 	extpromhttp "github.com/thanos-io/thanos/pkg/extprom/http"
 	"github.com/thanos-io/thanos/pkg/gate"
+	"github.com/thanos-io/thanos/pkg/logging"
 	"github.com/thanos-io/thanos/pkg/query"
 	"github.com/thanos-io/thanos/pkg/rules"
 	"github.com/thanos-io/thanos/pkg/rules/rulespb"
@@ -105,10 +106,10 @@ func NewQueryAPI(
 }
 
 // Register the API's endpoints in the given router.
-func (qapi *QueryAPI) Register(r *route.Router, tracer opentracing.Tracer, logger log.Logger, ins extpromhttp.InstrumentationMiddleware) {
-	qapi.baseAPI.Register(r, tracer, logger, ins)
+func (qapi *QueryAPI) Register(r *route.Router, tracer opentracing.Tracer, logger log.Logger, ins extpromhttp.InstrumentationMiddleware, logMiddleware *logging.HTTPServerMiddleware) {
+	qapi.baseAPI.Register(r, tracer, logger, ins, logMiddleware)
 
-	instr := api.GetInstr(tracer, logger, ins)
+	instr := api.GetInstr(tracer, logger, ins, logMiddleware)
 
 	r.Get("/query", instr("query", qapi.query))
 	r.Post("/query", instr("query", qapi.query))

--- a/pkg/api/rule/v1.go
+++ b/pkg/api/rule/v1.go
@@ -13,6 +13,7 @@ import (
 	"github.com/thanos-io/thanos/pkg/api"
 	qapi "github.com/thanos-io/thanos/pkg/api/query"
 	extpromhttp "github.com/thanos-io/thanos/pkg/extprom/http"
+	"github.com/thanos-io/thanos/pkg/logging"
 	"github.com/thanos-io/thanos/pkg/rules"
 	"github.com/thanos-io/thanos/pkg/rules/rulespb"
 )
@@ -47,10 +48,10 @@ func NewRuleAPI(
 	}
 }
 
-func (rapi *RuleAPI) Register(r *route.Router, tracer opentracing.Tracer, logger log.Logger, ins extpromhttp.InstrumentationMiddleware) {
-	rapi.baseAPI.Register(r, tracer, logger, ins)
+func (rapi *RuleAPI) Register(r *route.Router, tracer opentracing.Tracer, logger log.Logger, ins extpromhttp.InstrumentationMiddleware, logMiddleware *logging.HTTPServerMiddleware) {
+	rapi.baseAPI.Register(r, tracer, logger, ins, logMiddleware)
 
-	instr := api.GetInstr(tracer, logger, ins)
+	instr := api.GetInstr(tracer, logger, ins, logMiddleware)
 
 	r.Get("/alerts", instr("alerts", func(r *http.Request) (interface{}, []error, *api.ApiError) {
 		return struct{ Alerts []*rulespb.AlertInstance }{Alerts: rapi.alerts.Active()}, nil, nil

--- a/pkg/logging/http.go
+++ b/pkg/logging/http.go
@@ -38,7 +38,7 @@ func (m *HTTPServerMiddleware) HTTPMiddleware(name string, next http.Handler) ht
 	return func(w http.ResponseWriter, r *http.Request) {
 		wrapped := httputil.WrapResponseWriterWithStatus(w)
 		start := time.Now()
-		decision := m.opts.shouldLog(name)
+		decision := m.opts.shouldLog()
 
 		switch decision {
 		case NoLogCall:

--- a/pkg/logging/http.go
+++ b/pkg/logging/http.go
@@ -1,0 +1,65 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package logging
+
+import (
+	"fmt"
+
+	"net/http"
+	"time"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	httputil "github.com/thanos-io/thanos/pkg/server/http"
+)
+
+type HTTPServerMiddleware struct {
+	opts   *options
+	logger log.Logger
+}
+
+func (m *HTTPServerMiddleware) preCall(start time.Time) {
+	level.Debug(m.logger).Log("http.start_time", start.String(), "msg", "started call")
+}
+
+func (m *HTTPServerMiddleware) postCall(name string, start time.Time, wrapped *httputil.ResponseWriterWithStatus, r *http.Request) {
+	status := wrapped.Status()
+	logger := log.With(m.logger, "http.method", name, "http.request.id", r.Header.Get("X-Request-ID"), "http.code", fmt.Sprintf("%d", status),
+		"http.time_ms", fmt.Sprintf("%v", durationToMilliseconds(time.Since(start))))
+
+	if status >= 500 && status < 600 {
+		logger = log.With(logger, "http.error", fmt.Sprintf("%v", status))
+	}
+	m.opts.levelFunc(logger, status).Log("msg", "finished call")
+}
+
+func (m *HTTPServerMiddleware) HTTPMiddleware(name string, next http.Handler) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		wrapped := httputil.WrapResponseWriterWithStatus(w)
+		start := time.Now()
+		decision := m.opts.shouldLog(name)
+
+		switch decision {
+		case NoLogCall:
+			next.ServeHTTP(w, r)
+
+		case LogStartAndFinishCall:
+			m.preCall(start)
+			next.ServeHTTP(wrapped, r)
+			m.postCall(name, start, wrapped, r)
+
+		case LogFinishCall:
+			next.ServeHTTP(wrapped, r)
+			m.postCall(name, start, wrapped, r)
+		}
+	}
+}
+
+func NewHTTPServerMiddleware(logger log.Logger, opts ...Option) *HTTPServerMiddleware {
+	o := evaluateOpt(opts)
+	return &HTTPServerMiddleware{
+		logger: log.With(logger, "protocol", "http", "http.component", "server"),
+		opts:   o,
+	}
+}

--- a/pkg/logging/options.go
+++ b/pkg/logging/options.go
@@ -71,11 +71,12 @@ func DefaultErrorToCode(_ error) int {
 }
 
 // Decider function defines rules for suppressing the logging.
-type Decider func(fullMethodName string) Decision
+// TODO : Add the method name as a parameter in case we want to log based on method names.
+type Decider func() Decision
 
 // DefaultDeciderMethod is the default implementation of decider to see if you should log the call
 // by default this is set to LogStartAndFinishCall.
-func DefaultDeciderMethod(_ string) Decision {
+func DefaultDeciderMethod() Decision {
 	return LogStartAndFinishCall
 }
 

--- a/pkg/logging/options.go
+++ b/pkg/logging/options.go
@@ -1,0 +1,120 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package logging
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+)
+
+// Decision defines rules for enabling start and end of logging.
+type Decision int
+
+const (
+	// NoLogCall - Logging is disabled.
+	NoLogCall Decision = iota
+	// LogFinishCall - Only finish logs of request is enabled.
+	LogFinishCall
+	// LogStartAndFinishCall - Logging of start and end of request is enabled.
+	LogStartAndFinishCall
+)
+
+var defaultOptions = &options{
+	shouldLog:         DefaultDeciderMethod,
+	codeFunc:          DefaultErrorToCode,
+	levelFunc:         DefaultCodeToLevel,
+	durationFieldFunc: DurationToTimeMillisFields,
+}
+
+func evaluateOpt(opts []Option) *options {
+	optCopy := &options{}
+	*optCopy = *defaultOptions
+	optCopy.levelFunc = DefaultCodeToLevel
+	for _, o := range opts {
+		o(optCopy)
+	}
+	return optCopy
+}
+
+// WithDecider customizes the function for deciding if the HTTP Middlewares/Tripperwares should log.
+func WithDecider(f Decider) Option {
+	return func(o *options) {
+		o.shouldLog = f
+	}
+}
+
+// WithLevels customizes the function for mapping HTTP response codes and interceptor log level statements.
+func WithLevels(f CodeToLevel) Option {
+	return func(o *options) {
+		o.levelFunc = f
+	}
+}
+
+// Interface for the additional methods.
+
+// Types for the Options.
+type Option func(*options)
+
+// Fields represents logging fields. It has to have even number of elements (pairs).
+type Fields []string
+
+// ErrorToCode function determines the error code of the error
+// for the http response.
+type ErrorToCode func(err error) int
+
+func DefaultErrorToCode(_ error) int {
+	return 500
+}
+
+// Decider function defines rules for suppressing the logging.
+type Decider func(fullMethodName string) Decision
+
+// DefaultDeciderMethod is the default implementation of decider to see if you should log the call
+// by default this is set to LogStartAndFinishCall.
+func DefaultDeciderMethod(_ string) Decision {
+	return LogStartAndFinishCall
+}
+
+// CodeToLevel function defines the mapping between HTTP Response codes to log levels for server side.
+type CodeToLevel func(logger log.Logger, code int) log.Logger
+
+// DurationToFields function defines how to produce duration fields for logging.
+type DurationToFields func(duration time.Duration) Fields
+
+type options struct {
+	levelFunc         CodeToLevel
+	shouldLog         Decider
+	codeFunc          ErrorToCode
+	durationFieldFunc DurationToFields
+}
+
+// DefaultCodeToLevel is the helper mapper that maps HTTP Response codes to log levels.
+func DefaultCodeToLevel(logger log.Logger, code int) log.Logger {
+	if code >= 200 && code < 300 {
+		return level.Debug(logger)
+	}
+	if code >= 400 && code < 500 {
+		return level.Debug(logger)
+	}
+	return level.Error(logger)
+}
+
+// DurationToTimeMillisFields converts the duration to milliseconds and uses the key `http.time_ms`.
+func DurationToTimeMillisFields(duration time.Duration) Fields {
+	return Fields{"http.time_ms", fmt.Sprintf("%v", durationToMilliseconds(duration))}
+}
+
+func durationToMilliseconds(duration time.Duration) float32 {
+	return float32(duration.Nanoseconds()/1000) / 1000
+}
+
+// LogDecision defines mapping of flag options to the logging decision.
+var LogDecision = map[string]Decision{
+	"NoLogCall":             NoLogCall,
+	"LogFinishCall":         LogFinishCall,
+	"LogStartAndFinishCall": LogStartAndFinishCall,
+}

--- a/pkg/server/http/utils.go
+++ b/pkg/server/http/utils.go
@@ -1,0 +1,32 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package http
+
+import "net/http"
+
+// ResponseWriterWithStatus wraps around http.ResponseWriter to capture the status code of the response.
+type ResponseWriterWithStatus struct {
+	http.ResponseWriter
+	status          int
+	isHeaderWritten bool
+}
+
+// WrapResponseWriterWithStatus wraps the http.ResponseWriter for extracting status.
+func WrapResponseWriterWithStatus(w http.ResponseWriter) *ResponseWriterWithStatus {
+	return &ResponseWriterWithStatus{ResponseWriter: w}
+}
+
+// Status returns http response status.
+func (r *ResponseWriterWithStatus) Status() int {
+	return r.status
+}
+
+// WriteHeader writes the header.
+func (r *ResponseWriterWithStatus) WriteHeader(code int) {
+	if !r.isHeaderWritten {
+		r.status = code
+		r.ResponseWriter.WriteHeader(code)
+		r.isHeaderWritten = true
+	}
+}


### PR DESCRIPTION
* Initialised a HTTP Middleware to log all details of the request
* Added options for enabling logging and custom level of logging based on http response status code
* Added interface and types for the custom options in the logging middleware

Fixes #2844 

Signed-off-by: Yash Sharma <yashrsharma44@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes
The current logging looks like this - 
```powershell
level=debug name=query-0 ts=2020-07-27T08:55:01.712803436Z caller=http.go:45 protocol=http http.component=server  http.start_time="2020-07-27 14:25:01.712671672 +0530 IST m=+7.688823783" msg="started call"
level=debug name=query-0 ts=2020-07-27T08:55:01.715027845Z caller=proxy.go:295 msg="store Addr: 127.0.0.1:10901 LabelSets: [name:\"prometheus\" value:\"prom-0\" ] Mint: 0 Maxt: 9223372036854775807 queried;store Addr: 127.0.0.1:10911 LabelSets: [name:\"prometheus\" value:\"prom-1\" ] Mint: 0 Maxt: 9223372036854775807 queried;store Addr: 127.0.0.1:10921 LabelSets: [name:\"prometheus\" value:\"prom-2\" ] Mint: 0 Maxt: 9223372036854775807 queried"
level=debug name=sidecar-2 ts=2020-07-27T08:55:01.719357148Z caller=prometheus.go:259 msg="started handling ReadRequest_STREAMED_XOR_CHUNKS streamed read response."
level=debug name=sidecar-0 ts=2020-07-27T08:55:01.719529925Z caller=prometheus.go:259 msg="started handling ReadRequest_STREAMED_XOR_CHUNKS streamed read response."
level=debug name=sidecar-2 ts=2020-07-27T08:55:01.71962683Z caller=prometheus.go:335 msg="handled ReadRequest_STREAMED_XOR_CHUNKS request." frames=0 series=0
level=debug name=sidecar-0 ts=2020-07-27T08:55:01.719891905Z caller=prometheus.go:335 msg="handled ReadRequest_STREAMED_XOR_CHUNKS request." frames=0 series=0
level=debug name=sidecar-1 ts=2020-07-27T08:55:01.72048064Z caller=prometheus.go:259 msg="started handling ReadRequest_STREAMED_XOR_CHUNKS streamed read response."
level=debug name=sidecar-1 ts=2020-07-27T08:55:01.720773913Z caller=prometheus.go:335 msg="handled ReadRequest_STREAMED_XOR_CHUNKS request." frames=0 series=0
level=debug name=query-0 ts=2020-07-27T08:55:01.722059Z caller=http.go:35 protocol=http http.component=server http.method=query http.request.id=01EE7QPZAHD8BS1W2CXXQMHFYR http.code=200 http.time_ms=9.363 msg="finished call"

```

## Verification

<!-- How you tested it? How do you know it works? -->
