### PR TITLE
queryfrontend: fix invalid values for dns provider interval

### DIFF
--- a/pkg/queryfrontend/config.go
+++ b/pkg/queryfrontend/config.go
@@ -93,6 +93,11 @@ func NewCacheConfig(logger log.Logger, confContentYaml []byte) (*cortexcache.Con
 			config.Expiration = 24 * time.Hour
 		}
 
+		if config.Memcached.DNSProviderUpdateInterval <= 0 {
+			level.Warn(logger).Log("msg", "memcached dns provider update interval time set to invalid value, defaulting to 10s")
+			config.Memcached.DNSProviderUpdateInterval = 10 * time.Second
+		}
+
 		return &cortexcache.Config{
 			Memcache: cortexcache.MemcachedConfig{
 				Expiration:  config.Expiration,


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

Make sure `dns_provider_update_interval` has a sane default, with `0s` then `query-frontend` won't start. More context at #3324 

## Verification

Compile and test default config