### PR TITLE
ui: Fix labelSets in Stores page

### DIFF
--- a/pkg/ui/react-app/src/thanos/pages/stores/StoreLabels.tsx
+++ b/pkg/ui/react-app/src/thanos/pages/stores/StoreLabels.tsx
@@ -7,10 +7,10 @@ export type StoreLabelsProps = { labelSets: Labels[] };
 export const StoreLabels: FC<StoreLabelsProps> = ({ labelSets }) => {
   return (
     <ListGroup>
-      {labelSets.map(({ labels }, idx) => (
+      {labelSets.map((labels, idx) => (
         <ListGroupItem key={idx}>
-          {labels.map(label => (
-            <Badge key={label.name} color="primary" style={{ margin: '0px 5px' }}>{`${label.name}="${label.value}"`}</Badge>
+          {Object.entries(labels).map(([name, value]) => (
+            <Badge key={name} color="primary" style={{ margin: '0px 5px' }}>{`${name}="${value}"`}</Badge>
           ))}
         </ListGroupItem>
       ))}

--- a/pkg/ui/react-app/src/thanos/pages/stores/__testdata__/testdata.ts
+++ b/pkg/ui/react-app/src/thanos/pages/stores/__testdata__/testdata.ts
@@ -7,24 +7,10 @@ export const sampleAPIResponse: { status: string; data: StoreListProps } = {
       {
         labelSets: [
           {
-            labels: [
-              {
-                name: 'monitor',
-                value: 'prometheus_one',
-              },
-            ],
+            monitor: 'prometheus_one',
           },
           {
-            labels: [
-              {
-                name: 'monitor',
-                value: 'prometheus_one',
-              },
-              {
-                name: 'source',
-                value: 'Thanos',
-              },
-            ],
+            monitor: 'prometheus_two',
           },
         ],
         lastCheck: '2020-06-14T15:17:38.588378384Z',
@@ -46,68 +32,26 @@ export const sampleAPIResponse: { status: string; data: StoreListProps } = {
       {
         labelSets: [
           {
-            labels: [
-              {
-                name: 'monitor',
-                value: 'prometheus_one',
-              },
-            ],
+            monitor: 'prometheus_one',
           },
           {
-            labels: [
-              {
-                name: 'monitor',
-                value: 'prometheus_one',
-              },
-              {
-                name: 'source',
-                value: 'Thanos',
-              },
-            ],
+            monitor: 'prometheus_one',
+            source: 'Thanos',
           },
           {
-            labels: [
-              {
-                name: 'monitor',
-                value: 'prometheus_one',
-              },
-              {
-                name: 'source',
-                value: 'Thanos1',
-              },
-            ],
+            monitor: 'prometheus_one',
+            source: 'Thanos1',
           },
           {
-            labels: [
-              {
-                name: 'monitor',
-                value: 'prometheus_two',
-              },
-            ],
+            monitor: 'prometheus_two',
           },
           {
-            labels: [
-              {
-                name: 'monitor',
-                value: 'prometheus_two',
-              },
-              {
-                name: 'source',
-                value: 'Thanos',
-              },
-            ],
+            monitor: 'prometheus_two',
+            source: 'Thanos',
           },
           {
-            labels: [
-              {
-                name: 'monitor',
-                value: 'prometheus_two',
-              },
-              {
-                name: 'source',
-                value: 'Thanos2',
-              },
-            ],
+            monitor: 'prometheus_two',
+            source: 'Thanos2',
           },
         ],
         lastCheck: '2020-06-14T15:17:38.588246826Z',

--- a/pkg/ui/react-app/src/thanos/pages/stores/store.ts
+++ b/pkg/ui/react-app/src/thanos/pages/stores/store.ts
@@ -1,11 +1,4 @@
-export interface Label {
-  name: string;
-  value: string;
-}
-
-export interface Labels {
-  labels: Label[];
-}
+export type Labels = Record<string, string>;
 
 export interface Store {
   name: string;

--- a/pkg/ui/react-app/yarn.lock
+++ b/pkg/ui/react-app/yarn.lock
@@ -2902,9 +2902,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001020, caniuse-lite@^1.0.30001035:
-  version "1.0.30001035"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001035.tgz#2bb53b8aa4716b2ed08e088d4dc816a5fe089a1e"
-  integrity sha512-C1ZxgkuA4/bUEdMbU5WrGY4+UhMFFiXrgNAfxiMIqWgFTWfv/xsZCS2xEHT2LMq7xAZfuAnu6mcqyDl0ZR6wLQ==
+  version "1.0.30001137"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001137.tgz"
+  integrity sha512-54xKQZTqZrKVHmVz0+UvdZR6kQc7pJDgfhsMYDG19ID1BWoNnDMFm5Q3uSBSU401pBvKYMsHAt9qhEDcxmk8aw==
 
 capture-exit@^2.0.0:
   version "2.0.0"

--- a/pkg/ui/templates/stores.html
+++ b/pkg/ui/templates/stores.html
@@ -39,7 +39,7 @@
                 {{range $labelSets := $store.LabelSets}}
                 <tr>
                     <td>
-                    {{range $label := $labelSets.Labels}}
+                    {{range $label := $labelSets}}
                         <span class="badge badge-primary">{{$label.Name}}="{{$label.Value}}"</span>
                     {{end}}
                     </td>


### PR DESCRIPTION
Signed-off-by: Prem Kumar <prmsrswt@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

#2783 modified the `LabelSets` field of struct `StoreStatus` in `/pkg/query/storeset.go`, which broke the `stores.html` template for old UI and it also changed the structure of it's marshaled JSON, which resulted in the crashing of Stores page in new UI as well.

## Changes
- Update the Stores page in both old UI and new UI to match the modified struct.

## Verification
All React unit tests passed with the new response. Also tested manually.
