### PR TITLE
[RFC/WIP] receive: do not add tenant label if its value is DefaultTenant

### DIFF
--- a/pkg/receive/multitsdb.go
+++ b/pkg/receive/multitsdb.go
@@ -255,8 +255,11 @@ func (t *MultiTSDB) TSDBStores() map[string]storepb.StoreServer {
 }
 
 func (t *MultiTSDB) startTSDB(logger log.Logger, tenantID string, tenant *tenant) error {
+	lbls := t.labels
 	reg := prometheus.WrapRegistererWith(prometheus.Labels{"tenant": tenantID}, t.reg)
-	lbls := append(t.labels, labels.Label{Name: t.tenantLabelName, Value: tenantID})
+	if tenantID != DefaultTenant {
+		lbls = append(t.labels, labels.Label{Name: t.tenantLabelName, Value: tenantID})
+	}
 	dataDir := t.defaultTenantDataDir(tenantID)
 
 	level.Info(logger).Log("msg", "opening TSDB")

--- a/test/e2e/query_test.go
+++ b/test/e2e/query_test.go
@@ -88,7 +88,7 @@ func TestQuery(t *testing.T) {
 	testutil.Ok(t, err)
 	t.Cleanup(e2ethanos.CleanScenario(t, s))
 
-	receiver, err := e2ethanos.NewReceiver(s.SharedDir(), s.NetworkName(), "1", 1)
+	receiver, err := e2ethanos.NewReceiver(s.SharedDir(), s.NetworkName(), "test-tenant", "1", 1)
 	testutil.Ok(t, err)
 	testutil.Ok(t, s.StartAndWaitReady(receiver))
 
@@ -125,7 +125,7 @@ func TestQuery(t *testing.T) {
 			"prometheus": "prom-both-remote-write-and-sidecar",
 			"receive":    "1",
 			"replica":    "1234",
-			"tenant_id":  "default-tenant",
+			"tenant_id":  "test-tenant",
 		},
 		{
 			"job":        "myself",
@@ -156,7 +156,7 @@ func TestQuery(t *testing.T) {
 			"job":        "myself",
 			"prometheus": "prom-both-remote-write-and-sidecar",
 			"receive":    "1",
-			"tenant_id":  "default-tenant",
+			"tenant_id":  "test-tenant",
 		},
 		{
 			"job":        "myself",
@@ -256,7 +256,7 @@ func TestQueryLabelNames(t *testing.T) {
 	testutil.Ok(t, err)
 	t.Cleanup(e2ethanos.CleanScenario(t, s))
 
-	receiver, err := e2ethanos.NewReceiver(s.SharedDir(), s.NetworkName(), "1", 1)
+	receiver, err := e2ethanos.NewReceiver(s.SharedDir(), s.NetworkName(), "test-tenant", "1", 1)
 	testutil.Ok(t, err)
 	testutil.Ok(t, s.StartAndWaitReady(receiver))
 
@@ -300,7 +300,7 @@ func TestQueryLabelValues(t *testing.T) {
 	testutil.Ok(t, err)
 	t.Cleanup(e2ethanos.CleanScenario(t, s))
 
-	receiver, err := e2ethanos.NewReceiver(s.SharedDir(), s.NetworkName(), "1", 1)
+	receiver, err := e2ethanos.NewReceiver(s.SharedDir(), s.NetworkName(), "test-tenant", "1", 1)
 	testutil.Ok(t, err)
 	testutil.Ok(t, s.StartAndWaitReady(receiver))
 

--- a/test/e2e/receive_test.go
+++ b/test/e2e/receive_test.go
@@ -33,11 +33,11 @@ func TestReceive(t *testing.T) {
 		// receiver in the hashring than the one handling the request.
 		// The querier queries all the receivers and the test verifies
 		// the time series are forwarded to the correct receive node.
-		r1, err := e2ethanos.NewReceiver(s.SharedDir(), s.NetworkName(), "1", 1)
+		r1, err := e2ethanos.NewReceiver(s.SharedDir(), s.NetworkName(), "test-tenant", "1", 1)
 		testutil.Ok(t, err)
-		r2, err := e2ethanos.NewReceiver(s.SharedDir(), s.NetworkName(), "2", 1)
+		r2, err := e2ethanos.NewReceiver(s.SharedDir(), s.NetworkName(), "test-tenant", "2", 1)
 		testutil.Ok(t, err)
-		r3, err := e2ethanos.NewReceiver(s.SharedDir(), s.NetworkName(), "3", 1)
+		r3, err := e2ethanos.NewReceiver(s.SharedDir(), s.NetworkName(), "test-tenant", "3", 1)
 		testutil.Ok(t, err)
 
 		h := receive.HashringConfig{
@@ -49,11 +49,11 @@ func TestReceive(t *testing.T) {
 		}
 
 		// Recreate again, but with hashring config.
-		r1, err = e2ethanos.NewReceiver(s.SharedDir(), s.NetworkName(), "1", 1, h)
+		r1, err = e2ethanos.NewReceiver(s.SharedDir(), s.NetworkName(), "test-tenant", "1", 1, h)
 		testutil.Ok(t, err)
-		r2, err = e2ethanos.NewReceiver(s.SharedDir(), s.NetworkName(), "2", 1, h)
+		r2, err = e2ethanos.NewReceiver(s.SharedDir(), s.NetworkName(), "test-tenant", "2", 1, h)
 		testutil.Ok(t, err)
-		r3, err = e2ethanos.NewReceiver(s.SharedDir(), s.NetworkName(), "3", 1, h)
+		r3, err = e2ethanos.NewReceiver(s.SharedDir(), s.NetworkName(), "test-tenant", "3", 1, h)
 		testutil.Ok(t, err)
 		testutil.Ok(t, s.StartAndWaitReady(r1, r2, r3))
 
@@ -82,21 +82,21 @@ func TestReceive(t *testing.T) {
 				"prometheus": "prom1",
 				"receive":    "2",
 				"replica":    "0",
-				"tenant_id":  "default-tenant",
+				"tenant_id":  "test-tenant",
 			},
 			{
 				"job":        "myself",
 				"prometheus": "prom2",
 				"receive":    "1",
 				"replica":    "0",
-				"tenant_id":  "default-tenant",
+				"tenant_id":  "test-tenant",
 			},
 			{
 				"job":        "myself",
 				"prometheus": "prom3",
 				"receive":    "2",
 				"replica":    "0",
-				"tenant_id":  "default-tenant",
+				"tenant_id":  "test-tenant",
 			},
 		})
 	})
@@ -112,11 +112,11 @@ func TestReceive(t *testing.T) {
 		// receives Prometheus remote-written data. The querier queries all
 		// receivers and the test verifies that the time series are
 		// replicated to all of the nodes.
-		r1, err := e2ethanos.NewReceiver(s.SharedDir(), s.NetworkName(), "1", 3)
+		r1, err := e2ethanos.NewReceiver(s.SharedDir(), s.NetworkName(), "test-tenant", "1", 3)
 		testutil.Ok(t, err)
-		r2, err := e2ethanos.NewReceiver(s.SharedDir(), s.NetworkName(), "2", 3)
+		r2, err := e2ethanos.NewReceiver(s.SharedDir(), s.NetworkName(), "test-tenant", "2", 3)
 		testutil.Ok(t, err)
-		r3, err := e2ethanos.NewReceiver(s.SharedDir(), s.NetworkName(), "3", 3)
+		r3, err := e2ethanos.NewReceiver(s.SharedDir(), s.NetworkName(), "test-tenant", "3", 3)
 		testutil.Ok(t, err)
 
 		h := receive.HashringConfig{
@@ -128,11 +128,11 @@ func TestReceive(t *testing.T) {
 		}
 
 		// Recreate again, but with hashring config.
-		r1, err = e2ethanos.NewReceiver(s.SharedDir(), s.NetworkName(), "1", 3, h)
+		r1, err = e2ethanos.NewReceiver(s.SharedDir(), s.NetworkName(), "test-tenant", "1", 3, h)
 		testutil.Ok(t, err)
-		r2, err = e2ethanos.NewReceiver(s.SharedDir(), s.NetworkName(), "2", 3, h)
+		r2, err = e2ethanos.NewReceiver(s.SharedDir(), s.NetworkName(), "test-tenant", "2", 3, h)
 		testutil.Ok(t, err)
-		r3, err = e2ethanos.NewReceiver(s.SharedDir(), s.NetworkName(), "3", 3, h)
+		r3, err = e2ethanos.NewReceiver(s.SharedDir(), s.NetworkName(), "test-tenant", "3", 3, h)
 		testutil.Ok(t, err)
 		testutil.Ok(t, s.StartAndWaitReady(r1, r2, r3))
 
@@ -157,21 +157,21 @@ func TestReceive(t *testing.T) {
 				"prometheus": "prom1",
 				"receive":    "1",
 				"replica":    "0",
-				"tenant_id":  "default-tenant",
+				"tenant_id":  "test-tenant",
 			},
 			{
 				"job":        "myself",
 				"prometheus": "prom1",
 				"receive":    "2",
 				"replica":    "0",
-				"tenant_id":  "default-tenant",
+				"tenant_id":  "test-tenant",
 			},
 			{
 				"job":        "myself",
 				"prometheus": "prom1",
 				"receive":    "3",
 				"replica":    "0",
-				"tenant_id":  "default-tenant",
+				"tenant_id":  "test-tenant",
 			},
 		})
 	})
@@ -186,11 +186,11 @@ func TestReceive(t *testing.T) {
 		// The replication suite creates a three-node hashring but one of the
 		// receivers is dead. In this case, replication should still
 		// succeed and the time series should be replicated to the other nodes.
-		r1, err := e2ethanos.NewReceiver(s.SharedDir(), s.NetworkName(), "1", 3)
+		r1, err := e2ethanos.NewReceiver(s.SharedDir(), s.NetworkName(), "test-tenant", "1", 3)
 		testutil.Ok(t, err)
-		r2, err := e2ethanos.NewReceiver(s.SharedDir(), s.NetworkName(), "2", 3)
+		r2, err := e2ethanos.NewReceiver(s.SharedDir(), s.NetworkName(), "test-tenant", "2", 3)
 		testutil.Ok(t, err)
-		notRunningR3, err := e2ethanos.NewReceiver(s.SharedDir(), s.NetworkName(), "3", 3)
+		notRunningR3, err := e2ethanos.NewReceiver(s.SharedDir(), s.NetworkName(), "test-tenant", "3", 3)
 		testutil.Ok(t, err)
 
 		h := receive.HashringConfig{
@@ -202,9 +202,9 @@ func TestReceive(t *testing.T) {
 		}
 
 		// Recreate again, but with hashring config.
-		r1, err = e2ethanos.NewReceiver(s.SharedDir(), s.NetworkName(), "1", 3, h)
+		r1, err = e2ethanos.NewReceiver(s.SharedDir(), s.NetworkName(), "test-tenant", "1", 3, h)
 		testutil.Ok(t, err)
-		r2, err = e2ethanos.NewReceiver(s.SharedDir(), s.NetworkName(), "2", 3, h)
+		r2, err = e2ethanos.NewReceiver(s.SharedDir(), s.NetworkName(), "test-tenant", "2", 3, h)
 		testutil.Ok(t, err)
 		testutil.Ok(t, s.StartAndWaitReady(r1, r2))
 
@@ -229,14 +229,14 @@ func TestReceive(t *testing.T) {
 				"prometheus": "prom1",
 				"receive":    "1",
 				"replica":    "0",
-				"tenant_id":  "default-tenant",
+				"tenant_id":  "test-tenant",
 			},
 			{
 				"job":        "myself",
 				"prometheus": "prom1",
 				"receive":    "2",
 				"replica":    "0",
-				"tenant_id":  "default-tenant",
+				"tenant_id":  "test-tenant",
 			},
 		})
 	})


### PR DESCRIPTION
We have one peculiar use-case for Thanos Receive: we send off
some metrics from a Prometheus instance to a Thanos Receive instance so
that it would be persisted for a longer time. We achieve that by adding
some special external labels that are later picked up by Thanos
Compactor with the appropriate retention policies.

Also, we use the `tenant` label already and have no intention of using
Thanos Receive in a multi-tenant mode. We'd like to avoid running a
Prometheus/Sidecar pair on top of another one that is running in
federation. That simplifies the deployment and reduces the resource
usage as well, most likely.

Since the multiTSDB functionality got introduced into Thanos Receive
from 0.13.x, I believe, it started adding a mandatory label `tenant`
with the tenant's ID that clashes with our already-used `tenant` label.

In this PR, I propose _not_ adding a `tenant` label if it is equal to
`default-tenant`. Since the tenant's ID is deeply entrenched in the code
base now, I think this might be reasonable trade-off to make.

Other options include adding another flag which controls what label
_name_ to use. And, if it would be `""` then we could not add that at
all. Or maybe someone else has an even better idea? Let me know.

Signed-off-by: Giedrius Statkevičius <giedriuswork@gmail.com>


* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Verification

`make test-e2e-local` but fixing the tests is TBD.
