### PR TITLE
ci: Remove redundant linters and sort them alphabetically

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -29,24 +29,23 @@ output:
 
 linters:
   enable:
+    # Sorted alphabetically.
     - deadcode
     - errcheck
     - goconst
+    - godot
     - gofmt
     - goimports
     - gosimple
     - govet
     - ineffassign
+    - misspell
     - staticcheck
     - structcheck
     - typecheck
-    - unused
-    - varcheck
-    - godot
     - unparam
     - unused
     - varcheck
-    - misspell
 
 linters-settings:
   errcheck:


### PR DESCRIPTION
Signed-off-by: Kemal Akkoyun <kakkoyun@gmail.com>

* [x] Change is not relevant to the end user.

## Changes

* Remove redundant linters and sort them alphabetically

## Verification

* `make go-lint`
