### PR TITLE
Docs: Fix thanos tools bucket command in the GCS section (Storage)

### DIFF
--- a/docs/storage.md
+++ b/docs/storage.md
@@ -308,7 +308,7 @@ kubectl exec -it -n <namespace> <prometheus with sidecar pod name> -c <sidecar c
 Then test that you can at least list objects in the bucket, eg:
 
 ```sh
-thanos bucket ls --objstore.config="${OBJSTORE_CONFIG}"
+thanos tools bucket ls --objstore.config="${OBJSTORE_CONFIG}"
 ```
 
 ### Azure


### PR DESCRIPTION
Signed-off-by: Ricardo Ribeiro <j.ribeiro.fafe@gmail.com>

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

Small fix in the docs: add the missing `tools` sub command in the GCS section.

## Verification

NA