### PR TITLE
Tools: Add CLI to create tombstones in obj store

### DIFF
--- a/cmd/thanos/tools.go
+++ b/cmd/thanos/tools.go
@@ -19,6 +19,7 @@ import (
 func registerTools(m map[string]setupFunc, app *kingpin.Application) {
 	cmd := app.Command("tools", "Tools utility commands")
 
+	registerDelete(m, cmd, "tools")
 	registerBucket(m, cmd, "tools")
 	registerCheckRules(m, cmd, "tools")
 }

--- a/cmd/thanos/tools_delete.go
+++ b/cmd/thanos/tools_delete.go
@@ -18,17 +18,21 @@ import (
 )
 
 func registerDelete(m map[string]setupFunc, app *kingpin.CmdClause, pre string) {
-	cmd := app.Command("delete", "Delete series command")
+	cmd := app.Command("delete", "Delete series command for the object storage. NOTE: Currently it only performs Store API masking in the object storage at chunk level with respect to the tombstones created by the user (Doesn't actually delete the data in objstore).")
 
-	matcher := cmd.Flag("matcher", "The string representing label matchers").Default("").String()
+	matchers := cmd.Flag("matchers", "The string representing label matchers").Default("").String()
 
 	objStoreConfig := regCommonObjStoreFlags(cmd, "", true)
 
-	minTime := model.TimeOrDuration(cmd.Flag("min-time", "Start of time range limit to delete. Option can be a constant time in RFC3339 format or time duration relative to current time, such as -1d or 2h45m. Valid duration units are ms, s, m, h, d, w, y.").
+	minTime := model.TimeOrDuration(cmd.Flag("min-time", "Start of time range limit to delete. Option can be a constant time in RFC3339 format or time duration relative to current time, such as -1d (Calculates the actual timestamp at the tombstone creation time) or 2h45m. Valid duration units are ms, s, m, h, d, w, y.").
 		Default("0000-01-01T00:00:00Z"))
 
-	maxTime := model.TimeOrDuration(cmd.Flag("max-time", "End of time range limit to delete. Option can be a constant time in RFC3339 format or time duration relative to current time, such as -1d or 2h45m. Valid duration units are ms, s, m, h, d, w, y.").
+	maxTime := model.TimeOrDuration(cmd.Flag("max-time", "End of time range limit to delete. Option can be a constant time in RFC3339 format or time duration relative to current time, such as -1d (Calculates the actual timestamp at the tombstone creation time) or 2h45m. Valid duration units are ms, s, m, h, d, w, y.").
 		Default("9999-12-31T23:59:59Z"))
+
+	author := cmd.Flag("author", "Author of the deletion request").Default("not specified").String()
+
+	reason := cmd.Flag("reason", "Reason to perform the deletion request").Default("not specified").String()
 
 	m[pre+" delete"] = func(g *run.Group, logger log.Logger, reg *prometheus.Registry, _ opentracing.Tracer, _ <-chan struct{}, _ bool) error {
 		confContentYaml, err := objStoreConfig.Content()
@@ -45,18 +49,13 @@ func registerDelete(m map[string]setupFunc, app *kingpin.CmdClause, pre string) 
 		// Dummy actor to immediately kill the group after the run function returns.
 		g.Add(func() error { return nil }, func(error) {})
 
-		_, err = parser.ParseMetricSelector(*matcher)
+		_, err = parser.ParseMetricSelector(*matchers)
 		if err != nil {
 			return err
 		}
 
-		ts := tombstone.NewTombstone(*matcher, minTime.PrometheusTimestamp(), maxTime.PrometheusTimestamp())
+		ts := tombstone.NewTombstone(*matchers, minTime.PrometheusTimestamp(), maxTime.PrometheusTimestamp(), *author, *reason)
 
-		err = tombstone.UploadTombstone(ts, bkt, logger)
-		if err != nil {
-			return err
-		}
-
-		return nil
+		return tombstone.UploadTombstone(ts, bkt, logger)
 	}
 }

--- a/cmd/thanos/tools_delete.go
+++ b/cmd/thanos/tools_delete.go
@@ -1,0 +1,93 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/cespare/xxhash"
+	"github.com/go-kit/kit/log"
+	"github.com/oklog/run"
+	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/thanos-io/thanos/pkg/model"
+	"github.com/thanos-io/thanos/pkg/runutil"
+
+	"github.com/thanos-io/thanos/pkg/objstore"
+	"github.com/thanos-io/thanos/pkg/objstore/client"
+	kingpin "gopkg.in/alecthomas/kingpin.v2"
+)
+
+type Tombstone struct {
+	Matcher string `json:"matcher"`
+	MinTime int64  `json:"minTime"`
+	MaxTime int64  `json:"maxTime"`
+}
+
+func registerDelete(m map[string]setupFunc, app *kingpin.CmdClause, pre string) {
+	cmd := app.Command("delete", "Delete series command")
+
+	matcher := cmd.Flag("matcher", "The string representing label matchers").Default("").String()
+
+	objStoreConfig := regCommonObjStoreFlags(cmd, "", true)
+
+	minTime := model.TimeOrDuration(cmd.Flag("min-time", "Start of time range limit to delete. Option can be a constant time in RFC3339 format or time duration relative to current time, such as -1d or 2h45m. Valid duration units are ms, s, m, h, d, w, y.").
+		Default("0000-01-01T00:00:00Z"))
+
+	maxTime := model.TimeOrDuration(cmd.Flag("max-time", "End of time range limit to delete. Option can be a constant time in RFC3339 format or time duration relative to current time, such as -1d or 2h45m. Valid duration units are ms, s, m, h, d, w, y.").
+		Default("9999-12-31T23:59:59Z"))
+
+	m[pre+" delete"] = func(g *run.Group, logger log.Logger, reg *prometheus.Registry, _ opentracing.Tracer, _ <-chan struct{}, _ bool) error {
+		confContentYaml, err := objStoreConfig.Content()
+		if err != nil {
+			return err
+		}
+
+		bkt, err := client.NewBucket(logger, confContentYaml, reg, pre+" delete")
+		if err != nil {
+			return err
+		}
+		defer runutil.CloseWithLogOnErr(logger, bkt, "tools delete")
+
+		// Dummy actor to immediately kill the group after the run function returns.
+		g.Add(func() error { return nil }, func(error) {})
+
+		_, err = parser.ParseMetricSelector(*matcher)
+		if err != nil {
+			return err
+		}
+
+		ts := Tombstone{Matcher: *matcher, MinTime: minTime.PrometheusTimestamp(), MaxTime: maxTime.PrometheusTimestamp()}
+		b, err := json.Marshal(ts)
+		if err != nil {
+			return err
+		}
+
+		tmpDir := os.TempDir()
+
+		tsPath := tmpDir + "/tombstone.json"
+		err = ioutil.WriteFile(tsPath, b, 0644)
+		if err != nil {
+			return err
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+		defer cancel()
+
+		hash := xxhash.Sum64(b)
+
+		err = objstore.UploadFile(ctx, logger, bkt, tsPath, "tombstones/"+strconv.FormatUint(hash, 10)+".json")
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+}

--- a/docs/components/tools.md
+++ b/docs/components/tools.md
@@ -37,7 +37,10 @@ Flags:
 
 Subcommands:
   tools delete [<flags>]
-    Delete series command
+    Delete series command for the object storage. NOTE: Currently it only
+    performs Store API masking in the object storage at chunk level with respect
+    to the tombstones created by the user (Doesn't actually delete the data in
+    objstore).
 
   tools bucket verify [<flags>]
     Verify all blocks in the bucket against specified issues

--- a/docs/components/tools.md
+++ b/docs/components/tools.md
@@ -36,6 +36,9 @@ Flags:
                            https://thanos.io/tracing.md/#configuration
 
 Subcommands:
+  tools delete [<flags>]
+    Delete series command
+
   tools bucket verify [<flags>]
     Verify all blocks in the bucket against specified issues
 

--- a/pkg/tombstone/tombstone.go
+++ b/pkg/tombstone/tombstone.go
@@ -1,0 +1,74 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package tombstone
+
+import (
+	"context"
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"path"
+	"strconv"
+	"time"
+
+	"github.com/cespare/xxhash"
+	"github.com/go-kit/kit/log"
+	"github.com/prometheus/prometheus/pkg/timestamp"
+
+	"github.com/thanos-io/thanos/pkg/objstore"
+)
+
+const (
+	// TombstoneDir is the name of directory to upload tombstones.
+	TombstoneDir = "tombstones"
+)
+
+// Tombstone represents a tombstone.
+type Tombstone struct {
+	Matcher      string `json:"matcher"`
+	MinTime      int64  `json:"minTime"`
+	MaxTime      int64  `json:"maxTime"`
+	CreationTime int64  `json:"creationTime"`
+}
+
+// NewTombstone returns a new instance of Tombstone.
+func NewTombstone(matcher string, minTime, maxTime int64) Tombstone {
+	return Tombstone{
+		Matcher:      matcher,
+		MinTime:      minTime,
+		MaxTime:      maxTime,
+		CreationTime: timestamp.FromTime(time.Now()),
+	}
+}
+
+// GenName generates file name based on Matcher, MinTime and MaxTime of a tombstone.
+func GenName(ts Tombstone) string {
+	hash := xxhash.Sum64([]byte(ts.Matcher + string(ts.MinTime) + string(ts.MaxTime)))
+	return strconv.FormatUint(hash, 10) + ".json"
+}
+
+// UploadTombstone uploads the given tombstone to object storage.
+func UploadTombstone(tombstone Tombstone, bkt objstore.Bucket, logger log.Logger) error {
+	b, err := json.Marshal(tombstone)
+	if err != nil {
+		return err
+	}
+
+	tmpDir := os.TempDir()
+
+	tsPath := tmpDir + "/tombstone.json"
+	err = ioutil.WriteFile(tsPath, b, 0644)
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	err = objstore.UploadFile(ctx, logger, bkt, tsPath, path.Join(TombstoneDir, GenName(tombstone)))
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/tombstone/tombstone.go
+++ b/pkg/tombstone/tombstone.go
@@ -21,30 +21,34 @@ import (
 
 const (
 	// TombstoneDir is the name of directory to upload tombstones.
-	TombstoneDir = "tombstones"
+	TombstoneDir = "thanos/tombstones"
 )
 
 // Tombstone represents a tombstone.
 type Tombstone struct {
-	Matcher      string `json:"matcher"`
+	Matchers     string `json:"matchers"`
 	MinTime      int64  `json:"minTime"`
 	MaxTime      int64  `json:"maxTime"`
 	CreationTime int64  `json:"creationTime"`
+	Author       string `json:"author"`
+	Reason       string `json:"reason"`
 }
 
 // NewTombstone returns a new instance of Tombstone.
-func NewTombstone(matcher string, minTime, maxTime int64) Tombstone {
+func NewTombstone(matchers string, minTime, maxTime int64, author string, reason string) Tombstone {
 	return Tombstone{
-		Matcher:      matcher,
+		Matchers:     matchers,
 		MinTime:      minTime,
 		MaxTime:      maxTime,
 		CreationTime: timestamp.FromTime(time.Now()),
+		Author:       author,
+		Reason:       reason,
 	}
 }
 
-// GenName generates file name based on Matcher, MinTime and MaxTime of a tombstone.
+// GenName generates file name based on Matchers, MinTime and MaxTime of a tombstone.
 func GenName(ts Tombstone) string {
-	hash := xxhash.Sum64([]byte(ts.Matcher + string(ts.MinTime) + string(ts.MaxTime)))
+	hash := xxhash.Sum64([]byte(ts.Matchers + strconv.FormatInt(ts.MinTime, 10) + strconv.FormatInt(ts.MaxTime, 10)))
 	return strconv.FormatUint(hash, 10) + ".json"
 }
 
@@ -58,17 +62,13 @@ func UploadTombstone(tombstone Tombstone, bkt objstore.Bucket, logger log.Logger
 	tmpDir := os.TempDir()
 
 	tsPath := tmpDir + "/tombstone.json"
-	err = ioutil.WriteFile(tsPath, b, 0644)
-	if err != nil {
+	if err := ioutil.WriteFile(tsPath, b, 0644); err != nil {
 		return err
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 
-	err = objstore.UploadFile(ctx, logger, bkt, tsPath, path.Join(TombstoneDir, GenName(tombstone)))
-	if err != nil {
-		return err
-	}
-	return nil
+	return objstore.UploadFile(ctx, logger, bkt, tsPath, path.Join(TombstoneDir, GenName(tombstone)))
+
 }

--- a/pkg/tombstone/tombstone_test.go
+++ b/pkg/tombstone/tombstone_test.go
@@ -16,8 +16,8 @@ func TestUploadTombstone(t *testing.T) {
 	bkt := objstore.WithNoopInstr(objstore.NewInMemBucket())
 
 	{
-		SampleTombstone := NewTombstone("up{a=\"b\"}", 00, 9999999)
-		err := UploadTombstone(SampleTombstone, bkt, log.NewNopLogger())
+		sampleTombstone := NewTombstone("up{a=\"b\"}", 00, 9999999, "john", "some valid reason")
+		err := UploadTombstone(sampleTombstone, bkt, log.NewNopLogger())
 		testutil.Ok(t, err)
 	}
 }

--- a/pkg/tombstone/tombstone_test.go
+++ b/pkg/tombstone/tombstone_test.go
@@ -1,0 +1,23 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package tombstone
+
+import (
+	"testing"
+
+	"github.com/go-kit/kit/log"
+
+	"github.com/thanos-io/thanos/pkg/objstore"
+	"github.com/thanos-io/thanos/pkg/testutil"
+)
+
+func TestUploadTombstone(t *testing.T) {
+	bkt := objstore.WithNoopInstr(objstore.NewInMemBucket())
+
+	{
+		SampleTombstone := NewTombstone("up{a=\"b\"}", 00, 9999999)
+		err := UploadTombstone(SampleTombstone, bkt, log.NewNopLogger())
+		testutil.Ok(t, err)
+	}
+}


### PR DESCRIPTION
Signed-off-by: Harshitha1234 <harshithachowdary.t17@iiits.in>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes
- Add `thanos tools delete` command tool to create tombstones in object storage
<!-- Enumerate changes you made -->
## TODO
* [x] Refactor tombstone logic into its own package.
* [x] Write tests.

## Verification

<!-- How you tested it? How do you know it works? -->
