### PR TITLE
Correctly handle auto downsampling in codec

### DIFF
--- a/pkg/queryfrontend/cache_splitter.go
+++ b/pkg/queryfrontend/cache_splitter.go
@@ -8,17 +8,32 @@ import (
 	"time"
 
 	"github.com/cortexproject/cortex/pkg/querier/queryrange"
+
+	"github.com/thanos-io/thanos/pkg/compact/downsample"
 )
 
-// constSplitter is a utility for using a constant split interval when determining cache keys.
-type constSplitter time.Duration
+// thanosCacheSplitter is a utility for using split interval when determining cache keys.
+type thanosCacheSplitter struct {
+	interval    time.Duration
+	resolutions []int64
+}
+
+func newThanosCacheSplitter(interval time.Duration) thanosCacheSplitter {
+	return thanosCacheSplitter{
+		interval:    interval,
+		resolutions: []int64{downsample.ResLevel2, downsample.ResLevel1, downsample.ResLevel0},
+	}
+}
 
 // TODO(yeya24): Add other request params as request key.
 // GenerateCacheKey generates a cache key based on the Request and interval.
-func (t constSplitter) GenerateCacheKey(_ string, r queryrange.Request) string {
-	currentInterval := r.GetStart() / time.Duration(t).Milliseconds()
+func (t thanosCacheSplitter) GenerateCacheKey(_ string, r queryrange.Request) string {
+	currentInterval := r.GetStart() / t.interval.Milliseconds()
 	if tr, ok := r.(*ThanosRequest); ok {
-		return fmt.Sprintf("%s:%d:%d:%d", tr.Query, tr.Step, currentInterval, tr.MaxSourceResolution)
+		i := 0
+		for ; i < len(t.resolutions) && t.resolutions[i] > tr.MaxSourceResolution; i++ {
+		}
+		return fmt.Sprintf("%s:%d:%d:%d", tr.Query, tr.Step, currentInterval, i)
 	}
 	return fmt.Sprintf("%s:%d:%d", r.GetQuery(), r.GetStep(), currentInterval)
 }

--- a/pkg/queryfrontend/cache_splitter.go
+++ b/pkg/queryfrontend/cache_splitter.go
@@ -12,14 +12,14 @@ import (
 	"github.com/thanos-io/thanos/pkg/compact/downsample"
 )
 
-// thanosCacheSplitter is a utility for using split interval when determining cache keys.
-type thanosCacheSplitter struct {
+// thanosCacheKeyGenerator is a utility for using split interval when determining cache keys.
+type thanosCacheKeyGenerator struct {
 	interval    time.Duration
 	resolutions []int64
 }
 
-func newThanosCacheSplitter(interval time.Duration) thanosCacheSplitter {
-	return thanosCacheSplitter{
+func newThanosCacheKeyGenerator(interval time.Duration) thanosCacheKeyGenerator {
+	return thanosCacheKeyGenerator{
 		interval:    interval,
 		resolutions: []int64{downsample.ResLevel2, downsample.ResLevel1, downsample.ResLevel0},
 	}
@@ -27,7 +27,7 @@ func newThanosCacheSplitter(interval time.Duration) thanosCacheSplitter {
 
 // TODO(yeya24): Add other request params as request key.
 // GenerateCacheKey generates a cache key based on the Request and interval.
-func (t thanosCacheSplitter) GenerateCacheKey(_ string, r queryrange.Request) string {
+func (t thanosCacheKeyGenerator) GenerateCacheKey(_ string, r queryrange.Request) string {
 	currentInterval := r.GetStart() / t.interval.Milliseconds()
 	if tr, ok := r.(*ThanosRequest); ok {
 		i := 0

--- a/pkg/queryfrontend/cache_splitter_test.go
+++ b/pkg/queryfrontend/cache_splitter_test.go
@@ -1,0 +1,83 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package queryfrontend
+
+import (
+	"testing"
+
+	"github.com/cortexproject/cortex/pkg/querier/queryrange"
+
+	"github.com/thanos-io/thanos/pkg/testutil"
+)
+
+func TestGenerateCacheKey(t *testing.T) {
+	splitter := newThanosCacheSplitter(hour)
+
+	for _, tc := range []struct {
+		name             string
+		req              queryrange.Request
+		expectedCacheKey string
+	}{
+		{
+			name: "non thanos req",
+			req: &queryrange.PrometheusRequest{
+				Query: "up",
+				Start: 0,
+				Step:  60 * seconds,
+			},
+			expectedCacheKey: "up:60000:0",
+		},
+		{
+			name: "non downsampling resolution specified",
+			req: &ThanosRequest{
+				Query: "up",
+				Start: 0,
+				Step:  60 * seconds,
+			},
+			expectedCacheKey: "up:60000:0:2",
+		},
+		{
+			name: "10s step",
+			req: &ThanosRequest{
+				Query: "up",
+				Start: 0,
+				Step:  10 * seconds,
+			},
+			expectedCacheKey: "up:10000:0:2",
+		},
+		{
+			name: "1m downsampling resolution",
+			req: &ThanosRequest{
+				Query:               "up",
+				Start:               0,
+				Step:                10 * seconds,
+				MaxSourceResolution: 60 * seconds,
+			},
+			expectedCacheKey: "up:10000:0:2",
+		},
+		{
+			name: "5m downsampling resolution, different cache key",
+			req: &ThanosRequest{
+				Query:               "up",
+				Start:               0,
+				Step:                10 * seconds,
+				MaxSourceResolution: 300 * seconds,
+			},
+			expectedCacheKey: "up:10000:0:1",
+		},
+		{
+			name: "1h downsampling resolution, different cache key",
+			req: &ThanosRequest{
+				Query:               "up",
+				Start:               0,
+				Step:                10 * seconds,
+				MaxSourceResolution: hour,
+			},
+			expectedCacheKey: "up:10000:0:0",
+		},
+	} {
+		key := splitter.GenerateCacheKey("", tc.req)
+		testutil.Equals(t, tc.expectedCacheKey, key)
+	}
+}

--- a/pkg/queryfrontend/cache_splitter_test.go
+++ b/pkg/queryfrontend/cache_splitter_test.go
@@ -12,12 +12,12 @@ import (
 )
 
 func TestGenerateCacheKey(t *testing.T) {
-	splitter := newThanosCacheSplitter(hour)
+	splitter := newThanosCacheKeyGenerator(hour)
 
 	for _, tc := range []struct {
-		name             string
-		req              queryrange.Request
-		expectedCacheKey string
+		name     string
+		req      queryrange.Request
+		expected string
 	}{
 		{
 			name: "non thanos req",
@@ -26,7 +26,7 @@ func TestGenerateCacheKey(t *testing.T) {
 				Start: 0,
 				Step:  60 * seconds,
 			},
-			expectedCacheKey: "up:60000:0",
+			expected: "up:60000:0",
 		},
 		{
 			name: "non downsampling resolution specified",
@@ -35,7 +35,7 @@ func TestGenerateCacheKey(t *testing.T) {
 				Start: 0,
 				Step:  60 * seconds,
 			},
-			expectedCacheKey: "up:60000:0:2",
+			expected: "up:60000:0:2",
 		},
 		{
 			name: "10s step",
@@ -44,7 +44,7 @@ func TestGenerateCacheKey(t *testing.T) {
 				Start: 0,
 				Step:  10 * seconds,
 			},
-			expectedCacheKey: "up:10000:0:2",
+			expected: "up:10000:0:2",
 		},
 		{
 			name: "1m downsampling resolution",
@@ -54,7 +54,7 @@ func TestGenerateCacheKey(t *testing.T) {
 				Step:                10 * seconds,
 				MaxSourceResolution: 60 * seconds,
 			},
-			expectedCacheKey: "up:10000:0:2",
+			expected: "up:10000:0:2",
 		},
 		{
 			name: "5m downsampling resolution, different cache key",
@@ -64,7 +64,7 @@ func TestGenerateCacheKey(t *testing.T) {
 				Step:                10 * seconds,
 				MaxSourceResolution: 300 * seconds,
 			},
-			expectedCacheKey: "up:10000:0:1",
+			expected: "up:10000:0:1",
 		},
 		{
 			name: "1h downsampling resolution, different cache key",
@@ -74,10 +74,10 @@ func TestGenerateCacheKey(t *testing.T) {
 				Step:                10 * seconds,
 				MaxSourceResolution: hour,
 			},
-			expectedCacheKey: "up:10000:0:0",
+			expected: "up:10000:0:0",
 		},
 	} {
 		key := splitter.GenerateCacheKey("", tc.req)
-		testutil.Equals(t, tc.expectedCacheKey, key)
+		testutil.Equals(t, tc.expected, key)
 	}
 }

--- a/pkg/queryfrontend/codec_test.go
+++ b/pkg/queryfrontend/codec_test.go
@@ -85,6 +85,20 @@ func TestCodec_DecodeRequest(t *testing.T) {
 			expectedError:   httpgrpc.Errorf(http.StatusBadRequest, "negative max_source_resolution is not accepted. Try a positive integer"),
 		},
 		{
+			name: "auto downsampling enabled",
+			url:  "/api/v1/query_range?start=123&end=456&step=10&max_source_resolution=auto",
+			expectedRequest: &ThanosRequest{
+				Path:                "/api/v1/query_range",
+				Start:               123000,
+				End:                 456000,
+				Step:                10000,
+				MaxSourceResolution: 2000,
+				AutoDownsampling:    true,
+				Dedup:               true,
+				StoreMatchers:       [][]storepb.LabelMatcher{},
+			},
+		},
+		{
 			name:            "cannot parse partial_response",
 			url:             "/api/v1/query_range?start=123&end=456&step=1&partial_response=bar",
 			partialResponse: false,

--- a/pkg/queryfrontend/request.go
+++ b/pkg/queryfrontend/request.go
@@ -22,6 +22,7 @@ type ThanosRequest struct {
 	Query               string
 	Dedup               bool
 	PartialResponse     bool
+	AutoDownsampling    bool
 	MaxSourceResolution int64
 	ReplicaLabels       []string
 	StoreMatchers       [][]storepb.LabelMatcher
@@ -64,7 +65,7 @@ func (r *ThanosRequest) WithQuery(query string) queryrange.Request {
 
 // LogToSpan writes information about this request to an OpenTracing span.
 func (r *ThanosRequest) LogToSpan(sp opentracing.Span) {
-	sp.LogFields(
+	fields := []otlog.Field{
 		otlog.String("query", r.GetQuery()),
 		otlog.String("start", timestamp.Time(r.GetStart()).String()),
 		otlog.String("end", timestamp.Time(r.GetEnd()).String()),
@@ -73,7 +74,11 @@ func (r *ThanosRequest) LogToSpan(sp opentracing.Span) {
 		otlog.Bool("partial_response", r.PartialResponse),
 		otlog.Object("replicaLabels", r.ReplicaLabels),
 		otlog.Object("storeMatchers", r.StoreMatchers),
-	)
+		otlog.Bool("auto-downsampling", r.AutoDownsampling),
+		otlog.Int64("max_source_resolution (ms)", r.MaxSourceResolution),
+	}
+
+	sp.LogFields(fields...)
 }
 
 // Reset implements proto.Message interface required by queryrange.Request,

--- a/pkg/queryfrontend/roundtrip.go
+++ b/pkg/queryfrontend/roundtrip.go
@@ -67,7 +67,7 @@ func NewTripperWare(
 		queryCacheMiddleware, _, err := queryrange.NewResultsCacheMiddleware(
 			logger,
 			*cacheConfig,
-			newThanosCacheSplitter(splitQueryInterval),
+			newThanosCacheKeyGenerator(splitQueryInterval),
 			limits,
 			codec,
 			cacheExtractor,

--- a/pkg/queryfrontend/roundtrip.go
+++ b/pkg/queryfrontend/roundtrip.go
@@ -67,7 +67,7 @@ func NewTripperWare(
 		queryCacheMiddleware, _, err := queryrange.NewResultsCacheMiddleware(
 			logger,
 			*cacheConfig,
-			constSplitter(splitQueryInterval),
+			newThanosCacheSplitter(splitQueryInterval),
 			limits,
 			codec,
 			cacheExtractor,

--- a/pkg/queryfrontend/roundtrip_test.go
+++ b/pkg/queryfrontend/roundtrip_test.go
@@ -290,14 +290,24 @@ func TestRoundTripCacheMiddleware(t *testing.T) {
 		Step:  10 * seconds,
 	}
 
-	// same query params as testRequest, but with different maxSourceResolution,
-	// so won't be cached in this case.
+	// same query params as testRequest, different maxSourceResolution
+	// but still in the same downsampling level, so it will be cached in this case.
 	testRequest3 := &ThanosRequest{
 		Path:                "/api/v1/query_range",
 		Start:               0,
 		End:                 2 * hour,
 		Step:                10 * seconds,
 		MaxSourceResolution: 10 * seconds,
+	}
+
+	// same query params as testRequest, different maxSourceResolution
+	// and downsampling level so it won't be cached in this case.
+	testRequest4 := &ThanosRequest{
+		Path:                "/api/v1/query_range",
+		Start:               0,
+		End:                 2 * hour,
+		Step:                10 * seconds,
+		MaxSourceResolution: 1 * hour,
 	}
 
 	cacheConf := &queryrange.ResultsCacheConfig{
@@ -345,13 +355,18 @@ func TestRoundTripCacheMiddleware(t *testing.T) {
 			expected: 2,
 		},
 		{
-			name:     "different max source resolution won't be cached",
+			name:     "do it again",
+			req:      testRequest2,
+			expected: 3,
+		},
+		{
+			name:     "different max source resolution but still same level",
 			req:      testRequest3,
 			expected: 3,
 		},
 		{
-			name:     "do it again",
-			req:      testRequest2,
+			name:     "different max source resolution and different level",
+			req:      testRequest4,
 			expected: 4,
 		},
 		{

--- a/pkg/queryfrontend/roundtrip_test.go
+++ b/pkg/queryfrontend/roundtrip_test.go
@@ -103,7 +103,7 @@ func TestRoundTripRetryMiddleware(t *testing.T) {
 				Step:  10 * seconds,
 			},
 			handlerAndResult: counter,
-			// not go through tripperware so no error.
+			// Not go through tripperware so no error.
 			expectedError: false,
 			expected:      1,
 		},
@@ -117,7 +117,7 @@ func TestRoundTripRetryMiddleware(t *testing.T) {
 				Step:  10 * seconds,
 			},
 			handlerAndResult: counter,
-			// not go through tripperware so no error.
+			// Not go through tripperware so no error.
 			expectedError: false,
 			expected:      1,
 		},
@@ -282,7 +282,7 @@ func TestRoundTripCacheMiddleware(t *testing.T) {
 		MaxSourceResolution: 1 * seconds,
 	}
 
-	// non query range request, won't be cached.
+	// Non query range request, won't be cached.
 	testRequest2 := &ThanosRequest{
 		Path:  "/api/v1/query",
 		Start: 0,
@@ -290,7 +290,7 @@ func TestRoundTripCacheMiddleware(t *testing.T) {
 		Step:  10 * seconds,
 	}
 
-	// same query params as testRequest, different maxSourceResolution
+	// Same query params as testRequest, different maxSourceResolution
 	// but still in the same downsampling level, so it will be cached in this case.
 	testRequest3 := &ThanosRequest{
 		Path:                "/api/v1/query_range",
@@ -300,7 +300,7 @@ func TestRoundTripCacheMiddleware(t *testing.T) {
 		MaxSourceResolution: 10 * seconds,
 	}
 
-	// same query params as testRequest, different maxSourceResolution
+	// Same query params as testRequest, different maxSourceResolution
 	// and downsampling level so it won't be cached in this case.
 	testRequest4 := &ThanosRequest{
 		Path:                "/api/v1/query_range",
@@ -339,36 +339,12 @@ func TestRoundTripCacheMiddleware(t *testing.T) {
 		handlerAndResult func() (*int, http.Handler)
 		expected         int
 	}{
-		{
-			name:     "first request",
-			req:      testRequest,
-			expected: 1,
-		},
-		{
-			name:     "same request as the first one, directly use cache",
-			req:      testRequest,
-			expected: 1,
-		},
-		{
-			name:     "non query range request won't be cached",
-			req:      testRequest2,
-			expected: 2,
-		},
-		{
-			name:     "do it again",
-			req:      testRequest2,
-			expected: 3,
-		},
-		{
-			name:     "different max source resolution but still same level",
-			req:      testRequest3,
-			expected: 3,
-		},
-		{
-			name:     "different max source resolution and different level",
-			req:      testRequest4,
-			expected: 4,
-		},
+		{name: "first request", req: testRequest, expected: 1},
+		{name: "same request as the first one, directly use cache", req: testRequest, expected: 1},
+		{name: "non query range request won't be cached", req: testRequest2, expected: 2},
+		{name: "do it again", req: testRequest2, expected: 3},
+		{name: "different max source resolution but still same level", req: testRequest3, expected: 3},
+		{name: "different max source resolution and different level", req: testRequest4, expected: 4},
 		{
 			name: "request but will be partitioned",
 			req: &ThanosRequest{


### PR DESCRIPTION
Signed-off-by: Ben Ye <yb532204897@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

1. Handle `max_source_resolution=auto` correctly.
2. Generating cache key based on resolution level instead of time

## Verification

<!-- How you tested it? How do you know it works? -->
