### PR TITLE
Adds SSE-KMS and SSE-C config to S3 Objstore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 - [#2976](https://github.com/thanos-io/thanos/pull/2976) Query: Better rounding for incoming query timestamps.
 - [#2929](https://github.com/thanos-io/thanos/pull/2929) Mixin: Fix expression for 'unhealthy sidecar' alert and also increase the timeout for 10 minutes.
 - [#3024](https://github.com/thanos-io/thanos/pull/3024) Query: consider group name and file for deduplication
-- [#3064](https://github.com/thanos-io/thanos/pull/3064) s3: Add SSE/SSE-KMS/SSE-C configuration 
+- [#3064](https://github.com/thanos-io/thanos/pull/3064) s3: Add SSE/SSE-KMS/SSE-C configuration
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 - [#2976](https://github.com/thanos-io/thanos/pull/2976) Query: Better rounding for incoming query timestamps.
 - [#2929](https://github.com/thanos-io/thanos/pull/2929) Mixin: Fix expression for 'unhealthy sidecar' alert and also increase the timeout for 10 minutes.
 - [#3024](https://github.com/thanos-io/thanos/pull/3024) Query: consider group name and file for deduplication
+- [#3064](https://github.com/thanos-io/thanos/pull/3064) s3: Add SSE/SSE-KMS/SSE-C configuration 
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 
 :warning: **WARNING** :warning: Thanos Rule's `/api/v1/rules` endpoint no longer returns the old, deprecated `partial_response_strategy`. The old, deprecated value has been fixed to `WARN` for quite some time. _Please_ use `partialResponseStrategy`.
 
+:warning: **WARNING** :warning: The `sse_encryption` value is now deprecated in favour of `sse_config`. If you used `sse_encryption`, the migration strategy is to set up the following block:
+
+```yaml
+
+---
+sse_config:
+  type: SSE-S3
+```
+
+
 ### Fixed
 
 - [#2937](https://github.com/thanos-io/thanos/pull/2937) Receive: Fixing auto-configuration of --receive.local-endpoint
@@ -29,7 +39,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 - [#2976](https://github.com/thanos-io/thanos/pull/2976) Query: Better rounding for incoming query timestamps.
 - [#2929](https://github.com/thanos-io/thanos/pull/2929) Mixin: Fix expression for 'unhealthy sidecar' alert and also increase the timeout for 10 minutes.
 - [#3024](https://github.com/thanos-io/thanos/pull/3024) Query: consider group name and file for deduplication
-- [#3064](https://github.com/thanos-io/thanos/pull/3064) s3: Add SSE/SSE-KMS/SSE-C configuration
+- [#3064](https://github.com/thanos-io/thanos/pull/3064) s3: Add SSE/SSE-KMS/SSE-C configuration.
 
 ### Added
 

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -86,6 +86,11 @@ config:
   encrypt_sse: false
   secret_key: ""
   put_user_metadata: {}
+  sse_config:
+    enabled: false
+    kms_key_id: ""
+    kms_encryption_context: {}
+    encryption_key: ""
   http_config:
     idle_conn_timeout: 1m30s
     response_header_timeout: 2m
@@ -114,6 +119,18 @@ For debug and testing purposes you can set
 * `http_config.insecure_skip_verify: true` to disable TLS certificate verification (if your S3 based storage is using a self-signed certificate, for example)
 
 * `trace.enable: true` to enable the minio client's verbose logging. Each request and response will be logged into the debug logger, so debug level logging must be enabled for this functionality.
+
+#### S3 Server-Side Encryption
+
+SSE can be configued using the `sse_config`. [SSE-S3](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingServerSideEncryption.html), [SSE-KMS](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html), and [SSE-C](https://docs.aws.amazon.com/AmazonS3/latest/dev/ServerSideEncryptionCustomerKeys.html) are supported.
+
+The following combinations are allowed:
+* If `enabled` is set to `true` but nothing else is set, we default to using [SSE-S3](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingServerSideEncryption.html).
+* If `kms_key_id` is set, [SSE-KMS](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html) is used, and the objects that Thanos uploads will be encrypted using that key.
+* If `kms_encryption_context` is set with `kms_key_id`, you will add an [encryption context](https://docs.aws.amazon.com/kms/latest/developerguide/services-s3.html#s3-encryption-context) that provides a layer of integrity checks. Note that you do not have to set this as AWS will provide a default one for you.
+* If `encryption_key` is set, [SSE-C](https://docs.aws.amazon.com/AmazonS3/latest/dev/ServerSideEncryptionCustomerKeys.html) is set up using the key provided.
+
+Thanos will throw an error if `encryption_key` AND `kms_key_id` is set.
 
 #### Credentials
 

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -131,6 +131,26 @@ SSE can be configued using the `sse_config`. [SSE-S3](https://docs.aws.amazon.co
 
 If the SSE Config block is set but the `type` is not one of `SSE-S3`, `SSE-KMS`, or `SSE-C`, an error is raised.
 
+You will also need to apply the following AWS IAM policy for the user to access the KMS key:
+
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "KMSAccess",
+            "Effect": "Allow",
+            "Action": [
+                "kms:GenerateDataKey",
+                "kms:Encrypt",
+                "kms:Decrypt"
+            ],
+            "Resource": "arn:aws:kms:<region>:<account>:key/<KMS key id>"
+        }
+    ]
+}
+```
+
 #### Credentials
 
 By default Thanos will try to retrieve credentials from the following sources:

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -83,14 +83,8 @@ config:
   access_key: ""
   insecure: false
   signature_version2: false
-  encrypt_sse: false
   secret_key: ""
   put_user_metadata: {}
-  sse_config:
-    enabled: false
-    kms_key_id: ""
-    kms_encryption_context: {}
-    encryption_key: ""
   http_config:
     idle_conn_timeout: 1m30s
     response_header_timeout: 2m
@@ -98,6 +92,11 @@ config:
   trace:
     enable: false
   part_size: 134217728
+  sse_config:
+    enabled: false
+    kms_key_id: ""
+    kms_encryption_context: {}
+    encryption_key: ""
 ```
 
 At a minimum, you will need to provide a value for the `bucket`, `endpoint`, `access_key`, and `secret_key` keys. The rest of the keys are optional.

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -93,7 +93,7 @@ config:
     enable: false
   part_size: 134217728
   sse_config:
-    type: SSE-S3|SSE-KMS|SSE-C
+    type: ""
     kms_key_id: ""
     kms_encryption_context: {}
     encryption_key: ""

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -93,7 +93,7 @@ config:
     enable: false
   part_size: 134217728
   sse_config:
-    enabled: false
+    type: SSE-S3|SSE-KMS|SSE-C
     kms_key_id: ""
     kms_encryption_context: {}
     encryption_key: ""
@@ -123,13 +123,13 @@ For debug and testing purposes you can set
 
 SSE can be configued using the `sse_config`. [SSE-S3](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingServerSideEncryption.html), [SSE-KMS](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html), and [SSE-C](https://docs.aws.amazon.com/AmazonS3/latest/dev/ServerSideEncryptionCustomerKeys.html) are supported.
 
-The following combinations are allowed:
-* If `enabled` is set to `true` but nothing else is set, we default to using [SSE-S3](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingServerSideEncryption.html).
-* If `kms_key_id` is set, [SSE-KMS](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html) is used, and the objects that Thanos uploads will be encrypted using that key.
-* If `kms_encryption_context` is set with `kms_key_id`, you will add an [encryption context](https://docs.aws.amazon.com/kms/latest/developerguide/services-s3.html#s3-encryption-context) that provides a layer of integrity checks. Note that you do not have to set this as AWS will provide a default one for you.
-* If `encryption_key` is set, [SSE-C](https://docs.aws.amazon.com/AmazonS3/latest/dev/ServerSideEncryptionCustomerKeys.html) is set up using the key provided.
+* If type is set to `SSE-S3` you do not need to configure other options.
 
-Thanos will throw an error if `encryption_key` AND `kms_key_id` is set.
+* If type is set to `SSE-KMS` you must set `kms_key_id`. The `kms_encryption_context` is optional, as [AWS provides a default encryption context](https://docs.aws.amazon.com/kms/latest/developerguide/services-s3.html#s3-encryption-context).
+
+* If type is set to `SSE-C` you must provide a path to the encryption key using `encryption_key`.
+
+If the SSE Config block is set but the `type` is not one of `SSE-S3`, `SSE-KMS`, or `SSE-C`, an error is raised.
 
 #### Credentials
 

--- a/pkg/objstore/s3/s3.go
+++ b/pkg/objstore/s3/s3.go
@@ -32,17 +32,19 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-// DirDelim is the delimiter used to model a directory structure in an object store bucket.
-const DirDelim = "/"
+const (
+	// DirDelim is the delimiter used to model a directory structure in an object store bucket.
+	DirDelim = "/"
 
-// SSEKMS is the name of the SSE-KMS method for objectstore encryption.
-const SSEKMS = "SSE-KMS"
+	// SSEKMS is the name of the SSE-KMS method for objectstore encryption.
+	SSEKMS = "SSE-KMS"
 
-// SSEC is the name of the SSE-C method for objstore encryption.
-const SSEC = "SSE-C"
+	// SSEC is the name of the SSE-C method for objstore encryption.
+	SSEC = "SSE-C"
 
-// SSES3 is the name of the SSE-S3 method for objstore encryption.
-const SSES3 = "SSE-S3"
+	// SSES3 is the name of the SSE-S3 method for objstore encryption.
+	SSES3 = "SSE-S3"
+)
 
 var DefaultConfig = Config{
 	PutUserMetadata: map[string]string{},

--- a/pkg/objstore/s3/s3.go
+++ b/pkg/objstore/s3/s3.go
@@ -210,7 +210,7 @@ func NewBucketWithConfig(logger log.Logger, config Config, component string) (*B
 			sse = encrypt.NewSSE()
 
 		default:
-			sseErrMsg := errors.New("A type of SSE-S3, SSE-C, or SSE-KMS was not provided in sse_config")
+			sseErrMsg := errors.Errorf("Unsupported type %q was provided. Supported types are SSE-S3, SSE-KMS, SSE-C", config.SSEConfig.Type)
 			return nil, errors.Wrap(sseErrMsg, "Initialize s3 client SSE Config")
 		}
 	}

--- a/pkg/objstore/s3/s3.go
+++ b/pkg/objstore/s3/s3.go
@@ -185,7 +185,7 @@ func NewBucketWithConfig(logger log.Logger, config Config, component string) (*B
 	var sse encrypt.ServerSide
 	if config.SSEConfig.Type != "" {
 		switch {
-		case config.SSEConfig.Type != "SSE-KMS":
+		case config.SSEConfig.Type == "SSE-KMS":
 			sse, err = encrypt.NewSSEKMS(config.SSEConfig.KMSKeyID, config.SSEConfig.KMSEncryptionContext)
 			if err != nil {
 				return nil, errors.Wrap(err, "initialize s3 client SSE-KMS")

--- a/pkg/objstore/s3/s3.go
+++ b/pkg/objstore/s3/s3.go
@@ -35,8 +35,13 @@ import (
 // DirDelim is the delimiter used to model a directory structure in an object store bucket.
 const DirDelim = "/"
 
+// SSEKMS is the name of the SSE-KMS method for objectstore encryption.
 const SSEKMS = "SSE-KMS"
+
+// SSEC is the name of the SSE-C method for objstore encryption.
 const SSEC = "SSE-C"
+
+// SSES3 is the name of the SSE-S3 method for objstore encryption.
 const SSES3 = "SSE-S3"
 
 var DefaultConfig = Config{

--- a/pkg/objstore/s3/s3_test.go
+++ b/pkg/objstore/s3/s3_test.go
@@ -24,6 +24,18 @@ insecure: false`)
 	}
 }
 
+func TestParseConfig_SSEConfig(t *testing.T) {
+	input := []byte(`sse_config:
+  enabled: true`)
+
+	cfg, err := parseConfig(input)
+	testutil.Ok(t, err)
+
+	if !cfg.SSEConfig.Enable {
+		t.Errorf("parsing of sse_config failed: got %v, expected %v", cfg.SSEConfig.Enable, true)
+	}
+}
+
 func TestParseConfig_DefaultHTTPConfig(t *testing.T) {
 	input := []byte(`bucket: abcd
 insecure: false`)

--- a/pkg/objstore/s3/s3_test.go
+++ b/pkg/objstore/s3/s3_test.go
@@ -25,15 +25,88 @@ insecure: false`)
 }
 
 func TestParseConfig_SSEConfig(t *testing.T) {
-	input := []byte(`sse_config:
-  enabled: true`)
+	input := []byte(`bucket: abdd
+endpoint: "s3-endpoint"
+sse_config:
+  type: SSE-S3`)
 
 	cfg, err := parseConfig(input)
 	testutil.Ok(t, err)
+	testutil.Ok(t, validate(cfg))
 
-	if !cfg.SSEConfig.Enable {
-		t.Errorf("parsing of sse_config failed: got %v, expected %v", cfg.SSEConfig.Enable, true)
-	}
+	input2 := []byte(`bucket: abdd
+endpoint: "s3-endpoint"
+sse_config:
+  type: SSE-C`)
+
+	cfg, err = parseConfig(input2)
+	testutil.Ok(t, err)
+	testutil.NotOk(t, validate(cfg))
+
+	input3 := []byte(`bucket: abdd
+endpoint: "s3-endpoint"
+sse_config:
+  type: SSE-C
+  kms_key_id: qweasd`)
+
+	cfg, err = parseConfig(input3)
+	testutil.Ok(t, err)
+	testutil.NotOk(t, validate(cfg))
+
+	input4 := []byte(`bucket: abdd
+endpoint: "s3-endpoint"
+sse_config:
+  type: SSE-C
+  encryption_key: /some/file`)
+
+	cfg, err = parseConfig(input4)
+	testutil.Ok(t, err)
+	testutil.Ok(t, validate(cfg))
+
+	input5 := []byte(`bucket: abdd
+endpoint: "s3-endpoint"
+sse_config:
+  type: SSE-KMS`)
+
+	cfg, err = parseConfig(input5)
+	testutil.Ok(t, err)
+	testutil.NotOk(t, validate(cfg))
+
+	input6 := []byte(`bucket: abdd
+endpoint: "s3-endpoint"
+sse_config:
+  type: SSE-KMS
+  kms_key_id: abcd1234-ab12-cd34-1234567890ab`)
+
+	cfg, err = parseConfig(input6)
+	testutil.Ok(t, err)
+	testutil.Ok(t, validate(cfg))
+
+	input7 := []byte(`bucket: abdd
+endpoint: "s3-endpoint"
+sse_config:
+  type: SSE-KMS
+  kms_key_id: abcd1234-ab12-cd34-1234567890ab
+  kms_encryption_context:
+    key: value
+    something: else
+    a: b`)
+
+	cfg, err = parseConfig(input7)
+	testutil.Ok(t, err)
+	testutil.Ok(t, validate(cfg))
+
+	input8 := []byte(`bucket: abdd
+endpoint: "s3-endpoint"
+sse_config:
+  type: SSE-MagicKey
+  kms_key_id: abcd1234-ab12-cd34-1234567890ab
+  encryption_key: /some/file`)
+
+	cfg, err = parseConfig(input8)
+	testutil.Ok(t, err)
+	// Since the error handling for "proper type" if done as we're setting up the bucket.
+	testutil.Ok(t, validate(cfg))
 }
 
 func TestParseConfig_DefaultHTTPConfig(t *testing.T) {


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Adds S3 SSE via a `sse_config` block. It's a reimplementation of #2170 since it looks like it was abandoned. It solves #946. 

There are 3 types of SSE you can use: [SSE-S3](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingServerSideEncryption.html), [SSE-KMS](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html), and [SSE-C](https://docs.aws.amazon.com/AmazonS3/latest/dev/ServerSideEncryptionCustomerKeys.html).

```
  sse_config:
    # Whether or not we use SSE at all. This should be set at the very minimum to enable SSE-S3.
    enabled: false
    # If someone wants to use their KMS key, we let them set that up by passing in kms_key_id. This sets up SSE-KMS
    kms_key_id: ""
    # kms_encryption_context provides additional variables to use for encryption/decryption. It doesn't need to be set as AWS provides a default encryption context, but you _can_ set it if you want something more.
    kms_encryption_context: {}
    # encryption_key is what it says on the tin. This sets up SSE-C.
    encryption_key: ""
```

## Verification
I can verify if this works when I get back to work. We're currently running into 403 errors from not providing a KMS key ID, so when we don't get 403s I'll know it works.

<!-- How you tested it? How do you know it works? -->
