### PR TITLE
ui: Fix Block Viewer for Compactor and Store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ We use *breaking :warning:* word for marking changes that are not backward compa
 ### Fixed
 
 * [#3095](https://github.com/thanos-io/thanos/pull/3095) Rule: update manager when all rule files are removed.
+* [#3098](https://github.com/thanos-io/thanos/pull/3098) ui: Fix Block Viewer for Compactor and Store
 
 ## [v0.15.0-rc.0](https://github.com/thanos-io/thanos/releases/tag/v0.15.0-rc.0) - 2020.08.26
 

--- a/cmd/thanos/tools_bucket.go
+++ b/cmd/thanos/tools_bucket.go
@@ -346,8 +346,8 @@ func registerBucketWeb(m map[string]setupFunc, root *kingpin.CmdClause, name str
 		router := route.New()
 		ins := extpromhttp.NewInstrumentationMiddleware(reg)
 
-		bucketUI := ui.NewBucketUI(logger, *label, *webExternalPrefix, *webPrefixHeaderName)
-		bucketUI.Register(router, ins)
+		bucketUI := ui.NewBucketUI(logger, *label, *webExternalPrefix, *webPrefixHeaderName, "", component.Bucket)
+		bucketUI.Register(router, true, ins)
 
 		flagsMap := getFlagsMap(cmd.Model().Flags)
 
@@ -392,7 +392,7 @@ func registerBucketWeb(m map[string]setupFunc, root *kingpin.CmdClause, name str
 		}
 		fetcher.UpdateOnChange(func(blocks []metadata.Meta, err error) {
 			bucketUI.Set(blocks, err)
-			api.Set(blocks, err)
+			api.SetGlobal(blocks, err)
 		})
 
 		ctx, cancel := context.WithCancel(context.Background())

--- a/pkg/ui/bucket.go
+++ b/pkg/ui/bucket.go
@@ -8,6 +8,7 @@ import (
 	"html/template"
 	"net/http"
 	"path"
+	"strings"
 	"time"
 
 	"github.com/go-kit/kit/log"
@@ -22,6 +23,7 @@ type Bucket struct {
 	*BaseUI
 
 	externalPrefix, prefixHeader string
+	uiPrefix                     string
 	// Unique Prometheus label that identifies each shard, used as the title. If
 	// not present, all labels are displayed externally as a legend.
 	Label       string
@@ -30,41 +32,44 @@ type Bucket struct {
 	Err         error
 }
 
-func NewBucketUI(logger log.Logger, label, externalPrefix, prefixHeader string) *Bucket {
+func NewBucketUI(logger log.Logger, label, externalPrefix, prefixHeader, uiPrefix string, comp component.Component) *Bucket {
 	tmplVariables := map[string]string{
-		"Component": component.Bucket.String(),
+		"Component": comp.String(),
 	}
 
 	return &Bucket{
-		BaseUI:         NewBaseUI(log.With(logger, "component", "bucketUI"), "bucket_menu.html", queryTmplFuncs(), tmplVariables, externalPrefix, prefixHeader, component.Bucket),
+		BaseUI:         NewBaseUI(log.With(logger, "component", "bucketUI"), "bucket_menu.html", queryTmplFuncs(), tmplVariables, externalPrefix, prefixHeader, comp),
 		Blocks:         "[]",
 		Label:          label,
 		externalPrefix: externalPrefix,
 		prefixHeader:   prefixHeader,
+		uiPrefix:       uiPrefix,
 	}
 }
 
 // Register registers http routes for bucket UI.
-func (b *Bucket) Register(r *route.Router, ins extpromhttp.InstrumentationMiddleware) {
+func (b *Bucket) Register(r *route.Router, registerNewUI bool, ins extpromhttp.InstrumentationMiddleware) {
 	instrf := func(name string, next func(w http.ResponseWriter, r *http.Request)) http.HandlerFunc {
 		return ins.NewHandler(b.externalPrefix+name, http.HandlerFunc(next))
 	}
-	r.WithPrefix(b.externalPrefix).Get("/", instrf("root", b.root))
-	r.WithPrefix(b.externalPrefix).Get("/static/*filepath", instrf("static", b.serveStaticAsset))
-	// Make sure that "<path-prefix>/new" is redirected to "<path-prefix>/new/" and
-	// not just the naked "/new/", which would be the default behavior of the router
-	// with the "RedirectTrailingSlash" option (https://godoc.org/github.com/julienschmidt/httprouter#Router.RedirectTrailingSlash),
-	// and which breaks users with a --web.route-prefix that deviates from the path derived
-	// from the external URL.
-	r.WithPrefix(b.externalPrefix).Get("/new", func(w http.ResponseWriter, r *http.Request) {
-		http.Redirect(w, r, path.Join(GetWebPrefix(b.logger, b.externalPrefix, b.prefixHeader, r), "new")+"/", http.StatusFound)
-	})
-	r.WithPrefix(b.externalPrefix).Get("/new/*filepath", instrf("react-static", b.serveReactUI))
+	r.WithPrefix(b.uiPrefix).Get("/", instrf("root", b.root))
+	r.WithPrefix(b.uiPrefix).Get("/static/*filepath", instrf("static", b.serveStaticAsset))
+	if registerNewUI {
+		// Make sure that "<path-prefix>/new" is redirected to "<path-prefix>/new/" and
+		// not just the naked "/new/", which would be the default behavior of the router
+		// with the "RedirectTrailingSlash" option (https://godoc.org/github.com/julienschmidt/httprouter#Router.RedirectTrailingSlash),
+		// and which breaks users with a --web.route-prefix that deviates from the path derived
+		// from the external URL.
+		r.Get("/new", func(w http.ResponseWriter, r *http.Request) {
+			http.Redirect(w, r, path.Join(GetWebPrefix(b.logger, b.externalPrefix, b.prefixHeader, r), "new")+"/", http.StatusFound)
+		})
+		r.Get("/new/*filepath", instrf("react-static", b.serveReactUI))
+	}
 }
 
 // Handle / of bucket UIs.
 func (b *Bucket) root(w http.ResponseWriter, r *http.Request) {
-	b.executeTemplate(w, "bucket.html", GetWebPrefix(b.logger, b.externalPrefix, b.prefixHeader, r), b)
+	b.executeTemplate(w, "bucket.html", GetWebPrefix(b.logger, path.Join(b.externalPrefix, strings.TrimPrefix(b.uiPrefix, "/")), b.prefixHeader, r), b)
 }
 
 func (b *Bucket) Set(blocks []metadata.Meta, err error) {

--- a/pkg/ui/react-app/src/App.tsx
+++ b/pkg/ui/react-app/src/App.tsx
@@ -15,7 +15,8 @@ const defaultRouteConfig: { [component: string]: string } = {
   query: '/graph',
   rule: '/alerts',
   bucket: '/blocks',
-  compact: '/blocks',
+  compact: '/loaded',
+  store: '/loaded',
 };
 
 const App: FC<PathPrefixProps & ThanosComponentProps> = ({ pathPrefix, thanosComponent }) => {
@@ -46,6 +47,7 @@ const App: FC<PathPrefixProps & ThanosComponentProps> = ({ pathPrefix, thanosCom
             <Targets path="/targets" pathPrefix={pathPrefix} />
             <Stores path="/stores" pathPrefix={pathPrefix} />
             <Blocks path="/blocks" pathPrefix={pathPrefix} />
+            <Blocks path="/loaded" pathPrefix={pathPrefix} view="loaded" />
           </Router>
         </QueryParamProvider>
       </Container>

--- a/pkg/ui/react-app/src/thanos/Navbar.tsx
+++ b/pkg/ui/react-app/src/thanos/Navbar.tsx
@@ -41,7 +41,11 @@ const navConfig: { [component: string]: (NavConfig | NavDropDown)[] } = {
     { name: 'Rules', uri: '/new/rules' },
   ],
   bucket: [{ name: 'Blocks', uri: '/new/blocks' }],
-  compact: [{ name: 'Blocks', uri: '/new/blocks' }],
+  compact: [
+    { name: 'Global Blocks', uri: '/new/blocks' },
+    { name: 'Loaded Blocks', uri: '/new/loaded' },
+  ],
+  store: [{ name: 'Loaded Blocks', uri: '/new/loaded' }],
 };
 
 const defaultClassicUIRoute: { [component: string]: string } = {
@@ -49,6 +53,7 @@ const defaultClassicUIRoute: { [component: string]: string } = {
   rule: '/alerts',
   bucket: '/',
   compact: '/loaded',
+  store: '/loaded',
 };
 
 interface NavigationProps {

--- a/pkg/ui/react-app/src/thanos/pages/blocks/Blocks.test.tsx
+++ b/pkg/ui/react-app/src/thanos/pages/blocks/Blocks.test.tsx
@@ -25,7 +25,18 @@ describe('Blocks', () => {
         blocks = mount(<Blocks />);
       });
       blocks.update();
-      expect(mock).toHaveBeenCalledWith('/api/v1/blocks', { cache: 'no-store', credentials: 'same-origin' });
+      expect(mock).toHaveBeenCalledWith('/api/v1/blocks?view=global', { cache: 'no-store', credentials: 'same-origin' });
+
+      const sourceViews = blocks.find(SourceView);
+      expect(sourceViews).toHaveLength(8);
+    });
+
+    it('fetched data with different view', async () => {
+      await act(async () => {
+        blocks = mount(<Blocks view="loaded" />);
+      });
+      blocks.update();
+      expect(mock).toHaveBeenCalledWith('/api/v1/blocks?view=loaded', { cache: 'no-store', credentials: 'same-origin' });
 
       const sourceViews = blocks.find(SourceView);
       expect(sourceViews).toHaveLength(8);
@@ -49,7 +60,7 @@ describe('Blocks', () => {
       });
       blocks.update();
 
-      expect(mock).toHaveBeenCalledWith('/api/v1/blocks', { cache: 'no-store', credentials: 'same-origin' });
+      expect(mock).toHaveBeenCalledWith('/api/v1/blocks?view=global', { cache: 'no-store', credentials: 'same-origin' });
 
       const alert = blocks.find(Alert);
       expect(alert.prop('color')).toBe('warning');
@@ -67,7 +78,7 @@ describe('Blocks', () => {
       });
       blocks.update();
 
-      expect(mock).toHaveBeenCalledWith('/api/v1/blocks', { cache: 'no-store', credentials: 'same-origin' });
+      expect(mock).toHaveBeenCalledWith('/api/v1/blocks?view=global', { cache: 'no-store', credentials: 'same-origin' });
 
       const alert = blocks.find(Alert);
       expect(alert.prop('color')).toBe('danger');

--- a/pkg/ui/react-app/src/thanos/pages/blocks/Blocks.tsx
+++ b/pkg/ui/react-app/src/thanos/pages/blocks/Blocks.tsx
@@ -92,8 +92,14 @@ export const BlocksContent: FC<{ data: BlockListProps }> = ({ data }) => {
 
 const BlocksWithStatusIndicator = withStatusIndicator(BlocksContent);
 
-export const Blocks: FC<RouteComponentProps & PathPrefixProps> = ({ pathPrefix = '' }) => {
-  const { response, error, isLoading } = useFetch<BlockListProps>(`${pathPrefix}/api/v1/blocks`);
+interface BlocksProps {
+  view?: string;
+}
+
+export const Blocks: FC<RouteComponentProps & PathPrefixProps & BlocksProps> = ({ pathPrefix = '', view = 'global' }) => {
+  const { response, error, isLoading } = useFetch<BlockListProps>(
+    `${pathPrefix}/api/v1/blocks${view ? '?view=' + view : ''}`
+  );
   const { status: responseStatus } = response;
   const badResponse = responseStatus !== 'success' && responseStatus !== 'start fetching';
 

--- a/pkg/ui/templates/bucket_menu.html
+++ b/pkg/ui/templates/bucket_menu.html
@@ -11,7 +11,7 @@
                     <a class="nav-link" href="https://thanos.io/tip/thanos/getting-started.md/" target="_blank">Help</a>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link" href="{{ pathPrefix }}/new/" target="_blank">New UI</a>
+                    <a class="nav-link" href="/new/" target="_blank">New UI</a>
                 </li>
             </ul>
         </div>

--- a/pkg/ui/ui.go
+++ b/pkg/ui/ui.go
@@ -36,6 +36,7 @@ var (
 		"/version",
 		"/stores",
 		"/blocks",
+		"/loaded",
 	}
 )
 


### PR DESCRIPTION
Signed-off-by: Prem Kumar <prmsrswt@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->
Fixes #3093

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes
- Modified the Blocks API to serve loaded blocks and global blocks
- Fix Block Viewer not working because of incorrect handling of the external prefix.

## Verification
Tested locally for Bucket web, Compactor, and Store using docker-compose setup.
