### PR TITLE
Wrap meta fetcher metrics with thanos prefix in replicate

### DIFF
--- a/pkg/replicate/replicator.go
+++ b/pkg/replicate/replicator.go
@@ -151,7 +151,8 @@ func RunReplicate(
 		Help: "The Duration of replication runs split by success and error.",
 	}, []string{"result"})
 
-	fetcher, err := thanosblock.NewMetaFetcher(logger, 32, fromBkt, "", reg, nil, nil)
+	fetcher, err := thanosblock.NewMetaFetcher(logger, 32, fromBkt, "",
+		extprom.WrapRegistererWithPrefix("thanos_", reg), nil, nil)
 	if err != nil {
 		return errors.Wrapf(err, "create meta fetcher with bucket %v", fromBkt)
 	}


### PR DESCRIPTION
Signed-off-by: Ben Ye <yb532204897@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

When I looked at the replicate metrics, I found that these fetch metrics are not wrapped. So I just add `thanos_` prefix in this pr.

![Screenshot from 2020-07-17 17-13-45](https://user-images.githubusercontent.com/25150124/87831243-ea2d5600-c850-11ea-9cf7-66d6ac585246.png)


## Verification

<!-- How you tested it? How do you know it works? -->

With this pr,

![Screenshot from 2020-07-17 17-15-06](https://user-images.githubusercontent.com/25150124/87831289-1d6fe500-c851-11ea-93f4-cba4ac296086.png)

