### PR TITLE
website/layour: fix TOC title

### DIFF
--- a/website/layouts/_default/single.html
+++ b/website/layouts/_default/single.html
@@ -7,7 +7,7 @@
             <div class="DocSearch-content col-12 col-lg-9">
                 {{ partial "versioning/banner.html" . }}
                 {{ if or (eq .Params.toc true) (and (gt .WordCount 400) (ne .Params.toc false)) }}
-                <h1>Table of Content</h1>
+                <h1>Table of Contents</h1>
                 {{ .TableOfContents }}
                 {{ end }}
                 {{ $content := replace .Content "<table>" "<table class='table table-striped'>" }}


### PR DESCRIPTION
The correct term is `Table of Contents` in plural. This commit fixes the
title for the TOC.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>

* [x] Change is not relevant to the end user.

cc @thisisobate 