### PR TITLE
feat: Allow callers to the minio objstore to inject a RoundTripper

### DIFF
--- a/pkg/objstore/s3/s3.go
+++ b/pkg/objstore/s3/s3.go
@@ -72,6 +72,9 @@ type Config struct {
 	// PartSize used for multipart upload. Only used if uploaded object size is known and larger than configured PartSize.
 	PartSize  uint64    `yaml:"part_size"`
 	SSEConfig SSEConfig `yaml:"sse_config"`
+
+	// Allow upstream callers to inject a round tripper
+	Transport http.RoundTripper `yaml:"-"`
 }
 
 // SSEConfig deals with the configuration of SSE for Minio. The following options are valid:
@@ -92,6 +95,35 @@ type HTTPConfig struct {
 	IdleConnTimeout       model.Duration `yaml:"idle_conn_timeout"`
 	ResponseHeaderTimeout model.Duration `yaml:"response_header_timeout"`
 	InsecureSkipVerify    bool           `yaml:"insecure_skip_verify"`
+}
+
+// DefaultTransport - this default transport is based on the Minio
+// DefaultTransport up until the following commit:
+// https://github.com/minio/minio-go/commit/008c7aa71fc17e11bf980c209a4f8c4d687fc884
+// The values have since diverged.
+func DefaultTransport(config Config) *http.Transport {
+	return &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+			DualStack: true,
+		}).DialContext,
+
+		MaxIdleConns:          100,
+		MaxIdleConnsPerHost:   100,
+		IdleConnTimeout:       time.Duration(config.HTTPConfig.IdleConnTimeout),
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+		ResponseHeaderTimeout: time.Duration(config.HTTPConfig.ResponseHeaderTimeout),
+		// Set this value so that the underlying transport round-tripper
+		// doesn't try to auto decode the body of objects with
+		// content-encoding set to `gzip`.
+		//
+		// Refer: https://golang.org/src/net/http/transport.go?h=roundTrip#L1843.
+		DisableCompression: true,
+		TLSClientConfig:    &tls.Config{InsecureSkipVerify: config.HTTPConfig.InsecureSkipVerify},
+	}
 }
 
 // Bucket implements the store.Bucket interface against s3-compatible APIs.
@@ -157,36 +189,20 @@ func NewBucketWithConfig(logger log.Logger, config Config, component string) (*B
 		}
 	}
 
-	client, err := minio.New(config.Endpoint, &minio.Options{
-		Creds:  credentials.NewChainCredentials(chain),
-		Secure: !config.Insecure,
-		Region: config.Region,
-		Transport: &http.Transport{
-			Proxy: http.ProxyFromEnvironment,
-			DialContext: (&net.Dialer{
-				Timeout:   30 * time.Second,
-				KeepAlive: 30 * time.Second,
-				DualStack: true,
-			}).DialContext,
+	// Check if a roundtripper has been set in the config
+	// otherwise build the default transport.
+	var rt http.RoundTripper
+	if config.Transport != nil {
+		rt = config.Transport
+	} else {
+		rt = DefaultTransport(config)
+	}
 
-			MaxIdleConns:          100,
-			MaxIdleConnsPerHost:   100,
-			IdleConnTimeout:       time.Duration(config.HTTPConfig.IdleConnTimeout),
-			TLSHandshakeTimeout:   10 * time.Second,
-			ExpectContinueTimeout: 1 * time.Second,
-			// The ResponseHeaderTimeout here is the only change
-			// from the default minio transport, it was introduced
-			// to cover cases where the tcp connection works but
-			// the server never answers. Defaults to 2 minutes.
-			ResponseHeaderTimeout: time.Duration(config.HTTPConfig.ResponseHeaderTimeout),
-			// Set this value so that the underlying transport round-tripper
-			// doesn't try to auto decode the body of objects with
-			// content-encoding set to `gzip`.
-			//
-			// Refer: https://golang.org/src/net/http/transport.go?h=roundTrip#L1843.
-			DisableCompression: true,
-			TLSClientConfig:    &tls.Config{InsecureSkipVerify: config.HTTPConfig.InsecureSkipVerify},
-		},
+	client, err := minio.New(config.Endpoint, &minio.Options{
+		Creds:     credentials.NewChainCredentials(chain),
+		Secure:    !config.Insecure,
+		Region:    config.Region,
+		Transport: rt,
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "initialize s3 client")


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

# Inject Roundtripper to Minio Bucket using Config

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

The reason for this change was to provide a bit more control over the transport level of this client. I noticed that the default Minio transport has diverged significantly from this implementation. Instead of exposing more values as HTTPConfigs or introducing changes to the default config, I thought it made more sense to give the package caller extra control over the client.

* [ ] I added CHANGELOG entry for this change. **Question:** There is no change from a user perspective, should I still add an entry?
* [x] Change is not relevant to the end user.

## Changes

- Create a `DefaultTransport` function that generates an `*http.Transport` from the Config as it currently exists. This function was made public since it allows a caller to generate a Transport that respects the provided config but then tweak values within the transport.
- Add a `Transport http.Roundtripper` field to the `s3.Config` struct that will replace the default transport if set

## Verification

I am assuming no unexpected behavior due to the nature of the change as long as the existing test cases pass.