### PR TITLE
Docs: Fix broken helm chart link and query frontend invalid argument

### DIFF
--- a/docs/components/query-frontend.md
+++ b/docs/components/query-frontend.md
@@ -15,7 +15,7 @@ Example command to run Query Frontend:
 
 ```bash
 thanos query-frontend \
-    --http-address     "http://0.0.0.0:9090" \
+    --http-address     "0.0.0.0:9090" \
     --query-frontend.downstream-url="<thanos-querier>:<querier-http-port>"
 ```
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -79,7 +79,7 @@ Our friendly community maintains a few different ways of installing Thanos on Ku
 
 * [prometheus-operator](https://github.com/coreos/prometheus-operator): Prometheus operator has support for deploying Prometheus with Thanos
 * [kube-thanos](https://github.com/thanos-io/kube-thanos): Jsonnet based Kubernetes templates.
-* [Community Helm charts](https://hub.helm.sh/charts?q=thanos)
+* [Community Helm charts](https://artifacthub.io/packages/search?ts_query_web=thanos)
 
 If you want to add yourself to this list, let us know!
 


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

- Fix broken helm chart link and query frontend invalid argument

## Verification

Manually verified the doc fixes.