### PR TITLE
change: change test-e2e target to depend on docker-multi-stage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -210,7 +210,7 @@ test-local:
 
 .PHONY: test-e2e
 test-e2e: ## Runs all Thanos e2e docker-based e2e tests from test/e2e. Required access to docker daemon.
-test-e2e: docker
+test-e2e: docker-multi-stage
 	@echo ">> cleaning docker environment."
 	@docker system prune -f --volumes
 	@echo ">> cleaning e2e test garbage."

--- a/Makefile
+++ b/Makefile
@@ -124,14 +124,19 @@ deps: ## Ensures fresh go.mod and go.sum.
 	@go mod tidy
 	@go mod verify
 
+
 .PHONY: docker
 docker: ## Builds 'thanos' docker with no tag.
+ifeq ($(OS)_$(ARCH), linux_x86_64)
 docker: build
 	@echo ">> copying Thanos from $(PREFIX) to ./thanos_tmp_for_docker"
 	@cp $(PREFIX)/thanos ./thanos_tmp_for_docker
 	@echo ">> building docker image 'thanos'"
 	@docker build -t "thanos" .
 	@rm ./thanos_tmp_for_docker
+else
+docker: docker-multi-stage
+endif
 
 .PHONY: docker-multi-stage
 docker-multi-stage: ## Builds 'thanos' docker image using multi-stage.
@@ -210,7 +215,7 @@ test-local:
 
 .PHONY: test-e2e
 test-e2e: ## Runs all Thanos e2e docker-based e2e tests from test/e2e. Required access to docker daemon.
-test-e2e: docker-multi-stage
+test-e2e: docker
 	@echo ">> cleaning docker environment."
 	@docker system prune -f --volumes
 	@echo ">> cleaning e2e test garbage."


### PR DESCRIPTION
* [x] Change is not relevant to the end user.

## Changes

~~Update the Makefile `test-e2e` target to depend on the `docker-multi-stage` instead of `docker` target. This ensures people running on Mac OS X will be able to run the integration tests easily.~~

I updated the `make docker` command to run as normal if the OS is linux and the Arch is x86_64. Otherwise `make docker` will default to `make docker-multi-stage`. 

## Verification

Ran `make test-e2e`

**Note**: This does not change the fact that images built using `make docker` will not work on Mac OS X. Also if other Mac users are not experiencing this issue, I would be interested to know if there is something misconfigured with my local environment causing this to fail.

Fixes: #2803 