### PR TITLE
Improve store to not load chunks from obj store for Series API

### DIFF
--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -741,12 +741,13 @@ func blockSeries(
 
 		// Reserve chunksLimiter if we save chunks.
 		if len(s.chks) > 0 {
+			hasValidChunk = true
 			if err := chunksLimiter.Reserve(uint64(len(s.chks))); err != nil {
 				return nil, nil, errors.Wrap(err, "exceeded chunks limit")
 			}
 		}
 
-		if hasValidChunk || len(s.chks) > 0 {
+		if hasValidChunk {
 			for _, l := range lset {
 				// Skip if the external labels of the block overrule the series' label.
 				// NOTE(fabxc): maybe move it to a prefixed version to still ensure uniqueness of series?

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -797,8 +797,7 @@ func blockSeriesWithoutChunks(
 		return nil, nil, errors.Wrap(err, "preload series")
 	}
 
-	// Transform all series into the response types and mark their relevant chunks
-	// for preloading.
+	// Transform all series into the response types.
 	var (
 		res  []seriesEntry
 		lset labels.Labels


### PR DESCRIPTION
Signed-off-by: Ben Ye <yb532204897@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

Using the similar idea of https://github.com/prometheus/prometheus/pull/8050 to only fetch labels for `/api/v1/series` API. Changes:

1. Only sort and dedup labels when there is at least one chunk in the specified time range. If no chunk is valid, then not necessary to sort labels.

2. Series query not load chunks. 

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
