### PR TITLE
*: match naming convention in metrics and documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#2906](https://github.com/thanos-io/thanos/pull/2906) Tools: Refactor Bucket replicate execution. Removed all `thanos_replicate_origin_.*` metrics.
     - `thanos_replicate_origin_meta_loads_total` can be replaced by `blocks_meta_synced{state="loaded"}`.
     - `thanos_replicate_origin_partial_meta_reads_total` can be replaced by `blocks_meta_synced{state="failed"}`.
+- [#3309](https://github.com/thanos-io/thanos/pull/3309) Compact: *breaking :warning:* Rename metrics under `thanos_compactor_*` to `thanos_compact`
 
 ## [v0.16.0](https://github.com/thanos-io/thanos/releases) - 2020.10.26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#2906](https://github.com/thanos-io/thanos/pull/2906) Tools: Refactor Bucket replicate execution. Removed all `thanos_replicate_origin_.*` metrics.
     - `thanos_replicate_origin_meta_loads_total` can be replaced by `blocks_meta_synced{state="loaded"}`.
     - `thanos_replicate_origin_partial_meta_reads_total` can be replaced by `blocks_meta_synced{state="failed"}`.
-- [#3309](https://github.com/thanos-io/thanos/pull/3309) Compact: *breaking :warning:* Rename metrics under `thanos_compactor_*` to `thanos_compact`
+- [#3309](https://github.com/thanos-io/thanos/pull/3309) Compact: *breaking :warning:* Rename metrics to match naming convention. This includes metrics starting with `thanos_compactor` to `thanos_compact`, `thanos_querier` to `thanos_query` and `thanos_ruler` to `thanos_rule`.
 
 ## [v0.16.0](https://github.com/thanos-io/thanos/releases) - 2020.10.26
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ In the code and documentation prefer non-offensive terminology, for example:
 
 Thanos is a distributed system composed with several services and CLI tools as listed [here](/cmd/thanos).
 
-When we refer to them as technical reference we use verb form: `store`, `compact`, `rule`, `query`. This includes:
+When we refer to them as technical reference we use verb form: `store`, `compact`, `rule`, `query`, `query_frontend`. This includes:
 
 * Code
 * Metrics
@@ -59,7 +59,7 @@ When we refer to them as technical reference we use verb form: `store`, `compact
 * Package names
 * Log messages, traces
 
-However, when speaking about those or explaining we use `actor` noun form: `store gateway, compactor, ruler, querier`. This includes areas like:
+However, when speaking about those or explaining we use `actor` noun form: `store gateway`, `compactor`, `ruler`, `querier`, `query frontend`. This includes areas like:
 
 * Public communication
 * Documentation

--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -101,32 +101,32 @@ func runCompact(
 ) error {
 	deleteDelay := time.Duration(conf.deleteDelay)
 	halted := promauto.With(reg).NewGauge(prometheus.GaugeOpts{
-		Name: "thanos_compactor_halted",
+		Name: "thanos_compact_halted",
 		Help: "Set to 1 if the compactor halted due to an unexpected error.",
 	})
 	halted.Set(0)
 	retried := promauto.With(reg).NewCounter(prometheus.CounterOpts{
-		Name: "thanos_compactor_retries_total",
+		Name: "thanos_compact_retries_total",
 		Help: "Total number of retries after retriable compactor error.",
 	})
 	iterations := promauto.With(reg).NewCounter(prometheus.CounterOpts{
-		Name: "thanos_compactor_iterations_total",
+		Name: "thanos_compact_iterations_total",
 		Help: "Total number of iterations that were executed successfully.",
 	})
 	partialUploadDeleteAttempts := promauto.With(reg).NewCounter(prometheus.CounterOpts{
-		Name: "thanos_compactor_aborted_partial_uploads_deletion_attempts_total",
+		Name: "thanos_compact_aborted_partial_uploads_deletion_attempts_total",
 		Help: "Total number of started deletions of blocks that are assumed aborted and only partially uploaded.",
 	})
 	blocksCleaned := promauto.With(reg).NewCounter(prometheus.CounterOpts{
-		Name: "thanos_compactor_blocks_cleaned_total",
+		Name: "thanos_compact_blocks_cleaned_total",
 		Help: "Total number of blocks deleted in compactor.",
 	})
 	blockCleanupFailures := promauto.With(reg).NewCounter(prometheus.CounterOpts{
-		Name: "thanos_compactor_block_cleanup_failures_total",
+		Name: "thanos_compact_block_cleanup_failures_total",
 		Help: "Failures encountered while deleting blocks in compactor.",
 	})
 	blocksMarked := promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
-		Name: "thanos_compactor_blocks_marked_total",
+		Name: "thanos_compact_blocks_marked_total",
 		Help: "Total number of blocks marked in compactor.",
 	}, []string{"marker"})
 	blocksMarked.WithLabelValues(metadata.NoCompactMarkFilename)

--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -267,7 +267,7 @@ func runQuery(
 	fileSDCache := cache.New()
 	dnsStoreProvider := dns.NewProvider(
 		logger,
-		extprom.WrapRegistererWithPrefix("thanos_querier_store_apis_", reg),
+		extprom.WrapRegistererWithPrefix("thanos_query_store_apis_", reg),
 		dns.ResolverType(dnsSDResolver),
 	)
 
@@ -279,7 +279,7 @@ func runQuery(
 
 	dnsRuleProvider := dns.NewProvider(
 		logger,
-		extprom.WrapRegistererWithPrefix("thanos_querier_rule_apis_", reg),
+		extprom.WrapRegistererWithPrefix("thanos_query_rule_apis_", reg),
 		dns.ResolverType(dnsSDResolver),
 	)
 

--- a/cmd/thanos/rule.go
+++ b/cmd/thanos/rule.go
@@ -341,7 +341,7 @@ func runRule(
 
 	queryProvider := dns.NewProvider(
 		logger,
-		extprom.WrapRegistererWithPrefix("thanos_ruler_query_apis_", reg),
+		extprom.WrapRegistererWithPrefix("thanos_rule_query_apis_", reg),
 		dns.ResolverType(dnsSDResolver),
 	)
 	var queryClients []*http_util.Client
@@ -404,7 +404,7 @@ func runRule(
 
 	amProvider := dns.NewProvider(
 		logger,
-		extprom.WrapRegistererWithPrefix("thanos_ruler_alertmanagers_", reg),
+		extprom.WrapRegistererWithPrefix("thanos_rule_alertmanagers_", reg),
 		dns.ResolverType(dnsSDResolver),
 	)
 	var alertmgrs []*alert.Alertmanager

--- a/cmd/thanos/rule.go
+++ b/cmd/thanos/rule.go
@@ -219,7 +219,7 @@ func registerRule(app *extkingpin.App) {
 	})
 }
 
-// RuleMetrics defines thanos rule metrics.
+// RuleMetrics defines Thanos Ruler metrics.
 type RuleMetrics struct {
 	configSuccess     prometheus.Gauge
 	configSuccessTime prometheus.Gauge

--- a/docs/components/tools.md
+++ b/docs/components/tools.md
@@ -553,9 +553,9 @@ Flags:
 
 The `tools rules-check` subcommand contains tools for validation of Prometheus rules.
 
-This is allowing to check the rules with the same validation as is used by the Thanos rule node.
+This is allowing to check the rules with the same validation as is used by the Thanos Ruler node.
 
-NOTE: The check is equivalent to the `promtool check rules` with addition of Thanos rule extended rules file syntax,
+NOTE: The check is equivalent to the `promtool check rules` with addition of Thanos Ruler extended rules file syntax,
 which includes `partial_response_strategy` field which `promtool` does not allow.
 
 If the check fails the command fails with exit code `1`, otherwise `0`.

--- a/docs/operating/reverse-proxy.md
+++ b/docs/operating/reverse-proxy.md
@@ -20,7 +20,7 @@ Let's look into some example scenarios. All examples are using nginx as a revers
 
 ### Serving Thanos on a subdomain
 
-Serving a Thanos component on the root of a subdomain is pretty straight-forward. Let's say you want to run Thanos Query behind a nginx reverse proxy, accessible on domain `thanos.example.com`. A basic nginx configuration would look like this:
+Serving a Thanos component on the root of a subdomain is pretty straight-forward. Let's say you want to run Thanos Querier behind a nginx reverse proxy, accessible on domain `thanos.example.com`. A basic nginx configuration would look like this:
 
 ```
 http {
@@ -37,11 +37,11 @@ http {
 
 ### Serving Thanos on a sub-path
 
-Things become a little tricky when you want to serve Thanos on a sub-path. Let's say, you want to run Thanos Query behind an nginx server, accessible on the URL `http://example.com/thanos`. The Thanos web UI depends on it being accessed on the same URL as Thanos itself is listening. This is because the UI needs to know the URL from where to load static assets and what URL to use in links or redirects. If Thanos is behind a reverse proxy, particularly one where Thanos is not at the root, this doesn't work so well.
+Things become a little tricky when you want to serve Thanos on a sub-path. Let's say, you want to run Thanos Querier behind an nginx server, accessible on the URL `http://example.com/thanos`. The Thanos web UI depends on it being accessed on the same URL as Thanos itself is listening. This is because the UI needs to know the URL from where to load static assets and what URL to use in links or redirects. If Thanos is behind a reverse proxy, particularly one where Thanos is not at the root, this doesn't work so well.
 
 To tackle this problem, Thanos provides a flag `--web.external-prefix`.
 
-Let's say we have Thanos Query running on the usual port, we need nginx running with the following configuration:
+Let's say we have Thanos Querier running on the usual port, we need nginx running with the following configuration:
 
 ```
 http {
@@ -56,7 +56,7 @@ http {
 }
 ```
 
-With this configuration, you can access Thanos Query on `http://example.com/thanos`. Notice that because we are using `http://localhost:10902/thanos/` as the reverse proxy target, every request path will be prefixed with `/thanos`. To make this work we need to run Thanos Query like this:
+With this configuration, you can access Thanos Querier on `http://example.com/thanos`. Notice that because we are using `http://localhost:10902/thanos/` as the reverse proxy target, every request path will be prefixed with `/thanos`. To make this work we need to run Thanos Querier like this:
 
 ```
 thanos query --web.external-prefix="thanos"

--- a/docs/quick-tutorial.md
+++ b/docs/quick-tutorial.md
@@ -118,13 +118,13 @@ Now that we have setup the Sidecar for one or more Prometheus instances, we want
 
 The Query component is stateless and horizontally scalable and can be deployed with any number of replicas. Once connected to the Sidecars, it automatically detects which Prometheus servers need to be contacted for a given PromQL query.
 
-Query also implements Prometheus's official HTTP API and can thus be used with external tools such as Grafana. It also serves a derivative of Prometheus's UI for ad-hoc querying and stores status.
+Thanos Querier also implements Prometheus's official HTTP API and can thus be used with external tools such as Grafana. It also serves a derivative of Prometheus's UI for ad-hoc querying and stores status.
 
-Below, we will set up a Query to connect to our Sidecars, and expose its HTTP UI.
+Below, we will set up a Thanos Querier to connect to our Sidecars, and expose its HTTP UI.
 
 ```bash
 thanos query \
-    --http-address 0.0.0.0:19192 \                                # HTTP Endpoint for Query UI
+    --http-address 0.0.0.0:19192 \                                # HTTP Endpoint for Thanos Querier UI
     --store        1.2.3.4:19090 \                                # Static gRPC Store API Address for the query node to query
     --store        1.2.3.5:19090 \                                # Also repeatable
     --store        dnssrv+_grpc._tcp.thanos-store.monitoring.svc  # Supports DNS A & SRV records
@@ -149,7 +149,7 @@ global:
 
 In a Kubernetes stateful deployment, the replica label can also be the pod name.
 
-Reload your Prometheus instances, and then, in Query, we will define `replica` as the label we want to enable deduplication to occur on:
+Reload your Prometheus instances, and then, in Thanos Querier, we will define `replica` as the label we want to enable deduplication to occur on:
 
 ```bash
 thanos query \
@@ -170,11 +170,11 @@ The only required communication between nodes is for Thanos Querier to be able t
 The metadata includes the information about time windows and external labels for each node.
 
 There are various ways to tell query component about the StoreAPIs it should query data from. The simplest way is to use a static list of well known addresses to query.
-These are repeatable so can add as many endpoint as needed. You can put DNS domain prefixed by `dns+` or `dnssrv+` to have Thanos Query do an `A` or `SRV` lookup to get all required IPs to communicate with.
+These are repeatable so can add as many endpoint as needed. You can put DNS domain prefixed by `dns+` or `dnssrv+` to have Thanos Querier do an `A` or `SRV` lookup to get all required IPs to communicate with.
 
 ```bash
 thanos query \
-    --http-address 0.0.0.0:19192 \              # Endpoint for Query UI
+    --http-address 0.0.0.0:19192 \              # Endpoint for Thanos Querier UI
     --grpc-address 0.0.0.0:19092 \              # gRPC endpoint for Store API
     --store        1.2.3.4:19090 \              # Static gRPC Store API Address for the query node to query
     --store        1.2.3.5:19090 \              # Also repeatable

--- a/docs/service-discovery.md
+++ b/docs/service-discovery.md
@@ -11,8 +11,8 @@ Service Discovery (SD) is a vital part of several Thanos components. It allows T
 SD is currently used in the following places within Thanos:
 
 * `Thanos Query` needs to know about [StoreAPI](https://github.com/thanos-io/thanos/blob/d3fb337da94d11c78151504b1fccb1d7e036f394/pkg/store/storepb/rpc.proto#L14) servers in order to query metrics from them.
-* `Thanos Rule` needs to know about `QueryAPI` servers in order to evaluate recording and alerting rules.
-* `Thanos Rule` needs to know about `Alertmanagers` HA replicas in order to send alerts.
+* `Thanos Ruler` needs to know about `QueryAPI` servers in order to evaluate recording and alerting rules.
+* `Thanos Ruler` needs to know about `Alertmanagers` HA replicas in order to send alerts.
 
 There are currently several ways to configure SD, described below in more detail:
 
@@ -28,11 +28,11 @@ The simplest way to tell a component about a peer is to use a static flag.
 
 The repeatable flag `--store=<store>` can be used to specify a `StoreAPI` that `Thanos Query` should use.
 
-### Thanos Rule
+### Thanos Ruler
 
-`Thanos Rule` supports the configuration of `QueryAPI` endpoints using YAML with the `--query.config=<content>` and `--query.config-file=<path>` flags in the `static_configs` section.
+`Thanos Ruler` supports the configuration of `QueryAPI` endpoints using YAML with the `--query.config=<content>` and `--query.config-file=<path>` flags in the `static_configs` section.
 
-`Thanos Rule` also supports the configuration of Alertmanager endpoints using YAML with the `--alertmanagers.config=<content>` and `--alertmanagers.config-file=<path>` flags in the `static_configs` section.
+`Thanos Ruler` also supports the configuration of Alertmanager endpoints using YAML with the `--alertmanagers.config=<content>` and `--alertmanagers.config-file=<path>` flags in the `static_configs` section.
 
 ## File Service Discovery
 
@@ -69,11 +69,11 @@ The `<path>` can be a glob pattern so you can specify several files using a sing
 
 The flag `--store.sd-interval=<5m>` can be used to change the fallback re-read interval from the default 5 minutes.
 
-### Thanos Rule
+### Thanos Ruler
 
-`Thanos Rule` supports the configuration of `QueryAPI` endpoints using YAML with the `--query.config=<content>` and `--query.config-file=<path>` flags in the `file_sd_configs` section.
+`Thanos Ruler` supports the configuration of `QueryAPI` endpoints using YAML with the `--query.config=<content>` and `--query.config-file=<path>` flags in the `file_sd_configs` section.
 
-`Thanos Rule` also supports the configuration of Alertmanager endpoints using YAML with the `--alertmanagers.config=<content>` and `--alertmanagers.config-file=<path>` flags in the `file_sd_configs` section.
+`Thanos Ruler` also supports the configuration of Alertmanager endpoints using YAML with the `--alertmanagers.config=<content>` and `--alertmanagers.config-file=<path>` flags in the `file_sd_configs` section.
 
 ## DNS Service Discovery
 
@@ -109,7 +109,7 @@ This configuration will instruct Thanos to discover all endpoints within the `th
 ```
 
 The default interval between DNS lookups is 30s. This interval can be changed using the `store.sd-dns-interval` flag for `StoreAPI`
-configuration in `Thanos Query`, or `query.sd-dns-interval` for `QueryAPI` configuration in `Thanos Rule`.
+configuration in `Thanos Query`, or `query.sd-dns-interval` for `QueryAPI` configuration in `Thanos Ruler`.
 
 ## Other
 

--- a/docs/service-discovery.md
+++ b/docs/service-discovery.md
@@ -10,7 +10,7 @@ Service Discovery (SD) is a vital part of several Thanos components. It allows T
 
 SD is currently used in the following places within Thanos:
 
-* `Thanos Query` needs to know about [StoreAPI](https://github.com/thanos-io/thanos/blob/d3fb337da94d11c78151504b1fccb1d7e036f394/pkg/store/storepb/rpc.proto#L14) servers in order to query metrics from them.
+* `Thanos Querier` needs to know about [StoreAPI](https://github.com/thanos-io/thanos/blob/d3fb337da94d11c78151504b1fccb1d7e036f394/pkg/store/storepb/rpc.proto#L14) servers in order to query metrics from them.
 * `Thanos Ruler` needs to know about `QueryAPI` servers in order to evaluate recording and alerting rules.
 * `Thanos Ruler` needs to know about `Alertmanagers` HA replicas in order to send alerts.
 
@@ -24,9 +24,9 @@ There are currently several ways to configure SD, described below in more detail
 
 The simplest way to tell a component about a peer is to use a static flag.
 
-### Thanos Query
+### Thanos Querier
 
-The repeatable flag `--store=<store>` can be used to specify a `StoreAPI` that `Thanos Query` should use.
+The repeatable flag `--store=<store>` can be used to specify a `StoreAPI` that `Thanos Querier` should use.
 
 ### Thanos Ruler
 
@@ -62,7 +62,7 @@ Both YAML and JSON files can be used. The format of the files is as follows:
 As a fallback, the file contents are periodically re-read at an interval that can be set using a flag specific to the component as shown below.
 The default value for all File SD re-read intervals is 5 minutes.
 
-### Thanos Query
+### Thanos Querier
 
 The repeatable flag `--store.sd-files=<path>` can be used to specify the path to files that contain addresses of `StoreAPI` servers.
 The `<path>` can be a glob pattern so you can specify several files using a single flag.
@@ -109,7 +109,7 @@ This configuration will instruct Thanos to discover all endpoints within the `th
 ```
 
 The default interval between DNS lookups is 30s. This interval can be changed using the `store.sd-dns-interval` flag for `StoreAPI`
-configuration in `Thanos Query`, or `query.sd-dns-interval` for `QueryAPI` configuration in `Thanos Ruler`.
+configuration in `Thanos Querier`, or `query.sd-dns-interval` for `QueryAPI` configuration in `Thanos Ruler`.
 
 ## Other
 

--- a/examples/alerts/alerts.md
+++ b/examples/alerts/alerts.md
@@ -21,7 +21,7 @@ rules:
   annotations:
     description: Thanos Compact {{$labels.job}} has failed to run and now is halted.
     summary: Thanos Compact has failed to run ans is now halted.
-  expr: thanos_compactor_halted{job=~"thanos-compact.*"} == 1
+  expr: thanos_compact_halted{job=~"thanos-compact.*"} == 1
   for: 5m
   labels:
     severity: warning

--- a/examples/alerts/alerts.md
+++ b/examples/alerts/alerts.md
@@ -374,9 +374,9 @@ rules:
     summary: Thanos Query is having high number of DNS failures.
   expr: |
     (
-      sum by (job) (rate(thanos_querier_store_apis_dns_failures_total{job=~"thanos-query.*"}[5m]))
+      sum by (job) (rate(thanos_query_store_apis_dns_failures_total{job=~"thanos-query.*"}[5m]))
     /
-      sum by (job) (rate(thanos_querier_store_apis_dns_lookups_total{job=~"thanos-query.*"}[5m]))
+      sum by (job) (rate(thanos_query_store_apis_dns_lookups_total{job=~"thanos-query.*"}[5m]))
     ) * 100 > 1
   for: 15m
   labels:

--- a/examples/alerts/alerts.md
+++ b/examples/alerts/alerts.md
@@ -67,7 +67,7 @@ rules:
 
 ## Ruler
 
-For Thanos ruler we run some alerts in local Prometheus, to make sure that Thanos Rule is working:
+For Thanos Ruler we run some alerts in local Prometheus, to make sure that Thanos Ruler is working:
 
 [embedmd]:# (../tmp/thanos-rule.rules.yaml yaml)
 ```yaml
@@ -162,9 +162,9 @@ rules:
     summary: Thanos Rule is having high number of DNS failures.
   expr: |
     (
-      sum by (job) (rate(thanos_ruler_query_apis_dns_failures_total{job=~"thanos-rule.*"}[5m]))
+      sum by (job) (rate(thanos_rule_query_apis_dns_failures_total{job=~"thanos-rule.*"}[5m]))
     /
-      sum by (job) (rate(thanos_ruler_query_apis_dns_lookups_total{job=~"thanos-rule.*"}[5m]))
+      sum by (job) (rate(thanos_rule_query_apis_dns_lookups_total{job=~"thanos-rule.*"}[5m]))
     * 100 > 1
     )
   for: 15m
@@ -177,9 +177,9 @@ rules:
     summary: Thanos Rule is having high number of DNS failures.
   expr: |
     (
-      sum by (job) (rate(thanos_ruler_alertmanagers_dns_failures_total{job=~"thanos-rule.*"}[5m]))
+      sum by (job) (rate(thanos_rule_alertmanagers_dns_failures_total{job=~"thanos-rule.*"}[5m]))
     /
-      sum by (job) (rate(thanos_ruler_alertmanagers_dns_lookups_total{job=~"thanos-rule.*"}[5m]))
+      sum by (job) (rate(thanos_rule_alertmanagers_dns_lookups_total{job=~"thanos-rule.*"}[5m]))
     * 100 > 1
     )
   for: 15m

--- a/examples/alerts/alerts.yaml
+++ b/examples/alerts/alerts.yaml
@@ -14,7 +14,7 @@ groups:
     annotations:
       description: Thanos Compact {{$labels.job}} has failed to run and now is halted.
       summary: Thanos Compact has failed to run ans is now halted.
-    expr: thanos_compactor_halted{job=~"thanos-compact.*"} == 1
+    expr: thanos_compact_halted{job=~"thanos-compact.*"} == 1
     for: 5m
     labels:
       severity: warning

--- a/examples/alerts/alerts.yaml
+++ b/examples/alerts/alerts.yaml
@@ -436,9 +436,9 @@ groups:
       summary: Thanos Rule is having high number of DNS failures.
     expr: |
       (
-        sum by (job) (rate(thanos_ruler_query_apis_dns_failures_total{job=~"thanos-rule.*"}[5m]))
+        sum by (job) (rate(thanos_rule_query_apis_dns_failures_total{job=~"thanos-rule.*"}[5m]))
       /
-        sum by (job) (rate(thanos_ruler_query_apis_dns_lookups_total{job=~"thanos-rule.*"}[5m]))
+        sum by (job) (rate(thanos_rule_query_apis_dns_lookups_total{job=~"thanos-rule.*"}[5m]))
       * 100 > 1
       )
     for: 15m
@@ -451,9 +451,9 @@ groups:
       summary: Thanos Rule is having high number of DNS failures.
     expr: |
       (
-        sum by (job) (rate(thanos_ruler_alertmanagers_dns_failures_total{job=~"thanos-rule.*"}[5m]))
+        sum by (job) (rate(thanos_rule_alertmanagers_dns_failures_total{job=~"thanos-rule.*"}[5m]))
       /
-        sum by (job) (rate(thanos_ruler_alertmanagers_dns_lookups_total{job=~"thanos-rule.*"}[5m]))
+        sum by (job) (rate(thanos_rule_alertmanagers_dns_lookups_total{job=~"thanos-rule.*"}[5m]))
       * 100 > 1
       )
     for: 15m

--- a/examples/alerts/alerts.yaml
+++ b/examples/alerts/alerts.yaml
@@ -123,9 +123,9 @@ groups:
       summary: Thanos Query is having high number of DNS failures.
     expr: |
       (
-        sum by (job) (rate(thanos_querier_store_apis_dns_failures_total{job=~"thanos-query.*"}[5m]))
+        sum by (job) (rate(thanos_query_store_apis_dns_failures_total{job=~"thanos-query.*"}[5m]))
       /
-        sum by (job) (rate(thanos_querier_store_apis_dns_lookups_total{job=~"thanos-query.*"}[5m]))
+        sum by (job) (rate(thanos_query_store_apis_dns_lookups_total{job=~"thanos-query.*"}[5m]))
       ) * 100 > 1
     for: 15m
     labels:

--- a/examples/alerts/rules.yaml
+++ b/examples/alerts/rules.yaml
@@ -17,11 +17,11 @@ groups:
     record: :grpc_client_failures_per_stream:sum_rate
   - expr: |
       (
-        sum(rate(thanos_querier_store_apis_dns_failures_total{job=~"thanos-query.*"}[5m]))
+        sum(rate(thanos_query_store_apis_dns_failures_total{job=~"thanos-query.*"}[5m]))
       /
-        sum(rate(thanos_querier_store_apis_dns_lookups_total{job=~"thanos-query.*"}[5m]))
+        sum(rate(thanos_query_store_apis_dns_lookups_total{job=~"thanos-query.*"}[5m]))
       )
-    record: :thanos_querier_store_apis_dns_failures_per_lookup:sum_rate
+    record: :thanos_query_store_apis_dns_failures_per_lookup:sum_rate
   - expr: |
       histogram_quantile(0.99,
         sum(rate(http_request_duration_seconds_bucket{job=~"thanos-query.*", handler="query"}[5m])) by (le)

--- a/examples/dashboards/query.json
+++ b/examples/dashboards/query.json
@@ -1144,7 +1144,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "sum(rate(thanos_querier_store_apis_dns_lookups_total{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job)",
+                     "expr": "sum(rate(thanos_query_store_apis_dns_lookups_total{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job)",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "lookups {{job}}",
@@ -1223,7 +1223,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "sum(rate(thanos_querier_store_apis_dns_failures_total{namespace=\"$namespace\",job=~\"$job\"}[$interval])) / sum(rate(thanos_querier_store_apis_dns_lookups_total{namespace=\"$namespace\",job=~\"$job\"}[$interval]))",
+                     "expr": "sum(rate(thanos_query_store_apis_dns_failures_total{namespace=\"$namespace\",job=~\"$job\"}[$interval])) / sum(rate(thanos_query_store_apis_dns_lookups_total{namespace=\"$namespace\",job=~\"$job\"}[$interval]))",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "error",

--- a/mixin/alerts/compact.libsonnet
+++ b/mixin/alerts/compact.libsonnet
@@ -28,7 +28,7 @@
               description: 'Thanos Compact {{$labels.job}} has failed to run and now is halted.',
               summary: 'Thanos Compact has failed to run ans is now halted.',
             },
-            expr: 'thanos_compactor_halted{%(selector)s} == 1' % thanos.compact,
+            expr: 'thanos_compact_halted{%(selector)s} == 1' % thanos.compact,
             'for': '5m',
             labels: {
               severity: 'warning',

--- a/mixin/alerts/query.libsonnet
+++ b/mixin/alerts/query.libsonnet
@@ -94,9 +94,9 @@
             },
             expr: |||
               (
-                sum by (job) (rate(thanos_querier_store_apis_dns_failures_total{%(selector)s}[5m]))
+                sum by (job) (rate(thanos_query_store_apis_dns_failures_total{%(selector)s}[5m]))
               /
-                sum by (job) (rate(thanos_querier_store_apis_dns_lookups_total{%(selector)s}[5m]))
+                sum by (job) (rate(thanos_query_store_apis_dns_lookups_total{%(selector)s}[5m]))
               ) * 100 > %(dnsErrorThreshold)s
             ||| % thanos.query,
             'for': '15m',

--- a/mixin/alerts/rule.libsonnet
+++ b/mixin/alerts/rule.libsonnet
@@ -132,9 +132,9 @@
             },
             expr: |||
               (
-                sum by (job) (rate(thanos_ruler_query_apis_dns_failures_total{%(selector)s}[5m]))
+                sum by (job) (rate(thanos_rule_query_apis_dns_failures_total{%(selector)s}[5m]))
               /
-                sum by (job) (rate(thanos_ruler_query_apis_dns_lookups_total{%(selector)s}[5m]))
+                sum by (job) (rate(thanos_rule_query_apis_dns_lookups_total{%(selector)s}[5m]))
               * 100 > %(rulerDnsErrorThreshold)s
               )
             ||| % thanos.rule,
@@ -151,9 +151,9 @@
             },
             expr: |||
               (
-                sum by (job) (rate(thanos_ruler_alertmanagers_dns_failures_total{%(selector)s}[5m]))
+                sum by (job) (rate(thanos_rule_alertmanagers_dns_failures_total{%(selector)s}[5m]))
               /
-                sum by (job) (rate(thanos_ruler_alertmanagers_dns_lookups_total{%(selector)s}[5m]))
+                sum by (job) (rate(thanos_rule_alertmanagers_dns_lookups_total{%(selector)s}[5m]))
               * 100 > %(alertManagerDnsErrorThreshold)s
               )
             ||| % thanos.rule,

--- a/mixin/dashboards/query.libsonnet
+++ b/mixin/dashboards/query.libsonnet
@@ -75,15 +75,15 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
         .addPanel(
           g.panel('Rate', 'Shows rate of DNS lookups to discover stores.') +
           g.queryPanel(
-            'sum(rate(thanos_querier_store_apis_dns_lookups_total{namespace="$namespace",job=~"$job"}[$interval])) by (job)',
+            'sum(rate(thanos_query_store_apis_dns_lookups_total{namespace="$namespace",job=~"$job"}[$interval])) by (job)',
             'lookups {{job}}'
           )
         )
         .addPanel(
           g.panel('Errors', 'Shows ratio of failures compared to the the total number of executed DNS lookups.') +
           g.qpsErrTotalPanel(
-            'thanos_querier_store_apis_dns_failures_total{namespace="$namespace",job=~"$job"}',
-            'thanos_querier_store_apis_dns_lookups_total{namespace="$namespace",job=~"$job"}',
+            'thanos_query_store_apis_dns_failures_total{namespace="$namespace",job=~"$job"}',
+            'thanos_query_store_apis_dns_lookups_total{namespace="$namespace",job=~"$job"}',
           )
         )
       )

--- a/mixin/rules/query.libsonnet
+++ b/mixin/rules/query.libsonnet
@@ -29,12 +29,12 @@
             ||| % thanos.query,
           },
           {
-            record: ':thanos_querier_store_apis_dns_failures_per_lookup:sum_rate',
+            record: ':thanos_query_store_apis_dns_failures_per_lookup:sum_rate',
             expr: |||
               (
-                sum(rate(thanos_querier_store_apis_dns_failures_total{%(selector)s}[5m]))
+                sum(rate(thanos_query_store_apis_dns_failures_total{%(selector)s}[5m]))
               /
-                sum(rate(thanos_querier_store_apis_dns_lookups_total{%(selector)s}[5m]))
+                sum(rate(thanos_query_store_apis_dns_lookups_total{%(selector)s}[5m]))
               )
             ||| % thanos.query,
           },

--- a/pkg/api/query/v1.go
+++ b/pkg/api/query/v1.go
@@ -59,7 +59,7 @@ const (
 	StoreMatcherParam        = "storeMatch[]"
 )
 
-// QueryAPI is an API used by Thanos Query.
+// QueryAPI is an API used by Thanos Querier.
 type QueryAPI struct {
 	baseAPI         *api.BaseAPI
 	logger          log.Logger

--- a/pkg/compact/compact_e2e_test.go
+++ b/pkg/compact/compact_e2e_test.go
@@ -236,7 +236,7 @@ func TestGroup_Compact_e2e(t *testing.T) {
 					{{Name: "a", Value: "6"}},
 				},
 			},
-			// Mix order to make sure compact is able to deduct min time / max time.
+			// Mix order to make sure compactor is able to deduct min time / max time.
 			// Currently TSDB does not produces empty blocks (see: https://github.com/prometheus/tsdb/pull/374). However before v2.7.0 it was
 			// so we still want to mimick this case as close as possible.
 			{

--- a/test/e2e/compact_test.go
+++ b/test/e2e/compact_test.go
@@ -559,8 +559,8 @@ func TestCompactWithStoreGateway(t *testing.T) {
 		testutil.Ok(t, c.WaitSumMetrics(e2e.Equals(2), "thanos_compact_group_compaction_runs_completed_total"))
 
 		// However, the blocks have been cleaned because that happens concurrently.
-		testutil.Ok(t, c.WaitSumMetrics(e2e.Equals(2), "thanos_compactor_blocks_cleaned_total"))
-		testutil.Ok(t, c.WaitSumMetrics(e2e.Equals(2), "thanos_compactor_aborted_partial_uploads_deletion_attempts_total"))
+		testutil.Ok(t, c.WaitSumMetrics(e2e.Equals(2), "thanos_compact_blocks_cleaned_total"))
+		testutil.Ok(t, c.WaitSumMetrics(e2e.Equals(2), "thanos_compact_aborted_partial_uploads_deletion_attempts_total"))
 
 		// Ensure bucket UI.
 		ensureGETStatusCode(t, http.StatusOK, "http://"+path.Join(c.HTTPEndpoint(), "global"))

--- a/test/e2e/compact_test.go
+++ b/test/e2e/compact_test.go
@@ -540,7 +540,7 @@ func TestCompactWithStoreGateway(t *testing.T) {
 		testutil.Ok(t, c.WaitSumMetrics(e2e.Equals(0), "thanos_blocks_meta_modified"))
 
 		// Expect compactor halted.
-		testutil.Ok(t, c.WaitSumMetrics(e2e.Equals(1), "thanos_compactor_halted"))
+		testutil.Ok(t, c.WaitSumMetrics(e2e.Equals(1), "thanos_compact_halted"))
 
 		// The compact directory is still there.
 		dataDir := filepath.Join(s.SharedDir(), "data", "compact", "expect-to-halt")
@@ -549,9 +549,9 @@ func TestCompactWithStoreGateway(t *testing.T) {
 		testutil.Equals(t, false, empty, "directory %s should not be empty", dataDir)
 
 		// We expect no ops.
-		testutil.Ok(t, c.WaitSumMetrics(e2e.Equals(0), "thanos_compactor_iterations_total"))
-		testutil.Ok(t, c.WaitSumMetrics(e2e.Equals(0), "thanos_compactor_block_cleanup_failures_total"))
-		testutil.Ok(t, c.WaitSumMetrics(e2e.Equals(0), "thanos_compactor_blocks_marked_total"))
+		testutil.Ok(t, c.WaitSumMetrics(e2e.Equals(0), "thanos_compact_iterations_total"))
+		testutil.Ok(t, c.WaitSumMetrics(e2e.Equals(0), "thanos_compact_block_cleanup_failures_total"))
+		testutil.Ok(t, c.WaitSumMetrics(e2e.Equals(0), "thanos_compact_blocks_marked_total"))
 		testutil.Ok(t, c.WaitSumMetrics(e2e.Equals(0), "thanos_compact_group_compactions_total"))
 		testutil.Ok(t, c.WaitSumMetrics(e2e.Equals(0), "thanos_compact_group_vertical_compactions_total"))
 		testutil.Ok(t, c.WaitSumMetrics(e2e.Equals(1), "thanos_compact_group_compactions_failures_total"))
@@ -577,11 +577,11 @@ func TestCompactWithStoreGateway(t *testing.T) {
 
 		// NOTE: We cannot assert on intermediate `thanos_blocks_meta_` metrics as those are gauge and change dynamically due to many
 		// compaction groups. Wait for at least first compaction iteration (next is in 5m).
-		testutil.Ok(t, c.WaitSumMetrics(e2e.Greater(0), "thanos_compactor_iterations_total"))
-		testutil.Ok(t, c.WaitSumMetrics(e2e.Equals(0), "thanos_compactor_blocks_cleaned_total"))
-		testutil.Ok(t, c.WaitSumMetrics(e2e.Equals(0), "thanos_compactor_block_cleanup_failures_total"))
-		testutil.Ok(t, c.WaitSumMetrics(e2e.Equals(2*4+2+2*3+2), "thanos_compactor_blocks_marked_total")) // 18.
-		testutil.Ok(t, c.WaitSumMetrics(e2e.Equals(0), "thanos_compactor_aborted_partial_uploads_deletion_attempts_total"))
+		testutil.Ok(t, c.WaitSumMetrics(e2e.Greater(0), "thanos_compact_iterations_total"))
+		testutil.Ok(t, c.WaitSumMetrics(e2e.Equals(0), "thanos_compact_blocks_cleaned_total"))
+		testutil.Ok(t, c.WaitSumMetrics(e2e.Equals(0), "thanos_compact_block_cleanup_failures_total"))
+		testutil.Ok(t, c.WaitSumMetrics(e2e.Equals(2*4+2+2*3+2), "thanos_compact_blocks_marked_total")) // 18.
+		testutil.Ok(t, c.WaitSumMetrics(e2e.Equals(0), "thanos_compact_aborted_partial_uploads_deletion_attempts_total"))
 		testutil.Ok(t, c.WaitSumMetrics(e2e.Equals(6), "thanos_compact_group_compactions_total"))
 		testutil.Ok(t, c.WaitSumMetrics(e2e.Equals(3), "thanos_compact_group_vertical_compactions_total"))
 		testutil.Ok(t, c.WaitSumMetrics(e2e.Equals(0), "thanos_compact_group_compactions_failures_total"))
@@ -598,7 +598,7 @@ func TestCompactWithStoreGateway(t *testing.T) {
 		)), "thanos_blocks_meta_synced"))
 		testutil.Ok(t, str.WaitSumMetrics(e2e.Equals(0), "thanos_blocks_meta_sync_failures_total"))
 
-		testutil.Ok(t, c.WaitSumMetrics(e2e.Equals(0), "thanos_compactor_halted"))
+		testutil.Ok(t, c.WaitSumMetrics(e2e.Equals(0), "thanos_compact_halted"))
 		// Make sure compactor does not modify anything else over time.
 		testutil.Ok(t, s.Stop(c))
 
@@ -626,11 +626,11 @@ func TestCompactWithStoreGateway(t *testing.T) {
 
 		// NOTE: We cannot assert on intermediate `thanos_blocks_meta_` metrics as those are gauge and change dynamically due to many
 		// compaction groups. Wait for at least first compaction iteration (next is in 5m).
-		testutil.Ok(t, c.WaitSumMetrics(e2e.Greater(0), "thanos_compactor_iterations_total"))
-		testutil.Ok(t, c.WaitSumMetrics(e2e.Equals(18), "thanos_compactor_blocks_cleaned_total"))
-		testutil.Ok(t, c.WaitSumMetrics(e2e.Equals(0), "thanos_compactor_block_cleanup_failures_total"))
-		testutil.Ok(t, c.WaitSumMetrics(e2e.Equals(0), "thanos_compactor_blocks_marked_total"))
-		testutil.Ok(t, c.WaitSumMetrics(e2e.Equals(0), "thanos_compactor_aborted_partial_uploads_deletion_attempts_total"))
+		testutil.Ok(t, c.WaitSumMetrics(e2e.Greater(0), "thanos_compact_iterations_total"))
+		testutil.Ok(t, c.WaitSumMetrics(e2e.Equals(18), "thanos_compact_blocks_cleaned_total"))
+		testutil.Ok(t, c.WaitSumMetrics(e2e.Equals(0), "thanos_compact_block_cleanup_failures_total"))
+		testutil.Ok(t, c.WaitSumMetrics(e2e.Equals(0), "thanos_compact_blocks_marked_total"))
+		testutil.Ok(t, c.WaitSumMetrics(e2e.Equals(0), "thanos_compact_aborted_partial_uploads_deletion_attempts_total"))
 		testutil.Ok(t, c.WaitSumMetrics(e2e.Equals(0), "thanos_compact_group_compactions_total"))
 		testutil.Ok(t, c.WaitSumMetrics(e2e.Equals(0), "thanos_compact_group_vertical_compactions_total"))
 		testutil.Ok(t, c.WaitSumMetrics(e2e.Equals(0), "thanos_compact_group_compactions_failures_total"))
@@ -643,7 +643,7 @@ func TestCompactWithStoreGateway(t *testing.T) {
 		testutil.Ok(t, str.WaitSumMetrics(e2e.Equals(float64(len(rawBlockIDs)+7+6-18-2)), "thanos_blocks_meta_synced"))
 		testutil.Ok(t, str.WaitSumMetrics(e2e.Equals(0), "thanos_blocks_meta_sync_failures_total"))
 
-		testutil.Ok(t, c.WaitSumMetrics(e2e.Equals(0), "thanos_compactor_halted"))
+		testutil.Ok(t, c.WaitSumMetrics(e2e.Equals(0), "thanos_compact_halted"))
 		// Make sure compactor does not modify anything else over time.
 		testutil.Ok(t, s.Stop(c))
 

--- a/test/e2e/rule_test.go
+++ b/test/e2e/rule_test.go
@@ -401,8 +401,8 @@ func TestRule(t *testing.T) {
 		// Attach querier to target files.
 		writeTargets(t, filepath.Join(s.SharedDir(), queryTargetsSubDir, "targets.yaml"), q.NetworkHTTPEndpoint())
 
-		testutil.Ok(t, r.WaitSumMetricsWithOptions(e2e.Equals(1), []string{"thanos_ruler_query_apis_dns_provider_results"}, e2e.WaitMissingMetrics))
-		testutil.Ok(t, r.WaitSumMetrics(e2e.Equals(1), "thanos_ruler_alertmanagers_dns_provider_results"))
+		testutil.Ok(t, r.WaitSumMetricsWithOptions(e2e.Equals(1), []string{"thanos_rule_query_apis_dns_provider_results"}, e2e.WaitMissingMetrics))
+		testutil.Ok(t, r.WaitSumMetrics(e2e.Equals(1), "thanos_rule_alertmanagers_dns_provider_results"))
 
 		var currentVal float64
 		testutil.Ok(t, r.WaitSumMetrics(func(sums ...float64) bool {
@@ -434,8 +434,8 @@ func TestRule(t *testing.T) {
 		// Attach am1 to target files.
 		writeTargets(t, filepath.Join(s.SharedDir(), amTargetsSubDir, "targets.yaml"), am1.NetworkHTTPEndpoint())
 
-		testutil.Ok(t, r.WaitSumMetrics(e2e.Equals(1), "thanos_ruler_query_apis_dns_provider_results"))
-		testutil.Ok(t, r.WaitSumMetrics(e2e.Equals(2), "thanos_ruler_alertmanagers_dns_provider_results"))
+		testutil.Ok(t, r.WaitSumMetrics(e2e.Equals(1), "thanos_rule_query_apis_dns_provider_results"))
+		testutil.Ok(t, r.WaitSumMetrics(e2e.Equals(2), "thanos_rule_alertmanagers_dns_provider_results"))
 
 		testutil.Ok(t, r.WaitSumMetrics(e2e.Equals(currentFailures), "prometheus_rule_evaluation_failures_total"))
 
@@ -458,8 +458,8 @@ func TestRule(t *testing.T) {
 	t.Run("am1 drops again", func(t *testing.T) {
 		testutil.Ok(t, os.RemoveAll(filepath.Join(s.SharedDir(), amTargetsSubDir, "targets.yaml")))
 
-		testutil.Ok(t, r.WaitSumMetrics(e2e.Equals(1), "thanos_ruler_query_apis_dns_provider_results"))
-		testutil.Ok(t, r.WaitSumMetrics(e2e.Equals(1), "thanos_ruler_alertmanagers_dns_provider_results"))
+		testutil.Ok(t, r.WaitSumMetrics(e2e.Equals(1), "thanos_rule_query_apis_dns_provider_results"))
+		testutil.Ok(t, r.WaitSumMetrics(e2e.Equals(1), "thanos_rule_alertmanagers_dns_provider_results"))
 		testutil.Ok(t, r.WaitSumMetrics(e2e.Equals(currentFailures), "prometheus_rule_evaluation_failures_total"))
 
 		var currentValAm1 float64
@@ -487,8 +487,8 @@ func TestRule(t *testing.T) {
 		// am2 is already registered in static addresses.
 		writeTargets(t, filepath.Join(s.SharedDir(), amTargetsSubDir, "targets.yaml"), am2.NetworkHTTPEndpoint())
 
-		testutil.Ok(t, r.WaitSumMetrics(e2e.Equals(1), "thanos_ruler_query_apis_dns_provider_results"))
-		testutil.Ok(t, r.WaitSumMetrics(e2e.Equals(1), "thanos_ruler_alertmanagers_dns_provider_results"))
+		testutil.Ok(t, r.WaitSumMetrics(e2e.Equals(1), "thanos_rule_query_apis_dns_provider_results"))
+		testutil.Ok(t, r.WaitSumMetrics(e2e.Equals(1), "thanos_rule_alertmanagers_dns_provider_results"))
 	})
 
 	t.Run("rule groups have last evaluation and evaluation duration set", func(t *testing.T) {


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.
:warning: This is a breaking change

## Changes
Rename metrics not following the components naming convention:
- `thanos_compact_*` (from `thanos_compactor_*`)
- `thanos_rule_*` (from `thanos_ruler_*`)
- `thanos_query_*` (from `thanos_querier_*`)

Also match the naming convention in the documentation and code comments

https://thanos.io/tip/contributing/contributing.md/#components-naming

## Verification

Has yet to be tested.
<!-- How you tested it? How do you know it works? -->

## Note
I feel like removing the metrics directly before any deprecation cycle has been done is a bit harsh. But before working on duplicating the two metrics, I'd like to have your opinion on this.