### PR TITLE
Extend bench bucket series with skip chunk test case

### DIFF
--- a/pkg/store/bucket_test.go
+++ b/pkg/store/bucket_test.go
@@ -1231,7 +1231,7 @@ func benchBucketSeries(t testutil.TB, skipChunk bool, samplesPerSeries, totalSer
 			Series:           seriesPerBlock,
 			PrependLabels:    extLset,
 			Random:           random,
-			SkipChunks:       t.IsBenchmark(),
+			SkipChunks:       false,
 		})
 		id := createBlockFromHead(t, blockDir, head)
 		testutil.Ok(t, head.Close())

--- a/pkg/store/bucket_test.go
+++ b/pkg/store/bucket_test.go
@@ -1154,7 +1154,7 @@ func TestBucketSeries(t *testing.T) {
 	})
 }
 
-func TestBucketSeriesSkipChunks(t *testing.T) {
+func TestBucketSkipChunksSeries(t *testing.T) {
 	tb := testutil.NewTB(t)
 	storetestutil.RunSeriesInterestingCases(tb, 200e3, 200e3, func(t testutil.TB, samplesPerSeries, series int) {
 		benchBucketSeries(t, true, samplesPerSeries, series, 1)
@@ -1169,7 +1169,7 @@ func BenchmarkBucketSeries(b *testing.B) {
 	})
 }
 
-func BenchmarkBucketSeriesSkipChunks(b *testing.B) {
+func BenchmarkBucketSkipChunksSeries(b *testing.B) {
 	tb := testutil.NewTB(b)
 	// 10e6 samples = ~1736 days with 15s scrape
 	storetestutil.RunSeriesInterestingCases(tb, 10e6, 10e5, func(t testutil.TB, samplesPerSeries, series int) {

--- a/pkg/store/storepb/testutil/series.go
+++ b/pkg/store/storepb/testutil/series.go
@@ -235,10 +235,14 @@ func TestServerSeries(t testutil.TB, store storepb.StoreServer, cases ...*Series
 					if len(c.ExpectedSeries) > 4 {
 						for j := range c.ExpectedSeries {
 							testutil.Equals(t, c.ExpectedSeries[j].Labels, srv.SeriesSet[j].Labels, "%v series chunks mismatch", j)
-							if len(c.ExpectedSeries[j].Chunks) > 20 {
-								testutil.Equals(t, len(c.ExpectedSeries[j].Chunks), len(srv.SeriesSet[j].Chunks), "%v series chunks number mismatch", j)
+
+							// Check chunks when it is not a skip chunk query
+							if !c.Req.SkipChunks {
+								if len(c.ExpectedSeries[j].Chunks) > 20 {
+									testutil.Equals(t, len(c.ExpectedSeries[j].Chunks), len(srv.SeriesSet[j].Chunks), "%v series chunks number mismatch", j)
+								}
+								testutil.Equals(t, c.ExpectedSeries[j].Chunks, srv.SeriesSet[j].Chunks, "%v series chunks mismatch", j)
 							}
-							testutil.Equals(t, c.ExpectedSeries[j].Chunks, srv.SeriesSet[j].Chunks, "%v series chunks mismatch", j)
 						}
 					} else {
 						testutil.Equals(t, c.ExpectedSeries, srv.SeriesSet)


### PR DESCRIPTION
Signed-off-by: Ben Ye <yb532204897@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

This pr fixes and extends the benchmark tests in bucket_test.go with skip chunk option so that we can measure the performance with `/api/v1/series` queries.

<!-- Enumerate changes you made -->

## Verification

Did some local benchmarks between current master and https://github.com/thanos-io/thanos/commit/2a7590f69a5ace6014ddcc932788056935f201ba, which is the commit before I introduced https://github.com/thanos-io/thanos/commit/053730c6054517186187b33b36d989069b08ad70.

Results:

```
➜  thanos git:(change-benchseries-skipchunks) ✗ benchcmp old new2 
benchcmp is deprecated in favor of benchstat: https://pkg.go.dev/golang.org/x/perf/cmd/benchstat
benchmark                                                                           old ns/op      new ns/op      delta
BenchmarkBucketSeriesSkipChunks/1000000SeriesWith1Samples/1of1000000-8              374105769      301182970      -19.49%
BenchmarkBucketSeriesSkipChunks/1000000SeriesWith1Samples/10of1000000-8             366452232      309757355      -15.47%
BenchmarkBucketSeriesSkipChunks/1000000SeriesWith1Samples/1000000of1000000-8        1467578057     1300962124     -11.35%
BenchmarkBucketSeriesSkipChunks/100000SeriesWith100Samples/1of10000000-8            31472869       24470688       -22.25%
BenchmarkBucketSeriesSkipChunks/100000SeriesWith100Samples/100of10000000-8          31160010       25012601       -19.73%
BenchmarkBucketSeriesSkipChunks/100000SeriesWith100Samples/10000000of10000000-8     134128144      117053813      -12.73%
BenchmarkBucketSeriesSkipChunks/1SeriesWith10000000Samples/1of10000000-8            2564966        2696107        +5.11%
BenchmarkBucketSeriesSkipChunks/1SeriesWith10000000Samples/100of10000000-8          2799881        2989642        +6.78%
BenchmarkBucketSeriesSkipChunks/1SeriesWith10000000Samples/10000000of10000000-8     29997992       7483051        -75.05%
```

```
➜  thanos git:(change-benchseries-skipchunks) ✗ benchcmp old1 new2
benchcmp is deprecated in favor of benchstat: https://pkg.go.dev/golang.org/x/perf/cmd/benchstat
benchmark                                                                           old ns/op      new ns/op      delta
BenchmarkBucketSeriesSkipChunks/1000000SeriesWith1Samples/1of1000000-8              370824340      301182970      -18.78%
BenchmarkBucketSeriesSkipChunks/1000000SeriesWith1Samples/10of1000000-8             361008121      309757355      -14.20%
BenchmarkBucketSeriesSkipChunks/1000000SeriesWith1Samples/1000000of1000000-8        1416173683     1300962124     -8.14%
BenchmarkBucketSeriesSkipChunks/100000SeriesWith100Samples/1of10000000-8            31943616       24470688       -23.39%
BenchmarkBucketSeriesSkipChunks/100000SeriesWith100Samples/100of10000000-8          32781041       25012601       -23.70%
BenchmarkBucketSeriesSkipChunks/100000SeriesWith100Samples/10000000of10000000-8     132956005      117053813      -11.96%
BenchmarkBucketSeriesSkipChunks/1SeriesWith10000000Samples/1of10000000-8            3796664        2696107        -28.99%
BenchmarkBucketSeriesSkipChunks/1SeriesWith10000000Samples/100of10000000-8          4202906        2989642        -28.87%
BenchmarkBucketSeriesSkipChunks/1SeriesWith10000000Samples/10000000of10000000-8     30378157       7483051        -75.37%
```

```
➜  thanos git:(change-benchseries-skipchunks) ✗ benchcmp old2 new2
benchcmp is deprecated in favor of benchstat: https://pkg.go.dev/golang.org/x/perf/cmd/benchstat
benchmark                                                                           old ns/op      new ns/op      delta
BenchmarkBucketSeriesSkipChunks/1000000SeriesWith1Samples/1of1000000-8              365262896      301182970      -17.54%
BenchmarkBucketSeriesSkipChunks/1000000SeriesWith1Samples/10of1000000-8             365881346      309757355      -15.34%
BenchmarkBucketSeriesSkipChunks/1000000SeriesWith1Samples/1000000of1000000-8        1472493317     1300962124     -11.65%
BenchmarkBucketSeriesSkipChunks/100000SeriesWith100Samples/1of10000000-8            32594123       24470688       -24.92%
BenchmarkBucketSeriesSkipChunks/100000SeriesWith100Samples/100of10000000-8          33246343       25012601       -24.77%
BenchmarkBucketSeriesSkipChunks/100000SeriesWith100Samples/10000000of10000000-8     132272646      117053813      -11.51%
BenchmarkBucketSeriesSkipChunks/1SeriesWith10000000Samples/1of10000000-8            3441730        2696107        -21.66%
BenchmarkBucketSeriesSkipChunks/1SeriesWith10000000Samples/100of10000000-8          5469016        2989642        -45.33%
BenchmarkBucketSeriesSkipChunks/1SeriesWith10000000Samples/10000000of10000000-8     30291587       7483051        -75.30%

```

<!-- How you tested it? How do you know it works? -->
