### PR TITLE
React-ui: Display statistics in Block viewer

### DIFF
--- a/pkg/ui/react-app/src/thanos/pages/blocks/Blocks.tsx
+++ b/pkg/ui/react-app/src/thanos/pages/blocks/Blocks.tsx
@@ -22,9 +22,18 @@ export interface BlockListProps {
 export const BlocksContent: FC<{ data: BlockListProps }> = ({ data }) => {
   const [selectedBlock, selectBlock] = useState<Block>();
 
-  const { blocks, label, err } = data;
+  const { blocks, label, err, refreshedAt } = data;
 
   const blockPools = useMemo(() => sortBlocks(blocks, label), [blocks, label]);
+
+  const blocksCount: { [key: string]: number } = {};
+
+  Object.keys(blockPools).forEach(key => {
+    Object.values(blockPools[key]).forEach(list => {
+      blocksCount[key] = blocksCount[key] ? blocksCount[key] + list.length : list.length;
+    });
+  });
+
   const [gridMinTime, gridMaxTime] = useMemo(() => {
     if (!err && blocks.length > 0) {
       let gridMinTime = blocks[0].minTime;
@@ -59,30 +68,37 @@ export const BlocksContent: FC<{ data: BlockListProps }> = ({ data }) => {
   return (
     <>
       {blocks.length > 0 ? (
-        <div className={styles.container}>
-          <div className={styles.grid}>
-            <div className={styles.sources}>
-              {Object.keys(blockPools).map(pk => (
-                <SourceView
-                  key={pk}
-                  data={blockPools[pk]}
-                  title={pk}
-                  selectBlock={selectBlock}
-                  gridMinTime={viewMinTime}
-                  gridMaxTime={viewMaxTime}
-                />
-              ))}
-            </div>
-            <TimeRange
-              gridMinTime={gridMinTime}
-              gridMaxTime={gridMaxTime}
-              viewMinTime={viewMinTime}
-              viewMaxTime={viewMaxTime}
-              onChange={setViewTime}
-            />
+        <>
+          <div className={styles.stats}>
+            <span>Refreshed at: {new Date(refreshedAt).toLocaleString()}</span>
+            <span> Total blocks: {blocks.length}</span>
           </div>
-          <BlockDetails selectBlock={selectBlock} block={selectedBlock} />
-        </div>
+          <div className={styles.container}>
+            <div className={styles.grid}>
+              <div className={styles.sources}>
+                {Object.keys(blockPools).map(pk => (
+                  <SourceView
+                    key={pk}
+                    data={blockPools[pk]}
+                    title={pk}
+                    selectBlock={selectBlock}
+                    gridMinTime={viewMinTime}
+                    gridMaxTime={viewMaxTime}
+                    blocksCount={blocksCount}
+                  />
+                ))}
+              </div>
+              <TimeRange
+                gridMinTime={gridMinTime}
+                gridMaxTime={gridMaxTime}
+                viewMinTime={viewMinTime}
+                viewMaxTime={viewMaxTime}
+                onChange={setViewTime}
+              />
+            </div>
+            <BlockDetails selectBlock={selectBlock} block={selectedBlock} />
+          </div>
+        </>
       ) : (
         <UncontrolledAlert color="warning">No blocks found.</UncontrolledAlert>
       )}

--- a/pkg/ui/react-app/src/thanos/pages/blocks/SourceView.test.tsx
+++ b/pkg/ui/react-app/src/thanos/pages/blocks/SourceView.test.tsx
@@ -16,12 +16,13 @@ describe('Blocks SourceView', () => {
     },
     gridMinTime: 1596096000000,
     gridMaxTime: 1595108031471,
+    blocksCount: {},
   };
 
   const sourceView = mount(<SourceView {...defaultProps} />);
 
   it('renders a paragraph with title', () => {
-    const title = sourceView.find('div > span');
+    const title = sourceView.find('div > span').first();
     expect(title).toHaveLength(1);
     expect(title.text()).toEqual(source);
   });

--- a/pkg/ui/react-app/src/thanos/pages/blocks/SourceView.tsx
+++ b/pkg/ui/react-app/src/thanos/pages/blocks/SourceView.tsx
@@ -24,14 +24,16 @@ export interface SourceViewProps {
   gridMinTime: number;
   gridMaxTime: number;
   selectBlock: React.Dispatch<React.SetStateAction<Block | undefined>>;
+  blocksCount: { [key: string]: number };
 }
 
-export const SourceView: FC<SourceViewProps> = ({ data, title, gridMaxTime, gridMinTime, selectBlock }) => {
+export const SourceView: FC<SourceViewProps> = ({ data, title, gridMaxTime, gridMinTime, selectBlock, blocksCount }) => {
   return (
     <>
       <div className={styles.source}>
         <div className={styles.title} title={title}>
           <span>{title}</span>
+          <span>(blocks count: {blocksCount[title]})</span>
         </div>
         <div className={styles.rowsContainer}>
           {Object.keys(data).map(k => (

--- a/pkg/ui/react-app/src/thanos/pages/blocks/blocks.module.css
+++ b/pkg/ui/react-app/src/thanos/pages/blocks/blocks.module.css
@@ -103,6 +103,13 @@
   box-sizing: border-box;
 }
 
+.stats {
+  justify-content: space-evenly;
+  display: flex;
+  flex-flow: row nowrap;
+  margin-bottom: 1em;
+}
+
 .rowsContainer {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->
Related to #3112 
<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->
Display `refreshedAt`, `total blocks`, and `blocks in each group` in the Block viewer
## Verification

<!-- How you tested it? How do you know it works? -->
Checked it in the browser