### PR TITLE
React-UI: Replace Alert components with UncontrolledAlert

### DIFF
--- a/pkg/ui/react-app/src/components/withStatusIndicator.tsx
+++ b/pkg/ui/react-app/src/components/withStatusIndicator.tsx
@@ -1,5 +1,5 @@
 import React, { FC, ComponentType } from 'react';
-import { Alert } from 'reactstrap';
+import { UncontrolledAlert } from 'reactstrap';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faSpinner } from '@fortawesome/free-solid-svg-icons';
 
@@ -19,7 +19,7 @@ export const withStatusIndicator = <T extends {}>(Component: ComponentType<T>): 
 }) => {
   if (error) {
     return (
-      <Alert color="danger">
+      <UncontrolledAlert color="danger">
         {customErrorMsg ? (
           customErrorMsg
         ) : (
@@ -27,7 +27,7 @@ export const withStatusIndicator = <T extends {}>(Component: ComponentType<T>): 
             <strong>Error:</strong> Error fetching {componentTitle || Component.displayName}: {error.message}
           </>
         )}
-      </Alert>
+      </UncontrolledAlert>
     );
   }
 

--- a/pkg/ui/react-app/src/pages/graph/DataTable.test.tsx
+++ b/pkg/ui/react-app/src/pages/graph/DataTable.test.tsx
@@ -9,7 +9,7 @@ describe('DataTable', () => {
     it('renders an alert', () => {
       const table = shallow(<DataTable data={null} />);
       const alert = table.find(UncontrolledAlert);
-      expect(Object.keys(alert.props())).toHaveLength(7);
+      expect(Object.keys(alert.props())).toHaveLength(2);
       expect(alert.prop('color')).toEqual('light');
       expect(alert.prop('children')).toEqual('No data queried yet');
     });
@@ -25,7 +25,7 @@ describe('DataTable', () => {
       };
       const table = shallow(<DataTable {...dataTableProps} />);
       const alert = table.find(UncontrolledAlert);
-      expect(Object.keys(alert.props())).toHaveLength(7);
+      expect(Object.keys(alert.props())).toHaveLength(2);
       expect(alert.prop('color')).toEqual('secondary');
       expect(alert.prop('children')).toEqual('Empty query result');
     });
@@ -109,7 +109,7 @@ describe('DataTable', () => {
           .first()
           .render()
           .text()
-      ).toEqual('Warning: Fetched 10001 metrics, only displaying first 10000.');
+      ).toContain('Warning: Fetched 10001 metrics, only displaying first 10000.');
     });
   });
 
@@ -138,7 +138,7 @@ describe('DataTable', () => {
           .first()
           .render()
           .text()
-      ).toEqual('Notice: Showing more than 1000 series, turning off label formatting for performance reasons.');
+      ).toContain('Notice: Showing more than 1000 series, turning off label formatting for performance reasons.');
     });
   });
 

--- a/pkg/ui/react-app/src/pages/graph/DataTable.test.tsx
+++ b/pkg/ui/react-app/src/pages/graph/DataTable.test.tsx
@@ -1,14 +1,14 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
 import DataTable, { QueryResult } from './DataTable';
-import { Alert, Table } from 'reactstrap';
+import { UncontrolledAlert, Table } from 'reactstrap';
 import SeriesName from './SeriesName';
 
 describe('DataTable', () => {
   describe('when data is null', () => {
     it('renders an alert', () => {
       const table = shallow(<DataTable data={null} />);
-      const alert = table.find(Alert);
+      const alert = table.find(UncontrolledAlert);
       expect(Object.keys(alert.props())).toHaveLength(7);
       expect(alert.prop('color')).toEqual('light');
       expect(alert.prop('children')).toEqual('No data queried yet');
@@ -24,7 +24,7 @@ describe('DataTable', () => {
         },
       };
       const table = shallow(<DataTable {...dataTableProps} />);
-      const alert = table.find(Alert);
+      const alert = table.find(UncontrolledAlert);
       expect(Object.keys(alert.props())).toHaveLength(7);
       expect(alert.prop('color')).toEqual('secondary');
       expect(alert.prop('children')).toEqual('Empty query result');
@@ -103,7 +103,7 @@ describe('DataTable', () => {
     });
 
     it('renders a warning', () => {
-      const alerts = dataTable.find(Alert);
+      const alerts = dataTable.find(UncontrolledAlert);
       expect(
         alerts
           .first()
@@ -132,7 +132,7 @@ describe('DataTable', () => {
     const dataTable = shallow(<DataTable {...dataTableProps} />);
 
     it('renders a warning', () => {
-      const alerts = dataTable.find(Alert);
+      const alerts = dataTable.find(UncontrolledAlert);
       expect(
         alerts
           .first()

--- a/pkg/ui/react-app/src/pages/graph/DataTable.tsx
+++ b/pkg/ui/react-app/src/pages/graph/DataTable.tsx
@@ -1,6 +1,6 @@
 import React, { FC, ReactNode } from 'react';
 
-import { Alert, Table } from 'reactstrap';
+import { UncontrolledAlert, Table } from 'reactstrap';
 
 import SeriesName from './SeriesName';
 import { Metric } from '../../types/types';
@@ -49,11 +49,11 @@ const limitSeries = <S extends InstantSample | RangeSamples>(series: S[]): S[] =
 
 const DataTable: FC<QueryResult> = ({ data }) => {
   if (data === null) {
-    return <Alert color="light">No data queried yet</Alert>;
+    return <UncontrolledAlert color="light">No data queried yet</UncontrolledAlert>;
   }
 
   if (data.result === null || data.result.length === 0) {
-    return <Alert color="secondary">Empty query result</Alert>;
+    return <UncontrolledAlert color="secondary">Empty query result</UncontrolledAlert>;
   }
 
   const maxFormattableSize = 1000;
@@ -111,21 +111,21 @@ const DataTable: FC<QueryResult> = ({ data }) => {
       );
       break;
     default:
-      return <Alert color="danger">Unsupported result value type</Alert>;
+      return <UncontrolledAlert color="danger">Unsupported result value type</UncontrolledAlert>;
   }
 
   return (
     <>
       {limited && (
-        <Alert color="danger">
+        <UncontrolledAlert color="danger">
           <strong>Warning:</strong> Fetched {data.result.length} metrics, only displaying first {rows.length}.
-        </Alert>
+        </UncontrolledAlert>
       )}
       {!doFormat && (
-        <Alert color="secondary">
+        <UncontrolledAlert color="secondary">
           <strong>Notice:</strong> Showing more than {maxFormattableSize} series, turning off label formatting for
           performance reasons.
-        </Alert>
+        </UncontrolledAlert>
       )}
       <Table hover size="sm" className="data-table">
         <tbody>{rows}</tbody>

--- a/pkg/ui/react-app/src/pages/graph/GraphTabContent.test.tsx
+++ b/pkg/ui/react-app/src/pages/graph/GraphTabContent.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
-import { Alert } from 'reactstrap';
+import { UncontrolledAlert } from 'reactstrap';
 import { GraphTabContent } from './GraphTabContent';
 
 describe('GraphTabContent', () => {
@@ -17,7 +17,7 @@ describe('GraphTabContent', () => {
       children: `Query result is of wrong type '`,
     };
     const graph = shallow(<GraphTabContent {...props} />);
-    const alert = graph.find(Alert);
+    const alert = graph.find(UncontrolledAlert);
     expect(alert.prop('color')).toEqual(props.color);
     expect(alert.childAt(0).text()).toEqual(props.children);
   });
@@ -38,7 +38,7 @@ describe('GraphTabContent', () => {
       },
     };
     const graph = shallow(<GraphTabContent {...props} />);
-    const alert = graph.find(Alert);
+    const alert = graph.find(UncontrolledAlert);
     expect(alert.prop('color')).toEqual(props.color);
     expect(alert.childAt(0).text()).toEqual(props.children);
   });

--- a/pkg/ui/react-app/src/pages/graph/GraphTabContent.tsx
+++ b/pkg/ui/react-app/src/pages/graph/GraphTabContent.tsx
@@ -1,5 +1,5 @@
 import React, { FC } from 'react';
-import { Alert } from 'reactstrap';
+import { UncontrolledAlert } from 'reactstrap';
 import Graph from './Graph';
 import { QueryParams } from '../../types/types';
 import { isPresent } from '../../utils';
@@ -13,14 +13,16 @@ interface GraphTabContentProps {
 
 export const GraphTabContent: FC<GraphTabContentProps> = ({ data, stacked, useLocalTime, lastQueryParams }) => {
   if (!isPresent(data)) {
-    return <Alert color="light">No data queried yet</Alert>;
+    return <UncontrolledAlert color="light">No data queried yet</UncontrolledAlert>;
   }
   if (data.result.length === 0) {
-    return <Alert color="secondary">Empty query result</Alert>;
+    return <UncontrolledAlert color="secondary">Empty query result</UncontrolledAlert>;
   }
   if (data.resultType !== 'matrix') {
     return (
-      <Alert color="danger">Query result is of wrong type '{data.resultType}', should be 'matrix' (range vector).</Alert>
+      <UncontrolledAlert color="danger">
+        Query result is of wrong type '{data.resultType}', should be 'matrix' (range vector).
+      </UncontrolledAlert>
     );
   }
   return <Graph data={data} stacked={stacked} useLocalTime={useLocalTime} queryParams={lastQueryParams} />;

--- a/pkg/ui/react-app/src/pages/graph/Panel.tsx
+++ b/pkg/ui/react-app/src/pages/graph/Panel.tsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 
-import { Alert, Button, Col, Nav, NavItem, NavLink, Row, TabContent, TabPane } from 'reactstrap';
+import { UncontrolledAlert, Button, Col, Nav, NavItem, NavLink, Row, TabContent, TabPane } from 'reactstrap';
 
 import moment from 'moment-timezone';
 
@@ -274,7 +274,7 @@ class Panel extends Component<PanelProps & PathPrefixProps, PanelState> {
           </Col>
         </Row>
         <Row>
-          <Col>{this.state.error && <Alert color="danger">{this.state.error}</Alert>}</Col>
+          <Col>{this.state.error && <UncontrolledAlert color="danger">{this.state.error}</UncontrolledAlert>}</Col>
         </Row>
         <Row>
           <Col>

--- a/pkg/ui/react-app/src/pages/graph/PanelList.tsx
+++ b/pkg/ui/react-app/src/pages/graph/PanelList.tsx
@@ -1,6 +1,6 @@
 import React, { FC, useState, useEffect } from 'react';
 import { RouteComponentProps } from '@reach/router';
-import { Alert, Button } from 'reactstrap';
+import { UncontrolledAlert, Button } from 'reactstrap';
 
 import Panel, { PanelOptions, PanelDefaultOptions } from './Panel';
 import Checkbox from '../../components/Checkbox';
@@ -150,18 +150,18 @@ const PanelList: FC<RouteComponentProps & PathPrefixProps> = ({ pathPrefix = '' 
         Use local time
       </Checkbox>
       {(delta > 30 || timeErr) && (
-        <Alert color="danger">
+        <UncontrolledAlert color="danger">
           <strong>Warning: </strong>
           {timeErr && `Unexpected response status when fetching server time: ${timeErr.message}`}
           {delta >= 30 &&
             `Error fetching server time: Detected ${delta} seconds time difference between your browser and the server. Thanos relies on accurate time and time drift might cause unexpected query results.`}
-        </Alert>
+        </UncontrolledAlert>
       )}
       {metricsErr && (
-        <Alert color="danger">
+        <UncontrolledAlert color="danger">
           <strong>Warning: </strong>
           Error fetching metrics list: Unexpected response status when fetching metric names: {metricsErr.message}
-        </Alert>
+        </UncontrolledAlert>
       )}
       <PanelListContent
         panels={decodePanelOptionsFromQueryString(window.location.search)}

--- a/pkg/ui/react-app/src/pages/rules/RulesContent.tsx
+++ b/pkg/ui/react-app/src/pages/rules/RulesContent.tsx
@@ -1,7 +1,7 @@
 import React, { FC } from 'react';
 import { RouteComponentProps } from '@reach/router';
 import { APIResponse } from '../../hooks/useFetch';
-import { Alert, Table, Badge } from 'reactstrap';
+import { UncontrolledAlert, Table, Badge } from 'reactstrap';
 import { formatRelative, createExternalExpressionLink, humanizeDuration } from '../../utils';
 import { Rule } from '../../types/types';
 import { now } from 'moment';
@@ -112,7 +112,7 @@ export const RulesContent: FC<RouteComponentProps & RulesContentProps> = ({ resp
                       <td>
                         <Badge color={getBadgeColor(r.health)}>{r.health.toUpperCase()}</Badge>
                       </td>
-                      <td>{r.lastError ? <Alert color="danger">{r.lastError}</Alert> : null}</td>
+                      <td>{r.lastError ? <UncontrolledAlert color="danger">{r.lastError}</UncontrolledAlert> : null}</td>
                       <td>{formatRelative(r.lastEvaluation, now())} ago</td>
                       <td>{humanizeDuration(parseFloat(r.evaluationTime) * 1000)}</td>
                     </tr>

--- a/pkg/ui/react-app/src/pages/targets/EndpointLink.test.tsx
+++ b/pkg/ui/react-app/src/pages/targets/EndpointLink.test.tsx
@@ -33,6 +33,6 @@ describe('EndpointLink', () => {
   it('renders an alert if url is invalid', () => {
     const endpointLink = shallow(<EndpointLink endpoint={'afdsacas'} globalUrl={'afdsacas'} />);
     const err = endpointLink.find(UncontrolledAlert);
-    expect(err.render().text()).toEqual('Error: Invalid URL');
+    expect(err.render().text()).toContain('Error: Invalid URL');
   });
 });

--- a/pkg/ui/react-app/src/pages/targets/EndpointLink.test.tsx
+++ b/pkg/ui/react-app/src/pages/targets/EndpointLink.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { Badge, Alert } from 'reactstrap';
+import { Badge, UncontrolledAlert } from 'reactstrap';
 import EndpointLink from './EndpointLink';
 
 describe('EndpointLink', () => {
@@ -32,7 +32,7 @@ describe('EndpointLink', () => {
 
   it('renders an alert if url is invalid', () => {
     const endpointLink = shallow(<EndpointLink endpoint={'afdsacas'} globalUrl={'afdsacas'} />);
-    const err = endpointLink.find(Alert);
+    const err = endpointLink.find(UncontrolledAlert);
     expect(err.render().text()).toEqual('Error: Invalid URL');
   });
 });

--- a/pkg/ui/react-app/src/pages/targets/EndpointLink.tsx
+++ b/pkg/ui/react-app/src/pages/targets/EndpointLink.tsx
@@ -1,5 +1,5 @@
 import React, { FC } from 'react';
-import { Badge, Alert } from 'reactstrap';
+import { Badge, UncontrolledAlert } from 'reactstrap';
 
 export interface EndpointLinkProps {
   endpoint: string;
@@ -12,9 +12,9 @@ const EndpointLink: FC<EndpointLinkProps> = ({ endpoint, globalUrl }) => {
     url = new URL(endpoint);
   } catch (e) {
     return (
-      <Alert color="danger">
+      <UncontrolledAlert color="danger">
         <strong>Error:</strong> {e.message}
-      </Alert>
+      </UncontrolledAlert>
     );
   }
 

--- a/pkg/ui/react-app/src/pages/targets/ScrapePoolList.test.tsx
+++ b/pkg/ui/react-app/src/pages/targets/ScrapePoolList.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { mount, ReactWrapper } from 'enzyme';
 import { act } from 'react-dom/test-utils';
-import { Alert } from 'reactstrap';
+import { UncontrolledAlert } from 'reactstrap';
 import { sampleApiResponse } from './__testdata__/testdata';
 import ScrapePoolList from './ScrapePoolList';
 import ScrapePoolPanel from './ScrapePoolPanel';
@@ -75,7 +75,7 @@ describe('ScrapePoolList', () => {
       scrapePoolList.update();
 
       expect(mock).toHaveBeenCalledWith('../api/v1/targets?state=active', { cache: 'no-store', credentials: 'same-origin' });
-      const alert = scrapePoolList.find(Alert);
+      const alert = scrapePoolList.find(UncontrolledAlert);
       expect(alert.prop('color')).toBe('danger');
       expect(alert.text()).toContain('Error fetching targets');
     });

--- a/pkg/ui/react-app/src/thanos/pages/blocks/Blocks.test.tsx
+++ b/pkg/ui/react-app/src/thanos/pages/blocks/Blocks.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { mount, ReactWrapper } from 'enzyme';
 import { FetchMock } from 'jest-fetch-mock/types';
-import { Alert } from 'reactstrap';
+import { UncontrolledAlert } from 'reactstrap';
 import Blocks from './Blocks';
 import { SourceView } from './SourceView';
 import { sampleAPIResponse } from './__testdata__/testdata';
@@ -62,7 +62,7 @@ describe('Blocks', () => {
 
       expect(mock).toHaveBeenCalledWith('/api/v1/blocks?view=global', { cache: 'no-store', credentials: 'same-origin' });
 
-      const alert = blocks.find(Alert);
+      const alert = blocks.find(UncontrolledAlert);
       expect(alert.prop('color')).toBe('warning');
       expect(alert.text()).toContain('No blocks found.');
     });
@@ -80,7 +80,7 @@ describe('Blocks', () => {
 
       expect(mock).toHaveBeenCalledWith('/api/v1/blocks?view=global', { cache: 'no-store', credentials: 'same-origin' });
 
-      const alert = blocks.find(Alert);
+      const alert = blocks.find(UncontrolledAlert);
       expect(alert.prop('color')).toBe('danger');
       expect(alert.text()).toContain('Error fetching blocks');
     });

--- a/pkg/ui/react-app/src/thanos/pages/blocks/Blocks.tsx
+++ b/pkg/ui/react-app/src/thanos/pages/blocks/Blocks.tsx
@@ -1,6 +1,6 @@
 import React, { FC, useMemo, useState } from 'react';
 import { RouteComponentProps } from '@reach/router';
-import { Alert } from 'reactstrap';
+import { UncontrolledAlert } from 'reactstrap';
 import { useQueryParams, withDefault, NumberParam } from 'use-query-params';
 import { withStatusIndicator } from '../../../components/withStatusIndicator';
 import { useFetch } from '../../../hooks/useFetch';
@@ -54,7 +54,7 @@ export const BlocksContent: FC<{ data: BlockListProps }> = ({ data }) => {
     });
   };
 
-  if (err) return <Alert color="danger">{err.toString()}</Alert>;
+  if (err) return <UncontrolledAlert color="danger">{err.toString()}</UncontrolledAlert>;
 
   return (
     <>
@@ -84,7 +84,7 @@ export const BlocksContent: FC<{ data: BlockListProps }> = ({ data }) => {
           <BlockDetails selectBlock={selectBlock} block={selectedBlock} />
         </div>
       ) : (
-        <Alert color="warning">No blocks found.</Alert>
+        <UncontrolledAlert color="warning">No blocks found.</UncontrolledAlert>
       )}
     </>
   );

--- a/pkg/ui/react-app/src/thanos/pages/stores/Stores.test.tsx
+++ b/pkg/ui/react-app/src/thanos/pages/stores/Stores.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { mount, ReactWrapper } from 'enzyme';
 import { FetchMock } from 'jest-fetch-mock/types';
-import { Alert } from 'reactstrap';
+import { UncontrolledAlert } from 'reactstrap';
 import Stores from './Stores';
 import StorePoolPanel from './StorePoolPanel';
 import { sampleAPIResponse } from './__testdata__/testdata';
@@ -55,7 +55,7 @@ describe('Stores', () => {
 
       expect(mock).toHaveBeenCalledWith('/api/v1/stores', { cache: 'no-store', credentials: 'same-origin' });
 
-      const alert = stores.find(Alert);
+      const alert = stores.find(UncontrolledAlert);
       expect(alert.prop('color')).toBe('warning');
       expect(alert.text()).toContain('No stores registered');
     });
@@ -73,7 +73,7 @@ describe('Stores', () => {
 
       expect(mock).toHaveBeenCalledWith('/api/v1/stores', { cache: 'no-store', credentials: 'same-origin' });
 
-      const alert = stores.find(Alert);
+      const alert = stores.find(UncontrolledAlert);
       expect(alert.prop('color')).toBe('danger');
       expect(alert.text()).toContain('Error fetching stores');
     });

--- a/pkg/ui/react-app/src/thanos/pages/stores/Stores.tsx
+++ b/pkg/ui/react-app/src/thanos/pages/stores/Stores.tsx
@@ -1,6 +1,6 @@
 import React, { FC } from 'react';
 import { RouteComponentProps } from '@reach/router';
-import { Alert } from 'reactstrap';
+import { UncontrolledAlert } from 'reactstrap';
 import { withStatusIndicator } from '../../../components/withStatusIndicator';
 import { useFetch } from '../../../hooks/useFetch';
 import PathPrefixProps from '../../../types/PathPrefixProps';
@@ -20,7 +20,7 @@ export const StoreContent: FC<{ data: StoreListProps }> = ({ data }) => {
           <StorePoolPanel key={storeGroup} title={storeGroup} storePool={data[storeGroup]} />
         ))
       ) : (
-        <Alert color="warning">No stores registered.</Alert>
+        <UncontrolledAlert color="warning">No stores registered.</UncontrolledAlert>
       )}
     </>
   );


### PR DESCRIPTION
 Replaces `reactstrap` Alert Component in the react-app with the UncontrolledAlert. This makes the alerts rendered on the UI dismissable, meaning the alerts now have an 'x' button which can be used to close the alerts.

Fixes #3168 

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
## Changes
Thanos `package/ui/react-app`
<!-- Enumerate changes you made -->
Replaced the Alert component with UncontrolledAlert component in all the relevant files
Made relevant changes to the affected tests

## Verification

<!-- How you tested it? How do you know it works? -->
Ran the `yarn run test` command and all the test suites passed.

@prmsrswt 