### PR TITLE
Limit queried chunks by bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#3146](https://github.com/thanos-io/thanos/pull/3146) Sidecar: Add `thanos_sidecar_prometheus_store_received_frames` histogram metric.
 - [#3147](https://github.com/thanos-io/thanos/pull/3147) Querier: Add `query.metadata.default-time-range` flag to specify the default metadata time range duration for retrieving labels through Labels and Series API when the range parameters are not specified. The zero value means range covers the time since the beginning.
 - [#3207](https://github.com/thanos-io/thanos/pull/3207) Query Frontend: Add `cache-compression-type` flag to use compression in the query frontend cache.
+- [#3089](https://github.com/thanos-io/thanos/pull/3089) Store: Add `store.grpc.series-sample-size-limit` flag to specify the maximum size of samples returned via a single Series call. The zero value means no limit.
 
 ### Changed
 

--- a/cmd/thanos/store.go
+++ b/cmd/thanos/store.go
@@ -69,7 +69,7 @@ func registerStore(app *extkingpin.App) {
 		Default("0").Uint()
 
 	maxSampleSize := cmd.Flag("store.grpc.series-sample-size-limit",
-		"Maximum size of samples returned via a single Series call. The Series call fails if this limit is exceeded. 0 means no limit.").
+		"Maximum size of samples returned (in bytes) via a single Series call. The Series call fails if this limit is exceeded. 0 means no limit.").
 		Default("0").Uint()
 
 	maxConcurrent := cmd.Flag("store.grpc.series-max-concurrency", "Maximum number of concurrent Series calls.").Default("20").Int()
@@ -297,7 +297,7 @@ func runStore(
 		store.WithChunksSizeLimit(store.NewChunksLimiterFactory(maxSampleSize)),
 	}
 
-	bs, err := store.New(
+	bs, err := store.NewBucketStoreWithOptions(
 		logger,
 		reg,
 		bkt,

--- a/docs/components/store.md
+++ b/docs/components/store.md
@@ -101,6 +101,10 @@ Flags:
                                  samples each chunk can contain), so the actual
                                  number of samples might be lower, even though
                                  the maximum could be hit.
+      --store.grpc.series-sample-size-limit=0
+                                 Maximum size of samples returned via a single
+                                 Series call. The Series call fails if this
+                                 limit is exceeded. 0 means no limit.
       --store.grpc.series-max-concurrency=20
                                  Maximum number of concurrent Series calls.
       --objstore.config-file=<file-path>

--- a/docs/components/store.md
+++ b/docs/components/store.md
@@ -102,9 +102,9 @@ Flags:
                                  number of samples might be lower, even though
                                  the maximum could be hit.
       --store.grpc.series-sample-size-limit=0
-                                 Maximum size of samples returned via a single
-                                 Series call. The Series call fails if this
-                                 limit is exceeded. 0 means no limit.
+                                 Maximum size of samples returned (in bytes) via
+                                 a single Series call. The Series call fails if
+                                 this limit is exceeded. 0 means no limit.
       --store.grpc.series-max-concurrency=20
                                  Maximum number of concurrent Series calls.
       --objstore.config-file=<file-path>

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -326,6 +326,7 @@ var defaultBucketStoreOptions = bucketStoreOptions{
 	chunksSizeLimitFactory: NewChunksLimiterFactory(noChunksSizeLimit),
 }
 
+// Deprecated. Use NewBucketStoreWithOptions instead.
 // NewBucketStore creates a new bucket backed store that implements the store API against
 // an object store bucket. It is optimized to work against high latency backends.
 func NewBucketStore(
@@ -350,7 +351,7 @@ func NewBucketStore(
 		WithChunksLimit(chunksLimiterFactory),
 		WithChunksSizeLimit(NewChunksLimiterFactory(noChunksSizeLimit)),
 	}
-	return New(logger,
+	return NewBucketStoreWithOptions(logger,
 		reg,
 		bkt,
 		fetcher,
@@ -369,9 +370,9 @@ func NewBucketStore(
 	)
 }
 
-// New creates a new bucket backed store that implements the store API against
+// NewBucketStoreWithOptions creates a new bucket backed store that implements the store API against
 // an object store bucket. It is optimized to work against high latency backends.
-func New(
+func NewBucketStoreWithOptions(
 	logger log.Logger,
 	reg prometheus.Registerer,
 	bkt objstore.InstrumentedBucketReader,

--- a/pkg/store/bucket_e2e_test.go
+++ b/pkg/store/bucket_e2e_test.go
@@ -156,7 +156,7 @@ func prepareStoreWithTestBlocks(t testing.TB, dir string, bkt objstore.Bucket, m
 	}, nil)
 	testutil.Ok(t, err)
 
-	store, err := New(
+	store, err := NewBucketStoreWithOptions(
 		s.logger,
 		nil,
 		objstore.WithNoopInstr(bkt),

--- a/pkg/store/bucket_e2e_test.go
+++ b/pkg/store/bucket_e2e_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/pkg/relabel"
 	"github.com/prometheus/prometheus/pkg/timestamp"
+
 	"github.com/thanos-io/thanos/pkg/block"
 	"github.com/thanos-io/thanos/pkg/block/metadata"
 	"github.com/thanos-io/thanos/pkg/model"
@@ -125,7 +126,8 @@ func prepareTestBlocks(t testing.TB, now time.Time, count int, dir string, bkt o
 	return
 }
 
-func prepareStoreWithTestBlocks(t testing.TB, dir string, bkt objstore.Bucket, manyParts bool, maxChunksLimit uint64, relabelConfig []*relabel.Config, filterConf *FilterConfig) *storeSuite {
+func prepareStoreWithTestBlocks(t testing.TB, dir string, bkt objstore.Bucket, manyParts bool, maxChunksLimit uint64,
+	maxChunksSizeLimit uint64, relabelConfig []*relabel.Config, filterConf *FilterConfig) *storeSuite {
 	series := []labels.Labels{
 		labels.FromStrings("a", "1", "b", "1"),
 		labels.FromStrings("a", "1", "b", "2"),
@@ -154,7 +156,7 @@ func prepareStoreWithTestBlocks(t testing.TB, dir string, bkt objstore.Bucket, m
 	}, nil)
 	testutil.Ok(t, err)
 
-	store, err := NewBucketStore(
+	store, err := New(
 		s.logger,
 		nil,
 		objstore.WithNoopInstr(bkt),
@@ -163,7 +165,6 @@ func prepareStoreWithTestBlocks(t testing.TB, dir string, bkt objstore.Bucket, m
 		s.cache,
 		nil,
 		0,
-		NewChunksLimiterFactory(maxChunksLimit),
 		false,
 		20,
 		filterConf,
@@ -171,6 +172,8 @@ func prepareStoreWithTestBlocks(t testing.TB, dir string, bkt objstore.Bucket, m
 		true,
 		DefaultPostingOffsetInMemorySampling,
 		true,
+		WithChunksLimit(NewChunksLimiterFactory(maxChunksLimit)),
+		WithChunksSizeLimit(NewChunksLimiterFactory(maxChunksSizeLimit)),
 	)
 	testutil.Ok(t, err)
 	s.store = store
@@ -430,7 +433,7 @@ func TestBucketStore_e2e(t *testing.T) {
 		testutil.Ok(t, err)
 		defer func() { testutil.Ok(t, os.RemoveAll(dir)) }()
 
-		s := prepareStoreWithTestBlocks(t, dir, bkt, false, 0, emptyRelabelConfig, allowAllFilterConf)
+		s := prepareStoreWithTestBlocks(t, dir, bkt, false, 0, 0, emptyRelabelConfig, allowAllFilterConf)
 
 		if ok := t.Run("no index cache", func(t *testing.T) {
 			s.cache.SwapWith(noopCache{})
@@ -485,7 +488,7 @@ func TestBucketStore_ManyParts_e2e(t *testing.T) {
 		testutil.Ok(t, err)
 		defer func() { testutil.Ok(t, os.RemoveAll(dir)) }()
 
-		s := prepareStoreWithTestBlocks(t, dir, bkt, true, 0, emptyRelabelConfig, allowAllFilterConf)
+		s := prepareStoreWithTestBlocks(t, dir, bkt, true, 0, 0, emptyRelabelConfig, allowAllFilterConf)
 
 		indexCache, err := storecache.NewInMemoryIndexCacheWithConfig(s.logger, nil, storecache.InMemoryIndexCacheConfig{
 			MaxItemSize: 1e5,
@@ -513,7 +516,7 @@ func TestBucketStore_TimePartitioning_e2e(t *testing.T) {
 	// The query will fetch 2 series from 2 blocks, so we do expect to hit a total of 4 chunks.
 	expectedChunks := uint64(2 * 2)
 
-	s := prepareStoreWithTestBlocks(t, dir, bkt, false, expectedChunks, emptyRelabelConfig, &FilterConfig{
+	s := prepareStoreWithTestBlocks(t, dir, bkt, false, expectedChunks, 0, emptyRelabelConfig, &FilterConfig{
 		MinTime: minTimeDuration,
 		MaxTime: filterMaxTime,
 	})
@@ -558,8 +561,9 @@ func TestBucketStore_Series_ChunksLimiter_e2e(t *testing.T) {
 	expectedChunks := uint64(2 * 6)
 
 	cases := map[string]struct {
-		maxChunksLimit uint64
-		expectedErr    string
+		maxChunksLimit     uint64
+		maxChunksSizeLimit uint64
+		expectedErr        string
 	}{
 		"should succeed if the max chunks limit is not exceeded": {
 			maxChunksLimit: expectedChunks,
@@ -567,6 +571,10 @@ func TestBucketStore_Series_ChunksLimiter_e2e(t *testing.T) {
 		"should fail if the max chunks limit is exceeded": {
 			maxChunksLimit: expectedChunks - 1,
 			expectedErr:    "exceeded chunks limit",
+		},
+		"should fail if the max chunks size limit is exceeded": {
+			maxChunksSizeLimit: maxChunkSize - 1,
+			expectedErr:        "exceeded chunks size limit",
 		},
 	}
 
@@ -580,7 +588,7 @@ func TestBucketStore_Series_ChunksLimiter_e2e(t *testing.T) {
 			testutil.Ok(t, err)
 			defer func() { testutil.Ok(t, os.RemoveAll(dir)) }()
 
-			s := prepareStoreWithTestBlocks(t, dir, bkt, false, testData.maxChunksLimit, emptyRelabelConfig, allowAllFilterConf)
+			s := prepareStoreWithTestBlocks(t, dir, bkt, false, testData.maxChunksLimit, testData.maxChunksSizeLimit, emptyRelabelConfig, allowAllFilterConf)
 			testutil.Ok(t, s.store.SyncBlocks(ctx))
 
 			req := &storepb.SeriesRequest{
@@ -614,7 +622,7 @@ func TestBucketStore_LabelNames_e2e(t *testing.T) {
 		testutil.Ok(t, err)
 		defer func() { testutil.Ok(t, os.RemoveAll(dir)) }()
 
-		s := prepareStoreWithTestBlocks(t, dir, bkt, false, 0, emptyRelabelConfig, allowAllFilterConf)
+		s := prepareStoreWithTestBlocks(t, dir, bkt, false, 0, 0, emptyRelabelConfig, allowAllFilterConf)
 
 		mint, maxt := s.store.TimeRange()
 		testutil.Equals(t, s.minTime, mint)
@@ -646,7 +654,7 @@ func TestBucketStore_LabelValues_e2e(t *testing.T) {
 		testutil.Ok(t, err)
 		defer func() { testutil.Ok(t, os.RemoveAll(dir)) }()
 
-		s := prepareStoreWithTestBlocks(t, dir, bkt, false, 0, emptyRelabelConfig, allowAllFilterConf)
+		s := prepareStoreWithTestBlocks(t, dir, bkt, false, 0, 0, emptyRelabelConfig, allowAllFilterConf)
 
 		mint, maxt := s.store.TimeRange()
 		testutil.Equals(t, s.minTime, mint)

--- a/pkg/store/bucket_test.go
+++ b/pkg/store/bucket_test.go
@@ -564,7 +564,7 @@ func TestBucketStore_Info(t *testing.T) {
 
 	defer testutil.Ok(t, os.RemoveAll(dir))
 
-	bucketStore, err := New(
+	bucketStore, err := NewBucketStoreWithOptions(
 		nil,
 		nil,
 		nil,
@@ -599,7 +599,7 @@ func TestSeries_ErrorInvalidLimiter(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	dir := t.TempDir()
-	store, err := New(
+	store, err := NewBucketStoreWithOptions(
 		nil,
 		nil,
 		nil,
@@ -856,7 +856,7 @@ func testSharding(t *testing.T, reuseDisk string, bkt objstore.Bucket, all ...ul
 			}, nil)
 			testutil.Ok(t, err)
 
-			bucketStore, err := New(
+			bucketStore, err := NewBucketStoreWithOptions(
 				logger,
 				nil,
 				objstore.WithNoopInstr(rec),
@@ -1611,7 +1611,7 @@ func TestSeries_RequestAndResponseHints(t *testing.T) {
 	indexCache, err := storecache.NewInMemoryIndexCacheWithConfig(logger, nil, storecache.InMemoryIndexCacheConfig{})
 	testutil.Ok(tb, err)
 
-	store, err := New(
+	store, err := NewBucketStoreWithOptions(
 		logger,
 		nil,
 		instrBkt,
@@ -1720,7 +1720,7 @@ func TestSeries_ErrorUnmarshallingRequestHints(t *testing.T) {
 	indexCache, err := storecache.NewInMemoryIndexCacheWithConfig(logger, nil, storecache.InMemoryIndexCacheConfig{})
 	testutil.Ok(tb, err)
 
-	store, err := New(
+	store, err := NewBucketStoreWithOptions(
 		logger,
 		nil,
 		instrBkt,
@@ -1823,7 +1823,7 @@ func TestBlockWithLargeChunks(t *testing.T) {
 	indexCache, err := storecache.NewInMemoryIndexCacheWithConfig(logger, nil, storecache.InMemoryIndexCacheConfig{})
 	testutil.Ok(t, err)
 
-	store, err := New(
+	store, err := NewBucketStoreWithOptions(
 		logger,
 		nil,
 		instrBkt,

--- a/pkg/store/limiter_test.go
+++ b/pkg/store/limiter_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	prom_testutil "github.com/prometheus/client_golang/prometheus/testutil"
+
 	"github.com/thanos-io/thanos/pkg/testutil"
 )
 
@@ -26,5 +27,69 @@ func TestLimiter(t *testing.T) {
 	testutil.Equals(t, float64(1), prom_testutil.ToFloat64(c))
 
 	testutil.NotOk(t, l.Reserve(2))
+	testutil.Equals(t, float64(1), prom_testutil.ToFloat64(c))
+}
+
+func TestNewWithFailedCounterFrom(t *testing.T) {
+	c := promauto.With(nil).NewCounter(prometheus.CounterOpts{})
+	expectedLimit := uint64(42)
+	l := NewLimiter(expectedLimit, c)
+
+	t.Run("should return error when from limiter is nil", func(t *testing.T) {
+		var nilLimiter *Limiter
+		_, err := l.NewWithFailedCounterFrom(nilLimiter)
+		testutil.NotOk(t, err)
+	})
+
+	t.Run("should return error when from limiter is of different type", func(t *testing.T) {
+		unknownLimiter := struct {
+			ChunksLimiter
+		}{}
+		_, err := l.NewWithFailedCounterFrom(unknownLimiter)
+		testutil.NotOk(t, err)
+	})
+
+	t.Run("should create new limiter with given counter", func(t *testing.T) {
+		c2 := promauto.With(nil).NewCounter(prometheus.CounterOpts{})
+		limit := uint64(1)
+		counterSource := NewLimiter(limit, c2)
+
+		err := l.Reserve(expectedLimit - 1)
+		testutil.Ok(t, err)
+
+		res, err := l.NewWithFailedCounterFrom(counterSource)
+		testutil.Ok(t, err)
+
+		resLimiter, ok := res.(*Limiter)
+		if !ok || resLimiter == nil {
+			t.Fatalf("unexpected limiter in result %#v", resLimiter)
+		}
+
+		testutil.Equals(t, resLimiter.failedCounter, counterSource.failedCounter)
+		testutil.Equals(t, resLimiter.failedOnce, counterSource.failedOnce)
+		testutil.Equals(t, resLimiter.limit, expectedLimit)
+		testutil.Equals(t, resLimiter.reserved, l.reserved)
+	})
+}
+
+func TestLimiterFailedOnce(t *testing.T) {
+	c := promauto.With(nil).NewCounter(prometheus.CounterOpts{})
+	factoryWithLimit1 := NewChunksLimiterFactory(1)
+	factoryWithLimit2 := NewChunksLimiterFactory(2)
+
+	l1 := factoryWithLimit1(c)
+	l2, err := factoryWithLimit2(c).NewWithFailedCounterFrom(l1)
+	testutil.Ok(t, err)
+
+	testutil.Ok(t, l1.Reserve(1))
+	testutil.Equals(t, float64(0), prom_testutil.ToFloat64(c))
+
+	testutil.Ok(t, l2.Reserve(2))
+	testutil.Equals(t, float64(0), prom_testutil.ToFloat64(c))
+
+	testutil.NotOk(t, l1.Reserve(1))
+	testutil.Equals(t, float64(1), prom_testutil.ToFloat64(c))
+
+	testutil.NotOk(t, l2.Reserve(1))
 	testutil.Equals(t, float64(1), prom_testutil.ToFloat64(c))
 }


### PR DESCRIPTION
Fixes: #2861

Signed-off-by: Max Neverov <neverov.max@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Add possibility to limit queried chunks by bytes via `store.grpc.series-sample-size-limit` flag.