### PR TITLE
Fix empty label names response

### DIFF
--- a/pkg/api/query/v1.go
+++ b/pkg/api/query/v1.go
@@ -550,6 +550,9 @@ func (qapi *QueryAPI) labelNames(r *http.Request) (interface{}, []error, *api.Ap
 	if err != nil {
 		return nil, nil, &api.ApiError{Typ: api.ErrorExec, Err: err}
 	}
+	if names == nil {
+		names = make([]string, 0)
+	}
 
 	return names, warnings, nil
 }


### PR DESCRIPTION
Signed-off-by: Ben Ye <yb532204897@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

To be consistent with Prometheus API. If no label names found, return an empty array instead of nothing.
<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
