### PR TITLE
Bump jsonnet-ci container image to latest release with go 1.14

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -285,7 +285,7 @@ web-serve: web-pre-process $(HUGO)
 	@echo ">> serving documentation website"
 	@cd $(WEB_DIR) && $(HUGO) --config hugo.yaml -v server
 
-# Check https://github.com/coreos/prometheus-operator/blob/master/scripts/jsonnet/Dockerfile for the image.
+# Check https://github.com/coreos/prometheus-operator/blob/v0.40.0/scripts/tooling/Dockerfile for the image.
 JSONNET_CONTAINER_CMD:=docker run --rm \
 		-u="$(shell id -u):$(shell id -g)" \
 		-v "$(shell go env GOCACHE):/.cache/go-build" \
@@ -293,7 +293,7 @@ JSONNET_CONTAINER_CMD:=docker run --rm \
 		-w "/go/src/github.com/thanos-io/thanos" \
 		-e USER=deadbeef \
 		-e GO111MODULE=on \
-		quay.io/coreos/jsonnet-ci:release-0.36
+		quay.io/coreos/jsonnet-ci:release-0.40
 
 .PHONY: examples-in-container
 examples-in-container:


### PR DESCRIPTION
Signed-off-by: Ben Ye <yb532204897@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

Tried to build mixins using `make examples-in-container`

```
>> Compiling and generating thanos-mixin
docker run --rm -u="1000:1000" -v "/home/yeya24/.cache/go-build:/.cache/go-build" -v "/home/yeya24/hub/gowork/thanos:/go/src/github.com/thanos-io/thanos:Z" -w "/go/src/github.com/thanos-io/thanos" -e USER=deadbeef -e GO111MODULE=on quay.io/coreos/jsonnet-ci:release-0.36 make  JB='/go/bin/jb' jsonnet-vendor
(re)installing /go/bin/jb-v0.4.0
flag provided but not defined: -modfile
usage: go build [-o output] [-i] [build flags] [packages]
Run 'go help build' for details.
make: *** [.bingo/Variables.mk:77: /go/bin/jb] Error 2
make: *** [Makefile:301: examples-in-container] Error 2
```

We are using bingo and it requires go 1.14+. So I update the jsonnet-ci image to the latest release, which is using go 1.14

## Verification

<!-- How you tested it? How do you know it works? -->
