### PR TITLE
Handling of bare path prefix in Querier

### DIFF
--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -421,6 +421,9 @@ func runQuery(
 			router.Get("/", func(w http.ResponseWriter, r *http.Request) {
 				http.Redirect(w, r, webRoutePrefix, http.StatusFound)
 			})
+			router.Get(webRoutePrefix, func(w http.ResponseWriter, r *http.Request) {
+				http.Redirect(w, r, webRoutePrefix+"/graph", http.StatusFound)
+			})
 			router = router.WithPrefix(webRoutePrefix)
 		}
 

--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -419,7 +419,7 @@ func runQuery(
 		// Redirect from / to /webRoutePrefix.
 		if webRoutePrefix != "/" {
 			router.Get("/", func(w http.ResponseWriter, r *http.Request) {
-				http.Redirect(w, r, webRoutePrefix, http.StatusFound)
+				http.Redirect(w, r, webRoutePrefix+"/graph", http.StatusFound)
 			})
 			router.Get(webRoutePrefix, func(w http.ResponseWriter, r *http.Request) {
 				http.Redirect(w, r, webRoutePrefix+"/graph", http.StatusFound)


### PR DESCRIPTION
Signed-off-by: aribalam <arib.alam.iitkgp@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->
Fixes #3180 

The details of the approach are given in [this comment](https://github.com/thanos-io/thanos/issues/3180#issuecomment-696401479).

## Verification

<!-- How you tested it? How do you know it works? -->

Setup: 

```
$ thanos query --http-address=127.0.0.1:9092 --web.route-prefix=thanos --web.external-prefix=thanos
$ thanos query-frontend --http-address=127.0.0.1:9093 --query-frontend.compress-responses --query-frontend.downstream-url=http://127.0.0.1:9092 --query-range.split-interval=24h --query-range.max-retries-per-request=5
```

The following request was made -

```
$ curl -iL --max-redirs 3 http://localhost:9093/thanos
TTP/1.1 302 Found
Content-Length: 36
Content-Type: text/html; charset=utf-8
Date: Mon, 21 Sep 2020 22:04:28 GMT
Location: /thanos/graph
Vary: Accept-Encoding
Vary: Accept-Encoding

HTTP/1.1 200 OK
Content-Type: text/html; charset=utf-8
Date: Mon, 21 Sep 2020 22:04:28 GMT
Vary: Accept-Encoding
Vary: Accept-Encoding
Transfer-Encoding: chunked

<!DOCTYPE html>
<html lang="en">
<-- truncated -->
</html>
```