### PR TITLE
Use hardcoded time in query frontend test, fix flakey

### DIFF
--- a/pkg/queryfrontend/roundtrip_test.go
+++ b/pkg/queryfrontend/roundtrip_test.go
@@ -19,7 +19,6 @@ import (
 	cortexvalidation "github.com/cortexproject/cortex/pkg/util/validation"
 	"github.com/go-kit/kit/log"
 	"github.com/prometheus/prometheus/pkg/labels"
-	"github.com/prometheus/prometheus/pkg/timestamp"
 	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/weaveworks/common/user"
 
@@ -432,7 +431,6 @@ func TestRoundTripQueryRangeCacheMiddleware(t *testing.T) {
 		},
 	}
 
-	now := time.Now()
 	tpw, err := NewTripperware(
 		Config{
 			QueryRangeConfig: QueryRangeConfig{
@@ -467,18 +465,18 @@ func TestRoundTripQueryRangeCacheMiddleware(t *testing.T) {
 			name: "request but will be partitioned",
 			req: &ThanosQueryRangeRequest{
 				Path:  "/api/v1/query_range",
-				Start: timestamp.FromTime(now.Add(-time.Hour)),
-				End:   timestamp.FromTime(now.Add(time.Hour)),
+				Start: 0,
+				End:   25 * hour,
 				Step:  10 * seconds,
 			},
-			expected: 6,
+			expected: 7,
 		},
 		{
 			name: "same query as the previous one",
 			req: &ThanosQueryRangeRequest{
 				Path:  "/api/v1/query_range",
-				Start: timestamp.FromTime(now.Add(-time.Hour)),
-				End:   timestamp.FromTime(now.Add(time.Hour)),
+				Start: 0,
+				End:   25 * hour,
 				Step:  10 * seconds,
 			},
 			expected: 7,
@@ -541,7 +539,6 @@ func TestRoundTripLabelsCacheMiddleware(t *testing.T) {
 		},
 	}
 
-	now := time.Now()
 	tpw, err := NewTripperware(
 		Config{
 			LabelsConfig: LabelsConfig{
@@ -575,17 +572,17 @@ func TestRoundTripLabelsCacheMiddleware(t *testing.T) {
 			name: "request but will be partitioned",
 			req: &ThanosLabelsRequest{
 				Path:  "/api/v1/labels",
-				Start: timestamp.FromTime(now.Add(-time.Hour)),
-				End:   timestamp.FromTime(now.Add(time.Hour)),
+				Start: 0,
+				End:   25 * hour,
 			},
-			expected: 5,
+			expected: 6,
 		},
 		{
 			name: "same query as the previous one",
 			req: &ThanosLabelsRequest{
 				Path:  "/api/v1/labels",
-				Start: timestamp.FromTime(now.Add(-time.Hour)),
-				End:   timestamp.FromTime(now.Add(time.Hour)),
+				Start: 0,
+				End:   25 * hour,
 			},
 			expected: 6,
 		},


### PR DESCRIPTION
Signed-off-by: Ben Ye <yb532204897@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Using the real time (time.Now()) might cause flaky when splitting queries. This pr changes it to use hardcoded time.
<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
