### PR TITLE
pkg/server/grpc: Allow passing arbitrary gRPC server options

### DIFF
--- a/pkg/server/grpc/grpc.go
+++ b/pkg/server/grpc/grpc.go
@@ -67,7 +67,7 @@ func New(logger log.Logger, reg prometheus.Registerer, tracer opentracing.Tracer
 		return status.Errorf(codes.Internal, "%s", p)
 	}
 
-	grpcOpts := []grpc.ServerOption{
+	options.grpcOpts = append(options.grpcOpts, []grpc.ServerOption{
 		grpc.MaxSendMsgSize(math.MaxInt32),
 		grpc_middleware.WithUnaryServerChain(
 			met.UnaryServerInterceptor(),
@@ -79,12 +79,12 @@ func New(logger log.Logger, reg prometheus.Registerer, tracer opentracing.Tracer
 			tracing.StreamServerInterceptor(tracer),
 			grpc_recovery.StreamServerInterceptor(grpc_recovery.WithRecoveryHandler(grpcPanicRecoveryHandler)),
 		),
-	}
+	}...)
 
 	if options.tlsConfig != nil {
-		grpcOpts = append(grpcOpts, grpc.Creds(credentials.NewTLS(options.tlsConfig)))
+		options.grpcOpts = append(options.grpcOpts, grpc.Creds(credentials.NewTLS(options.tlsConfig)))
 	}
-	s := grpc.NewServer(grpcOpts...)
+	s := grpc.NewServer(options.grpcOpts...)
 
 	// Register all configured servers.
 	for _, f := range options.registerServerFuncs {

--- a/pkg/server/grpc/option.go
+++ b/pkg/server/grpc/option.go
@@ -20,6 +20,8 @@ type options struct {
 	network     string
 
 	tlsConfig *tls.Config
+
+	grpcOpts []grpc.ServerOption
 }
 
 // Option overrides behavior of Server.
@@ -40,6 +42,14 @@ type registerServerFunc func(s *grpc.Server)
 func WithServer(f registerServerFunc) Option {
 	return optionFunc(func(o *options) {
 		o.registerServerFuncs = append(o.registerServerFuncs, f)
+	})
+}
+
+// WithGRPCServerOption allows adding raw grpc.ServerOption's to the
+// instantiated gRPC server.
+func WithGRPCServerOption(opt grpc.ServerOption) Option {
+	return optionFunc(func(o *options) {
+		o.grpcOpts = append(o.grpcOpts, opt)
 	})
 }
 


### PR DESCRIPTION
Signed-off-by: Frederic Branczyk <fbranczyk@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

Allow passing arbitrary gRPC server option to server instantiation.

## Verification

Still compiles :) 

@thanos-io/thanos-maintainers 