### PR TITLE
Fixed time format for Last-Modified header

### DIFF
--- a/pkg/objstore/clientutil/parse.go
+++ b/pkg/objstore/clientutil/parse.go
@@ -34,10 +34,14 @@ func ParseContentLength(m http.Header) (int64, error) {
 }
 
 // ParseLastModified returns the timestamp parsed from the Last-Modified
-// HTTP header in input (expected to be in the RFC3339 format).
-// Passing an optional second parameter to override the default format.
-func ParseLastModified(m http.Header, f ...string) (time.Time, error) {
-	const name = "Last-Modified"
+// HTTP header in input.
+// Passing an second parameter, named f, to specify the time format.
+// If f is empty then RFC3339 will be used as default format.
+func ParseLastModified(m http.Header, f string) (time.Time, error) {
+	const (
+		name          = "Last-Modified"
+		defaultFormat = time.RFC3339
+	)
 
 	v, ok := m[name]
 	if !ok {
@@ -48,12 +52,11 @@ func ParseLastModified(m http.Header, f ...string) (time.Time, error) {
 		return time.Time{}, errors.Errorf("%s header has no values", name)
 	}
 
-	format := time.RFC3339
-	if len(f) > 0 {
-		format = f[0]
+	if len(f) == 0 {
+		f = defaultFormat
 	}
 
-	mod, err := time.Parse(format, v[0])
+	mod, err := time.Parse(f, v[0])
 	if err != nil {
 		return time.Time{}, errors.Wrapf(err, "parse %s", name)
 	}

--- a/pkg/objstore/clientutil/parse.go
+++ b/pkg/objstore/clientutil/parse.go
@@ -35,7 +35,8 @@ func ParseContentLength(m http.Header) (int64, error) {
 
 // ParseLastModified returns the timestamp parsed from the Last-Modified
 // HTTP header in input (expected to be in the RFC3339 format).
-func ParseLastModified(m http.Header) (time.Time, error) {
+// Passing an optional second parameter to override the default format.
+func ParseLastModified(m http.Header, f ...string) (time.Time, error) {
 	const name = "Last-Modified"
 
 	v, ok := m[name]
@@ -47,7 +48,12 @@ func ParseLastModified(m http.Header) (time.Time, error) {
 		return time.Time{}, errors.Errorf("%s header has no values", name)
 	}
 
-	mod, err := time.Parse(time.RFC3339, v[0])
+	format := time.RFC3339
+	if len(f) > 0 {
+		format = f[0]
+	}
+
+	mod, err := time.Parse(format, v[0])
 	if err != nil {
 		return time.Time{}, errors.Wrapf(err, "parse %s", name)
 	}

--- a/pkg/objstore/clientutil/parse_test.go
+++ b/pkg/objstore/clientutil/parse_test.go
@@ -23,20 +23,27 @@ func TestParseLastModified(t *testing.T) {
 		"no header": {
 			expectedErr: "Last-Modified header not found",
 		},
-		"invalid header value": {
-			headerValue: "invalid",
-			expectedErr: `parse Last-Modified: parsing time "invalid" as "2006-01-02T15:04:05Z07:00": cannot parse "invalid" as "2006"`,
-		},
-		"valid header value": {
+		"empty format string to default RFC3339 format": {
 			headerValue: "2015-11-06T10:07:11.000Z",
 			expectedVal: time.Date(2015, time.November, 6, 10, 7, 11, 0, time.UTC),
+			format:      "",
 		},
-		"valid oss/cos header value": {
+		"valid RFC3339 header value": {
+			headerValue: "2015-11-06T10:07:11.000Z",
+			expectedVal: time.Date(2015, time.November, 6, 10, 7, 11, 0, time.UTC),
+			format:      time.RFC3339,
+		},
+		"invalid RFC3339 header value": {
+			headerValue: "invalid",
+			expectedErr: `parse Last-Modified: parsing time "invalid" as "2006-01-02T15:04:05Z07:00": cannot parse "invalid" as "2006"`,
+			format:      time.RFC3339,
+		},
+		"valid RFC1123 header value": {
 			headerValue: "Fri, 24 Feb 2012 06:07:48 GMT",
 			expectedVal: time.Date(2012, time.February, 24, 6, 7, 48, 0, location),
 			format:      time.RFC1123,
 		},
-		"invalid oss/cos header value": {
+		"invalid RFC1123 header value": {
 			headerValue: "invalid",
 			expectedErr: `parse Last-Modified: parsing time "invalid" as "Mon, 02 Jan 2006 15:04:05 MST": cannot parse "invalid" as "Mon"`,
 			format:      time.RFC1123,
@@ -50,16 +57,7 @@ func TestParseLastModified(t *testing.T) {
 				meta.Add(alioss.HTTPHeaderLastModified, testData.headerValue)
 			}
 
-			var (
-				actual time.Time
-				err    error
-			)
-
-			if len(testData.format) == 0 {
-				actual, err = ParseLastModified(meta)
-			} else {
-				actual, err = ParseLastModified(meta, testData.format)
-			}
+			actual, err := ParseLastModified(meta, testData.format)
 
 			if testData.expectedErr != "" {
 				testutil.NotOk(t, err)

--- a/pkg/objstore/clientutil/parse_test.go
+++ b/pkg/objstore/clientutil/parse_test.go
@@ -31,7 +31,7 @@ func TestParseLastModified(t *testing.T) {
 			headerValue: "2015-11-06T10:07:11.000Z",
 			expectedVal: time.Date(2015, time.November, 6, 10, 7, 11, 0, time.UTC),
 		},
-		"valid oss/cos  header value": {
+		"valid oss/cos header value": {
 			headerValue: "Fri, 24 Feb 2012 06:07:48 GMT",
 			expectedVal: time.Date(2012, time.February, 24, 6, 7, 48, 0, location),
 			format:      time.RFC1123,
@@ -66,7 +66,7 @@ func TestParseLastModified(t *testing.T) {
 				testutil.Equals(t, testData.expectedErr, err.Error())
 			} else {
 				testutil.Ok(t, err)
-				testutil.Equals(t, testData.expectedVal, actual)
+				testutil.Assert(t, testData.expectedVal.Equal(actual))
 			}
 		})
 	}

--- a/pkg/objstore/cos/cos.go
+++ b/pkg/objstore/cos/cos.go
@@ -106,6 +106,8 @@ func (b *Bucket) Attributes(ctx context.Context, name string) (objstore.ObjectAt
 		return objstore.ObjectAttributes{}, err
 	}
 
+	// tencent cos return Last-Modified header in RFC1123 format.
+	// see api doc for details: https://intl.cloud.tencent.com/document/product/436/7729
 	mod, err := clientutil.ParseLastModified(resp.Header, time.RFC1123)
 	if err != nil {
 		return objstore.ObjectAttributes{}, err

--- a/pkg/objstore/cos/cos.go
+++ b/pkg/objstore/cos/cos.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/go-kit/kit/log"
 	"github.com/mozillazg/go-cos"
@@ -105,7 +106,7 @@ func (b *Bucket) Attributes(ctx context.Context, name string) (objstore.ObjectAt
 		return objstore.ObjectAttributes{}, err
 	}
 
-	mod, err := clientutil.ParseLastModified(resp.Header)
+	mod, err := clientutil.ParseLastModified(resp.Header, time.RFC1123)
 	if err != nil {
 		return objstore.ObjectAttributes{}, err
 	}

--- a/pkg/objstore/oss/oss.go
+++ b/pkg/objstore/oss/oss.go
@@ -144,7 +144,7 @@ func (b *Bucket) Attributes(ctx context.Context, name string) (objstore.ObjectAt
 		return objstore.ObjectAttributes{}, err
 	}
 
-	mod, err := clientutil.ParseLastModified(m)
+	mod, err := clientutil.ParseLastModified(m, time.RFC1123)
 	if err != nil {
 		return objstore.ObjectAttributes{}, err
 	}

--- a/pkg/objstore/oss/oss.go
+++ b/pkg/objstore/oss/oss.go
@@ -144,6 +144,8 @@ func (b *Bucket) Attributes(ctx context.Context, name string) (objstore.ObjectAt
 		return objstore.ObjectAttributes{}, err
 	}
 
+	// aliyun oss return Last-Modified header in RFC1123 format.
+	// see api doc for details: https://www.alibabacloud.com/help/doc-detail/31985.htm
 	mod, err := clientutil.ParseLastModified(m, time.RFC1123)
 	if err != nil {
 		return objstore.ObjectAttributes{}, err


### PR DESCRIPTION
 Fixed time format for Last-Modified header when parsing oss/cos attributes.

Signed-off-by: Sabaping <bbq.yuki@outlook.com>

[COS api doc reference](https://intl.cloud.tencent.com/document/product/436/7729)
[OSS api doc reference](https://www.alibabacloud.com/help/doc-detail/31985.htm)

## Changes

1. `clientutil.ParseLastModified` function accepts optional format parameter
2. `Bucket.Attributes` function, for cos/oss object storage, passes additional `time.RFC1123` when calls `clientutil.ParseLastModified`.

## Verification

Unit test.
