### PR TITLE
WIP: Add cluster label to mixin dashboards

### DIFF
--- a/mixin/dashboards/compact.libsonnet
+++ b/mixin/dashboards/compact.libsonnet
@@ -7,6 +7,8 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
     selector: error 'must provide selector for Thanos Compact dashboard',
     title: error 'must provide title for Thanos Compact dashboard',
   },
+  local clusterNamespaceJob = '%s="$cluster",namespace="$namespace",job=~"$job"' % thanos.dashboard.clusterLabel,
+  local clusterNamespaceCompactSelector = '%s="$cluster",namespace="$namespace",%s' % [thanos.dashboard.clusterLabel, thanos.compact.selector],
   grafanaDashboards+:: {
     'compact.json':
       g.dashboard(thanos.compact.title)
@@ -18,7 +20,7 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
             'Shows rate of execution for compactions against blocks that are stored in the bucket by compaction group.'
           ) +
           g.queryPanel(
-            'sum(rate(thanos_compact_group_compactions_total{namespace="$namespace",job=~"$job"}[$interval])) by (job, group)',
+            'sum(rate(thanos_compact_group_compactions_total{%s}[$interval])) by (job, group)' % clusterNamespaceJob,
             'compaction {{job}} {{group}}'
           ) +
           g.stack
@@ -29,8 +31,8 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
             'Shows ratio of errors compared to the total number of executed compactions against blocks that are stored in the bucket.'
           ) +
           g.qpsErrTotalPanel(
-            'thanos_compact_group_compactions_failures_total{namespace="$namespace",job=~"$job"}',
-            'thanos_compact_group_compactions_total{namespace="$namespace",job=~"$job"}',
+            'thanos_compact_group_compactions_failures_total{%s}' % clusterNamespaceJob,
+            'thanos_compact_group_compactions_total{%s}' % clusterNamespaceJob,
           )
         )
       )
@@ -42,7 +44,7 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
             'Shows rate of execution for downsampling against blocks that are stored in the bucket by compaction group.'
           ) +
           g.queryPanel(
-            'sum(rate(thanos_compact_downsample_total{namespace="$namespace",job=~"$job"}[$interval])) by (job, group)',
+            'sum(rate(thanos_compact_downsample_total{%s}[$interval])) by (job, group)' % clusterNamespaceJob,
             'downsample {{job}} {{group}}'
           ) +
           g.stack
@@ -50,8 +52,8 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
         .addPanel(
           g.panel('Errors', 'Shows ratio of errors compared to the total number of executed downsampling against blocks that are stored in the bucket.') +
           g.qpsErrTotalPanel(
-            'thanos_compact_downsample_failed_total{namespace="$namespace",job=~"$job"}',
-            'thanos_compact_downsample_total{namespace="$namespace",job=~"$job"}',
+            'thanos_compact_downsample_failed_total{%s}' % clusterNamespaceJob,
+            'thanos_compact_downsample_total{%s}' % clusterNamespaceJob,
           )
         )
       )
@@ -63,7 +65,7 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
             'Shows rate of execution for removals of blocks if their data is available as part of a block with a higher compaction level.'
           ) +
           g.queryPanel(
-            'sum(rate(thanos_compact_garbage_collection_total{namespace="$namespace",job=~"$job"}[$interval])) by (job)',
+            'sum(rate(thanos_compact_garbage_collection_total{%s}[$interval])) by (job)' % clusterNamespaceJob,
             'garbage collection {{job}}'
           ) +
           g.stack
@@ -71,13 +73,13 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
         .addPanel(
           g.panel('Errors', 'Shows ratio of errors compared to the total number of executed garbage collections.') +
           g.qpsErrTotalPanel(
-            'thanos_compact_garbage_collection_failures_total{namespace="$namespace",job=~"$job"}',
-            'thanos_compact_garbage_collection_total{namespace="$namespace",job=~"$job"}',
+            'thanos_compact_garbage_collection_failures_total{%s}' % clusterNamespaceJob,
+            'thanos_compact_garbage_collection_total{%s}' % clusterNamespaceJob,
           )
         )
         .addPanel(
           g.panel('Duration', 'Shows how long has it taken to execute garbage collection in quantiles.') +
-          g.latencyPanel('thanos_compact_garbage_collection_duration_seconds', 'namespace="$namespace",job=~"$job"')
+          g.latencyPanel('thanos_compact_garbage_collection_duration_seconds', clusterNamespaceJob)
         )
       )
       .addRow(
@@ -88,7 +90,7 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
             'Shows rate of execution for all meta files from blocks in the bucket into the memory.'
           ) +
           g.queryPanel(
-            'sum(rate(thanos_blocks_meta_syncs_total{namespace="$namespace",job=~"$job"}[$interval])) by (job)',
+            'sum(rate(thanos_blocks_meta_syncs_total{%s}[$interval])) by (job)' % clusterNamespaceJob,
             'sync {{job}}'
           ) +
           g.stack
@@ -96,13 +98,13 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
         .addPanel(
           g.panel('Errors', 'Shows ratio of errors compared to the total number of executed meta file sync.') +
           g.qpsErrTotalPanel(
-            'thanos_blocks_meta_sync_failures_total{namespace="$namespace",job=~"$job"}',
-            'thanos_blocks_meta_syncs_total{namespace="$namespace",job=~"$job"}',
+            'thanos_blocks_meta_sync_failures_total{%s}' % clusterNamespaceJob,
+            'thanos_blocks_meta_syncs_total{%s}' % clusterNamespaceJob,
           )
         )
         .addPanel(
           g.panel('Duration', 'Shows how long has it taken to execute meta file sync, in quantiles.') +
-          g.latencyPanel('thanos_blocks_meta_sync_duration_seconds', 'namespace="$namespace",job=~"$job"')
+          g.latencyPanel('thanos_blocks_meta_sync_duration_seconds', clusterNamespaceJob)
         )
       )
       .addRow(
@@ -110,7 +112,7 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
         .addPanel(
           g.panel('Rate', 'Shows rate of execution for operations against the bucket.') +
           g.queryPanel(
-            'sum(rate(thanos_objstore_bucket_operations_total{namespace="$namespace",job=~"$job"}[$interval])) by (job, operation)',
+            'sum(rate(thanos_objstore_bucket_operations_total{%s}[$interval])) by (job, operation)' % clusterNamespaceJob,
             '{{job}} {{operation}}'
           ) +
           g.stack
@@ -118,21 +120,22 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
         .addPanel(
           g.panel('Errors', 'Shows ratio of errors compared to the total number of executed operations against the bucket.') +
           g.qpsErrTotalPanel(
-            'thanos_objstore_bucket_operation_failures_total{namespace="$namespace",job=~"$job"}',
-            'thanos_objstore_bucket_operations_total{namespace="$namespace",job=~"$job"}',
+            'thanos_objstore_bucket_operation_failures_total{%s}' % clusterNamespaceJob,
+            'thanos_objstore_bucket_operations_total{%s}' % clusterNamespaceJob,
           )
         )
         .addPanel(
           g.panel('Duration', 'Shows how long has it taken to execute operations against the bucket, in quantiles.') +
-          g.latencyPanel('thanos_objstore_bucket_operation_duration_seconds', 'namespace="$namespace",job=~"$job"')
+          g.latencyPanel('thanos_objstore_bucket_operation_duration_seconds', clusterNamespaceJob)
         )
       )
       .addRow(
         g.resourceUtilizationRow()
       ) +
+      g.template(thanos.dashboard.clusterLabel, 'up', '', false, '', if thanos.dashboard.showMultiCluster then '' else '2') +
       g.template('namespace', thanos.dashboard.namespaceQuery) +
-      g.template('job', 'up', 'namespace="$namespace",%(selector)s' % thanos.compact, true, '%(jobPrefix)s.*' % thanos.compact) +
-      g.template('pod', 'kube_pod_info', 'namespace="$namespace",created_by_name=~"%(jobPrefix)s.*"' % thanos.compact, true, '.*'),
+      g.template('job', 'up', clusterNamespaceCompactSelector, true, '%(jobPrefix)s.*' % thanos.compact) +
+      g.template('pod', 'kube_pod_info', '%(clusterLabel)s="$cluster",namespace="$namespace",created_by_name=~"%(jobPrefix)s.*"' % [thanos.dashboard.clusterLabel, thanos.compact.jobPrefix], true, '.*'),
 
     __overviewRows__+:: [
       g.row('Compact')
@@ -142,7 +145,7 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
           'Shows rate of execution for compactions against blocks that are stored in the bucket by compaction group.'
         ) +
         g.queryPanel(
-          'sum(rate(thanos_compact_group_compactions_total{namespace="$namespace",%(selector)s}[$interval])) by (job)' % thanos.compact,
+          'sum(rate(thanos_compact_group_compactions_total{%s}[$interval])) by (job)' % clusterNamespaceCompactSelector,
           'compaction {{job}}'
         ) +
         g.stack +
@@ -154,8 +157,8 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
           'Shows ratio of errors compared to the total number of executed compactions against blocks that are stored in the bucket.'
         ) +
         g.qpsErrTotalPanel(
-          'thanos_compact_group_compactions_failures_total{namespace="$namespace",%(selector)s}' % thanos.compact,
-          'thanos_compact_group_compactions_total{namespace="$namespace",%(selector)s}' % thanos.compact,
+          'thanos_compact_group_compactions_failures_total{%s}' % clusterNamespaceCompactSelector,
+          'thanos_compact_group_compactions_total{%s}' % clusterNamespaceCompactSelector,
         ) +
         g.addDashboardLink(thanos.compact.title)
       ) +

--- a/mixin/dashboards/defaults.libsonnet
+++ b/mixin/dashboards/defaults.libsonnet
@@ -8,6 +8,8 @@
     prefix: 'Thanos / ',
     tags: error 'must provide dashboard tags',
     namespaceQuery: error 'must provide a query for namespace variable for dashboard template',
+    showMultiCluster: false,
+    clusterLabel: 'cluster',
   },
 
   // Automatically add a uid to each dashboard based on the base64 encoding

--- a/mixin/dashboards/query.libsonnet
+++ b/mixin/dashboards/query.libsonnet
@@ -7,6 +7,11 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
     selector: error 'must provide selector for Thanos Query dashboard',
     title: error 'must provide title for Thanos Query dashboard',
   },
+  local cluster = '%s="$cluster"' % thanos.dashboard.clusterLabel,
+  local namespace = 'namespace="$namespace"',
+  local clusterNamespace = '%s,%s' % [cluster, namespace],
+  local clusterNamespaceJob = '%s,job=~"$job"' % [clusterNamespace],
+  local clusterNamespaceSelector = '%s,%s' % [clusterNamespace, thanos.query.selector],
   grafanaDashboards+:: {
     'query.json':
       g.dashboard(thanos.query.title)
@@ -14,60 +19,60 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
         g.row('Instant Query API')
         .addPanel(
           g.panel('Rate', 'Shows rate of requests against /query for the given time.') +
-          g.httpQpsPanel('http_requests_total', 'namespace="$namespace",job=~"$job",handler="query"')
+          g.httpQpsPanel('http_requests_total', '%s,handler="query"' % clusterNamespaceJob)
         )
         .addPanel(
           g.panel('Errors', 'Shows ratio of errors compared to the the total number of handled requests against /query.') +
-          g.httpErrPanel('http_requests_total', 'namespace="$namespace",job=~"$job",handler="query"')
+          g.httpErrPanel('http_requests_total', '%s,handler="query"' % clusterNamespaceJob)
         )
         .addPanel(
           g.panel('Duration', 'Shows how long has it taken to handle requests in quantiles.') +
-          g.latencyPanel('http_request_duration_seconds', 'namespace="$namespace",job=~"$job",handler="query"')
+          g.latencyPanel('http_request_duration_seconds', '%s,handler="query"' % clusterNamespaceJob)
         )
       )
       .addRow(
         g.row('Range Query API')
         .addPanel(
           g.panel('Rate', 'Shows rate of requests against /query_range for the given time range.') +
-          g.httpQpsPanel('http_requests_total', 'namespace="$namespace",job=~"$job",handler="query_range"')
+          g.httpQpsPanel('http_requests_total', '%s,handler="query_range"' % clusterNamespaceJob)
         )
         .addPanel(
           g.panel('Errors', 'Shows ratio of errors compared to the the total number of handled requests against /query_range.') +
-          g.httpErrPanel('http_requests_total', 'namespace="$namespace",job=~"$job",handler="query_range"')
+          g.httpErrPanel('http_requests_total', '%s,handler="query_range"' % clusterNamespaceJob)
         )
         .addPanel(
           g.panel('Duration', 'Shows how long has it taken to handle requests in quantiles.') +
-          g.latencyPanel('http_request_duration_seconds', 'namespace="$namespace",job=~"$job",handler="query_range"')
+          g.latencyPanel('http_request_duration_seconds', '%s,handler="query_range"' % clusterNamespaceJob)
         )
       )
       .addRow(
         g.row('gRPC (Unary)')
         .addPanel(
           g.panel('Rate', 'Shows rate of handled Unary gRPC requests from other queriers.') +
-          g.grpcQpsPanel('client', 'namespace="$namespace",job=~"$job",grpc_type="unary"')
+          g.grpcQpsPanel('client', '%s,grpc_type="unary"' % clusterNamespaceJob)
         )
         .addPanel(
           g.panel('Errors', 'Shows ratio of errors compared to the the total number of handled requests from other queriers.') +
-          g.grpcErrorsPanel('client', 'namespace="$namespace",job=~"$job",grpc_type="unary"')
+          g.grpcErrorsPanel('client', '%s,grpc_type="unary"' % clusterNamespaceJob)
         )
         .addPanel(
           g.panel('Duration', 'Shows how long has it taken to handle requests from other queriers, in quantiles.') +
-          g.grpcLatencyPanel('client', 'namespace="$namespace",job=~"$job",grpc_type="unary"')
+          g.grpcLatencyPanel('client', '%s,grpc_type="unary"' % clusterNamespaceJob)
         )
       )
       .addRow(
         g.row('gRPC (Stream)')
         .addPanel(
           g.panel('Rate', 'Shows rate of handled Streamed gRPC requests from other queriers.') +
-          g.grpcQpsPanel('client', 'namespace="$namespace",job=~"$job",grpc_type="server_stream"')
+          g.grpcQpsPanel('client', '%s,grpc_type="server_stream"' % clusterNamespaceJob)
         )
         .addPanel(
           g.panel('Errors', 'Shows ratio of errors compared to the the total number of handled requests from other queriers.') +
-          g.grpcErrorsPanel('client', 'namespace="$namespace",job=~"$job",grpc_type="server_stream"')
+          g.grpcErrorsPanel('client', '%s,grpc_type="server_stream"' % clusterNamespaceJob)
         )
         .addPanel(
           g.panel('Duration', 'Shows how long has it taken to handle requests from other queriers, in quantiles') +
-          g.grpcLatencyPanel('client', 'namespace="$namespace",job=~"$job",grpc_type="server_stream"')
+          g.grpcLatencyPanel('client', '%s,grpc_type="server_stream"' % clusterNamespaceJob)
         )
       )
       .addRow(
@@ -75,42 +80,43 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
         .addPanel(
           g.panel('Rate', 'Shows rate of DNS lookups to discover stores.') +
           g.queryPanel(
-            'sum(rate(thanos_querier_store_apis_dns_lookups_total{namespace="$namespace",job=~"$job"}[$interval])) by (job)',
+            'sum(rate(thanos_querier_store_apis_dns_lookups_total{%s}[$interval])) by (job)' % clusterNamespaceJob,
             'lookups {{job}}'
           )
         )
         .addPanel(
           g.panel('Errors', 'Shows ratio of failures compared to the the total number of executed DNS lookups.') +
           g.qpsErrTotalPanel(
-            'thanos_querier_store_apis_dns_failures_total{namespace="$namespace",job=~"$job"}',
-            'thanos_querier_store_apis_dns_lookups_total{namespace="$namespace",job=~"$job"}',
+            'thanos_querier_store_apis_dns_failures_total{%s}' % clusterNamespaceJob,
+            'thanos_querier_store_apis_dns_lookups_total{%s}' % clusterNamespaceJob,
           )
         )
       )
       .addRow(
         g.resourceUtilizationRow()
       ) +
+      g.template(thanos.dashboard.clusterLabel, 'up', '', false, '', if thanos.dashboard.showMultiCluster then '' else '2') +
       g.template('namespace', thanos.dashboard.namespaceQuery) +
-      g.template('job', 'up', 'namespace="$namespace",%(selector)s' % thanos.query, true, '%(jobPrefix)s.*' % thanos.query) +
-      g.template('pod', 'kube_pod_info', 'namespace="$namespace",created_by_name=~"%(jobPrefix)s.*"' % thanos.query, true, '.*'),
+      g.template('job', 'up', clusterNamespaceSelector, true, '%(jobPrefix)s.*' % thanos.query) +
+      g.template('pod', 'kube_pod_info', '%s,created_by_name=~"%s.*"' % [clusterNamespace, thanos.query.jobPrefix], true, '.*'),
 
     __overviewRows__+:: [
       g.row('Instant Query')
       .addPanel(
         g.panel('Requests Rate', 'Shows rate of requests against /query for the given time.') +
-        g.httpQpsPanel('http_requests_total', 'namespace="$namespace",%(selector)s,handler="query"' % thanos.query) +
+        g.httpQpsPanel('http_requests_total', '%s,handler="query"' % clusterNamespaceSelector) +
         g.addDashboardLink(thanos.query.title)
       )
       .addPanel(
         g.panel('Requests Errors', 'Shows ratio of errors compared to the the total number of handled requests against /query.') +
-        g.httpErrPanel('http_requests_total', 'namespace="$namespace",%(selector)s,handler="query"' % thanos.query) +
+        g.httpErrPanel('http_requests_total', '%s,handler="query"' % clusterNamespaceSelector) +
         g.addDashboardLink(thanos.query.title)
       )
       .addPanel(
         g.sloLatency(
           'Latency 99th Percentile',
           'Shows how long has it taken to handle requests.',
-          'http_request_duration_seconds_bucket{namespace="$namespace",%(selector)s,handler="query"}' % thanos.query,
+          'http_request_duration_seconds_bucket{%s,handler="query"}' % clusterNamespaceSelector,
           0.99,
           0.5,
           1
@@ -121,19 +127,19 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
       g.row('Range Query')
       .addPanel(
         g.panel('Requests Rate', 'Shows rate of requests against /query_range for the given time range.') +
-        g.httpQpsPanel('http_requests_total', 'namespace="$namespace",%(selector)s,handler="query_range"' % thanos.query) +
+        g.httpQpsPanel('http_requests_total', '%s,handler="query_range"' % clusterNamespaceSelector) +
         g.addDashboardLink(thanos.query.title)
       )
       .addPanel(
         g.panel('Requests Errors', 'Shows ratio of errors compared to the the total number of handled requests against /query_range.') +
-        g.httpErrPanel('http_requests_total', 'namespace="$namespace",%(selector)s,handler="query_range"' % thanos.query) +
+        g.httpErrPanel('http_requests_total', '%s,handler="query_range"' % clusterNamespaceSelector) +
         g.addDashboardLink(thanos.query.title)
       )
       .addPanel(
         g.sloLatency(
           'Latency 99th Percentile',
           'Shows how long has it taken to handle requests.',
-          'http_request_duration_seconds_bucket{namespace="$namespace",%(selector)s,handler="query_range"}' % thanos.query,
+          'http_request_duration_seconds_bucket{%s,handler="query_range"}' % clusterNamespaceSelector,
           0.99,
           0.5,
           1

--- a/mixin/lib/thanos-grafana-builder/builder.libsonnet
+++ b/mixin/lib/thanos-grafana-builder/builder.libsonnet
@@ -22,7 +22,7 @@ local template = grafana.template;
     ],
   },
 
-  template(name, metricName, selector='', includeAll=false, allValues='')::
+  template(name, metricName, selector='', includeAll=false, allValues='', hide='')::
     local t = if includeAll then
       template.new(
         name,
@@ -33,7 +33,8 @@ local template = grafana.template;
         sort=2,
         current='all',
         allValues=allValues,
-        includeAll=true
+        includeAll=true,
+        hide=hide,
       )
     else
       template.new(
@@ -43,6 +44,7 @@ local template = grafana.template;
         label=name,
         refresh=1,
         sort=2,
+        hide=hide,
       );
 
     {


### PR DESCRIPTION
Hi,

We run certain components (query, compact, etc) in each cluster, however have a shared Grafana instance (as I'm sure is common). It's helpful to view some of these metrics per cluster, so I added a template variable for it.

I'm relatively new to jsonnet, so if there's a better way to accomplish this across all files, let me know! I wanted to submit this after doing two files so I don't head too far down a path before getting some feedback.

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Add cluster label to `mixin/dashboards`

## Verification

Applied these two updated dashboards to our Grafana instance.