### PR TITLE
ui: Fix assets not loading when `--web.prefix-header` is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 
 ### Fixed
 
-- [#3234](https://github.com/thanos-io/thanos/pull/3234) UI: Fix assets not loading when `--web.external-header` is used.
+- [#3234](https://github.com/thanos-io/thanos/pull/3234) UI: Fix assets not loading when `--web.prefix-header` is used.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,13 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 
 ## Unreleased
 
-- [#3032](https://github.com/thanos-io/thanos/pull/3032) Query Frontend: Added support for Memacahce cache. Replaced underscores with hyphens in `log_queries_longer_than - > log-queries-longer-than`.
+### Fixed
+
+- [#3234](https://github.com/thanos-io/thanos/pull/3234) UI: Fix assets not loading when `--web.external-header` is used.
 
 ### Added
 
+- [#3032](https://github.com/thanos-io/thanos/pull/3032) Query Frontend: Added support for Memacahce cache. Replaced underscores with hyphens in `log_queries_longer_than - > log-queries-longer-than`.
 - [#3166](https://github.com/thanos-io/thanos/pull/3166) UIs: Added UI for passing a `storeMatch[]` parameter to queries.
 - [#3184](https://github.com/thanos-io/thanos/pull/3184) Compact: Fix web.prefix-header to use &wc.prefixHeaderName
 - [#3181](https://github.com/thanos-io/thanos/pull/3181) Logging: Add debug level logging for responses between 300-399

--- a/pkg/ui/ui.go
+++ b/pkg/ui/ui.go
@@ -158,7 +158,7 @@ func absolutePrefix(prefix string) func() string {
 		if prefix == "" {
 			return ""
 		}
-		return "/" + prefix
+		return path.Join("/", prefix)
 	}
 }
 


### PR DESCRIPTION
* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes
- Fix UI not working when using `--web.prefix-header` to set external prefix. Fixes #3226 

This was caused by incorrect handling of the prefix value we got from the header. If the header had `/` as a suffix, we were still adding another `/` as a suffix to it, resulting in `//prefix` which translates to an external network request.

## Verification
Tested it using a reverse proxy with prefix-stripping and the header `X-Forwarded-Prefix` set.
