### PR TITLE
querier: bugfix - data gaps when switching iterators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ We use *breaking :warning:* word for marking changes that are not backward compa
 * [#3095](https://github.com/thanos-io/thanos/pull/3095) Rule: update manager when all rule files are removed.
 * [#3098](https://github.com/thanos-io/thanos/pull/3098) ui: Fix Block Viewer for Compactor and Store
 * [#3105](https://github.com/thanos-io/thanos/pull/3105) Query: Fix overwriting maxSourceResolution when auto downsampling is enabled.
+* [#3010](https://github.com/thanos-io/thanos/pull/3010) Querier: Added a flag to override the default look back delta in promql. The flag should be set to at least 2 times the slowest scrape interval or left unset to use the Prometheus defaults of 5min.
 
 ## [v0.15.0-rc.0](https://github.com/thanos-io/thanos/releases/tag/v0.15.0-rc.0) - 2020.08.26
 

--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -70,6 +70,8 @@ func registerQuery(m map[string]setupFunc, app *kingpin.Application) {
 	maxConcurrentQueries := cmd.Flag("query.max-concurrent", "Maximum number of queries processed concurrently by query node.").
 		Default("20").Int()
 
+	lookbackDelta := cmd.Flag("query.lookback-delta", "The maximum lookback duration for retrieving metrics during expression evaluations. PromQL always evaluates the query for the certain timestamp (query range timestamps are deduced by step). Since scrape intervals might be different, PromQL looks back for given amount of time to get latest sample. If it exceeds the maximum lookback delta it assumes series is stale and returns none (a gap). This is why lookback delta should be set to at least 2 times of the slowest scrape interval. If unset it will use the promql default of 5m").Duration()
+
 	maxConcurrentSelects := cmd.Flag("query.max-concurrent-select", "Maximum number of select requests made concurrently per a query.").
 		Default("4").Int()
 
@@ -175,6 +177,7 @@ func registerQuery(m map[string]setupFunc, app *kingpin.Application) {
 			*maxConcurrentQueries,
 			*maxConcurrentSelects,
 			time.Duration(*queryTimeout),
+			*lookbackDelta,
 			time.Duration(*defaultEvaluationInterval),
 			time.Duration(*storeResponseTimeout),
 			*queryReplicaLabels,
@@ -222,6 +225,7 @@ func runQuery(
 	maxConcurrentQueries int,
 	maxConcurrentSelects int,
 	queryTimeout time.Duration,
+	lookbackDelta time.Duration,
 	defaultEvaluationInterval time.Duration,
 	storeResponseTimeout time.Duration,
 	queryReplicaLabels []string,
@@ -312,6 +316,7 @@ func runQuery(
 				NoStepSubqueryIntervalFn: func(rangeMillis int64) int64 {
 					return defaultEvaluationInterval.Milliseconds()
 				},
+				LookbackDelta: lookbackDelta,
 			},
 		)
 	)

--- a/docs/components/query.md
+++ b/docs/components/query.md
@@ -367,6 +367,19 @@ Flags:
       --query.timeout=2m         Maximum time to process query by query node.
       --query.max-concurrent=20  Maximum number of queries processed
                                  concurrently by query node.
+      --query.lookback-delta=QUERY.LOOKBACK-DELTA
+                                 The maximum lookback duration for retrieving
+                                 metrics during expression evaluations. PromQL
+                                 always evaluates the query for the certain
+                                 timestamp (query range timestamps are deduced
+                                 by step). Since scrape intervals might be
+                                 different, PromQL looks back for given amount
+                                 of time to get latest sample. If it exceeds the
+                                 maximum lookback delta it assumes series is
+                                 stale and returns none (a gap). This is why
+                                 lookback delta should be set to at least 2
+                                 times of the slowest scrape interval. If unset
+                                 it will use the promql default of 5m
       --query.max-concurrent-select=4
                                  Maximum number of select requests made
                                  concurrently per a query.


### PR DESCRIPTION
closes: https://github.com/thanos-io/thanos/issues/3001

Promql has a default 5m look back delta so if the penalty causes the
duration between the samples to be greater than 5m this will show as
gaps in the visualisation and when using the count function returns a
lower number then expected.

For example:
time is in mins

series 1
```
itA  t1 0.1  t3 0.3
itB  t1 0.1  t3 0.3 t4 0.4  t9 0.9
```

`it.penB = 2 * (ta - it.lastT), 2 * (3 - 1) = 4 `

```
merged t1 0.1  t3 0.3  t9 0.9
```

t4 is missing because the it.penB is 4 so it skips it.

When the time between  `t3 0.3`  and  `t9 0.9` is more then 5min(the default look
back) so when visualizing this it shows as gaps in the graph.

~When the penalty is resolution based the seek for itB always advances NO
more then the requested time so doesn’t skip samples when switching
between iterators.~ 

UPDATE: step based penalty wouldn't work when using promql functions. Adjusting the look back solves the problem so PR is updated to add it as a configurable flag.



