### PR TITLE
pkg/server/grpc: Register gRPC replection API

### DIFF
--- a/pkg/server/grpc/grpc.go
+++ b/pkg/server/grpc/grpc.go
@@ -22,6 +22,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
 	grpc_health "google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/reflection"
 	"google.golang.org/grpc/status"
 
 	"github.com/thanos-io/thanos/pkg/component"
@@ -94,6 +95,7 @@ func New(logger log.Logger, reg prometheus.Registerer, tracer opentracing.Tracer
 	reg.MustRegister(met)
 
 	grpc_health.RegisterHealthServer(s, probe.HealthServer())
+	reflection.Register(s)
 
 	return &Server{
 		logger: logger,


### PR DESCRIPTION
This is useful to have the gRPC server to be self describing. This could
for example be used to discover what capabilities a server has.

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

Add reflection API to grpc server instantiation.

## Verification

Ran

```
$ grpcurl -plaintext -v 127.0.0.1:10903 list
grpc.health.v1.Health
grpc.reflection.v1alpha.ServerReflection
thanos.Rules
thanos.Store
```

Against a local querier.

@thanos-io/thanos-maintainers 