### PR TITLE
query-frontend: Extract org id from from request headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#3398](https://github.com/thanos-io/thanos/pull/3398) Query Frontend: Add default config for query frontend memcached config.
 - [#3277](https://github.com/thanos-io/thanos/pull/3277) Thanos Query: Introduce dynamic lookback interval. This allows queries with large step to make use of downsampled data.
 - [#3409](https://github.com/thanos-io/thanos/pull/3409) Compactor: Added support for no-compact-mark.json which excludes the block from compaction.
+- [#3245](https://github.com/thanos-io/thanos/pull/3245) Query Frontend: Add `query-frontend.org-id-header` flag to specify HTTP header(s) to populate slow query log (e.g. X-Grafana-User).
 
 ### Fixed
 

--- a/cmd/thanos/query_frontend.go
+++ b/cmd/thanos/query_frontend.go
@@ -242,10 +242,7 @@ func runQueryFrontend(
 	return nil
 }
 
-func extractOrgId(
-	conf *queryFrontendConfig,
-	r *http.Request,
-) string {
+func extractOrgId(conf *queryFrontendConfig, r *http.Request) string {
 	for _, header := range conf.orgIdHeaders {
 		headerVal := r.Header.Get(header)
 		if headerVal != "" {

--- a/cmd/thanos/query_frontend.go
+++ b/cmd/thanos/query_frontend.go
@@ -116,7 +116,8 @@ func registerQueryFrontend(app *extkingpin.App) {
 	cmd.Flag("query-frontend.log-queries-longer-than", "Log queries that are slower than the specified duration. "+
 		"Set to 0 to disable. Set to < 0 to enable on all queries.").Default("0").DurationVar(&cfg.CortexFrontendConfig.LogQueriesLongerThan)
 
-	cmd.Flag("query-frontend.org-id-header", "Request header names used to set the org id field in the slow query log (repeated flag). "+
+	cmd.Flag("query-frontend.org-id-header", "Request header names used to identify the source of slow queries (repeated flag). "+
+		"The values of the header will be added to the org id field in the slow query log. "+
 		"If multiple headers match the request, the first matching arg specified will take precedence. "+
 		"If no headers match 'anonymous' will be used.").PlaceHolder("<http-header-name>").StringsVar(&cfg.orgIdHeaders)
 

--- a/cmd/thanos/query_frontend.go
+++ b/cmd/thanos/query_frontend.go
@@ -36,7 +36,7 @@ import (
 type queryFrontendConfig struct {
 	http httpConfig
 	queryfrontend.Config
-	orgIdHeaders         []string
+	orgIdHeaders []string
 }
 
 func registerQueryFrontend(app *extkingpin.App) {

--- a/cmd/thanos/query_frontend_test.go
+++ b/cmd/thanos/query_frontend_test.go
@@ -1,0 +1,46 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package main
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/thanos-io/thanos/pkg/testutil"
+)
+
+func Test_extractOrgId(t *testing.T) {
+	var testData = []struct {
+		configuredHeaders []string
+		requestHeaders    map[string]string
+		expectOrgId       string
+	}{
+		{
+			configuredHeaders: []string{"x-grafana-user", "x-server-id"},
+			requestHeaders:    map[string]string{"x-grafana-user": "imagrafanauser", "x-server-id": "iamserverid"},
+			expectOrgId:       "imagrafanauser",
+		},
+		{
+			configuredHeaders: []string{"x-server-id", "x-grafana-user"},
+			requestHeaders:    map[string]string{"x-grafana-user": "imagrafanauser", "x-server-id": "iamserverid"},
+			expectOrgId:       "iamserverid",
+		},
+		{
+			configuredHeaders: []string{},
+			requestHeaders:    map[string]string{"another-header": "another"},
+			expectOrgId:       "anonymous",
+		},
+	}
+	for _, data := range testData {
+		config := queryFrontendConfig{
+			orgIdHeaders: data.configuredHeaders,
+		}
+		req, _ := http.NewRequest("", "", nil)
+		for k, v := range data.requestHeaders {
+			req.Header.Set(k, v)
+		}
+		id := extractOrgId(&config, req)
+		testutil.Equals(t, data.expectOrgId, id)
+	}
+}

--- a/docs/components/query-frontend.md
+++ b/docs/components/query-frontend.md
@@ -222,12 +222,12 @@ Flags:
                                  Log queries that are slower than the specified
                                  duration. Set to 0 to disable. Set to < 0 to
                                  enable on all queries.
-      --query-frontend.org-id-header="org-id-header-name"
+      --query-frontend.org-id-header=<http-header-name> ...
                               Request header names used to set the org id field
-                              in the slow query log (repeated flag).  If
-                              multiple headers match the request, the first
-                              matching arg specified will take precedence.  If
-                              no headers match 'anonymous' will be used
+                              in the slow query log (repeated flag). If multiple
+                              headers match the request, the first matching arg
+                              specified will take precedence. If no headers
+                              match 'anonymous' will be used.
       --log.request.decision=LogFinishCall
                                  Request Logging for logging the start and end
                                  of requests. LogFinishCall is enabled by

--- a/docs/components/query-frontend.md
+++ b/docs/components/query-frontend.md
@@ -223,11 +223,13 @@ Flags:
                                  duration. Set to 0 to disable. Set to < 0 to
                                  enable on all queries.
       --query-frontend.org-id-header=<http-header-name> ...
-                                 Request header names used to set the org id
-                                 field in the slow query log (repeated flag). If
-                                 multiple headers match the request, the first
-                                 matching arg specified will take precedence. If
-                                 no headers match 'anonymous' will be used.
+                                 Request header names used to identify the
+                                 source of slow queries (repeated flag). The
+                                 values of the header will be added to the org
+                                 id field in the slow query log. If multiple
+                                 headers match the request, the first matching
+                                 arg specified will take precedence. If no
+                                 headers match 'anonymous' will be used.
       --log.request.decision=LogFinishCall
                                  Request Logging for logging the start and end
                                  of requests. LogFinishCall is enabled by

--- a/docs/components/query-frontend.md
+++ b/docs/components/query-frontend.md
@@ -223,11 +223,11 @@ Flags:
                                  duration. Set to 0 to disable. Set to < 0 to
                                  enable on all queries.
       --query-frontend.org-id-header=<http-header-name> ...
-                              Request header names used to set the org id field
-                              in the slow query log (repeated flag). If multiple
-                              headers match the request, the first matching arg
-                              specified will take precedence. If no headers
-                              match 'anonymous' will be used.
+                                 Request header names used to set the org id
+                                 field in the slow query log (repeated flag). If
+                                 multiple headers match the request, the first
+                                 matching arg specified will take precedence. If
+                                 no headers match 'anonymous' will be used.
       --log.request.decision=LogFinishCall
                                  Request Logging for logging the start and end
                                  of requests. LogFinishCall is enabled by

--- a/docs/components/query-frontend.md
+++ b/docs/components/query-frontend.md
@@ -222,6 +222,12 @@ Flags:
                                  Log queries that are slower than the specified
                                  duration. Set to 0 to disable. Set to < 0 to
                                  enable on all queries.
+      --query-frontend.org-id-header="org-id-header-name"
+                              Request header names used to set the org id field
+                              in the slow query log (repeated flag).  If
+                              multiple headers match the request, the first
+                              matching arg specified will take precedence.  If
+                              no headers match 'anonymous' will be used
       --log.request.decision=LogFinishCall
                                  Request Logging for logging the start and end
                                  of requests. LogFinishCall is enabled by


### PR DESCRIPTION
Signed-off-by: Neil Fordyce <neilfordyce@skyscanner.net>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes
1. Add `query-frontend.org-id-header` flag to specify HTTP header(s) to populate slow query log org_id field: Fixes #3177 
<!-- Enumerate changes you made -->

## Verification
Executed query-frontend pointed at a local querier with this configuration
`thanos query-frontend --http-address=127.0.0.1:9093 --query-frontend.downstream-url=http://localhost:9090 --query-frontend.log-queries-longer-than="-1s" --query-frontend.org-id-header="x-grafana-user" --query-frontend.org-id-header="x-scope-orgid"`

Ran query with expected headers
```
curl --request GET \
  --url 'http://localhost:9093/api/v1/query_range?query=up&dedup=true&partial_response=true&start=1594422000&end=1594508400&step=600&max_source_resolution=0s' \
  --header 'x-grafana-user: grafana-username'
```

grafana-username shows in org_id field of query frontend logs  
```
level=info ts=2020-09-28T13:11:22.645878Z caller=frontend.go:220 org_id=grafana-username msg="slow query detected" method=GET host=localhost:9093 path=/api/v1/query_range time_taken=811.734669ms param_dedup=true param_partial_response=true param_start=1594422000 param_end=1594508400 param_step=600 param_max_source_resolution=0s param_query=up
```

Further testing summary
| Input headers | org_id field contents | comment |
| -------------- | -------------------- | ---------- | 
| --header 'x-grafana-user: grafana-username' --header 'X-Scope-OrgId: another-org-id' | grafana-username | check first arg specified has precedence |
| --header 'X-Scope-OrgId: another-org-id' | another-org-id | check second arg works if first arg header not present |
| no headers | anonymous | check fallback if no headers match | 

  


<!-- How you tested it? How do you know it works? -->
