### PR TITLE
store: Prevent store from panic after range object storage

### DIFF
--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -1369,7 +1369,11 @@ func (b *bucketBlock) readIndexRange(ctx context.Context, off, length int64) ([]
 	if _, err := buf.ReadFrom(r); err != nil {
 		return nil, errors.Wrap(err, "read range")
 	}
-	return buf.Bytes(), nil
+	internalBuf := buf.Bytes()
+	if int64(len(internalBuf)) != length {
+		return nil, fmt.Errorf( "can't read index range for required length, required %d, actually %d", length, len(internalBuf))
+	}
+	return internalBuf, nil
 }
 
 func (b *bucketBlock) readChunkRange(ctx context.Context, seq int, off, length int64) (*[]byte, error) {
@@ -1396,6 +1400,10 @@ func (b *bucketBlock) readChunkRange(ctx context.Context, seq int, off, length i
 		return nil, errors.Wrap(err, "read range")
 	}
 	internalBuf := buf.Bytes()
+	if int64(len(internalBuf)) != length {
+		b.chunkPool.Put(c)
+		return nil, fmt.Errorf("can't read chunk range for required length, required %d, actually %d", length, len(internalBuf))
+	}
 	return &internalBuf, nil
 }
 


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

When the store uses the object store as the s3 interface, there is a probability that the loadChunks or loadSeries method panic will appear in the query. It is found that the s3 interface does not return complete data, and the store should return an error instead of panic

## Verification
I compared it after build the modified code. Under the same circumstances, the store will not panic, and the query returns the following error: Mint: 1601021768826 Maxt: 1602734400000: rpc error: code = Aborted desc = fetch series for block 01EMMWANSPNASD41ER54W9B2WQ: preload chunks: read range for 0: can't read chunk for required length, required 2723780, actually 48762
