### PR TITLE
Bucket Web UI: Added web.external-prefix to Bucket Web UI

### DIFF
--- a/cmd/thanos/tools_bucket.go
+++ b/cmd/thanos/tools_bucket.go
@@ -347,6 +347,8 @@ func registerBucketWeb(app extkingpin.AppClause, objStoreConfig *extflag.PathOrC
 		router := route.New()
 		ins := extpromhttp.NewInstrumentationMiddleware(reg)
 
+		router = router.WithPrefix("/" + strings.Trim(*webExternalPrefix, "/"))
+
 		bucketUI := ui.NewBucketUI(logger, *label, *webExternalPrefix, *webPrefixHeaderName, "", component.Bucket)
 		bucketUI.Register(router, true, ins)
 

--- a/cmd/thanos/tools_bucket.go
+++ b/cmd/thanos/tools_bucket.go
@@ -347,7 +347,9 @@ func registerBucketWeb(app extkingpin.AppClause, objStoreConfig *extflag.PathOrC
 		router := route.New()
 		ins := extpromhttp.NewInstrumentationMiddleware(reg)
 
-		router = router.WithPrefix("/" + strings.Trim(*webExternalPrefix, "/"))
+		if *webExternalPrefix != "" {
+			router = router.WithPrefix("/" + strings.Trim(*webExternalPrefix, "/"))
+		}
 
 		bucketUI := ui.NewBucketUI(logger, *label, *webExternalPrefix, *webPrefixHeaderName, "", component.Bucket)
 		bucketUI.Register(router, true, ins)

--- a/pkg/ui/templates/bucket_menu.html
+++ b/pkg/ui/templates/bucket_menu.html
@@ -11,7 +11,7 @@
                     <a class="nav-link" href="https://thanos.io/tip/thanos/getting-started.md/" target="_blank">Help</a>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link" href="/new/" target="_blank">New UI</a>
+                    <a class="nav-link" href="{{ pathPrefix }}/new/" target="_blank">New UI</a>
                 </li>
             </ul>
         </div>


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

Fixes #3211 

The router was not prefixed with the `webExternalPrefix` string before the routes for the Bucket Web UI was created. Moreover, the `bucket-menu.html` template was missing the `pathPrefix` in the link to new UI. 

The question remains, as to the Bucket Web UI should also support the `web.route-prefix` flag?

Also, the code for handling external prefixes and route prefix were becoming sort of repeating, with the same thing happening in querier too. Maybe we could create a function to the Base UI to automatically attach the required prefixes to the router.

@prmsrswt @bwplotka Any thoughts? 

## Verification

Started Bucket Web UI with `--web.external-prefix=thanos/bucket`. All links and assets were working fine.

<!-- How you tested it? How do you know it works? -->
