### PR TITLE
sidecar: fix sidecar crashing with lstat errors during a reload from a configmap update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 - [#2956](https://github.com/thanos-io/thanos/pull/2956) Store: Fix fetching of chunks bigger than 16000 bytes.
 - [#2970](https://github.com/thanos-io/thanos/pull/2970) Store: Upgrade minio-go/v7 to fix slowness when running on EKS.
 - [#2976](https://github.com/thanos-io/thanos/pull/2976) Query: Better rounding for incoming query timestamps.
+- [#2952](https://github.com/thanos-io/thanos/pull/2952) Sidecar: Fix sidecar crashing with lstat errors during a reload from a configmap update
 
 ### Added
 


### PR DESCRIPTION
During a reload it's possible that files are added/removed while
we walk the directory and we try to lstat a file that doesn't exist.

This is especially common if running in k8s with the configuration mounted
as a configmap, and the configmap contents change.

With this change we log when this happens but don't return the error so the
reloader process doesn't crash.

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.

## Changes

Add an error check during a reload for when a watch triggers on a file that gets removed. This fixes the issue reported in https://github.com/thanos-io/thanos/issues/2496

## Verification

Added a test to reproduce the initial error and to verify the fix
