### PR TITLE
Add instrumentation middlewares to query frontend

### DIFF
--- a/docs/components/query-frontend.md
+++ b/docs/components/query-frontend.md
@@ -125,5 +125,12 @@ Flags:
                               Log queries that are slower than the specified
                               duration. Set to 0 to disable. Set to < 0 to
                               enable on all queries.
+      --log.request.decision=LogFinishCall
+                              Request Logging for logging the start and end of
+                              requests. LogFinishCall is enabled by default.
+                              LogFinishCall : Logs the finish call of the
+                              requests. LogStartAndFinishCall : Logs the start
+                              and finish call of the requests. NoLogCall :
+                              Disable request logging.
 
 ```


### PR DESCRIPTION
Signed-off-by: Ben Ye <yb532204897@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

This pr adds instrument middleware to query frontend handler, including logging and tracing.

The tracing middleware is important because we don't have a start span before query range tripperware. So range query starts from step_align span and there are no spans for other queries.



## Verification

<!-- How you tested it? How do you know it works? -->

Before

![Screenshot from 2020-08-13 12-56-23](https://user-images.githubusercontent.com/25150124/90163712-75244200-dd64-11ea-8b9e-246aa45df618.png)

After

Query parameters are also logged in the first span.

![Screenshot from 2020-08-13 12-58-10](https://user-images.githubusercontent.com/25150124/90163889-b157a280-dd64-11ea-99f0-e7f1c33089f4.png)

Other queries are also working.

![Screenshot from 2020-08-13 12-59-40](https://user-images.githubusercontent.com/25150124/90164033-e19f4100-dd64-11ea-96e4-cec0138835b1.png)
