### PR TITLE
compact: Add a first pass of retention at the start of the compactor loop.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ We use _breaking :warning:_ to mark changes that are not backward compatible (re
 ### Changed
 
 - [#3705](https://github.com/thanos-io/thanos/pull/3705) Store: Fix race condition leading to failing queries or possibly incorrect query results.
+- [#3284](https://github.com/thanos-io/thanos/pull/3284) Retention policies are now applied at the start of the compactor loop. Retention policies that break downsampling are now logged as warnings.
 
 ## [v0.18.0](https://github.com/thanos-io/thanos/releases/tag/v0.18.0) - 2021.01.27
 
@@ -153,6 +154,14 @@ Highlights:
 - [#3122](https://github.com/thanos-io/thanos/pull/3122) \*: All Thanos components have now `/debug/fgprof` endpoint on HTTP port allowing to get [off-CPU profiles as well](https://github.com/felixge/fgprof).
 - [#3109](https://github.com/thanos-io/thanos/pull/3109) Query Frontend: Added support for `Cache-Control` HTTP response header which controls caching behaviour. So far `no-store` value is supported and it makes the response skip cache.
 - [#3092](https://github.com/thanos-io/thanos/pull/3092) Tools: Added `tools bucket cleanup` CLI tool that deletes all blocks marked to be deleted.
+||||||| parent of 4dc4ac45... Move retention at the start of the compactor loop.
+- [#3184](https://github.com/thanos-io/thanos/pull/3184) Compact: Fix web.prefix-header to use &wc.prefixHeaderName
+- [#3181](https://github.com/thanos-io/thanos/pull/3181) Logging: Add debug level logging for responses between 300-399
+- [#3133](https://github.com/thanos-io/thanos/pull/3133) Query: Allow passing a `storeMatch[]` to Labels APIs. Also time range metadata based store filtering is supported on Labels APIs.
+- [#3154](https://github.com/thanos-io/thanos/pull/3154) Query Frontend: Add metric `thanos_memcached_getmulti_gate_queries_max`.
+- [#3146](https://github.com/thanos-io/thanos/pull/3146) Sidecar: Add `thanos_sidecar_prometheus_store_received_frames` histogram metric.
+- [#3147](https://github.com/thanos-io/thanos/pull/3147) Querier: Add `query.metadata.default-time-range` flag to specify the default metadata time range duration for retrieving labels through Labels and Series API when the range parameters are not specified. The zero value means range covers the time since the beginning.
+- [#3207](https://github.com/thanos-io/thanos/pull/3207) Query Frontend: Add `cache-compression-type` flag to use compression in the query frontend cache.
 
 ### Changed
 

--- a/pkg/compact/retention.go
+++ b/pkg/compact/retention.go
@@ -6,6 +6,7 @@ package compact
 import (
 	"context"
 	"fmt"
+	"math"
 	"time"
 
 	"github.com/go-kit/kit/log"
@@ -17,6 +18,9 @@ import (
 	"github.com/thanos-io/thanos/pkg/block/metadata"
 	"github.com/thanos-io/thanos/pkg/objstore"
 )
+
+// RetentionPolicy is a map of retention durations by resolution level.
+type RetentionPolicy map[ResolutionLevel]time.Duration
 
 // ApplyRetentionPolicyByResolution removes blocks depending on the specified retentionByResolution based on blocks MaxTime.
 // A value of 0 disables the retention for its resolution.
@@ -45,4 +49,26 @@ func ApplyRetentionPolicyByResolution(
 	}
 	level.Info(logger).Log("msg", "optional retention apply done")
 	return nil
+}
+
+// InitialRetentionPolicy calculates a RetentionPolicy that is safe to apply
+// before compatction and downsampling take place.
+func (rp RetentionPolicy) InitialRetentionPolicy() RetentionPolicy {
+	retention := time.Duration(0)
+
+	if rp[ResolutionLevelRaw] != 0 && rp[ResolutionLevel5m] != 0 && rp[ResolutionLevel1h] != 0 {
+		retention = time.Duration(
+			math.Max(
+				math.Max(
+					float64(rp[ResolutionLevelRaw]), float64(rp[ResolutionLevel5m])),
+				float64(rp[ResolutionLevel1h]),
+			),
+		)
+	}
+	return RetentionPolicy{
+		ResolutionLevelRaw: retention,
+		ResolutionLevel5m:  retention,
+		ResolutionLevel1h:  retention,
+	}
+
 }


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

This PR tries to address issue #1708, with the fixes discussed there.

We cannot totally move the retention policy apply at the start of the compact loop, but we can add a first pass than only apply a retention that is safe, in that it'll enable us to downsample the other resolution levels.

Tested : actually I've stumbled upon the problem in a real-world scenario : 
<img width="1485" alt="Screenshot 2020-10-07 at 10 13 45" src="https://user-images.githubusercontent.com/3924134/95305558-6ea6d800-0886-11eb-87ea-05fc2438d771.png">

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

