### PR TITLE
added key prop in Navigation

### DIFF
--- a/pkg/ui/react-app/src/thanos/Navbar.tsx
+++ b/pkg/ui/react-app/src/thanos/Navbar.tsx
@@ -84,13 +84,13 @@ const Navigation: FC<PathPrefixProps & NavigationProps> = ({ pathPrefix, thanosC
               );
 
             return (
-              <UncontrolledDropdown nav inNavbar>
+              <UncontrolledDropdown key={config.name} nav inNavbar>
                 <DropdownToggle nav caret>
                   {config.name}
                 </DropdownToggle>
                 <DropdownMenu>
                   {config.children.map(c => (
-                    <DropdownItem tag={Link} to={`${pathPrefix}${c.uri}`}>
+                    <DropdownItem key={c.uri} tag={Link} to={`${pathPrefix}${c.uri}`}>
                       {c.name}
                     </DropdownItem>
                   ))}


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes
Fixes #3160 
Added `key` prop in `UncontrolledDropdown` & `DropdownItem` components of `Navigation` so that React can handle the minimal DOM change.

## Verification
The warnings shown in #3160 disappeared. 
