### PR TITLE
docs: Add blog post from Beat

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -110,6 +110,7 @@ We also have example Grafana dashboards [here](/examples/dashboards/dashboards.m
 
   * [Banzai Cloud user story](https://banzaicloud.com/blog/multi-cluster-monitoring/)
   * [A Production Thanos Deployment](https://www.omerlh.info/2020/02/08/a-production-thanos-deployment/)
+  * [Monitoring the Beat microservices: A tale of evolution](https://build.thebeat.co/monitoring-the-beat-microservices-a-tale-of-evolution-4e246882606e)
 
 * 2019:
 


### PR DESCRIPTION
Add blog post from Beat which uses Thanos to monitor kubernetes
clusters and AWS resources.


* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

Add blog post from Beat