### PR TITLE
website/layouts: fix links to contributing docs

### DIFF
--- a/website/layouts/_default/baseof.html
+++ b/website/layouts/_default/baseof.html
@@ -77,7 +77,7 @@
                         <li><a class="text-reset" href="{{ "/tip/thanos/storage.md" | relURL }}">Storage</a></li>
                         <li><a class="text-reset" href="{{ "/tip/thanos/service-discovery.md" | relURL }}">Service Discovery</a></li>
                         <li><a class="text-reset" href="{{ "/tip/thanos/maintainers" | relURL }}">Maintainers</a></li>
-                        <li><a class="text-reset" href="{{ "/tip/contributing/contributing" | relURL }}">Contributing</a></li>
+                        <li><a class="text-reset" href="{{ "/tip/contributing.md" | relURL }}">Contributing</a></li>
                     </ul>
                 </div>
                 <div class="col-12 col-md-6 col-lg">

--- a/website/layouts/index.html
+++ b/website/layouts/index.html
@@ -15,7 +15,7 @@
                     </a>
                 </li>
                 <li class="list-inline-item my-3">
-                    <a href="{{ "/tip/contributing/community.md" | relURL }}" class="btn btn-outline-secondary">
+                    <a href="{{ "/tip/community.md" | relURL }}" class="btn btn-outline-secondary">
                         <i class="fas fa-fw fa-comments"></i> Community
                     </a>
                 </li>
@@ -107,11 +107,11 @@
 <div class="container-fluid bg-light">
     <div class="row py-5">
         <div class="col text-center">
-            <h3 class="color-purple"><a href="{{ "/tip/contributing/community.md" | relURL }}">Join the community !</a></h3>
+            <h3 class="color-purple"><a href="{{ "/tip/community.md" | relURL }}">Join the community!</a></h3>
             <p>Join users and companies that are using Thanos in production.</p>
             <ul class="list-inline">
                 <li class="list-inline-item">
-                    <a href="{{ "/tip/contributing/community.md" | relURL }}" class="btn btn-outline-secondary">
+                    <a href="{{ "/tip/community.md" | relURL }}" class="btn btn-outline-secondary">
                         <i class="fas fa-fw fa-comments"></i> Community Meetings
                     </a>
                 </li>


### PR DESCRIPTION
We have some 404s in the links to the contributing docs, e.g.
contributing.md and community.md. This commit fixes those links.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>

* [x] Change is not relevant to the end user.