### PR TITLE
receive: Add ability to consume contents of the hashrings file directly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ We use _breaking :warning:_ to mark changes that are not backward compatible (re
 - [#3469](https://github.com/thanos-io/thanos/pull/3469) StoreAPI: Added `hints` field to `LabelNamesRequest` and `LabelValuesRequest`. Hints in an opaque data structure that can be used to carry additional information from the store and its content is implementation specific.
 - [#3421](https://github.com/thanos-io/thanos/pull/3421) Tools: Added `thanos tools bucket rewrite` command allowing to delete series from given block.
 - [#3388](https://github.com/thanos-io/thanos/pull/3378) Tools: Bucket replicator now can specify block IDs to copy.
+- [#3121](https://github.com/thanos-io/thanos/pull/3121) Receive: Added `--receive.hashrings` alternative to `receive.hashrings-file` flag (lower priority). Content of JSON file that contains the hashring configuration.
 
 ### Fixed
 
@@ -110,8 +111,13 @@ Highlights:
 
 ### Added
 
+<<<<<<< HEAD
 - [#3114](https://github.com/thanos-io/thanos/pull/3114) Query Frontend: Added support for Memacached cache.
   - **breaking** Renamed flag `log_queries_longer_than` to `log-queries-longer-than`.
+=======
+- [#3114](https://github.com/thanos-io/thanos/pull/3114) Query Frontend: Added support for Memcached cache.
+    - **breaking** Renamed flag `log_queries_longer_than` to `log-queries-longer-than`.
+>>>>>>> dedc7164 (Add ability to consume content of the hashring directly)
 - [#3166](https://github.com/thanos-io/thanos/pull/3166) UIs: Added UI for passing a `storeMatch[]` parameter to queries.
 - [#3181](https://github.com/thanos-io/thanos/pull/3181) Logging: Added debug level logging for responses between 300-399
 - [#3133](https://github.com/thanos-io/thanos/pull/3133) Query: Allowed passing a `storeMatch[]` to Labels APIs; Time range metadata based store filtering is supported on Labels APIs.
@@ -133,7 +139,7 @@ Highlights:
 - [#3022](https://github.com/thanos-io/thanos/pull/3022) \*: Thanos images are now build with Go 1.15.
 - [#3205](https://github.com/thanos-io/thanos/pull/3205) \*: Updated TSDB to ~2.21
 
-## [v0.15.0](https://github.com/thanos-io/thanos/releases) - 2020.09.07
+## [v0.15.0](https://github.com/thanos-io/thanos/releases/v0.15.0) - 2020.09.07
 
 Highlights:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,13 +111,8 @@ Highlights:
 
 ### Added
 
-<<<<<<< HEAD
-- [#3114](https://github.com/thanos-io/thanos/pull/3114) Query Frontend: Added support for Memacached cache.
-  - **breaking** Renamed flag `log_queries_longer_than` to `log-queries-longer-than`.
-=======
 - [#3114](https://github.com/thanos-io/thanos/pull/3114) Query Frontend: Added support for Memcached cache.
     - **breaking** Renamed flag `log_queries_longer_than` to `log-queries-longer-than`.
->>>>>>> dedc7164 (Add ability to consume content of the hashring directly)
 - [#3166](https://github.com/thanos-io/thanos/pull/3166) UIs: Added UI for passing a `storeMatch[]` parameter to queries.
 - [#3181](https://github.com/thanos-io/thanos/pull/3181) Logging: Added debug level logging for responses between 300-399
 - [#3133](https://github.com/thanos-io/thanos/pull/3133) Query: Allowed passing a `storeMatch[]` to Labels APIs; Time range metadata based store filtering is supported on Labels APIs.

--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -65,7 +65,7 @@ func registerReceive(app *extkingpin.App) {
 
 	retention := extkingpin.ModelDuration(cmd.Flag("tsdb.retention", "How long to retain raw samples on local storage. 0d - disables this retention.").Default("15d"))
 
-	hashringsFile := extflag.RegisterPathOrContent(cmd, "receive.hashrings", "JSON file that contains the hashring configuration.", false)
+	hashringsFile := extflag.RegisterPathOrContent(cmd, "receive.hashrings", "File that contains the hashring configuration.", false)
 
 	refreshInterval := extkingpin.ModelDuration(cmd.Flag("receive.hashrings-file-refresh-interval", "Refresh interval to re-read the hashring configuration file. (used as a fallback)").
 		Default("5m"))

--- a/docs/components/receive.md
+++ b/docs/components/receive.md
@@ -147,9 +147,13 @@ Flags:
                                  https://thanos.io/tip/thanos/storage.md/#configuration
       --tsdb.retention=15d       How long to retain raw samples on local
                                  storage. 0d - disables this retention.
-      --receive.hashrings-file=<path>
-                                 Path to file that contains the hashring
+      --receive.hashrings-file=<file-path>
+                                 Path to JSON file that contains the hashring
                                  configuration.
+      --receive.hashrings=<content>
+                                 Alternative to 'receive.hashrings-file' flag
+                                 (lower priority). Content of JSON file that
+                                 contains the hashring configuration.
       --receive.hashrings-file-refresh-interval=5m
                                  Refresh interval to re-read the hashring
                                  configuration file. (used as a fallback)

--- a/docs/components/receive.md
+++ b/docs/components/receive.md
@@ -148,12 +148,12 @@ Flags:
       --tsdb.retention=15d       How long to retain raw samples on local
                                  storage. 0d - disables this retention.
       --receive.hashrings-file=<file-path>
-                                 Path to JSON file that contains the hashring
+                                 Path to File that contains the hashring
                                  configuration.
       --receive.hashrings=<content>
                                  Alternative to 'receive.hashrings-file' flag
-                                 (lower priority). Content of JSON file that
-                                 contains the hashring configuration.
+                                 (lower priority). Content of File that contains
+                                 the hashring configuration.
       --receive.hashrings-file-refresh-interval=5m
                                  Refresh interval to re-read the hashring
                                  configuration file. (used as a fallback)

--- a/docs/components/receive.md
+++ b/docs/components/receive.md
@@ -147,12 +147,14 @@ Flags:
                                  https://thanos.io/tip/thanos/storage.md/#configuration
       --tsdb.retention=15d       How long to retain raw samples on local
                                  storage. 0d - disables this retention.
-      --receive.hashrings-file=<file-path>
-                                 Path to File that contains the hashring
-                                 configuration.
+      --receive.hashrings-file=<path>
+                                 Path to file that contains the hashring
+                                 configuration. A watcher is initialized to
+                                 watch changes and update the hashring
+                                 dynamically.
       --receive.hashrings=<content>
                                  Alternative to 'receive.hashrings-file' flag
-                                 (lower priority). Content of File that contains
+                                 (lower priority). Content of file that contains
                                  the hashring configuration.
       --receive.hashrings-file-refresh-interval=5m
                                  Refresh interval to re-read the hashring

--- a/pkg/extflag/pathorcontent.go
+++ b/pkg/extflag/pathorcontent.go
@@ -44,7 +44,8 @@ func RegisterPathOrContent(cmd FlagClause, flagName string, help string, require
 	}
 }
 
-// Content returns the content of the file. Flag that specifies path has priority.
+// Content returns the content of the file when given or directly the content that has passed to the flag.
+// Flag that specifies path has priority.
 // It returns error if the content is empty and required flag is set to true.
 func (p *PathOrContent) Content() ([]byte, error) {
 	fileFlagName := fmt.Sprintf("%s-file", p.flagName)
@@ -71,9 +72,9 @@ func (p *PathOrContent) Content() ([]byte, error) {
 	return content, nil
 }
 
-// Path returns the path of the file. Flag that specifies path has priority.
-// It returns error if the required flag is set to true and content is empty.
-// It also returns errors if both a path and content are given.
+// Path returns the path of the given file that has passed to the flag.
+// It returns error if both a path and content are given.
+// It returns error if the required flag is set to true and path is empty.
 func (p *PathOrContent) Path() (string, error) {
 	fileFlagName := fmt.Sprintf("%s-file", p.flagName)
 

--- a/pkg/extflag/pathorcontent.go
+++ b/pkg/extflag/pathorcontent.go
@@ -44,21 +44,20 @@ func RegisterPathOrContent(cmd FlagClause, flagName string, help string, require
 	}
 }
 
-// Content returns content of the file. Flag that specifies path has priority.
+// Content returns the content of the file. Flag that specifies path has priority.
 // It returns error if the content is empty and required flag is set to true.
 func (p *PathOrContent) Content() ([]byte, error) {
-	contentFlagName := p.flagName
 	fileFlagName := fmt.Sprintf("%s-file", p.flagName)
 
 	if len(*p.path) > 0 && len(*p.content) > 0 {
-		return nil, errors.Errorf("both %s and %s flags set.", fileFlagName, contentFlagName)
+		return nil, errors.Errorf("both %s and %s flags set.", fileFlagName, p.flagName)
 	}
 
 	var content []byte
 	if len(*p.path) > 0 {
 		c, err := ioutil.ReadFile(*p.path)
 		if err != nil {
-			return nil, errors.Wrapf(err, "loading YAML file %s for %s", *p.path, fileFlagName)
+			return nil, errors.Wrapf(err, "loading file %s for %s", *p.path, fileFlagName)
 		}
 		content = c
 	} else {
@@ -66,8 +65,24 @@ func (p *PathOrContent) Content() ([]byte, error) {
 	}
 
 	if len(content) == 0 && p.required {
-		return nil, errors.Errorf("flag %s or %s is required for running this command and content cannot be empty.", fileFlagName, contentFlagName)
+		return nil, errors.Errorf("flag %s or %s is required for running this command and content cannot be empty.", fileFlagName, p.flagName)
 	}
 
 	return content, nil
+}
+
+// Path returns the path of the file. Flag that specifies path has priority.
+// It returns error if the required flag is set to true.
+func (p *PathOrContent) Path() (string, error) {
+	fileFlagName := fmt.Sprintf("%s-file", p.flagName)
+
+	if len(*p.path) > 0 && len(*p.content) > 0 {
+		return "", errors.Errorf("both %s and %s flags set.", fileFlagName, p.flagName)
+	}
+
+	if len(*p.path) == 0 && p.required {
+		return "", errors.Errorf("flag %s or %s is required for running this command and content cannot be empty.", fileFlagName, p.flagName)
+	}
+
+	return *p.path, nil
 }

--- a/pkg/extflag/pathorcontent.go
+++ b/pkg/extflag/pathorcontent.go
@@ -72,7 +72,8 @@ func (p *PathOrContent) Content() ([]byte, error) {
 }
 
 // Path returns the path of the file. Flag that specifies path has priority.
-// It returns error if the required flag is set to true.
+// It returns error if the required flag is set to true and content is empty.
+// It also returns errors if both a path and content are given.
 func (p *PathOrContent) Path() (string, error) {
 	fileFlagName := fmt.Sprintf("%s-file", p.flagName)
 

--- a/pkg/extflag/pathorcontent.go
+++ b/pkg/extflag/pathorcontent.go
@@ -71,20 +71,3 @@ func (p *PathOrContent) Content() ([]byte, error) {
 
 	return content, nil
 }
-
-// Path returns the path of the given file that has passed to the flag.
-// It returns error if both a path and content are given.
-// It returns error if the required flag is set to true and path is empty.
-func (p *PathOrContent) Path() (string, error) {
-	fileFlagName := fmt.Sprintf("%s-file", p.flagName)
-
-	if len(*p.path) > 0 && len(*p.content) > 0 {
-		return "", errors.Errorf("both %s and %s flags set.", fileFlagName, p.flagName)
-	}
-
-	if len(*p.path) == 0 && p.required {
-		return "", errors.Errorf("flag %s or %s is required for running this command and content cannot be empty.", fileFlagName, p.flagName)
-	}
-
-	return *p.path, nil
-}

--- a/pkg/receive/hashring.go
+++ b/pkg/receive/hashring.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/cespare/xxhash"
 	"github.com/pkg/errors"
+
 	"github.com/thanos-io/thanos/pkg/store/storepb/prompb"
 )
 
@@ -158,14 +159,14 @@ func newMultiHashring(cfg []HashringConfig) Hashring {
 	return m
 }
 
-// HashringFromConfig creates multi-tenant hashrings from a
+// HashringFromConfigWatcher creates multi-tenant hashrings from a
 // hashring configuration file watcher.
 // The configuration file is watched for updates.
 // Hashrings are returned on the updates channel.
 // Which hashring to use for a tenant is determined
 // by the tenants field of the hashring configuration.
 // The updates chan is closed before exiting.
-func HashringFromConfig(ctx context.Context, updates chan<- Hashring, cw *ConfigWatcher) error {
+func HashringFromConfigWatcher(ctx context.Context, updates chan<- Hashring, cw *ConfigWatcher) error {
 	defer close(updates)
 	go cw.Run(ctx)
 
@@ -180,4 +181,19 @@ func HashringFromConfig(ctx context.Context, updates chan<- Hashring, cw *Config
 			return ctx.Err()
 		}
 	}
+}
+
+// HashringFromConfig loads raw configuration content and returns a Hashring if the given configuration is not valid.
+func HashringFromConfig(content []byte) (Hashring, error) {
+	config, err := parseConfig(content)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to parse configuration")
+	}
+
+	// If hashring is empty, return an error.
+	if len(config) == 0 {
+		return nil, errors.Wrapf(err, "failed to load configuration")
+	}
+
+	return newMultiHashring(config), err
 }

--- a/pkg/receive/hashring.go
+++ b/pkg/receive/hashring.go
@@ -184,8 +184,8 @@ func HashringFromConfigWatcher(ctx context.Context, updates chan<- Hashring, cw 
 }
 
 // HashringFromConfig loads raw configuration content and returns a Hashring if the given configuration is not valid.
-func HashringFromConfig(content []byte) (Hashring, error) {
-	config, err := parseConfig(content)
+func HashringFromConfig(content string) (Hashring, error) {
+	config, err := parseConfig([]byte(content))
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to parse configuration")
 	}

--- a/scripts/cfggen/main.go
+++ b/scripts/cfggen/main.go
@@ -15,6 +15,9 @@ import (
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/pkg/errors"
+	"gopkg.in/alecthomas/kingpin.v2"
+	"gopkg.in/yaml.v2"
+
 	"github.com/thanos-io/thanos/pkg/alert"
 	"github.com/thanos-io/thanos/pkg/cacheutil"
 	http_util "github.com/thanos-io/thanos/pkg/http"
@@ -34,8 +37,6 @@ import (
 	"github.com/thanos-io/thanos/pkg/tracing/jaeger"
 	"github.com/thanos-io/thanos/pkg/tracing/lightstep"
 	"github.com/thanos-io/thanos/pkg/tracing/stackdriver"
-	kingpin "gopkg.in/alecthomas/kingpin.v2"
-	yaml "gopkg.in/yaml.v2"
 )
 
 var (

--- a/scripts/quickstart.sh
+++ b/scripts/quickstart.sh
@@ -184,10 +184,6 @@ sleep 0.5
 
 if [ -n "${REMOTE_WRITE_ENABLED}" ]; then
 
-  cat <<-EOF >./data/hashring.json
-		[{"endpoints":["127.0.0.1:10907","127.0.0.1:11907","127.0.0.1:12907"]}]
-	EOF
-
   for i in $(seq 0 1 2); do
     ${THANOS_EXECUTABLE} receive \
       --debug.name receive${i} \
@@ -203,7 +199,7 @@ if [ -n "${REMOTE_WRITE_ENABLED}" ]; then
       --label "receive_replica=\"${i}\"" \
       --label 'receive="true"' \
       --receive.local-endpoint 127.0.0.1:1${i}907 \
-      --receive.hashrings-file ./data/hashring.json \
+      --receive.hashrings '[{"endpoints":["127.0.0.1:10907","127.0.0.1:11907","127.0.0.1:12907"]}]' \
       --remote-write.address 0.0.0.0:1${i}908 \
       ${OBJSTORECFG} &
 

--- a/test/e2e/receive_test.go
+++ b/test/e2e/receive_test.go
@@ -138,6 +138,82 @@ func TestReceive(t *testing.T) {
 		})
 	})
 
+	t.Run("hashring with config watcher", func(t *testing.T) {
+		t.Parallel()
+
+		s, err := e2e.NewScenario("e2e_test_receive_hashring")
+		testutil.Ok(t, err)
+		t.Cleanup(e2ethanos.CleanScenario(t, s))
+
+		r1, err := e2ethanos.NewReceiver(s.SharedDir(), s.NetworkName(), "1", 1)
+		testutil.Ok(t, err)
+		r2, err := e2ethanos.NewReceiver(s.SharedDir(), s.NetworkName(), "2", 1)
+		testutil.Ok(t, err)
+		r3, err := e2ethanos.NewReceiver(s.SharedDir(), s.NetworkName(), "3", 1)
+		testutil.Ok(t, err)
+
+		h := receive.HashringConfig{
+			Endpoints: []string{
+				r1.GRPCNetworkEndpointFor(s.NetworkName()),
+				r2.GRPCNetworkEndpointFor(s.NetworkName()),
+				r3.GRPCNetworkEndpointFor(s.NetworkName()),
+			},
+		}
+
+		// Recreate again, but with hashring config.
+		// TODO(kakkoyun): Update config file and wait config watcher to reconcile hashring.
+		r1, err = e2ethanos.NewReceiverWithConfigWatcher(s.SharedDir(), s.NetworkName(), "1", 1, h)
+		testutil.Ok(t, err)
+		r2, err = e2ethanos.NewReceiverWithConfigWatcher(s.SharedDir(), s.NetworkName(), "2", 1, h)
+		testutil.Ok(t, err)
+		r3, err = e2ethanos.NewReceiverWithConfigWatcher(s.SharedDir(), s.NetworkName(), "3", 1, h)
+		testutil.Ok(t, err)
+		testutil.Ok(t, s.StartAndWaitReady(r1, r2, r3))
+
+		prom1, _, err := e2ethanos.NewPrometheus(s.SharedDir(), "1", defaultPromConfig("prom1", 0, e2ethanos.RemoteWriteEndpoint(r1.NetworkEndpoint(8081)), ""), e2ethanos.DefaultPrometheusImage())
+		testutil.Ok(t, err)
+		prom2, _, err := e2ethanos.NewPrometheus(s.SharedDir(), "2", defaultPromConfig("prom2", 0, e2ethanos.RemoteWriteEndpoint(r2.NetworkEndpoint(8081)), ""), e2ethanos.DefaultPrometheusImage())
+		testutil.Ok(t, err)
+		prom3, _, err := e2ethanos.NewPrometheus(s.SharedDir(), "3", defaultPromConfig("prom3", 0, e2ethanos.RemoteWriteEndpoint(r3.NetworkEndpoint(8081)), ""), e2ethanos.DefaultPrometheusImage())
+		testutil.Ok(t, err)
+		testutil.Ok(t, s.StartAndWaitReady(prom1, prom2, prom3))
+
+		q, err := e2ethanos.NewQuerier(s.SharedDir(), "1", []string{r1.GRPCNetworkEndpoint(), r2.GRPCNetworkEndpoint(), r3.GRPCNetworkEndpoint()}, nil, nil, "", "")
+		testutil.Ok(t, err)
+		testutil.Ok(t, s.StartAndWaitReady(q))
+
+		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+		t.Cleanup(cancel)
+
+		testutil.Ok(t, q.WaitSumMetricsWithOptions(e2e.Equals(3), []string{"thanos_store_nodes_grpc_connections"}, e2e.WaitMissingMetrics))
+
+		queryAndAssertSeries(t, ctx, q.HTTPEndpoint(), queryUpWithoutInstance, promclient.QueryOptions{
+			Deduplicate: false,
+		}, []model.Metric{
+			{
+				"job":        "myself",
+				"prometheus": "prom1",
+				"receive":    "2",
+				"replica":    "0",
+				"tenant_id":  "default-tenant",
+			},
+			{
+				"job":        "myself",
+				"prometheus": "prom2",
+				"receive":    "1",
+				"replica":    "0",
+				"tenant_id":  "default-tenant",
+			},
+			{
+				"job":        "myself",
+				"prometheus": "prom3",
+				"receive":    "2",
+				"replica":    "0",
+				"tenant_id":  "default-tenant",
+			},
+		})
+	})
+
 	t.Run("replication", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
Signed-off-by: Kemal Akkoyun <kakkoyun@gmail.com>

* [x] I added CHANGELOG entry for this change.

Fixes #3026.

## Changes

* Added `--receive.hashrings` alternative to `receive.hashrings-file` flag (lower priority). Content of JSON file that contains the hashring configuration.

## Verification

* `make test-local`
* `make test-e2e`
