### PR TITLE
rules: manager: avoid panic when cloning when TZ != UTC

### DIFF
--- a/pkg/rules/manager.go
+++ b/pkg/rules/manager.go
@@ -383,6 +383,8 @@ func (m *Manager) Rules(r *rulespb.RulesRequest, s rulespb.Rules_RulesServer) er
 			continue
 		}
 
+		// https://github.com/gogo/protobuf/issues/519
+		g.LastEvaluation = g.LastEvaluation.UTC()
 		filtered := proto.Clone(g).(*rulespb.RuleGroup)
 		filtered.Rules = nil
 		for _, rule := range g.Rules {

--- a/pkg/rules/manager.go
+++ b/pkg/rules/manager.go
@@ -378,13 +378,13 @@ func (m *Manager) Rules(r *rulespb.RulesRequest, s rulespb.Rules_RulesServer) er
 
 	pgs := make([]*rulespb.RuleGroup, 0, len(groups))
 	for _, g := range groups {
+		// https://github.com/gogo/protobuf/issues/519
+		g.LastEvaluation = g.LastEvaluation.UTC()
 		if r.Type == rulespb.RulesRequest_ALL {
 			pgs = append(pgs, g)
 			continue
 		}
 
-		// https://github.com/gogo/protobuf/issues/519
-		g.LastEvaluation = g.LastEvaluation.UTC()
 		filtered := proto.Clone(g).(*rulespb.RuleGroup)
 		filtered.Rules = nil
 		for _, rule := range g.Rules {


### PR DESCRIPTION
The following panic can be observed when calling `/api/v1/rules` without
this change when the TZ is _not_ UTC:

```
2020/07/22 21:44:22 http: panic serving 127.0.0.1:49368: merger not found for type:int
goroutine 529 [running]:
net/http.(*conn).serve.func1(0xc00029e640)
        /usr/lib/go-1.14/src/net/http/server.go:1772 +0x139
panic(0x1e0a400, 0xc000368c30)
        /usr/lib/go-1.14/src/runtime/panic.go:975 +0x3e3
github.com/gogo/protobuf/proto.(*mergeInfo).computeMergeInfo(0xc0008b8780)
        /home/gstatkevicius/go/pkg/mod/github.com/gogo/protobuf@v1.3.1/proto/table_merge.go:662 +0xfc6
github.com/gogo/protobuf/proto.(*mergeInfo).merge(0xc0008b8780, 0xc0007447a0, 0xc00057bb00)
        /home/gstatkevicius/go/pkg/mod/github.com/gogo/protobuf@v1.3.1/proto/table_merge.go:113 +0x4a2
github.com/gogo/protobuf/proto.(*mergeInfo).computeMergeInfo.func27(0xc000091b70, 0x3991910)
        /home/gstatkevicius/go/pkg/mod/github.com/gogo/protobuf@v1.3.1/proto/table_merge.go:545 +0x381
github.com/gogo/protobuf/proto.(*mergeInfo).merge(0xc0008b8700, 0xc000091b60, 0x3991900)
        /home/gstatkevicius/go/pkg/mod/github.com/gogo/protobuf@v1.3.1/proto/table_merge.go:139 +0x46a
github.com/gogo/protobuf/proto.(*mergeInfo).computeMergeInfo.func30(0xc00061e470, 0xc00061e370)
        /home/gstatkevicius/go/pkg/mod/github.com/gogo/protobuf@v1.3.1/proto/table_merge.go:587 +0x5c
github.com/gogo/protobuf/proto.(*mergeInfo).merge(0xc0008b8340, 0xc00061e460, 0xc00061e360)
        /home/gstatkevicius/go/pkg/mod/github.com/gogo/protobuf@v1.3.1/proto/table_merge.go:139 +0x46a
github.com/gogo/protobuf/proto.(*mergeInfo).computeMergeInfo.func28(0xc00061e460, 0xc00061e360)
        /home/gstatkevicius/go/pkg/mod/github.com/gogo/protobuf@v1.3.1/proto/table_merge.go:555 +0x3e
github.com/gogo/protobuf/proto.(*mergeInfo).merge(0xc0008b83c0, 0xc00061e400, 0xc00061e300)
        /home/gstatkevicius/go/pkg/mod/github.com/gogo/protobuf@v1.3.1/proto/table_merge.go:139 +0x46a
github.com/gogo/protobuf/proto.(*InternalMessageInfo).Merge(0x398a440, 0x2676ea0, 0xc00061e400, 0x2676ea0, 0xc00061e300)
        /home/gstatkevicius/go/pkg/mod/github.com/gogo/protobuf@v1.3.1/proto/table_merge.go:50 +0x4c
github.com/thanos-io/thanos/pkg/rules/rulespb.(*RecordingRule).XXX_Merge(0xc00061e400, 0x2676ea0, 0xc00061e300)
        /home/gstatkevicius/dev/thanos/pkg/rules/rulespb/rpc.pb.go:527 +0x57
```

Let's use the workaround given here:
https://github.com/gogo/protobuf/issues/519.

Signed-off-by: Giedrius Statkevičius <giedriuswork@gmail.com>


* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

Forcing the conversion of `LastEvaluation` into UTC to fix the observed panic

## Verification

`PROMETHEUS_EXECUTABLE=~/dev/prometheus/prometheus ./scripts/quickstart.sh` and opened `http://localhost:19999/api/v1/rules`
