### PR TITLE
Disable Azure blob exception logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 
 ### Fixed
 - [#3257](https://github.com/thanos-io/thanos/pull/3257) Ruler: Prevent Ruler from crashing when using default DNS to lookup hosts that results in "No such hosts" errors.
+- [#3331](https://github.com/thanos-io/thanos/pull/3331) Disable Azure blob exception logging
 
 ## [v0.16.0](https://github.com/thanos-io/thanos/releases) - Release in progress
 

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/thanos-io/thanos
 require (
 	cloud.google.com/go v0.56.0
 	cloud.google.com/go/storage v1.6.0
+	github.com/Azure/azure-pipeline-go v0.2.2
 	github.com/Azure/azure-storage-blob-go v0.8.0
 	github.com/NYTimes/gziphandler v1.1.1
 	github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d

--- a/pkg/objstore/azure/helpers.go
+++ b/pkg/objstore/azure/helpers.go
@@ -10,6 +10,7 @@ import (
 	"regexp"
 	"time"
 
+	"github.com/Azure/azure-pipeline-go/pipeline"
 	blob "github.com/Azure/azure-storage-blob-go/azblob"
 )
 
@@ -34,6 +35,14 @@ func getContainerURL(ctx context.Context, conf Config) (blob.ContainerURL, error
 	p := blob.NewPipeline(c, blob.PipelineOptions{
 		Retry:     retryOptions,
 		Telemetry: blob.TelemetryOptions{Value: "Thanos"},
+		RequestLog: blob.RequestLogOptions{
+			// Log a warning if an operation takes longer than the specified duration.
+			// (-1=no logging; 0=default 3s threshold)
+			LogWarningIfTryOverThreshold: -1,
+		},
+		Log: pipeline.LogOptions{
+			ShouldLog: nil,
+		},
 	})
 	u, err := url.Parse(fmt.Sprintf("https://%s.%s", conf.StorageAccountName, conf.Endpoint))
 	if err != nil {


### PR DESCRIPTION
Ever since the introduction of the deletion marker, Thanos compact has been filling the logs with Azure blob storage exceptions. As discussed in #2565, the error logging should be handled by Thanos itself, so this patch turns off standard logging from the Azure library.

However, [due to the way logging is set up in the library][1], it will always log errors to syslog, regardless of how `ShouldLog` is configured. As such, and until that can be a configurable behavior, care should be taken to handle that from the syslog side as well.

[1]: https://github.com/Azure/azure-storage-blob-go/blob/48358e1de5110852097ebbc11c53581d64d47300/azblob/zc_policy_request_log.go#L100-L102

Signed-off-by: Pedro Araujo <phcrva@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Disabled exception logging from the Azure Blob storage module

## Verification

Compiled locally and ran `thanos compact` against an Azure blob storage container.
