### PR TITLE
Querier UI: Updating enable/disable metric automcomplete with upstream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#3312](https://github.com/thanos-io/thanos/pull/3312) s3: add list_objects_version config option for compatibility.
 - [#3356](https://github.com/thanos-io/thanos/pull/3356) Query Frontend: Add a flag to disable step alignment middleware for query range.
 - [#3378](https://github.com/thanos-io/thanos/pull/3378) Ruler: added the ability to send queries via the HTTP method POST. Helps when alerting/recording rules are extra long because it encodes the actual parameters inside of the body instead of the URI. Thanos Ruler now uses POST by default unless `--query.http-method` is set `GET`.
+- [#3381](https://github.com/thanos-io/thanos/pull/3381) Querier UI: Add ability to enable or disable metric autocomplete functionality.
 
 ### Fixed
 - [#3257](https://github.com/thanos-io/thanos/pull/3257) Ruler: Prevent Ruler from crashing when using default DNS to lookup hosts that results in "No such hosts" errors.

--- a/pkg/ui/react-app/src/pages/graph/ExpressionInput.test.tsx
+++ b/pkg/ui/react-app/src/pages/graph/ExpressionInput.test.tsx
@@ -30,7 +30,7 @@ describe('ExpressionInput', () => {
       // Do nothing.
     },
     loading: false,
-    enable: true,
+    enableMetricAutocomplete: true,
   };
 
   let expressionInput: ReactWrapper;
@@ -175,9 +175,13 @@ describe('ExpressionInput', () => {
       instance.createAutocompleteSection({ closeMenu: spyCloseMenu });
       setTimeout(() => expect(spyCloseMenu).toHaveBeenCalled());
     });
-    it('should not render list if enable is false', () => {
+    it('should not render list if enableMetricAutocomplete is false', () => {
       const input = mount(
-        <ExpressionInput autocompleteSections={{ title: ['foo', 'bar', 'baz'] }} {...({} as any)} enable={false} />
+        <ExpressionInput
+          autocompleteSections={{ title: ['foo', 'bar', 'baz'] }}
+          {...({} as any)}
+          enableMetricAutocomplete={false}
+        />
       );
       const instance: any = input.instance();
       const spyCloseMenu = jest.fn();
@@ -186,7 +190,11 @@ describe('ExpressionInput', () => {
     });
     it('should render autosuggest-dropdown', () => {
       const input = mount(
-        <ExpressionInput autocompleteSections={{ title: ['foo', 'bar', 'baz'] }} {...({} as any)} enable={true} />
+        <ExpressionInput
+          autocompleteSections={{ title: ['foo', 'bar', 'baz'] }}
+          {...({} as any)}
+          enableMetricAutocomplete={true}
+        />
       );
       const instance: any = input.instance();
       const spyGetMenuProps = jest.fn();

--- a/pkg/ui/react-app/src/pages/graph/ExpressionInput.tsx
+++ b/pkg/ui/react-app/src/pages/graph/ExpressionInput.tsx
@@ -14,7 +14,7 @@ interface ExpressionInputProps {
   autocompleteSections: { [key: string]: string[] };
   executeQuery: () => void;
   loading: boolean;
-  enable: boolean;
+  enableMetricAutocomplete: boolean;
 }
 
 interface ExpressionInputState {
@@ -78,7 +78,7 @@ class ExpressionInput extends Component<ExpressionInputProps, ExpressionInputSta
     const { autocompleteSections } = this.props;
     let index = 0;
     const sections =
-      inputValue!.length && this.props.enable
+      inputValue!.length && this.props.enableMetricAutocomplete
         ? Object.entries(autocompleteSections).reduce((acc, [title, items]) => {
             const matches = this.getSearchMatches(inputValue!, items);
             return !matches.length

--- a/pkg/ui/react-app/src/pages/graph/Panel.tsx
+++ b/pkg/ui/react-app/src/pages/graph/Panel.tsx
@@ -284,7 +284,7 @@ class Panel extends Component<PanelProps & PathPrefixProps, PanelState> {
               onExpressionChange={this.handleExpressionChange}
               executeQuery={this.executeQuery}
               loading={this.state.loading}
-              enable={this.props.enableMetricAutocomplete}
+              enableMetricAutocomplete={this.props.enableMetricAutocomplete}
               autocompleteSections={{
                 'Query History': pastQueries,
                 'Metric Names': metricNames,


### PR DESCRIPTION
Bringing in changes suggested by Prometheus developers to keep in sync.
Also updated CHANGELOG.

Signed-off-by: Jarod Watkins <jarod@42lines.net>
