### PR TITLE
receive: Track replications

### DIFF
--- a/examples/alerts/alerts.md
+++ b/examples/alerts/alerts.md
@@ -412,16 +412,18 @@ rules:
   for: 10m
   labels:
     severity: critical
-- alert: ThanosReceiveHighForwardRequestFailures
+- alert: ThanosReceiveHighReplicationFailures
   annotations:
-    message: Thanos Receive {{$labels.job}} is failing to forward {{ $value | humanize
+    message: Thanos Receive {{$labels.job}} is failing to replicate {{ $value | humanize
       }}% of requests.
   expr: |
+    thanos_receive_replication_factor > 1
+      and
     (
       (
-        sum by (job) (rate(thanos_receive_forward_requests_total{result="error", job=~"thanos-receive.*"}[5m]))
+        sum by (job) (rate(thanos_receive_replications_total{result="error", job=~"thanos-receive.*"}[5m]))
       /
-        sum by (job) (rate(thanos_receive_forward_requests_total{job=~"thanos-receive.*"}[5m]))
+        sum by (job) (rate(thanos_receive_replications_total{job=~"thanos-receive.*"}[5m]))
       )
       >
       (
@@ -430,6 +432,19 @@ rules:
         max by (job) (thanos_receive_hashring_nodes{job=~"thanos-receive.*"})
       )
     ) * 100
+  for: 5m
+  labels:
+    severity: warning
+- alert: ThanosReceiveHighForwardRequestFailures
+  annotations:
+    message: Thanos Receive {{$labels.job}} is failing to forward {{ $value | humanize
+      }}% of requests.
+  expr: |
+    (
+      sum by (job) (rate(thanos_receive_forward_requests_total{result="error", job=~"thanos-receive.*"}[5m]))
+    /
+      sum by (job) (rate(thanos_receive_forward_requests_total{job=~"thanos-receive.*"}[5m]))
+    ) * 100 > 20
   for: 5m
   labels:
     severity: warning

--- a/examples/alerts/alerts.yaml
+++ b/examples/alerts/alerts.yaml
@@ -173,16 +173,18 @@ groups:
     for: 10m
     labels:
       severity: critical
-  - alert: ThanosReceiveHighForwardRequestFailures
+  - alert: ThanosReceiveHighReplicationFailures
     annotations:
-      message: Thanos Receive {{$labels.job}} is failing to forward {{ $value | humanize
-        }}% of requests.
+      message: Thanos Receive {{$labels.job}} is failing to replicate {{ $value |
+        humanize }}% of requests.
     expr: |
+      thanos_receive_replication_factor > 1
+        and
       (
         (
-          sum by (job) (rate(thanos_receive_forward_requests_total{result="error", job=~"thanos-receive.*"}[5m]))
+          sum by (job) (rate(thanos_receive_replications_total{result="error", job=~"thanos-receive.*"}[5m]))
         /
-          sum by (job) (rate(thanos_receive_forward_requests_total{job=~"thanos-receive.*"}[5m]))
+          sum by (job) (rate(thanos_receive_replications_total{job=~"thanos-receive.*"}[5m]))
         )
         >
         (
@@ -191,6 +193,19 @@ groups:
           max by (job) (thanos_receive_hashring_nodes{job=~"thanos-receive.*"})
         )
       ) * 100
+    for: 5m
+    labels:
+      severity: warning
+  - alert: ThanosReceiveHighForwardRequestFailures
+    annotations:
+      message: Thanos Receive {{$labels.job}} is failing to forward {{ $value | humanize
+        }}% of requests.
+    expr: |
+      (
+        sum by (job) (rate(thanos_receive_forward_requests_total{result="error", job=~"thanos-receive.*"}[5m]))
+      /
+        sum by (job) (rate(thanos_receive_forward_requests_total{job=~"thanos-receive.*"}[5m]))
+      ) * 100 > 20
     for: 5m
     labels:
       severity: warning

--- a/examples/alerts/rules.yaml
+++ b/examples/alerts/rules.yaml
@@ -7,7 +7,6 @@ groups:
       /
         sum(rate(grpc_client_started_total{job=~"thanos-query.*", grpc_type="unary"}[5m]))
       )
-    labels: {}
     record: :grpc_client_failures_per_unary:sum_rate
   - expr: |
       (
@@ -15,7 +14,6 @@ groups:
       /
         sum(rate(grpc_client_started_total{job=~"thanos-query.*", grpc_type="server_stream"}[5m]))
       )
-    labels: {}
     record: :grpc_client_failures_per_stream:sum_rate
   - expr: |
       (
@@ -23,7 +21,6 @@ groups:
       /
         sum(rate(thanos_querier_store_apis_dns_lookups_total{job=~"thanos-query.*"}[5m]))
       )
-    labels: {}
     record: :thanos_querier_store_apis_dns_failures_per_lookup:sum_rate
   - expr: |
       histogram_quantile(0.99,
@@ -47,7 +44,6 @@ groups:
       /
         rate(grpc_server_started_total{job=~"thanos-receive.*", grpc_type="unary"}[5m])
       )
-    labels: {}
     record: :grpc_server_failures_per_unary:sum_rate
   - expr: |
       sum(
@@ -55,7 +51,6 @@ groups:
       /
         rate(grpc_server_started_total{job=~"thanos-receive.*", grpc_type="server_stream"}[5m])
       )
-    labels: {}
     record: :grpc_server_failures_per_stream:sum_rate
   - expr: |
       sum(
@@ -63,7 +58,6 @@ groups:
       /
         rate(http_requests_total{handler="receive", job=~"thanos-receive.*"}[5m])
       )
-    labels: {}
     record: :http_failure_per_request:sum_rate
   - expr: |
       histogram_quantile(0.99,
@@ -78,7 +72,6 @@ groups:
       /
         sum(rate(thanos_receive_replications_total{job=~"thanos-receive.*"}[5m]))
       )
-    labels: {}
     record: :thanos_receive_replication_failure_per_requests:sum_rate
   - expr: |
       (
@@ -86,7 +79,6 @@ groups:
       /
         sum(rate(thanos_receive_forward_requests_total{job=~"thanos-receive.*"}[5m]))
       )
-    labels: {}
     record: :thanos_receive_forward_failure_per_requests:sum_rate
   - expr: |
       (
@@ -94,7 +86,6 @@ groups:
       /
         sum(rate(thanos_receive_hashrings_file_refreshes_total{job=~"thanos-receive.*"}[5m]))
       )
-    labels: {}
     record: :thanos_receive_hashring_file_failure_per_refresh:sum_rate
 - name: thanos-store.rules
   rules:
@@ -104,7 +95,6 @@ groups:
       /
         sum(rate(grpc_server_started_total{job=~"thanos-store.*", grpc_type="unary"}[5m]))
       )
-    labels: {}
     record: :grpc_server_failures_per_unary:sum_rate
   - expr: |
       (
@@ -112,7 +102,6 @@ groups:
       /
         sum(rate(grpc_server_started_total{job=~"thanos-store.*", grpc_type="server_stream"}[5m]))
       )
-    labels: {}
     record: :grpc_server_failures_per_stream:sum_rate
   - expr: |
       (
@@ -120,7 +109,6 @@ groups:
       /
         sum(rate(thanos_objstore_bucket_operations_total{job=~"thanos-store.*"}[5m]))
       )
-    labels: {}
     record: :thanos_objstore_bucket_failures_per_operation:sum_rate
   - expr: |
       histogram_quantile(0.99,

--- a/examples/alerts/rules.yaml
+++ b/examples/alerts/rules.yaml
@@ -74,6 +74,14 @@ groups:
     record: :http_request_duration_seconds:histogram_quantile
   - expr: |
       (
+        sum(rate(thanos_receive_replications_total{result="error", job=~"thanos-receive.*"}[5m]))
+      /
+        sum(rate(thanos_receive_replications_total{job=~"thanos-receive.*"}[5m]))
+      )
+    labels: {}
+    record: :thanos_receive_replication_failure_per_requests:sum_rate
+  - expr: |
+      (
         sum(rate(thanos_receive_forward_requests_total{result="error", job=~"thanos-receive.*"}[5m]))
       /
         sum(rate(thanos_receive_forward_requests_total{job=~"thanos-receive.*"}[5m]))

--- a/examples/dashboards/receive.json
+++ b/examples/dashboards/receive.json
@@ -555,9 +555,177 @@
                "dashLength": 10,
                "dashes": false,
                "datasource": "$datasource",
-               "description": "Shows rate of forwarded requests to other receive nodes.",
+               "description": "Shows rate of replications to other receive nodes.",
                "fill": 1,
                "id": 7,
+               "legend": {
+                  "avg": false,
+                  "current": false,
+                  "max": false,
+                  "min": false,
+                  "show": true,
+                  "total": false,
+                  "values": false
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null as zero",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "span": 6,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "sum(rate(thanos_receive_replications_total{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job)",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "all {{job}}",
+                     "legendLink": null,
+                     "step": 10
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Rate",
+               "tooltip": {
+                  "shared": false,
+                  "sort": 0,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": false
+                  }
+               ]
+            },
+            {
+               "aliasColors": {
+                  "error": "#E24D42"
+               },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$datasource",
+               "description": "Shows ratio of errors compared to the total number of replications to other receive nodes.",
+               "fill": 10,
+               "id": 8,
+               "legend": {
+                  "avg": false,
+                  "current": false,
+                  "max": false,
+                  "min": false,
+                  "show": true,
+                  "total": false,
+                  "values": false
+               },
+               "lines": true,
+               "linewidth": 0,
+               "links": [ ],
+               "nullPointMode": "null as zero",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "span": 6,
+               "stack": true,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "sum(rate(thanos_receive_replications_total{namespace=\"$namespace\",job=~\"$job\",result=\"error\"}[$interval])) / sum(rate(thanos_receive_replications_total{namespace=\"$namespace\",job=~\"$job\"}[$interval]))",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "error",
+                     "refId": "A",
+                     "step": 10
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Errors",
+               "tooltip": {
+                  "shared": false,
+                  "sort": 0,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "percentunit",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": false
+                  }
+               ]
+            }
+         ],
+         "repeat": null,
+         "repeatIteration": null,
+         "repeatRowId": null,
+         "showTitle": true,
+         "title": "Replication",
+         "titleSize": "h6"
+      },
+      {
+         "collapse": true,
+         "height": "250px",
+         "panels": [
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$datasource",
+               "description": "Shows rate of forwarded requests to other receive nodes.",
+               "fill": 1,
+               "id": 9,
                "legend": {
                   "avg": false,
                   "current": false,
@@ -636,7 +804,7 @@
                "datasource": "$datasource",
                "description": "Shows ratio of errors compared to the total number of forwareded requests to other receive nodes.",
                "fill": 10,
-               "id": 8,
+               "id": 10,
                "legend": {
                   "avg": false,
                   "current": false,
@@ -744,7 +912,7 @@
                "datasource": "$datasource",
                "description": "Shows rate of handled Unary gRPC requests from queriers.",
                "fill": 10,
-               "id": 9,
+               "id": 11,
                "legend": {
                   "avg": false,
                   "current": false,
@@ -823,7 +991,7 @@
                "datasource": "$datasource",
                "description": "Shows ratio of errors compared to the total number of handled requests from queriers.",
                "fill": 10,
-               "id": 10,
+               "id": 12,
                "legend": {
                   "avg": false,
                   "current": false,
@@ -900,7 +1068,7 @@
                "datasource": "$datasource",
                "description": "Shows how long has it taken to handle requests from queriers, in quantiles.",
                "fill": 1,
-               "id": 11,
+               "id": 13,
                "legend": {
                   "avg": false,
                   "current": false,
@@ -1005,7 +1173,7 @@
                "datasource": "$datasource",
                "description": "Shows rate of handled Unary gRPC requests from queriers.",
                "fill": 10,
-               "id": 12,
+               "id": 14,
                "legend": {
                   "avg": false,
                   "current": false,
@@ -1082,7 +1250,7 @@
                "datasource": "$datasource",
                "description": "Shows ratio of errors compared to the total number of handled requests from queriers.",
                "fill": 10,
-               "id": 13,
+               "id": 15,
                "legend": {
                   "avg": false,
                   "current": false,
@@ -1159,7 +1327,7 @@
                "datasource": "$datasource",
                "description": "Shows how long has it taken to handle requests from queriers, in quantiles.",
                "fill": 1,
-               "id": 14,
+               "id": 16,
                "legend": {
                   "avg": false,
                   "current": false,
@@ -1283,7 +1451,7 @@
                "datasource": "$datasource",
                "description": "Shows rate of handled Streamed gRPC requests from queriers.",
                "fill": 10,
-               "id": 15,
+               "id": 17,
                "legend": {
                   "avg": false,
                   "current": false,
@@ -1362,7 +1530,7 @@
                "datasource": "$datasource",
                "description": "Shows ratio of errors compared to the total number of handled requests from queriers.",
                "fill": 10,
-               "id": 16,
+               "id": 18,
                "legend": {
                   "avg": false,
                   "current": false,
@@ -1439,7 +1607,7 @@
                "datasource": "$datasource",
                "description": "Shows how long has it taken to handle requests from queriers, in quantiles.",
                "fill": 1,
-               "id": 17,
+               "id": 19,
                "legend": {
                   "avg": false,
                   "current": false,
@@ -1544,7 +1712,7 @@
                "datasource": "$datasource",
                "description": "Shows rate of handled Streamed gRPC requests from queriers.",
                "fill": 10,
-               "id": 18,
+               "id": 20,
                "legend": {
                   "avg": false,
                   "current": false,
@@ -1621,7 +1789,7 @@
                "datasource": "$datasource",
                "description": "Shows ratio of errors compared to the total number of handled requests from queriers.",
                "fill": 10,
-               "id": 19,
+               "id": 21,
                "legend": {
                   "avg": false,
                   "current": false,
@@ -1698,7 +1866,7 @@
                "datasource": "$datasource",
                "description": "Shows how long has it taken to handle requests from queriers, in quantiles.",
                "fill": 1,
-               "id": 20,
+               "id": 22,
                "legend": {
                   "avg": false,
                   "current": false,
@@ -1803,7 +1971,7 @@
                "datasource": "$datasource",
                "description": "Shows the relative time of last successful upload to the object-store bucket.",
                "fill": 1,
-               "id": 21,
+               "id": 23,
                "legend": {
                   "avg": false,
                   "current": false,
@@ -1926,7 +2094,7 @@
                "dashes": false,
                "datasource": "$datasource",
                "fill": 1,
-               "id": 22,
+               "id": 24,
                "legend": {
                   "avg": false,
                   "current": false,
@@ -2042,7 +2210,7 @@
                "dashes": false,
                "datasource": "$datasource",
                "fill": 1,
-               "id": 23,
+               "id": 25,
                "legend": {
                   "avg": false,
                   "current": false,
@@ -2118,7 +2286,7 @@
                "dashes": false,
                "datasource": "$datasource",
                "fill": 1,
-               "id": 24,
+               "id": 26,
                "legend": {
                   "avg": false,
                   "current": false,

--- a/mixin/alerts/receive.libsonnet
+++ b/mixin/alerts/receive.libsonnet
@@ -3,6 +3,7 @@
   receive+:: {
     selector: error 'must provide selector for Thanos Receive alerts',
     httpErrorThreshold: 5,
+    forwardErrorThreshold: 20,
     refreshErrorThreshold: 0,
     p99LatencyThreshold: 10,
   },
@@ -46,16 +47,18 @@
             },
           },
           {
-            alert: 'ThanosReceiveHighForwardRequestFailures',
+            alert: 'ThanosReceiveHighReplicationFailures',
             annotations: {
-              message: 'Thanos Receive {{$labels.job}} is failing to forward {{ $value | humanize }}% of requests.',
+              message: 'Thanos Receive {{$labels.job}} is failing to replicate {{ $value | humanize }}% of requests.',
             },
             expr: |||
+              thanos_receive_replication_factor > 1
+                and
               (
                 (
-                  sum by (job) (rate(thanos_receive_forward_requests_total{result="error", %(selector)s}[5m]))
+                  sum by (job) (rate(thanos_receive_replications_total{result="error", %(selector)s}[5m]))
                 /
-                  sum by (job) (rate(thanos_receive_forward_requests_total{%(selector)s}[5m]))
+                  sum by (job) (rate(thanos_receive_replications_total{%(selector)s}[5m]))
                 )
                 >
                 (
@@ -64,6 +67,23 @@
                   max by (job) (thanos_receive_hashring_nodes{%(selector)s})
                 )
               ) * 100
+            ||| % thanos.receive,
+            'for': '5m',
+            labels: {
+              severity: 'warning',
+            },
+          },
+          {
+            alert: 'ThanosReceiveHighForwardRequestFailures',
+            annotations: {
+              message: 'Thanos Receive {{$labels.job}} is failing to forward {{ $value | humanize }}% of requests.',
+            },
+            expr: |||
+              (
+                sum by (job) (rate(thanos_receive_forward_requests_total{result="error", %(selector)s}[5m]))
+              /
+                sum by (job) (rate(thanos_receive_forward_requests_total{%(selector)s}[5m]))
+              ) * 100 > %(forwardErrorThreshold)s
             ||| % thanos.receive,
             'for': '5m',
             labels: {

--- a/mixin/dashboards/receive.libsonnet
+++ b/mixin/dashboards/receive.libsonnet
@@ -42,6 +42,23 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
         g.collapse
       )
       .addRow(
+        g.row('Replication')
+        .addPanel(
+          g.panel('Rate', 'Shows rate of replications to other receive nodes.') +
+          g.queryPanel(
+            'sum(rate(thanos_receive_replications_total{namespace="$namespace",job=~"$job"}[$interval])) by (job)',
+            'all {{job}}',
+          )
+        )
+        .addPanel(
+          g.panel('Errors', 'Shows ratio of errors compared to the total number of replications to other receive nodes.') +
+          g.qpsErrTotalPanel(
+            'thanos_receive_replications_total{namespace="$namespace",job=~"$job",result="error"}',
+            'thanos_receive_replications_total{namespace="$namespace",job=~"$job"}',
+          )
+        )
+      )
+      .addRow(
         g.row('Forward Request')
         .addPanel(
           g.panel('Rate', 'Shows rate of forwarded requests to other receive nodes.') +
@@ -56,7 +73,8 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
             'thanos_receive_forward_requests_total{namespace="$namespace",job=~"$job",result="error"}',
             'thanos_receive_forward_requests_total{namespace="$namespace",job=~"$job"}',
           )
-        )
+        ) +
+        g.collapse
       )
       .addRow(
         g.row('gRPC (Unary)')

--- a/mixin/rules/query.libsonnet
+++ b/mixin/rules/query.libsonnet
@@ -17,8 +17,6 @@
                 sum(rate(grpc_client_started_total{%(selector)s, grpc_type="unary"}[5m]))
               )
             ||| % thanos.query,
-            labels: {
-            },
           },
           {
             record: ':grpc_client_failures_per_stream:sum_rate',
@@ -29,8 +27,6 @@
                 sum(rate(grpc_client_started_total{%(selector)s, grpc_type="server_stream"}[5m]))
               )
             ||| % thanos.query,
-            labels: {
-            },
           },
           {
             record: ':thanos_querier_store_apis_dns_failures_per_lookup:sum_rate',
@@ -41,8 +37,6 @@
                 sum(rate(thanos_querier_store_apis_dns_lookups_total{%(selector)s}[5m]))
               )
             ||| % thanos.query,
-            labels: {
-            },
           },
           {
             record: ':query_duration_seconds:histogram_quantile',

--- a/mixin/rules/receive.libsonnet
+++ b/mixin/rules/receive.libsonnet
@@ -17,8 +17,6 @@
                 rate(grpc_server_started_total{%(selector)s, grpc_type="unary"}[5m])
               )
             ||| % thanos.receive,
-            labels: {
-            },
           },
           {
             record: ':grpc_server_failures_per_stream:sum_rate',
@@ -29,8 +27,6 @@
                 rate(grpc_server_started_total{%(selector)s, grpc_type="server_stream"}[5m])
               )
             ||| % thanos.receive,
-            labels: {
-            },
           },
           {
             record: ':http_failure_per_request:sum_rate',
@@ -41,8 +37,6 @@
                 rate(http_requests_total{handler="receive", %(selector)s}[5m])
               )
             ||| % thanos.receive,
-            labels: {
-            },
           },
           {
             record: ':http_request_duration_seconds:histogram_quantile',
@@ -64,8 +58,6 @@
                 sum(rate(thanos_receive_replications_total{%(selector)s}[5m]))
               )
             ||| % thanos.receive,
-            labels: {
-            },
           },
           {
             record: ':thanos_receive_forward_failure_per_requests:sum_rate',
@@ -76,8 +68,6 @@
                 sum(rate(thanos_receive_forward_requests_total{%(selector)s}[5m]))
               )
             ||| % thanos.receive,
-            labels: {
-            },
           },
           {
             record: ':thanos_receive_hashring_file_failure_per_refresh:sum_rate',
@@ -88,8 +78,6 @@
                 sum(rate(thanos_receive_hashrings_file_refreshes_total{%(selector)s}[5m]))
               )
             ||| % thanos.receive,
-            labels: {
-            },
           },
         ],
       },

--- a/mixin/rules/receive.libsonnet
+++ b/mixin/rules/receive.libsonnet
@@ -56,6 +56,18 @@
             },
           },
           {
+            record: ':thanos_receive_replication_failure_per_requests:sum_rate',
+            expr: |||
+              (
+                sum(rate(thanos_receive_replications_total{result="error", %(selector)s}[5m]))
+              /
+                sum(rate(thanos_receive_replications_total{%(selector)s}[5m]))
+              )
+            ||| % thanos.receive,
+            labels: {
+            },
+          },
+          {
             record: ':thanos_receive_forward_failure_per_requests:sum_rate',
             expr: |||
               (

--- a/mixin/rules/store.libsonnet
+++ b/mixin/rules/store.libsonnet
@@ -17,8 +17,6 @@
                 sum(rate(grpc_server_started_total{%(selector)s, grpc_type="unary"}[5m]))
               )
             ||| % thanos.store,
-            labels: {
-            },
           },
           {
             record: ':grpc_server_failures_per_stream:sum_rate',
@@ -29,8 +27,6 @@
                 sum(rate(grpc_server_started_total{%(selector)s, grpc_type="server_stream"}[5m]))
               )
             ||| % thanos.store,
-            labels: {
-            },
           },
           {
             record: ':thanos_objstore_bucket_failures_per_operation:sum_rate',
@@ -41,8 +37,6 @@
                 sum(rate(thanos_objstore_bucket_operations_total{%(selector)s}[5m]))
               )
             ||| % thanos.store,
-            labels: {
-            },
           },
           {
             record: ':thanos_objstore_bucket_operation_duration_seconds:histogram_quantile',

--- a/pkg/receive/handler.go
+++ b/pkg/receive/handler.go
@@ -109,7 +109,7 @@ func NewHandler(logger log.Logger, o *Options) *Handler {
 		replications: promauto.With(o.Registry).NewCounterVec(
 			prometheus.CounterOpts{
 				Name: "thanos_receive_replications_total",
-				Help: "The number of replication operation.",
+				Help: "The number of replication operations started by the receiver. The success of replication is fulfilled when a quorum is met.",
 			}, []string{"result"},
 		),
 		replicationFactor: promauto.With(o.Registry).NewGauge(

--- a/pkg/rules/rules_test.go
+++ b/pkg/rules/rules_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/prometheus/prometheus/storage"
+
 	"github.com/thanos-io/thanos/pkg/rules/rulespb"
 	"github.com/thanos-io/thanos/pkg/store/storepb"
 	"github.com/thanos-io/thanos/pkg/testutil"
@@ -61,8 +62,8 @@ func testRulesAgainstExamples(t *testing.T, dir string, server rulespb.RulesServ
 			Name: "thanos-receive.rules",
 			File: filepath.Join(dir, "alerts.yaml"),
 			Rules: []*rulespb.Rule{
-				someAlert, someAlert, someAlert, someAlert, someAlert, someAlert,
-				someRecording, someRecording, someRecording, someRecording, someRecording, someRecording,
+				someAlert, someAlert, someAlert, someAlert, someAlert, someAlert, someAlert,
+				someRecording, someRecording, someRecording, someRecording, someRecording, someRecording, someRecording,
 			},
 			Interval:                          60,
 			DeprecatedPartialResponseStrategy: storepb.PartialResponseStrategy_WARN, PartialResponseStrategy: storepb.PartialResponseStrategy_ABORT,


### PR DESCRIPTION
This PR adds a new metric to track replication behaviour. Previously, `thanos_receive_forward_requests_total` was used. However, that metric is now misleading because we have recently changed how replication behaves (https://github.com/thanos-io/thanos/pull/2621).

* [x] I added CHANGELOG entry for this change.

## Changes

* Add a new metric to track replicated request `thanos_receive_replications_total` https://github.com/thanos-io/thanos/pull/2852/commits/fd0497105ab76fdc2cbcfd0c74f4a642f389ec45
* Add alerts and dashboards for the new metric https://github.com/thanos-io/thanos/pull/2852/commits/0aa495da1bb6e44c56c2653c55e8c4bc70b1e62c
* Modify alerts for the `thanos_forward_requests_total` https://github.com/thanos-io/thanos/pull/2852/commits/0aa495da1bb6e44c56c2653c55e8c4bc70b1e62c

## Verification

* `make test-local`
* `make examples`
* `make example-rules-lint`

cc @krasi-georgiev 
