### PR TITLE
receive: Fixed leak on receive and querier proxying Store API Series, which was leaking on errors.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 - [#2665](https://github.com/thanos-io/thanos/pull/2665) Swift: fix issue with missing Content-Type HTTP headers.
 - [#2800](https://github.com/thanos-io/thanos/pull/2800) Query: Fix handling of `--web.external-prefix` and `--web.route-prefix`
 - [#2834](https://github.com/thanos-io/thanos/pull/2834) Query: Fix rendered JSON state value for rules and alerts should be in lowercase
-- [#2866](https://github.com/thanos-io/thanos/pull/2866) Receive: Fixed a leak on receive Store API Series, which was leaking on errors.
+- [#2866](https://github.com/thanos-io/thanos/pull/2866) Receive, Querier: Fixed leaks on receive and qwuerier Store API Series, which were leaking on errors.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 - [#2665](https://github.com/thanos-io/thanos/pull/2665) Swift: fix issue with missing Content-Type HTTP headers.
 - [#2800](https://github.com/thanos-io/thanos/pull/2800) Query: Fix handling of `--web.external-prefix` and `--web.route-prefix`
 - [#2834](https://github.com/thanos-io/thanos/pull/2834) Query: Fix rendered JSON state value for rules and alerts should be in lowercase
+- [#2866](https://github.com/thanos-io/thanos/pull/2866) Receive: Fixed a leak on receive Store API Series, which was leaking on errors.
 
 ### Changed
 

--- a/pkg/receive/multitsdb.go
+++ b/pkg/receive/multitsdb.go
@@ -23,6 +23,7 @@ import (
 	"github.com/thanos-io/thanos/pkg/objstore"
 	"github.com/thanos-io/thanos/pkg/shipper"
 	"github.com/thanos-io/thanos/pkg/store"
+	"github.com/thanos-io/thanos/pkg/store/storepb"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -211,11 +212,11 @@ func (t *MultiTSDB) Sync(ctx context.Context) error {
 	return merr.Err()
 }
 
-func (t *MultiTSDB) TSDBStores() map[string]*store.TSDBStore {
+func (t *MultiTSDB) TSDBStores() map[string]storepb.StoreServer {
 	t.mtx.RLock()
 	defer t.mtx.RUnlock()
 
-	res := make(map[string]*store.TSDBStore, len(t.tenants))
+	res := make(map[string]storepb.StoreServer, len(t.tenants))
 	for k, tenant := range t.tenants {
 		s := tenant.store()
 		if s != nil {

--- a/pkg/store/multitsdb.go
+++ b/pkg/store/multitsdb.go
@@ -139,11 +139,19 @@ func (s *tenantSeriesSetServer) Send(r *storepb.SeriesResponse) error {
 		s.directCh.send(r)
 		return nil
 	}
+
+	// TODO(bwplotka): Consider avoid copying / learn why it has to copied.
+	chunks := make([]storepb.AggrChunk, len(series.Chunks))
+	copy(chunks, series.Chunks)
+
 	// For series, pass it to our AggChunkSeriesSet.
 	select {
 	case <-s.ctx.Done():
 		return s.ctx.Err()
-	case s.recv <- series:
+	case s.recv <- &storepb.Series{
+		Labels: series.Labels,
+		Chunks: chunks,
+	}:
 		return nil
 	}
 }

--- a/pkg/store/multitsdb.go
+++ b/pkg/store/multitsdb.go
@@ -186,12 +186,12 @@ func (s *MultiTSDBStore) Series(r *storepb.SeriesRequest, srv storepb.Store_Seri
 
 	// Allow to buffer max 10 series response.
 	// Each might be quite large (multi chunk long series given by sidecar).
-	respSender, respCh := newCancellableRespChannel(gctx, 10)
+	respSender, respCh := newCancelableRespChannel(gctx, 10)
 
 	g.Go(func() error {
 		// This go routine is responsible for calling store's Series concurrently. Merged results
 		// are passed to respCh and sent concurrently to client (if buffer of 10 have room).
-		// When this go routine finishes or is cancelled, respCh channel is closed.
+		// When this go routine finishes or is canceled, respCh channel is closed.
 
 		var (
 			seriesSet []storepb.SeriesSet

--- a/pkg/store/multitsdb.go
+++ b/pkg/store/multitsdb.go
@@ -90,9 +90,9 @@ type tenantSeriesSetServer struct {
 
 	ctx context.Context
 
-	warnCh warnSender
-	recv   chan *storepb.Series
-	cur    *storepb.Series
+	directCh directSender
+	recv     chan *storepb.Series
+	cur      *storepb.Series
 
 	err    error
 	tenant string
@@ -103,13 +103,13 @@ type tenantSeriesSetServer struct {
 func newTenantSeriesSetServer(
 	ctx context.Context,
 	tenant string,
-	warnCh warnSender,
+	directCh directSender,
 ) *tenantSeriesSetServer {
 	return &tenantSeriesSetServer{
-		ctx:    ctx,
-		tenant: tenant,
-		warnCh: warnCh,
-		recv:   make(chan *storepb.Series),
+		ctx:      ctx,
+		tenant:   tenant,
+		directCh: directCh,
+		recv:     make(chan *storepb.Series),
 	}
 }
 
@@ -120,27 +120,30 @@ func (s *tenantSeriesSetServer) Series(store storepb.StoreServer, r *storepb.Ser
 	tracing.DoInSpan(s.ctx, "multitsdb_tenant_series", func(_ context.Context) {
 		err = store.Series(r, s)
 	})
-
 	if err != nil {
 		if r.PartialResponseDisabled || r.PartialResponseStrategy == storepb.PartialResponseStrategy_ABORT {
 			s.err = errors.Wrapf(err, "get series for tenant %s", s.tenant)
 		} else {
 			// Consistently prefix tenant specific warnings as done in various other places.
 			err = errors.New(prefixTenantWarning(s.tenant, err.Error()))
-			s.warnCh.send(storepb.NewWarnSeriesResponse(err))
+			s.directCh.send(storepb.NewWarnSeriesResponse(err))
 		}
 	}
-
 	close(s.recv)
 }
 
 func (s *tenantSeriesSetServer) Send(r *storepb.SeriesResponse) error {
 	series := r.GetSeries()
-	chunks := make([]storepb.AggrChunk, len(series.Chunks))
-	copy(chunks, series.Chunks)
-	s.recv <- &storepb.Series{
-		Labels: series.Labels,
-		Chunks: chunks,
+	if series == nil {
+		// Proxy non series responses directly to client
+		s.directCh.send(r)
+		return nil
+	}
+	// For series, pass it to our AggChunkSeriesSet.
+	select {
+	case <-s.ctx.Done():
+		return s.ctx.Err()
+	case s.recv <- series:
 	}
 	return nil
 }
@@ -157,29 +160,31 @@ func (s *tenantSeriesSetServer) At() ([]storepb.Label, []storepb.AggrChunk) {
 	return s.cur.Labels, s.cur.Chunks
 }
 
-func (s *tenantSeriesSetServer) Err() error {
-	return s.err
-}
+func (s *tenantSeriesSetServer) Err() error { return s.err }
 
 // Series returns all series for a requested time range and label matcher. The
 // returned data may exceed the requested time bounds. The data returned may
 // have been read and merged from multiple underlying TSDBStore instances.
 func (s *MultiTSDBStore) Series(r *storepb.SeriesRequest, srv storepb.Store_SeriesServer) error {
+	span, ctx := tracing.StartSpan(srv.Context(), "multitsdb_series")
+	defer span.Finish()
+
 	stores := s.tsdbStores()
 	if len(stores) == 0 {
 		return nil
 	}
 
-	var (
-		g, gctx   = errgroup.WithContext(srv.Context())
-		span, ctx = tracing.StartSpan(gctx, "multitsdb_series")
-		// Allow to buffer max 10 series response.
-		// Each might be quite large (multi chunk long series given by sidecar).
-		respSender, respRecv, closeFn = newRespCh(gctx, 10)
-	)
-	defer span.Finish()
+	g, gctx := errgroup.WithContext(ctx)
+
+	// Allow to buffer max 10 series response.
+	// Each might be quite large (multi chunk long series given by sidecar).
+	respSender, respCh := newCancellableRespChannel(gctx, 10)
 
 	g.Go(func() error {
+		// This go routine is responsible for calling store's Series concurrently. Merged results
+		// are passed to respCh and sent concurrently to client (if buffer of 10 have room).
+		// When this go routine finishes or is cancelled, respCh channel is closed.
+
 		var (
 			seriesSet []storepb.SeriesSet
 			wg        = &sync.WaitGroup{}
@@ -187,7 +192,7 @@ func (s *MultiTSDBStore) Series(r *storepb.SeriesRequest, srv storepb.Store_Seri
 
 		defer func() {
 			wg.Wait()
-			closeFn()
+			close(respCh)
 		}()
 
 		for tenant, store := range stores {
@@ -214,13 +219,16 @@ func (s *MultiTSDBStore) Series(r *storepb.SeriesRequest, srv storepb.Store_Seri
 		}
 		return mergedSet.Err()
 	})
-
-	for resp := range respRecv {
-		if err := srv.Send(resp); err != nil {
-			return status.Error(codes.Unknown, errors.Wrap(err, "send series response").Error())
+	g.Go(func() error {
+		// Go routine for gathering merged responses and sending them over to client. It stops when
+		// respCh channel is closed OR on error from client.
+		for resp := range respCh {
+			if err := srv.Send(resp); err != nil {
+				return status.Error(codes.Unknown, errors.Wrap(err, "send series response").Error())
+			}
 		}
-	}
-
+		return nil
+	})
 	return g.Wait()
 }
 

--- a/pkg/store/multitsdb.go
+++ b/pkg/store/multitsdb.go
@@ -144,8 +144,8 @@ func (s *tenantSeriesSetServer) Send(r *storepb.SeriesResponse) error {
 	case <-s.ctx.Done():
 		return s.ctx.Err()
 	case s.recv <- series:
+		return nil
 	}
-	return nil
 }
 
 func (s *tenantSeriesSetServer) Next() (ok bool) {

--- a/pkg/store/multitsdb_test.go
+++ b/pkg/store/multitsdb_test.go
@@ -243,7 +243,7 @@ func (s *mockedSeriesServer) Send(r *storepb.SeriesResponse) error {
 func (s *mockedSeriesServer) Context() context.Context { return s.ctx }
 
 // Regression test against https://github.com/thanos-io/thanos/issues/2823.
-// This is different leak than in TestTenantSeriesSetServert_NotLeakingIfNotExhausted
+// This is different leak than in TestTenantSeriesSetServert_NotLeakingIfNotExhausted.
 func TestMultiTSDBStore_NotLeakingOnPrematureFinish(t *testing.T) {
 	defer leaktest.CheckTimeout(t, 10*time.Second)()
 
@@ -277,7 +277,7 @@ func TestMultiTSDBStore_NotLeakingOnPrematureFinish(t *testing.T) {
 		}
 	})
 
-	if ok := t.Run("failing send", func(t *testing.T) {
+	t.Run("failing send", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		// We mimic failing series server, but practically context cancel will do the same.
 		testutil.NotOk(t, m.Series(&storepb.SeriesRequest{PartialResponseStrategy: storepb.PartialResponseStrategy_ABORT}, &mockedSeriesServer{
@@ -288,7 +288,5 @@ func TestMultiTSDBStore_NotLeakingOnPrematureFinish(t *testing.T) {
 			},
 		}))
 		testutil.NotOk(t, ctx.Err())
-	}); !ok {
-		return
-	}
+	})
 }

--- a/pkg/store/multitsdb_test.go
+++ b/pkg/store/multitsdb_test.go
@@ -209,7 +209,7 @@ func TestTenantSeriesSetServert_NotLeakingIfNotExhausted(t *testing.T) {
 		testutil.Equals(t, 3, i)
 	})
 
-	t.Run("cancelled, not exhausted StoreSet", func(t *testing.T) {
+	t.Run("canceled, not exhausted StoreSet", func(t *testing.T) {
 		defer leaktest.CheckTimeout(t, 10*time.Second)()
 
 		ctx, cancel := context.WithCancel(context.Background())

--- a/pkg/store/proxy.go
+++ b/pkg/store/proxy.go
@@ -184,19 +184,19 @@ func mergeLabels(a []storepb.Label, b labels.Labels) []storepb.Label {
 	return res
 }
 
-// cancellableRespSender is a response channel that does need to be exhausted on cancel.
-type cancellableRespSender struct {
+// cancelableRespSender is a response channel that does need to be exhausted on cancel.
+type cancelableRespSender struct {
 	ctx context.Context
 	ch  chan<- *storepb.SeriesResponse
 }
 
-func newCancellableRespChannel(ctx context.Context, buffer int) (*cancellableRespSender, chan *storepb.SeriesResponse) {
+func newCancelableRespChannel(ctx context.Context, buffer int) (*cancelableRespSender, chan *storepb.SeriesResponse) {
 	respCh := make(chan *storepb.SeriesResponse, buffer)
-	return &cancellableRespSender{ctx: ctx, ch: respCh}, respCh
+	return &cancelableRespSender{ctx: ctx, ch: respCh}, respCh
 }
 
 // send or return on cancel.
-func (s cancellableRespSender) send(r *storepb.SeriesResponse) {
+func (s cancelableRespSender) send(r *storepb.SeriesResponse) {
 	select {
 	case <-s.ctx.Done():
 	case s.ch <- r:
@@ -222,12 +222,12 @@ func (s *ProxyStore) Series(r *storepb.SeriesRequest, srv storepb.Store_SeriesSe
 
 	// Allow to buffer max 10 series response.
 	// Each might be quite large (multi chunk long series given by sidecar).
-	respSender, respCh := newCancellableRespChannel(gctx, 10)
+	respSender, respCh := newCancelableRespChannel(gctx, 10)
 
 	g.Go(func() error {
 		// This go routine is responsible for calling store's Series concurrently. Merged results
 		// are passed to respCh and sent concurrently to client (if buffer of 10 have room).
-		// When this go routine finishes or is cancelled, respCh channel is closed.
+		// When this go routine finishes or is canceled, respCh channel is closed.
 
 		var (
 			seriesSet      []storepb.SeriesSet

--- a/pkg/store/proxy.go
+++ b/pkg/store/proxy.go
@@ -195,7 +195,7 @@ func newCancellableRespChannel(ctx context.Context, buffer int) (*cancellableRes
 	return &cancellableRespSender{ctx: ctx, ch: respCh}, respCh
 }
 
-// send or returns on cancel.
+// send or return on cancel.
 func (s cancellableRespSender) send(r *storepb.SeriesResponse) {
 	select {
 	case <-s.ctx.Done():

--- a/pkg/store/proxy.go
+++ b/pkg/store/proxy.go
@@ -184,18 +184,23 @@ func mergeLabels(a []storepb.Label, b labels.Labels) []storepb.Label {
 	return res
 }
 
-type ctxRespSender struct {
+// cancellableRespSender is a response channel that does need to be exhausted on cancel.
+type cancellableRespSender struct {
 	ctx context.Context
 	ch  chan<- *storepb.SeriesResponse
 }
 
-func newRespCh(ctx context.Context, buffer int) (*ctxRespSender, <-chan *storepb.SeriesResponse, func()) {
+func newCancellableRespChannel(ctx context.Context, buffer int) (*cancellableRespSender, chan *storepb.SeriesResponse) {
 	respCh := make(chan *storepb.SeriesResponse, buffer)
-	return &ctxRespSender{ctx: ctx, ch: respCh}, respCh, func() { close(respCh) }
+	return &cancellableRespSender{ctx: ctx, ch: respCh}, respCh
 }
 
-func (s ctxRespSender) send(r *storepb.SeriesResponse) {
-	s.ch <- r
+// send or returns on cancel.
+func (s cancellableRespSender) send(r *storepb.SeriesResponse) {
+	select {
+	case <-s.ctx.Done():
+	case s.ch <- r:
+	}
 }
 
 // Series returns all series for a requested time range and label matcher. Requested series are taken from other
@@ -213,15 +218,17 @@ func (s *ProxyStore) Series(r *storepb.SeriesRequest, srv storepb.Store_SeriesSe
 		return status.Error(codes.InvalidArgument, errors.New("no matchers specified (excluding external labels)").Error())
 	}
 
-	var (
-		g, gctx = errgroup.WithContext(srv.Context())
+	g, gctx := errgroup.WithContext(srv.Context())
 
-		// Allow to buffer max 10 series response.
-		// Each might be quite large (multi chunk long series given by sidecar).
-		respSender, respRecv, closeFn = newRespCh(gctx, 10)
-	)
+	// Allow to buffer max 10 series response.
+	// Each might be quite large (multi chunk long series given by sidecar).
+	respSender, respCh := newCancellableRespChannel(gctx, 10)
 
 	g.Go(func() error {
+		// This go routine is responsible for calling store's Series concurrently. Merged results
+		// are passed to respCh and sent concurrently to client (if buffer of 10 have room).
+		// When this go routine finishes or is cancelled, respCh channel is closed.
+
 		var (
 			seriesSet      []storepb.SeriesSet
 			storeDebugMsgs []string
@@ -239,7 +246,7 @@ func (s *ProxyStore) Series(r *storepb.SeriesRequest, srv storepb.Store_SeriesSe
 
 		defer func() {
 			wg.Wait()
-			closeFn()
+			close(respCh)
 		}()
 
 		for _, st := range s.stores() {
@@ -306,21 +313,25 @@ func (s *ProxyStore) Series(r *storepb.SeriesRequest, srv storepb.Store_SeriesSe
 		}
 		return mergedSet.Err()
 	})
-
-	for resp := range respRecv {
-		if err := srv.Send(resp); err != nil {
-			return status.Error(codes.Unknown, errors.Wrap(err, "send series response").Error())
+	g.Go(func() error {
+		// Go routine for gathering merged responses and sending them over to client. It stops when
+		// respCh channel is closed OR on error from client.
+		for resp := range respCh {
+			if err := srv.Send(resp); err != nil {
+				return status.Error(codes.Unknown, errors.Wrap(err, "send series response").Error())
+			}
 		}
-	}
-
+		return nil
+	})
 	if err := g.Wait(); err != nil {
+		// TODO(bwplotka): Replace with request logger.
 		level.Error(s.logger).Log("err", err)
 		return err
 	}
 	return nil
 }
 
-type warnSender interface {
+type directSender interface {
 	send(*storepb.SeriesResponse)
 }
 
@@ -331,7 +342,7 @@ type streamSeriesSet struct {
 	logger log.Logger
 
 	stream storepb.Store_SeriesClient
-	warnCh warnSender
+	warnCh directSender
 
 	currSeries *storepb.Series
 	recvCh     chan *storepb.Series
@@ -367,7 +378,7 @@ func startStreamSeriesSet(
 	closeSeries context.CancelFunc,
 	wg *sync.WaitGroup,
 	stream storepb.Store_SeriesClient,
-	warnCh warnSender,
+	warnCh directSender,
 	name string,
 	partialResponse bool,
 	responseTimeout time.Duration,

--- a/pkg/store/proxy_test.go
+++ b/pkg/store/proxy_test.go
@@ -1705,7 +1705,7 @@ func TestProxyStore_NotLeakingOnPrematureFinish(t *testing.T) {
 		responseTimeout: 0,
 	}
 
-	if ok := t.Run("failling send", func(t *testing.T) {
+	t.Run("failling send", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		// We mimic failing series server, but practically context cancel will do the same.
 		testutil.NotOk(t, p.Series(&storepb.SeriesRequest{Matchers: []storepb.LabelMatcher{{}}, PartialResponseStrategy: storepb.PartialResponseStrategy_ABORT}, &mockedSeriesServer{
@@ -1716,7 +1716,5 @@ func TestProxyStore_NotLeakingOnPrematureFinish(t *testing.T) {
 			},
 		}))
 		testutil.NotOk(t, ctx.Err())
-	}); !ok {
-		return
-	}
+	})
 }

--- a/pkg/store/proxy_test.go
+++ b/pkg/store/proxy_test.go
@@ -1653,3 +1653,70 @@ func benchProxySeries(t testutil.TB, totalSamples, totalSeries int) {
 		},
 	)
 }
+
+func TestProxyStore_NotLeakingOnPrematureFinish(t *testing.T) {
+	defer leaktest.CheckTimeout(t, 10*time.Second)()
+
+	clients := []Client{
+		&testClient{
+			StoreClient: &mockedStoreAPI{
+				RespSeries: []*storepb.SeriesResponse{
+					// Ensure more than 10 (internal respCh channel).
+					storeSeriesResponse(t, labels.FromStrings("a", "a"), []sample{{0, 0}, {2, 1}, {3, 2}}),
+					storeSeriesResponse(t, labels.FromStrings("a", "b"), []sample{{0, 0}, {2, 1}, {3, 2}}),
+					storeSeriesResponse(t, labels.FromStrings("a", "c"), []sample{{0, 0}, {2, 1}, {3, 2}}),
+					storeSeriesResponse(t, labels.FromStrings("a", "d"), []sample{{0, 0}, {2, 1}, {3, 2}}),
+					storeSeriesResponse(t, labels.FromStrings("a", "e"), []sample{{0, 0}, {2, 1}, {3, 2}}),
+					storeSeriesResponse(t, labels.FromStrings("a", "f"), []sample{{0, 0}, {2, 1}, {3, 2}}),
+					storeSeriesResponse(t, labels.FromStrings("a", "g"), []sample{{0, 0}, {2, 1}, {3, 2}}),
+					storeSeriesResponse(t, labels.FromStrings("a", "h"), []sample{{0, 0}, {2, 1}, {3, 2}}),
+					storeSeriesResponse(t, labels.FromStrings("a", "i"), []sample{{0, 0}, {2, 1}, {3, 2}}),
+					storeSeriesResponse(t, labels.FromStrings("a", "j"), []sample{{0, 0}, {2, 1}, {3, 2}}),
+				},
+			},
+			minTime: math.MinInt64,
+			maxTime: math.MaxInt64,
+		},
+		&testClient{
+			StoreClient: &mockedStoreAPI{
+				RespSeries: []*storepb.SeriesResponse{
+					storeSeriesResponse(t, labels.FromStrings("b", "a"), []sample{{0, 0}, {2, 1}, {3, 2}}),
+					storeSeriesResponse(t, labels.FromStrings("b", "b"), []sample{{0, 0}, {2, 1}, {3, 2}}),
+					storeSeriesResponse(t, labels.FromStrings("b", "c"), []sample{{0, 0}, {2, 1}, {3, 2}}),
+					storeSeriesResponse(t, labels.FromStrings("b", "d"), []sample{{0, 0}, {2, 1}, {3, 2}}),
+					storeSeriesResponse(t, labels.FromStrings("b", "e"), []sample{{0, 0}, {2, 1}, {3, 2}}),
+					storeSeriesResponse(t, labels.FromStrings("b", "f"), []sample{{0, 0}, {2, 1}, {3, 2}}),
+					storeSeriesResponse(t, labels.FromStrings("b", "g"), []sample{{0, 0}, {2, 1}, {3, 2}}),
+					storeSeriesResponse(t, labels.FromStrings("b", "h"), []sample{{0, 0}, {2, 1}, {3, 2}}),
+					storeSeriesResponse(t, labels.FromStrings("b", "i"), []sample{{0, 0}, {2, 1}, {3, 2}}),
+					storeSeriesResponse(t, labels.FromStrings("b", "j"), []sample{{0, 0}, {2, 1}, {3, 2}}),
+				},
+			},
+			minTime: math.MinInt64,
+			maxTime: math.MaxInt64,
+		},
+	}
+
+	logger := log.NewNopLogger()
+	p := &ProxyStore{
+		logger:          logger,
+		stores:          func() []Client { return clients },
+		metrics:         newProxyStoreMetrics(nil),
+		responseTimeout: 0,
+	}
+
+	if ok := t.Run("failling send", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		// We mimic failing series server, but practically context cancel will do the same.
+		testutil.NotOk(t, p.Series(&storepb.SeriesRequest{Matchers: []storepb.LabelMatcher{{}}, PartialResponseStrategy: storepb.PartialResponseStrategy_ABORT}, &mockedSeriesServer{
+			ctx: ctx,
+			send: func(*storepb.SeriesResponse) error {
+				cancel()
+				return ctx.Err()
+			},
+		}))
+		testutil.NotOk(t, ctx.Err())
+	}); !ok {
+		return
+	}
+}


### PR DESCRIPTION
Fixes: https://github.com/thanos-io/thanos/issues/2823

TestTenantSeriesSetServert_NotLeakingIfNotExhausted was showing leaks:

```
    TestTenantSeriesSetServert_NotLeakingIfNotExhausted/cancelled,_not_exhausted_StoreSet: leaktest.go:132: leaktest: timed out checking goroutines
    TestTenantSeriesSetServert_NotLeakingIfNotExhausted/cancelled,_not_exhausted_StoreSet: leaktest.go:150: leaktest: leaked goroutine: goroutine 84 [chan send]:
        github.com/thanos-io/thanos/pkg/store.(*tenantSeriesSetServer).Send(0xc000708360, 0xc0003104c0, 0x0, 0x0)
        	/home/bwplotka/Repos/thanos/pkg/store/multitsdb.go:141 +0x13e
        github.com/thanos-io/thanos/pkg/store.(*mockedStoreServer).Series(0xc0004e6330, 0xc0007083c0, 0x20ac2c0, 0xc000708360, 0x5116a0, 0x0)
        	/home/bwplotka/Repos/thanos/pkg/store/multitsdb_test.go:173 +0x76
        github.com/thanos-io/thanos/pkg/store.(*tenantSeriesSetServer).Series.func1(0x2097760, 0xc00003c940)
        	/home/bwplotka/Repos/thanos/pkg/store/multitsdb.go:121 +0x56
        github.com/thanos-io/thanos/pkg/tracing.DoInSpan(0x2097760, 0xc00003c940, 0x1c8bace, 0x17, 0xc000173760, 0x0, 0x0, 0x0)
        	/home/bwplotka/Repos/thanos/pkg/tracing/tracing.go:72 +0xcc
        github.com/thanos-io/thanos/pkg/store.(*tenantSeriesSetServer).Series(0xc000708360, 0x20983e0, 0xc0004e6330, 0xc0007083c0)
        	/home/bwplotka/Repos/thanos/pkg/store/multitsdb.go:120 +0xfa
        github.com/thanos-io/thanos/pkg/store.TestTenantSeriesSetServert_NotLeakingIfNotExhausted.func2.1(0xc000708360, 0xc0004e6330)
        	/home/bwplotka/Repos/thanos/pkg/store/multitsdb_test.go:225 +0x62
        created by github.com/thanos-io/thanos/pkg/store.TestTenantSeriesSetServert_NotLeakingIfNotExhausted.func2
        	/home/bwplotka/Repos/thanos/pkg/store/multitsdb_test.go:224 +0x618
    --- FAIL: TestTenantSeriesSetServert_NotLeakingIfNotExhausted/cancelled,_not_exhausted_StoreSet (10.03s)
FAIL

Process finished with exit code 1

```

TestMultiTSDBStore_NotLeakingOnSendError was showing:

```
TestMultiTSDBStore_NotLeakingOnSendError: leaktest.go:150: leaktest: leaked goroutine: goroutine 84 [chan send]:
        github.com/thanos-io/thanos/pkg/store.ctxRespSender.send(...)
        	/home/bwplotka/Repos/thanos/pkg/store/proxy.go:198
        github.com/thanos-io/thanos/pkg/store.(*MultiTSDBStore).Series.func1(0x0, 0x0)
        	/home/bwplotka/Repos/thanos/pkg/store/multitsdb.go:214 +0x5cf
        golang.org/x/sync/errgroup.(*Group).Go.func1(0xc0002708d0, 0xc000416380)
        	/home/bwplotka/Repos/thanosgopath/pkg/mod/golang.org/x/sync@v0.0.0-20200317015054-43a5402ce75a/errgroup/errgroup.go:57 +0x59
        created by golang.org/x/sync/errgroup.(*Group).Go
        	/home/bwplotka/Repos/thanosgopath/pkg/mod/golang.org/x/sync@v0.0.0-20200317015054-43a5402ce75a/errgroup/errgroup.go:54 +0x66
--- FAIL: TestMultiTSDBStore_NotLeakingOnSendError (10.02s)
```

Signed-off-by: Bartlomiej Plotka <bwplotka@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
