### PR TITLE
store/memcached: Mitigate bloating logs when async buffer is full

### DIFF
--- a/pkg/cache/memcached.go
+++ b/pkg/cache/memcached.go
@@ -68,7 +68,7 @@ func (c *MemcachedCache) Store(ctx context.Context, data map[string][]byte, ttl 
 	}
 
 	if firstErr != nil {
-		level.Warn(c.logger).Log("msg", "failed to store one or more items into memcached", "failed", failed, "firstErr", firstErr)
+		level.Debug(c.logger).Log("msg", "failed to store one or more items into memcached", "failed", failed, "firstErr", firstErr)
 	}
 }
 

--- a/pkg/cache/memcached.go
+++ b/pkg/cache/memcached.go
@@ -68,7 +68,7 @@ func (c *MemcachedCache) Store(ctx context.Context, data map[string][]byte, ttl 
 	}
 
 	if firstErr != nil {
-		level.Debug(c.logger).Log("msg", "failed to store one or more items into memcached", "failed", failed, "firstErr", firstErr)
+		level.Warn(c.logger).Log("msg", "failed to store one or more items into memcached", "failed", failed, "firstErr", firstErr)
 	}
 }
 

--- a/pkg/cacheutil/memcached_client.go
+++ b/pkg/cacheutil/memcached_client.go
@@ -234,7 +234,6 @@ func newMemcachedClient(
 	}, []string{"operation", "reason"})
 	c.skipped.WithLabelValues(opGetMulti, reasonMaxItemSize)
 	c.skipped.WithLabelValues(opSet, reasonMaxItemSize)
-	c.skipped.WithLabelValues(opGetMulti, reasonAsyncBufferFull)
 	c.skipped.WithLabelValues(opSet, reasonAsyncBufferFull)
 
 	c.duration = promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
@@ -303,7 +302,7 @@ func (c *memcachedClient) SetAsync(_ context.Context, key string, value []byte, 
 
 	if err == errMemcachedAsyncBufferFull {
 		c.skipped.WithLabelValues(opSet, reasonAsyncBufferFull).Inc()
-		level.Debug(c.logger).Log("msg", "failed to store item to memcached, check your configuration", "err", err, "size", len(c.asyncQueue))
+		level.Debug(c.logger).Log("msg", "failed to store item to memcached because the async buffer is full", "err", err, "size", len(c.asyncQueue))
 		return nil
 	}
 	return err

--- a/pkg/store/cache/memcached.go
+++ b/pkg/store/cache/memcached.go
@@ -13,6 +13,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/prometheus/pkg/labels"
+
 	"github.com/thanos-io/thanos/pkg/cacheutil"
 )
 


### PR DESCRIPTION
Signed-off-by: Kemal Akkoyun <kakkoyun@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->


* [X] Change is not relevant to the end-user.

## Changes

* Change the log level for async buffer full error.
* Add a label to track the occurrence of the error.

## Verification

* `make test-local`

cc @pstibrany