### PR TITLE
querier: Fix overwriting maxSourceResolution when auto downsampling is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ We use *breaking :warning:* word for marking changes that are not backward compa
 
 * [#3095](https://github.com/thanos-io/thanos/pull/3095) Rule: update manager when all rule files are removed.
 * [#3098](https://github.com/thanos-io/thanos/pull/3098) ui: Fix Block Viewer for Compactor and Store
+* [#3105](https://github.com/thanos-io/thanos/pull/3105) Query: Fix overwriting maxSourceResolution when auto downsampling is enabled.
 
 ## [v0.15.0-rc.0](https://github.com/thanos-io/thanos/releases/tag/v0.15.0-rc.0) - 2020.08.26
 

--- a/pkg/api/query/v1.go
+++ b/pkg/api/query/v1.go
@@ -195,7 +195,8 @@ func (qapi *QueryAPI) parseDownsamplingParamMillis(r *http.Request, defaultVal t
 	val := r.FormValue(maxSourceResolutionParam)
 	if qapi.enableAutodownsampling || (val == "auto") {
 		maxSourceResolution = defaultVal
-	} else if val != "" {
+	}
+	if val != "" && val != "auto" {
 		var err error
 		maxSourceResolution, err = parseDuration(val)
 		if err != nil {

--- a/pkg/api/query/v1_test.go
+++ b/pkg/api/query/v1_test.go
@@ -1040,6 +1040,14 @@ func TestParseDownsamplingParamMillis(t *testing.T) {
 			result:                   int64((1 * time.Hour) / 6),
 			fail:                     true,
 		},
+		// maxSourceResolution param can be overwritten.
+		{
+			maxSourceResolutionParam: "1m",
+			enableAutodownsampling:   true,
+			step:                     time.Hour,
+			result:                   int64(time.Minute / (1000 * 1000)),
+			fail:                     false,
+		},
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
Signed-off-by: Ben Ye <yb532204897@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->
This pr makes maxSourceResolution overwritable when auto downsampling is enabled. For more context, please check https://cloud-native.slack.com/archives/CL25937SP/p1598839574028300

## Verification

<!-- How you tested it? How do you know it works? -->
