### PR TITLE
receive: Unify error handling

### DIFF
--- a/pkg/receive/handler.go
+++ b/pkg/receive/handler.go
@@ -674,12 +674,6 @@ type retryState struct {
 func countCause(errs []error, f func(error) bool) int {
 	var n int
 	for _, err := range errs {
-		errs, ok := err.(errutil.MultiError)
-		if ok {
-			n += countCause(errs, f)
-			continue
-		}
-
 		if f(errors.Cause(err)) {
 			n++
 		}

--- a/pkg/receive/handler_test.go
+++ b/pkg/receive/handler_test.go
@@ -165,46 +165,7 @@ func TestDetermineWriteErrorCause(t *testing.T) {
 			exp:       errors.New("baz: 3 errors: 3 errors: qux; rpc error: code = AlreadyExists desc = conflict; rpc error: code = AlreadyExists desc = conflict; foo; bar"),
 		},
 	} {
-
 		err := determineWriteErrorCause(tc.err, tc.threshold)
-		if tc.exp != nil {
-			testutil.NotOk(t, err)
-			testutil.Equals(t, tc.exp.Error(), err.Error())
-			continue
-		}
-		testutil.Ok(t, err)
-	}
-}
-
-func TestWriteErrorCause(t *testing.T) {
-	for _, tc := range []struct {
-		name string
-		err  error
-		exp  error
-	}{
-		{
-			name: "nested matching multierror",
-			err: errors.Wrap(errors.Wrap(errutil.MultiError([]error{
-				tsdb.ErrNotReady,
-				errors.New("foo"),
-				errors.New("bar"),
-			}), "baz"), "qux"),
-			exp: errNotReady,
-		},
-		{
-			name: "deep nested matching multierror",
-			err: errors.Wrap(errutil.MultiError([]error{
-				errutil.MultiError([]error{
-					errors.New("qux"),
-					status.Error(codes.AlreadyExists, "conflict"),
-				}),
-				errors.New("foo"),
-				errors.New("bar"),
-			}), "baz"),
-			exp: errors.New("baz: 3 errors: 2 errors: qux; rpc error: code = AlreadyExists desc = conflict; foo; bar"),
-		},
-	} {
-		err := writeErrorCause(tc.err)
 		if tc.exp != nil {
 			testutil.NotOk(t, err)
 			testutil.Equals(t, tc.exp.Error(), err.Error())

--- a/pkg/receive/handler_test.go
+++ b/pkg/receive/handler_test.go
@@ -32,7 +32,7 @@ import (
 	"github.com/thanos-io/thanos/pkg/testutil"
 )
 
-func TestFindCause(t *testing.T) {
+func TestDetermineWriteErrorCause(t *testing.T) {
 	for _, tc := range []struct {
 		name      string
 		err       error
@@ -166,7 +166,7 @@ func TestFindCause(t *testing.T) {
 		},
 	} {
 
-		err := findCause(tc.err, tc.threshold)
+		err := determineWriteErrorCause(tc.err, tc.threshold)
 		if tc.exp != nil {
 			testutil.NotOk(t, err)
 			testutil.Equals(t, tc.exp.Error(), err.Error())
@@ -176,7 +176,7 @@ func TestFindCause(t *testing.T) {
 	}
 }
 
-func TestRootCause(t *testing.T) {
+func TestWriteErrorCause(t *testing.T) {
 	for _, tc := range []struct {
 		name string
 		err  error
@@ -201,10 +201,10 @@ func TestRootCause(t *testing.T) {
 				errors.New("foo"),
 				errors.New("bar"),
 			}), "baz"),
-			exp: errors.New("3 errors: 2 errors: qux; rpc error: code = AlreadyExists desc = conflict; foo; bar"),
+			exp: errors.New("baz: 3 errors: 2 errors: qux; rpc error: code = AlreadyExists desc = conflict; foo; bar"),
 		},
 	} {
-		err := rootCause(tc.err)
+		err := writeErrorCause(tc.err)
 		if tc.exp != nil {
 			testutil.NotOk(t, err)
 			testutil.Equals(t, tc.exp.Error(), err.Error())

--- a/pkg/receive/handler_test.go
+++ b/pkg/receive/handler_test.go
@@ -161,7 +161,7 @@ func TestCause(t *testing.T) {
 				errors.New("bar"),
 			}), "baz"),
 			threshold: 1,
-			exp:       errConflict,
+			exp:       errors.New("unexpected error: baz: 3 errors: 3 errors: qux; rpc error: code = AlreadyExists desc = conflict; rpc error: code = AlreadyExists desc = conflict; foo; bar"),
 		},
 	} {
 		got := cause(tc.err, tc.threshold)
@@ -204,7 +204,7 @@ func TestRootCause(t *testing.T) {
 				errors.New("foo"),
 				errors.New("bar"),
 			}), "baz"),
-			exp: errConflict,
+			exp: errors.New("3 errors: 2 errors: qux; rpc error: code = AlreadyExists desc = conflict; foo; bar"),
 		},
 	} {
 		got := rootCause(tc.err)


### PR DESCRIPTION
The Receiver has a couple of similar error modes that could be originated from different resources (i.e local tsdb, forward requests for other peers in the ring), this PR attempts to unify how errors are returned from those paths and how the errors handled, especially for the nested errors, in order to provide consistent fail mode behaviour and make the code easier to follow.

One other reason was, for some cases because of the wrapped errors, it was wrongly categorising the root cause of the errors, this PR also attempts to fix it.

Signed-off-by: Kemal Akkoyun <kakkoyun@gmail.com>

* [x] Change is not relevant to the end-user.

## Changes

* Unify error handling paths for fan-out forward requests.

## Verification

* `make test-local`
