### PR TITLE
fixed the broken links that leads to 404 error, Signed-off-by:raphlbr…

### DIFF
--- a/cmd/thanos/flags.go
+++ b/cmd/thanos/flags.go
@@ -60,7 +60,7 @@ func regCommonTracingFlags(app extkingpin.FlagClause) *extflag.PathOrContent {
 	return extflag.RegisterPathOrContent(
 		app,
 		"tracing.config",
-		"YAML file with tracing configuration. See format details: https://thanos.io/tip/tracing.md/#configuration ",
+		"YAML file with tracing configuration. See format details: https://thanos.io/tip/thanos/tracing.md/#configuration ",
 		false,
 	)
 }

--- a/docs/components/compact.md
+++ b/docs/components/compact.md
@@ -92,12 +92,12 @@ Flags:
       --tracing.config-file=<file-path>
                                 Path to YAML file with tracing configuration.
                                 See format details:
-                                https://thanos.io/tip/tracing.md/#configuration
+                                https://thanos.io/tip/thanos/tracing.md/#configuration
       --tracing.config=<content>
                                 Alternative to 'tracing.config-file' flag (lower
                                 priority). Content of YAML file with tracing
                                 configuration. See format details:
-                                https://thanos.io/tip/tracing.md/#configuration
+                                https://thanos.io/tip/thanos/tracing.md/#configuration
       --http-address="0.0.0.0:10902"
                                 Listen host:port for HTTP endpoints.
       --http-grace-period=2m    Time to wait after an interrupt received for

--- a/docs/components/query-frontend.md
+++ b/docs/components/query-frontend.md
@@ -83,12 +83,12 @@ Flags:
       --tracing.config-file=<file-path>
                               Path to YAML file with tracing configuration. See
                               format details:
-                              https://thanos.io/tip/tracing.md/#configuration
+                              https://thanos.io/tip/thanos/tracing.md/#configuration
       --tracing.config=<content>
                               Alternative to 'tracing.config-file' flag (lower
                               priority). Content of YAML file with tracing
                               configuration. See format details:
-                              https://thanos.io/tip/tracing.md/#configuration
+                              https://thanos.io/tip/thanos/tracing.md/#configuration
       --query-range.split-interval=24h
                               Split queries by an interval and execute in
                               parallel, 0 disables it.

--- a/docs/components/query.md
+++ b/docs/components/query.md
@@ -299,12 +299,12 @@ Flags:
       --tracing.config-file=<file-path>
                                  Path to YAML file with tracing configuration.
                                  See format details:
-                                 https://thanos.io/tip/tracing.md/#configuration
+                                 https://thanos.io/tip/thanos/tracing.md/#configuration
       --tracing.config=<content>
                                  Alternative to 'tracing.config-file' flag
                                  (lower priority). Content of YAML file with
                                  tracing configuration. See format details:
-                                 https://thanos.io/tip/tracing.md/#configuration
+                                 https://thanos.io/tip/thanos/tracing.md/#configuration
       --http-address="0.0.0.0:10902"
                                  Listen host:port for HTTP endpoints.
       --http-grace-period=2m     Time to wait after an interrupt received for

--- a/docs/components/receive.md
+++ b/docs/components/receive.md
@@ -79,12 +79,12 @@ Flags:
       --tracing.config-file=<file-path>
                                  Path to YAML file with tracing configuration.
                                  See format details:
-                                 https://thanos.io/tip/tracing.md/#configuration
+                                 https://thanos.io/tip/thanos/tracing.md/#configuration
       --tracing.config=<content>
                                  Alternative to 'tracing.config-file' flag
                                  (lower priority). Content of YAML file with
                                  tracing configuration. See format details:
-                                 https://thanos.io/tip/tracing.md/#configuration
+                                 https://thanos.io/tip/thanos/tracing.md/#configuration
       --http-address="0.0.0.0:10902"
                                  Listen host:port for HTTP endpoints.
       --http-grace-period=2m     Time to wait after an interrupt received for

--- a/docs/components/rule.md
+++ b/docs/components/rule.md
@@ -245,12 +245,12 @@ Flags:
       --tracing.config-file=<file-path>
                                  Path to YAML file with tracing configuration.
                                  See format details:
-                                 https://thanos.io/tip/tracing.md/#configuration
+                                 https://thanos.io/tip/thanos/tracing.md/#configuration
       --tracing.config=<content>
                                  Alternative to 'tracing.config-file' flag
                                  (lower priority). Content of YAML file with
                                  tracing configuration. See format details:
-                                 https://thanos.io/tip/tracing.md/#configuration
+                                 https://thanos.io/tip/thanos/tracing.md/#configuration
       --http-address="0.0.0.0:10902"
                                  Listen host:port for HTTP endpoints.
       --http-grace-period=2m     Time to wait after an interrupt received for

--- a/docs/components/sidecar.md
+++ b/docs/components/sidecar.md
@@ -97,12 +97,12 @@ Flags:
       --tracing.config-file=<file-path>
                                  Path to YAML file with tracing configuration.
                                  See format details:
-                                 https://thanos.io/tip/tracing.md/#configuration
+                                 https://thanos.io/tip/thanos/tracing.md/#configuration
       --tracing.config=<content>
                                  Alternative to 'tracing.config-file' flag
                                  (lower priority). Content of YAML file with
                                  tracing configuration. See format details:
-                                 https://thanos.io/tip/tracing.md/#configuration
+                                 https://thanos.io/tip/thanos/tracing.md/#configuration
       --http-address="0.0.0.0:10902"
                                  Listen host:port for HTTP endpoints.
       --http-grace-period=2m     Time to wait after an interrupt received for

--- a/docs/components/store.md
+++ b/docs/components/store.md
@@ -44,12 +44,12 @@ Flags:
       --tracing.config-file=<file-path>
                                  Path to YAML file with tracing configuration.
                                  See format details:
-                                 https://thanos.io/tip/tracing.md/#configuration
+                                 https://thanos.io/tip/thanos/tracing.md/#configuration
       --tracing.config=<content>
                                  Alternative to 'tracing.config-file' flag
                                  (lower priority). Content of YAML file with
                                  tracing configuration. See format details:
-                                 https://thanos.io/tip/tracing.md/#configuration
+                                 https://thanos.io/tip/thanos/tracing.md/#configuration
       --http-address="0.0.0.0:10902"
                                  Listen host:port for HTTP endpoints.
       --http-grace-period=2m     Time to wait after an interrupt received for

--- a/docs/components/tools.md
+++ b/docs/components/tools.md
@@ -28,12 +28,12 @@ Flags:
       --tracing.config-file=<file-path>
                            Path to YAML file with tracing configuration. See
                            format details:
-                           https://thanos.io/tip/tracing.md/#configuration
+                           https://thanos.io/tip/thanos/tracing.md/#configuration
       --tracing.config=<content>
                            Alternative to 'tracing.config-file' flag (lower
                            priority). Content of YAML file with tracing
                            configuration. See format details:
-                           https://thanos.io/tip/tracing.md/#configuration
+                           https://thanos.io/tip/thanos/tracing.md/#configuration
 
 Subcommands:
   tools bucket verify [<flags>]
@@ -101,12 +101,12 @@ Flags:
       --tracing.config-file=<file-path>
                            Path to YAML file with tracing configuration. See
                            format details:
-                           https://thanos.io/tip/tracing.md/#configuration
+                           https://thanos.io/tip/thanos/tracing.md/#configuration
       --tracing.config=<content>
                            Alternative to 'tracing.config-file' flag (lower
                            priority). Content of YAML file with tracing
                            configuration. See format details:
-                           https://thanos.io/tip/tracing.md/#configuration
+                           https://thanos.io/tip/thanos/tracing.md/#configuration
       --objstore.config-file=<file-path>
                            Path to YAML file that contains object store
                            configuration. See format details:
@@ -173,12 +173,12 @@ Flags:
       --tracing.config-file=<file-path>
                                 Path to YAML file with tracing configuration.
                                 See format details:
-                                https://thanos.io/tip/tracing.md/#configuration
+                                https://thanos.io/tip/thanos/tracing.md/#configuration
       --tracing.config=<content>
                                 Alternative to 'tracing.config-file' flag (lower
                                 priority). Content of YAML file with tracing
                                 configuration. See format details:
-                                https://thanos.io/tip/tracing.md/#configuration
+                                https://thanos.io/tip/thanos/tracing.md/#configuration
       --objstore.config-file=<file-path>
                                 Path to YAML file that contains object store
                                 configuration. See format details:
@@ -246,12 +246,12 @@ Flags:
       --tracing.config-file=<file-path>
                            Path to YAML file with tracing configuration. See
                            format details:
-                           https://thanos.io/tip/tracing.md/#configuration
+                           https://thanos.io/tip/thanos/tracing.md/#configuration
       --tracing.config=<content>
                            Alternative to 'tracing.config-file' flag (lower
                            priority). Content of YAML file with tracing
                            configuration. See format details:
-                           https://thanos.io/tip/tracing.md/#configuration
+                           https://thanos.io/tip/thanos/tracing.md/#configuration
       --objstore.config-file=<file-path>
                            Path to YAML file that contains object store
                            configuration. See format details:
@@ -324,12 +324,12 @@ Flags:
       --tracing.config-file=<file-path>
                            Path to YAML file with tracing configuration. See
                            format details:
-                           https://thanos.io/tip/tracing.md/#configuration
+                           https://thanos.io/tip/thanos/tracing.md/#configuration
       --tracing.config=<content>
                            Alternative to 'tracing.config-file' flag (lower
                            priority). Content of YAML file with tracing
                            configuration. See format details:
-                           https://thanos.io/tip/tracing.md/#configuration
+                           https://thanos.io/tip/thanos/tracing.md/#configuration
       --objstore.config-file=<file-path>
                            Path to YAML file that contains object store
                            configuration. See format details:
@@ -371,12 +371,12 @@ Flags:
       --tracing.config-file=<file-path>
                              Path to YAML file with tracing configuration. See
                              format details:
-                             https://thanos.io/tip/tracing.md/#configuration
+                             https://thanos.io/tip/thanos/tracing.md/#configuration
       --tracing.config=<content>
                              Alternative to 'tracing.config-file' flag (lower
                              priority). Content of YAML file with tracing
                              configuration. See format details:
-                             https://thanos.io/tip/tracing.md/#configuration
+                             https://thanos.io/tip/thanos/tracing.md/#configuration
       --objstore.config-file=<file-path>
                              Path to YAML file that contains object store
                              configuration. See format details:
@@ -426,12 +426,12 @@ Flags:
       --tracing.config-file=<file-path>
                                  Path to YAML file with tracing configuration.
                                  See format details:
-                                 https://thanos.io/tip/tracing.md/#configuration
+                                 https://thanos.io/tip/thanos/tracing.md/#configuration
       --tracing.config=<content>
                                  Alternative to 'tracing.config-file' flag
                                  (lower priority). Content of YAML file with
                                  tracing configuration. See format details:
-                                 https://thanos.io/tip/tracing.md/#configuration
+                                 https://thanos.io/tip/thanos/tracing.md/#configuration
       --objstore.config-file=<file-path>
                                  Path to YAML file that contains object store
                                  configuration. See format details:
@@ -503,12 +503,12 @@ Flags:
       --tracing.config-file=<file-path>
                               Path to YAML file with tracing configuration. See
                               format details:
-                              https://thanos.io/tip/tracing.md/#configuration
+                              https://thanos.io/tip/thanos/tracing.md/#configuration
       --tracing.config=<content>
                               Alternative to 'tracing.config-file' flag (lower
                               priority). Content of YAML file with tracing
                               configuration. See format details:
-                              https://thanos.io/tip/tracing.md/#configuration
+                              https://thanos.io/tip/thanos/tracing.md/#configuration
       --objstore.config-file=<file-path>
                               Path to YAML file that contains object store
                               configuration. See format details:
@@ -558,12 +558,12 @@ Flags:
       --tracing.config-file=<file-path>
                            Path to YAML file with tracing configuration. See
                            format details:
-                           https://thanos.io/tip/tracing.md/#configuration
+                           https://thanos.io/tip/thanos/tracing.md/#configuration
       --tracing.config=<content>
                            Alternative to 'tracing.config-file' flag (lower
                            priority). Content of YAML file with tracing
                            configuration. See format details:
-                           https://thanos.io/tip/tracing.md/#configuration
+                           https://thanos.io/tip/thanos/tracing.md/#configuration
       --rules=RULES ...    The rule files glob to check (repeated).
 
 ```


### PR DESCRIPTION
…ume@gmail.com

Signed-off-by: Oghenebrume50 <raphlbrume@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes
Following this issue #3135 I discovered that the broken link(https://thanos.io/tip/tracing.md/#configuration) reflects in other parts of the documentation I changed it to https://thanos.io/tip/thanos/tracing.md/#configuration which works perfectly well, 

This PR doesn't fix #3135 but it was inspired by it

## Verification

<!-- How you tested it? How do you know it works? -->
I ran `make web-serve` and the correct link shows up properly
