### PR TITLE
mixin: Fix absent alerts

### DIFF
--- a/examples/alerts/alerts.md
+++ b/examples/alerts/alerts.md
@@ -575,6 +575,15 @@ rules:
 ```yaml
 name: thanos-component-absent.rules
 rules:
+- alert: ThanosBucketReplicateIsDown
+  annotations:
+    description: ThanosBucketReplicate has disappeared from Prometheus target discovery.
+    summary: thanos component has disappeared from Prometheus target discovery.
+  expr: |
+    absent(up{job=~"thanos-bucket-replicate.*"} == 1)
+  for: 5m
+  labels:
+    severity: critical
 - alert: ThanosCompactIsDown
   annotations:
     description: ThanosCompact has disappeared from Prometheus target discovery.

--- a/examples/alerts/alerts.yaml
+++ b/examples/alerts/alerts.yaml
@@ -483,8 +483,56 @@ groups:
     for: 3m
     labels:
       severity: critical
+- name: thanos-bucket-replicate.rules
+  rules:
+  - alert: ThanosBucketReplicateIsDown
+    annotations:
+      description: Thanos Replicate has disappeared from Prometheus target discovery.
+      summary: Thanos Replicate has disappeared from Prometheus target discovery.
+    expr: |
+      absent(up{job=~"thanos-bucket-replicate.*"})
+    for: 5m
+    labels:
+      severity: critical
+  - alert: ThanosBucketReplicateErrorRate
+    annotations:
+      description: Thanos Replicate failing to run, {{ $value | humanize }}% of attempts
+        failed.
+      summary: Thanose Replicate is failing to run.
+    expr: |
+      (
+        sum(rate(thanos_replicate_replication_runs_total{result="error", job=~"thanos-bucket-replicate.*"}[5m]))
+      / on (namespace) group_left
+        sum(rate(thanos_replicate_replication_runs_total{job=~"thanos-bucket-replicate.*"}[5m]))
+      ) * 100 >= 10
+    for: 5m
+    labels:
+      severity: critical
+  - alert: ThanosBucketReplicateRunLatency
+    annotations:
+      description: Thanos Replicate {{$labels.job}} has a 99th percentile latency
+        of {{ $value }} seconds for the replicate operations.
+      summary: Thanos Replicate has a high latency for replicate operations.
+    expr: |
+      (
+        histogram_quantile(0.9, sum by (job, le) (rate(thanos_replicate_replication_run_duration_seconds_bucket{job=~"thanos-bucket-replicate.*"}[5m]))) > 20
+      and
+        sum by (job) (rate(thanos_replicate_replication_run_duration_seconds_bucket{job=~"thanos-bucket-replicate.*"}[5m])) > 0
+      )
+    for: 5m
+    labels:
+      severity: critical
 - name: thanos-component-absent.rules
   rules:
+  - alert: ThanosBucketReplicateIsDown
+    annotations:
+      description: ThanosBucketReplicate has disappeared from Prometheus target discovery.
+      summary: thanos component has disappeared from Prometheus target discovery.
+    expr: |
+      absent(up{job=~"thanos-bucket-replicate.*"} == 1)
+    for: 5m
+    labels:
+      severity: critical
   - alert: ThanosCompactIsDown
     annotations:
       description: ThanosCompact has disappeared from Prometheus target discovery.
@@ -536,45 +584,6 @@ groups:
       summary: thanos component has disappeared from Prometheus target discovery.
     expr: |
       absent(up{job=~"thanos-store.*"} == 1)
-    for: 5m
-    labels:
-      severity: critical
-- name: thanos-bucket-replicate.rules
-  rules:
-  - alert: ThanosBucketReplicateIsDown
-    annotations:
-      description: Thanos Replicate has disappeared from Prometheus target discovery.
-      summary: Thanos Replicate has disappeared from Prometheus target discovery.
-    expr: |
-      absent(up{job=~"thanos-bucket-replicate.*"})
-    for: 5m
-    labels:
-      severity: critical
-  - alert: ThanosBucketReplicateErrorRate
-    annotations:
-      description: Thanos Replicate failing to run, {{ $value | humanize }}% of attempts
-        failed.
-      summary: Thanose Replicate is failing to run.
-    expr: |
-      (
-        sum(rate(thanos_replicate_replication_runs_total{result="error", job=~"thanos-bucket-replicate.*"}[5m]))
-      / on (namespace) group_left
-        sum(rate(thanos_replicate_replication_runs_total{job=~"thanos-bucket-replicate.*"}[5m]))
-      ) * 100 >= 10
-    for: 5m
-    labels:
-      severity: critical
-  - alert: ThanosBucketReplicateRunLatency
-    annotations:
-      description: Thanos Replicate {{$labels.job}} has a 99th percentile latency
-        of {{ $value }} seconds for the replicate operations.
-      summary: Thanos Replicate has a high latency for replicate operations.
-    expr: |
-      (
-        histogram_quantile(0.9, sum by (job, le) (rate(thanos_replicate_replication_run_duration_seconds_bucket{job=~"thanos-bucket-replicate.*"}[5m]))) > 20
-      and
-        sum by (job) (rate(thanos_replicate_replication_run_duration_seconds_bucket{job=~"thanos-bucket-replicate.*"}[5m])) > 0
-      )
     for: 5m
     labels:
       severity: critical

--- a/mixin/alerts/absent.libsonnet
+++ b/mixin/alerts/absent.libsonnet
@@ -1,14 +1,13 @@
+local capitalize(str) = std.asciiUpper(std.substr(str, 0, 1)) + std.asciiLower(std.substr(str, 1, std.length(str)));
+local titlize(str) = std.join('', std.map(capitalize, std.split(str, '_')));
 {
   local thanos = self,
 
   // We build alerts for the presence of all these jobs.
   jobs:: {
-    ThanosQuery: thanos.query.selector,
-    ThanosStore: thanos.store.selector,
-    ThanosReceive: thanos.receive.selector,
-    ThanosRule: thanos.rule.selector,
-    ThanosCompact: thanos.compact.selector,
-    ThanosSidecar: thanos.sidecar.selector,
+    ['Thanos%s' % titlize(component)]: thanos[component].selector
+    for component in std.objectFieldsAll(thanos)
+    if component != 'jobs' && std.type(thanos[component]) == 'object' && std.objectHas(thanos[component], 'selector')
   },
 
   prometheusAlerts+:: {

--- a/mixin/alerts/alerts.libsonnet
+++ b/mixin/alerts/alerts.libsonnet
@@ -4,5 +4,5 @@
 (import 'sidecar.libsonnet') +
 (import 'store.libsonnet') +
 (import 'rule.libsonnet') +
-(import 'absent.libsonnet') +
-(import 'bucket_replicate.libsonnet')
+(import 'bucket_replicate.libsonnet') +
+(import 'absent.libsonnet')

--- a/pkg/rules/rules_test.go
+++ b/pkg/rules/rules_test.go
@@ -50,7 +50,7 @@ func testRulesAgainstExamples(t *testing.T, dir string, server rulespb.RulesServ
 		{
 			Name:                    "thanos-component-absent.rules",
 			File:                    filepath.Join(dir, "alerts.yaml"),
-			Rules:                   []*rulespb.Rule{someAlert, someAlert, someAlert, someAlert, someAlert, someAlert},
+			Rules:                   []*rulespb.Rule{someAlert, someAlert, someAlert, someAlert, someAlert, someAlert, someAlert},
 			Interval:                60,
 			PartialResponseStrategy: storepb.PartialResponseStrategy_ABORT,
 		},


### PR DESCRIPTION
When someone excludes certain components at the downstream, this prevents generating absent alerts. This PR makes sure that those alerts are generated without any errors.


<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

