### PR TITLE
Query Frontend: Set CORS header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#3257](https://github.com/thanos-io/thanos/pull/3257) Ruler: Prevent Ruler from crashing when using default DNS to lookup hosts that results in "No such hosts" errors.
 - [#3331](https://github.com/thanos-io/thanos/pull/3331) Disable Azure blob exception logging
 - [#3341](https://github.com/thanos-io/thanos/pull/3341) Disable Azure blob syslog exception logging
+- [#3414](https://github.com/thanos-io/thanos/pull/3414) Set CORS for Query Frontend
 
 ### Changed
 

--- a/cmd/thanos/query_frontend.go
+++ b/cmd/thanos/query_frontend.go
@@ -19,6 +19,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/weaveworks/common/user"
 
+	"github.com/thanos-io/thanos/pkg/api"
 	"github.com/thanos-io/thanos/pkg/component"
 	"github.com/thanos-io/thanos/pkg/extflag"
 	"github.com/thanos-io/thanos/pkg/extkingpin"
@@ -199,6 +200,7 @@ func runQueryFrontend(
 		instr := func(f http.HandlerFunc) http.HandlerFunc {
 			hf := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				name := "query-frontend"
+				api.SetCORS(w)
 				ins.NewHandler(
 					name,
 					logMiddleware.HTTPMiddleware(


### PR DESCRIPTION
Set CORS to the query frontend component in order to be able
to freely access it from Grafana's living elsewhere.

Signed-off-by: Markos Chandras <markos@chandras.me>

* [x] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

Set `Access-Control-Allow-Origin` Header to Query Frontend

## Verification

- `make test-e2e-local`
- Tested also with local grafana connected to a local Thanos frontend using our internal Thanos querier and everything worked fine. No CORS errors anymore.
