### PR TITLE
Fix the name of the previous SSE setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 
 :warning: **WARNING** :warning: Thanos Rule's `/api/v1/rules` endpoint no longer returns the old, deprecated `partial_response_strategy`. The old, deprecated value has been fixed to `WARN` for quite some time. _Please_ use `partialResponseStrategy`.
 
-:warning: **WARNING** :warning: The `sse_encryption` value is now deprecated in favour of `sse_config`. If you used `sse_encryption`, the migration strategy is to set up the following block:
+:warning: **WARNING** :warning: The `encryption_sse` value is now deprecated in favour of `sse_config`. If you used `encryption_sse`, the migration strategy is to set up the following block:
 
 ```yaml
 


### PR DESCRIPTION
* [x] I added CHANGELOG entry for this change. - This is a changelog change
* [ ] Change is not relevant to the end user.

## Changes

Fix the changelog to refer to the correct previous setting.

## Verification

The PR here: https://github.com/thanos-io/thanos/pull/3064/files#diff-23ce6f3804b08b263e06e0c152bf4ee5L86
`encrypt_sse` was removed, not `sse_encrypt`