### PR TITLE
reloader: Fixed test flakiness.

### DIFF
--- a/pkg/reloader/reloader.go
+++ b/pkg/reloader/reloader.go
@@ -219,6 +219,7 @@ func (r *Reloader) Watch(ctx context.Context) error {
 
 		if err := r.apply(ctx); err != nil {
 			// Critical error.
+			// TODO(bwplotka): There is no need to get process down in this case and decrease availability, handle the error in different way.
 			return err
 		}
 	}

--- a/pkg/reloader/reloader_test.go
+++ b/pkg/reloader/reloader_test.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"os"
 	"path"
+	"path/filepath"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -24,6 +25,9 @@ import (
 
 func TestReloader_ConfigApply(t *testing.T) {
 	defer leaktest.CheckTimeout(t, 10*time.Second)()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
 
 	l, err := net.Listen("tcp", "localhost:0")
 	testutil.Ok(t, err)
@@ -43,9 +47,7 @@ func TestReloader_ConfigApply(t *testing.T) {
 		reloads.Store(reloads.Load().(int) + 1) // The only writer.
 		resp.WriteHeader(http.StatusOK)
 	})
-	go func() {
-		_ = srv.Serve(l)
-	}()
+	go func() { _ = srv.Serve(l) }()
 	defer func() { testutil.Ok(t, srv.Close()) }()
 
 	reloadURL, err := url.Parse(fmt.Sprintf("http://%s", l.Addr().String()))
@@ -55,18 +57,21 @@ func TestReloader_ConfigApply(t *testing.T) {
 	testutil.Ok(t, err)
 	defer func() { testutil.Ok(t, os.RemoveAll(dir)) }()
 
-	testutil.Ok(t, os.Mkdir(dir+"/in", os.ModePerm))
-	testutil.Ok(t, os.Mkdir(dir+"/out", os.ModePerm))
+	testutil.Ok(t, os.Mkdir(filepath.Join(dir, "in"), os.ModePerm))
+	testutil.Ok(t, os.Mkdir(filepath.Join(dir, "out"), os.ModePerm))
 
 	var (
-		input  = path.Join(dir, "in", "cfg.yaml.tmpl")
-		output = path.Join(dir, "out", "cfg.yaml")
+		input  = filepath.Join(dir, "in", "cfg.yaml.tmpl")
+		output = filepath.Join(dir, "out", "cfg.yaml")
 	)
 	reloader := New(nil, nil, reloadURL, input, output, nil)
 	reloader.watchInterval = 9999 * time.Hour // Disable interval to test watch logic only.
 	reloader.retryInterval = 100 * time.Millisecond
 
-	testNoConfig(t, reloader)
+	// Fail without config.
+	err = reloader.Watch(ctx)
+	testutil.NotOk(t, err)
+	testutil.Assert(t, strings.HasSuffix(err.Error(), "no such file or directory"), "expect error since there is no input config.")
 
 	testutil.Ok(t, ioutil.WriteFile(input, []byte(`
 config:
@@ -75,93 +80,74 @@ config:
   c: $(TEST_RELOADER_THANOS_ENV2)
 `), os.ModePerm))
 
-	testUnsetVariables(t, reloader)
+	// Fail with config but without unset variables.
+	err = reloader.Watch(ctx)
+	testutil.NotOk(t, err)
+	testutil.Assert(t, strings.HasSuffix(err.Error(), `found reference to unset environment variable "TEST_RELOADER_THANOS_ENV"`), "expect error since there envvars are not set.")
 
 	testutil.Ok(t, os.Setenv("TEST_RELOADER_THANOS_ENV", "2"))
 	testutil.Ok(t, os.Setenv("TEST_RELOADER_THANOS_ENV2", "3"))
 
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+	rctx, cancel2 := context.WithCancel(ctx)
 	g := sync.WaitGroup{}
 	g.Add(1)
 	go func() {
 		defer g.Done()
-		defer cancel()
+		testutil.Ok(t, reloader.Watch(rctx))
+	}()
 
-		reloadsSeen := 0
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-time.After(300 * time.Millisecond):
-			}
+	reloadsSeen := 0
+	for {
+		select {
+		case <-ctx.Done():
+			break
+		case <-time.After(300 * time.Millisecond):
+		}
 
-			rel := reloads.Load().(int)
-			if rel <= reloadsSeen {
-				continue
-			}
-			reloadsSeen = rel
+		rel := reloads.Load().(int)
+		if rel <= reloadsSeen {
+			// Nothing new.
+			continue
+		}
 
-			switch rel {
-			case 1:
-				// Initial apply seen (without doing nothing)
-
-				// Output looks as expected?
-				f, err := ioutil.ReadFile(output)
-				testutil.Ok(t, err)
-
-				testutil.Equals(t, `
+		if reloadsSeen == 0 {
+			// Initial apply seen (without doing nothing).
+			f, err := ioutil.ReadFile(output)
+			testutil.Ok(t, err)
+			testutil.Equals(t, `
 config:
   a: 1
   b: 2
   c: 3
 `, string(f))
 
-				// Change config, expect reload in another iteration.
-				testutil.Ok(t, ioutil.WriteFile(input, []byte(`
+			// Change config, expect reload in another iteration.
+			testutil.Ok(t, ioutil.WriteFile(input, []byte(`
 config:
   a: changed
   b: $(TEST_RELOADER_THANOS_ENV)
   c: $(TEST_RELOADER_THANOS_ENV2)
 `), os.ModePerm))
-			case 2:
-				f, err := ioutil.ReadFile(output)
-				testutil.Ok(t, err)
-
-				testutil.Equals(t, `
+		} else {
+			// Another apply, ensure we see change.
+			f, err := ioutil.ReadFile(output)
+			testutil.Ok(t, err)
+			testutil.Equals(t, `
 config:
   a: changed
   b: 2
   c: 3
 `, string(f))
-			}
-
-			if rel > 1 {
-				// All good.
-				return
-			}
+			// All good, break
+			break
 		}
-	}()
-	err = reloader.Watch(ctx)
-	testutil.Ok(t, err)
-	cancel()
+		reloadsSeen = rel
+	}
+	cancel2()
 	g.Wait()
-	testutil.Equals(t, 2, reloads.Load().(int))
-}
 
-func testNoConfig(t *testing.T, reloader *Reloader) {
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
-	err := reloader.Watch(ctx)
-	cancel()
-	testutil.NotOk(t, err)
-	testutil.Assert(t, strings.HasSuffix(err.Error(), "no such file or directory"), "expect error since there is no input config.")
-}
-
-func testUnsetVariables(t *testing.T, reloader *Reloader) {
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
-	err := reloader.Watch(ctx)
-	cancel()
-	testutil.NotOk(t, err)
-	testutil.Assert(t, strings.HasSuffix(err.Error(), `found reference to unset environment variable "TEST_RELOADER_THANOS_ENV"`), "expect error since there envvars are not set.")
+	testutil.Ok(t, os.Unsetenv("TEST_RELOADER_THANOS_ENV"))
+	testutil.Ok(t, os.Unsetenv("TEST_RELOADER_THANOS_ENV2"))
 }
 
 func TestReloader_RuleApply(t *testing.T) {


### PR DESCRIPTION
Fixes: https://github.com/thanos-io/thanos/issues/2622

E.g https://app.circleci.com/pipelines/github/thanos-io/thanos/1545/workflows/851eeb7a-8e4c-4b7e-b7c4-5e63582004a0/jobs/9566/steps

Reason for flakiness: We expected exact number of reloads. It can happen that there were more reloads than asserting go routine was waiting for, which is ok, test was not expecting that.

Signed-off-by: Bartlomiej Plotka <bwplotka@gmail.com>
