### PR TITLE
Receive: Fixing auto-configuration of --receive.local-endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 
 ### Fixed
 
+- [#2937](https://github.com/thanos-io/thanos/pull/2937) Receive: Fixing auto-configuration of --receive.local-endpoint
 - [#2665](https://github.com/thanos-io/thanos/pull/2665) Swift: fix issue with missing Content-Type HTTP headers.
 - [#2800](https://github.com/thanos-io/thanos/pull/2800) Query: Fix handling of `--web.external-prefix` and `--web.route-prefix`
 - [#2834](https://github.com/thanos-io/thanos/pull/2834) Query: Fix rendered JSON state value for rules and alerts should be in lowercase

--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -70,7 +70,7 @@ func registerReceive(m map[string]setupFunc, app *kingpin.Application) {
 	refreshInterval := modelDuration(cmd.Flag("receive.hashrings-file-refresh-interval", "Refresh interval to re-read the hashring configuration file. (used as a fallback)").
 		Default("5m"))
 
-	local := cmd.Flag("receive.local-endpoint", "Endpoint of local receive node. Used to identify the local node in the hashring configuration.").String()
+	localEndpoint := cmd.Flag("receive.local-endpoint", "Endpoint of local receive node. Used to identify the local node in the hashring configuration.").String()
 
 	tenantHeader := cmd.Flag("receive.tenant-header", "HTTP header to determine tenant for write requests.").Default(receive.DefaultTenantHeader).String()
 
@@ -120,14 +120,14 @@ func registerReceive(m map[string]setupFunc, app *kingpin.Application) {
 
 		// Local is empty, so try to generate a local endpoint
 		// based on the hostname and the listening port.
-		if *local == "" {
+		if *localEndpoint == "" {
 			hostname, err := os.Hostname()
 			if hostname == "" || err != nil {
 				return errors.New("--receive.local-endpoint is empty and host could not be determined.")
 			}
-			parts := strings.Split(*rwAddress, ":")
+			parts := strings.Split(*grpcBindAddr, ":")
 			port := parts[len(parts)-1]
-			*local = fmt.Sprintf("http://%s:%s/api/v1/receive", hostname, port)
+			*localEndpoint = fmt.Sprintf("%s:%s", hostname, port)
 		}
 
 		return runReceive(
@@ -156,7 +156,7 @@ func registerReceive(m map[string]setupFunc, app *kingpin.Application) {
 			*ignoreBlockSize,
 			lset,
 			cw,
-			*local,
+			*localEndpoint,
 			*tenantHeader,
 			*defaultTenantID,
 			*tenantLabelName,


### PR DESCRIPTION
* [x] I added CHANGELOG entry for this change.

## Changes

Updated code that configures the local endpoint if --receive.local-endpoint is not specified.

## Verification

Tested on a 3 node cluster in GKE using a StatefulSet deployment. In this case the node upon startup will use local hostname which includes the StatefulSet pod index, e.g: thanos-receive-us-west2-1. The GRPC port is appended and this lines up with the hash ring configuration. All nodes in hash-ring then begin to correctly participate in replication of time series.
