### PR TITLE
Compact: Fix web.prefix-header to use &wc.prefixHeaderName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 
 ### Added
 
+- [#3184](https://github.com/thanos-io/thanos/pull/3184) Compact: Fix web.prefix-header to use &wc.prefixHeaderName
 - [#3181](https://github.com/thanos-io/thanos/pull/3181) Logging: Add debug level logging for responses between 300-399
 - [#3133](https://github.com/thanos-io/thanos/pull/3133) Query: Allow passing a `storeMatch[]` to Labels APIs. Also time range metadata based store filtering is supported on Labels APIs.
 - [#3154](https://github.com/thanos-io/thanos/pull/3154) Query Frontend: Add metric `thanos_memcached_getmulti_gate_queries_max`.

--- a/cmd/thanos/config.go
+++ b/cmd/thanos/config.go
@@ -153,6 +153,6 @@ func (wc *webConfig) registerFlag(cmd extkingpin.FlagClause) *webConfig {
 		"Static prefix for all HTML links and redirect URLs in the bucket web UI interface. Actual endpoints are still served on / or the web.route-prefix. This allows thanos bucket web UI to be served behind a reverse proxy that strips a URL sub-path.").
 		Default("").StringVar(&wc.externalPrefix)
 	cmd.Flag("web.prefix-header", "Name of HTTP request header used for dynamic prefixing of UI links and redirects. This option is ignored if web.external-prefix argument is set. Security risk: enable this option only if a reverse proxy in front of thanos is resetting the header. The --web.prefix-header=X-Forwarded-Prefix option can be useful, for example, if Thanos UI is served via Traefik reverse proxy with PathPrefixStrip option enabled, which sends the stripped prefix value in X-Forwarded-Prefix header. This allows thanos UI to be served on a sub-path.").
-		Default("").StringVar(&wc.externalPrefix)
+		Default("").StringVar(&wc.prefixHeaderName)
 	return wc
 }


### PR DESCRIPTION
Signed-off-by: Daksh Sagar <daksh.sagar@yahoo.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->
Fix web.prefix-header to use `&wc.prefixHeaderName` instead of `&wc.externalPrefix`

Fixes #3156 

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes
`cmd/thanos/config.go` in `registerFlag` method, make cmd.Flag("web.prefix-header", "...", "...") use the `prefixHeaderName`  field instead of `externalPrefix`
<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
