### PR TITLE
mixin: adding ability to have configurable namespace and selector

### DIFF
--- a/mixin/README.md
+++ b/mixin/README.md
@@ -100,7 +100,7 @@ This project is intended to be used as a library. You can extend and customize d
   dashboard+:: {
     prefix: 'Thanos / ',
     tags: ['thanos-mixin'],
-    namespaceQuery: 'kube_pod_info',
+    namespaceMetric: 'kube_pod_info',
   },
 }
 ```

--- a/mixin/config.libsonnet
+++ b/mixin/config.libsonnet
@@ -2,36 +2,43 @@
   query+:: {
     jobPrefix: 'thanos-query',
     selector: 'job=~"%s.*"' % self.jobPrefix,
+    namespaceLabel: $.dashboard.namespaceLabel, 
     title: '%(prefix)sQuery' % $.dashboard.prefix,
   },
   store+:: {
     jobPrefix: 'thanos-store',
     selector: 'job=~"%s.*"' % self.jobPrefix,
+    namespaceLabel: $.dashboard.namespaceLabel, 
     title: '%(prefix)sStore' % $.dashboard.prefix,
   },
   receive+:: {
     jobPrefix: 'thanos-receive',
     selector: 'job=~"%s.*"' % self.jobPrefix,
+    namespaceLabel: $.dashboard.namespaceLabel, 
     title: '%(prefix)sReceive' % $.dashboard.prefix,
   },
   rule+:: {
     jobPrefix: 'thanos-rule',
     selector: 'job=~"%s.*"' % self.jobPrefix,
+    namespaceLabel: $.dashboard.namespaceLabel, 
     title: '%(prefix)sRule' % $.dashboard.prefix,
   },
   compact+:: {
     jobPrefix: 'thanos-compact',
     selector: 'job=~"%s.*"' % self.jobPrefix,
+    namespaceLabel: $.dashboard.namespaceLabel, 
     title: '%(prefix)sCompact' % $.dashboard.prefix,
   },
   sidecar+:: {
     jobPrefix: 'thanos-sidecar',
     selector: 'job=~"%s.*"' % self.jobPrefix,
+    namespaceLabel: $.dashboard.namespaceLabel, 
     title: '%(prefix)sSidecar' % $.dashboard.prefix,
   },
   bucket_replicate+:: {
     jobPrefix: 'thanos-bucket-replicate',
     selector: 'job=~"%s.*"' % self.jobPrefix,
+    namespaceLabel: $.dashboard.namespaceLabel, 
     title: '%(prefix)sBucketReplicate' % $.dashboard.prefix,
   },
   overview+:: {
@@ -40,6 +47,7 @@
   dashboard+:: {
     prefix: 'Thanos / ',
     tags: ['thanos-mixin'],
-    namespaceQuery: 'kube_pod_info',
+    namespaceMetric: 'kube_pod_info',
+    namespaceLabel: 'namespace',
   },
 }

--- a/mixin/dashboards/bucket_replicate.libsonnet
+++ b/mixin/dashboards/bucket_replicate.libsonnet
@@ -16,14 +16,14 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
         .addPanel(
           g.panel('Rate') +
           g.qpsErrTotalPanel(
-            'thanos_replicate_replication_runs_total{result="error", namespace="$namespace",%(selector)s}' % thanos.bucket_replicate,
-            'thanos_replicate_replication_runs_total{namespace="$namespace",%(selector)s}' % thanos.bucket_replicate,
+            'thanos_replicate_replication_runs_total{result="error", %(namespaceLabel)s="$namespace",%(selector)s}' % thanos.bucket_replicate,
+            'thanos_replicate_replication_runs_total{%(namespaceLabel)s="$namespace",%(selector)s}' % thanos.bucket_replicate,
           )
         )
         .addPanel(
           g.panel('Errors', 'Shows rate of errors.') +
           g.queryPanel(
-            'sum(rate(thanos_replicate_replication_runs_total{result="error", namespace="$namespace",%(selector)s}[$interval])) by (result)' % thanos.bucket_replicate,
+            'sum(rate(thanos_replicate_replication_runs_total{result="error", %(namespaceLabel)s="$namespace",%(selector)s}[$interval])) by (result)' % thanos.bucket_replicate,
             '{{result}}'
           ) +
           { yaxes: g.yaxes('percentunit') } +
@@ -31,7 +31,7 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
         )
         .addPanel(
           g.panel('Duration', 'Shows how long has it taken to run a replication cycle.') +
-          g.latencyPanel('thanos_replicate_replication_run_duration_seconds', 'result="success", namespace="$namespace",%(selector)s' % thanos.bucket_replicate)
+          g.latencyPanel('thanos_replicate_replication_run_duration_seconds', 'result="success", %(namespaceLabel)s="$namespace",%(selector)s' % thanos.bucket_replicate)
         )
       )
       .addRow(
@@ -40,19 +40,19 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
           g.panel('Metrics') +
           g.queryPanel(
             [
-              'sum(rate(thanos_replicate_origin_iterations_total{namespace="$namespace",%(selector)s}[$interval]))' % thanos.bucket_replicate,
-              'sum(rate(thanos_replicate_origin_meta_loads_total{namespace="$namespace",%(selector)s}[$interval]))' % thanos.bucket_replicate,
-              'sum(rate(thanos_replicate_origin_partial_meta_reads_total{namespace="$namespace",%(selector)s}[$interval]))' % thanos.bucket_replicate,
-              'sum(rate(thanos_replicate_blocks_already_replicated_total{namespace="$namespace",%(selector)s}[$interval]))' % thanos.bucket_replicate,
-              'sum(rate(thanos_replicate_blocks_replicated_total{namespace="$namespace",%(selector)s}[$interval]))' % thanos.bucket_replicate,
-              'sum(rate(thanos_replicate_objects_replicated_total{namespace="$namespace",%(selector)s}[$interval]))' % thanos.bucket_replicate,
+              'sum(rate(thanos_replicate_origin_iterations_total{%(namespaceLabel)s="$namespace",%(selector)s}[$interval]))' % thanos.bucket_replicate,
+              'sum(rate(thanos_replicate_origin_meta_loads_total{%(namespaceLabel)s="$namespace",%(selector)s}[$interval]))' % thanos.bucket_replicate,
+              'sum(rate(thanos_replicate_origin_partial_meta_reads_total{%(namespaceLabel)s="$namespace",%(selector)s}[$interval]))' % thanos.bucket_replicate,
+              'sum(rate(thanos_replicate_blocks_already_replicated_total{%(namespaceLabel)s="$namespace",%(selector)s}[$interval]))' % thanos.bucket_replicate,
+              'sum(rate(thanos_replicate_blocks_replicated_total{%(namespaceLabel)s="$namespace",%(selector)s}[$interval]))' % thanos.bucket_replicate,
+              'sum(rate(thanos_replicate_objects_replicated_total{%(namespaceLabel)s="$namespace",%(selector)s}[$interval]))' % thanos.bucket_replicate,
             ],
             ['iterations', 'meta loads', 'partial meta reads', 'already replicated blocks', 'replicated blocks', 'replicated objects']
           )
         )
       )
       +
-      g.template('namespace', 'kube_pod_info') +
-      g.template('job', 'up', 'namespace="$namespace",%(selector)s' % thanos.bucket_replicate, true, '%(jobPrefix)s.*' % thanos.bucket_replicate),
+      g.template('namespace', thanos.dashboard.namespaceMetric) +
+      g.template('job', 'up', '%(namespaceLabel)s="$namespace",%(selector)s' % thanos.bucket_replicate, true, '%(jobPrefix)s.*' % thanos.bucket_replicate),
   },
 }

--- a/mixin/dashboards/bucket_replicate.libsonnet
+++ b/mixin/dashboards/bucket_replicate.libsonnet
@@ -6,9 +6,10 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
     jobPrefix: error 'must provide job prefix for Thanos Bucket Replicate dashboard',
     selector: error 'must provide selector for Thanos Bucket Replicate dashboard',
     title: error 'must provide title for Thanos Bucket Replicate dashboard',
+    namespaceLabel: error 'must provide namespace label', 
   },
   grafanaDashboards+:: {
-    'bucket_replicate.json':
+    'thanos-bucket_replicate.json':
       g.dashboard(thanos.bucket_replicate.title)
       .addRow(
         g.row('Bucket Replicate Runs')

--- a/mixin/dashboards/compact.libsonnet
+++ b/mixin/dashboards/compact.libsonnet
@@ -19,7 +19,7 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
             'Shows rate of execution for compactions against blocks that are stored in the bucket by compaction group.'
           ) +
           g.queryPanel(
-            'sum(rate(thanos_compact_group_compactions_total{%(namespaceLabel)s="$namespace",%(selector)s}[$interval])) by (job, group)' % thanos.compact,
+            'sum(rate(thanos_compact_group_compactions_total{%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s}[$interval])) by (job, group)' % thanos.compact,
             'compaction {{job}} {{group}}'
           ) +
           g.stack
@@ -30,8 +30,8 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
             'Shows ratio of errors compared to the total number of executed compactions against blocks that are stored in the bucket.'
           ) +
           g.qpsErrTotalPanel(
-            'thanos_compact_group_compactions_failures_total{%(namespaceLabel)s="$namespace",%(selector)s}' % thanos.compact,
-            'thanos_compact_group_compactions_total{%(namespaceLabel)s="$namespace",%(selector)s}' % thanos.compact,
+            'thanos_compact_group_compactions_failures_total{%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s}' % thanos.compact,
+            'thanos_compact_group_compactions_total{%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s}' % thanos.compact,
           )
         )
       )
@@ -43,7 +43,7 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
             'Shows rate of execution for downsampling against blocks that are stored in the bucket by compaction group.'
           ) +
           g.queryPanel(
-            'sum(rate(thanos_compact_downsample_total{%(namespaceLabel)s="$namespace",%(selector)s}[$interval])) by (job, group)' % thanos.compact,
+            'sum(rate(thanos_compact_downsample_total{%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s}[$interval])) by (job, group)' % thanos.compact,
             'downsample {{job}} {{group}}'
           ) +
           g.stack
@@ -51,8 +51,8 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
         .addPanel(
           g.panel('Errors', 'Shows ratio of errors compared to the total number of executed downsampling against blocks that are stored in the bucket.') +
           g.qpsErrTotalPanel(
-            'thanos_compact_downsample_failed_total{%(namespaceLabel)s="$namespace",%(selector)s}' % thanos.compact,
-            'thanos_compact_downsample_total{%(namespaceLabel)s="$namespace",%(selector)s}' % thanos.compact,
+            'thanos_compact_downsample_failed_total{%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s}' % thanos.compact,
+            'thanos_compact_downsample_total{%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s}' % thanos.compact,
           )
         )
       )
@@ -64,7 +64,7 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
             'Shows rate of execution for removals of blocks if their data is available as part of a block with a higher compaction level.'
           ) +
           g.queryPanel(
-            'sum(rate(thanos_compact_garbage_collection_total{%(namespaceLabel)s="$namespace",%(selector)s}[$interval])) by (job)' % thanos.compact,
+            'sum(rate(thanos_compact_garbage_collection_total{%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s}[$interval])) by (job)' % thanos.compact,
             'garbage collection {{job}}'
           ) +
           g.stack
@@ -72,13 +72,13 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
         .addPanel(
           g.panel('Errors', 'Shows ratio of errors compared to the total number of executed garbage collections.') +
           g.qpsErrTotalPanel(
-            'thanos_compact_garbage_collection_failures_total{%(namespaceLabel)s="$namespace",%(selector)s}' % thanos.compact,
-            'thanos_compact_garbage_collection_total{%(namespaceLabel)s="$namespace",%(selector)s}' % thanos.compact,
+            'thanos_compact_garbage_collection_failures_total{%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s}' % thanos.compact,
+            'thanos_compact_garbage_collection_total{%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s}' % thanos.compact,
           )
         )
         .addPanel(
           g.panel('Duration', 'Shows how long has it taken to execute garbage collection in quantiles.') +
-          g.latencyPanel('thanos_compact_garbage_collection_duration_seconds', '%(namespaceLabel)s="$namespace",%(selector)s' % thanos.compact)
+          g.latencyPanel('thanos_compact_garbage_collection_duration_seconds', '%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s' % thanos.compact)
         )
       )
       .addRow(
@@ -89,7 +89,7 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
             'Shows rate of execution for all meta files from blocks in the bucket into the memory.'
           ) +
           g.queryPanel(
-            'sum(rate(thanos_blocks_meta_syncs_total{%(namespaceLabel)s="$namespace",%(selector)s}[$interval])) by (job)' % thanos.compact,
+            'sum(rate(thanos_blocks_meta_syncs_total{%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s}[$interval])) by (job)' % thanos.compact,
             'sync {{job}}'
           ) +
           g.stack
@@ -97,13 +97,13 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
         .addPanel(
           g.panel('Errors', 'Shows ratio of errors compared to the total number of executed meta file sync.') +
           g.qpsErrTotalPanel(
-            'thanos_blocks_meta_sync_failures_total{%(namespaceLabel)s="$namespace",%(selector)s}' % thanos.compact,
-            'thanos_blocks_meta_syncs_total{%(namespaceLabel)s="$namespace",%(selector)s}' % thanos.compact,
+            'thanos_blocks_meta_sync_failures_total{%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s}' % thanos.compact,
+            'thanos_blocks_meta_syncs_total{%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s}' % thanos.compact,
           )
         )
         .addPanel(
           g.panel('Duration', 'Shows how long has it taken to execute meta file sync, in quantiles.') +
-          g.latencyPanel('thanos_blocks_meta_sync_duration_seconds', '%(namespaceLabel)s="$namespace",%(selector)s' % thanos.compact)
+          g.latencyPanel('thanos_blocks_meta_sync_duration_seconds', '%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s' % thanos.compact)
         )
       )
       .addRow(
@@ -111,7 +111,7 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
         .addPanel(
           g.panel('Rate', 'Shows rate of execution for operations against the bucket.') +
           g.queryPanel(
-            'sum(rate(thanos_objstore_bucket_operations_total{%(namespaceLabel)s="$namespace",%(selector)s}[$interval])) by (job, operation)' % thanos.compact,
+            'sum(rate(thanos_objstore_bucket_operations_total{%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s}[$interval])) by (job, operation)' % thanos.compact,
             '{{job}} {{operation}}'
           ) +
           g.stack
@@ -119,20 +119,20 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
         .addPanel(
           g.panel('Errors', 'Shows ratio of errors compared to the total number of executed operations against the bucket.') +
           g.qpsErrTotalPanel(
-            'thanos_objstore_bucket_operation_failures_total{%(namespaceLabel)s="$namespace",%(selector)s}' % thanos.compact,
-            'thanos_objstore_bucket_operations_total{%(namespaceLabel)s="$namespace",%(selector)s}' % thanos.compact,
+            'thanos_objstore_bucket_operation_failures_total{%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s}' % thanos.compact,
+            'thanos_objstore_bucket_operations_total{%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s}' % thanos.compact,
           )
         )
         .addPanel(
           g.panel('Duration', 'Shows how long has it taken to execute operations against the bucket, in quantiles.') +
-          g.latencyPanel('thanos_objstore_bucket_operation_duration_seconds', '%(namespaceLabel)s="$namespace",%(selector)s' % thanos.compact)
+          g.latencyPanel('thanos_objstore_bucket_operation_duration_seconds', '%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s' % thanos.compact)
         )
       )
       .addRow(
         g.resourceUtilizationRow(thanos.compact.namespaceLabel, thanos.compact.selector)
       ) +
       g.template('namespace', thanos.dashboard.namespaceMetric) +
-      g.template('job', 'up', '%(namespaceLabel)s="$namespace",%(selector)s' % thanos.compact, true, '%(jobPrefix)s.*' % thanos.compact) +
+      g.template('job', 'up', '%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s' % thanos.compact, true, '%(jobPrefix)s.*' % thanos.compact) +
       g.template('pod', 'kube_pod_info', '%(namespaceLabel)s="$namespace",created_by_name=~"%(jobPrefix)s.*"' % thanos.compact, true, '.*'),
 
     __overviewRows__+:: [
@@ -143,7 +143,7 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
           'Shows rate of execution for compactions against blocks that are stored in the bucket by compaction group.'
         ) +
         g.queryPanel(
-          'sum(rate(thanos_compact_group_compactions_total{%(namespaceLabel)s="$namespace",%(selector)s}[$interval])) by (job)' % thanos.compact,
+          'sum(rate(thanos_compact_group_compactions_total{%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s}[$interval])) by (job)' % thanos.compact,
           'compaction {{job}}'
         ) +
         g.stack +
@@ -155,8 +155,8 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
           'Shows ratio of errors compared to the total number of executed compactions against blocks that are stored in the bucket.'
         ) +
         g.qpsErrTotalPanel(
-          'thanos_compact_group_compactions_failures_total{%(namespaceLabel)s="$namespace",%(selector)s}' % thanos.compact,
-          'thanos_compact_group_compactions_total{%(namespaceLabel)s="$namespace",%(selector)s}' % thanos.compact,
+          'thanos_compact_group_compactions_failures_total{%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s}' % thanos.compact,
+          'thanos_compact_group_compactions_total{%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s}' % thanos.compact,
         ) +
         g.addDashboardLink(thanos.compact.title)
       ) +

--- a/mixin/dashboards/compact.libsonnet
+++ b/mixin/dashboards/compact.libsonnet
@@ -9,7 +9,7 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
     namespaceLabel: error 'must provide namespace label', 
   },
   grafanaDashboards+:: {
-    'compact.json':
+    'thanos-compact.json':
       g.dashboard(thanos.compact.title)
       .addRow(
         g.row('Group Compaction')

--- a/mixin/dashboards/compact.libsonnet
+++ b/mixin/dashboards/compact.libsonnet
@@ -129,7 +129,7 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
         )
       )
       .addRow(
-        g.resourceUtilizationRow()
+        g.resourceUtilizationRow(thanos.compact.namespaceLabel, thanos.compact.selector)
       ) +
       g.template('namespace', thanos.dashboard.namespaceMetric) +
       g.template('job', 'up', '%(namespaceLabel)s="$namespace",%(selector)s' % thanos.compact, true, '%(jobPrefix)s.*' % thanos.compact) +

--- a/mixin/dashboards/compact.libsonnet
+++ b/mixin/dashboards/compact.libsonnet
@@ -6,6 +6,7 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
     jobPrefix: error 'must provide job prefix for Thanos Compact dashboard',
     selector: error 'must provide selector for Thanos Compact dashboard',
     title: error 'must provide title for Thanos Compact dashboard',
+    namespaceLabel: error 'must provide namespace label', 
   },
   grafanaDashboards+:: {
     'compact.json':
@@ -18,7 +19,7 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
             'Shows rate of execution for compactions against blocks that are stored in the bucket by compaction group.'
           ) +
           g.queryPanel(
-            'sum(rate(thanos_compact_group_compactions_total{namespace="$namespace",job=~"$job"}[$interval])) by (job, group)',
+            'sum(rate(thanos_compact_group_compactions_total{%(namespaceLabel)s="$namespace",%(selector)s}[$interval])) by (job, group)' % thanos.compact,
             'compaction {{job}} {{group}}'
           ) +
           g.stack
@@ -29,8 +30,8 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
             'Shows ratio of errors compared to the total number of executed compactions against blocks that are stored in the bucket.'
           ) +
           g.qpsErrTotalPanel(
-            'thanos_compact_group_compactions_failures_total{namespace="$namespace",job=~"$job"}',
-            'thanos_compact_group_compactions_total{namespace="$namespace",job=~"$job"}',
+            'thanos_compact_group_compactions_failures_total{%(namespaceLabel)s="$namespace",%(selector)s}' % thanos.compact,
+            'thanos_compact_group_compactions_total{%(namespaceLabel)s="$namespace",%(selector)s}' % thanos.compact,
           )
         )
       )
@@ -42,7 +43,7 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
             'Shows rate of execution for downsampling against blocks that are stored in the bucket by compaction group.'
           ) +
           g.queryPanel(
-            'sum(rate(thanos_compact_downsample_total{namespace="$namespace",job=~"$job"}[$interval])) by (job, group)',
+            'sum(rate(thanos_compact_downsample_total{%(namespaceLabel)s="$namespace",%(selector)s}[$interval])) by (job, group)' % thanos.compact,
             'downsample {{job}} {{group}}'
           ) +
           g.stack
@@ -50,8 +51,8 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
         .addPanel(
           g.panel('Errors', 'Shows ratio of errors compared to the total number of executed downsampling against blocks that are stored in the bucket.') +
           g.qpsErrTotalPanel(
-            'thanos_compact_downsample_failed_total{namespace="$namespace",job=~"$job"}',
-            'thanos_compact_downsample_total{namespace="$namespace",job=~"$job"}',
+            'thanos_compact_downsample_failed_total{%(namespaceLabel)s="$namespace",%(selector)s}' % thanos.compact,
+            'thanos_compact_downsample_total{%(namespaceLabel)s="$namespace",%(selector)s}' % thanos.compact,
           )
         )
       )
@@ -63,7 +64,7 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
             'Shows rate of execution for removals of blocks if their data is available as part of a block with a higher compaction level.'
           ) +
           g.queryPanel(
-            'sum(rate(thanos_compact_garbage_collection_total{namespace="$namespace",job=~"$job"}[$interval])) by (job)',
+            'sum(rate(thanos_compact_garbage_collection_total{%(namespaceLabel)s="$namespace",%(selector)s}[$interval])) by (job)' % thanos.compact,
             'garbage collection {{job}}'
           ) +
           g.stack
@@ -71,13 +72,13 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
         .addPanel(
           g.panel('Errors', 'Shows ratio of errors compared to the total number of executed garbage collections.') +
           g.qpsErrTotalPanel(
-            'thanos_compact_garbage_collection_failures_total{namespace="$namespace",job=~"$job"}',
-            'thanos_compact_garbage_collection_total{namespace="$namespace",job=~"$job"}',
+            'thanos_compact_garbage_collection_failures_total{%(namespaceLabel)s="$namespace",%(selector)s}' % thanos.compact,
+            'thanos_compact_garbage_collection_total{%(namespaceLabel)s="$namespace",%(selector)s}' % thanos.compact,
           )
         )
         .addPanel(
           g.panel('Duration', 'Shows how long has it taken to execute garbage collection in quantiles.') +
-          g.latencyPanel('thanos_compact_garbage_collection_duration_seconds', 'namespace="$namespace",job=~"$job"')
+          g.latencyPanel('thanos_compact_garbage_collection_duration_seconds', '%(namespaceLabel)s="$namespace",%(selector)s' % thanos.compact)
         )
       )
       .addRow(
@@ -88,7 +89,7 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
             'Shows rate of execution for all meta files from blocks in the bucket into the memory.'
           ) +
           g.queryPanel(
-            'sum(rate(thanos_blocks_meta_syncs_total{namespace="$namespace",job=~"$job"}[$interval])) by (job)',
+            'sum(rate(thanos_blocks_meta_syncs_total{%(namespaceLabel)s="$namespace",%(selector)s}[$interval])) by (job)' % thanos.compact,
             'sync {{job}}'
           ) +
           g.stack
@@ -96,13 +97,13 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
         .addPanel(
           g.panel('Errors', 'Shows ratio of errors compared to the total number of executed meta file sync.') +
           g.qpsErrTotalPanel(
-            'thanos_blocks_meta_sync_failures_total{namespace="$namespace",job=~"$job"}',
-            'thanos_blocks_meta_syncs_total{namespace="$namespace",job=~"$job"}',
+            'thanos_blocks_meta_sync_failures_total{%(namespaceLabel)s="$namespace",%(selector)s}' % thanos.compact,
+            'thanos_blocks_meta_syncs_total{%(namespaceLabel)s="$namespace",%(selector)s}' % thanos.compact,
           )
         )
         .addPanel(
           g.panel('Duration', 'Shows how long has it taken to execute meta file sync, in quantiles.') +
-          g.latencyPanel('thanos_blocks_meta_sync_duration_seconds', 'namespace="$namespace",job=~"$job"')
+          g.latencyPanel('thanos_blocks_meta_sync_duration_seconds', '%(namespaceLabel)s="$namespace",%(selector)s' % thanos.compact)
         )
       )
       .addRow(
@@ -110,7 +111,7 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
         .addPanel(
           g.panel('Rate', 'Shows rate of execution for operations against the bucket.') +
           g.queryPanel(
-            'sum(rate(thanos_objstore_bucket_operations_total{namespace="$namespace",job=~"$job"}[$interval])) by (job, operation)',
+            'sum(rate(thanos_objstore_bucket_operations_total{%(namespaceLabel)s="$namespace",%(selector)s}[$interval])) by (job, operation)' % thanos.compact,
             '{{job}} {{operation}}'
           ) +
           g.stack
@@ -118,21 +119,21 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
         .addPanel(
           g.panel('Errors', 'Shows ratio of errors compared to the total number of executed operations against the bucket.') +
           g.qpsErrTotalPanel(
-            'thanos_objstore_bucket_operation_failures_total{namespace="$namespace",job=~"$job"}',
-            'thanos_objstore_bucket_operations_total{namespace="$namespace",job=~"$job"}',
+            'thanos_objstore_bucket_operation_failures_total{%(namespaceLabel)s="$namespace",%(selector)s}' % thanos.compact,
+            'thanos_objstore_bucket_operations_total{%(namespaceLabel)s="$namespace",%(selector)s}' % thanos.compact,
           )
         )
         .addPanel(
           g.panel('Duration', 'Shows how long has it taken to execute operations against the bucket, in quantiles.') +
-          g.latencyPanel('thanos_objstore_bucket_operation_duration_seconds', 'namespace="$namespace",job=~"$job"')
+          g.latencyPanel('thanos_objstore_bucket_operation_duration_seconds', '%(namespaceLabel)s="$namespace",%(selector)s' % thanos.compact)
         )
       )
       .addRow(
         g.resourceUtilizationRow()
       ) +
-      g.template('namespace', thanos.dashboard.namespaceQuery) +
-      g.template('job', 'up', 'namespace="$namespace",%(selector)s' % thanos.compact, true, '%(jobPrefix)s.*' % thanos.compact) +
-      g.template('pod', 'kube_pod_info', 'namespace="$namespace",created_by_name=~"%(jobPrefix)s.*"' % thanos.compact, true, '.*'),
+      g.template('namespace', thanos.dashboard.namespaceMetric) +
+      g.template('job', 'up', '%(namespaceLabel)s="$namespace",%(selector)s' % thanos.compact, true, '%(jobPrefix)s.*' % thanos.compact) +
+      g.template('pod', 'kube_pod_info', '%(namespaceLabel)s="$namespace",created_by_name=~"%(jobPrefix)s.*"' % thanos.compact, true, '.*'),
 
     __overviewRows__+:: [
       g.row('Compact')
@@ -142,7 +143,7 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
           'Shows rate of execution for compactions against blocks that are stored in the bucket by compaction group.'
         ) +
         g.queryPanel(
-          'sum(rate(thanos_compact_group_compactions_total{namespace="$namespace",%(selector)s}[$interval])) by (job)' % thanos.compact,
+          'sum(rate(thanos_compact_group_compactions_total{%(namespaceLabel)s="$namespace",%(selector)s}[$interval])) by (job)' % thanos.compact,
           'compaction {{job}}'
         ) +
         g.stack +
@@ -154,8 +155,8 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
           'Shows ratio of errors compared to the total number of executed compactions against blocks that are stored in the bucket.'
         ) +
         g.qpsErrTotalPanel(
-          'thanos_compact_group_compactions_failures_total{namespace="$namespace",%(selector)s}' % thanos.compact,
-          'thanos_compact_group_compactions_total{namespace="$namespace",%(selector)s}' % thanos.compact,
+          'thanos_compact_group_compactions_failures_total{%(namespaceLabel)s="$namespace",%(selector)s}' % thanos.compact,
+          'thanos_compact_group_compactions_total{%(namespaceLabel)s="$namespace",%(selector)s}' % thanos.compact,
         ) +
         g.addDashboardLink(thanos.compact.title)
       ) +

--- a/mixin/dashboards/defaults.libsonnet
+++ b/mixin/dashboards/defaults.libsonnet
@@ -30,8 +30,9 @@
             for panel in super.panels
           ],
         }
-        for row in if "rows" in super then super.rows else []
+        for row in super.rows
       ],
+      // for row in if "rows" in super then super.rows else []
 
       templating+: {
         list+: [

--- a/mixin/dashboards/defaults.libsonnet
+++ b/mixin/dashboards/defaults.libsonnet
@@ -7,7 +7,7 @@
   dashboard:: {
     prefix: 'Thanos / ',
     tags: error 'must provide dashboard tags',
-    namespaceQuery: error 'must provide a query for namespace variable for dashboard template',
+    namespaceMetric: error 'must provide a query for namespace variable for dashboard template',
   },
 
   // Automatically add a uid to each dashboard based on the base64 encoding

--- a/mixin/dashboards/defaults.libsonnet
+++ b/mixin/dashboards/defaults.libsonnet
@@ -30,7 +30,7 @@
             for panel in super.panels
           ],
         }
-        for row in super.rows
+        for row in if "rows" in super then super.rows else []
       ],
 
       templating+: {

--- a/mixin/dashboards/overview.libsonnet
+++ b/mixin/dashboards/overview.libsonnet
@@ -6,7 +6,7 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
     title: error 'must provide title for Thanos Overview dashboard',
   },
   grafanaDashboards+:: {
-    'overview.json':
+    'thanos-overview.json':
       g.dashboard(thanos.overview.title) +
       g.template('namespace', thanos.dashboard.namespaceMetric),
   },
@@ -14,7 +14,7 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
 {
   local grafanaDashboards = super.grafanaDashboards,
   grafanaDashboards+:: {
-    'overview.json'+: {
+    'thanos-overview.json'+: {
 
       __enumeratedRows__+:: std.foldl(
         function(acc, row)

--- a/mixin/dashboards/overview.libsonnet
+++ b/mixin/dashboards/overview.libsonnet
@@ -8,7 +8,7 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
   grafanaDashboards+:: {
     'overview.json':
       g.dashboard(thanos.overview.title) +
-      g.template('namespace', thanos.dashboard.namespaceQuery),
+      g.template('namespace', thanos.dashboard.namespaceMetric),
   },
 } +
 {

--- a/mixin/dashboards/query.libsonnet
+++ b/mixin/dashboards/query.libsonnet
@@ -6,9 +6,10 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
     jobPrefix: error 'must provide job prefix for Thanos Query dashboard',
     selector: error 'must provide selector for Thanos Query dashboard',
     title: error 'must provide title for Thanos Query dashboard',
+    namespaceLabel: error 'must provide namespace label', 
   },
   grafanaDashboards+:: {
-    'query.json':
+    'thanos-query.json':
       g.dashboard(thanos.query.title)
       .addRow(
         g.row('Instant Query API')

--- a/mixin/dashboards/query.libsonnet
+++ b/mixin/dashboards/query.libsonnet
@@ -15,60 +15,60 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
         g.row('Instant Query API')
         .addPanel(
           g.panel('Rate', 'Shows rate of requests against /query for the given time.') +
-          g.httpQpsPanel('http_requests_total', 'namespace="$namespace",job=~"$job",handler="query"')
+          g.httpQpsPanel('http_requests_total', '%(namespaceLabel)s="$namespace",%(selector)s,handler="query"' % thanos.query)
         )
         .addPanel(
           g.panel('Errors', 'Shows ratio of errors compared to the the total number of handled requests against /query.') +
-          g.httpErrPanel('http_requests_total', 'namespace="$namespace",job=~"$job",handler="query"')
+          g.httpErrPanel('http_requests_total', '%(namespaceLabel)s="$namespace",%(selector)s,handler="query"' % thanos.query)
         )
         .addPanel(
           g.panel('Duration', 'Shows how long has it taken to handle requests in quantiles.') +
-          g.latencyPanel('http_request_duration_seconds', 'namespace="$namespace",job=~"$job",handler="query"')
+          g.latencyPanel('http_request_duration_seconds', '%(namespaceLabel)s="$namespace",%(selector)s,handler="query"' % thanos.query)
         )
       )
       .addRow(
         g.row('Range Query API')
         .addPanel(
           g.panel('Rate', 'Shows rate of requests against /query_range for the given time range.') +
-          g.httpQpsPanel('http_requests_total', 'namespace="$namespace",job=~"$job",handler="query_range"')
+          g.httpQpsPanel('http_requests_total', '%(namespaceLabel)s="$namespace",%(selector)s,handler="query_range"' % thanos.query)
         )
         .addPanel(
           g.panel('Errors', 'Shows ratio of errors compared to the the total number of handled requests against /query_range.') +
-          g.httpErrPanel('http_requests_total', 'namespace="$namespace",job=~"$job",handler="query_range"')
+          g.httpErrPanel('http_requests_total', '%(namespaceLabel)s="$namespace",%(selector)s,handler="query_range"' % thanos.query)
         )
         .addPanel(
           g.panel('Duration', 'Shows how long has it taken to handle requests in quantiles.') +
-          g.latencyPanel('http_request_duration_seconds', 'namespace="$namespace",job=~"$job",handler="query_range"')
+          g.latencyPanel('http_request_duration_seconds', '%(namespaceLabel)s="$namespace",%(selector)s,handler="query_range"' % thanos.query)
         )
       )
       .addRow(
         g.row('gRPC (Unary)')
         .addPanel(
           g.panel('Rate', 'Shows rate of handled Unary gRPC requests from other queriers.') +
-          g.grpcQpsPanel('client', 'namespace="$namespace",job=~"$job",grpc_type="unary"')
+          g.grpcQpsPanel('client', '%(namespaceLabel)s="$namespace",%(selector)s,grpc_type="unary"' % thanos.query)
         )
         .addPanel(
           g.panel('Errors', 'Shows ratio of errors compared to the the total number of handled requests from other queriers.') +
-          g.grpcErrorsPanel('client', 'namespace="$namespace",job=~"$job",grpc_type="unary"')
+          g.grpcErrorsPanel('client', '%(namespaceLabel)s="$namespace",%(selector)s,grpc_type="unary"' % thanos.query)
         )
         .addPanel(
           g.panel('Duration', 'Shows how long has it taken to handle requests from other queriers, in quantiles.') +
-          g.grpcLatencyPanel('client', 'namespace="$namespace",job=~"$job",grpc_type="unary"')
+          g.grpcLatencyPanel('client', '%(namespaceLabel)s="$namespace",%(selector)s,grpc_type="unary"' % thanos.query)
         )
       )
       .addRow(
         g.row('gRPC (Stream)')
         .addPanel(
           g.panel('Rate', 'Shows rate of handled Streamed gRPC requests from other queriers.') +
-          g.grpcQpsPanel('client', 'namespace="$namespace",job=~"$job",grpc_type="server_stream"')
+          g.grpcQpsPanel('client', '%(namespaceLabel)s="$namespace",%(selector)s,grpc_type="server_stream"' % thanos.query)
         )
         .addPanel(
           g.panel('Errors', 'Shows ratio of errors compared to the the total number of handled requests from other queriers.') +
-          g.grpcErrorsPanel('client', 'namespace="$namespace",job=~"$job",grpc_type="server_stream"')
+          g.grpcErrorsPanel('client', '%(namespaceLabel)s="$namespace",%(selector)s,grpc_type="server_stream"' % thanos.query)
         )
         .addPanel(
           g.panel('Duration', 'Shows how long has it taken to handle requests from other queriers, in quantiles') +
-          g.grpcLatencyPanel('client', 'namespace="$namespace",job=~"$job",grpc_type="server_stream"')
+          g.grpcLatencyPanel('client', '%(namespaceLabel)s="$namespace",%(selector)s,grpc_type="server_stream"' % thanos.query)
         )
       )
       .addRow(
@@ -76,15 +76,15 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
         .addPanel(
           g.panel('Rate', 'Shows rate of DNS lookups to discover stores.') +
           g.queryPanel(
-            'sum(rate(thanos_querier_store_apis_dns_lookups_total{namespace="$namespace",job=~"$job"}[$interval])) by (job)',
+            'sum(rate(thanos_querier_store_apis_dns_lookups_total{%(namespaceLabel)s="$namespace",%(selector)s}[$interval])) by (job)' % thanos.query,
             'lookups {{job}}'
           )
         )
         .addPanel(
           g.panel('Errors', 'Shows ratio of failures compared to the the total number of executed DNS lookups.') +
           g.qpsErrTotalPanel(
-            'thanos_querier_store_apis_dns_failures_total{namespace="$namespace",job=~"$job"}',
-            'thanos_querier_store_apis_dns_lookups_total{namespace="$namespace",job=~"$job"}',
+            'thanos_querier_store_apis_dns_failures_total{%(namespaceLabel)s="$namespace",%(selector)s}' % thanos.query,
+            'thanos_querier_store_apis_dns_lookups_total{%(namespaceLabel)s="$namespace",%(selector)s}' % thanos.query,
           )
         )
       )
@@ -92,26 +92,26 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
         g.resourceUtilizationRow()
       ) +
       g.template('namespace', thanos.dashboard.namespaceMetric) +
-      g.template('job', 'up', 'namespace="$namespace",%(selector)s' % thanos.query, true, '%(jobPrefix)s.*' % thanos.query) +
-      g.template('pod', 'kube_pod_info', 'namespace="$namespace",created_by_name=~"%(jobPrefix)s.*"' % thanos.query, true, '.*'),
+      g.template('job', 'up', '%(namespaceLabel)s="$namespace",%(selector)s' % thanos.query, true, '%(jobPrefix)s.*' % thanos.query) +
+      g.template('pod', 'kube_pod_info', '%(namespaceLabel)s="$namespace",created_by_name=~"%(jobPrefix)s.*"' % thanos.query, true, '.*'),
 
     __overviewRows__+:: [
       g.row('Instant Query')
       .addPanel(
         g.panel('Requests Rate', 'Shows rate of requests against /query for the given time.') +
-        g.httpQpsPanel('http_requests_total', 'namespace="$namespace",%(selector)s,handler="query"' % thanos.query) +
+        g.httpQpsPanel('http_requests_total', '%(namespaceLabel)s="$namespace",%(selector)s,handler="query"' % thanos.query) +
         g.addDashboardLink(thanos.query.title)
       )
       .addPanel(
         g.panel('Requests Errors', 'Shows ratio of errors compared to the the total number of handled requests against /query.') +
-        g.httpErrPanel('http_requests_total', 'namespace="$namespace",%(selector)s,handler="query"' % thanos.query) +
+        g.httpErrPanel('http_requests_total', '%(namespaceLabel)s="$namespace",%(selector)s,handler="query"' % thanos.query) +
         g.addDashboardLink(thanos.query.title)
       )
       .addPanel(
         g.sloLatency(
           'Latency 99th Percentile',
           'Shows how long has it taken to handle requests.',
-          'http_request_duration_seconds_bucket{namespace="$namespace",%(selector)s,handler="query"}' % thanos.query,
+          'http_request_duration_seconds_bucket{%(namespaceLabel)s="$namespace",%(selector)s,handler="query"}' % thanos.query,
           0.99,
           0.5,
           1
@@ -122,19 +122,19 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
       g.row('Range Query')
       .addPanel(
         g.panel('Requests Rate', 'Shows rate of requests against /query_range for the given time range.') +
-        g.httpQpsPanel('http_requests_total', 'namespace="$namespace",%(selector)s,handler="query_range"' % thanos.query) +
+        g.httpQpsPanel('http_requests_total', '%(namespaceLabel)s="$namespace",%(selector)s,handler="query_range"' % thanos.query) +
         g.addDashboardLink(thanos.query.title)
       )
       .addPanel(
         g.panel('Requests Errors', 'Shows ratio of errors compared to the the total number of handled requests against /query_range.') +
-        g.httpErrPanel('http_requests_total', 'namespace="$namespace",%(selector)s,handler="query_range"' % thanos.query) +
+        g.httpErrPanel('http_requests_total', '%(namespaceLabel)s="$namespace",%(selector)s,handler="query_range"' % thanos.query) +
         g.addDashboardLink(thanos.query.title)
       )
       .addPanel(
         g.sloLatency(
           'Latency 99th Percentile',
           'Shows how long has it taken to handle requests.',
-          'http_request_duration_seconds_bucket{namespace="$namespace",%(selector)s,handler="query_range"}' % thanos.query,
+          'http_request_duration_seconds_bucket{%(namespaceLabel)s="$namespace",%(selector)s,handler="query_range"}' % thanos.query,
           0.99,
           0.5,
           1

--- a/mixin/dashboards/query.libsonnet
+++ b/mixin/dashboards/query.libsonnet
@@ -90,7 +90,7 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
       .addRow(
         g.resourceUtilizationRow()
       ) +
-      g.template('namespace', thanos.dashboard.namespaceQuery) +
+      g.template('namespace', thanos.dashboard.namespaceMetric) +
       g.template('job', 'up', 'namespace="$namespace",%(selector)s' % thanos.query, true, '%(jobPrefix)s.*' % thanos.query) +
       g.template('pod', 'kube_pod_info', 'namespace="$namespace",created_by_name=~"%(jobPrefix)s.*"' % thanos.query, true, '.*'),
 

--- a/mixin/dashboards/query.libsonnet
+++ b/mixin/dashboards/query.libsonnet
@@ -89,7 +89,7 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
         )
       )
       .addRow(
-        g.resourceUtilizationRow()
+        g.resourceUtilizationRow(thanos.query.namespaceLabel, thanos.query.selector)
       ) +
       g.template('namespace', thanos.dashboard.namespaceMetric) +
       g.template('job', 'up', '%(namespaceLabel)s="$namespace",%(selector)s' % thanos.query, true, '%(jobPrefix)s.*' % thanos.query) +

--- a/mixin/dashboards/query.libsonnet
+++ b/mixin/dashboards/query.libsonnet
@@ -15,60 +15,60 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
         g.row('Instant Query API')
         .addPanel(
           g.panel('Rate', 'Shows rate of requests against /query for the given time.') +
-          g.httpQpsPanel('http_requests_total', '%(namespaceLabel)s="$namespace",%(selector)s,handler="query"' % thanos.query)
+          g.httpQpsPanel('http_requests_total', '%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s,handler="query"' % thanos.query)
         )
         .addPanel(
           g.panel('Errors', 'Shows ratio of errors compared to the the total number of handled requests against /query.') +
-          g.httpErrPanel('http_requests_total', '%(namespaceLabel)s="$namespace",%(selector)s,handler="query"' % thanos.query)
+          g.httpErrPanel('http_requests_total', '%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s,handler="query"' % thanos.query)
         )
         .addPanel(
           g.panel('Duration', 'Shows how long has it taken to handle requests in quantiles.') +
-          g.latencyPanel('http_request_duration_seconds', '%(namespaceLabel)s="$namespace",%(selector)s,handler="query"' % thanos.query)
+          g.latencyPanel('http_request_duration_seconds', '%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s,handler="query"' % thanos.query)
         )
       )
       .addRow(
         g.row('Range Query API')
         .addPanel(
           g.panel('Rate', 'Shows rate of requests against /query_range for the given time range.') +
-          g.httpQpsPanel('http_requests_total', '%(namespaceLabel)s="$namespace",%(selector)s,handler="query_range"' % thanos.query)
+          g.httpQpsPanel('http_requests_total', '%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s,handler="query_range"' % thanos.query)
         )
         .addPanel(
           g.panel('Errors', 'Shows ratio of errors compared to the the total number of handled requests against /query_range.') +
-          g.httpErrPanel('http_requests_total', '%(namespaceLabel)s="$namespace",%(selector)s,handler="query_range"' % thanos.query)
+          g.httpErrPanel('http_requests_total', '%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s,handler="query_range"' % thanos.query)
         )
         .addPanel(
           g.panel('Duration', 'Shows how long has it taken to handle requests in quantiles.') +
-          g.latencyPanel('http_request_duration_seconds', '%(namespaceLabel)s="$namespace",%(selector)s,handler="query_range"' % thanos.query)
+          g.latencyPanel('http_request_duration_seconds', '%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s,handler="query_range"' % thanos.query)
         )
       )
       .addRow(
         g.row('gRPC (Unary)')
         .addPanel(
           g.panel('Rate', 'Shows rate of handled Unary gRPC requests from other queriers.') +
-          g.grpcQpsPanel('client', '%(namespaceLabel)s="$namespace",%(selector)s,grpc_type="unary"' % thanos.query)
+          g.grpcQpsPanel('client', '%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s,grpc_type="unary"' % thanos.query)
         )
         .addPanel(
           g.panel('Errors', 'Shows ratio of errors compared to the the total number of handled requests from other queriers.') +
-          g.grpcErrorsPanel('client', '%(namespaceLabel)s="$namespace",%(selector)s,grpc_type="unary"' % thanos.query)
+          g.grpcErrorsPanel('client', '%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s,grpc_type="unary"' % thanos.query)
         )
         .addPanel(
           g.panel('Duration', 'Shows how long has it taken to handle requests from other queriers, in quantiles.') +
-          g.grpcLatencyPanel('client', '%(namespaceLabel)s="$namespace",%(selector)s,grpc_type="unary"' % thanos.query)
+          g.grpcLatencyPanel('client', '%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s,grpc_type="unary"' % thanos.query)
         )
       )
       .addRow(
         g.row('gRPC (Stream)')
         .addPanel(
           g.panel('Rate', 'Shows rate of handled Streamed gRPC requests from other queriers.') +
-          g.grpcQpsPanel('client', '%(namespaceLabel)s="$namespace",%(selector)s,grpc_type="server_stream"' % thanos.query)
+          g.grpcQpsPanel('client', '%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s,grpc_type="server_stream"' % thanos.query)
         )
         .addPanel(
           g.panel('Errors', 'Shows ratio of errors compared to the the total number of handled requests from other queriers.') +
-          g.grpcErrorsPanel('client', '%(namespaceLabel)s="$namespace",%(selector)s,grpc_type="server_stream"' % thanos.query)
+          g.grpcErrorsPanel('client', '%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s,grpc_type="server_stream"' % thanos.query)
         )
         .addPanel(
           g.panel('Duration', 'Shows how long has it taken to handle requests from other queriers, in quantiles') +
-          g.grpcLatencyPanel('client', '%(namespaceLabel)s="$namespace",%(selector)s,grpc_type="server_stream"' % thanos.query)
+          g.grpcLatencyPanel('client', '%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s,grpc_type="server_stream"' % thanos.query)
         )
       )
       .addRow(
@@ -76,15 +76,15 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
         .addPanel(
           g.panel('Rate', 'Shows rate of DNS lookups to discover stores.') +
           g.queryPanel(
-            'sum(rate(thanos_querier_store_apis_dns_lookups_total{%(namespaceLabel)s="$namespace",%(selector)s}[$interval])) by (job)' % thanos.query,
+            'sum(rate(thanos_querier_store_apis_dns_lookups_total{%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s}[$interval])) by (job)' % thanos.query,
             'lookups {{job}}'
           )
         )
         .addPanel(
           g.panel('Errors', 'Shows ratio of failures compared to the the total number of executed DNS lookups.') +
           g.qpsErrTotalPanel(
-            'thanos_querier_store_apis_dns_failures_total{%(namespaceLabel)s="$namespace",%(selector)s}' % thanos.query,
-            'thanos_querier_store_apis_dns_lookups_total{%(namespaceLabel)s="$namespace",%(selector)s}' % thanos.query,
+            'thanos_querier_store_apis_dns_failures_total{%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s}' % thanos.query,
+            'thanos_querier_store_apis_dns_lookups_total{%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s}' % thanos.query,
           )
         )
       )
@@ -92,26 +92,26 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
         g.resourceUtilizationRow(thanos.query.namespaceLabel, thanos.query.selector)
       ) +
       g.template('namespace', thanos.dashboard.namespaceMetric) +
-      g.template('job', 'up', '%(namespaceLabel)s="$namespace",%(selector)s' % thanos.query, true, '%(jobPrefix)s.*' % thanos.query) +
+      g.template('job', 'up', '%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s' % thanos.query, true, '%(jobPrefix)s.*' % thanos.query) +
       g.template('pod', 'kube_pod_info', '%(namespaceLabel)s="$namespace",created_by_name=~"%(jobPrefix)s.*"' % thanos.query, true, '.*'),
 
     __overviewRows__+:: [
       g.row('Instant Query')
       .addPanel(
         g.panel('Requests Rate', 'Shows rate of requests against /query for the given time.') +
-        g.httpQpsPanel('http_requests_total', '%(namespaceLabel)s="$namespace",%(selector)s,handler="query"' % thanos.query) +
+        g.httpQpsPanel('http_requests_total', '%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s,handler="query"' % thanos.query) +
         g.addDashboardLink(thanos.query.title)
       )
       .addPanel(
         g.panel('Requests Errors', 'Shows ratio of errors compared to the the total number of handled requests against /query.') +
-        g.httpErrPanel('http_requests_total', '%(namespaceLabel)s="$namespace",%(selector)s,handler="query"' % thanos.query) +
+        g.httpErrPanel('http_requests_total', '%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s,handler="query"' % thanos.query) +
         g.addDashboardLink(thanos.query.title)
       )
       .addPanel(
         g.sloLatency(
           'Latency 99th Percentile',
           'Shows how long has it taken to handle requests.',
-          'http_request_duration_seconds_bucket{%(namespaceLabel)s="$namespace",%(selector)s,handler="query"}' % thanos.query,
+          'http_request_duration_seconds_bucket{%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s,handler="query"}' % thanos.query,
           0.99,
           0.5,
           1
@@ -122,19 +122,19 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
       g.row('Range Query')
       .addPanel(
         g.panel('Requests Rate', 'Shows rate of requests against /query_range for the given time range.') +
-        g.httpQpsPanel('http_requests_total', '%(namespaceLabel)s="$namespace",%(selector)s,handler="query_range"' % thanos.query) +
+        g.httpQpsPanel('http_requests_total', '%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s,handler="query_range"' % thanos.query) +
         g.addDashboardLink(thanos.query.title)
       )
       .addPanel(
         g.panel('Requests Errors', 'Shows ratio of errors compared to the the total number of handled requests against /query_range.') +
-        g.httpErrPanel('http_requests_total', '%(namespaceLabel)s="$namespace",%(selector)s,handler="query_range"' % thanos.query) +
+        g.httpErrPanel('http_requests_total', '%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s,handler="query_range"' % thanos.query) +
         g.addDashboardLink(thanos.query.title)
       )
       .addPanel(
         g.sloLatency(
           'Latency 99th Percentile',
           'Shows how long has it taken to handle requests.',
-          'http_request_duration_seconds_bucket{%(namespaceLabel)s="$namespace",%(selector)s,handler="query_range"}' % thanos.query,
+          'http_request_duration_seconds_bucket{%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s,handler="query_range"}' % thanos.query,
           0.99,
           0.5,
           1

--- a/mixin/dashboards/receive.libsonnet
+++ b/mixin/dashboards/receive.libsonnet
@@ -15,15 +15,15 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
         g.row('WRITE - Incoming Request')
         .addPanel(
           g.panel('Rate', 'Shows rate of incoming requests.') +
-          g.httpQpsPanel('http_requests_total', 'handler="receive",namespace="$namespace",job=~"$job"')
+          g.httpQpsPanel('http_requests_total', 'handler="receive",%(namespaceLabel)s="$namespace",%(selector)s' % thanos.receive)
         )
         .addPanel(
           g.panel('Errors', 'Shows ratio of errors compared to the total number of handled incoming requests.') +
-          g.httpErrPanel('http_requests_total', 'handler="receive",namespace="$namespace",job=~"$job"')
+          g.httpErrPanel('http_requests_total', 'handler="receive",%(namespaceLabel)s="$namespace",%(selector)s' % thanos.receive)
         )
         .addPanel(
           g.panel('Duration', 'Shows how long has it taken to handle incoming requests in quantiles.') +
-          g.latencyPanel('http_request_duration_seconds', 'handler="receive",namespace="$namespace",job=~"$job"')
+          g.latencyPanel('http_request_duration_seconds', 'handler="receive",%(namespaceLabel)s="$namespace",%(selector)s' % thanos.receive)
         )
       )
       .addRow(
@@ -31,15 +31,15 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
         .addPanel(
           g.panel('Rate', 'Shows rate of replications to other receive nodes.') +
           g.queryPanel(
-            'sum(rate(thanos_receive_replications_total{namespace="$namespace",job=~"$job"}[$interval])) by (job)',
+            'sum(rate(thanos_receive_replications_total{%(namespaceLabel)s="$namespace",%(selector)s}[$interval])) by (job)' % thanos.receive,
             'all {{job}}',
           )
         )
         .addPanel(
           g.panel('Errors', 'Shows ratio of errors compared to the total number of replications to other receive nodes.') +
           g.qpsErrTotalPanel(
-            'thanos_receive_replications_total{namespace="$namespace",job=~"$job",result="error"}',
-            'thanos_receive_replications_total{namespace="$namespace",job=~"$job"}',
+            'thanos_receive_replications_total{%(namespaceLabel)s="$namespace",%(selector)s,result="error"}' % thanos.receive,
+            'thanos_receive_replications_total{%(namespaceLabel)s="$namespace",%(selector)s}' % thanos.receive,
           )
         )
       )
@@ -48,15 +48,15 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
         .addPanel(
           g.panel('Rate', 'Shows rate of forwarded requests to other receive nodes.') +
           g.queryPanel(
-            'sum(rate(thanos_receive_forward_requests_total{namespace="$namespace",job=~"$job"}[$interval])) by (job)',
+            'sum(rate(thanos_receive_forward_requests_total{%(namespaceLabel)s="$namespace",%(selector)s}[$interval])) by (job)' % thanos.receive,
             'all {{job}}',
           )
         )
         .addPanel(
           g.panel('Errors', 'Shows ratio of errors compared to the total number of forwareded requests to other receive nodes.') +
           g.qpsErrTotalPanel(
-            'thanos_receive_forward_requests_total{namespace="$namespace",job=~"$job",result="error"}',
-            'thanos_receive_forward_requests_total{namespace="$namespace",job=~"$job"}',
+            'thanos_receive_forward_requests_total{%(namespaceLabel)s="$namespace",%(selector)s,result="error"}' % thanos.receive,
+            'thanos_receive_forward_requests_total{%(namespaceLabel)s="$namespace",%(selector)s}' % thanos.receive,
           )
         )
       )
@@ -64,45 +64,45 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
         g.row('WRITE - gRPC (Unary)')
         .addPanel(
           g.panel('Rate', 'Shows rate of handled Unary gRPC requests from queriers.') +
-          g.grpcQpsPanel('server', 'namespace="$namespace",job=~"$job",grpc_type="unary",grpc_method="RemoteWrite"')
+          g.grpcQpsPanel('server', '%(namespaceLabel)s="$namespace",%(selector)s,grpc_type="unary",grpc_method="RemoteWrite"' % thanos.receive)
         )
         .addPanel(
           g.panel('Errors', 'Shows ratio of errors compared to the total number of handled requests from queriers.') +
-          g.grpcErrorsPanel('server', 'namespace="$namespace",job=~"$job",grpc_type="unary",grpc_method="RemoteWrite"')
+          g.grpcErrorsPanel('server', '%(namespaceLabel)s="$namespace",%(selector)s,grpc_type="unary",grpc_method="RemoteWrite"' % thanos.receive)
         )
         .addPanel(
           g.panel('Duration', 'Shows how long has it taken to handle requests from queriers, in quantiles.') +
-          g.grpcLatencyPanel('server', 'namespace="$namespace",job=~"$job",grpc_type="unary",grpc_method="RemoteWrite"')
+          g.grpcLatencyPanel('server', '%(namespaceLabel)s="$namespace",%(selector)s,grpc_type="unary",grpc_method="RemoteWrite"' % thanos.receive)
         )
       )
       .addRow(
         g.row('READ - gRPC (Unary)')
         .addPanel(
           g.panel('Rate', 'Shows rate of handled Unary gRPC requests from queriers.') +
-          g.grpcQpsPanel('server', 'namespace="$namespace",job=~"$job",grpc_type="unary",grpc_method!="RemoteWrite"')
+          g.grpcQpsPanel('server', '%(namespaceLabel)s="$namespace",%(selector)s,grpc_type="unary",grpc_method!="RemoteWrite"' % thanos.receive)
         )
         .addPanel(
           g.panel('Errors', 'Shows ratio of errors compared to the total number of handled requests from queriers.') +
-          g.grpcErrorsPanel('server', 'namespace="$namespace",job=~"$job",grpc_type="unary",grpc_method!="RemoteWrite"')
+          g.grpcErrorsPanel('server', '%(namespaceLabel)s="$namespace",%(selector)s,grpc_type="unary",grpc_method!="RemoteWrite"' % thanos.receive)
         )
         .addPanel(
           g.panel('Duration', 'Shows how long has it taken to handle requests from queriers, in quantiles.') +
-          g.grpcLatencyPanel('server', 'namespace="$namespace",job=~"$job",grpc_type="unary",grpc_method!="RemoteWrite"')
+          g.grpcLatencyPanel('server', '%(namespaceLabel)s="$namespace",%(selector)s,grpc_type="unary",grpc_method!="RemoteWrite"' % thanos.receive)
         )
       )
       .addRow(
         g.row('READ - gRPC (Stream)')
         .addPanel(
           g.panel('Rate', 'Shows rate of handled Streamed gRPC requests from queriers.') +
-          g.grpcQpsPanel('server', 'namespace="$namespace",job=~"$job",grpc_type="server_stream"')
+          g.grpcQpsPanel('server', '%(namespaceLabel)s="$namespace",%(selector)s,grpc_type="server_stream"' % thanos.receive)
         )
         .addPanel(
           g.panel('Errors', 'Shows ratio of errors compared to the total number of handled requests from queriers.') +
-          g.grpcErrorsPanel('server', 'namespace="$namespace",job=~"$job",grpc_type="server_stream"')
+          g.grpcErrorsPanel('server', '%(namespaceLabel)s="$namespace",%(selector)s,grpc_type="server_stream"' % thanos.receive)
         )
         .addPanel(
           g.panel('Duration', 'Shows how long has it taken to handle requests from queriers, in quantiles.') +
-          g.grpcLatencyPanel('server', 'namespace="$namespace",job=~"$job",grpc_type="server_stream"')
+          g.grpcLatencyPanel('server', '%(namespaceLabel)s="$namespace",%(selector)s,grpc_type="server_stream"' % thanos.receive)
         )
       )
       .addRow(
@@ -110,7 +110,7 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
         .addPanel(
           g.panel('Successful Upload', 'Shows the relative time of last successful upload to the object-store bucket.') +
           g.tablePanel(
-            ['time() - max(thanos_objstore_bucket_last_successful_upload_time{namespace="$namespace",job=~"$job"}) by (job, bucket)'],
+            ['time() - max(thanos_objstore_bucket_last_successful_upload_time{%(namespaceLabel)s="$namespace",%(selector)s}) by (job, bucket)'] % thanos.receive,
             {
               Value: {
                 alias: 'Uploaded Ago',
@@ -125,26 +125,26 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
         g.resourceUtilizationRow()
       ) +
       g.template('namespace', thanos.dashboard.namespaceMetric) +
-      g.template('job', 'up', 'namespace="$namespace",%(selector)s' % thanos.receive, true, '%(jobPrefix)s.*' % thanos.receive) +
-      g.template('pod', 'kube_pod_info', 'namespace="$namespace",created_by_name=~"%(jobPrefix)s.*"' % thanos.receive, true, '.*'),
+      g.template('job', 'up', '%(namespaceLabel)s="$namespace",%(selector)s' % thanos.receive, true, '%(jobPrefix)s.*' % thanos.receive) +
+      g.template('pod', 'kube_pod_info', '%(namespaceLabel)s="$namespace",created_by_name=~"%(jobPrefix)s.*"' % thanos.receive, true, '.*'),
 
     __overviewRows__+:: [
       g.row('Receive')
       .addPanel(
         g.panel('Incoming Requests Rate', 'Shows rate of incoming requests.') +
-        g.httpQpsPanel('http_requests_total', 'handler="receive",namespace="$namespace",%(selector)s' % thanos.receive) +
+        g.httpQpsPanel('http_requests_total', 'handler="receive",%(namespaceLabel)s="$namespace",%(selector)s' % thanos.receive) +
         g.addDashboardLink(thanos.receive.title)
       )
       .addPanel(
         g.panel('Incoming Requests Errors', 'Shows ratio of errors compared to the total number of handled incoming requests.') +
-        g.httpErrPanel('http_requests_total', 'handler="receive",namespace="$namespace",%(selector)s' % thanos.receive) +
+        g.httpErrPanel('http_requests_total', 'handler="receive",%(namespaceLabel)s="$namespace",%(selector)s' % thanos.receive) +
         g.addDashboardLink(thanos.receive.title)
       )
       .addPanel(
         g.sloLatency(
           'Incoming Requests Latency 99th Percentile',
           'Shows how long has it taken to handle incoming requests.',
-          'http_request_duration_seconds_bucket{handler="receive",namespace="$namespace",%(selector)s}' % thanos.receive,
+          'http_request_duration_seconds_bucket{handler="receive",%(namespaceLabel)s="$namespace",%(selector)s}' % thanos.receive,
           0.99,
           0.5,
           1

--- a/mixin/dashboards/receive.libsonnet
+++ b/mixin/dashboards/receive.libsonnet
@@ -123,7 +123,7 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
       .addRow(
         g.resourceUtilizationRow()
       ) +
-      g.template('namespace', thanos.dashboard.namespaceQuery) +
+      g.template('namespace', thanos.dashboard.namespaceMetric) +
       g.template('job', 'up', 'namespace="$namespace",%(selector)s' % thanos.receive, true, '%(jobPrefix)s.*' % thanos.receive) +
       g.template('pod', 'kube_pod_info', 'namespace="$namespace",created_by_name=~"%(jobPrefix)s.*"' % thanos.receive, true, '.*'),
 

--- a/mixin/dashboards/receive.libsonnet
+++ b/mixin/dashboards/receive.libsonnet
@@ -6,9 +6,10 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
     jobPrefix: error 'must provide job prefix for Thanos Receive dashboard',
     selector: error 'must provide selector for Thanos Receive dashboard',
     title: error 'must provide title for Thanos Receive dashboard',
+    namespaceLabel: error 'must provide namespace label', 
   },
   grafanaDashboards+:: {
-    'receive.json':
+    'thanos-receive.json':
       g.dashboard(thanos.receive.title)
       .addRow(
         g.row('WRITE - Incoming Request')

--- a/mixin/dashboards/receive.libsonnet
+++ b/mixin/dashboards/receive.libsonnet
@@ -15,15 +15,15 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
         g.row('WRITE - Incoming Request')
         .addPanel(
           g.panel('Rate', 'Shows rate of incoming requests.') +
-          g.httpQpsPanel('http_requests_total', 'handler="receive",%(namespaceLabel)s="$namespace",%(selector)s' % thanos.receive)
+          g.httpQpsPanel('http_requests_total', 'handler="receive",%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s' % thanos.receive)
         )
         .addPanel(
           g.panel('Errors', 'Shows ratio of errors compared to the total number of handled incoming requests.') +
-          g.httpErrPanel('http_requests_total', 'handler="receive",%(namespaceLabel)s="$namespace",%(selector)s' % thanos.receive)
+          g.httpErrPanel('http_requests_total', 'handler="receive",%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s' % thanos.receive)
         )
         .addPanel(
           g.panel('Duration', 'Shows how long has it taken to handle incoming requests in quantiles.') +
-          g.latencyPanel('http_request_duration_seconds', 'handler="receive",%(namespaceLabel)s="$namespace",%(selector)s' % thanos.receive)
+          g.latencyPanel('http_request_duration_seconds', 'handler="receive",%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s' % thanos.receive)
         )
       )
       .addRow(
@@ -31,15 +31,15 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
         .addPanel(
           g.panel('Rate', 'Shows rate of replications to other receive nodes.') +
           g.queryPanel(
-            'sum(rate(thanos_receive_replications_total{%(namespaceLabel)s="$namespace",%(selector)s}[$interval])) by (job)' % thanos.receive,
+            'sum(rate(thanos_receive_replications_total{%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s}[$interval])) by (job)' % thanos.receive,
             'all {{job}}',
           )
         )
         .addPanel(
           g.panel('Errors', 'Shows ratio of errors compared to the total number of replications to other receive nodes.') +
           g.qpsErrTotalPanel(
-            'thanos_receive_replications_total{%(namespaceLabel)s="$namespace",%(selector)s,result="error"}' % thanos.receive,
-            'thanos_receive_replications_total{%(namespaceLabel)s="$namespace",%(selector)s}' % thanos.receive,
+            'thanos_receive_replications_total{%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s,result="error"}' % thanos.receive,
+            'thanos_receive_replications_total{%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s}' % thanos.receive,
           )
         )
       )
@@ -48,15 +48,15 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
         .addPanel(
           g.panel('Rate', 'Shows rate of forwarded requests to other receive nodes.') +
           g.queryPanel(
-            'sum(rate(thanos_receive_forward_requests_total{%(namespaceLabel)s="$namespace",%(selector)s}[$interval])) by (job)' % thanos.receive,
+            'sum(rate(thanos_receive_forward_requests_total{%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s}[$interval])) by (job)' % thanos.receive,
             'all {{job}}',
           )
         )
         .addPanel(
           g.panel('Errors', 'Shows ratio of errors compared to the total number of forwareded requests to other receive nodes.') +
           g.qpsErrTotalPanel(
-            'thanos_receive_forward_requests_total{%(namespaceLabel)s="$namespace",%(selector)s,result="error"}' % thanos.receive,
-            'thanos_receive_forward_requests_total{%(namespaceLabel)s="$namespace",%(selector)s}' % thanos.receive,
+            'thanos_receive_forward_requests_total{%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s,result="error"}' % thanos.receive,
+            'thanos_receive_forward_requests_total{%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s}' % thanos.receive,
           )
         )
       )
@@ -64,45 +64,45 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
         g.row('WRITE - gRPC (Unary)')
         .addPanel(
           g.panel('Rate', 'Shows rate of handled Unary gRPC requests from queriers.') +
-          g.grpcQpsPanel('server', '%(namespaceLabel)s="$namespace",%(selector)s,grpc_type="unary",grpc_method="RemoteWrite"' % thanos.receive)
+          g.grpcQpsPanel('server', '%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s,grpc_type="unary",grpc_method="RemoteWrite"' % thanos.receive)
         )
         .addPanel(
           g.panel('Errors', 'Shows ratio of errors compared to the total number of handled requests from queriers.') +
-          g.grpcErrorsPanel('server', '%(namespaceLabel)s="$namespace",%(selector)s,grpc_type="unary",grpc_method="RemoteWrite"' % thanos.receive)
+          g.grpcErrorsPanel('server', '%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s,grpc_type="unary",grpc_method="RemoteWrite"' % thanos.receive)
         )
         .addPanel(
           g.panel('Duration', 'Shows how long has it taken to handle requests from queriers, in quantiles.') +
-          g.grpcLatencyPanel('server', '%(namespaceLabel)s="$namespace",%(selector)s,grpc_type="unary",grpc_method="RemoteWrite"' % thanos.receive)
+          g.grpcLatencyPanel('server', '%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s,grpc_type="unary",grpc_method="RemoteWrite"' % thanos.receive)
         )
       )
       .addRow(
         g.row('READ - gRPC (Unary)')
         .addPanel(
           g.panel('Rate', 'Shows rate of handled Unary gRPC requests from queriers.') +
-          g.grpcQpsPanel('server', '%(namespaceLabel)s="$namespace",%(selector)s,grpc_type="unary",grpc_method!="RemoteWrite"' % thanos.receive)
+          g.grpcQpsPanel('server', '%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s,grpc_type="unary",grpc_method!="RemoteWrite"' % thanos.receive)
         )
         .addPanel(
           g.panel('Errors', 'Shows ratio of errors compared to the total number of handled requests from queriers.') +
-          g.grpcErrorsPanel('server', '%(namespaceLabel)s="$namespace",%(selector)s,grpc_type="unary",grpc_method!="RemoteWrite"' % thanos.receive)
+          g.grpcErrorsPanel('server', '%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s,grpc_type="unary",grpc_method!="RemoteWrite"' % thanos.receive)
         )
         .addPanel(
           g.panel('Duration', 'Shows how long has it taken to handle requests from queriers, in quantiles.') +
-          g.grpcLatencyPanel('server', '%(namespaceLabel)s="$namespace",%(selector)s,grpc_type="unary",grpc_method!="RemoteWrite"' % thanos.receive)
+          g.grpcLatencyPanel('server', '%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s,grpc_type="unary",grpc_method!="RemoteWrite"' % thanos.receive)
         )
       )
       .addRow(
         g.row('READ - gRPC (Stream)')
         .addPanel(
           g.panel('Rate', 'Shows rate of handled Streamed gRPC requests from queriers.') +
-          g.grpcQpsPanel('server', '%(namespaceLabel)s="$namespace",%(selector)s,grpc_type="server_stream"' % thanos.receive)
+          g.grpcQpsPanel('server', '%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s,grpc_type="server_stream"' % thanos.receive)
         )
         .addPanel(
           g.panel('Errors', 'Shows ratio of errors compared to the total number of handled requests from queriers.') +
-          g.grpcErrorsPanel('server', '%(namespaceLabel)s="$namespace",%(selector)s,grpc_type="server_stream"' % thanos.receive)
+          g.grpcErrorsPanel('server', '%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s,grpc_type="server_stream"' % thanos.receive)
         )
         .addPanel(
           g.panel('Duration', 'Shows how long has it taken to handle requests from queriers, in quantiles.') +
-          g.grpcLatencyPanel('server', '%(namespaceLabel)s="$namespace",%(selector)s,grpc_type="server_stream"' % thanos.receive)
+          g.grpcLatencyPanel('server', '%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s,grpc_type="server_stream"' % thanos.receive)
         )
       )
       .addRow(
@@ -110,7 +110,7 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
         .addPanel(
           g.panel('Successful Upload', 'Shows the relative time of last successful upload to the object-store bucket.') +
           g.tablePanel(
-            ['time() - max(thanos_objstore_bucket_last_successful_upload_time{%(namespaceLabel)s="$namespace",%(selector)s}) by (job, bucket)'] % thanos.receive,
+            ['time() - max(thanos_objstore_bucket_last_successful_upload_time{%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s}) by (job, bucket)'] % thanos.receive,
             {
               Value: {
                 alias: 'Uploaded Ago',
@@ -125,26 +125,26 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
         g.resourceUtilizationRow(thanos.receive.namespaceLabel, thanos.receive.selector)
       ) +
       g.template('namespace', thanos.dashboard.namespaceMetric) +
-      g.template('job', 'up', '%(namespaceLabel)s="$namespace",%(selector)s' % thanos.receive, true, '%(jobPrefix)s.*' % thanos.receive) +
+      g.template('job', 'up', '%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s' % thanos.receive, true, '%(jobPrefix)s.*' % thanos.receive) +
       g.template('pod', 'kube_pod_info', '%(namespaceLabel)s="$namespace",created_by_name=~"%(jobPrefix)s.*"' % thanos.receive, true, '.*'),
 
     __overviewRows__+:: [
       g.row('Receive')
       .addPanel(
         g.panel('Incoming Requests Rate', 'Shows rate of incoming requests.') +
-        g.httpQpsPanel('http_requests_total', 'handler="receive",%(namespaceLabel)s="$namespace",%(selector)s' % thanos.receive) +
+        g.httpQpsPanel('http_requests_total', 'handler="receive",%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s' % thanos.receive) +
         g.addDashboardLink(thanos.receive.title)
       )
       .addPanel(
         g.panel('Incoming Requests Errors', 'Shows ratio of errors compared to the total number of handled incoming requests.') +
-        g.httpErrPanel('http_requests_total', 'handler="receive",%(namespaceLabel)s="$namespace",%(selector)s' % thanos.receive) +
+        g.httpErrPanel('http_requests_total', 'handler="receive",%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s' % thanos.receive) +
         g.addDashboardLink(thanos.receive.title)
       )
       .addPanel(
         g.sloLatency(
           'Incoming Requests Latency 99th Percentile',
           'Shows how long has it taken to handle incoming requests.',
-          'http_request_duration_seconds_bucket{handler="receive",%(namespaceLabel)s="$namespace",%(selector)s}' % thanos.receive,
+          'http_request_duration_seconds_bucket{handler="receive",%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s}' % thanos.receive,
           0.99,
           0.5,
           1

--- a/mixin/dashboards/receive.libsonnet
+++ b/mixin/dashboards/receive.libsonnet
@@ -122,7 +122,7 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
         )
       )
       .addRow(
-        g.resourceUtilizationRow()
+        g.resourceUtilizationRow(thanos.receive.namespaceLabel, thanos.receive.selector)
       ) +
       g.template('namespace', thanos.dashboard.namespaceMetric) +
       g.template('job', 'up', '%(namespaceLabel)s="$namespace",%(selector)s' % thanos.receive, true, '%(jobPrefix)s.*' % thanos.receive) +

--- a/mixin/dashboards/rule.libsonnet
+++ b/mixin/dashboards/rule.libsonnet
@@ -17,8 +17,8 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
           g.panel('Rule Group Evaluations') +
           g.queryPanel(
             |||
-              sum by (strategy) (rate(prometheus_rule_evaluations_total{namespace="$namespace",job="$job"}[$interval]))
-            |||,
+              sum by (strategy) (rate(prometheus_rule_evaluations_total{%(namespaceLabel)s="$namespace",%(selector)s}[$interval]))
+            ||| % thanos.rule,
             '{{ strategy }}',
           )
         )
@@ -26,8 +26,8 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
           g.panel('Rule Group Evaluations Missed') +
           g.queryPanel(
             |||
-              sum by (strategy) (increase(prometheus_rule_group_iterations_missed_total{namespace="$namespace",job="$job"}[$interval]))
-            |||,
+              sum by (strategy) (increase(prometheus_rule_group_iterations_missed_total{%(namespaceLabel)s="$namespace",%(selector)s}[$interval]))
+            ||| % thanos.rule,
             '{{ strategy }}',
           )
         )
@@ -36,11 +36,11 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
           g.queryPanel(
             |||
               (
-                max by(rule_group) (prometheus_rule_group_last_duration_seconds{namespace="$namespace",job="$job"})
+                max by(rule_group) (prometheus_rule_group_last_duration_seconds{%(namespaceLabel)s="$namespace",%(selector)s})
                 >
-                sum by(rule_group) (prometheus_rule_group_interval_seconds{namespace="$namespace",job="$job"})
+                sum by(rule_group) (prometheus_rule_group_interval_seconds{%(namespaceLabel)s="$namespace",%(selector)s})
               )
-            |||,
+            ||| % thanos.rule,
             '{{ rule_group }}',
           )
         )
@@ -50,14 +50,14 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
         .addPanel(
           g.panel('Dropped Rate', 'Shows rate of dropped alerts.') +
           g.queryPanel(
-            'sum(rate(thanos_alert_sender_alerts_dropped_total{namespace="$namespace",job=~"$job"}[$interval])) by (job, alertmanager)',
+            'sum(rate(thanos_alert_sender_alerts_dropped_total{%(namespaceLabel)s="$namespace",job=~"$job"}[$interval])) by (job, alertmanager)' % thanos.rule,
             '{{alertmanager}}'
           )
         )
         .addPanel(
           g.panel('Sent Rate', 'Shows rate of alerts that successfully sent to alert manager.') +
           g.queryPanel(
-            'sum(rate(thanos_alert_sender_alerts_sent_total{namespace="$namespace",job=~"$job"}[$interval])) by (job, alertmanager)',
+            'sum(rate(thanos_alert_sender_alerts_sent_total{%(namespaceLabel)s="$namespace",job=~"$job"}[$interval])) by (job, alertmanager)' % thanos.rule,
             '{{alertmanager}}'
           ) +
           g.stack
@@ -65,13 +65,13 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
         .addPanel(
           g.panel('Sent Errors', 'Shows ratio of errors compared to the total number of sent alerts.') +
           g.qpsErrTotalPanel(
-            'thanos_alert_sender_errors_total{namespace="$namespace",job=~"$job"}',
-            'thanos_alert_sender_alerts_sent_total{namespace="$namespace",job=~"$job"}',
+            'thanos_alert_sender_errors_total{%(namespaceLabel)s="$namespace",job=~"$job"}' % thanos.rule,
+            'thanos_alert_sender_alerts_sent_total{%(namespaceLabel)s="$namespace",job=~"$job"}' % thanos.rule,
           )
         )
         .addPanel(
           g.panel('Sent Duration', 'Shows how long has it taken to send alerts to alert manager.') +
-          g.latencyPanel('thanos_alert_sender_latency_seconds', 'namespace="$namespace",job=~"$job"'),
+          g.latencyPanel('thanos_alert_sender_latency_seconds', '%(namespaceLabel)s="$namespace",job=~"$job"' % thanos.rule),
         )
       )
       .addRow(
@@ -79,15 +79,15 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
         .addPanel(
           g.panel('Push Rate', 'Shows rate of queued alerts.') +
           g.queryPanel(
-            'sum(rate(thanos_alert_queue_alerts_dropped_total{namespace="$namespace",job=~"$job"}[$interval])) by (job, pod)',
+            'sum(rate(thanos_alert_queue_alerts_dropped_total{%(namespaceLabel)s="$namespace",job=~"$job"}[$interval])) by (job, pod)' % thanos.rule,
             '{{pod}}'
           )
         )
         .addPanel(
           g.panel('Drop Ratio', 'Shows ratio of dropped alerts compared to the total number of queued alerts.') +
           g.qpsErrTotalPanel(
-            'thanos_alert_queue_alerts_dropped_total{namespace="$namespace",job=~"$job"}',
-            'thanos_alert_queue_alerts_pushed_total{namespace="$namespace",job=~"$job"}',
+            'thanos_alert_queue_alerts_dropped_total{%(namespaceLabel)s="$namespace",job=~"$job"}' % thanos.rule,
+            'thanos_alert_queue_alerts_pushed_total{%(namespaceLabel)s="$namespace",job=~"$job"}' % thanos.rule,
           )
         )
       )
@@ -95,45 +95,45 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
         g.row('gRPC (Unary)')
         .addPanel(
           g.panel('Rate', 'Shows rate of handled Unary gRPC requests.') +
-          g.grpcQpsPanel('server', 'namespace="$namespace",job=~"$job",grpc_type="unary"')
+          g.grpcQpsPanel('server', '%(namespaceLabel)s="$namespace",job=~"$job",grpc_type="unary"') % thanos.rule
         )
         .addPanel(
           g.panel('Errors', 'Shows ratio of errors compared to the total number of handled requests.') +
-          g.grpcErrorsPanel('server', 'namespace="$namespace",job=~"$job",grpc_type="unary"')
+          g.grpcErrorsPanel('server', '%(namespaceLabel)s="$namespace",job=~"$job",grpc_type="unary"' % thanos.rule)
         )
         .addPanel(
           g.panel('Duration', 'Shows how long has it taken to handle requests, in quantiles.') +
-          g.grpcLatencyPanel('server', 'namespace="$namespace",job=~"$job",grpc_type="unary"')
+          g.grpcLatencyPanel('server', '%(namespaceLabel)s="$namespace",job=~"$job",grpc_type="unary"' % thanos.rule)
         )
       )
       .addRow(
         g.row('gRPC (Stream)')
         .addPanel(
           g.panel('Rate', 'Shows rate of handled Streamed gRPC requests.') +
-          g.grpcQpsPanel('server', 'namespace="$namespace",job=~"$job",grpc_type="server_stream"')
+          g.grpcQpsPanel('server', '%(namespaceLabel)s="$namespace",job=~"$job",grpc_type="server_stream"' % thanos.rule)
         )
         .addPanel(
           g.panel('Errors', 'Shows ratio of errors compared to the total number of handled requests.') +
-          g.grpcErrorsPanel('server', 'namespace="$namespace",job=~"$job",grpc_type="server_stream"')
+          g.grpcErrorsPanel('server', '%(namespaceLabel)s="$namespace",job=~"$job",grpc_type="server_stream"' % thanos.rule)
         )
         .addPanel(
           g.panel('Duration', 'Shows how long has it taken to handle requests, in quantiles') +
-          g.grpcLatencyPanel('server', 'namespace="$namespace",job=~"$job",grpc_type="server_stream"')
+          g.grpcLatencyPanel('server', '%(namespaceLabel)s="$namespace",job=~"$job",grpc_type="server_stream"' % thanos.rule)
         )
       )
       .addRow(
         g.resourceUtilizationRow()
       ) +
       g.template('namespace', thanos.dashboard.namespaceMetric) +
-      g.template('job', 'up', 'namespace="$namespace",%(selector)s' % thanos.rule, true, '%(jobPrefix)s.*' % thanos.rule) +
-      g.template('pod', 'kube_pod_info', 'namespace="$namespace",created_by_name=~"%(jobPrefix)s.*"' % thanos.rule, true, '.*'),
+      g.template('job', 'up', '%(namespaceLabel)s="$namespace",%(selector)s' % thanos.rule, true, '%(jobPrefix)s.*' % thanos.rule) +
+      g.template('pod', 'kube_pod_info', '%(namespaceLabel)s="$namespace",created_by_name=~"%(jobPrefix)s.*"' % thanos.rule, true, '.*'),
 
     __overviewRows__+:: [
       g.row('Rule')
       .addPanel(
         g.panel('Alert Sent Rate', 'Shows rate of alerts that successfully sent to alert manager.') +
         g.queryPanel(
-          'sum(rate(thanos_alert_sender_alerts_sent_total{namespace="$namespace",%(selector)s}[$interval])) by (job, alertmanager)' % thanos.rule,
+          'sum(rate(thanos_alert_sender_alerts_sent_total{%(namespaceLabel)s="$namespace",%(selector)s}[$interval])) by (job, alertmanager)' % thanos.rule,
           '{{alertmanager}}'
         ) +
         g.addDashboardLink(thanos.rule.title) +
@@ -142,8 +142,8 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
       .addPanel(
         g.panel('Alert Sent Errors', 'Shows ratio of errors compared to the total number of sent alerts.') +
         g.qpsErrTotalPanel(
-          'thanos_alert_sender_errors_total{namespace="$namespace",%(selector)s}' % thanos.rule,
-          'thanos_alert_sender_alerts_sent_total{namespace="$namespace",%(selector)s}' % thanos.rule,
+          'thanos_alert_sender_errors_total{%(namespaceLabel)s="$namespace",%(selector)s}' % thanos.rule,
+          'thanos_alert_sender_alerts_sent_total{%(namespaceLabel)s="$namespace",%(selector)s}' % thanos.rule,
         ) +
         g.addDashboardLink(thanos.rule.title)
       )
@@ -151,7 +151,7 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
         g.sloLatency(
           'Alert Sent Duration',
           'Shows how long has it taken to send alerts to alert manager.',
-          'thanos_alert_sender_latency_seconds_bucket{namespace="$namespace",%(selector)s}' % thanos.rule,
+          'thanos_alert_sender_latency_seconds_bucket{%(namespaceLabel)s="$namespace",%(selector)s}' % thanos.rule,
           0.99,
           0.5,
           1

--- a/mixin/dashboards/rule.libsonnet
+++ b/mixin/dashboards/rule.libsonnet
@@ -122,7 +122,7 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
         )
       )
       .addRow(
-        g.resourceUtilizationRow()
+        g.resourceUtilizationRow(thanos.rule.namespaceLabel, thanos.rule.selector)
       ) +
       g.template('namespace', thanos.dashboard.namespaceMetric) +
       g.template('job', 'up', '%(namespaceLabel)s="$namespace",%(selector)s' % thanos.rule, true, '%(jobPrefix)s.*' % thanos.rule) +

--- a/mixin/dashboards/rule.libsonnet
+++ b/mixin/dashboards/rule.libsonnet
@@ -17,7 +17,7 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
           g.panel('Rule Group Evaluations') +
           g.queryPanel(
             |||
-              sum by (strategy) (rate(prometheus_rule_evaluations_total{%(namespaceLabel)s="$namespace",%(selector)s}[$interval]))
+              sum by (strategy) (rate(prometheus_rule_evaluations_total{%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s}[$interval]))
             ||| % thanos.rule,
             '{{ strategy }}',
           )
@@ -26,7 +26,7 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
           g.panel('Rule Group Evaluations Missed') +
           g.queryPanel(
             |||
-              sum by (strategy) (increase(prometheus_rule_group_iterations_missed_total{%(namespaceLabel)s="$namespace",%(selector)s}[$interval]))
+              sum by (strategy) (increase(prometheus_rule_group_iterations_missed_total{%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s}[$interval]))
             ||| % thanos.rule,
             '{{ strategy }}',
           )
@@ -36,9 +36,9 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
           g.queryPanel(
             |||
               (
-                max by(rule_group) (prometheus_rule_group_last_duration_seconds{%(namespaceLabel)s="$namespace",%(selector)s})
+                max by(rule_group) (prometheus_rule_group_last_duration_seconds{%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s})
                 >
-                sum by(rule_group) (prometheus_rule_group_interval_seconds{%(namespaceLabel)s="$namespace",%(selector)s})
+                sum by(rule_group) (prometheus_rule_group_interval_seconds{%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s})
               )
             ||| % thanos.rule,
             '{{ rule_group }}',
@@ -125,7 +125,7 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
         g.resourceUtilizationRow(thanos.rule.namespaceLabel, thanos.rule.selector)
       ) +
       g.template('namespace', thanos.dashboard.namespaceMetric) +
-      g.template('job', 'up', '%(namespaceLabel)s="$namespace",%(selector)s' % thanos.rule, true, '%(jobPrefix)s.*' % thanos.rule) +
+      g.template('job', 'up', '%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s' % thanos.rule, true, '%(jobPrefix)s.*' % thanos.rule) +
       g.template('pod', 'kube_pod_info', '%(namespaceLabel)s="$namespace",created_by_name=~"%(jobPrefix)s.*"' % thanos.rule, true, '.*'),
 
     __overviewRows__+:: [
@@ -133,7 +133,7 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
       .addPanel(
         g.panel('Alert Sent Rate', 'Shows rate of alerts that successfully sent to alert manager.') +
         g.queryPanel(
-          'sum(rate(thanos_alert_sender_alerts_sent_total{%(namespaceLabel)s="$namespace",%(selector)s}[$interval])) by (job, alertmanager)' % thanos.rule,
+          'sum(rate(thanos_alert_sender_alerts_sent_total{%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s}[$interval])) by (job, alertmanager)' % thanos.rule,
           '{{alertmanager}}'
         ) +
         g.addDashboardLink(thanos.rule.title) +
@@ -142,8 +142,8 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
       .addPanel(
         g.panel('Alert Sent Errors', 'Shows ratio of errors compared to the total number of sent alerts.') +
         g.qpsErrTotalPanel(
-          'thanos_alert_sender_errors_total{%(namespaceLabel)s="$namespace",%(selector)s}' % thanos.rule,
-          'thanos_alert_sender_alerts_sent_total{%(namespaceLabel)s="$namespace",%(selector)s}' % thanos.rule,
+          'thanos_alert_sender_errors_total{%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s}' % thanos.rule,
+          'thanos_alert_sender_alerts_sent_total{%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s}' % thanos.rule,
         ) +
         g.addDashboardLink(thanos.rule.title)
       )
@@ -151,7 +151,7 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
         g.sloLatency(
           'Alert Sent Duration',
           'Shows how long has it taken to send alerts to alert manager.',
-          'thanos_alert_sender_latency_seconds_bucket{%(namespaceLabel)s="$namespace",%(selector)s}' % thanos.rule,
+          'thanos_alert_sender_latency_seconds_bucket{%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s}' % thanos.rule,
           0.99,
           0.5,
           1

--- a/mixin/dashboards/rule.libsonnet
+++ b/mixin/dashboards/rule.libsonnet
@@ -123,7 +123,7 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
       .addRow(
         g.resourceUtilizationRow()
       ) +
-      g.template('namespace', thanos.dashboard.namespaceQuery) +
+      g.template('namespace', thanos.dashboard.namespaceMetric) +
       g.template('job', 'up', 'namespace="$namespace",%(selector)s' % thanos.rule, true, '%(jobPrefix)s.*' % thanos.rule) +
       g.template('pod', 'kube_pod_info', 'namespace="$namespace",created_by_name=~"%(jobPrefix)s.*"' % thanos.rule, true, '.*'),
 

--- a/mixin/dashboards/rule.libsonnet
+++ b/mixin/dashboards/rule.libsonnet
@@ -95,7 +95,7 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
         g.row('gRPC (Unary)')
         .addPanel(
           g.panel('Rate', 'Shows rate of handled Unary gRPC requests.') +
-          g.grpcQpsPanel('server', '%(namespaceLabel)s="$namespace",job=~"$job",grpc_type="unary"') % thanos.rule
+          g.grpcQpsPanel('server', '%(namespaceLabel)s="$namespace",job=~"$job",grpc_type="unary"' % thanos.rule)
         )
         .addPanel(
           g.panel('Errors', 'Shows ratio of errors compared to the total number of handled requests.') +

--- a/mixin/dashboards/rule.libsonnet
+++ b/mixin/dashboards/rule.libsonnet
@@ -6,9 +6,10 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
     jobPrefix: error 'must provide job prefix for Thanos Rule dashboard',
     selector: error 'must provide selector for Thanos Rule dashboard',
     title: error 'must provide title for Thanos Rule dashboard',
+    namespaceLabel: error 'must provide namespace label', 
   },
   grafanaDashboards+:: {
-    'rule.json':
+    'thanos-rule.json':
       g.dashboard(thanos.rule.title)
       .addRow(
         g.row('Rule Group Evaluations')

--- a/mixin/dashboards/sidecar.libsonnet
+++ b/mixin/dashboards/sidecar.libsonnet
@@ -14,30 +14,30 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
         g.row('gRPC (Unary)')
         .addPanel(
           g.panel('Rate', 'Shows rate of handled Unary gRPC requests from queriers.') +
-          g.grpcQpsPanel('server', 'namespace="$namespace",job=~"$job",grpc_type="unary"')
+          g.grpcQpsPanel('server', 'namespace="$namespace",%(selector)s,grpc_type="unary"' % thanos.sidecar)
         )
         .addPanel(
           g.panel('Errors', 'Shows ratio of errors compared to the total number of handled requests from queriers.') +
-          g.grpcErrorsPanel('server', 'namespace="$namespace",job=~"$job",grpc_type="unary"')
+          g.grpcErrorsPanel('server', 'namespace="$namespace",%(selector)s,grpc_type="unary"' % thanos.sidecar)
         )
         .addPanel(
           g.panel('Duration', 'Shows how long has it taken to handle requests from queriers, in quantiles.') +
-          g.grpcLatencyPanel('server', 'namespace="$namespace",job=~"$job",grpc_type="unary"')
+          g.grpcLatencyPanel('server', 'namespace="$namespace",%(selector)s,grpc_type="unary"' % thanos.sidecar)
         )
       )
       .addRow(
         g.row('gRPC (Stream)')
         .addPanel(
           g.panel('Rate', 'Shows rate of handled Streamed gRPC requests from queriers.') +
-          g.grpcQpsPanel('server', 'namespace="$namespace",job=~"$job",grpc_type="server_stream"')
+          g.grpcQpsPanel('server', 'namespace="$namespace",%(selector)s,grpc_type="server_stream"' % thanos.sidecar)
         )
         .addPanel(
           g.panel('Errors') +
-          g.grpcErrorsPanel('server', 'namespace="$namespace",job=~"$job",grpc_type="server_stream"')
+          g.grpcErrorsPanel('server', 'namespace="$namespace",%(selector)s,grpc_type="server_stream"' % thanos.sidecar)
         )
         .addPanel(
           g.panel('Duration', 'Shows how long has it taken to handle requests from queriers, in quantiles.') +
-          g.grpcLatencyPanel('server', 'namespace="$namespace",job=~"$job",grpc_type="server_stream"')
+          g.grpcLatencyPanel('server', 'namespace="$namespace",%(selector)s,grpc_type="server_stream"' % thanos.sidecar)
         )
       )
       .addRow(
@@ -45,7 +45,7 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
         .addPanel(
           g.panel('Successful Upload', 'Shows the relative time of last successful upload to the object-store bucket.') +
           g.tablePanel(
-            ['time() - max(thanos_objstore_bucket_last_successful_upload_time{namespace="$namespace",job=~"$job"}) by (job, bucket)'],
+            ['time() - max(thanos_objstore_bucket_last_successful_upload_time{namespace="$namespace",%(selector)s}) by (job, bucket)'] % thanos.sidecar,
             {
               Value: {
                 alias: 'Uploaded Ago',
@@ -61,7 +61,7 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
         .addPanel(
           g.panel('Rate') +
           g.queryPanel(
-            'sum(rate(thanos_objstore_bucket_operations_total{namespace="$namespace",job=~"$job"}[$interval])) by (job, operation)',
+            'sum(rate(thanos_objstore_bucket_operations_total{namespace="$namespace",%(selector)s}[$interval])) by (job, operation)' % thanos.sidecar,
             '{{job}} {{operation}}'
           ) +
           g.stack
@@ -69,19 +69,19 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
         .addPanel(
           g.panel('Errors') +
           g.qpsErrTotalPanel(
-            'thanos_objstore_bucket_operation_failures_total{namespace="$namespace",job=~"$job"}',
-            'thanos_objstore_bucket_operations_total{namespace="$namespace",job=~"$job"}',
+            'thanos_objstore_bucket_operation_failures_total{namespace="$namespace",%(selector)s}' % thanos.sidecar,
+            'thanos_objstore_bucket_operations_total{namespace="$namespace",%(selector)s}' % thanos.sidecar,
           )
         )
         .addPanel(
           g.panel('Duration') +
-          g.latencyPanel('thanos_objstore_bucket_operation_duration_seconds', 'namespace="$namespace",job=~"$job"')
+          g.latencyPanel('thanos_objstore_bucket_operation_duration_seconds', 'namespace="$namespace",%(selector)s' % thanos.sidecar)
         )
       )
       .addRow(
         g.resourceUtilizationRow()
       ) +
-      g.template('namespace', thanos.dashboard.namespaceQuery) +
+      g.template('namespace', thanos.dashboard.namespaceMetric) +
       g.template('job', 'up', 'namespace="$namespace",%(selector)s' % thanos.sidecar, true, '%(jobPrefix)s.*' % thanos.sidecar) +
       g.template('pod', 'kube_pod_info', 'namespace="$namespace",created_by_name=~"%(jobPrefix)s.*"' % thanos.sidecar, true, '.*'),
 

--- a/mixin/dashboards/sidecar.libsonnet
+++ b/mixin/dashboards/sidecar.libsonnet
@@ -6,9 +6,10 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
     jobPrefix: error 'must provide job prefix for Thanos Sidecar dashboard',
     selector: error 'must provide selector for Thanos Sidecar dashboard',
     title: error 'must provide title for Thanos Sidecar dashboard',
+    namespaceLabel: error 'must provide namespace label', 
   },
   grafanaDashboards+:: {
-    'sidecar.json':
+    'thanos-sidecar.json':
       g.dashboard(thanos.sidecar.title)
       .addRow(
         g.row('gRPC (Unary)')

--- a/mixin/dashboards/sidecar.libsonnet
+++ b/mixin/dashboards/sidecar.libsonnet
@@ -15,30 +15,30 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
         g.row('gRPC (Unary)')
         .addPanel(
           g.panel('Rate', 'Shows rate of handled Unary gRPC requests from queriers.') +
-          g.grpcQpsPanel('server', 'namespace="$namespace",%(selector)s,grpc_type="unary"' % thanos.sidecar)
+          g.grpcQpsPanel('server', '%(namespaceLabel)s="$namespace",%(selector)s,grpc_type="unary"' % thanos.sidecar)
         )
         .addPanel(
           g.panel('Errors', 'Shows ratio of errors compared to the total number of handled requests from queriers.') +
-          g.grpcErrorsPanel('server', 'namespace="$namespace",%(selector)s,grpc_type="unary"' % thanos.sidecar)
+          g.grpcErrorsPanel('server', '%(namespaceLabel)s="$namespace",%(selector)s,grpc_type="unary"' % thanos.sidecar)
         )
         .addPanel(
           g.panel('Duration', 'Shows how long has it taken to handle requests from queriers, in quantiles.') +
-          g.grpcLatencyPanel('server', 'namespace="$namespace",%(selector)s,grpc_type="unary"' % thanos.sidecar)
+          g.grpcLatencyPanel('server', '%(namespaceLabel)s="$namespace",%(selector)s,grpc_type="unary"' % thanos.sidecar)
         )
       )
       .addRow(
         g.row('gRPC (Stream)')
         .addPanel(
           g.panel('Rate', 'Shows rate of handled Streamed gRPC requests from queriers.') +
-          g.grpcQpsPanel('server', 'namespace="$namespace",%(selector)s,grpc_type="server_stream"' % thanos.sidecar)
+          g.grpcQpsPanel('server', '%(namespaceLabel)s="$namespace",%(selector)s,grpc_type="server_stream"' % thanos.sidecar)
         )
         .addPanel(
           g.panel('Errors') +
-          g.grpcErrorsPanel('server', 'namespace="$namespace",%(selector)s,grpc_type="server_stream"' % thanos.sidecar)
+          g.grpcErrorsPanel('server', '%(namespaceLabel)s="$namespace",%(selector)s,grpc_type="server_stream"' % thanos.sidecar)
         )
         .addPanel(
           g.panel('Duration', 'Shows how long has it taken to handle requests from queriers, in quantiles.') +
-          g.grpcLatencyPanel('server', 'namespace="$namespace",%(selector)s,grpc_type="server_stream"' % thanos.sidecar)
+          g.grpcLatencyPanel('server', '%(namespaceLabel)s="$namespace",%(selector)s,grpc_type="server_stream"' % thanos.sidecar)
         )
       )
       .addRow(
@@ -46,7 +46,7 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
         .addPanel(
           g.panel('Successful Upload', 'Shows the relative time of last successful upload to the object-store bucket.') +
           g.tablePanel(
-            ['time() - max(thanos_objstore_bucket_last_successful_upload_time{namespace="$namespace",%(selector)s}) by (job, bucket)' % thanos.sidecar],
+            ['time() - max(thanos_objstore_bucket_last_successful_upload_time{%(namespaceLabel)s="$namespace",%(selector)s}) by (job, bucket)' % thanos.sidecar],
             {
               Value: {
                 alias: 'Uploaded Ago',
@@ -62,7 +62,7 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
         .addPanel(
           g.panel('Rate') +
           g.queryPanel(
-            'sum(rate(thanos_objstore_bucket_operations_total{namespace="$namespace",%(selector)s}[$interval])) by (job, operation)' % thanos.sidecar,
+            'sum(rate(thanos_objstore_bucket_operations_total{%(namespaceLabel)s="$namespace",%(selector)s}[$interval])) by (job, operation)' % thanos.sidecar,
             '{{job}} {{operation}}'
           ) +
           g.stack
@@ -70,39 +70,39 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
         .addPanel(
           g.panel('Errors') +
           g.qpsErrTotalPanel(
-            'thanos_objstore_bucket_operation_failures_total{namespace="$namespace",%(selector)s}' % thanos.sidecar,
-            'thanos_objstore_bucket_operations_total{namespace="$namespace",%(selector)s}' % thanos.sidecar,
+            'thanos_objstore_bucket_operation_failures_total{%(namespaceLabel)s="$namespace",%(selector)s}' % thanos.sidecar,
+            'thanos_objstore_bucket_operations_total{%(namespaceLabel)s="$namespace",%(selector)s}' % thanos.sidecar,
           )
         )
         .addPanel(
           g.panel('Duration') +
-          g.latencyPanel('thanos_objstore_bucket_operation_duration_seconds', 'namespace="$namespace",%(selector)s' % thanos.sidecar)
+          g.latencyPanel('thanos_objstore_bucket_operation_duration_seconds', '%(namespaceLabel)s="$namespace",%(selector)s' % thanos.sidecar)
         )
       )
       .addRow(
         g.resourceUtilizationRow()
       ) +
       g.template('namespace', thanos.dashboard.namespaceMetric) +
-      g.template('job', 'up', 'namespace="$namespace",%(selector)s' % thanos.sidecar, true, '%(jobPrefix)s.*' % thanos.sidecar) +
-      g.template('pod', 'kube_pod_info', 'namespace="$namespace",created_by_name=~"%(jobPrefix)s.*"' % thanos.sidecar, true, '.*'),
+      g.template('job', 'up', '%(namespaceLabel)s="$namespace",%(selector)s' % thanos.sidecar, true, '%(jobPrefix)s.*' % thanos.sidecar) +
+      g.template('pod', 'kube_pod_info', '%(namespaceLabel)s="$namespace",created_by_name=~"%(jobPrefix)s.*"' % thanos.sidecar, true, '.*'),
 
     __overviewRows__+:: [
       g.row('Sidecar')
       .addPanel(
         g.panel('gPRC (Unary) Rate', 'Shows rate of handled Unary gRPC requests from queriers.') +
-        g.grpcQpsPanel('server', 'namespace="$namespace",%(selector)s,grpc_type="unary"' % thanos.sidecar) +
+        g.grpcQpsPanel('server', '%(namespaceLabel)s="$namespace",%(selector)s,grpc_type="unary"' % thanos.sidecar) +
         g.addDashboardLink(thanos.sidecar.title)
       )
       .addPanel(
         g.panel('gPRC (Unary) Errors', 'Shows ratio of errors compared to the total number of handled requests from queriers.') +
-        g.grpcErrorsPanel('server', 'namespace="$namespace",%(selector)s,grpc_type="unary"' % thanos.sidecar) +
+        g.grpcErrorsPanel('server', '%(namespaceLabel)s="$namespace",%(selector)s,grpc_type="unary"' % thanos.sidecar) +
         g.addDashboardLink(thanos.sidecar.title)
       )
       .addPanel(
         g.sloLatency(
           'gPRC (Unary) Latency 99th Percentile',
           'Shows how long has it taken to handle requests from queriers, in quantiles.',
-          'grpc_server_handling_seconds_bucket{grpc_type="unary",namespace="$namespace",%(selector)s}' % thanos.sidecar,
+          'grpc_server_handling_seconds_bucket{grpc_type="unary",%(namespaceLabel)s="$namespace",%(selector)s}' % thanos.sidecar,
           0.99,
           0.5,
           1

--- a/mixin/dashboards/sidecar.libsonnet
+++ b/mixin/dashboards/sidecar.libsonnet
@@ -15,30 +15,30 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
         g.row('gRPC (Unary)')
         .addPanel(
           g.panel('Rate', 'Shows rate of handled Unary gRPC requests from queriers.') +
-          g.grpcQpsPanel('server', '%(namespaceLabel)s="$namespace",%(selector)s,grpc_type="unary"' % thanos.sidecar)
+          g.grpcQpsPanel('server', '%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s,grpc_type="unary"' % thanos.sidecar)
         )
         .addPanel(
           g.panel('Errors', 'Shows ratio of errors compared to the total number of handled requests from queriers.') +
-          g.grpcErrorsPanel('server', '%(namespaceLabel)s="$namespace",%(selector)s,grpc_type="unary"' % thanos.sidecar)
+          g.grpcErrorsPanel('server', '%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s,grpc_type="unary"' % thanos.sidecar)
         )
         .addPanel(
           g.panel('Duration', 'Shows how long has it taken to handle requests from queriers, in quantiles.') +
-          g.grpcLatencyPanel('server', '%(namespaceLabel)s="$namespace",%(selector)s,grpc_type="unary"' % thanos.sidecar)
+          g.grpcLatencyPanel('server', '%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s,grpc_type="unary"' % thanos.sidecar)
         )
       )
       .addRow(
         g.row('gRPC (Stream)')
         .addPanel(
           g.panel('Rate', 'Shows rate of handled Streamed gRPC requests from queriers.') +
-          g.grpcQpsPanel('server', '%(namespaceLabel)s="$namespace",%(selector)s,grpc_type="server_stream"' % thanos.sidecar)
+          g.grpcQpsPanel('server', '%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s,grpc_type="server_stream"' % thanos.sidecar)
         )
         .addPanel(
           g.panel('Errors') +
-          g.grpcErrorsPanel('server', '%(namespaceLabel)s="$namespace",%(selector)s,grpc_type="server_stream"' % thanos.sidecar)
+          g.grpcErrorsPanel('server', '%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s,grpc_type="server_stream"' % thanos.sidecar)
         )
         .addPanel(
           g.panel('Duration', 'Shows how long has it taken to handle requests from queriers, in quantiles.') +
-          g.grpcLatencyPanel('server', '%(namespaceLabel)s="$namespace",%(selector)s,grpc_type="server_stream"' % thanos.sidecar)
+          g.grpcLatencyPanel('server', '%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s,grpc_type="server_stream"' % thanos.sidecar)
         )
       )
       .addRow(
@@ -46,7 +46,7 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
         .addPanel(
           g.panel('Successful Upload', 'Shows the relative time of last successful upload to the object-store bucket.') +
           g.tablePanel(
-            ['time() - max(thanos_objstore_bucket_last_successful_upload_time{%(namespaceLabel)s="$namespace",%(selector)s}) by (job, bucket)' % thanos.sidecar],
+            ['time() - max(thanos_objstore_bucket_last_successful_upload_time{%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s}) by (job, bucket)' % thanos.sidecar],
             {
               Value: {
                 alias: 'Uploaded Ago',
@@ -62,7 +62,7 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
         .addPanel(
           g.panel('Rate') +
           g.queryPanel(
-            'sum(rate(thanos_objstore_bucket_operations_total{%(namespaceLabel)s="$namespace",%(selector)s}[$interval])) by (job, operation)' % thanos.sidecar,
+            'sum(rate(thanos_objstore_bucket_operations_total{%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s}[$interval])) by (job, operation)' % thanos.sidecar,
             '{{job}} {{operation}}'
           ) +
           g.stack
@@ -70,39 +70,39 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
         .addPanel(
           g.panel('Errors') +
           g.qpsErrTotalPanel(
-            'thanos_objstore_bucket_operation_failures_total{%(namespaceLabel)s="$namespace",%(selector)s}' % thanos.sidecar,
-            'thanos_objstore_bucket_operations_total{%(namespaceLabel)s="$namespace",%(selector)s}' % thanos.sidecar,
+            'thanos_objstore_bucket_operation_failures_total{%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s}' % thanos.sidecar,
+            'thanos_objstore_bucket_operations_total{%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s}' % thanos.sidecar,
           )
         )
         .addPanel(
           g.panel('Duration') +
-          g.latencyPanel('thanos_objstore_bucket_operation_duration_seconds', '%(namespaceLabel)s="$namespace",%(selector)s' % thanos.sidecar)
+          g.latencyPanel('thanos_objstore_bucket_operation_duration_seconds', '%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s' % thanos.sidecar)
         )
       )
       .addRow(
         g.resourceUtilizationRow(thanos.sidecar.namespaceLabel, thanos.sidecar.selector)
       ) +
       g.template('namespace', thanos.dashboard.namespaceMetric) +
-      g.template('job', 'up', '%(namespaceLabel)s="$namespace",%(selector)s' % thanos.sidecar, true, '%(jobPrefix)s.*' % thanos.sidecar) +
+      g.template('job', 'up', '%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s' % thanos.sidecar, true, '%(jobPrefix)s.*' % thanos.sidecar) +
       g.template('pod', 'kube_pod_info', '%(namespaceLabel)s="$namespace",created_by_name=~"%(jobPrefix)s.*"' % thanos.sidecar, true, '.*'),
 
     __overviewRows__+:: [
       g.row('Sidecar')
       .addPanel(
         g.panel('gPRC (Unary) Rate', 'Shows rate of handled Unary gRPC requests from queriers.') +
-        g.grpcQpsPanel('server', '%(namespaceLabel)s="$namespace",%(selector)s,grpc_type="unary"' % thanos.sidecar) +
+        g.grpcQpsPanel('server', '%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s,grpc_type="unary"' % thanos.sidecar) +
         g.addDashboardLink(thanos.sidecar.title)
       )
       .addPanel(
         g.panel('gPRC (Unary) Errors', 'Shows ratio of errors compared to the total number of handled requests from queriers.') +
-        g.grpcErrorsPanel('server', '%(namespaceLabel)s="$namespace",%(selector)s,grpc_type="unary"' % thanos.sidecar) +
+        g.grpcErrorsPanel('server', '%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s,grpc_type="unary"' % thanos.sidecar) +
         g.addDashboardLink(thanos.sidecar.title)
       )
       .addPanel(
         g.sloLatency(
           'gPRC (Unary) Latency 99th Percentile',
           'Shows how long has it taken to handle requests from queriers, in quantiles.',
-          'grpc_server_handling_seconds_bucket{grpc_type="unary",%(namespaceLabel)s="$namespace",%(selector)s}' % thanos.sidecar,
+          'grpc_server_handling_seconds_bucket{grpc_type="unary",%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s}' % thanos.sidecar,
           0.99,
           0.5,
           1

--- a/mixin/dashboards/sidecar.libsonnet
+++ b/mixin/dashboards/sidecar.libsonnet
@@ -80,7 +80,7 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
         )
       )
       .addRow(
-        g.resourceUtilizationRow()
+        g.resourceUtilizationRow(thanos.sidecar.namespaceLabel, thanos.sidecar.selector)
       ) +
       g.template('namespace', thanos.dashboard.namespaceMetric) +
       g.template('job', 'up', '%(namespaceLabel)s="$namespace",%(selector)s' % thanos.sidecar, true, '%(jobPrefix)s.*' % thanos.sidecar) +

--- a/mixin/dashboards/sidecar.libsonnet
+++ b/mixin/dashboards/sidecar.libsonnet
@@ -45,7 +45,7 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
         .addPanel(
           g.panel('Successful Upload', 'Shows the relative time of last successful upload to the object-store bucket.') +
           g.tablePanel(
-            ['time() - max(thanos_objstore_bucket_last_successful_upload_time{namespace="$namespace",%(selector)s}) by (job, bucket)'] % thanos.sidecar,
+            ['time() - max(thanos_objstore_bucket_last_successful_upload_time{namespace="$namespace",%(selector)s}) by (job, bucket)' % thanos.sidecar],
             {
               Value: {
                 alias: 'Uploaded Ago',

--- a/mixin/dashboards/store.libsonnet
+++ b/mixin/dashboards/store.libsonnet
@@ -215,7 +215,7 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
       .addRow(
         g.resourceUtilizationRow()
       ) +
-      g.template('namespace', thanos.dashboard.namespaceQuery) +
+      g.template('namespace', thanos.dashboard.namespaceMetric) +
       g.template('job', 'up', 'namespace="$namespace",%(selector)s' % thanos.store, true, '%(jobPrefix)s.*' % thanos.store) +
       g.template('pod', 'kube_pod_info', 'namespace="$namespace",created_by_name=~"%(jobPrefix)s.*"' % thanos.store, true, '.*'),
 

--- a/mixin/dashboards/store.libsonnet
+++ b/mixin/dashboards/store.libsonnet
@@ -15,30 +15,30 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
         g.row('gRPC (Unary)')
         .addPanel(
           g.panel('Rate', 'Shows rate of handled Unary gRPC requests from queriers.') +
-          g.grpcQpsPanel('server', 'namespace="$namespace",job=~"$job",grpc_type="unary"')
+          g.grpcQpsPanel('server', '%(namespaceLabel)s="$namespace",%(selector)s,grpc_type="unary"' % thanos.store)
         )
         .addPanel(
           g.panel('Errors', 'Shows ratio of errors compared to the total number of handled requests from queriers.') +
-          g.grpcErrorsPanel('server', 'namespace="$namespace",job=~"$job",grpc_type="unary"')
+          g.grpcErrorsPanel('server', '%(namespaceLabel)s="$namespace",%(selector)s,grpc_type="unary"' % thanos.store)
         )
         .addPanel(
           g.panel('Duration', 'Shows how long has it taken to handle requests from queriers, in quantiles.') +
-          g.grpcLatencyPanel('server', 'namespace="$namespace",job=~"$job",grpc_type="unary"')
+          g.grpcLatencyPanel('server', '%(namespaceLabel)s="$namespace",%(selector)s,grpc_type="unary"' % thanos.store)
         )
       )
       .addRow(
         g.row('gRPC (Stream)')
         .addPanel(
           g.panel('Rate', 'Shows rate of handled Streamed gRPC requests from queriers.') +
-          g.grpcQpsPanel('server', 'namespace="$namespace",job=~"$job",grpc_type="server_stream"')
+          g.grpcQpsPanel('server', '%(namespaceLabel)s="$namespace",%(selector)s,grpc_type="server_stream"' % thanos.store)
         )
         .addPanel(
           g.panel('Errors', 'Shows ratio of errors compared to the total number of handled requests from queriers.') +
-          g.grpcErrorsPanel('server', 'namespace="$namespace",job=~"$job",grpc_type="server_stream"')
+          g.grpcErrorsPanel('server', '%(namespaceLabel)s="$namespace",%(selector)s,grpc_type="server_stream"' % thanos.store)
         )
         .addPanel(
           g.panel('Duration', 'Shows how long has it taken to handle requests from queriers, in quantiles.') +
-          g.grpcLatencyPanel('server', 'namespace="$namespace",job=~"$job",grpc_type="server_stream"')
+          g.grpcLatencyPanel('server', '%(namespaceLabel)s="$namespace",%(selector)s,grpc_type="server_stream"' % thanos.store)
         )
       )
       .addRow(
@@ -46,15 +46,15 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
         .addPanel(
           g.panel('Rate', 'Shows rate of execution for operations against the bucket.') +
           g.queryPanel(
-            'sum(rate(thanos_objstore_bucket_operations_total{namespace="$namespace",job=~"$job"}[$interval])) by (job, operation)',
+            'sum(rate(thanos_objstore_bucket_operations_total{%(namespaceLabel)s="$namespace",%(selector)s}[$interval])) by (job, operation)' % thanos.store,
             '{{job}} {{operation}}'
           ) +
           g.stack
         )
         .addPanel(
-          g.panel('Errors', 'Shows ratio of errors compared to the total number of executed operations against the bucket.') +
+          g.panel('Errors', 'Shows ratio of errors compared to the total number of executed operations against the bucket.' % thanos.store) +
           g.queryPanel(
-            'sum by (job, operation) (rate(thanos_objstore_bucket_operation_failures_total{namespace="$namespace",job=~"$job"}[$interval])) / sum by (job, operation) (rate(thanos_objstore_bucket_operations_total{namespace="$namespace",job=~"$job"}[$interval]))',
+            'sum by (job, operation) (rate(thanos_objstore_bucket_operation_failures_total{%(namespaceLabel)s="$namespace",%(selector)s}[$interval])) / sum by (job, operation) (rate(thanos_objstore_bucket_operations_total{%(namespaceLabel)s="$namespace",%(selector)s}[$interval]))' % thanos.store,
             '{{job}} {{operation}}'
           ) +
           { yaxes: g.yaxes({ format: 'percentunit' }) } +
@@ -62,7 +62,7 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
         )
         .addPanel(
           g.panel('Duration', 'Shows how long has it taken to execute operations against the bucket, in quantiles.') +
-          $.latencyByOperationPanel('thanos_objstore_bucket_operation_duration_seconds', 'namespace="$namespace",job=~"$job"')
+          $.latencyByOperationPanel('thanos_objstore_bucket_operation_duration_seconds', '%(namespaceLabel)s="$namespace",%(selector)s' % thanos.store)
         )
       )
       .addRow(
@@ -70,7 +70,7 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
         .addPanel(
           g.panel('Block Load Rate', 'Shows rate of block loads from the bucket.') +
           g.queryPanel(
-            'sum(rate(thanos_bucket_store_block_loads_total{namespace="$namespace",job=~"$job"}[$interval]))',
+            'sum(rate(thanos_bucket_store_block_loads_total{%(namespaceLabel)s="$namespace",%(selector)s}[$interval]))' % thanos.store,
             'block loads'
           ) +
           g.stack
@@ -78,14 +78,14 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
         .addPanel(
           g.panel('Block Load Errors', 'Shows ratio of errors compared to the total number of block loads from the bucket.') +
           g.qpsErrTotalPanel(
-            'thanos_bucket_store_block_load_failures_total{namespace="$namespace",job=~"$job"}',
-            'thanos_bucket_store_block_loads_total{namespace="$namespace",job=~"$job"}',
+            'thanos_bucket_store_block_load_failures_total{%(namespaceLabel)s="$namespace",%(selector)s}' % thanos.store,
+            'thanos_bucket_store_block_loads_total{%(namespaceLabel)s="$namespace",%(selector)s}' % thanos.store,
           )
         )
         .addPanel(
           g.panel('Block Drop Rate', 'Shows rate of block drops.') +
           g.queryPanel(
-            'sum(rate(thanos_bucket_store_block_drops_total{namespace="$namespace",job=~"$job"}[$interval])) by (job, operation)',
+            'sum(rate(thanos_bucket_store_block_drops_total{%(namespaceLabel)s="$namespace",%(selector)s}[$interval])) by (job, operation)' % thanos.store,
             'block drops {{job}}'
           ) +
           g.stack
@@ -93,8 +93,8 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
         .addPanel(
           g.panel('Block Drop Errors', 'Shows ratio of errors compared to the total number of block drops.') +
           g.qpsErrTotalPanel(
-            'thanos_bucket_store_block_drop_failures_total{namespace="$namespace",job=~"$job"}',
-            'thanos_bucket_store_block_drops_total{namespace="$namespace",job=~"$job"}',
+            'thanos_bucket_store_block_drop_failures_total{%(namespaceLabel)s="$namespace",%(selector)s}' % thanos.store,
+            'thanos_bucket_store_block_drops_total{%(namespaceLabel)s="$namespace",%(selector)s}' % thanos.store,
           )
         )
       )
@@ -103,7 +103,7 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
         .addPanel(
           g.panel('Requests', 'Show rate of cache requests.') +
           g.queryPanel(
-            'sum(rate(thanos_store_index_cache_requests_total{namespace="$namespace",job=~"$job"}[$interval])) by (job, item_type)',
+            'sum(rate(thanos_store_index_cache_requests_total{%(namespaceLabel)s="$namespace",%(selector)s}[$interval])) by (job, item_type)' % thanos.store,
             '{{job}} {{item_type}}',
           ) +
           g.stack
@@ -111,7 +111,7 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
         .addPanel(
           g.panel('Hits', 'Shows ratio of errors compared to the total number of cache hits.') +
           g.queryPanel(
-            'sum(rate(thanos_store_index_cache_hits_total{namespace="$namespace",job=~"$job"}[$interval])) by (job, item_type)',
+            'sum(rate(thanos_store_index_cache_hits_total{%(namespaceLabel)s="$namespace",%(selector)s}[$interval])) by (job, item_type)' % thanos.store,
             '{{job}} {{item_type}}',
           ) +
           g.stack
@@ -119,7 +119,7 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
         .addPanel(
           g.panel('Added', 'Show rate of added items to cache.') +
           g.queryPanel(
-            'sum(rate(thanos_store_index_cache_items_added_total{namespace="$namespace",job=~"$job"}[$interval])) by (job, item_type)',
+            'sum(rate(thanos_store_index_cache_items_added_total{%(namespaceLabel)s="$namespace",%(selector)s}[$interval])) by (job, item_type)' % thanos.store,
             '{{job}} {{item_type}}',
           ) +
           g.stack
@@ -127,7 +127,7 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
         .addPanel(
           g.panel('Evicted', 'Show rate of evicted items from cache.') +
           g.queryPanel(
-            'sum(rate(thanos_store_index_cache_items_evicted_total{namespace="$namespace",job=~"$job"}[$interval])) by (job, item_type)',
+            'sum(rate(thanos_store_index_cache_items_evicted_total{%(namespaceLabel)s="$namespace",%(selector)s}[$interval])) by (job, item_type)' % thanos.store,
             '{{job}} {{item_type}}',
           ) +
           g.stack
@@ -139,9 +139,9 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
           g.panel('Chunk Size', 'Shows size of chunks that have sent to the bucket.') +
           g.queryPanel(
             [
-              'histogram_quantile(0.99, sum(rate(thanos_bucket_store_sent_chunk_size_bytes_bucket{namespace="$namespace",job=~"$job"}[$interval])) by (job, le))',
-              'sum(rate(thanos_bucket_store_sent_chunk_size_bytes_sum{namespace="$namespace",job=~"$job"}[$interval])) by (job) / sum(rate(thanos_bucket_store_sent_chunk_size_bytes_count{namespace="$namespace",job=~"$job"}[$interval])) by (job)',
-              'histogram_quantile(0.99, sum(rate(thanos_bucket_store_sent_chunk_size_bytes_bucket{namespace="$namespace",job=~"$job"}[$interval])) by (job, le))',
+              'histogram_quantile(0.99, sum(rate(thanos_bucket_store_sent_chunk_size_bytes_bucket{%(namespaceLabel)s="$namespace",%(selector)s}[$interval])) by (job, le))' % thanos.store,
+              'sum(rate(thanos_bucket_store_sent_chunk_size_bytes_sum{%(namespaceLabel)s="$namespace",%(selector)s}[$interval])) by (job) / sum(rate(thanos_bucket_store_sent_chunk_size_bytes_count{%(namespaceLabel)s="$namespace",%(selector)s}[$interval])) by (job)' % thanos.store,
+              'histogram_quantile(0.99, sum(rate(thanos_bucket_store_sent_chunk_size_bytes_bucket{%(namespaceLabel)s="$namespace",%(selector)s}[$interval])) by (job, le))' % thanos.store,
             ],
             [
               'P99',
@@ -158,9 +158,9 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
           g.panel('Block queried') +
           g.queryPanel(
             [
-              'thanos_bucket_store_series_blocks_queried{namespace="$namespace",job=~"$job",quantile="0.99"}',
-              'sum(rate(thanos_bucket_store_series_blocks_queried_sum{namespace="$namespace",job=~"$job"}[$interval])) by (job) / sum(rate(thanos_bucket_store_series_blocks_queried_count{namespace="$namespace",job=~"$job"}[$interval])) by (job)',
-              'thanos_bucket_store_series_blocks_queried{namespace="$namespace",job=~"$job",quantile="0.50"}',
+              'thanos_bucket_store_series_blocks_queried{%(namespaceLabel)s="$namespace",%(selector)s,quantile="0.99"}' % thanos.store,
+              'sum(rate(thanos_bucket_store_series_blocks_queried_sum{%(namespaceLabel)s="$namespace",%(selector)s}[$interval])) by (job) / sum(rate(thanos_bucket_store_series_blocks_queried_count{%(namespaceLabel)s="$namespace",%(selector)s}[$interval])) by (job)' % thanos.store,
+              'thanos_bucket_store_series_blocks_queried{%(namespaceLabel)s="$namespace",%(selector)s,quantile="0.50"}' % thanos.store,
             ], [
               'P99',
               'mean {{job}}',
@@ -172,9 +172,9 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
           g.panel('Data Fetched', 'Show the size of data fetched') +
           g.queryPanel(
             [
-              'thanos_bucket_store_series_data_fetched{namespace="$namespace",job=~"$job",quantile="0.99"}',
-              'sum(rate(thanos_bucket_store_series_data_fetched_sum{namespace="$namespace",job=~"$job"}[$interval])) by (job) / sum(rate(thanos_bucket_store_series_data_fetched_count{namespace="$namespace",job=~"$job"}[$interval])) by (job)',
-              'thanos_bucket_store_series_data_fetched{namespace="$namespace",job=~"$job",quantile="0.50"}',
+              'thanos_bucket_store_series_data_fetched{%(namespaceLabel)s="$namespace",%(selector)s,quantile="0.99"}' % thanos.store,
+              'sum(rate(thanos_bucket_store_series_data_fetched_sum{%(namespaceLabel)s="$namespace",%(selector)s}[$interval])) by (job) / sum(rate(thanos_bucket_store_series_data_fetched_count{%(namespaceLabel)s="$namespace",%(selector)s}[$interval])) by (job)' % thanos.store,
+              'thanos_bucket_store_series_data_fetched{%(namespaceLabel)s="$namespace",%(selector)s,quantile="0.50"}' % thanos.store,
             ], [
               'P99',
               'mean {{job}}',
@@ -187,9 +187,9 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
           g.panel('Result series') +
           g.queryPanel(
             [
-              'thanos_bucket_store_series_result_series{namespace="$namespace",job=~"$job",quantile="0.99"}',
-              'sum(rate(thanos_bucket_store_series_result_series_sum{namespace="$namespace",job=~"$job"}[$interval])) by (job) / sum(rate(thanos_bucket_store_series_result_series_count{namespace="$namespace",job=~"$job"}[$interval])) by (job)',
-              'thanos_bucket_store_series_result_series{namespace="$namespace",job=~"$job",quantile="0.50"}',
+              'thanos_bucket_store_series_result_series{%(namespaceLabel)s="$namespace",%(selector)s,quantile="0.99"}' % thanos.store,
+              'sum(rate(thanos_bucket_store_series_result_series_sum{%(namespaceLabel)s="$namespace",%(selector)s}[$interval])) by (job) / sum(rate(thanos_bucket_store_series_result_series_count{%(namespaceLabel)s="$namespace",%(selector)s}[$interval])) by (job)' % thanos.store,
+              'thanos_bucket_store_series_result_series{%(namespaceLabel)s="$namespace",%(selector)s,quantile="0.50"}' % thanos.store,
             ], [
               'P99',
               'mean {{job}}',
@@ -202,41 +202,41 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
         g.row('Series Operation Durations')
         .addPanel(
           g.panel('Get All', 'Shows how long has it taken to get all series.') +
-          g.latencyPanel('thanos_bucket_store_series_get_all_duration_seconds', 'namespace="$namespace",job=~"$job"')
+          g.latencyPanel('thanos_bucket_store_series_get_all_duration_seconds', '%(namespaceLabel)s="$namespace",%(selector)s' % thanos.store)
         )
         .addPanel(
           g.panel('Merge', 'Shows how long has it taken to merge series.') +
-          g.latencyPanel('thanos_bucket_store_series_merge_duration_seconds', 'namespace="$namespace",job=~"$job"')
+          g.latencyPanel('thanos_bucket_store_series_merge_duration_seconds', '%(namespaceLabel)s="$namespace",%(selector)s' % thanos.store)
         )
         .addPanel(
           g.panel('Gate', 'Shows how long has it taken for a series to wait at the gate.') +
-          g.latencyPanel('thanos_bucket_store_series_gate_duration_seconds', 'namespace="$namespace",job=~"$job"')
+          g.latencyPanel('thanos_bucket_store_series_gate_duration_seconds', '%(namespaceLabel)s="$namespace",%(selector)s' % thanos.store)
         )
       )
       .addRow(
         g.resourceUtilizationRow()
       ) +
       g.template('namespace', thanos.dashboard.namespaceMetric) +
-      g.template('job', 'up', 'namespace="$namespace",%(selector)s' % thanos.store, true, '%(jobPrefix)s.*' % thanos.store) +
-      g.template('pod', 'kube_pod_info', 'namespace="$namespace",created_by_name=~"%(jobPrefix)s.*"' % thanos.store, true, '.*'),
+      g.template('job', 'up', '%(namespaceLabel)s="$namespace",%(selector)s' % thanos.store, true, '%(jobPrefix)s.*' % thanos.store) +
+      g.template('pod', 'kube_pod_info', '%(namespaceLabel)s="$namespace",created_by_name=~"%(jobPrefix)s.*"' % thanos.store, true, '.*'),
 
     __overviewRows__+:: [
       g.row('Store')
       .addPanel(
         g.panel('gPRC (Unary) Rate', 'Shows rate of handled Unary gRPC requests from queriers.') +
-        g.grpcQpsPanel('server', 'namespace="$namespace",%(selector)s,grpc_type="unary"' % thanos.store) +
+        g.grpcQpsPanel('server', '%(namespaceLabel)s="$namespace",%(selector)s,grpc_type="unary"' % thanos.store) +
         g.addDashboardLink(thanos.store.title)
       )
       .addPanel(
         g.panel('gPRC (Unary) Errors', 'Shows ratio of errors compared to the total number of handled requests from queriers.') +
-        g.grpcErrorsPanel('server', 'namespace="$namespace",%(selector)s,grpc_type="unary"' % thanos.store) +
+        g.grpcErrorsPanel('server', '%(namespaceLabel)s="$namespace",%(selector)s,grpc_type="unary"' % thanos.store) +
         g.addDashboardLink(thanos.store.title)
       )
       .addPanel(
         g.sloLatency(
           'gRPC Latency 99th Percentile',
           'Shows how long has it taken to handle requests from queriers.',
-          'grpc_server_handling_seconds_bucket{grpc_type="unary",namespace="$namespace",%(selector)s}' % thanos.store,
+          'grpc_server_handling_seconds_bucket{grpc_type="unary",%(namespaceLabel)s="$namespace",%(selector)s}' % thanos.store,
           0.99,
           0.5,
           1

--- a/mixin/dashboards/store.libsonnet
+++ b/mixin/dashboards/store.libsonnet
@@ -15,30 +15,30 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
         g.row('gRPC (Unary)')
         .addPanel(
           g.panel('Rate', 'Shows rate of handled Unary gRPC requests from queriers.') +
-          g.grpcQpsPanel('server', '%(namespaceLabel)s="$namespace",%(selector)s,grpc_type="unary"' % thanos.store)
+          g.grpcQpsPanel('server', '%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s,grpc_type="unary"' % thanos.store)
         )
         .addPanel(
           g.panel('Errors', 'Shows ratio of errors compared to the total number of handled requests from queriers.') +
-          g.grpcErrorsPanel('server', '%(namespaceLabel)s="$namespace",%(selector)s,grpc_type="unary"' % thanos.store)
+          g.grpcErrorsPanel('server', '%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s,grpc_type="unary"' % thanos.store)
         )
         .addPanel(
           g.panel('Duration', 'Shows how long has it taken to handle requests from queriers, in quantiles.') +
-          g.grpcLatencyPanel('server', '%(namespaceLabel)s="$namespace",%(selector)s,grpc_type="unary"' % thanos.store)
+          g.grpcLatencyPanel('server', '%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s,grpc_type="unary"' % thanos.store)
         )
       )
       .addRow(
         g.row('gRPC (Stream)')
         .addPanel(
           g.panel('Rate', 'Shows rate of handled Streamed gRPC requests from queriers.') +
-          g.grpcQpsPanel('server', '%(namespaceLabel)s="$namespace",%(selector)s,grpc_type="server_stream"' % thanos.store)
+          g.grpcQpsPanel('server', '%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s,grpc_type="server_stream"' % thanos.store)
         )
         .addPanel(
           g.panel('Errors', 'Shows ratio of errors compared to the total number of handled requests from queriers.') +
-          g.grpcErrorsPanel('server', '%(namespaceLabel)s="$namespace",%(selector)s,grpc_type="server_stream"' % thanos.store)
+          g.grpcErrorsPanel('server', '%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s,grpc_type="server_stream"' % thanos.store)
         )
         .addPanel(
           g.panel('Duration', 'Shows how long has it taken to handle requests from queriers, in quantiles.') +
-          g.grpcLatencyPanel('server', '%(namespaceLabel)s="$namespace",%(selector)s,grpc_type="server_stream"' % thanos.store)
+          g.grpcLatencyPanel('server', '%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s,grpc_type="server_stream"' % thanos.store)
         )
       )
       .addRow(
@@ -46,7 +46,7 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
         .addPanel(
           g.panel('Rate', 'Shows rate of execution for operations against the bucket.') +
           g.queryPanel(
-            'sum(rate(thanos_objstore_bucket_operations_total{%(namespaceLabel)s="$namespace",%(selector)s}[$interval])) by (job, operation)' % thanos.store,
+            'sum(rate(thanos_objstore_bucket_operations_total{%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s}[$interval])) by (job, operation)' % thanos.store,
             '{{job}} {{operation}}'
           ) +
           g.stack
@@ -54,7 +54,7 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
         .addPanel(
           g.panel('Errors', 'Shows ratio of errors compared to the total number of executed operations against the bucket.' % thanos.store) +
           g.queryPanel(
-            'sum by (job, operation) (rate(thanos_objstore_bucket_operation_failures_total{%(namespaceLabel)s="$namespace",%(selector)s}[$interval])) / sum by (job, operation) (rate(thanos_objstore_bucket_operations_total{%(namespaceLabel)s="$namespace",%(selector)s}[$interval]))' % thanos.store,
+            'sum by (job, operation) (rate(thanos_objstore_bucket_operation_failures_total{%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s}[$interval])) / sum by (job, operation) (rate(thanos_objstore_bucket_operations_total{%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s}[$interval]))' % thanos.store,
             '{{job}} {{operation}}'
           ) +
           { yaxes: g.yaxes({ format: 'percentunit' }) } +
@@ -62,7 +62,7 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
         )
         .addPanel(
           g.panel('Duration', 'Shows how long has it taken to execute operations against the bucket, in quantiles.') +
-          $.latencyByOperationPanel('thanos_objstore_bucket_operation_duration_seconds', '%(namespaceLabel)s="$namespace",%(selector)s' % thanos.store)
+          $.latencyByOperationPanel('thanos_objstore_bucket_operation_duration_seconds', '%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s' % thanos.store)
         )
       )
       .addRow(
@@ -70,7 +70,7 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
         .addPanel(
           g.panel('Block Load Rate', 'Shows rate of block loads from the bucket.') +
           g.queryPanel(
-            'sum(rate(thanos_bucket_store_block_loads_total{%(namespaceLabel)s="$namespace",%(selector)s}[$interval]))' % thanos.store,
+            'sum(rate(thanos_bucket_store_block_loads_total{%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s}[$interval]))' % thanos.store,
             'block loads'
           ) +
           g.stack
@@ -78,14 +78,14 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
         .addPanel(
           g.panel('Block Load Errors', 'Shows ratio of errors compared to the total number of block loads from the bucket.') +
           g.qpsErrTotalPanel(
-            'thanos_bucket_store_block_load_failures_total{%(namespaceLabel)s="$namespace",%(selector)s}' % thanos.store,
-            'thanos_bucket_store_block_loads_total{%(namespaceLabel)s="$namespace",%(selector)s}' % thanos.store,
+            'thanos_bucket_store_block_load_failures_total{%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s}' % thanos.store,
+            'thanos_bucket_store_block_loads_total{%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s}' % thanos.store,
           )
         )
         .addPanel(
           g.panel('Block Drop Rate', 'Shows rate of block drops.') +
           g.queryPanel(
-            'sum(rate(thanos_bucket_store_block_drops_total{%(namespaceLabel)s="$namespace",%(selector)s}[$interval])) by (job, operation)' % thanos.store,
+            'sum(rate(thanos_bucket_store_block_drops_total{%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s}[$interval])) by (job, operation)' % thanos.store,
             'block drops {{job}}'
           ) +
           g.stack
@@ -93,8 +93,8 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
         .addPanel(
           g.panel('Block Drop Errors', 'Shows ratio of errors compared to the total number of block drops.') +
           g.qpsErrTotalPanel(
-            'thanos_bucket_store_block_drop_failures_total{%(namespaceLabel)s="$namespace",%(selector)s}' % thanos.store,
-            'thanos_bucket_store_block_drops_total{%(namespaceLabel)s="$namespace",%(selector)s}' % thanos.store,
+            'thanos_bucket_store_block_drop_failures_total{%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s}' % thanos.store,
+            'thanos_bucket_store_block_drops_total{%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s}' % thanos.store,
           )
         )
       )
@@ -103,7 +103,7 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
         .addPanel(
           g.panel('Requests', 'Show rate of cache requests.') +
           g.queryPanel(
-            'sum(rate(thanos_store_index_cache_requests_total{%(namespaceLabel)s="$namespace",%(selector)s}[$interval])) by (job, item_type)' % thanos.store,
+            'sum(rate(thanos_store_index_cache_requests_total{%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s}[$interval])) by (job, item_type)' % thanos.store,
             '{{job}} {{item_type}}',
           ) +
           g.stack
@@ -111,7 +111,7 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
         .addPanel(
           g.panel('Hits', 'Shows ratio of errors compared to the total number of cache hits.') +
           g.queryPanel(
-            'sum(rate(thanos_store_index_cache_hits_total{%(namespaceLabel)s="$namespace",%(selector)s}[$interval])) by (job, item_type)' % thanos.store,
+            'sum(rate(thanos_store_index_cache_hits_total{%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s}[$interval])) by (job, item_type)' % thanos.store,
             '{{job}} {{item_type}}',
           ) +
           g.stack
@@ -119,7 +119,7 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
         .addPanel(
           g.panel('Added', 'Show rate of added items to cache.') +
           g.queryPanel(
-            'sum(rate(thanos_store_index_cache_items_added_total{%(namespaceLabel)s="$namespace",%(selector)s}[$interval])) by (job, item_type)' % thanos.store,
+            'sum(rate(thanos_store_index_cache_items_added_total{%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s}[$interval])) by (job, item_type)' % thanos.store,
             '{{job}} {{item_type}}',
           ) +
           g.stack
@@ -127,7 +127,7 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
         .addPanel(
           g.panel('Evicted', 'Show rate of evicted items from cache.') +
           g.queryPanel(
-            'sum(rate(thanos_store_index_cache_items_evicted_total{%(namespaceLabel)s="$namespace",%(selector)s}[$interval])) by (job, item_type)' % thanos.store,
+            'sum(rate(thanos_store_index_cache_items_evicted_total{%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s}[$interval])) by (job, item_type)' % thanos.store,
             '{{job}} {{item_type}}',
           ) +
           g.stack
@@ -139,9 +139,9 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
           g.panel('Chunk Size', 'Shows size of chunks that have sent to the bucket.') +
           g.queryPanel(
             [
-              'histogram_quantile(0.99, sum(rate(thanos_bucket_store_sent_chunk_size_bytes_bucket{%(namespaceLabel)s="$namespace",%(selector)s}[$interval])) by (job, le))' % thanos.store,
-              'sum(rate(thanos_bucket_store_sent_chunk_size_bytes_sum{%(namespaceLabel)s="$namespace",%(selector)s}[$interval])) by (job) / sum(rate(thanos_bucket_store_sent_chunk_size_bytes_count{%(namespaceLabel)s="$namespace",%(selector)s}[$interval])) by (job)' % thanos.store,
-              'histogram_quantile(0.99, sum(rate(thanos_bucket_store_sent_chunk_size_bytes_bucket{%(namespaceLabel)s="$namespace",%(selector)s}[$interval])) by (job, le))' % thanos.store,
+              'histogram_quantile(0.99, sum(rate(thanos_bucket_store_sent_chunk_size_bytes_bucket{%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s}[$interval])) by (job, le))' % thanos.store,
+              'sum(rate(thanos_bucket_store_sent_chunk_size_bytes_sum{%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s}[$interval])) by (job) / sum(rate(thanos_bucket_store_sent_chunk_size_bytes_count{%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s}[$interval])) by (job)' % thanos.store,
+              'histogram_quantile(0.99, sum(rate(thanos_bucket_store_sent_chunk_size_bytes_bucket{%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s}[$interval])) by (job, le))' % thanos.store,
             ],
             [
               'P99',
@@ -158,9 +158,9 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
           g.panel('Block queried') +
           g.queryPanel(
             [
-              'thanos_bucket_store_series_blocks_queried{%(namespaceLabel)s="$namespace",%(selector)s,quantile="0.99"}' % thanos.store,
-              'sum(rate(thanos_bucket_store_series_blocks_queried_sum{%(namespaceLabel)s="$namespace",%(selector)s}[$interval])) by (job) / sum(rate(thanos_bucket_store_series_blocks_queried_count{%(namespaceLabel)s="$namespace",%(selector)s}[$interval])) by (job)' % thanos.store,
-              'thanos_bucket_store_series_blocks_queried{%(namespaceLabel)s="$namespace",%(selector)s,quantile="0.50"}' % thanos.store,
+              'thanos_bucket_store_series_blocks_queried{%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s,quantile="0.99"}' % thanos.store,
+              'sum(rate(thanos_bucket_store_series_blocks_queried_sum{%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s}[$interval])) by (job) / sum(rate(thanos_bucket_store_series_blocks_queried_count{%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s}[$interval])) by (job)' % thanos.store,
+              'thanos_bucket_store_series_blocks_queried{%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s,quantile="0.50"}' % thanos.store,
             ], [
               'P99',
               'mean {{job}}',
@@ -172,9 +172,9 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
           g.panel('Data Fetched', 'Show the size of data fetched') +
           g.queryPanel(
             [
-              'thanos_bucket_store_series_data_fetched{%(namespaceLabel)s="$namespace",%(selector)s,quantile="0.99"}' % thanos.store,
-              'sum(rate(thanos_bucket_store_series_data_fetched_sum{%(namespaceLabel)s="$namespace",%(selector)s}[$interval])) by (job) / sum(rate(thanos_bucket_store_series_data_fetched_count{%(namespaceLabel)s="$namespace",%(selector)s}[$interval])) by (job)' % thanos.store,
-              'thanos_bucket_store_series_data_fetched{%(namespaceLabel)s="$namespace",%(selector)s,quantile="0.50"}' % thanos.store,
+              'thanos_bucket_store_series_data_fetched{%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s,quantile="0.99"}' % thanos.store,
+              'sum(rate(thanos_bucket_store_series_data_fetched_sum{%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s}[$interval])) by (job) / sum(rate(thanos_bucket_store_series_data_fetched_count{%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s}[$interval])) by (job)' % thanos.store,
+              'thanos_bucket_store_series_data_fetched{%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s,quantile="0.50"}' % thanos.store,
             ], [
               'P99',
               'mean {{job}}',
@@ -187,9 +187,9 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
           g.panel('Result series') +
           g.queryPanel(
             [
-              'thanos_bucket_store_series_result_series{%(namespaceLabel)s="$namespace",%(selector)s,quantile="0.99"}' % thanos.store,
-              'sum(rate(thanos_bucket_store_series_result_series_sum{%(namespaceLabel)s="$namespace",%(selector)s}[$interval])) by (job) / sum(rate(thanos_bucket_store_series_result_series_count{%(namespaceLabel)s="$namespace",%(selector)s}[$interval])) by (job)' % thanos.store,
-              'thanos_bucket_store_series_result_series{%(namespaceLabel)s="$namespace",%(selector)s,quantile="0.50"}' % thanos.store,
+              'thanos_bucket_store_series_result_series{%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s,quantile="0.99"}' % thanos.store,
+              'sum(rate(thanos_bucket_store_series_result_series_sum{%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s}[$interval])) by (job) / sum(rate(thanos_bucket_store_series_result_series_count{%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s}[$interval])) by (job)' % thanos.store,
+              'thanos_bucket_store_series_result_series{%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s,quantile="0.50"}' % thanos.store,
             ], [
               'P99',
               'mean {{job}}',
@@ -202,41 +202,41 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
         g.row('Series Operation Durations')
         .addPanel(
           g.panel('Get All', 'Shows how long has it taken to get all series.') +
-          g.latencyPanel('thanos_bucket_store_series_get_all_duration_seconds', '%(namespaceLabel)s="$namespace",%(selector)s' % thanos.store)
+          g.latencyPanel('thanos_bucket_store_series_get_all_duration_seconds', '%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s' % thanos.store)
         )
         .addPanel(
           g.panel('Merge', 'Shows how long has it taken to merge series.') +
-          g.latencyPanel('thanos_bucket_store_series_merge_duration_seconds', '%(namespaceLabel)s="$namespace",%(selector)s' % thanos.store)
+          g.latencyPanel('thanos_bucket_store_series_merge_duration_seconds', '%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s' % thanos.store)
         )
         .addPanel(
           g.panel('Gate', 'Shows how long has it taken for a series to wait at the gate.') +
-          g.latencyPanel('thanos_bucket_store_series_gate_duration_seconds', '%(namespaceLabel)s="$namespace",%(selector)s' % thanos.store)
+          g.latencyPanel('thanos_bucket_store_series_gate_duration_seconds', '%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s' % thanos.store)
         )
       )
       .addRow(
         g.resourceUtilizationRow(thanos.store.namespaceLabel, thanos.store.selector)
       ) +
       g.template('namespace', thanos.dashboard.namespaceMetric) +
-      g.template('job', 'up', '%(namespaceLabel)s="$namespace",%(selector)s' % thanos.store, true, '%(jobPrefix)s.*' % thanos.store) +
+      g.template('job', 'up', '%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s' % thanos.store, true, '%(jobPrefix)s.*' % thanos.store) +
       g.template('pod', 'kube_pod_info', '%(namespaceLabel)s="$namespace",created_by_name=~"%(jobPrefix)s.*"' % thanos.store, true, '.*'),
 
     __overviewRows__+:: [
       g.row('Store')
       .addPanel(
         g.panel('gPRC (Unary) Rate', 'Shows rate of handled Unary gRPC requests from queriers.') +
-        g.grpcQpsPanel('server', '%(namespaceLabel)s="$namespace",%(selector)s,grpc_type="unary"' % thanos.store) +
+        g.grpcQpsPanel('server', '%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s,grpc_type="unary"' % thanos.store) +
         g.addDashboardLink(thanos.store.title)
       )
       .addPanel(
         g.panel('gPRC (Unary) Errors', 'Shows ratio of errors compared to the total number of handled requests from queriers.') +
-        g.grpcErrorsPanel('server', '%(namespaceLabel)s="$namespace",%(selector)s,grpc_type="unary"' % thanos.store) +
+        g.grpcErrorsPanel('server', '%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s,grpc_type="unary"' % thanos.store) +
         g.addDashboardLink(thanos.store.title)
       )
       .addPanel(
         g.sloLatency(
           'gRPC Latency 99th Percentile',
           'Shows how long has it taken to handle requests from queriers.',
-          'grpc_server_handling_seconds_bucket{grpc_type="unary",%(namespaceLabel)s="$namespace",%(selector)s}' % thanos.store,
+          'grpc_server_handling_seconds_bucket{grpc_type="unary",%(namespaceLabel)s="$namespace",job=~"$job",%(selector)s}' % thanos.store,
           0.99,
           0.5,
           1

--- a/mixin/dashboards/store.libsonnet
+++ b/mixin/dashboards/store.libsonnet
@@ -214,7 +214,7 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
         )
       )
       .addRow(
-        g.resourceUtilizationRow()
+        g.resourceUtilizationRow(thanos.store.namespaceLabel, thanos.store.selector)
       ) +
       g.template('namespace', thanos.dashboard.namespaceMetric) +
       g.template('job', 'up', '%(namespaceLabel)s="$namespace",%(selector)s' % thanos.store, true, '%(jobPrefix)s.*' % thanos.store) +

--- a/mixin/dashboards/store.libsonnet
+++ b/mixin/dashboards/store.libsonnet
@@ -6,9 +6,10 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
     jobPrefix: error 'must provide job prefix for Thanos Store dashboard',
     selector: error 'must provide selector for Thanos Store dashboard',
     title: error 'must provide title for Thanos Store dashboard',
+    namespaceLabel: error 'must provide namespace label', 
   },
   grafanaDashboards+:: {
-    'store.json':
+    'thanos-store.json':
       g.dashboard(thanos.store.title)
       .addRow(
         g.row('gRPC (Unary)')

--- a/mixin/lib/thanos-grafana-builder/builder.libsonnet
+++ b/mixin/lib/thanos-grafana-builder/builder.libsonnet
@@ -147,18 +147,18 @@ local template = grafana.template;
     yaxes: $.yaxes({ format: 'percentunit', max: 1 }),
   } + $.stack,
 
-  resourceUtilizationRow()::
+  resourceUtilizationRow(namespace, selector)::
     $.row('Resources')
     .addPanel(
       $.panel('Memory Used') +
       $.queryPanel(
         [
-          'go_memstats_alloc_bytes{namespace="$namespace",job=~"$job",kubernetes_pod_name=~"$pod"}',
-          'go_memstats_heap_alloc_bytes{namespace="$namespace",job=~"$job",kubernetes_pod_name=~"$pod"}',
-          'rate(go_memstats_alloc_bytes_total{namespace="$namespace",job=~"$job",kubernetes_pod_name=~"$pod"}[30s])',
-          'rate(go_memstats_heap_alloc_bytes{namespace="$namespace",job=~"$job",kubernetes_pod_name=~"$pod"}[30s])',
-          'go_memstats_stack_inuse_bytes{namespace="$namespace",job=~"$job",kubernetes_pod_name=~"$pod"}',
-          'go_memstats_heap_inuse_bytes{namespace="$namespace",job=~"$job",kubernetes_pod_name=~"$pod"}',
+          'go_memstats_alloc_bytes{%s="$namespace",%s,kubernetes_pod_name=~"$pod"}' % [namespace, selector],
+          'go_memstats_heap_alloc_bytes{%s="$namespace",%s,kubernetes_pod_name=~"$pod"}' % [namespace, selector],
+          'rate(go_memstats_alloc_bytes_total{%s="$namespace",%s,kubernetes_pod_name=~"$pod"}[30s])' % [namespace, selector],
+          'rate(go_memstats_heap_alloc_bytes{%s="$namespace",%s,kubernetes_pod_name=~"$pod"}[30s])' % [namespace, selector],
+          'go_memstats_stack_inuse_bytes{%s="$namespace",%s,kubernetes_pod_name=~"$pod"}' % [namespace, selector],
+          'go_memstats_heap_inuse_bytes{%s="$namespace",%s,kubernetes_pod_name=~"$pod"}' % [namespace, selector],
         ],
         [
           'alloc all {{pod}}',
@@ -174,14 +174,14 @@ local template = grafana.template;
     .addPanel(
       $.panel('Goroutines') +
       $.queryPanel(
-        'go_goroutines{namespace="$namespace",job=~"$job"}',
+        'go_goroutines{%s="$namespace",%s}' % [namespace, selector],
         '{{pod}}'
       )
     )
     .addPanel(
       $.panel('GC Time Quantiles') +
       $.queryPanel(
-        'go_gc_duration_seconds{namespace="$namespace",job=~"$job",kubernetes_pod_name=~"$pod"}',
+        'go_gc_duration_seconds{%s="$namespace",%s,kubernetes_pod_name=~"$pod"}' % [namespace, selector],
         '{{quantile}} {{pod}}'
       )
     ) +


### PR DESCRIPTION
Currently the thanos mixins are built with specific namespace and selector and have somewhat inconsistency in the selectors between alerts and dashboards.

In dashboards the queries are mostly based on `namespace` and `job` labels however in alerts its mostly using the `selector` property.

## Changes
To make the dashboards consistent, the following changes are done

- using `selector` variable instead of `job=~{jobPrefix}`
- adding ability to use `namespace` label for cases where the label name for `namespace` is different for example the prometheus stable chart, it relabels `namespace` -> `kubernetes_namespace`.

Looking forward for the feedback, if the changes makes sense and any improvement required.

Thank you

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

Will update these once the changes are acceptable to reviewers

## Verification

Installed on test system and works perfectly fine.
