### PR TITLE
Fix quickstart

### DIFF
--- a/cmd/thanos/main.go
+++ b/cmd/thanos/main.go
@@ -65,7 +65,7 @@ func main() {
 
 	cmd, err := app.Parse(os.Args[1:])
 	if err != nil {
-		fmt.Fprintln(os.Stderr, errors.Wrapf(err, "Error parsing commandline arguments"))
+		fmt.Fprintln(os.Stderr, errors.Wrapf(err, "Error parsing commandline arguments: %v", os.Args))
 		app.Usage(os.Args[1:])
 		os.Exit(2)
 	}


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Fixes: #2986 

Changes in `quickstart.sh`:
* `MINIO_ENABLED` is disabled by default
* `S3_ENDPOINT` is empty by default and filled in only when minio is enabled, hence [thanos does not run store](https://github.com/thanos-io/thanos/blob/master/scripts/quickstart.sh#L168)
* thanos arguments are parsed correctly (no empty arguments `OBJSTORECFG`, and `STORES`)
* thanos arguments are dumped in console on parse error. **NOTE** please object if you think it might be a security issue - i'll remove it

I didn't add anything to the changelog, since the last ~10 commits to the quickstart.sh are not reflected there.

## Verification

Verified manually by running `PROMETHEUS_EXECUTABLE=~/go/src/github.com/prometheus/prometheus/prometheus THANOS_EXECUTABLE=~/go/bin/thanos MINIO_ENABLED="" ./scripts/quickstart.sh`.

log is attached.
[log.txt](https://github.com/thanos-io/thanos/files/5028594/log.txt)

Note, that there are still errors `level=error name=query-0 ts=2020-08-05T13:14:02.164403579Z caller=logger.go:22 msg="failed to flush Jaeger spans to server: write udp 127.0.0.1:54187->127.0.0.1:6831: write: connection refused"`, that might need investigation

