### PR TITLE
chore: Include half-open block maxtime for labels API

### DIFF
--- a/pkg/store/proxy.go
+++ b/pkg/store/proxy.go
@@ -511,7 +511,7 @@ func (s *streamSeriesSet) Err() error {
 // matchers.
 func storeMatches(s Client, mint, maxt int64, storeMatcher [][]storepb.LabelMatcher, matchers ...storepb.LabelMatcher) (bool, error) {
 	storeMinTime, storeMaxTime := s.TimeRange()
-	if mint > storeMaxTime || maxt < storeMinTime {
+	if mint > storeMaxTime || maxt <= storeMinTime {
 		return false, nil
 	}
 	match, err := storeMatchMetadata(s, storeMatcher)

--- a/pkg/store/proxy_test.go
+++ b/pkg/store/proxy_test.go
@@ -1399,7 +1399,15 @@ func TestStoreMatches(t *testing.T) {
 			ms: []storepb.LabelMatcher{
 				{Type: storepb.LabelMatcher_EQ, Name: "b", Value: "1"},
 			},
-			ok: true,
+			ok: false,
+		},
+		{
+			s: &testClient{labelSets: []storepb.LabelSet{{Labels: []storepb.Label{{Name: "a", Value: "b"}}}}},
+			ms: []storepb.LabelMatcher{
+				{Type: storepb.LabelMatcher_EQ, Name: "b", Value: "1"},
+			},
+			maxt: 1,
+			ok:   true,
 		},
 		{
 			s:    &testClient{minTime: 100, maxTime: 200},
@@ -1416,13 +1424,13 @@ func TestStoreMatches(t *testing.T) {
 		{
 			s:    &testClient{minTime: 100, maxTime: 200},
 			mint: 50,
-			maxt: 99,
+			maxt: 100,
 			ok:   false,
 		},
 		{
 			s:    &testClient{minTime: 100, maxTime: 200},
 			mint: 50,
-			maxt: 100,
+			maxt: 101,
 			ok:   true,
 		},
 		{
@@ -1430,28 +1438,32 @@ func TestStoreMatches(t *testing.T) {
 			ms: []storepb.LabelMatcher{
 				{Type: storepb.LabelMatcher_EQ, Name: "a", Value: "b"},
 			},
-			ok: true,
+			maxt: 1,
+			ok:   true,
 		},
 		{
 			s: &testClient{labelSets: []storepb.LabelSet{{Labels: []storepb.Label{{Name: "a", Value: "b"}}}}},
 			ms: []storepb.LabelMatcher{
 				{Type: storepb.LabelMatcher_EQ, Name: "a", Value: "c"},
 			},
-			ok: false,
+			maxt: 1,
+			ok:   false,
 		},
 		{
 			s: &testClient{labelSets: []storepb.LabelSet{{Labels: []storepb.Label{{Name: "a", Value: "b"}}}}},
 			ms: []storepb.LabelMatcher{
 				{Type: storepb.LabelMatcher_RE, Name: "a", Value: "b|c"},
 			},
-			ok: true,
+			maxt: 1,
+			ok:   true,
 		},
 		{
 			s: &testClient{labelSets: []storepb.LabelSet{{Labels: []storepb.Label{{Name: "a", Value: "b"}}}}},
 			ms: []storepb.LabelMatcher{
 				{Type: storepb.LabelMatcher_NEQ, Name: "a", Value: ""},
 			},
-			ok: true,
+			maxt: 1,
+			ok:   true,
 		},
 		{
 			s: &testClient{labelSets: []storepb.LabelSet{
@@ -1462,7 +1474,8 @@ func TestStoreMatches(t *testing.T) {
 			ms: []storepb.LabelMatcher{
 				{Type: storepb.LabelMatcher_EQ, Name: "a", Value: "e"},
 			},
-			ok: false,
+			maxt: 1,
+			ok:   false,
 		},
 		{
 			s: &testClient{labelSets: []storepb.LabelSet{
@@ -1473,7 +1486,8 @@ func TestStoreMatches(t *testing.T) {
 			ms: []storepb.LabelMatcher{
 				{Type: storepb.LabelMatcher_EQ, Name: "a", Value: "c"},
 			},
-			ok: true,
+			maxt: 1,
+			ok:   true,
 		},
 		{
 			s: &testClient{labelSets: []storepb.LabelSet{
@@ -1484,7 +1498,8 @@ func TestStoreMatches(t *testing.T) {
 			ms: []storepb.LabelMatcher{
 				{Type: storepb.LabelMatcher_NEQ, Name: "a", Value: ""},
 			},
-			ok: true,
+			maxt: 1,
+			ok:   true,
 		},
 	}
 


### PR DESCRIPTION
Signed-off-by: Ben Ye <yb532204897@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

TSDB block time range is half open, which is [b.meta.MinTime, b.meta.MaxTime). So when checking whether a block time is  overlapped with a time range, we can include the max time case. Added a `overlapsClosedInterval` method for the block which is the same as https://github.com/prometheus/prometheus/blob/b521612042/tsdb/block.go#L615.

## Verification

<!-- How you tested it? How do you know it works? -->
