### PR TITLE
react-app: Fixes `statsCount` prop being overriten by spread `response.data` object in `src/pages/alerts/Alerts.tsx`

### DIFF
--- a/pkg/ui/react-app/src/pages/alerts/Alerts.tsx
+++ b/pkg/ui/react-app/src/pages/alerts/Alerts.tsx
@@ -20,7 +20,7 @@ const Alerts: FC<RouteComponentProps & PathPrefixProps> = ({ pathPrefix = '' }) 
     response.data.groups.forEach(el => el.rules.forEach(r => ruleStatsCount[r.state]++));
   }
 
-  return <AlertsWithStatusIndicator statsCount={ruleStatsCount} {...response.data} error={error} isLoading={isLoading} />;
+  return <AlertsWithStatusIndicator {...response.data} statsCount={ruleStatsCount} error={error} isLoading={isLoading} />;
 };
 
 export default Alerts;


### PR DESCRIPTION
Fixes linter warning about `statsCount` prop being overwritten.

Fixes #3172 

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->
Moved `statsCount` prop after the spread `response.data` object.
## Verification

<!-- How you tested it? How do you know it works? -->
Ran `yarn run test` and all the test suites passed