### PR TITLE
Replace Leaktest with Goleak

### DIFF
--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -373,6 +373,7 @@ func runReceive(
 		if cw != nil {
 			// Check the hashring configuration on before running the watcher.
 			if err := cw.ValidateConfig(); err != nil {
+				cw.Stop()
 				close(updates)
 				return errors.Wrap(err, "failed to validate hashring configuration file")
 			}

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,6 @@ require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/facette/natsort v0.0.0-20181210072756-2cd4dd1e2dcb
 	github.com/fatih/structtag v1.1.0
-	github.com/fortytw2/leaktest v1.3.0
 	github.com/fsnotify/fsnotify v1.4.7
 	github.com/go-kit/kit v0.10.0
 	github.com/go-openapi/strfmt v0.19.5
@@ -56,6 +55,7 @@ require (
 	go.elastic.co/apm/module/apmot v1.5.0
 	go.uber.org/atomic v1.6.0
 	go.uber.org/automaxprocs v1.2.0
+	go.uber.org/goleak v1.1.0
 	golang.org/x/crypto v0.0.0-20200728195943-123391ffb6de
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
 	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208

--- a/go.sum
+++ b/go.sum
@@ -272,7 +272,6 @@ github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL
 github.com/fatih/structtag v1.1.0 h1:6j4mUV/ES2duvnAzKMFkN6/A5mCaNYPD3xfbAkLLOF8=
 github.com/fatih/structtag v1.1.0/go.mod h1:mBJUNpUnHmRKrKlQQlmCrh5PuhftFbNv8Ys4/aAZl94=
 github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
-github.com/fortytw2/leaktest v1.3.0 h1:u8491cBMTQ8ft8aeV+adlcytMZylmA5nnwwkRZjI8vw=
 github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
 github.com/franela/goblin v0.0.0-20200105215937-c9ffbefa60db/go.mod h1:7dvUGVsVBjqR7JHJk0brhHOZYGmfBYOrK0ZhYMEtBr4=
 github.com/franela/goreq v0.0.0-20171204163338-bcd34c9993f8/go.mod h1:ZhphrRTfi2rbfLwlschooIH4+wKKDR4Pdxhh+TRoA20=
@@ -1042,6 +1041,8 @@ go.uber.org/automaxprocs v1.2.0 h1:+RUihKM+nmYUoB9w0D0Ov5TJ2PpFO2FgenTxMJiZBZA=
 go.uber.org/automaxprocs v1.2.0/go.mod h1:YfO3fm683kQpzETxlTGZhGIVmXAhaw3gxeBADbpZtnU=
 go.uber.org/goleak v1.0.0 h1:qsup4IcBdlmsnGfqyLl4Ntn3C2XCCuKAE7DwHpScyUo=
 go.uber.org/goleak v1.0.0/go.mod h1:8a7PlsEVH3e/a/GLqe5IIrQx6GzcnRmZEufDUTk4A7A=
+go.uber.org/goleak v1.1.0 h1:MJDxhkyAAWXEJf/y4NSOPYD/bBx7JAzIjUbv12/4FFs=
+go.uber.org/goleak v1.1.0/go.mod h1:8a7PlsEVH3e/a/GLqe5IIrQx6GzcnRmZEufDUTk4A7A=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
 go.uber.org/multierr v1.3.0/go.mod h1:VgVr7evmIr6uPjLBxg28wmKNXyqE9akIJ5XnfpiKl+4=
 go.uber.org/multierr v1.4.0/go.mod h1:VgVr7evmIr6uPjLBxg28wmKNXyqE9akIJ5XnfpiKl+4=

--- a/pkg/api/query/v1_test.go
+++ b/pkg/api/query/v1_test.go
@@ -29,7 +29,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/fortytw2/leaktest"
 	"github.com/prometheus/common/route"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/pkg/timestamp"
@@ -51,9 +50,11 @@ import (
 	"github.com/thanos-io/thanos/pkg/testutil/testpromcompatibility"
 )
 
-func TestEndpoints(t *testing.T) {
-	defer leaktest.CheckTimeout(t, 10*time.Second)()
+func TestMain(m *testing.M) {
+	testutil.TolerantVerifyLeakMain(m)
+}
 
+func TestEndpoints(t *testing.T) {
 	lbls := []labels.Labels{
 		{
 			labels.Label{Name: "__name__", Value: "test_metric1"},

--- a/pkg/block/block_test.go
+++ b/pkg/block/block_test.go
@@ -14,8 +14,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/fortytw2/leaktest"
 	"github.com/go-kit/kit/log"
+	"github.com/oklog/ulid"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	promtest "github.com/prometheus/client_golang/prometheus/testutil"
@@ -24,8 +24,6 @@ import (
 	"github.com/thanos-io/thanos/pkg/objstore"
 	"github.com/thanos-io/thanos/pkg/testutil"
 	"github.com/thanos-io/thanos/pkg/testutil/e2eutil"
-
-	"github.com/oklog/ulid"
 )
 
 func TestIsBlockDir(t *testing.T) {
@@ -75,7 +73,7 @@ func TestIsBlockDir(t *testing.T) {
 }
 
 func TestUpload(t *testing.T) {
-	defer leaktest.CheckTimeout(t, 10*time.Second)()
+	defer testutil.TolerantVerifyLeak(t)
 
 	ctx := context.Background()
 
@@ -179,8 +177,7 @@ func TestUpload(t *testing.T) {
 }
 
 func TestDelete(t *testing.T) {
-	defer leaktest.CheckTimeout(t, 10*time.Second)()
-
+	defer testutil.TolerantVerifyLeak(t)
 	ctx := context.Background()
 
 	tmpDir, err := ioutil.TempDir("", "test-block-delete")
@@ -226,8 +223,7 @@ func TestDelete(t *testing.T) {
 }
 
 func TestMarkForDeletion(t *testing.T) {
-	defer leaktest.CheckTimeout(t, 10*time.Second)()
-
+	defer testutil.TolerantVerifyLeak(t)
 	ctx := context.Background()
 
 	tmpDir, err := ioutil.TempDir("", "test-block-mark-for-delete")

--- a/pkg/block/metadata/deletionmark_test.go
+++ b/pkg/block/metadata/deletionmark_test.go
@@ -13,16 +13,19 @@ import (
 	"testing"
 	"time"
 
-	"github.com/fortytw2/leaktest"
 	"github.com/oklog/ulid"
 	"github.com/pkg/errors"
+	"go.uber.org/goleak"
+
 	"github.com/thanos-io/thanos/pkg/objstore"
 	"github.com/thanos-io/thanos/pkg/testutil"
 )
 
-func TestReadDeletionMark(t *testing.T) {
-	defer leaktest.CheckTimeout(t, 10*time.Second)()
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}
 
+func TestReadDeletionMark(t *testing.T) {
 	ctx := context.Background()
 
 	tmpDir, err := ioutil.TempDir("", "test-read-deletion-mark")

--- a/pkg/cacheutil/cacheutil_test.go
+++ b/pkg/cacheutil/cacheutil_test.go
@@ -1,0 +1,14 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package cacheutil
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}

--- a/pkg/cacheutil/memcached_client_test.go
+++ b/pkg/cacheutil/memcached_client_test.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/bradfitz/gomemcache/memcache"
-	"github.com/fortytw2/leaktest"
 	"github.com/go-kit/kit/log"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
@@ -66,8 +65,6 @@ func TestMemcachedClientConfig_validate(t *testing.T) {
 }
 
 func TestNewMemcachedClient(t *testing.T) {
-	defer leaktest.CheckTimeout(t, 10*time.Second)()
-
 	// Should return error on empty YAML config.
 	conf := []byte{}
 	cache, err := NewMemcachedClient(log.NewNopLogger(), "test", conf, nil)
@@ -130,8 +127,6 @@ dns_provider_update_interval: 1s
 }
 
 func TestMemcachedClient_SetAsync(t *testing.T) {
-	defer leaktest.CheckTimeout(t, 10*time.Second)()
-
 	ctx := context.Background()
 	config := defaultMemcachedClientConfig
 	config.Addresses = []string{"127.0.0.1:11211"}
@@ -157,8 +152,6 @@ func TestMemcachedClient_SetAsync(t *testing.T) {
 }
 
 func TestMemcachedClient_SetAsyncWithCustomMaxItemSize(t *testing.T) {
-	defer leaktest.CheckTimeout(t, 10*time.Second)()
-
 	ctx := context.Background()
 	config := defaultMemcachedClientConfig
 	config.Addresses = []string{"127.0.0.1:11211"}
@@ -185,8 +178,6 @@ func TestMemcachedClient_SetAsyncWithCustomMaxItemSize(t *testing.T) {
 }
 
 func TestMemcachedClient_GetMulti(t *testing.T) {
-	defer leaktest.CheckTimeout(t, 10*time.Second)()
-
 	tests := map[string]struct {
 		maxBatchSize          int
 		maxConcurrency        int

--- a/pkg/cacheutil/memcached_server_selector_test.go
+++ b/pkg/cacheutil/memcached_server_selector_test.go
@@ -7,12 +7,11 @@ import (
 	"fmt"
 	"net"
 	"testing"
-	"time"
 
 	"github.com/bradfitz/gomemcache/memcache"
 	"github.com/facette/natsort"
-	"github.com/fortytw2/leaktest"
 	"github.com/pkg/errors"
+
 	"github.com/thanos-io/thanos/pkg/testutil"
 )
 
@@ -42,8 +41,6 @@ func TestNatSort(t *testing.T) {
 }
 
 func TestMemcachedJumpHashSelector_PickServer(t *testing.T) {
-	defer leaktest.CheckTimeout(t, 10*time.Second)()
-
 	tests := []struct {
 		addrs        []string
 		key          string
@@ -90,8 +87,6 @@ func TestMemcachedJumpHashSelector_PickServer(t *testing.T) {
 }
 
 func TestMemcachedJumpHashSelector_Each_ShouldRespectServersOrdering(t *testing.T) {
-	defer leaktest.CheckTimeout(t, 10*time.Second)()
-
 	tests := []struct {
 		input    []string
 		expected []string
@@ -123,8 +118,6 @@ func TestMemcachedJumpHashSelector_Each_ShouldRespectServersOrdering(t *testing.
 }
 
 func TestMemcachedJumpHashSelector_PickServer_ShouldEvenlyDistributeKeysToServers(t *testing.T) {
-	defer leaktest.CheckTimeout(t, 10*time.Second)()
-
 	servers := []string{"127.0.0.1:11211", "127.0.0.2:11211", "127.0.0.3:11211"}
 	selector := MemcachedJumpHashSelector{}
 	testutil.Ok(t, selector.SetServers(servers...))
@@ -151,8 +144,6 @@ func TestMemcachedJumpHashSelector_PickServer_ShouldEvenlyDistributeKeysToServer
 }
 
 func TestMemcachedJumpHashSelector_PickServer_ShouldUseConsistentHashing(t *testing.T) {
-	defer leaktest.CheckTimeout(t, 10*time.Second)()
-
 	servers := []string{
 		"127.0.0.1:11211",
 		"127.0.0.2:11211",
@@ -205,8 +196,6 @@ func TestMemcachedJumpHashSelector_PickServer_ShouldUseConsistentHashing(t *test
 }
 
 func TestMemcachedJumpHashSelector_PickServer_ShouldReturnErrNoServersOnNoServers(t *testing.T) {
-	defer leaktest.CheckTimeout(t, 10*time.Second)()
-
 	s := MemcachedJumpHashSelector{}
 	_, err := s.PickServer("foo")
 	testutil.Equals(t, memcache.ErrNoServers, err)

--- a/pkg/compact/downsample/aggr_test.go
+++ b/pkg/compact/downsample/aggr_test.go
@@ -5,16 +5,13 @@ package downsample
 
 import (
 	"testing"
-	"time"
 
-	"github.com/fortytw2/leaktest"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
+
 	"github.com/thanos-io/thanos/pkg/testutil"
 )
 
 func TestAggrChunk(t *testing.T) {
-	defer leaktest.CheckTimeout(t, 10*time.Second)()
-
 	var input [5][]sample
 
 	input[AggrCount] = []sample{{100, 30}, {200, 50}, {300, 60}, {400, 67}}

--- a/pkg/compact/downsample/downsample_test.go
+++ b/pkg/compact/downsample/downsample_test.go
@@ -10,9 +10,7 @@ import (
 	"path/filepath"
 	"sort"
 	"testing"
-	"time"
 
-	"github.com/fortytw2/leaktest"
 	"github.com/go-kit/kit/log"
 	"github.com/pkg/errors"
 	"github.com/prometheus/prometheus/pkg/labels"
@@ -23,13 +21,18 @@ import (
 	"github.com/prometheus/prometheus/tsdb/chunks"
 	"github.com/prometheus/prometheus/tsdb/index"
 	"github.com/prometheus/prometheus/tsdb/tombstones"
+	"go.uber.org/goleak"
+
 	"github.com/thanos-io/thanos/pkg/block"
 	"github.com/thanos-io/thanos/pkg/block/metadata"
 	"github.com/thanos-io/thanos/pkg/testutil"
 )
 
-func TestDownsampleCounterBoundaryReset(t *testing.T) {
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}
 
+func TestDownsampleCounterBoundaryReset(t *testing.T) {
 	toAggrChunks := func(t *testing.T, cm []chunks.Meta) (res []*AggrChunk) {
 		for i := range cm {
 			achk, ok := cm[i].Chunk.(*AggrChunk)
@@ -207,8 +210,6 @@ var (
 )
 
 func TestDownsample(t *testing.T) {
-	defer leaktest.CheckTimeout(t, 10*time.Second)()
-
 	type downsampleTestCase struct {
 		name string
 
@@ -594,8 +595,6 @@ var (
 )
 
 func TestApplyCounterResetsIterator(t *testing.T) {
-	defer leaktest.CheckTimeout(t, 10*time.Second)()
-
 	for _, tcase := range []struct {
 		name string
 

--- a/pkg/objstore/objtesting/foreach.go
+++ b/pkg/objstore/objtesting/foreach.go
@@ -74,7 +74,7 @@ func ForeachStore(t *testing.T, testFn func(t *testing.T, bkt objstore.Bucket)) 
 			t.Parallel()
 			defer closeFn()
 
-			// TODO(bwplotka): Add leaktest when https://github.com/GoogleCloudPlatform/google-cloud-go/issues/1025 is resolved.
+			// TODO(bwplotka): Add goleak when https://github.com/GoogleCloudPlatform/google-cloud-go/issues/1025 is resolved.
 			testFn(t, bkt)
 		})
 	}
@@ -89,8 +89,8 @@ func ForeachStore(t *testing.T, testFn func(t *testing.T, bkt objstore.Bucket)) 
 			t.Parallel()
 			defer closeFn()
 
-			// TODO(bwplotka): Add leaktest when we fix potential leak in minio library.
-			// We cannot use leaktest for detecting our own potential leaks, when leaktest detects leaks in minio itself.
+			// TODO(bwplotka): Add goleak when we fix potential leak in minio library.
+			// We cannot use goleak for detecting our own potential leaks, when goleak detects leaks in minio itself.
 			// This needs to be investigated more.
 
 			testFn(t, bkt)

--- a/pkg/query/internal/test-storeset-pre-v0.8.0/storeset_test.go
+++ b/pkg/query/internal/test-storeset-pre-v0.8.0/storeset_test.go
@@ -9,19 +9,17 @@ import (
 	"math"
 	"net"
 	"os"
+	"sort"
 	"testing"
 	"time"
 
-	"github.com/thanos-io/thanos/pkg/store"
-
-	"sort"
-
-	"github.com/fortytw2/leaktest"
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/log/level"
 	"github.com/thanos-io/thanos/pkg/component"
+	"github.com/thanos-io/thanos/pkg/store"
 	"github.com/thanos-io/thanos/pkg/store/storepb"
 	"github.com/thanos-io/thanos/pkg/testutil"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -124,9 +122,11 @@ func specsFromAddrFunc(addrs []string) func() []StoreSpec {
 	}
 }
 
-func TestPre0_8_0_StoreSet_AgainstNewStoreGW(t *testing.T) {
-	defer leaktest.CheckTimeout(t, 10*time.Second)()
+func TestMain(m *testing.M) {
+	testutil.TolerantVerifyLeakMain(m)
+}
 
+func TestPre0_8_0_StoreSet_AgainstNewStoreGW(t *testing.T) {
 	st, err := startTestStores([]testStoreMeta{
 		{
 			storeType: component.Sidecar,

--- a/pkg/query/querier_test.go
+++ b/pkg/query/querier_test.go
@@ -16,7 +16,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/fortytw2/leaktest"
 	"github.com/go-kit/kit/log"
 	"github.com/pkg/errors"
 	"github.com/prometheus/prometheus/pkg/gate"
@@ -39,7 +38,6 @@ type sample struct {
 }
 
 func TestQueryableCreator_MaxResolution(t *testing.T) {
-	t.Cleanup(leaktest.CheckTimeout(t, 10*time.Second))
 	testProxy := &storeServer{resps: []*storepb.SeriesResponse{}}
 	queryableCreator := NewQueryableCreator(nil, nil, testProxy, 2, 5*time.Second)
 
@@ -59,7 +57,6 @@ func TestQueryableCreator_MaxResolution(t *testing.T) {
 
 // Tests E2E how PromQL works with downsampled data.
 func TestQuerier_DownsampledData(t *testing.T) {
-	t.Cleanup(leaktest.CheckTimeout(t, 10*time.Second))
 	testProxy := &storeServer{
 		resps: []*storepb.SeriesResponse{
 			storeSeriesResponse(t, labels.FromStrings("__name__", "a", "zzz", "a", "aaa", "bbb"), []sample{{99, 1}, {199, 5}}),                   // Downsampled chunk from Store.
@@ -515,8 +512,6 @@ func TestQuerier_Select(t *testing.T) {
 
 				t.Run(fmt.Sprintf("dedup=%v", sc.dedup), func(t *testing.T) {
 					t.Run("querier.Select", func(t *testing.T) {
-						t.Cleanup(leaktest.CheckTimeout(t, 10*time.Second))
-
 						res := q.Select(false, tcase.hints, tcase.matchers...)
 						testSelectResponse(t, sc.expected, res)
 
@@ -528,8 +523,6 @@ func TestQuerier_Select(t *testing.T) {
 					})
 					// Integration test: Make sure the PromQL would select exactly the same.
 					t.Run("through PromQL with 100s step", func(t *testing.T) {
-						t.Cleanup(leaktest.CheckTimeout(t, 10*time.Second))
-
 						catcher := &querierResponseCatcher{t: t, Querier: q}
 						q, err := e.NewRangeQuery(&mockedQueryable{catcher}, tcase.equivalentQuery, timestamp.Time(tcase.mint), timestamp.Time(tcase.maxt), 100*time.Second)
 						testutil.Ok(t, err)
@@ -691,8 +684,6 @@ func TestQuerierWithDedupUnderstoodByPromQL_Rate(t *testing.T) {
 			MaxSamples: math.MaxInt64,
 		})
 		t.Run("Rate=5mStep=100s", func(t *testing.T) {
-			t.Cleanup(leaktest.CheckTimeout(t, 10*time.Second))
-
 			q, err := e.NewRangeQuery(&mockedQueryable{q}, `rate(gitlab_transaction_cache_read_hit_count_total[5m])`, timestamp.Time(realSeriesWithStaleMarkerMint).Add(5*time.Minute), timestamp.Time(realSeriesWithStaleMarkerMaxt), 100*time.Second)
 			testutil.Ok(t, err)
 
@@ -722,8 +713,6 @@ func TestQuerierWithDedupUnderstoodByPromQL_Rate(t *testing.T) {
 			}, vec)
 		})
 		t.Run("Rate=30mStep=500s", func(t *testing.T) {
-			t.Cleanup(leaktest.CheckTimeout(t, 10*time.Second))
-
 			q, err := e.NewRangeQuery(&mockedQueryable{q}, `rate(gitlab_transaction_cache_read_hit_count_total[30m])`, timestamp.Time(realSeriesWithStaleMarkerMint).Add(30*time.Minute), timestamp.Time(realSeriesWithStaleMarkerMaxt), 500*time.Second)
 			testutil.Ok(t, err)
 
@@ -765,8 +754,6 @@ func TestQuerierWithDedupUnderstoodByPromQL_Rate(t *testing.T) {
 			MaxSamples: math.MaxInt64,
 		})
 		t.Run("Rate=5mStep=100s", func(t *testing.T) {
-			t.Cleanup(leaktest.CheckTimeout(t, 10*time.Second))
-
 			q, err := e.NewRangeQuery(&mockedQueryable{q}, `rate(gitlab_transaction_cache_read_hit_count_total[5m])`, timestamp.Time(realSeriesWithStaleMarkerMint).Add(5*time.Minute), timestamp.Time(realSeriesWithStaleMarkerMaxt), 100*time.Second)
 			testutil.Ok(t, err)
 
@@ -791,8 +778,6 @@ func TestQuerierWithDedupUnderstoodByPromQL_Rate(t *testing.T) {
 			}, vec)
 		})
 		t.Run("Rate=30mStep=500s", func(t *testing.T) {
-			t.Cleanup(leaktest.CheckTimeout(t, 10*time.Second))
-
 			q, err := e.NewRangeQuery(&mockedQueryable{q}, `rate(gitlab_transaction_cache_read_hit_count_total[30m])`, timestamp.Time(realSeriesWithStaleMarkerMint).Add(30*time.Minute), timestamp.Time(realSeriesWithStaleMarkerMaxt), 500*time.Second)
 			testutil.Ok(t, err)
 
@@ -815,8 +800,6 @@ func TestQuerierWithDedupUnderstoodByPromQL_Rate(t *testing.T) {
 }
 
 func TestSortReplicaLabel(t *testing.T) {
-	t.Cleanup(leaktest.CheckTimeout(t, 10*time.Second))
-
 	tests := []struct {
 		input       []storepb.Series
 		exp         []storepb.Series
@@ -882,8 +865,6 @@ func expandSeries(t testing.TB, it chunkenc.Iterator) (res []sample) {
 }
 
 func TestDedupSeriesSet(t *testing.T) {
-	t.Cleanup(leaktest.CheckTimeout(t, 10*time.Second))
-
 	tests := []struct {
 		input       []series
 		exp         []series
@@ -1213,8 +1194,6 @@ func TestDedupSeriesSet(t *testing.T) {
 }
 
 func TestDedupSeriesIterator(t *testing.T) {
-	t.Cleanup(leaktest.CheckTimeout(t, 10*time.Second))
-
 	// The deltas between timestamps should be at least 10000 to not be affected
 	// by the initial penalty of 5000, that will cause the second iterator to seek
 	// ahead this far at least once.

--- a/pkg/query/query_test.go
+++ b/pkg/query/query_test.go
@@ -1,0 +1,14 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package query
+
+import (
+	"testing"
+
+	"github.com/thanos-io/thanos/pkg/testutil"
+)
+
+func TestMain(m *testing.M) {
+	testutil.TolerantVerifyLeakMain(m)
+}

--- a/pkg/query/storeset_test.go
+++ b/pkg/query/storeset_test.go
@@ -12,7 +12,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/fortytw2/leaktest"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -131,8 +130,6 @@ func (s *testStores) CloseOne(addr string) {
 }
 
 func TestStoreSet_Update(t *testing.T) {
-	defer leaktest.CheckTimeout(t, 10*time.Second)()
-
 	stores, err := startTestStores([]testStoreMeta{
 		{
 			storeType: component.Sidecar,
@@ -500,8 +497,6 @@ func TestStoreSet_Update(t *testing.T) {
 }
 
 func TestStoreSet_Update_NoneAvailable(t *testing.T) {
-	defer leaktest.CheckTimeout(t, 10*time.Second)()
-
 	st, err := startTestStores([]testStoreMeta{
 		{
 			extlsetFn: func(addr string) []storepb.LabelSet {
@@ -565,8 +560,6 @@ func TestStoreSet_Update_NoneAvailable(t *testing.T) {
 
 // TestQuerierStrict tests what happens when the strict mode is enabled/disabled.
 func TestQuerierStrict(t *testing.T) {
-	defer leaktest.CheckTimeout(t, 5*time.Second)()
-
 	st, err := startTestStores([]testStoreMeta{
 		{
 			minTime: 12345,
@@ -767,6 +760,7 @@ func TestStoreSet_Update_Rules(t *testing.T) {
 			testGRPCOpts, time.Minute)
 
 		t.Run(tc.name, func(t *testing.T) {
+			defer storeSet.Close()
 			storeSet.Update(context.Background())
 			testutil.Equals(t, tc.expectedStores, len(storeSet.stores))
 

--- a/pkg/receive/config.go
+++ b/pkg/receive/config.go
@@ -126,7 +126,7 @@ func NewConfigWatcher(logger log.Logger, reg prometheus.Registerer, path string,
 
 // Run starts the ConfigWatcher until the given context is canceled.
 func (cw *ConfigWatcher) Run(ctx context.Context) {
-	defer cw.stop()
+	defer cw.Stop()
 
 	cw.refresh(ctx)
 
@@ -238,8 +238,8 @@ func (cw *ConfigWatcher) refresh(ctx context.Context) {
 	}
 }
 
-// stop shuts down the config watcher.
-func (cw *ConfigWatcher) stop() {
+// Stop shuts down the config watcher.
+func (cw *ConfigWatcher) Stop() {
 	level.Debug(cw.logger).Log("msg", "stopping hashring configuration watcher...", "path", cw.path)
 
 	done := make(chan struct{})

--- a/pkg/receive/handler_test.go
+++ b/pkg/receive/handler_test.go
@@ -15,7 +15,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/fortytw2/leaktest"
 	"github.com/go-kit/kit/log"
 	"github.com/gogo/protobuf/proto"
 	"github.com/golang/snappy"
@@ -23,9 +22,10 @@ import (
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/storage"
 	terrors "github.com/prometheus/prometheus/tsdb/errors"
+	"google.golang.org/grpc"
+
 	"github.com/thanos-io/thanos/pkg/store/storepb"
 	"github.com/thanos-io/thanos/pkg/store/storepb/prompb"
-	"google.golang.org/grpc"
 )
 
 func TestCountCause(t *testing.T) {
@@ -183,7 +183,6 @@ func newHandlerHashring(appendables []*fakeAppendable, replicationFactor uint64)
 }
 
 func TestReceiveQuorum(t *testing.T) {
-	defer leaktest.CheckTimeout(t, 10*time.Second)()
 	appenderErrFn := func() error { return errors.New("failed to get appender") }
 	conflictErrFn := func() error { return storage.ErrOutOfBounds }
 	commitErrFn := func() error { return errors.New("failed to commit") }
@@ -520,7 +519,6 @@ func TestReceiveQuorum(t *testing.T) {
 }
 
 func TestReceiveWithConsistencyDelay(t *testing.T) {
-	defer leaktest.CheckTimeout(t, 10*time.Second)()
 	appenderErrFn := func() error { return errors.New("failed to get appender") }
 	conflictErrFn := func() error { return storage.ErrOutOfBounds }
 	commitErrFn := func() error { return errors.New("failed to commit") }

--- a/pkg/receive/multitsdb_test.go
+++ b/pkg/receive/multitsdb_test.go
@@ -10,21 +10,20 @@ import (
 	"testing"
 	"time"
 
-	"github.com/fortytw2/leaktest"
 	"github.com/go-kit/kit/log"
 	"github.com/gogo/protobuf/types"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb"
+	"golang.org/x/sync/errgroup"
+
 	"github.com/thanos-io/thanos/pkg/runutil"
 	"github.com/thanos-io/thanos/pkg/store/storepb"
 	"github.com/thanos-io/thanos/pkg/testutil"
-	"golang.org/x/sync/errgroup"
 )
 
 func TestMultiTSDB(t *testing.T) {
-	defer leaktest.CheckTimeout(t, 10*time.Second)()
 	dir, err := ioutil.TempDir("", "test")
 	testutil.Ok(t, err)
 	defer func() { testutil.Ok(t, os.RemoveAll(dir)) }()

--- a/pkg/receive/receive_test.go
+++ b/pkg/receive/receive_test.go
@@ -1,0 +1,14 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package receive
+
+import (
+	"testing"
+
+	"github.com/thanos-io/thanos/pkg/testutil"
+)
+
+func TestMain(m *testing.M) {
+	testutil.TolerantVerifyLeakMain(m)
+}

--- a/pkg/reloader/reloader_test.go
+++ b/pkg/reloader/reloader_test.go
@@ -18,14 +18,17 @@ import (
 	"testing"
 	"time"
 
-	"github.com/fortytw2/leaktest"
-	"github.com/thanos-io/thanos/pkg/testutil"
 	"go.uber.org/atomic"
+	"go.uber.org/goleak"
+
+	"github.com/thanos-io/thanos/pkg/testutil"
 )
 
-func TestReloader_ConfigApply(t *testing.T) {
-	defer leaktest.CheckTimeout(t, 10*time.Second)()
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}
 
+func TestReloader_ConfigApply(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
 	defer cancel()
 
@@ -159,8 +162,6 @@ config:
 }
 
 func TestReloader_RuleApply(t *testing.T) {
-	defer leaktest.CheckTimeout(t, 10*time.Second)()
-
 	l, err := net.Listen("tcp", "localhost:0")
 	testutil.Ok(t, err)
 

--- a/pkg/rules/prometheus_test.go
+++ b/pkg/rules/prometheus_test.go
@@ -9,18 +9,15 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
-	"github.com/fortytw2/leaktest"
 	"github.com/prometheus/prometheus/pkg/labels"
+
 	"github.com/thanos-io/thanos/pkg/promclient"
 	"github.com/thanos-io/thanos/pkg/testutil"
 	"github.com/thanos-io/thanos/pkg/testutil/e2eutil"
 )
 
 func TestPrometheus_Rules_e2e(t *testing.T) {
-	defer leaktest.CheckTimeout(t, 10*time.Second)()
-
 	p, err := e2eutil.NewPrometheus()
 	testutil.Ok(t, err)
 	defer func() { testutil.Ok(t, p.Stop()) }()

--- a/pkg/rules/rules_test.go
+++ b/pkg/rules/rules_test.go
@@ -18,6 +18,10 @@ import (
 	"github.com/thanos-io/thanos/pkg/testutil"
 )
 
+func TestMain(m *testing.M) {
+	testutil.TolerantVerifyLeakMain(m)
+}
+
 // testRulesAgainstExamples tests against alerts.yaml and rules.yaml examples.
 func testRulesAgainstExamples(t *testing.T, dir string, server rulespb.RulesServer) {
 	t.Helper()

--- a/pkg/store/cache/cache_test.go
+++ b/pkg/store/cache/cache_test.go
@@ -13,8 +13,13 @@ import (
 	"github.com/oklog/ulid"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/thanos-io/thanos/pkg/testutil"
+	"go.uber.org/goleak"
 	"golang.org/x/crypto/blake2b"
 )
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}
 
 func TestCacheKey_string(t *testing.T) {
 	t.Parallel()

--- a/pkg/store/cache/inmemory_test.go
+++ b/pkg/store/cache/inmemory_test.go
@@ -10,9 +10,7 @@ import (
 	"fmt"
 	"math"
 	"testing"
-	"time"
 
-	"github.com/fortytw2/leaktest"
 	"github.com/go-kit/kit/log"
 	"github.com/hashicorp/golang-lru/simplelru"
 	"github.com/oklog/ulid"
@@ -23,8 +21,6 @@ import (
 )
 
 func TestNewInMemoryIndexCache(t *testing.T) {
-	defer leaktest.CheckTimeout(t, 10*time.Second)()
-
 	// Should return error on invalid YAML config.
 	conf := []byte("invalid")
 	cache, err := NewInMemoryIndexCache(log.NewNopLogger(), nil, conf)
@@ -51,8 +47,6 @@ max_item_size: 2KB
 }
 
 func TestInMemoryIndexCache_AvoidsDeadlock(t *testing.T) {
-	defer leaktest.CheckTimeout(t, 10*time.Second)()
-
 	metrics := prometheus.NewRegistry()
 	cache, err := NewInMemoryIndexCacheWithConfig(log.NewNopLogger(), metrics, InMemoryIndexCacheConfig{
 		MaxItemSize: sliceHeaderSize + 5,
@@ -85,8 +79,6 @@ func TestInMemoryIndexCache_AvoidsDeadlock(t *testing.T) {
 }
 
 func TestInMemoryIndexCache_UpdateItem(t *testing.T) {
-	defer leaktest.CheckTimeout(t, 10*time.Second)()
-
 	const maxSize = 2 * (sliceHeaderSize + 1)
 
 	var errorLogs []string
@@ -190,8 +182,6 @@ func TestInMemoryIndexCache_UpdateItem(t *testing.T) {
 
 // This should not happen as we hardcode math.MaxInt, but we still add test to check this out.
 func TestInMemoryIndexCache_MaxNumberOfItemsHit(t *testing.T) {
-	defer leaktest.CheckTimeout(t, 10*time.Second)()
-
 	metrics := prometheus.NewRegistry()
 	cache, err := NewInMemoryIndexCacheWithConfig(log.NewNopLogger(), metrics, InMemoryIndexCacheConfig{
 		MaxItemSize: 2*sliceHeaderSize + 10,
@@ -224,8 +214,6 @@ func TestInMemoryIndexCache_MaxNumberOfItemsHit(t *testing.T) {
 }
 
 func TestInMemoryIndexCache_Eviction_WithMetrics(t *testing.T) {
-	defer leaktest.CheckTimeout(t, 10*time.Second)()
-
 	metrics := prometheus.NewRegistry()
 	cache, err := NewInMemoryIndexCacheWithConfig(log.NewNopLogger(), metrics, InMemoryIndexCacheConfig{
 		MaxItemSize: 2*sliceHeaderSize + 5,

--- a/pkg/store/cache/memcached_test.go
+++ b/pkg/store/cache/memcached_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/fortytw2/leaktest"
 	"github.com/go-kit/kit/log"
 	"github.com/oklog/ulid"
 	"github.com/pkg/errors"
@@ -110,7 +109,6 @@ func TestMemcachedIndexCache_FetchMultiPostings(t *testing.T) {
 
 func TestMemcachedIndexCache_FetchMultiSeries(t *testing.T) {
 	t.Parallel()
-	defer leaktest.CheckTimeout(t, 10*time.Second)()
 
 	// Init some data to conveniently define test cases later one.
 	block1 := ulid.MustNew(1, nil)

--- a/pkg/store/prometheus_test.go
+++ b/pkg/store/prometheus_test.go
@@ -11,12 +11,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/fortytw2/leaktest"
 	"github.com/pkg/errors"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/pkg/timestamp"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
+
 	"github.com/thanos-io/thanos/pkg/component"
 	"github.com/thanos-io/thanos/pkg/promclient"
 	"github.com/thanos-io/thanos/pkg/store/storepb"
@@ -37,7 +37,7 @@ func TestPrometheusStore_Series_promOnPath_e2e(t *testing.T) {
 func testPrometheusStoreSeriesE2e(t *testing.T, prefix string) {
 	t.Helper()
 
-	defer leaktest.CheckTimeout(t, 10*time.Second)()
+	defer testutil.TolerantVerifyLeak(t)
 
 	p, err := e2eutil.NewPrometheusOnPath(prefix)
 	testutil.Ok(t, err)
@@ -171,7 +171,7 @@ func getExternalLabels() labels.Labels {
 func TestPrometheusStore_SeriesLabels_e2e(t *testing.T) {
 	t.Helper()
 
-	defer leaktest.CheckTimeout(t, 10*time.Second)()
+	defer testutil.TolerantVerifyLeak(t)
 
 	p, err := e2eutil.NewPrometheus()
 	testutil.Ok(t, err)
@@ -351,8 +351,9 @@ func TestPrometheusStore_SeriesLabels_e2e(t *testing.T) {
 		})
 	}
 }
+
 func TestPrometheusStore_LabelNames_e2e(t *testing.T) {
-	defer leaktest.CheckTimeout(t, 10*time.Second)()
+	defer testutil.TolerantVerifyLeak(t)
 
 	p, err := e2eutil.NewPrometheus()
 	testutil.Ok(t, err)
@@ -397,7 +398,7 @@ func TestPrometheusStore_LabelNames_e2e(t *testing.T) {
 }
 
 func TestPrometheusStore_LabelValues_e2e(t *testing.T) {
-	defer leaktest.CheckTimeout(t, 10*time.Second)()
+	defer testutil.TolerantVerifyLeak(t)
 
 	p, err := e2eutil.NewPrometheus()
 	testutil.Ok(t, err)
@@ -445,7 +446,7 @@ func TestPrometheusStore_LabelValues_e2e(t *testing.T) {
 
 // Test to check external label values retrieve.
 func TestPrometheusStore_ExternalLabelValues_e2e(t *testing.T) {
-	defer leaktest.CheckTimeout(t, 10*time.Second)()
+	defer testutil.TolerantVerifyLeak(t)
 
 	p, err := e2eutil.NewPrometheus()
 	testutil.Ok(t, err)
@@ -485,7 +486,7 @@ func TestPrometheusStore_ExternalLabelValues_e2e(t *testing.T) {
 }
 
 func TestPrometheusStore_Series_MatchExternalLabel_e2e(t *testing.T) {
-	defer leaktest.CheckTimeout(t, 10*time.Second)()
+	defer testutil.TolerantVerifyLeak(t)
 
 	p, err := e2eutil.NewPrometheus()
 	testutil.Ok(t, err)
@@ -550,7 +551,7 @@ func TestPrometheusStore_Series_MatchExternalLabel_e2e(t *testing.T) {
 }
 
 func TestPrometheusStore_Info(t *testing.T) {
-	defer leaktest.CheckTimeout(t, 10*time.Second)()
+	defer testutil.TolerantVerifyLeak(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -621,7 +622,7 @@ func testSeries_SplitSamplesIntoChunksWithMaxSizeOf120(t *testing.T, appender st
 
 // Regression test for https://github.com/thanos-io/thanos/issues/396.
 func TestPrometheusStore_Series_SplitSamplesIntoChunksWithMaxSizeOf120(t *testing.T) {
-	defer leaktest.CheckTimeout(t, 10*time.Second)()
+	defer testutil.TolerantVerifyLeak(t)
 
 	p, err := e2eutil.NewPrometheus()
 	testutil.Ok(t, err)
@@ -643,12 +644,4 @@ func TestPrometheusStore_Series_SplitSamplesIntoChunksWithMaxSizeOf120(t *testin
 
 		return proxy
 	})
-}
-
-func TestRuleGroupToProto(t *testing.T) {
-
-}
-
-func TestRuleGroupFromProto(t *testing.T) {
-
 }

--- a/pkg/store/proxy_test.go
+++ b/pkg/store/proxy_test.go
@@ -15,7 +15,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/fortytw2/leaktest"
 	"github.com/go-kit/kit/log"
 	"github.com/gogo/protobuf/proto"
 	"github.com/gogo/protobuf/types"
@@ -23,13 +22,14 @@ import (
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/pkg/timestamp"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
 	"github.com/thanos-io/thanos/pkg/component"
 	"github.com/thanos-io/thanos/pkg/store/storepb"
 	storetestutil "github.com/thanos-io/thanos/pkg/store/storepb/testutil"
 	"github.com/thanos-io/thanos/pkg/testutil"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 type testClient struct {
@@ -58,7 +58,7 @@ func (c testClient) Addr() string {
 }
 
 func TestProxyStore_Info(t *testing.T) {
-	defer leaktest.CheckTimeout(t, 10*time.Second)()
+	defer testutil.TolerantVerifyLeak(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -79,7 +79,7 @@ func TestProxyStore_Info(t *testing.T) {
 }
 
 func TestProxyStore_Series(t *testing.T) {
-	defer leaktest.CheckTimeout(t, 10*time.Second)()
+	defer testutil.TolerantVerifyLeak(t)
 
 	for _, tc := range []struct {
 		title          string
@@ -452,7 +452,7 @@ func TestProxyStore_SeriesSlowStores(t *testing.T) {
 		t.Skip("enable THANOS_ENABLE_STORE_READ_TIMEOUT_TESTS to run store-read-timeout tests")
 	}
 
-	defer leaktest.CheckTimeout(t, 20*time.Second)()
+	defer testutil.TolerantVerifyLeak(t)
 
 	for _, tc := range []struct {
 		title          string
@@ -973,7 +973,7 @@ func TestProxyStore_SeriesSlowStores(t *testing.T) {
 }
 
 func TestProxyStore_Series_RequestParamsProxied(t *testing.T) {
-	defer leaktest.CheckTimeout(t, 10*time.Second)()
+	defer testutil.TolerantVerifyLeak(t)
 
 	m := &mockedStoreAPI{
 		RespSeries: []*storepb.SeriesResponse{
@@ -1016,7 +1016,7 @@ func TestProxyStore_Series_RequestParamsProxied(t *testing.T) {
 }
 
 func TestProxyStore_Series_RegressionFillResponseChannel(t *testing.T) {
-	defer leaktest.CheckTimeout(t, 10*time.Second)()
+	defer testutil.TolerantVerifyLeak(t)
 
 	var cls []Client
 	for i := 0; i < 10; i++ {
@@ -1071,7 +1071,7 @@ func TestProxyStore_Series_RegressionFillResponseChannel(t *testing.T) {
 }
 
 func TestProxyStore_LabelValues(t *testing.T) {
-	defer leaktest.CheckTimeout(t, 10*time.Second)()
+	defer testutil.TolerantVerifyLeak(t)
 
 	m1 := &mockedStoreAPI{
 		RespLabelValues: &storepb.LabelValuesResponse{
@@ -1111,7 +1111,7 @@ func TestProxyStore_LabelValues(t *testing.T) {
 }
 
 func TestProxyStore_LabelNames(t *testing.T) {
-	defer leaktest.CheckTimeout(t, 10*time.Second)()
+	defer testutil.TolerantVerifyLeak(t)
 
 	for _, tc := range []struct {
 		title     string
@@ -1225,6 +1225,8 @@ func TestProxyStore_LabelNames(t *testing.T) {
 }
 
 func TestProxyStore_storeMatch(t *testing.T) {
+	defer testutil.TolerantVerifyLeak(t)
+
 	storeAPIs := []Client{
 		&testClient{
 			StoreClient: &mockedStoreAPI{
@@ -1310,8 +1312,6 @@ func seriesEquals(t *testing.T, expected []rawSeries, got []storepb.Series) {
 }
 
 func TestStoreMatches(t *testing.T) {
-	defer leaktest.CheckTimeout(t, 10*time.Second)()
-
 	cases := []struct {
 		s          Client
 		mint, maxt int64
@@ -1718,7 +1718,7 @@ func benchProxySeries(t testutil.TB, totalSamples, totalSeries int) {
 }
 
 func TestProxyStore_NotLeakingOnPrematureFinish(t *testing.T) {
-	defer leaktest.CheckTimeout(t, 10*time.Second)()
+	defer testutil.TolerantVerifyLeak(t)
 
 	clients := []Client{
 		&testClient{

--- a/pkg/store/tsdb_test.go
+++ b/pkg/store/tsdb_test.go
@@ -9,9 +9,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/fortytw2/leaktest"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/pkg/timestamp"
+
 	"github.com/thanos-io/thanos/pkg/component"
 	"github.com/thanos-io/thanos/pkg/store/storepb"
 	"github.com/thanos-io/thanos/pkg/testutil"
@@ -19,7 +19,7 @@ import (
 )
 
 func TestTSDBStore_Info(t *testing.T) {
-	defer leaktest.CheckTimeout(t, 10*time.Second)()
+	defer testutil.TolerantVerifyLeak(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -53,7 +53,7 @@ func TestTSDBStore_Info(t *testing.T) {
 }
 
 func TestTSDBStore_Series(t *testing.T) {
-	defer leaktest.CheckTimeout(t, 10*time.Second)()
+	defer testutil.TolerantVerifyLeak(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -178,9 +178,9 @@ func TestTSDBStore_Series(t *testing.T) {
 }
 
 func TestTSDBStore_LabelNames(t *testing.T) {
-	var err error
-	defer leaktest.CheckTimeout(t, 10*time.Second)()
+	defer testutil.TolerantVerifyLeak(t)
 
+	var err error
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -284,9 +284,9 @@ func TestTSDBStore_LabelNames(t *testing.T) {
 }
 
 func TestTSDBStore_LabelValues(t *testing.T) {
-	var err error
-	defer leaktest.CheckTimeout(t, 10*time.Second)()
+	defer testutil.TolerantVerifyLeak(t)
 
+	var err error
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -383,7 +383,7 @@ func TestTSDBStore_LabelValues(t *testing.T) {
 
 // Regression test for https://github.com/thanos-io/thanos/issues/1038.
 func TestTSDBStore_Series_SplitSamplesIntoChunksWithMaxSizeOf120(t *testing.T) {
-	defer leaktest.CheckTimeout(t, 10*time.Second)()
+	defer testutil.TolerantVerifyLeak(t)
 
 	db, err := e2eutil.NewTSDB()
 	defer func() { testutil.Ok(t, db.Close()) }()

--- a/pkg/testutil/testutil.go
+++ b/pkg/testutil/testutil.go
@@ -14,6 +14,7 @@ import (
 	"github.com/pmezard/go-difflib/difflib"
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
+	"go.uber.org/goleak"
 )
 
 // Assert fails the test if the condition is false.
@@ -151,4 +152,28 @@ func GatherAndCompare(t *testing.T, g1 prometheus.Gatherer, g2 prometheus.Gather
 		}
 	}
 	Equals(t, m1.String(), m2.String())
+}
+
+// TolerantVerifyLeakMain verifies go leaks but excludes the go routines that are
+// launched as side effects of some of our dependencies.
+func TolerantVerifyLeakMain(m *testing.M) {
+	goleak.VerifyTestMain(m,
+		// https://github.com/census-instrumentation/opencensus-go/blob/d7677d6af5953e0506ac4c08f349c62b917a443a/stats/view/worker.go#L34
+		goleak.IgnoreTopFunction("go.opencensus.io/stats/view.(*worker).start"),
+		// https://github.com/kubernetes/klog/blob/c85d02d1c76a9ebafa81eb6d35c980734f2c4727/klog.go#L417
+		goleak.IgnoreTopFunction("k8s.io/klog/v2.(*loggingT).flushDaemon"),
+		goleak.IgnoreTopFunction("k8s.io/klog.(*loggingT).flushDaemon"),
+	)
+}
+
+// TolerantVerifyLeak verifies go leaks but excludes the go routines that are
+// launched as side effects of some of our dependencies.
+func TolerantVerifyLeak(t *testing.T) {
+	goleak.VerifyNone(t,
+		// https://github.com/census-instrumentation/opencensus-go/blob/d7677d6af5953e0506ac4c08f349c62b917a443a/stats/view/worker.go#L34
+		goleak.IgnoreTopFunction("go.opencensus.io/stats/view.(*worker).start"),
+		// https://github.com/kubernetes/klog/blob/c85d02d1c76a9ebafa81eb6d35c980734f2c4727/klog.go#L417
+		goleak.IgnoreTopFunction("k8s.io/klog/v2.(*loggingT).flushDaemon"),
+		goleak.IgnoreTopFunction("k8s.io/klog.(*loggingT).flushDaemon"),
+	)
 }

--- a/pkg/tracing/stackdriver/tracer_test.go
+++ b/pkg/tracing/stackdriver/tracer_test.go
@@ -9,20 +9,20 @@ package stackdriver
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/thanos-io/thanos/pkg/testutil"
 	"github.com/thanos-io/thanos/pkg/tracing"
 
-	"github.com/fortytw2/leaktest"
 	"github.com/opentracing/basictracer-go"
 )
+
+func TestMain(m *testing.M) {
+	testutil.TolerantVerifyLeakMain(m)
+}
 
 // This test shows that if sample factor will enable tracing on client process, even when it would be disabled on server
 // it will be still enabled for all spans within this span.
 func TestContextTracing_ClientEnablesTracing(t *testing.T) {
-	defer leaktest.CheckTimeout(t, 10*time.Second)()
-
 	m := &basictracer.InMemorySpanRecorder{}
 	r := &forceRecorder{wrapped: m}
 


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

Fixes: #3023
Replaced leaktest with goleak library.
Exposed [stop method](https://github.com/thanos-io/thanos/pull/3029/files#diff-2f6756629a1dc79c6131d406178ec0b4R242) in config watcher to correctly shut it down in case of invalid configuration.
Thanos still has goroutine leaks in storage tests with cloud providers, that's why I didn't use `VerifyTestMain` everywhere as it resulted in failed `block` and `store` tests ([see the pipeline](https://app.circleci.com/pipelines/github/thanos-io/thanos/2853/workflows/6f7cf06e-83cc-4e32-a24c-dfa3fa511f1d/jobs/11097)).
I found that [this issue](https://github.com/googleapis/google-cloud-go/issues/1025) was closed, but the `gcs` code was not adjusted. It seems that idle connections should be idle for a while for performance reasons and it is in general ok.
Also for the reference see [this issue](https://github.com/thanos-io/thanos/issues/234).
Goleak allows to exclude top functions, so `internal/poll.runtime_pollWait` might be added to the list of ignored functions, but it might hide real problems in other tests. 


## Verification

<!-- How you tested it? How do you know it works? -->
