### PR TITLE
memcached: Initialize forgotten label for failure metric

### DIFF
--- a/pkg/cacheutil/memcached_client.go
+++ b/pkg/cacheutil/memcached_client.go
@@ -254,10 +254,12 @@ func newMemcachedClient(
 	c.failures.WithLabelValues(opGetMulti, reasonTimeout)
 	c.failures.WithLabelValues(opGetMulti, reasonMalformedKey)
 	c.failures.WithLabelValues(opGetMulti, reasonServerError)
+	c.failures.WithLabelValues(opGetMulti, reasonNetworkError)
 	c.failures.WithLabelValues(opGetMulti, reasonOther)
 	c.failures.WithLabelValues(opSet, reasonTimeout)
 	c.failures.WithLabelValues(opSet, reasonMalformedKey)
 	c.failures.WithLabelValues(opSet, reasonServerError)
+	c.failures.WithLabelValues(opSet, reasonNetworkError)
 	c.failures.WithLabelValues(opSet, reasonOther)
 
 	c.skipped = promauto.With(reg).NewCounterVec(prometheus.CounterOpts{


### PR DESCRIPTION
Signed-off-by: Kemal Akkoyun <kakkoyun@gmail.com>

A minor left-over of #3019 

## Changes

* Initialize metric with the new label.

## Verification

* `make test-local`
