### PR TITLE
pkg/gate: Prefix gate metrics for selects

### DIFF
--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -307,7 +307,7 @@ func runQuery(
 		rulesProxy       = rules.NewProxy(logger, stores.GetRulesClients)
 		queryableCreator = query.NewQueryableCreator(
 			logger,
-			extprom.WrapRegistererWithPrefix("thanos_query_concurrent_selects_", reg),
+			extprom.WrapRegistererWithPrefix("thanos_query_", reg),
 			proxy,
 			maxConcurrentSelects,
 			queryTimeout,

--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -304,8 +304,14 @@ func runQuery(
 		)
 		proxy            = store.NewProxyStore(logger, reg, stores.Get, component.Query, selectorLset, storeResponseTimeout)
 		rulesProxy       = rules.NewProxy(logger, stores.GetRulesClients)
-		queryableCreator = query.NewQueryableCreator(logger, reg, proxy, maxConcurrentSelects, queryTimeout)
-		engine           = promql.NewEngine(
+		queryableCreator = query.NewQueryableCreator(
+			logger,
+			extprom.WrapRegistererWithPrefix("thanos_query_concurrent_selects_", reg),
+			proxy,
+			maxConcurrentSelects,
+			queryTimeout,
+		)
+		engine = promql.NewEngine(
 			promql.EngineOpts{
 				Logger: logger,
 				Reg:    reg,

--- a/cmd/thanos/store.go
+++ b/cmd/thanos/store.go
@@ -14,7 +14,6 @@ import (
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/common/route"
 
 	blocksAPI "github.com/thanos-io/thanos/pkg/api/blocks"
@@ -286,11 +285,7 @@ func runStore(
 		return errors.Errorf("max concurrency value cannot be lower than 0 (got %v)", maxConcurrency)
 	}
 
-	queriesGate := gate.NewKeeper(extprom.WrapRegistererWithPrefix("thanos_bucket_store_series_", reg)).NewGate(maxConcurrency)
-	promauto.With(reg).NewGauge(prometheus.GaugeOpts{
-		Name: "thanos_bucket_store_queries_concurrent_max",
-		Help: "Number of maximum concurrent queries.",
-	}).Set(float64(maxConcurrency))
+	queriesGate := gate.New(extprom.WrapRegistererWithPrefix("thanos_bucket_store_series_", reg), maxConcurrency)
 
 	bs, err := store.NewBucketStore(
 		logger,

--- a/pkg/api/query/v1_test.go
+++ b/pkg/api/query/v1_test.go
@@ -30,6 +30,7 @@ import (
 	"time"
 
 	"github.com/prometheus/common/route"
+	promgate "github.com/prometheus/prometheus/pkg/gate"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/pkg/timestamp"
 	"github.com/prometheus/prometheus/promql"
@@ -116,7 +117,7 @@ func TestEndpoints(t *testing.T) {
 			MaxSamples: 10000,
 			Timeout:    timeout,
 		}),
-		gate: gate.NewKeeper(nil).NewGate(4),
+		gate: gate.New(nil, 4),
 	}
 
 	start := time.Unix(0, 0)
@@ -1053,7 +1054,7 @@ func TestParseDownsamplingParamMillis(t *testing.T) {
 	for i, test := range tests {
 		api := QueryAPI{
 			enableAutodownsampling: test.enableAutodownsampling,
-			gate:                   gate.NewKeeper(nil).NewGate(4),
+			gate:                   gate.New(nil, 4),
 		}
 		v := url.Values{}
 		v.Set(MaxSourceResolutionParam, test.maxSourceResolutionParam)
@@ -1101,7 +1102,7 @@ func TestParseStoreMatchersParam(t *testing.T) {
 	} {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
 			api := QueryAPI{
-				gate: gate.NewKeeper(nil).NewGate(4),
+				gate: promgate.New(4),
 			}
 			v := url.Values{}
 			v.Set(StoreMatcherParam, tc.storeMatchers)

--- a/pkg/cacheutil/memcached_client.go
+++ b/pkg/cacheutil/memcached_client.go
@@ -231,8 +231,10 @@ func newMemcachedClient(
 		dnsProvider: dnsProvider,
 		asyncQueue:  make(chan func(), config.MaxAsyncBufferSize),
 		stop:        make(chan struct{}, 1),
-		getMultiGate: gate.NewKeeper(extprom.WrapRegistererWithPrefix("thanos_memcached_getmulti_", reg)).
-			NewGate(config.MaxGetMultiConcurrency),
+		getMultiGate: gate.New(
+			extprom.WrapRegistererWithPrefix("thanos_memcached_getmulti_", reg),
+			config.MaxGetMultiConcurrency,
+		),
 	}
 
 	c.clientInfo = promauto.With(reg).NewGaugeFunc(prometheus.GaugeOpts{

--- a/pkg/gate/gate.go
+++ b/pkg/gate/gate.go
@@ -12,67 +12,144 @@ import (
 	promgate "github.com/prometheus/prometheus/pkg/gate"
 )
 
-// Gate is an interface that mimics prometheus/pkg/gate behavior.
+var (
+	MaxGaugeOpts = prometheus.GaugeOpts{
+		Name: "gate_queries_max",
+		Help: "Maximum number of concurrent queries.",
+	}
+	InFlightGaugeOpts = prometheus.GaugeOpts{
+		Name: "gate_queries_in_flight",
+		Help: "Number of queries that are currently in flight.",
+	}
+	DurationHistogramOpts = prometheus.HistogramOpts{
+		Name:    "gate_duration_seconds",
+		Help:    "How many seconds it took for queries to wait at the gate.",
+		Buckets: []float64{0.01, 0.1, 0.3, 0.6, 1, 3, 6, 9, 20, 30, 60, 90, 120, 240, 360, 720},
+	}
+)
+
+// Gate controls the maximum number of concurrently running and waiting queries.
+//
+// Example of use:
+//
+//   g := gate.New(r, 5)
+//
+//   if err := g.Start(ctx); err != nil {
+//      return
+//   }
+//   defer g.Done()
+//
 type Gate interface {
+	// Start initiates a new request and waits until it's our turn to fulfill a request.
 	Start(ctx context.Context) error
+	// Done finishes a query.
 	Done()
 }
 
-// Gate wraps the Prometheus gate with extra metrics.
-type gate struct {
-	g *promgate.Gate
-	m *metrics
-}
-
-type metrics struct {
-	inflightQueries prometheus.Gauge
-	gateTiming      prometheus.Histogram
-}
-
 // Keeper is used to create multiple gates sharing the same metrics.
+//
+// Deprecated: when Keeper is used to create several gates, the metric tracking
+// the number of in-flight metric isn't meaningful because it is hard to say
+// whether requests are being blocked or not. For clients that call
+// gate.(*Keeper).NewGate only once, it is recommended to use gate.New()
+// instead. Otherwise it is recommended to use the
+// github.com/prometheus/prometheus/pkg/gate package directly and wrap the
+// returned gate with gate.InstrumentGateDuration().
 type Keeper struct {
-	m *metrics
+	reg prometheus.Registerer
 }
 
 // NewKeeper creates a new Keeper.
+//
+// Deprecated: see Keeper.
 func NewKeeper(reg prometheus.Registerer) *Keeper {
 	return &Keeper{
-		m: &metrics{
-			inflightQueries: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
-				Name: "gate_queries_in_flight",
-				Help: "Number of queries that are currently in flight.",
-			}),
-			gateTiming: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
-				Name:    "gate_duration_seconds",
-				Help:    "How many seconds it took for queries to wait at the gate.",
-				Buckets: []float64{0.01, 0.1, 0.3, 0.6, 1, 3, 6, 9, 20, 30, 60, 90, 120, 240, 360, 720},
-			}),
-		},
+		reg: reg,
 	}
 }
 
-// NewGate returns a new Gate that collects metrics.
+// NewGate returns a new Gate ready for use.
+//
+// Deprecated: see Keeper.
 func (k *Keeper) NewGate(maxConcurrent int) Gate {
-	return &gate{g: promgate.New(maxConcurrent), m: k.m}
+	return New(k.reg, maxConcurrent)
 }
 
-// Start initiates a new request and waits until it's our turn to fulfill a request.
-func (g *gate) Start(ctx context.Context) error {
+// New returns an instrumented gate limiting the number of requests being
+// executed concurrently.
+//
+// The gate implementation is based on the
+// github.com/prometheus/prometheus/pkg/gate package.
+//
+// It can be called several times but not with the same registerer otherwise it
+// will panic when trying to register the same metric multiple times.
+func New(reg prometheus.Registerer, maxConcurrent int) Gate {
+	promauto.With(reg).NewGauge(MaxGaugeOpts).Set(float64(maxConcurrent))
+
+	return InstrumentGateDuration(
+		promauto.With(reg).NewHistogram(DurationHistogramOpts),
+		InstrumentGateInFlight(
+			promauto.With(reg).NewGauge(InFlightGaugeOpts),
+			promgate.New(maxConcurrent),
+		),
+	)
+}
+
+type instrumentedDurationGate struct {
+	g        Gate
+	duration prometheus.Observer
+}
+
+// InstrumentGateDuration instruments the provided Gate to track how much time
+// the request has been waiting in the gate.
+func InstrumentGateDuration(duration prometheus.Observer, g Gate) Gate {
+	return &instrumentedDurationGate{
+		g:        g,
+		duration: duration,
+	}
+}
+
+// Start implements the Gate interface.
+func (g *instrumentedDurationGate) Start(ctx context.Context) error {
 	start := time.Now()
 	defer func() {
-		g.m.gateTiming.Observe(time.Since(start).Seconds())
+		g.duration.Observe(time.Since(start).Seconds())
 	}()
 
+	return g.g.Start(ctx)
+}
+
+// Done implements the Gate interface.
+func (g *instrumentedDurationGate) Done() {
+	g.g.Done()
+}
+
+type instrumentedInFlightGate struct {
+	g        Gate
+	inflight prometheus.Gauge
+}
+
+// InstrumentGateInFlight instruments the provided Gate to track how many
+// requests are currently in flight.
+func InstrumentGateInFlight(inflight prometheus.Gauge, g Gate) Gate {
+	return &instrumentedInFlightGate{
+		g:        g,
+		inflight: inflight,
+	}
+}
+
+// Start implements the Gate interface.
+func (g *instrumentedInFlightGate) Start(ctx context.Context) error {
 	if err := g.g.Start(ctx); err != nil {
 		return err
 	}
 
-	g.m.inflightQueries.Inc()
+	g.inflight.Inc()
 	return nil
 }
 
-// Done finishes a query.
-func (g *gate) Done() {
-	g.m.inflightQueries.Dec()
+// Done implements the Gate interface.
+func (g *instrumentedInFlightGate) Done() {
+	g.inflight.Dec()
 	g.g.Done()
 }

--- a/pkg/query/querier.go
+++ b/pkg/query/querier.go
@@ -49,7 +49,7 @@ func NewQueryableCreator(logger log.Logger, reg prometheus.Registerer, proxy sto
 			maxResolutionMillis: maxResolutionMillis,
 			partialResponse:     partialResponse,
 			skipChunks:          skipChunks,
-			gateFn: func() gate.Gate {
+			gateProviderFn: func() gate.Gate {
 				return gate.InstrumentGateDuration(duration, promgate.New(maxConcurrentSelects))
 			},
 			maxConcurrentSelects: maxConcurrentSelects,
@@ -67,14 +67,14 @@ type queryable struct {
 	maxResolutionMillis  int64
 	partialResponse      bool
 	skipChunks           bool
-	gateFn               func() gate.Gate
+	gateProviderFn       func() gate.Gate
 	maxConcurrentSelects int
 	selectTimeout        time.Duration
 }
 
 // Querier returns a new storage querier against the underlying proxy store API.
 func (q *queryable) Querier(ctx context.Context, mint, maxt int64) (storage.Querier, error) {
-	return newQuerier(ctx, q.logger, mint, maxt, q.replicaLabels, q.storeMatchers, q.proxy, q.deduplicate, q.maxResolutionMillis, q.partialResponse, q.skipChunks, q.gateFn(), q.selectTimeout), nil
+	return newQuerier(ctx, q.logger, mint, maxt, q.replicaLabels, q.storeMatchers, q.proxy, q.deduplicate, q.maxResolutionMillis, q.partialResponse, q.skipChunks, q.gateProviderFn(), q.selectTimeout), nil
 }
 
 type querier struct {

--- a/pkg/query/querier.go
+++ b/pkg/query/querier.go
@@ -18,6 +18,7 @@ import (
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/storage"
 
+	"github.com/thanos-io/thanos/pkg/extprom"
 	"github.com/thanos-io/thanos/pkg/gate"
 	"github.com/thanos-io/thanos/pkg/store"
 	"github.com/thanos-io/thanos/pkg/store/storepb"
@@ -34,7 +35,9 @@ type QueryableCreator func(deduplicate bool, replicaLabels []string, storeMatche
 
 // NewQueryableCreator creates QueryableCreator.
 func NewQueryableCreator(logger log.Logger, reg prometheus.Registerer, proxy storepb.StoreServer, maxConcurrentSelects int, selectTimeout time.Duration) QueryableCreator {
-	duration := promauto.With(reg).NewHistogram(gate.DurationHistogramOpts)
+	duration := promauto.With(
+		extprom.WrapRegistererWithPrefix("concurrent_selects_", reg),
+	).NewHistogram(gate.DurationHistogramOpts)
 
 	return func(deduplicate bool, replicaLabels []string, storeMatchers [][]storepb.LabelMatcher, maxResolutionMillis int64, partialResponse, skipChunks bool) storage.Queryable {
 		return &queryable{

--- a/pkg/query/querier_test.go
+++ b/pkg/query/querier_test.go
@@ -362,7 +362,7 @@ func TestQuerier_Select_AfterPromQL(t *testing.T) {
 						g := gate.New(2)
 						mq := &mockedQueryable{
 							Creator: func(mint, maxt int64) storage.Querier {
-								return newQuerier(context.Background(), nil, nil, mint, maxt, tcase.replicaLabels, nil, tcase.storeAPI, sc.dedup, 0, true, false, g, timeout)
+								return newQuerier(context.Background(), nil, mint, maxt, tcase.replicaLabels, nil, tcase.storeAPI, sc.dedup, 0, true, false, g, timeout)
 							},
 						}
 						t.Cleanup(func() {
@@ -606,7 +606,7 @@ func TestQuerier_Select(t *testing.T) {
 				{dedup: true, expected: []series{tcase.expectedAfterDedup}},
 			} {
 				g := gate.New(2)
-				q := newQuerier(context.Background(), nil, nil, tcase.mint, tcase.maxt, tcase.replicaLabels, nil, tcase.storeAPI, sc.dedup, 0, true, false, g, timeout)
+				q := newQuerier(context.Background(), nil, tcase.mint, tcase.maxt, tcase.replicaLabels, nil, tcase.storeAPI, sc.dedup, 0, true, false, g, timeout)
 				t.Cleanup(func() { testutil.Ok(t, q.Close()) })
 
 				t.Run(fmt.Sprintf("dedup=%v", sc.dedup), func(t *testing.T) {
@@ -853,7 +853,7 @@ func TestQuerierWithDedupUnderstoodByPromQL_Rate(t *testing.T) {
 
 		timeout := 100 * time.Second
 		g := gate.New(2)
-		q := newQuerier(context.Background(), logger, nil, realSeriesWithStaleMarkerMint, realSeriesWithStaleMarkerMaxt, []string{"replica"}, nil, s, false, 0, true, false, g, timeout)
+		q := newQuerier(context.Background(), logger, realSeriesWithStaleMarkerMint, realSeriesWithStaleMarkerMaxt, []string{"replica"}, nil, s, false, 0, true, false, g, timeout)
 		t.Cleanup(func() {
 			testutil.Ok(t, q.Close())
 		})
@@ -923,7 +923,7 @@ func TestQuerierWithDedupUnderstoodByPromQL_Rate(t *testing.T) {
 
 		timeout := 5 * time.Second
 		g := gate.New(2)
-		q := newQuerier(context.Background(), logger, nil, realSeriesWithStaleMarkerMint, realSeriesWithStaleMarkerMaxt, []string{"replica"}, nil, s, true, 0, true, false, g, timeout)
+		q := newQuerier(context.Background(), logger, realSeriesWithStaleMarkerMint, realSeriesWithStaleMarkerMaxt, []string{"replica"}, nil, s, true, 0, true, false, g, timeout)
 		t.Cleanup(func() {
 			testutil.Ok(t, q.Close())
 		})

--- a/pkg/ui/query.go
+++ b/pkg/ui/query.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/go-kit/kit/log"
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/common/route"
 
@@ -31,11 +30,10 @@ type Query struct {
 	cwd     string
 	birth   time.Time
 	version api.ThanosVersion
-	reg     prometheus.Registerer
 	now     func() model.Time
 }
 
-func NewQueryUI(logger log.Logger, reg prometheus.Registerer, storeSet *query.StoreSet, externalPrefix, prefixHeader string) *Query {
+func NewQueryUI(logger log.Logger, storeSet *query.StoreSet, externalPrefix, prefixHeader string) *Query {
 	tmplVariables := map[string]string{
 		"Component": component.Query.String(),
 	}
@@ -49,7 +47,6 @@ func NewQueryUI(logger log.Logger, reg prometheus.Registerer, storeSet *query.St
 		cwd:            runtimeInfo().CWD,
 		birth:          runtimeInfo().StartTime,
 		version:        *api.BuildInfo,
-		reg:            reg,
 		now:            model.Now,
 	}
 }


### PR DESCRIPTION
* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

The metrics on the gates for concurrent selects were exposed without a prefix (e.g. `gate_queries_in_flight` and `gate_duration_seconds`) unlike the gate metrics for the query API. The first commit 60950ff adds the `thanos_query_concurrent_selects_` prefix.
After more thinking, I felt that exposing the number of in-flight queries doesn't make much sense for concurrent selects because each query creates a new gate. Thus we can have (max number of concurrent selects per query x max number of concurrent queries) selects in flight and it doesn't tell whether a query is blocked on too many selects or not. I've added another commit 
722181c that removes the `thanos_query_concurrent_selects_gate_queries_in_flight` metric.

The following metrics have also been added to record the maximum number of concurrent requests per gate:
* `thanos_query_gate_queries_max`
* `thanos_bucket_store_series_gate_queries_max`, previously known as `thanos_bucket_store_queries_concurrent_max.`
* `thanos_memcached_getmulti_gate_queries_max`

## Verification

Tested manually.
