### PR TITLE
ui: Fix "too many redirects" when using query frontend

### DIFF
--- a/pkg/ui/query.go
+++ b/pkg/ui/query.go
@@ -84,7 +84,7 @@ func (q *Query) Register(r *route.Router, ins extpromhttp.InstrumentationMiddlew
 	// and which breaks users with a --web.route-prefix that deviates from the path derived
 	// from the external URL.
 	r.Get("/new", func(w http.ResponseWriter, r *http.Request) {
-		http.Redirect(w, r, path.Join(GetWebPrefix(q.logger, q.externalPrefix, q.prefixHeader, r), "new")+"/", http.StatusFound)
+		http.Redirect(w, r, path.Join(GetWebPrefix(q.logger, q.externalPrefix, q.prefixHeader, r), "new")+"/graph", http.StatusFound)
 	})
 	r.Get("/new/*filepath", instrf("react-static", q.serveReactUI))
 


### PR DESCRIPTION
Signed-off-by: Prem Kumar <prmsrswt@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes
Fixes #3043 

When using the UI via `query-frontend` we were getting redirected from `/new/` to `/new/` itself, which causes an infinite loop.
We had a redirect from `/new` to `/new/` (notice the trailing slash) and I suspect this the reason why we are getting this problem. The Query Frontend passes all requests other than `query_range` directly to upstream but I think that it is removing the trailing slash somehow. So when we request `/new/` the query frontend requests `/new` from upstream and get a 302 Redirection from upstream for `/new/` resulting in an infinite loop.

## Verification
Tested locally.
