### PR TITLE
Fix broken links on Contributing Page

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ all relevant information as template suggest.
 * If you have a quick question you might want to also ask on #thanos or #thanos-dev slack channel in the CNCF workspace.
 We are recommending, using GitHub issues for issues and feedback, because GitHub issues are track-able.
 
-If you encounter security vulnerability, please refer to [Reporting a Vulnerability process](SECURITY.md)
+If you encounter security vulnerability, please refer to [Reporting a Vulnerability process](/SECURITY.md)
 
 ## Adding New Features / Components
 
@@ -34,7 +34,7 @@ When contributing not obvious change to Thanos repository, please first
 discuss the change you wish to make via issue or slack, or any other
 method with the owners of this repository before making a change.
 
-Adding a large new feature or/and component to Thanos should be done by first creating a [proposal](docs/proposals) document outlining the design decisions of the change, motivations for the change, and any alternatives that might have been considered.
+Adding a large new feature or/and component to Thanos should be done by first creating a [proposal](/docs/proposals) document outlining the design decisions of the change, motivations for the change, and any alternatives that might have been considered.
 
 ## General Naming
 
@@ -46,7 +46,7 @@ In the code and documentation prefer non-offensive terminology, for example:
 
 ## Components Naming
 
-Thanos is a distributed system composed with several services and CLI tools as listed [here](cmd/thanos).
+Thanos is a distributed system composed with several services and CLI tools as listed [here](/cmd/thanos).
 
 When we refer to them as technical reference we use verb form: `store`, `compact`, `rule`, `query`. This includes:
 


### PR DESCRIPTION
Signed-off-by: Kartik Ramesh <kartikx2000@gmail.com>
Fixes issue #3283 
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes
* Made changes to `Reporting a Vulnerability Process`, `proposal` and `CLI tools` links in `Contributing.md` to point to the correct files in the Thanos GitHub repo.
<!-- Enumerate changes you made -->

## Verification
I tested the website on localhost and the links now direct to the desired pages.
<!-- How you tested it? How do you know it works? -->
