### PR TITLE
Improve doc about exposing UI sub-path behind reverse proxy with nginx ingress

### DIFF
--- a/docs/components/query.md
+++ b/docs/components/query.md
@@ -260,6 +260,30 @@ If `PathPrefixStrip: /some-path` option or `traefik.frontend.rule.type: PathPref
 Kubernetes Ingress annotation is set, then `Traefik` writes the stripped prefix into X-Forwarded-Prefix header.
 Then, `thanos query --web.prefix-header=X-Forwarded-Prefix` will serve correct HTTP redirects and links prefixed by the stripped path.
 
+For ingress controller nginx, use the flag `--web.prefix-header=X-Forwarded-Prefix` for thanos query
+and use the below example of Ingress configuration to access Thanos on `/thanos` prefix:
+```
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/rewrite-target: /$1
+    nginx.ingress.kubernetes.io/x-forwarded-prefix: /thanos
+  labels:
+    app.kubernetes.io/name: thanos-query
+  name: thanos-query
+spec:
+  rules:
+  - host: ${MY-HOST-FQDN}
+    http:
+      paths:
+      - backend:
+          serviceName: thanos-query
+          servicePort: 9090
+        path: /thanos/?(.*)
+```
+
 ## File SD
 
 `--store.sd-file` flag provides a path to a JSON or YAML formatted file, which contains a list of targets in [Prometheus target format](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#file_sd_config).


### PR DESCRIPTION
…

Signed-off-by: Shay Berman <shay.berman@redislabs.com>

query

* [X] Change is not relevant to the end user.

## Changes

Adding clarification of how to set dynamic path configuration with Ingress nginx inside the section `Expose UI on a sub-path` [link](https://github.com/thanos-io/thanos/blob/master/docs/components/query.md#expose-ui-on-a-sub-path).
Currently the detail describe on this section is more focus on Trafix and less on nginx ingress.
So I just added an example of Igress (it was hard to find this info, and took me quite time to understand how to do it, so why not to help everyone with simple example).

## Verification

I used the ingress object in the example and setting of the thanos query as mentioned, then I access to `http://MY-HOST-FQDN/thanos` and it works well.
