### PR TITLE
cmd/thanos: Extract logger instantiation to pkg/logging

### DIFF
--- a/cmd/thanos/main.go
+++ b/cmd/thanos/main.go
@@ -23,41 +23,11 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/version"
 	"github.com/thanos-io/thanos/pkg/extkingpin"
+	"github.com/thanos-io/thanos/pkg/logging"
 	"github.com/thanos-io/thanos/pkg/tracing/client"
 	"go.uber.org/automaxprocs/maxprocs"
 	"gopkg.in/alecthomas/kingpin.v2"
 )
-
-const (
-	logFormatLogfmt = "logfmt"
-	logFormatJson   = "json"
-)
-
-func setupLogger(logLevel, logFormat, debugName string) log.Logger {
-	var lvl level.Option
-	switch logLevel {
-	case "error":
-		lvl = level.AllowError()
-	case "warn":
-		lvl = level.AllowWarn()
-	case "info":
-		lvl = level.AllowInfo()
-	case "debug":
-		lvl = level.AllowDebug()
-	default:
-		panic("unexpected log level")
-	}
-	logger := log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr))
-	if logFormat == logFormatJson {
-		logger = log.NewJSONLogger(log.NewSyncWriter(os.Stderr))
-	}
-	logger = level.NewFilter(logger, lvl)
-
-	if debugName != "" {
-		logger = log.With(logger, "name", debugName)
-	}
-	return log.With(logger, "ts", log.DefaultTimestampUTC, "caller", log.DefaultCaller)
-}
 
 func main() {
 	if os.Getenv("DEBUG") != "" {
@@ -70,7 +40,7 @@ func main() {
 	logLevel := app.Flag("log.level", "Log filtering level.").
 		Default("info").Enum("error", "warn", "info", "debug")
 	logFormat := app.Flag("log.format", "Log format to use. Possible options: logfmt or json.").
-		Default(logFormatLogfmt).Enum(logFormatLogfmt, logFormatJson)
+		Default(logging.LogFormatLogfmt).Enum(logging.LogFormatLogfmt, logging.LogFormatJSON)
 	tracingConfig := extkingpin.RegisterCommonTracingFlags(app)
 
 	registerSidecar(app)
@@ -83,7 +53,14 @@ func main() {
 	registerQueryFrontend(app)
 
 	cmd, setup := app.Parse()
-	logger := setupLogger(*logLevel, *logFormat, *debugName)
+	logger := logging.NewLogger(*logFormat, *debugName)
+	logger, err := logging.WithLogLevel(logger, *logLevel)
+	if err != nil {
+		// This log line intentionally does not call the error level
+		// explicitly, as the log level configuration failed.
+		logger.Log("level", "error", "err", err)
+		os.Exit(1)
+	}
 
 	// Running in container with limits but with empty/wrong value of GOMAXPROCS env var could lead to throttling by cpu
 	// maxprocs will automate adjustment by using cgroups info about cpu limit if it set as value for runtime.GOMAXPROCS.

--- a/pkg/logging/logger.go
+++ b/pkg/logging/logger.go
@@ -1,0 +1,55 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package logging
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+)
+
+const (
+	LogFormatLogfmt = "logfmt"
+	LogFormatJSON   = "json"
+)
+
+// NewLogger returns a log.Logger that prints in the provided format with a UTC
+// timestamp and the caller of the log entry.
+func NewLogger(logFormat, debugName string) log.Logger {
+	logger := log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr))
+	if logFormat == LogFormatJSON {
+		logger = log.NewJSONLogger(log.NewSyncWriter(os.Stderr))
+	}
+
+	logger = log.With(logger, "ts", log.DefaultTimestampUTC, "caller", log.DefaultCaller)
+
+	if debugName != "" {
+		logger = log.With(logger, "name", debugName)
+	}
+
+	return logger
+}
+
+// WithLogLevel returns the passed logger with the appropriate log level
+// filter. If an unknown log level is passed an error is returned alongside the
+// original logger.
+func WithLogLevel(logger log.Logger, logLevel string) (log.Logger, error) {
+	var lvl level.Option
+	switch logLevel {
+	case "error":
+		lvl = level.AllowError()
+	case "warn":
+		lvl = level.AllowWarn()
+	case "info":
+		lvl = level.AllowInfo()
+	case "debug":
+		lvl = level.AllowDebug()
+	default:
+		return logger, fmt.Errorf("unexpected log level: %s (expected error, warn, info or debug)", logLevel)
+	}
+
+	return level.NewFilter(logger, lvl), nil
+}


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

Extract logger instantiation to the `pkg/logging` package.

## Verification

Moved code, and still compiles :) 

@thanos-io/thanos-maintainers 
