### PR TITLE
Solve community contributing links

### DIFF
--- a/website/layouts/_default/baseof.html
+++ b/website/layouts/_default/baseof.html
@@ -76,7 +76,7 @@
                         <li><a class="text-reset" href="{{ "/tip/thanos/storage.md" | relURL }}">Storage</a></li>
                         <li><a class="text-reset" href="{{ "/tip/thanos/service-discovery.md" | relURL }}">Service Discovery</a></li>
                         <li><a class="text-reset" href="{{ "/tip/thanos/maintainers" | relURL }}">Maintainers</a></li>
-                        <li><a class="text-reset" href="{{ "/tip/contributing/contributing.md/" | relURL }}">Contributing</a></li>
+                        <li><a class="text-reset" href="{{ "/tip/contributing/contributing.md" | relURL }}">Contributing</a></li>
                     </ul>
                 </div>
                 <div class="col-12 col-md-6 col-lg">

--- a/website/layouts/_default/baseof.html
+++ b/website/layouts/_default/baseof.html
@@ -76,7 +76,7 @@
                         <li><a class="text-reset" href="{{ "/tip/thanos/storage.md" | relURL }}">Storage</a></li>
                         <li><a class="text-reset" href="{{ "/tip/thanos/service-discovery.md" | relURL }}">Service Discovery</a></li>
                         <li><a class="text-reset" href="{{ "/tip/thanos/maintainers" | relURL }}">Maintainers</a></li>
-                        <li><a class="text-reset" href="{{ "/tip/contributing.md" | relURL }}">Contributing</a></li>
+                        <li><a class="text-reset" href="{{ "/tip/contributing/contributing.md/" | relURL }}">Contributing</a></li>
                     </ul>
                 </div>
                 <div class="col-12 col-md-6 col-lg">

--- a/website/layouts/index.html
+++ b/website/layouts/index.html
@@ -15,7 +15,7 @@
                     </a>
                 </li>
                 <li class="list-inline-item my-3">
-                    <a href="{{ "/tip/contributing/community.md/" | relURL }}" class="btn btn-outline-secondary">
+                    <a href="{{ "/tip/contributing/community.md" | relURL }}" class="btn btn-outline-secondary">
                         <i class="fas fa-fw fa-comments"></i>&nbsp;Community
                     </a>
                 </li>

--- a/website/layouts/index.html
+++ b/website/layouts/index.html
@@ -15,7 +15,7 @@
                     </a>
                 </li>
                 <li class="list-inline-item my-3">
-                    <a href="{{ "/tip/community.md" | relURL }}" class="btn btn-outline-secondary">
+                    <a href="{{ "/tip/contributing/community.md/" | relURL }}" class="btn btn-outline-secondary">
                         <i class="fas fa-fw fa-comments"></i>&nbsp;Community
                     </a>
                 </li>


### PR DESCRIPTION
Fixes #3270

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes
- Changed the "Community" link on the landing page to direct to the /tip/contributing/community.md page.
- Changed the "Contributing" link on the landing page footer to direct to the /tip/contributing/contributing.md page.

## Verification
- I am unable to replicate locally 

