### PR TITLE
receive: relax quorum for 2 replicas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#3154](https://github.com/thanos-io/thanos/pull/3154) Querier: Add metric `thanos_query_gate_queries_max`. Remove metric `thanos_query_concurrent_selects_gate_queries_in_flight`.
 - [#3154](https://github.com/thanos-io/thanos/pull/3154) Store: Rename metric `thanos_bucket_store_queries_concurrent_max` to `thanos_bucket_store_series_gate_queries_max`.
 - [#3179](https://github.com/thanos-io/thanos/pull/3179) Store: context.Canceled will not increase `thanos_objstore_bucket_operation_failures_total`.
+- [#3231](https://github.com/thanos-io/thanos/pull/3231) Receive: fix remote-write error in case one of `--receive.replication-factor=2` replicas is down.
 
 ## [v0.15.0](https://github.com/thanos-io/thanos/releases) - 2020.09.07
 

--- a/pkg/receive/handler.go
+++ b/pkg/receive/handler.go
@@ -383,6 +383,10 @@ func (h *Handler) forward(ctx context.Context, tenant string, r replica, wreq *p
 
 // writeQuorum returns minimum number of replicas that has to confirm write success before claiming replication success.
 func (h *Handler) writeQuorum() int {
+	// special case for 2 replicas: to be available when one replica down (#3194)
+	if h.options.ReplicationFactor == 2 {
+		return 1
+	}
 	return int((h.options.ReplicationFactor / 2) + 1)
 }
 


### PR DESCRIPTION
Signed-off-by: Alexander Ryabov <alexander.ryabov@jetbrains.com>

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Fixes https://github.com/thanos-io/thanos/issues/3194

## Verification

Tests added. Also, we have working 2-node installation with the same patch.
