### PR TITLE
ci: Enable a set of linters to catch unused code

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -43,6 +43,9 @@ linters:
     - unused
     - varcheck
     - godot
+    - unparam
+    - unused
+    - varcheck
 
 linters-settings:
   errcheck:

--- a/cmd/thanos/config.go
+++ b/cmd/thanos/config.go
@@ -1,6 +1,8 @@
 // Copyright (c) The Thanos Authors.
 // Licensed under the Apache License 2.0.
 
+//nolint:unparam
+// TODO(kakkoyun): Fix linter issues - The pattern we use makes linter unhappy (returning unused config pointers).
 package main
 
 import (

--- a/pkg/objstore/oss/oss.go
+++ b/pkg/objstore/oss/oss.go
@@ -20,9 +20,10 @@ import (
 	alioss "github.com/aliyun/aliyun-oss-go-sdk/oss"
 	"github.com/go-kit/kit/log"
 	"github.com/pkg/errors"
+	"gopkg.in/yaml.v2"
+
 	"github.com/thanos-io/thanos/pkg/objstore"
 	"github.com/thanos-io/thanos/pkg/objstore/clientutil"
-	"gopkg.in/yaml.v2"
 )
 
 // Part size for multi part upload.
@@ -300,7 +301,7 @@ func (b *Bucket) setRange(start, end int64, name string) (alioss.Option, error) 
 	return opt, nil
 }
 
-func (b *Bucket) getRange(ctx context.Context, name string, off, length int64) (io.ReadCloser, error) {
+func (b *Bucket) getRange(_ context.Context, name string, off, length int64) (io.ReadCloser, error) {
 	if len(name) == 0 {
 		return nil, errors.New("given object name should not empty")
 	}

--- a/pkg/objstore/swift/swift.go
+++ b/pkg/objstore/swift/swift.go
@@ -19,8 +19,9 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/objectstorage/v1/objects"
 	"github.com/gophercloud/gophercloud/pagination"
 	"github.com/pkg/errors"
-	"github.com/thanos-io/thanos/pkg/objstore"
 	"gopkg.in/yaml.v2"
+
+	"github.com/thanos-io/thanos/pkg/objstore"
 )
 
 // DirDelim is the delimiter used to model a directory structure in an object store bucket.
@@ -55,12 +56,7 @@ func NewContainer(logger log.Logger, conf []byte) (*Container, error) {
 		return nil, err
 	}
 
-	authOpts, err := authOptsFromConfig(sc)
-	if err != nil {
-		return nil, err
-	}
-
-	provider, err := openstack.AuthenticatedClient(authOpts)
+	provider, err := openstack.AuthenticatedClient(authOptsFromConfig(sc))
 	if err != nil {
 		return nil, err
 	}
@@ -193,7 +189,7 @@ func parseConfig(conf []byte) (*SwiftConfig, error) {
 	return &sc, err
 }
 
-func authOptsFromConfig(sc *SwiftConfig) (gophercloud.AuthOptions, error) {
+func authOptsFromConfig(sc *SwiftConfig) gophercloud.AuthOptions {
 	authOpts := gophercloud.AuthOptions{
 		IdentityEndpoint: sc.AuthUrl,
 		Username:         sc.Username,
@@ -237,7 +233,7 @@ func authOptsFromConfig(sc *SwiftConfig) (gophercloud.AuthOptions, error) {
 			authOpts.Scope.ProjectID = sc.ProjectID
 		}
 	}
-	return authOpts, nil
+	return authOpts
 }
 
 func (c *Container) createContainer(name string) error {

--- a/pkg/objstore/swift/swift_test.go
+++ b/pkg/objstore/swift/swift_test.go
@@ -44,9 +44,7 @@ func TestAuthOptsFromConfig(t *testing.T) {
 		ProjectDomainName: "projectDomain",
 	}
 
-	authOpts, err := authOptsFromConfig(input)
-	testutil.Ok(t, err)
-
+	authOpts := authOptsFromConfig(input)
 	testutil.Equals(t, "http://identity.something.com/v3", authOpts.IdentityEndpoint)
 	testutil.Equals(t, "thanos", authOpts.Username)
 	testutil.Equals(t, "userDomain", authOpts.DomainName)

--- a/pkg/receive/writer.go
+++ b/pkg/receive/writer.go
@@ -149,7 +149,8 @@ type fakeAppender struct {
 
 var _ storage.Appender = &fakeAppender{}
 
-func newFakeAppender(addErr, addFastErr, commitErr, rollbackErr func() error) *fakeAppender {
+// TODO(kakkoyun): Linter - `addFastErr` always receives `nil`.
+func newFakeAppender(addErr, addFastErr, commitErr, rollbackErr func() error) *fakeAppender { //nolint:unparam
 	if addErr == nil {
 		addErr = nilErrFn
 	}

--- a/pkg/store/cache/caching_bucket_test.go
+++ b/pkg/store/cache/caching_bucket_test.go
@@ -1,6 +1,7 @@
 // Copyright (c) The Thanos Authors.
 // Licensed under the Apache License 2.0.
 
+//nolint:unparam
 package storecache
 
 import (

--- a/pkg/store/prometheus.go
+++ b/pkg/store/prometheus.go
@@ -27,6 +27,9 @@ import (
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/storage/remote"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
 	"github.com/thanos-io/thanos/pkg/component"
 	thanoshttp "github.com/thanos-io/thanos/pkg/http"
 	"github.com/thanos-io/thanos/pkg/promclient"
@@ -34,8 +37,6 @@ import (
 	"github.com/thanos-io/thanos/pkg/store/storepb"
 	"github.com/thanos-io/thanos/pkg/store/storepb/prompb"
 	"github.com/thanos-io/thanos/pkg/tracing"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 // PrometheusStore implements the store node API on top of the Prometheus remote read API.
@@ -477,7 +478,8 @@ func matchesExternalLabels(ms []storepb.LabelMatcher, externalLabels labels.Labe
 }
 
 // encodeChunk translates the sample pairs into a chunk.
-func (p *PrometheusStore) encodeChunk(ss []prompb.Sample) (storepb.Chunk_Encoding, []byte, error) {
+// TODO(kakkoyun): Linter - result 0 (github.com/thanos-io/thanos/pkg/store/storepb.Chunk_Encoding) is always 0.
+func (p *PrometheusStore) encodeChunk(ss []prompb.Sample) (storepb.Chunk_Encoding, []byte, error) { //nolint:unparam
 	c := chunkenc.NewXORChunk()
 
 	a, err := c.Appender()

--- a/pkg/tracing/jaeger/config_yaml.go
+++ b/pkg/tracing/jaeger/config_yaml.go
@@ -64,11 +64,7 @@ func ParseConfigFromYaml(cfg []byte) (*config.Configuration, error) {
 		c.Tags = parseTags(conf.Tags)
 	}
 
-	if s, err := samplerConfigFromConfig(*conf); err == nil {
-		c.Sampler = s
-	} else {
-		return nil, errors.Wrap(err, "cannot obtain sampler config from YAML")
-	}
+	c.Sampler = samplerConfigFromConfig(*conf)
 
 	if r, err := reporterConfigFromConfig(*conf); err == nil {
 		c.Reporter = r
@@ -80,7 +76,7 @@ func ParseConfigFromYaml(cfg []byte) (*config.Configuration, error) {
 }
 
 // samplerConfigFromConfig creates a new SamplerConfig based on the YAML Config.
-func samplerConfigFromConfig(cfg Config) (*config.SamplerConfig, error) {
+func samplerConfigFromConfig(cfg Config) *config.SamplerConfig {
 	sc := &config.SamplerConfig{}
 
 	if cfg.SamplerType != "" {
@@ -103,7 +99,7 @@ func samplerConfigFromConfig(cfg Config) (*config.SamplerConfig, error) {
 		sc.SamplingRefreshInterval = cfg.SamplerRefreshInterval
 	}
 
-	return sc, nil
+	return sc
 }
 
 // reporterConfigFromConfig creates a new ReporterConfig based on the YAML Config.


### PR DESCRIPTION
Signed-off-by: Kemal Akkoyun <kakkoyun@gmail.com>

* [x] Change is not relevant to the end-user.

## Changes

* Enabled  `unparam`, `unused` and `varcheck`
* Applied fixes accordingly
* Added notes for more complicated or critical ones for now

## Verification

* `make go-lint`
