### PR TITLE
Fix thanos.shipper.json uploaded blocks

### DIFF
--- a/pkg/shipper/shipper.go
+++ b/pkg/shipper/shipper.go
@@ -282,6 +282,7 @@ func (s *Shipper) Sync(ctx context.Context) (uploaded int, err error) {
 			return 0, errors.Wrap(err, "check exists")
 		}
 		if ok {
+			meta.Uploaded = append(meta.Uploaded, m.ULID)
 			continue
 		}
 


### PR DESCRIPTION
* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

In Cortex we would like to use `thanos.shipper.json` as source of truth to know if a specific block has been shipped to the storage. We found an edge case where `thanos.shipper.json` doesn't actually get updated with the whole list of blocks shipper and this PR should fix it.

Change is not relevant to the end user because doesn't affect Thanos.

## Verification

N/A
