### PR TITLE
ruler,receive,sidecar: StoreAPI Series encodes chunks to 120 samples instead of single, big one.

### DIFF
--- a/pkg/store/multitsdb_test.go
+++ b/pkg/store/multitsdb_test.go
@@ -118,7 +118,7 @@ func benchMultiTSDBSeries(t testutil.TB, totalSamples, totalSeries int, flushToB
 
 	tsdbs := map[string]*TSDBStore{}
 	for i, db := range dbs {
-		tsdbs[fmt.Sprintf("%v", i)] = &TSDBStore{db: db, logger: logger, maxSamplesPerChunk: 120} // On production we have math.MaxInt64
+		tsdbs[fmt.Sprintf("%v", i)] = &TSDBStore{db: db, logger: logger}
 	}
 
 	store := NewMultiTSDBStore(logger, nil, component.Receive, func() map[string]*TSDBStore { return tsdbs })

--- a/pkg/store/prometheus.go
+++ b/pkg/store/prometheus.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"math"
 	"net/http"
 	"net/url"
 	"path"
@@ -240,10 +239,7 @@ func (p *PrometheusStore) handleSampledPrometheusResponse(s storepb.Store_Series
 			continue
 		}
 
-		// XOR encoding supports a max size of 2^16 - 1 samples, so we need
-		// to chunk all samples into groups of no more than 2^16 - 1
-		// See: https://github.com/thanos-io/thanos/pull/718.
-		aggregatedChunks, err := p.chunkSamples(e, math.MaxUint16)
+		aggregatedChunks, err := p.chunkSamples(e, maxSamplesPerChunk)
 		if err != nil {
 			return err
 		}

--- a/pkg/store/prometheus_test.go
+++ b/pkg/store/prometheus_test.go
@@ -545,7 +545,7 @@ func TestPrometheusStore_Info(t *testing.T) {
 	testutil.Equals(t, int64(456), resp.MaxTime)
 }
 
-func testSeries_SplitSamplesIntoChunksWithMaxSizeOfUint16_e2e(t *testing.T, appender storage.Appender, newStore func() storepb.StoreServer) {
+func testSeries_SplitSamplesIntoChunksWithMaxSizeOf120(t *testing.T, appender storage.Appender, newStore func() storepb.StoreServer) {
 	baseT := timestamp.FromTime(time.Now().AddDate(0, 0, -2)) / 1000 * 1000
 
 	offset := int64(2*math.MaxUint16 + 5)
@@ -580,30 +580,30 @@ func testSeries_SplitSamplesIntoChunksWithMaxSizeOfUint16_e2e(t *testing.T, appe
 		{Name: "region", Value: "eu-west"},
 	}, firstSeries.Labels)
 
-	testutil.Equals(t, 3, len(firstSeries.Chunks))
+	testutil.Equals(t, 1093, len(firstSeries.Chunks))
 
 	chunk, err := chunkenc.FromData(chunkenc.EncXOR, firstSeries.Chunks[0].Raw.Data)
 	testutil.Ok(t, err)
-	testutil.Equals(t, math.MaxUint16, chunk.NumSamples())
+	testutil.Equals(t, 120, chunk.NumSamples())
 
 	chunk, err = chunkenc.FromData(chunkenc.EncXOR, firstSeries.Chunks[1].Raw.Data)
 	testutil.Ok(t, err)
-	testutil.Equals(t, math.MaxUint16, chunk.NumSamples())
+	testutil.Equals(t, 120, chunk.NumSamples())
 
-	chunk, err = chunkenc.FromData(chunkenc.EncXOR, firstSeries.Chunks[2].Raw.Data)
+	chunk, err = chunkenc.FromData(chunkenc.EncXOR, firstSeries.Chunks[len(firstSeries.Chunks)-1].Raw.Data)
 	testutil.Ok(t, err)
-	testutil.Equals(t, 5, chunk.NumSamples())
+	testutil.Equals(t, 35, chunk.NumSamples())
 }
 
 // Regression test for https://github.com/thanos-io/thanos/issues/396.
-func TestPrometheusStore_Series_SplitSamplesIntoChunksWithMaxSizeOfUint16_e2e(t *testing.T) {
+func TestPrometheusStore_Series_SplitSamplesIntoChunksWithMaxSizeOf120(t *testing.T) {
 	defer leaktest.CheckTimeout(t, 10*time.Second)()
 
 	p, err := e2eutil.NewPrometheus()
 	testutil.Ok(t, err)
 	defer func() { testutil.Ok(t, p.Stop()) }()
 
-	testSeries_SplitSamplesIntoChunksWithMaxSizeOfUint16_e2e(t, p.Appender(), func() storepb.StoreServer {
+	testSeries_SplitSamplesIntoChunksWithMaxSizeOf120(t, p.Appender(), func() storepb.StoreServer {
 		testutil.Ok(t, p.Start())
 
 		u, err := url.Parse(fmt.Sprintf("http://%s", p.Addr()))

--- a/pkg/store/tsdb_test.go
+++ b/pkg/store/tsdb_test.go
@@ -290,14 +290,14 @@ func TestTSDBStore_LabelValues(t *testing.T) {
 }
 
 // Regression test for https://github.com/thanos-io/thanos/issues/1038.
-func TestTSDBStore_Series_SplitSamplesIntoChunksWithMaxSizeOfUint16_e2e(t *testing.T) {
+func TestTSDBStore_Series_SplitSamplesIntoChunksWithMaxSizeOf120(t *testing.T) {
 	defer leaktest.CheckTimeout(t, 10*time.Second)()
 
 	db, err := e2eutil.NewTSDB()
 	defer func() { testutil.Ok(t, db.Close()) }()
 	testutil.Ok(t, err)
 
-	testSeries_SplitSamplesIntoChunksWithMaxSizeOfUint16_e2e(t, db.Appender(), func() storepb.StoreServer {
+	testSeries_SplitSamplesIntoChunksWithMaxSizeOf120(t, db.Appender(), func() storepb.StoreServer {
 		tsdbStore := NewTSDBStore(nil, nil, db, component.Rule, labels.FromStrings("region", "eu-west"))
 
 		return tsdbStore


### PR DESCRIPTION
This is to have a unified chunk size and should reduce the load on queriers.
This also will be much more comparable when a chunk iterator will be done.

See following benchmark results for Receive (multiTSDB):

```
 benchstat -delta-test none _dev/bench_outs/0-receiveseries/benchBenchmarkMultiTSDBSeries.out _dev/bench_outs/1-receiveseries/benchBenchmarkMultiTSDBSeries.out
name                                                                                                  old time/op    new time/op    delta
MultiTSDBSeries/1000000SeriesWith1Samples/headOnly/4_TSDBs_with_1_samples,_250000_series_each-12         6.41s ± 0%     6.16s ± 0%   -3.85%
MultiTSDBSeries/1000000SeriesWith1Samples/blocksOnly/4_TSDBs_with_1_samples,_250000_series_each-12       5.77s ± 0%     6.16s ± 0%   +6.61%
MultiTSDBSeries/100000SeriesWith100Samples/headOnly/4_TSDBs_with_25_samples,_25000_series_each-12        3.68s ± 0%     3.96s ± 0%   +7.43%
MultiTSDBSeries/100000SeriesWith100Samples/blocksOnly/4_TSDBs_with_25_samples,_25000_series_each-12      4.04s ± 0%     4.02s ± 0%   -0.46%
MultiTSDBSeries/1SeriesWith10000000Samples/headOnly/4_TSDBs_with_2500000_samples,_1_series_each-12       1.53s ± 0%     1.57s ± 0%   +2.08%
MultiTSDBSeries/1SeriesWith10000000Samples/blocksOnly/4_TSDBs_with_2500000_samples,_1_series_each-12     1.67s ± 0%     1.66s ± 0%   -1.12%

name                                                                                                  old alloc/op   new alloc/op   delta
MultiTSDBSeries/1000000SeriesWith1Samples/headOnly/4_TSDBs_with_1_samples,_250000_series_each-12        4.08GB ± 0%    4.08GB ± 0%   +0.03%
MultiTSDBSeries/1000000SeriesWith1Samples/blocksOnly/4_TSDBs_with_1_samples,_250000_series_each-12      4.08GB ± 0%    4.08GB ± 0%   -0.01%
MultiTSDBSeries/100000SeriesWith100Samples/headOnly/4_TSDBs_with_25_samples,_25000_series_each-12       1.73GB ± 0%    1.72GB ± 0%   -0.37%
MultiTSDBSeries/100000SeriesWith100Samples/blocksOnly/4_TSDBs_with_25_samples,_25000_series_each-12     1.66GB ± 0%    1.67GB ± 0%   +0.57%
MultiTSDBSeries/1SeriesWith10000000Samples/headOnly/4_TSDBs_with_2500000_samples,_1_series_each-12      2.71GB ± 0%    2.47GB ± 0%   -8.68%
MultiTSDBSeries/1SeriesWith10000000Samples/blocksOnly/4_TSDBs_with_2500000_samples,_1_series_each-12    2.68GB ± 0%    2.46GB ± 0%   -8.14%

name                                                                                                  old allocs/op  new allocs/op  delta
MultiTSDBSeries/1000000SeriesWith1Samples/headOnly/4_TSDBs_with_1_samples,_250000_series_each-12         44.9M ± 0%     44.9M ± 0%   +0.00%
MultiTSDBSeries/1000000SeriesWith1Samples/blocksOnly/4_TSDBs_with_1_samples,_250000_series_each-12       44.9M ± 0%     44.9M ± 0%   -0.00%
MultiTSDBSeries/100000SeriesWith100Samples/headOnly/4_TSDBs_with_25_samples,_25000_series_each-12        27.1M ± 0%     27.1M ± 0%   -0.01%
MultiTSDBSeries/100000SeriesWith100Samples/blocksOnly/4_TSDBs_with_25_samples,_25000_series_each-12      27.1M ± 0%     27.1M ± 0%   +0.01%
MultiTSDBSeries/1SeriesWith10000000Samples/headOnly/4_TSDBs_with_2500000_samples,_1_series_each-12       1.02M ± 0%     1.69M ± 0%  +65.15%
MultiTSDBSeries/1SeriesWith10000000Samples/blocksOnly/4_TSDBs_with_2500000_samples,_1_series_each-12     1.02M ± 0%     1.69M ± 0%  +65.34%
```

Signed-off-by: Bartlomiej Plotka <bwplotka@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
