### PR TITLE
made docsearch attribute reflect version of page

### DIFF
--- a/website/layouts/_default/baseof.html
+++ b/website/layouts/_default/baseof.html
@@ -2,9 +2,10 @@
 <html lang="en">
 
 <head>
+    {{ $version     := index (split .File.Path "/") 0 }}
     <meta http-equiv="content-type" content="text/html;charset=utf-8">
     <meta name="docsearch:language" content="en" />
-    <meta name="docsearch:version" content="1.0.0" />
+    <meta name="docsearch:version" content="{{ $version }}" />
     <meta http-equiv="X-UA-Compatible" content="chrome=1">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.2.1/css/bootstrap.min.css"

--- a/website/layouts/_default/baseof.html
+++ b/website/layouts/_default/baseof.html
@@ -2,7 +2,7 @@
 <html lang="en">
 
 <head>
-    {{ $version     := index (split .File.Path "/") 0 }}
+    {{ $version := index (split .File.Path "/") 0 }}
     <meta http-equiv="content-type" content="text/html;charset=utf-8">
     <meta name="docsearch:language" content="en" />
     <meta name="docsearch:version" content="{{ $version }}" />


### PR DESCRIPTION
Signed-off-by: thisisobate <obasiuche62@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes
Made docsearch attribute reflect the version of the page
<!-- Enumerate changes you made -->

## Verification
Works on local
<!-- How you tested it? How do you know it works? -->
