### PR TITLE
Only alloc labelsets in bucket series entry when it is a Series query

### DIFF
--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -707,10 +707,10 @@ func blockSeries(
 		if err := indexr.LoadedSeries(id, &lset, &chks); err != nil {
 			return nil, nil, errors.Wrap(err, "read series")
 		}
-		s := seriesEntry{
-			lset: make(labels.Labels, 0, len(lset)+len(extLset)),
-			refs: make([]uint64, 0, len(chks)),
-			chks: make([]storepb.AggrChunk, 0, len(chks)),
+		s := seriesEntry{lset: make(labels.Labels, 0, len(lset)+len(extLset))}
+		if !req.SkipChunks {
+			s.refs = make([]uint64, 0, len(chks))
+			s.chks = make([]storepb.AggrChunk, 0, len(chks))
 		}
 
 		// hasValidChunk is used to check whether there is at least one chunk in the required time range.


### PR DESCRIPTION
Signed-off-by: Ben Ye <yb532204897@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

It is not necessary to alloc `s.refs` and `s.chks` when we don't need to load chunks.
<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
