### PR TITLE
.*: Add header for remote read version

### DIFF
--- a/pkg/store/prometheus.go
+++ b/pkg/store/prometheus.go
@@ -419,6 +419,7 @@ func (p *PrometheusStore) startPromRemoteRead(ctx context.Context, q *prompb.Que
 	}
 	preq.Header.Add("Content-Encoding", "snappy")
 	preq.Header.Set("Content-Type", "application/x-stream-protobuf")
+	preq.Header.Set("X-Prometheus-Remote-Read-Version", "0.1.0")
 
 	preq.Header.Set("User-Agent", thanoshttp.ThanosUserAgent)
 	tracing.DoInSpan(ctx, "query_prometheus_request", func(ctx context.Context) {


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] Change is not relevant to the end user.

## Changes

Added a http header to the remote_read request.
While Prometheus itself doesn't care about this header, for some third party remote_read compatible api, it is required.
The version match the one made by Prometheus when performing a remote read (see https://github.com/prometheus/prometheus/blob/v2.20.0-rc.1/storage/remote/client.go#L237) .

## Verification

<!-- How you tested it? How do you know it works? -->
Manually tested again a third party API (Cortex)