### PR TITLE
*: Handling query logging for code 3xx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 
 ### Added
 
-- [#3181](https://github.com/thanos-io/thanos/pull/3181) Query Frontend: Add debug level logging for responses between 300-399
+- [#3181](https://github.com/thanos-io/thanos/pull/3181) Logging: Add debug level logging for responses between 300-399
 - [#3133](https://github.com/thanos-io/thanos/pull/3133) Query: Allow passing a `storeMatch[]` to Labels APIs. Also time range metadata based store filtering is supported on Labels APIs.
 - [#3154](https://github.com/thanos-io/thanos/pull/3154) Query Frontend: Add metric `thanos_memcached_getmulti_gate_queries_max`.
 - [#3146](https://github.com/thanos-io/thanos/pull/3146) Sidecar: Add `thanos_sidecar_prometheus_store_received_frames` histogram metric.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 
 ### Added
 
+- [#3181](https://github.com/thanos-io/thanos/pull/3181) Query Frontend: Add debug level logging for responses between 300-399
 - [#3133](https://github.com/thanos-io/thanos/pull/3133) Query: Allow passing a `storeMatch[]` to Labels APIs. Also time range metadata based store filtering is supported on Labels APIs.
 - [#3154](https://github.com/thanos-io/thanos/pull/3154) Query Frontend: Add metric `thanos_memcached_getmulti_gate_queries_max`.
 - [#3146](https://github.com/thanos-io/thanos/pull/3146) Sidecar: Add `thanos_sidecar_prometheus_store_received_frames` histogram metric.

--- a/pkg/logging/options.go
+++ b/pkg/logging/options.go
@@ -98,6 +98,9 @@ func DefaultCodeToLevel(logger log.Logger, code int) log.Logger {
 	if code >= 200 && code < 300 {
 		return level.Debug(logger)
 	}
+	if code >= 300 && code < 400 {
+		return level.Info(logger)
+	}
 	if code >= 400 && code < 500 {
 		return level.Debug(logger)
 	}

--- a/pkg/logging/options.go
+++ b/pkg/logging/options.go
@@ -95,13 +95,7 @@ type options struct {
 
 // DefaultCodeToLevel is the helper mapper that maps HTTP Response codes to log levels.
 func DefaultCodeToLevel(logger log.Logger, code int) log.Logger {
-	if code >= 200 && code < 300 {
-		return level.Debug(logger)
-	}
-	if code >= 300 && code < 400 {
-		return level.Info(logger)
-	}
-	if code >= 400 && code < 500 {
+	if code >= 200 && code < 500 {
 		return level.Debug(logger)
 	}
 	return level.Error(logger)


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

- [x] I added CHANGELOG entry for this change.
- [ ] Change is not relevant to the end user.

## Changes

Fixes #3174
Handled logging for return codes 3xx at Info level. Initially the responses were logged as error

@yashrsharma44 @yeya24 Please let me know if it should be handled in any other way.

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
