### PR TITLE
Fetching large chunks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 - [#2895](https://github.com/thanos-io/thanos/pull/2895) Compact: Fix increment of `thanos_compact_downsample_total` metric for downsample of 5m resolution blocks.
 - [#2858](https://github.com/thanos-io/thanos/pull/2858) Store: Fix `--store.grpc.series-sample-limit` implementation. The limit is now applied to the sum of all samples fetched across all queried blocks via a single Series call, instead of applying it individually to each block.
 - [#2936](https://github.com/thanos-io/thanos/pull/2936) Compact: Fix ReplicaLabelRemover panic when replicaLabels are not specified.
+- [#2956](https://github.com/thanos-io/thanos/pull/2956) Store: Fix fetching of chunks bigger than 16000 bytes.
 
 ### Added
 

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -1966,14 +1966,15 @@ func (r *bucketIndexReader) Close() error {
 type bucketChunkReader struct {
 	ctx   context.Context
 	block *bucketBlock
-	stats *queryStats
 
 	preloads [][]uint32
-	mtx      sync.Mutex
-	chunks   map[uint64]chunkenc.Chunk
 
-	// Byte slice to return to the chunk pool on close.
-	chunkBytes []*[]byte
+	// Mutex protects access to following fields, when updated from chunks-loading goroutines.
+	// After chunks are loaded, mutex is no longer used.
+	mtx        sync.Mutex
+	chunks     map[uint64]chunkenc.Chunk
+	stats      *queryStats
+	chunkBytes []*[]byte // Byte slice to return to the chunk pool on close.
 }
 
 func newBucketChunkReader(ctx context.Context, block *bucketBlock) *bucketChunkReader {

--- a/pkg/store/bucket_test.go
+++ b/pkg/store/bucket_test.go
@@ -1764,10 +1764,10 @@ func TestBlockWithLargeChunks(t *testing.T) {
 
 	// Instance a real bucket store we'll use to query the series.
 	fetcher, err := block.NewMetaFetcher(logger, 10, instrBkt, tmpDir, nil, nil, nil)
-	testutil.Ok(tb, err)
+	testutil.Ok(t, err)
 
 	indexCache, err := storecache.NewInMemoryIndexCacheWithConfig(logger, nil, storecache.InMemoryIndexCacheConfig{})
-	testutil.Ok(tb, err)
+	testutil.Ok(t, err)
 
 	store, err := NewBucketStore(
 		logger,
@@ -1787,8 +1787,8 @@ func TestBlockWithLargeChunks(t *testing.T) {
 		DefaultPostingOffsetInMemorySampling,
 		true,
 	)
-	testutil.Ok(tb, err)
-	testutil.Ok(tb, store.SyncBlocks(context.Background()))
+	testutil.Ok(t, err)
+	testutil.Ok(t, store.SyncBlocks(context.Background()))
 
 	req := &storepb.SeriesRequest{
 		MinTime: math.MinInt64,

--- a/pkg/store/bucket_test.go
+++ b/pkg/store/bucket_test.go
@@ -1741,7 +1741,7 @@ func TestBlockWithLargeChunks(t *testing.T) {
 	})
 
 	blockDir := filepath.Join(tmpDir, "block")
-	b := createBlockWithLargeChunk(t, tb, blockDir, labels.FromStrings("__name__", "test"), rand.New(rand.NewSource(0)), err)
+	b := createBlockWithLargeChunk(t, tb, blockDir, labels.FromStrings("__name__", "test"), rand.New(rand.NewSource(0)))
 
 	thanosMeta := metadata.Thanos{
 		Labels:     labels.Labels{{Name: "ext1", Value: "1"}}.Map(),
@@ -1807,7 +1807,7 @@ func TestBlockWithLargeChunks(t *testing.T) {
 // This method relies on a bug in TSDB Compactor which will just merge overlapping chunks into one big chunk.
 // If compactor is fixed in the future, we may need a different way of generating the block, or commit
 // existing block to the repository.
-func createBlockWithLargeChunk(t *testing.T, tb testutil.TB, dir string, lbls labels.Labels, random *rand.Rand, err error) ulid.ULID {
+func createBlockWithLargeChunk(t *testing.T, tb testutil.TB, dir string, lbls labels.Labels, random *rand.Rand) ulid.ULID {
 	// Block covering time [0 ... 10000)
 	b1 := createBlockWithOneSeriesWithStep(tb, dir, lbls, 0, 10000, random, 1)
 

--- a/pkg/store/bucket_test.go
+++ b/pkg/store/bucket_test.go
@@ -1801,6 +1801,7 @@ func TestBlockWithLargeChunks(t *testing.T) {
 	}
 	srv := newStoreSeriesServer(context.Background())
 	testutil.Ok(t, store.Series(req, srv))
+	testutil.Equals(t, 1, len(srv.SeriesSet))
 }
 
 // This method relies on a bug in TSDB Compactor which will just merge overlapping chunks into one big chunk.

--- a/pkg/store/bucket_test.go
+++ b/pkg/store/bucket_test.go
@@ -1729,3 +1729,120 @@ func TestBigEndianPostingsCount(t *testing.T) {
 	}
 	testutil.Equals(t, count, c)
 }
+
+func TestBlockWithLargeChunks(t *testing.T) {
+	tb := testutil.NewTB(t)
+
+	tmpDir, err := ioutil.TempDir(os.TempDir(), "large-chunk-test")
+	testutil.Ok(t, err)
+	t.Cleanup(func() {
+		_ = os.RemoveAll(tmpDir)
+	})
+
+	blockDir := filepath.Join(tmpDir, "block")
+	b := createBlockWithLargeChunk(t, tb, blockDir, labels.FromStrings("__name__", "test"), rand.New(rand.NewSource(0)), err)
+
+	thanosMeta := metadata.Thanos{
+		Labels:     labels.Labels{{Name: "ext1", Value: "1"}}.Map(),
+		Downsample: metadata.ThanosDownsample{Resolution: 0},
+		Source:     metadata.TestSource,
+	}
+
+	_, err = metadata.InjectThanos(log.NewNopLogger(), filepath.Join(blockDir, b.String()), thanosMeta, nil)
+	testutil.Ok(t, err)
+
+	bucketDir := filepath.Join(os.TempDir(), "bkt")
+	bkt, err := filesystem.NewBucket(bucketDir)
+	testutil.Ok(t, err)
+	t.Cleanup(func() {
+		_ = os.RemoveAll(bucketDir)
+	})
+
+	logger := log.NewNopLogger()
+	instrBkt := objstore.WithNoopInstr(bkt)
+
+	testutil.Ok(t, block.Upload(context.Background(), logger, bkt, filepath.Join(blockDir, b.String())))
+
+	// Instance a real bucket store we'll use to query the series.
+	fetcher, err := block.NewMetaFetcher(logger, 10, instrBkt, tmpDir, nil, nil, nil)
+	testutil.Ok(tb, err)
+
+	indexCache, err := storecache.NewInMemoryIndexCacheWithConfig(logger, nil, storecache.InMemoryIndexCacheConfig{})
+	testutil.Ok(tb, err)
+
+	store, err := NewBucketStore(
+		logger,
+		nil,
+		instrBkt,
+		fetcher,
+		tmpDir,
+		indexCache,
+		nil,
+		1000000,
+		NewChunksLimiterFactory(10000/MaxSamplesPerChunk),
+		false,
+		10,
+		nil,
+		false,
+		true,
+		DefaultPostingOffsetInMemorySampling,
+		true,
+	)
+	testutil.Ok(tb, err)
+	testutil.Ok(tb, store.SyncBlocks(context.Background()))
+
+	req := &storepb.SeriesRequest{
+		MinTime: math.MinInt64,
+		MaxTime: math.MaxInt64,
+		Matchers: []storepb.LabelMatcher{
+			{Type: storepb.LabelMatcher_EQ, Name: "__name__", Value: "test"},
+		},
+	}
+	srv := newStoreSeriesServer(context.Background())
+	testutil.Ok(t, store.Series(req, srv))
+}
+
+// This method relies on a bug in TSDB Compactor which will just merge overlapping chunks into one big chunk.
+// If compactor is fixed in the future, we may need a different way of generating the block, or commit
+// existing block to the repository.
+func createBlockWithLargeChunk(t *testing.T, tb testutil.TB, dir string, lbls labels.Labels, random *rand.Rand, err error) ulid.ULID {
+	// Block covering time [0 ... 10000)
+	b1 := createBlockWithOneSeriesWithStep(tb, dir, lbls, 0, 10000, random, 1)
+
+	// This block has only 10 samples, but it completely overlaps entire first block.
+	// This will make compactor to merge all chunks into one.
+	b2 := createBlockWithOneSeriesWithStep(tb, dir, lbls, 0, 11, random, 1000)
+
+	// Merge the blocks together.
+	compactor, err := tsdb.NewLeveledCompactor(context.Background(), nil, log.NewNopLogger(), []int64{1000000}, nil)
+	testutil.Ok(t, err)
+
+	blocksToCompact := []string{filepath.Join(dir, b1.String()), filepath.Join(dir, b2.String())}
+	newBlock, err := compactor.Compact(dir, blocksToCompact, nil)
+	testutil.Ok(t, err)
+
+	for _, b := range blocksToCompact {
+		err := os.RemoveAll(b)
+		testutil.Ok(t, err)
+	}
+
+	return newBlock
+}
+
+func createBlockWithOneSeriesWithStep(t testutil.TB, dir string, lbls labels.Labels, blockIndex int, totalSamples int, random *rand.Rand, step int64) ulid.ULID {
+	h, err := tsdb.NewHead(nil, nil, nil, int64(totalSamples)*step, dir, nil, tsdb.DefaultStripeSize, nil)
+	testutil.Ok(t, err)
+	defer func() { testutil.Ok(t, h.Close()) }()
+
+	app := h.Appender()
+
+	ts := int64(blockIndex * totalSamples)
+	ref, err := app.Add(lbls, ts, random.Float64())
+	testutil.Ok(t, err)
+	for i := 1; i < totalSamples; i++ {
+		testutil.Ok(t, app.AddFast(ref, ts+step*int64(i), random.Float64()))
+	}
+	testutil.Ok(t, app.Commit())
+
+	return createBlockFromHead(t, dir, h)
+}


### PR DESCRIPTION
* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

This PR fixes issue with fetching chunks that are bigger than 16000 bytes. Under some circumstances it is possible to come across chunks like that, and under some conditions Thanos may currently fail to fetch such chunks. This PR adds fetching of remaining chunk data from the bucket.

## Verification

Added unit test. Also tested manually against real block found in our test cluster.

Fixes issue https://github.com/thanos-io/thanos/issues/2945.