### PR TITLE
Fix bucket replicate file path in dashboards doc

### DIFF
--- a/examples/dashboards/dashboards.md
+++ b/examples/dashboards/dashboards.md
@@ -9,7 +9,7 @@ There exists Grafana dashboards for each component (not all of them complete) ta
 - [Thanos Receiver](receive.json)
 - [Thanos Sidecar](sidecar.json)
 - [Thanos Ruler](rule.json)
-- [Thanos Replicate](bucket_replicate.json)
+- [Thanos Replicate](bucket-replicate.json)
 
 You can import them via `Import -> Paste JSON` in Grafana.
 These dashboards require Grafana 5 or above, importing them in older versions are known not to work.


### PR DESCRIPTION
Signed-off-by: Ben Ye <yb532204897@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

The file name updated in https://github.com/thanos-io/thanos/pull/2781 and the doc should be updated as well.

Caught by our markdown checker.  https://github.com/thanos-io/thanos/pull/3245/checks?check_run_id=1177044878

## Verification

<!-- How you tested it? How do you know it works? -->
