### PR TITLE
Add HTTP port for Query Frontend service

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -141,19 +141,20 @@ Vanilla Prometheus might be totally enough for small setups.
 However, in case you want to play and run Thanos components
 on a single node, we recommend following the port layout:
 
-| Component | Interface               | Port  |
-| --------- | ----------------------- | ----- |
-| Sidecar   | gRPC                    | 10901 |
-| Sidecar   | HTTP                    | 10902 |
-| Query     | gRPC                    | 10903 |
-| Query     | HTTP                    | 10904 |
-| Store     | gRPC                    | 10905 |
-| Store     | HTTP                    | 10906 |
-| Receive   | gRPC (store API)        | 10907 |
-| Receive   | HTTP (remote write API) | 10908 |
-| Receive   | HTTP                    | 10909 |
-| Rule      | gRPC                    | 10910 |
-| Rule      | HTTP                    | 10911 |
-| Compact   | HTTP                    | 10912 |
+| Component      | Interface               | Port  |
+| -------------- | ----------------------- | ----- |
+| Sidecar        | gRPC                    | 10901 |
+| Sidecar        | HTTP                    | 10902 |
+| Query          | gRPC                    | 10903 |
+| Query          | HTTP                    | 10904 |
+| Store          | gRPC                    | 10905 |
+| Store          | HTTP                    | 10906 |
+| Receive        | gRPC (store API)        | 10907 |
+| Receive        | HTTP (remote write API) | 10908 |
+| Receive        | HTTP                    | 10909 |
+| Rule           | gRPC                    | 10910 |
+| Rule           | HTTP                    | 10911 |
+| Compact        | HTTP                    | 10912 |
+| Query Frontend | HTTP                    | 10913 |
 
 You can see example one-node setup [here](/scripts/quickstart.sh)


### PR DESCRIPTION
Add Query Frontend HTTP port service for single node deployments.

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->
<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->
Adds default port for Query Frontend HTTP service for single node deployments.

## Verification

<!-- How you tested it? How do you know it works? -->
