### PR TITLE
*: Cleanup and simplify logging instantiation

### DIFF
--- a/cmd/thanos/main.go
+++ b/cmd/thanos/main.go
@@ -51,14 +51,7 @@ func main() {
 	registerQueryFrontend(app)
 
 	cmd, setup := app.Parse()
-	logger := logging.NewLogger(*logFormat, *debugName)
-	logger, err := logging.WithLogLevel(logger, *logLevel)
-	if err != nil {
-		// This log line intentionally does not call the error level
-		// explicitly, as the log level configuration failed.
-		logger.Log("level", "error", "err", err)
-		os.Exit(1)
-	}
+	logger := logging.NewLogger(*logLevel, *logFormat, *debugName)
 
 	// Running in container with limits but with empty/wrong value of GOMAXPROCS env var could lead to throttling by cpu
 	// maxprocs will automate adjustment by using cgroups info about cpu limit if it set as value for runtime.GOMAXPROCS.


### PR DESCRIPTION
Signed-off-by: Frederic Branczyk <fbranczyk@gmail.com>

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

After https://github.com/thanos-io/thanos/pull/3424, and re-reading all the surrounding code, I feel like this makes more sense, and we don't have to fiddle with the log caller if it were to ever change in go-kit, since we can use the default correctly now (again).

@thanos-io/thanos-maintainers 