### PR TITLE
Add more validations for memcached client config

### DIFF
--- a/pkg/cacheutil/memcached_client.go
+++ b/pkg/cacheutil/memcached_client.go
@@ -38,8 +38,10 @@ const (
 )
 
 var (
-	errMemcachedAsyncBufferFull = errors.New("the async buffer is full")
-	errMemcachedConfigNoAddrs   = errors.New("no memcached addresses provided")
+	errMemcachedAsyncBufferFull                = errors.New("the async buffer is full")
+	errMemcachedConfigNoAddrs                  = errors.New("no memcached addresses provided")
+	errMemcachedDNSUpdateIntervalNotPositive   = errors.New("dns_provider_update_interval must be positive")
+	errMemcachedMaxAsyncConcurrencyNotPositive = errors.New("max_async_concurrency must be positive")
 
 	defaultMemcachedClientConfig = MemcachedClientConfig{
 		Timeout:                   500 * time.Millisecond,
@@ -118,6 +120,16 @@ type MemcachedClientConfig struct {
 func (c *MemcachedClientConfig) validate() error {
 	if len(c.Addresses) == 0 {
 		return errMemcachedConfigNoAddrs
+	}
+
+	// Avoid panic in time ticker.
+	if c.DNSProviderUpdateInterval <= 0 {
+		return errMemcachedDNSUpdateIntervalNotPositive
+	}
+
+	// Set async only available when MaxAsyncConcurrency > 0.
+	if c.MaxAsyncConcurrency <= 0 {
+		return errMemcachedMaxAsyncConcurrencyNotPositive
 	}
 
 	return nil

--- a/pkg/cacheutil/memcached_client.go
+++ b/pkg/cacheutil/memcached_client.go
@@ -40,8 +40,8 @@ const (
 var (
 	errMemcachedAsyncBufferFull                = errors.New("the async buffer is full")
 	errMemcachedConfigNoAddrs                  = errors.New("no memcached addresses provided")
-	errMemcachedDNSUpdateIntervalNotPositive   = errors.New("dns_provider_update_interval must be positive")
-	errMemcachedMaxAsyncConcurrencyNotPositive = errors.New("max_async_concurrency must be positive")
+	errMemcachedDNSUpdateIntervalNotPositive   = errors.New("DNS provider update interval must be positive")
+	errMemcachedMaxAsyncConcurrencyNotPositive = errors.New("max async concurrency must be positive")
 
 	defaultMemcachedClientConfig = MemcachedClientConfig{
 		Timeout:                   500 * time.Millisecond,

--- a/pkg/cacheutil/memcached_client_test.go
+++ b/pkg/cacheutil/memcached_client_test.go
@@ -27,15 +27,34 @@ func TestMemcachedClientConfig_validate(t *testing.T) {
 	}{
 		"should pass on valid config": {
 			config: MemcachedClientConfig{
-				Addresses: []string{"127.0.0.1:11211"},
+				Addresses:                 []string{"127.0.0.1:11211"},
+				MaxAsyncConcurrency:       1,
+				DNSProviderUpdateInterval: time.Second,
 			},
 			expected: nil,
 		},
 		"should fail on no addresses": {
 			config: MemcachedClientConfig{
-				Addresses: []string{},
+				Addresses:                 []string{},
+				MaxAsyncConcurrency:       1,
+				DNSProviderUpdateInterval: time.Second,
 			},
 			expected: errMemcachedConfigNoAddrs,
+		},
+		"should fail on max_async_concurrency <= 0": {
+			config: MemcachedClientConfig{
+				Addresses:                 []string{"127.0.0.1:11211"},
+				MaxAsyncConcurrency:       0,
+				DNSProviderUpdateInterval: time.Second,
+			},
+			expected: errMemcachedMaxAsyncConcurrencyNotPositive,
+		},
+		"should fail on dns_provider_update_interval <= 0": {
+			config: MemcachedClientConfig{
+				Addresses:           []string{"127.0.0.1:11211"},
+				MaxAsyncConcurrency: 1,
+			},
+			expected: errMemcachedDNSUpdateIntervalNotPositive,
 		},
 	}
 


### PR DESCRIPTION
Signed-off-by: Ben Ye <yb532204897@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

Add two more validations to Memcached client config.

1. If `dns_provider_update_interval` <= 0, it will panic in https://github.com/thanos-io/thanos/blob/master/pkg/cacheutil/memcached_client.go#L525.

2. if `max_async_concurrency` <= 0, `SetAsync` never works.

## Verification

<!-- How you tested it? How do you know it works? -->
