### PR TITLE
change from switch case to if else with a check on the url path suffix

### DIFF
--- a/pkg/queryfrontend/roundtrip.go
+++ b/pkg/queryfrontend/roundtrip.go
@@ -5,9 +5,9 @@ package queryfrontend
 
 import (
 	"net/http"
-	"time"
 	"strings"
-	
+	"time"
+
 	"github.com/cortexproject/cortex/pkg/querier/frontend"
 	"github.com/cortexproject/cortex/pkg/querier/queryrange"
 	"github.com/cortexproject/cortex/pkg/util/validation"

--- a/pkg/queryfrontend/roundtrip.go
+++ b/pkg/queryfrontend/roundtrip.go
@@ -6,7 +6,8 @@ package queryfrontend
 import (
 	"net/http"
 	"time"
-
+	"strings"
+	
 	"github.com/cortexproject/cortex/pkg/querier/frontend"
 	"github.com/cortexproject/cortex/pkg/querier/queryrange"
 	"github.com/cortexproject/cortex/pkg/util/validation"
@@ -15,7 +16,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-	"strings"
 )
 
 const (

--- a/pkg/queryfrontend/roundtrip.go
+++ b/pkg/queryfrontend/roundtrip.go
@@ -15,6 +15,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	"strings"
 )
 
 const (
@@ -103,17 +104,15 @@ func NewTripperware(
 	return func(next http.RoundTripper) http.RoundTripper {
 		queryRangeTripper := queryrange.NewRoundTripper(next, codec, queryRangeMiddleware...)
 		return frontend.RoundTripFunc(func(r *http.Request) (*http.Response, error) {
-			switch r.URL.Path {
-			case "/api/v1/query":
+			if strings.HasSuffix(r.URL.Path, "/api/v1/query") {
 				if r.Method == http.MethodGet || r.Method == http.MethodPost {
 					queriesCount.WithLabelValues(labelQuery).Inc()
 				}
-			case "/api/v1/query_range":
+			} else if strings.HasSuffix(r.URL.Path, "/api/v1/query_range") {
 				if r.Method == http.MethodGet || r.Method == http.MethodPost {
 					queriesCount.WithLabelValues(labelQueryRange).Inc()
 					return queryRangeTripper.RoundTrip(r)
 				}
-			default:
 			}
 			return next.RoundTrip(r)
 		})


### PR DESCRIPTION
Signed-off-by: Oghenebrume50 <raphlbrume@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes
Changed the check on the exact matching part for the URL to a match on a specified suffix

## Verification
I queried the API using this `curl "http://localhost:9093/thanos/api/v1/query_range?query=time()&dedup=true&partial_response=true&start=1600269819.107&end=1600273419.107&step=14&max_source_resolution=0s&_=1600273386626"` and got an okay response. 

I am not exactly sure if this is the correct solution for this but I am open to better clarification

