### PR TITLE
ci: Enable prealloc

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -32,6 +32,7 @@ linters:
     # Sorted alphabetically.
     - deadcode
     - errcheck
+    - exportloopref
     - goconst
     - godot
     - gofmt
@@ -40,13 +41,13 @@ linters:
     - govet
     - ineffassign
     - misspell
+    - prealloc
     - staticcheck
     - structcheck
     - typecheck
     - unparam
     - unused
     - varcheck
-    - exportloopref
 
 linters-settings:
   errcheck:

--- a/cmd/thanos/rule.go
+++ b/cmd/thanos/rule.go
@@ -300,15 +300,15 @@ func runRule(
 ) error {
 	metrics := newRuleMetrics(reg)
 
-	var queryCfg []query.Config
+	var queryCfgs []query.Config
 	var err error
 	if len(queryConfigYAML) > 0 {
-		queryCfg, err = query.LoadConfigs(queryConfigYAML)
+		queryCfgs, err = query.LoadConfigs(queryConfigYAML)
 		if err != nil {
 			return err
 		}
 	} else {
-		queryCfg, err = query.BuildQueryConfig(queryAddrs)
+		queryCfgs, err = query.BuildQueryConfig(queryAddrs)
 		if err != nil {
 			return err
 		}
@@ -320,7 +320,7 @@ func runRule(
 				Files:           querySDFiles,
 				RefreshInterval: model.Duration(querySDInterval),
 			})
-			queryCfg = append(queryCfg,
+			queryCfgs = append(queryCfgs,
 				query.Config{
 					EndpointsConfig: http_util.EndpointsConfig{
 						Scheme:        "http",
@@ -336,8 +336,8 @@ func runRule(
 		extprom.WrapRegistererWithPrefix("thanos_ruler_query_apis_", reg),
 		dns.ResolverType(dnsSDResolver),
 	)
-	var queryClients []*http_util.Client
-	for _, cfg := range queryCfg {
+	queryClients := make([]*http_util.Client, 0, len(queryCfgs))
+	for _, cfg := range queryCfgs {
 		c, err := http_util.NewHTTPClient(cfg.HTTPClientConfig, "query")
 		if err != nil {
 			return err
@@ -399,7 +399,7 @@ func runRule(
 		extprom.WrapRegistererWithPrefix("thanos_ruler_alertmanagers_", reg),
 		dns.ResolverType(dnsSDResolver),
 	)
-	var alertmgrs []*alert.Alertmanager
+	alertmgrs := make([]*alert.Alertmanager, 0, len(alertingCfg.Alertmanagers))
 	for _, cfg := range alertingCfg.Alertmanagers {
 		c, err := http_util.NewHTTPClient(cfg.HTTPClientConfig, "alertmanager")
 		if err != nil {

--- a/pkg/alert/alert.go
+++ b/pkg/alert/alert.go
@@ -281,7 +281,7 @@ func NewSender(
 	if logger == nil {
 		logger = log.NewNopLogger()
 	}
-	var (
+	var ( //nolint:prealloc
 		versions       []APIVersion
 		versionPresent map[APIVersion]struct{}
 	)

--- a/pkg/api/query/v1.go
+++ b/pkg/api/query/v1.go
@@ -455,8 +455,9 @@ func (qapi *QueryAPI) series(r *http.Request) (interface{}, []error, *api.ApiErr
 		end = maxTime
 	}
 
-	var matcherSets [][]*labels.Matcher
-	for _, s := range r.Form["match[]"] {
+	selectors := r.Form["match[]"]
+	matcherSets := make([][]*labels.Matcher, 0, len(selectors))
+	for _, s := range selectors {
 		matchers, err := parser.ParseMetricSelector(s)
 		if err != nil {
 			return nil, nil, &api.ApiError{Typ: api.ErrorBadData, Err: err}
@@ -488,7 +489,7 @@ func (qapi *QueryAPI) series(r *http.Request) (interface{}, []error, *api.ApiErr
 
 	var (
 		metrics = []labels.Labels{}
-		sets    []storage.SeriesSet
+		sets    = make([]storage.SeriesSet, 0, len(matcherSets))
 	)
 	for _, mset := range matcherSets {
 		sets = append(sets, q.Select(false, nil, mset...))

--- a/pkg/block/node.go
+++ b/pkg/block/node.go
@@ -5,6 +5,7 @@ package block
 
 import (
 	"github.com/oklog/ulid"
+
 	"github.com/thanos-io/thanos/pkg/block/metadata"
 )
 
@@ -24,7 +25,7 @@ func NewNode(meta *metadata.Meta) *Node {
 
 // getNonRootIDs returns list of ids which are not on root level.
 func getNonRootIDs(root *Node) []ulid.ULID {
-	var ulids []ulid.ULID
+	ulids := make([]ulid.ULID, 0, len(root.Children))
 	for _, node := range root.Children {
 		ulids = append(ulids, childrenToULIDs(node)...)
 		ulids = remove(ulids, node.ULID)

--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -562,7 +562,7 @@ func IsRetryError(err error) bool {
 }
 
 func (cg *Group) areBlocksOverlapping(include *metadata.Meta, excludeDirs ...string) error {
-	var (
+	var ( //nolint:prealloc
 		metas   []tsdb.BlockMeta
 		exclude = map[ulid.ULID]struct{}{}
 	)

--- a/pkg/compact/downsample/aggr.go
+++ b/pkg/compact/downsample/aggr.go
@@ -21,7 +21,7 @@ type AggrChunk []byte
 // EncodeAggrChunk encodes a new aggregate chunk from the array of chunks for each aggregate.
 // Each array entry corresponds to the respective AggrType number.
 func EncodeAggrChunk(chks [5]chunkenc.Chunk) *AggrChunk {
-	var b []byte
+	var b []byte //nolint:prealloc
 	buf := [8]byte{}
 
 	for _, c := range chks {

--- a/pkg/compact/downsample/downsample_test.go
+++ b/pkg/compact/downsample/downsample_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/prometheus/prometheus/tsdb/chunks"
 	"github.com/prometheus/prometheus/tsdb/index"
 	"github.com/prometheus/prometheus/tsdb/tombstones"
+
 	"github.com/thanos-io/thanos/pkg/block"
 	"github.com/thanos-io/thanos/pkg/block/metadata"
 	"github.com/thanos-io/thanos/pkg/testutil"
@@ -678,7 +679,7 @@ func TestApplyCounterResetsIterator(t *testing.T) {
 }
 
 func TestCounterSeriesIteratorSeek(t *testing.T) {
-	chunks := [][]sample{
+	chnks := [][]sample{
 		{{100, 10}, {200, 20}, {300, 10}, {400, 20}, {400, 5}},
 	}
 
@@ -686,8 +687,8 @@ func TestCounterSeriesIteratorSeek(t *testing.T) {
 		{200, 20}, {300, 30}, {400, 40},
 	}
 
-	var its []chunkenc.Iterator
-	for _, c := range chunks {
+	var its []chunkenc.Iterator //nolint:prealloc
+	for _, c := range chnks {
 		its = append(its, newSampleIterator(c))
 	}
 
@@ -710,12 +711,12 @@ func TestCounterSeriesIteratorSeek(t *testing.T) {
 }
 
 func TestCounterSeriesIteratorSeekExtendTs(t *testing.T) {
-	chunks := [][]sample{
+	chnks := [][]sample{
 		{{100, 10}, {200, 20}, {300, 10}, {400, 20}, {400, 5}},
 	}
 
-	var its []chunkenc.Iterator
-	for _, c := range chunks {
+	var its []chunkenc.Iterator //nolint:prealloc
+	for _, c := range chnks {
 		its = append(its, newSampleIterator(c))
 	}
 
@@ -726,15 +727,15 @@ func TestCounterSeriesIteratorSeekExtendTs(t *testing.T) {
 }
 
 func TestCounterSeriesIteratorSeekAfterNext(t *testing.T) {
-	chunks := [][]sample{
+	chnks := [][]sample{
 		{{100, 10}},
 	}
 	exp := []sample{
 		{100, 10},
 	}
 
-	var its []chunkenc.Iterator
-	for _, c := range chunks {
+	var its []chunkenc.Iterator //nolint:prealloc
+	for _, c := range chnks {
 		its = append(its, newSampleIterator(c))
 	}
 

--- a/pkg/discovery/dns/provider.go
+++ b/pkg/discovery/dns/provider.go
@@ -157,7 +157,7 @@ func (p *Provider) Addresses() []string {
 	p.RLock()
 	defer p.RUnlock()
 
-	var result []string
+	result := make([]string, 0, len(p.resolved))
 	for _, addrs := range p.resolved {
 		result = append(result, addrs...)
 	}

--- a/pkg/discovery/dns/provider_test.go
+++ b/pkg/discovery/dns/provider_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/go-kit/kit/log"
 	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
+
 	"github.com/thanos-io/thanos/pkg/testutil"
 )
 
@@ -36,7 +37,7 @@ func TestProvider(t *testing.T) {
 	testutil.Ok(t, err)
 	result := prv.Addresses()
 	sort.Strings(result)
-	testutil.Equals(t, []string(nil), result)
+	testutil.Equals(t, []string{}, result)
 	testutil.Equals(t, 1, promtestutil.CollectAndCount(prv.resolverAddrs))
 	testutil.Equals(t, float64(0), promtestutil.ToFloat64(prv.resolverAddrs.WithLabelValues("any+x")))
 
@@ -63,7 +64,7 @@ func TestProvider(t *testing.T) {
 	testutil.Ok(t, err)
 	result = prv.Addresses()
 	sort.Strings(result)
-	testutil.Equals(t, []string(nil), result)
+	testutil.Equals(t, []string{}, result)
 	testutil.Equals(t, 1, promtestutil.CollectAndCount(prv.resolverAddrs))
 	testutil.Equals(t, float64(0), promtestutil.ToFloat64(prv.resolverAddrs.WithLabelValues("any+x")))
 

--- a/pkg/extprom/tx_gauge_test.go
+++ b/pkg/extprom/tx_gauge_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
+
 	"github.com/thanos-io/thanos/pkg/testutil"
 )
 
@@ -174,7 +175,7 @@ func toFloat64(t *testing.T, c prometheus.Collector) map[string]float64 {
 }
 
 func lbToString(pairs []*dto.LabelPair) string {
-	var ret []string
+	var ret []string //nolint:prealloc
 	for _, r := range pairs {
 		ret = append(ret, r.String())
 	}

--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -188,7 +188,7 @@ func NewClient(logger log.Logger, cfg EndpointsConfig, client *http.Client, prov
 		logger = log.NewNopLogger()
 	}
 
-	var discoverers []*file.Discovery
+	discoverers := make([]*file.Discovery, 0, len(cfg.FileSDConfigs))
 	for _, sdCfg := range cfg.FileSDConfigs {
 		fileSDCfg, err := sdCfg.convert()
 		if err != nil {
@@ -215,7 +215,7 @@ func (c *Client) Do(req *http.Request) (*http.Response, error) {
 
 // Endpoints returns the list of known endpoints.
 func (c *Client) Endpoints() []*url.URL {
-	var urls []*url.URL
+	urls := make([]*url.URL, 0, len(c.provider.Addresses()))
 	for _, addr := range c.provider.Addresses() {
 		urls = append(urls,
 			&url.URL{

--- a/pkg/objstore/inmem.go
+++ b/pkg/objstore/inmem.go
@@ -66,7 +66,7 @@ func (b *InMemBucket) Iter(_ context.Context, dir string, f func(string) error) 
 	}
 	b.mtx.RUnlock()
 
-	var keys []string
+	keys := make([]string, 0, len(unique))
 	for n := range unique {
 		keys = append(keys, n)
 	}

--- a/pkg/query/querier_test.go
+++ b/pkg/query/querier_test.go
@@ -607,7 +607,7 @@ func (q *querierResponseCatcher) Select(selectSorted bool, p *storage.SelectHint
 func (q querierResponseCatcher) Close() error { return nil }
 
 func (q *querierResponseCatcher) warns() []storage.Warnings {
-	var warns []storage.Warnings
+	var warns []storage.Warnings //nolint:prealloc
 	for _, r := range q.resp {
 		warns = append(warns, r.Warnings())
 	}

--- a/pkg/receive/handler_test.go
+++ b/pkg/receive/handler_test.go
@@ -23,9 +23,10 @@ import (
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/storage"
 	terrors "github.com/prometheus/prometheus/tsdb/errors"
+	"google.golang.org/grpc"
+
 	"github.com/thanos-io/thanos/pkg/store/storepb"
 	"github.com/thanos-io/thanos/pkg/store/storepb/prompb"
-	"google.golang.org/grpc"
 )
 
 func TestCountCause(t *testing.T) {
@@ -145,7 +146,7 @@ func newHandlerHashring(appendables []*fakeAppendable, replicationFactor uint64)
 			Hashring: "test",
 		},
 	}
-	var handlers []*Handler
+	var handlers []*Handler //nolint:prealloc
 	// create a fake peer group where we manually fill the cache with fake addresses pointed to our handlers
 	// This removes the network from the tests and creates a more consistent testing harness.
 	peers := &peerGroup{

--- a/pkg/rules/proxy.go
+++ b/pkg/rules/proxy.go
@@ -10,11 +10,12 @@ import (
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/pkg/errors"
-	"github.com/thanos-io/thanos/pkg/rules/rulespb"
-	"github.com/thanos-io/thanos/pkg/store/storepb"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	"github.com/thanos-io/thanos/pkg/rules/rulespb"
+	"github.com/thanos-io/thanos/pkg/store/storepb"
 )
 
 // Proxy implements rulespb.Rules gRPC that fanouts requests to given rulespb.Rules and deduplication on the way.
@@ -35,7 +36,7 @@ func (s *Proxy) Rules(req *rulespb.RulesRequest, srv rulespb.Rules_RulesServer) 
 	var (
 		g, gctx  = errgroup.WithContext(srv.Context())
 		respChan = make(chan *rulespb.RuleGroup, 10)
-		groups   []*rulespb.RuleGroup
+		groups   = make([]*rulespb.RuleGroup, 0, len(s.rules()))
 	)
 
 	for _, rulesClient := range s.rules() {

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -1430,7 +1430,7 @@ func newBucketIndexReader(ctx context.Context, block *bucketBlock) *bucketIndexR
 // chunk where the series contains the matching label-value pair for a given block of data. Postings can be fetched by
 // single label name=value.
 func (r *bucketIndexReader) ExpandedPostings(ms []*labels.Matcher) ([]uint64, error) {
-	var (
+	var ( //nolint:prealloc
 		postingGroups []*postingGroup
 		allRequested  = false
 		hasAdds       = false
@@ -1610,7 +1610,7 @@ type postingPtr struct {
 // It returns one postings for each key, in the same order.
 // If postings for given key is not fetched, entry at given index will be nil.
 func (r *bucketIndexReader) fetchPostings(keys []labels.Label) ([]index.Postings, error) {
-	var ptrs []postingPtr
+	var ptrs []postingPtr //nolint:prealloc
 
 	output := make([]index.Postings, len(keys))
 

--- a/pkg/store/bucket_test.go
+++ b/pkg/store/bucket_test.go
@@ -39,6 +39,8 @@ import (
 	"github.com/prometheus/prometheus/tsdb"
 	"github.com/prometheus/prometheus/tsdb/encoding"
 
+	"go.uber.org/atomic"
+
 	"github.com/thanos-io/thanos/pkg/block"
 	"github.com/thanos-io/thanos/pkg/block/indexheader"
 	"github.com/thanos-io/thanos/pkg/block/metadata"
@@ -52,7 +54,6 @@ import (
 	storetestutil "github.com/thanos-io/thanos/pkg/store/storepb/testutil"
 	"github.com/thanos-io/thanos/pkg/testutil"
 	"github.com/thanos-io/thanos/pkg/testutil/e2eutil"
-	"go.uber.org/atomic"
 )
 
 var emptyRelabelConfig = make([]*relabel.Config, 0)
@@ -1253,12 +1254,12 @@ func benchBucketSeries(t testutil.TB, samplesPerSeries, totalSeries int, request
 		chunksLimiterFactory: NewChunksLimiterFactory(0),
 	}
 
-	for _, block := range blocks {
-		block.indexHeaderReader, err = indexheader.NewBinaryReader(context.Background(), log.NewNopLogger(), bkt, tmpDir, block.meta.ULID, DefaultPostingOffsetInMemorySampling)
+	for _, blck := range blocks {
+		blck.indexHeaderReader, err = indexheader.NewBinaryReader(context.Background(), log.NewNopLogger(), bkt, tmpDir, blck.meta.ULID, DefaultPostingOffsetInMemorySampling)
 		testutil.Ok(t, err)
 	}
 
-	var bCases []*storetestutil.SeriesCase
+	var bCases []*storetestutil.SeriesCase //nolint:prealloc
 	for _, p := range requestedRatios {
 		seriesCut := int(p * float64(numOfBlocks*seriesPerBlock))
 		if seriesCut == 0 {

--- a/pkg/store/proxy_test.go
+++ b/pkg/store/proxy_test.go
@@ -22,13 +22,14 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
 	"github.com/thanos-io/thanos/pkg/component"
 	"github.com/thanos-io/thanos/pkg/store/storepb"
 	storetestutil "github.com/thanos-io/thanos/pkg/store/storepb/testutil"
 	"github.com/thanos-io/thanos/pkg/testutil"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 type testClient struct {
@@ -1584,7 +1585,7 @@ func benchProxySeries(t testutil.TB, totalSamples, totalSeries int) {
 	}
 
 	var allResps []*storepb.SeriesResponse
-	var expected []storepb.Series
+	var expected []storepb.Series //nolint:prealloc
 	lastLabels := storepb.Series{}
 	for _, c := range clients {
 		m := c.(*testClient).StoreClient.(*mockedStoreAPI)

--- a/pkg/store/storepb/custom.go
+++ b/pkg/store/storepb/custom.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gogo/protobuf/types"
 	"github.com/pkg/errors"
 	"github.com/prometheus/prometheus/pkg/labels"
+
 	"github.com/thanos-io/thanos/pkg/store/storepb/prompb"
 )
 
@@ -378,7 +379,7 @@ func PrompbLabelsToLabelsUnsafe(lset []prompb.Label) []Label {
 }
 
 func LabelsToString(lset []Label) string {
-	var s []string
+	s := make([]string, 0, len(lset))
 	for _, l := range lset {
 		s = append(s, l.String())
 	}
@@ -386,7 +387,7 @@ func LabelsToString(lset []Label) string {
 }
 
 func LabelSetsToString(lsets []LabelSet) string {
-	s := []string{}
+	s := make([]string, 0, len(lsets))
 	for _, ls := range lsets {
 		s = append(s, LabelsToString(ls.Labels))
 	}

--- a/pkg/store/storepb/custom_test.go
+++ b/pkg/store/storepb/custom_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
+
 	"github.com/thanos-io/thanos/pkg/store/storepb/prompb"
 	"github.com/thanos-io/thanos/pkg/testutil"
 )
@@ -54,7 +55,7 @@ func newSeries(tb testing.TB, lset labels.Labels, smplChunks [][]sample) Series 
 }
 
 func newListSeriesSet(tb testing.TB, raw []rawSeries) *listSeriesSet {
-	var series []Series
+	var series []Series //nolint:prealloc
 	for _, s := range raw {
 		series = append(series, newSeries(tb, s.lset, s.chunks))
 	}
@@ -338,7 +339,7 @@ func TestMergeSeriesSets(t *testing.T) {
 }
 
 func TestMergeSeriesSetError(t *testing.T) {
-	var input []SeriesSet
+	var input []SeriesSet //nolint:prealloc
 	for _, iss := range [][]rawSeries{{{
 		lset:   labels.FromStrings("a", "a"),
 		chunks: [][]sample{{{1, 1}, {2, 2}}, {{3, 3}, {4, 4}}},
@@ -494,7 +495,7 @@ func TestLabelsToPromLabelsUnsafe(t *testing.T) {
 }
 
 func TestPrompbLabelsToLabelsUnsafe(t *testing.T) {
-	var pb []prompb.Label
+	var pb []prompb.Label //nolint:prealloc
 	for _, l := range labels.FromMap(testLsetMap) {
 		pb = append(pb, prompb.Label{Name: l.Name, Value: l.Value})
 	}

--- a/pkg/verifier/duplicated_compaction.go
+++ b/pkg/verifier/duplicated_compaction.go
@@ -5,9 +5,7 @@ package verifier
 
 import (
 	"context"
-
 	"fmt"
-
 	"strings"
 	"time"
 
@@ -16,6 +14,7 @@ import (
 	"github.com/oklog/ulid"
 	"github.com/pkg/errors"
 	"github.com/prometheus/prometheus/tsdb"
+
 	"github.com/thanos-io/thanos/pkg/block"
 	"github.com/thanos-io/thanos/pkg/objstore"
 )
@@ -151,7 +150,7 @@ func sameULIDSlices(a []ulid.ULID, b []ulid.ULID) bool {
 }
 
 func sprintMetas(ms []tsdb.BlockMeta) string {
-	var infos []string
+	infos := make([]string, 0, len(ms))
 	for _, m := range ms {
 		infos = append(infos, fmt.Sprintf("<ulid: %s, mint: %d, maxt: %d, range: %s>", m.ULID, m.MinTime, m.MaxTime, (time.Duration((m.MaxTime-m.MinTime)/1000)*time.Second).String()))
 	}

--- a/test/e2e/rule_test.go
+++ b/test/e2e/rule_test.go
@@ -101,7 +101,7 @@ func reloadRulesHTTP(t *testing.T, ctx context.Context, endpoint string) {
 func writeTargets(t *testing.T, path string, addrs ...string) {
 	t.Helper()
 
-	var tgs []model.LabelSet
+	var tgs []model.LabelSet //nolint:prealloc
 	for _, a := range addrs {
 		tgs = append(
 			tgs,


### PR DESCRIPTION
Signed-off-by: Kemal Akkoyun <kakkoyun@gmail.com>

This PR enables `prealloc` linter to hint possible pre-allocations. Tests and complex code pieces are skipped.

* [x] Change is not relevant to the end user.

## Changes

* Enable prealloc
* Fix code accordingly

## Verification

* `make go-lint`
