### PR TITLE
query-frontend: Update documentation for query-fronted in-memory cache

### DIFF
--- a/docs/components/query-frontend.md
+++ b/docs/components/query-frontend.md
@@ -58,6 +58,14 @@ config:
   max_size_items: 0
   validity: 0s
 ```
+`max_size: ` Maximum memory size of the cache in bytes. A unit suffix (KB, MB, GB) may be applied.
+
+**_NOTE:** If both `max_size` and `max_size_items` are not set, then the *cache* would not be created.
+
+If either of `max_size` or `max_size_items` is set, then there is not limit on other field.
+For example - only set `max_size_item` to 1000, then `max_size` is unlimited. Similarly, if only `max_size` is set, then `max_size_items` is unlimited.
+
+Example configuration: [kube-thanos](https://github.com/thanos-io/kube-thanos/blob/master/examples/all/manifests/thanos-query-frontend-deployment.yaml#L50-L54)
 
 #### Memcached
 


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->
query-frontend: Add the documentation about the in memory cache config in  `docs/components/query-frontend.md`

Fixes #3189 
<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->
Update documentation for the in-memory cache config.
## Verification

<!-- How you tested it? How do you know it works? -->
ran `make web-serve` locally