### PR TITLE
Check bucket series time range when decoding chunks from index

### DIFF
--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -707,8 +707,8 @@ func blockSeries(
 		if err := indexr.LoadedSeries(id, &lset, &chks, req); err != nil {
 			return nil, nil, errors.Wrap(err, "read series")
 		}
-		s := seriesEntry{lset: make(labels.Labels, 0, len(lset)+len(extLset))}
 		if len(chks) > 0 {
+			s := seriesEntry{lset: make(labels.Labels, 0, len(lset)+len(extLset))}
 			if !req.SkipChunks {
 				s.refs = make([]uint64, 0, len(chks))
 				s.chks = make([]storepb.AggrChunk, 0, len(chks))


### PR DESCRIPTION
Signed-off-by: Ben Ye <yb532204897@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

This idea behind this pr is to check the chunk time range when decoding the series from the index. This change can benefit a lot the `skipChunk` queries because it can immediately return if it finds a valid chunk instead of decoding all the chunks in this series. 

<!-- Enumerate changes you made -->

Verification

Uses the benchmarks from https://github.com/thanos-io/thanos/pull/3366. Benchmark and compare between this pr and current master.

1. `SkipChunk` query. 

It is expected that this type of query should be much faster than before.

```
➜  thanos git:(improve-index-valid) ✗ benchcmp old new9
benchcmp is deprecated in favor of benchstat: https://pkg.go.dev/golang.org/x/perf/cmd/benchstat
benchmark                                                                           old ns/op      new ns/op      delta
BenchmarkBucketSeriesSkipChunks/1000000SeriesWith1Samples/1of1000000-8              374105769      304828968      -18.52%
BenchmarkBucketSeriesSkipChunks/1000000SeriesWith1Samples/10of1000000-8             366452232      287316200      -21.60%
BenchmarkBucketSeriesSkipChunks/1000000SeriesWith1Samples/1000000of1000000-8        1467578057     1077410930     -26.59%
BenchmarkBucketSeriesSkipChunks/100000SeriesWith100Samples/1of10000000-8            31472869       22883196       -27.29%
BenchmarkBucketSeriesSkipChunks/100000SeriesWith100Samples/100of10000000-8          31160010       23195988       -25.56%
BenchmarkBucketSeriesSkipChunks/100000SeriesWith100Samples/10000000of10000000-8     134128144      108503863      -19.10%
BenchmarkBucketSeriesSkipChunks/1SeriesWith10000000Samples/1of10000000-8            2564966        99784          -96.11%
BenchmarkBucketSeriesSkipChunks/1SeriesWith10000000Samples/100of10000000-8          2799881        125497         -95.52%
BenchmarkBucketSeriesSkipChunks/1SeriesWith10000000Samples/10000000of10000000-8     29997992       373188         -98.76%
```

2. Normal series query

The expected performance of this should be almost the same or a little bit slower than before. However, this pr is about 10% - 20% slower when there are a lot of samples in one series. Not sure how to improve this case. I think there is no extra overhead except we are using more if-else statements than before when decoding the index.

```
➜  thanos git:(improve-index-valid) ✗ benchcmp b-old c-13
benchcmp is deprecated in favor of benchstat: https://pkg.go.dev/golang.org/x/perf/cmd/benchstat
benchmark                                                                 old ns/op      new ns/op      delta
BenchmarkBucketSeries/1000000SeriesWith1Samples/1of1000000-8              317048216      274136169      -13.53%
BenchmarkBucketSeries/1000000SeriesWith1Samples/10of1000000-8             316798190      278900447      -11.96%
BenchmarkBucketSeries/1000000SeriesWith1Samples/1000000of1000000-8        1535423045     1519882954     -1.01%
BenchmarkBucketSeries/100000SeriesWith100Samples/1of10000000-8            25975122       23109618       -11.03%
BenchmarkBucketSeries/100000SeriesWith100Samples/100of10000000-8          25753028       23400939       -9.13%
BenchmarkBucketSeries/100000SeriesWith100Samples/10000000of10000000-8     138522971      137316413      -0.87%
BenchmarkBucketSeries/1SeriesWith10000000Samples/1of10000000-8            2516395        129818         -94.84%
BenchmarkBucketSeries/1SeriesWith10000000Samples/100of10000000-8          2500083        152185         -93.91%
BenchmarkBucketSeries/1SeriesWith10000000Samples/10000000of10000000-8     33321908       36184470       +8.59%
```