### PR TITLE
pkg/rules/rulespb: fix JSON marshaling for nil slices

### DIFF
--- a/pkg/query/api/v1_test.go
+++ b/pkg/query/api/v1_test.go
@@ -1359,6 +1359,7 @@ func TestRulesHandler(t *testing.T) {
 			EvaluationTime: all[3].GetAlert().EvaluationDurationSeconds,
 			Duration:       all[3].GetAlert().DurationSeconds,
 			Annotations:    nil,
+			Alerts:         []*testpromcompatibility.Alert{},
 			Type:           "alerting",
 		},
 	}

--- a/pkg/rules/rulespb/custom.go
+++ b/pkg/rules/rulespb/custom.go
@@ -177,6 +177,15 @@ func (r1 *Rule) Compare(r2 *Rule) int {
 	return 0
 }
 
+func (r *RuleGroups) MarshalJSON() ([]byte, error) {
+	if r.Groups == nil {
+		// Ensure that empty slices are marshaled as '[]' and not 'null'.
+		return []byte(`{"groups":[]}`), nil
+	}
+	type plain RuleGroups
+	return json.Marshal((*plain)(r))
+}
+
 func (m *Rule) UnmarshalJSON(entry []byte) error {
 	decider := struct {
 		Type string `json:"type"`
@@ -219,6 +228,10 @@ func (m *Rule) MarshalJSON() ([]byte, error) {
 		})
 	}
 	a := m.GetAlert()
+	if a.Alerts == nil {
+		// Ensure that empty slices are marshaled as '[]' and not 'null'.
+		a.Alerts = make([]*AlertInstance, 0)
+	}
 	return json.Marshal(struct {
 		*Alert
 		Type string `json:"type"`


### PR DESCRIPTION
Go's `encoding/json` turns nil slices into `null` instead of `[]`. This
is problematic for consumers expecting that the `alerts` field is a JSON
array. The same is true for empty rule groups.

* [ ] I added CHANGELOG entry for this change.
* [X] Change is not relevant to the end user (the feature hasn't been released yet).

## Changes

The solution is to enforce that nil slices are converted to zero-length
slices when encoding.

## Verification

I've updated the unit tests to cover the issue.