### PR TITLE
scripts/quickstart: connect Ruler to Query, fix recording rule

### DIFF
--- a/scripts/quickstart.sh
+++ b/scripts/quickstart.sh
@@ -74,8 +74,8 @@ cat >data/rules.yml <<-EOF
 	groups:
 	  - name: example
 	    rules:
-	    - record: job:http_inprogress_requests:sum
-	      expr: sum(http_inprogress_requests) by (job)
+	    - record: job:go_threads:sum
+	      expr: sum(go_threads) by (job)
 EOF
 
 STORES=""
@@ -249,6 +249,20 @@ QUERIER_JAEGER_CONFIG=$(
 	EOF
 )
 
+# Start Thanos Ruler.
+${THANOS_EXECUTABLE} rule \
+  --data-dir data/ \
+  --eval-interval "30s" \
+  --rule-file "data/rules.yml" \
+  --alert.query-url "http://0.0.0.0:9090" \
+  --query "http://0.0.0.0:10904" \
+  --query "http://0.0.0.0:10914" \
+  --http-address="0.0.0.0:19999" \
+  --grpc-address="0.0.0.0:19998" \
+  ${OBJSTORECFG} &
+
+STORES="${STORES} --store 127.0.0.1:19998"
+
 # Start two query nodes.
 for i in $(seq 0 1); do
   ${THANOS_EXECUTABLE} query \
@@ -276,18 +290,6 @@ if [ -n "${GCS_BUCKET}" -o -n "${S3_ENDPOINT}" ]; then
 fi
 
 sleep 0.5
-
-# Start Thanos Ruler.
-${THANOS_EXECUTABLE} rule \
-  --data-dir data/ \
-  --eval-interval "30s" \
-  --rule-file "data/rules.yml" \
-  --alert.query-url "http://0.0.0.0:9090" \
-  --query "http://0.0.0.0:10904" \
-  --query "http://0.0.0.0:10914" \
-  --http-address="0.0.0.0:19999" \
-  --grpc-address="0.0.0.0:19998" \
-  ${OBJSTORECFG} &
 
 echo "all started; waiting for signal"
 


### PR DESCRIPTION
Move Thanos Ruler execution a bit earlier, before Thanos Query, so that
we could connect it to Thanos Query using the STORES variable. Also, fix
the recording rule so that it would use a more "universal" metric. On my
machine I couldn't find `http_inprogress_requests` so it didn't work
OOB.

Signed-off-by: Giedrius Statkevičius <giedriuswork@gmail.com>


* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Verification

Ran the script and was able to query the result of the recording rule via Thanos Query on http://localhost:10904/ that is connected to Thanos Ruler.