### PR TITLE
Store-gateway: add support to lazy mmap index-headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#3277](https://github.com/thanos-io/thanos/pull/3277) Thanos Query: Introduce dynamic lookback interval. This allows queries with large step to make use of downsampled data.
 - [#3409](https://github.com/thanos-io/thanos/pull/3409) Compactor: Added support for no-compact-mark.json which excludes the block from compaction.
 - [#3245](https://github.com/thanos-io/thanos/pull/3245) Query Frontend: Add `query-frontend.org-id-header` flag to specify HTTP header(s) to populate slow query log (e.g. X-Grafana-User).
+- [#3431](https://github.com/thanos-io/thanos/pull/3431) Store: Added experimental support to lazy load index-headers at query time. When enabled via `--store.enable-index-header-lazy-reader=true` flag, the store-gateway will load into memory an index-header only once required at query time and will be automatically released after `--store.index-header-lazy-reader-idle-timeout` of inactivity.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,8 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#3277](https://github.com/thanos-io/thanos/pull/3277) Thanos Query: Introduce dynamic lookback interval. This allows queries with large step to make use of downsampled data.
 - [#3409](https://github.com/thanos-io/thanos/pull/3409) Compactor: Added support for no-compact-mark.json which excludes the block from compaction.
 - [#3245](https://github.com/thanos-io/thanos/pull/3245) Query Frontend: Add `query-frontend.org-id-header` flag to specify HTTP header(s) to populate slow query log (e.g. X-Grafana-User).
-- [#3431](https://github.com/thanos-io/thanos/pull/3431) Store: Added experimental support to lazy load index-headers at query time. When enabled via `--store.enable-index-header-lazy-reader=true` flag, the store-gateway will load into memory an index-header only once required at query time and will be automatically released after `--store.index-header-lazy-reader-idle-timeout` of inactivity.
+- [#3431](https://github.com/thanos-io/thanos/pull/3431) Store: Added experimental support to lazy load index-headers at query time. When enabled via `--store.enable-index-header-lazy-reader` flag, the store-gateway will load into memory an index-header only once it's required at query time. Index-header will be automatically released after `--store.index-header-lazy-reader-idle-timeout` of inactivity.
+   * This, generally, reduces baseline memory usage of store when inactive, as well as a total number of mapped files (which is limited to 64k in some systems.
 
 ### Fixed
 

--- a/cmd/thanos/store.go
+++ b/cmd/thanos/store.go
@@ -107,8 +107,8 @@ func registerStore(app *extkingpin.App) {
 		"Default is 24h, half of the default value for --delete-delay on compactor.").
 		Default("24h"))
 
-	lazyIndexReaderEnabled := cmd.Flag("store.enable-index-header-lazy-reader", "If true, Store Gateway will lazy memory map index-header only once required by a query.").
-		Hidden().Default("false").Bool()
+	lazyIndexReaderEnabled := cmd.Flag("store.enable-index-header-lazy-reader", "If true, Store Gateway will lazy memory map index-header only once the block is required by a query.").
+		Default("false").Bool()
 
 	lazyIndexReaderIdleTimeout := cmd.Flag("store.index-header-lazy-reader-idle-timeout", "If index-header lazy reader is enabled and this idle timeout setting is > 0, memory map-ed index-headers will be automatically released after 'idle timeout' inactivity.").
 		Hidden().Default("5m").Duration()

--- a/cmd/thanos/store.go
+++ b/cmd/thanos/store.go
@@ -107,6 +107,12 @@ func registerStore(app *extkingpin.App) {
 		"Default is 24h, half of the default value for --delete-delay on compactor.").
 		Default("24h"))
 
+	lazyIndexReaderEnabled := cmd.Flag("store.enable-index-header-lazy-loading", "If true, Store Gateway will lazy memory map index-header only once required by a query.").
+		Hidden().Default("false").Bool()
+
+	lazyIndexReaderIdleTimeout := cmd.Flag("store.lazy-index-header-idle-timeout", "If index-header lazy loading is enabled and this idle timeout setting is > 0, memory map-ed index-headers will be automatically released after 'idle timeout' inactivity.").
+		Hidden().Default("5m").Duration()
+
 	webExternalPrefix := cmd.Flag("web.external-prefix", "Static prefix for all HTML links and redirect URLs in the bucket web UI interface. Actual endpoints are still served on / or the web.route-prefix. This allows thanos bucket web UI to be served behind a reverse proxy that strips a URL sub-path.").Default("").String()
 	webPrefixHeaderName := cmd.Flag("web.prefix-header", "Name of HTTP request header used for dynamic prefixing of UI links and redirects. This option is ignored if web.external-prefix argument is set. Security risk: enable this option only if a reverse proxy in front of thanos is resetting the header. The --web.prefix-header=X-Forwarded-Prefix option can be useful, for example, if Thanos UI is served via Traefik reverse proxy with PathPrefixStrip option enabled, which sends the stripped prefix value in X-Forwarded-Prefix header. This allows thanos UI to be served on a sub-path.").Default("").String()
 
@@ -152,6 +158,8 @@ func registerStore(app *extkingpin.App) {
 			*postingOffsetsInMemSampling,
 			cachingBucketConfig,
 			getFlagsMap(cmd.Flags()),
+			*lazyIndexReaderEnabled,
+			*lazyIndexReaderIdleTimeout,
 		)
 	})
 }
@@ -184,6 +192,8 @@ func runStore(
 	postingOffsetsInMemSampling int,
 	cachingBucketConfig *extflag.PathOrContent,
 	flagsMap map[string]string,
+	lazyIndexReaderEnabled bool,
+	lazyIndexReaderIdleTimeout time.Duration,
 ) error {
 	grpcProbe := prober.NewGRPC()
 	httpProbe := prober.NewHTTP()
@@ -304,6 +314,8 @@ func runStore(
 		enablePostingsCompression,
 		postingOffsetsInMemSampling,
 		false,
+		lazyIndexReaderEnabled,
+		lazyIndexReaderIdleTimeout,
 	)
 	if err != nil {
 		return errors.Wrap(err, "create object storage store")

--- a/cmd/thanos/store.go
+++ b/cmd/thanos/store.go
@@ -107,10 +107,10 @@ func registerStore(app *extkingpin.App) {
 		"Default is 24h, half of the default value for --delete-delay on compactor.").
 		Default("24h"))
 
-	lazyIndexReaderEnabled := cmd.Flag("store.enable-index-header-lazy-loading", "If true, Store Gateway will lazy memory map index-header only once required by a query.").
+	lazyIndexReaderEnabled := cmd.Flag("store.enable-index-header-lazy-reader", "If true, Store Gateway will lazy memory map index-header only once required by a query.").
 		Hidden().Default("false").Bool()
 
-	lazyIndexReaderIdleTimeout := cmd.Flag("store.lazy-index-header-idle-timeout", "If index-header lazy loading is enabled and this idle timeout setting is > 0, memory map-ed index-headers will be automatically released after 'idle timeout' inactivity.").
+	lazyIndexReaderIdleTimeout := cmd.Flag("store.index-header-lazy-reader-idle-timeout", "If index-header lazy reader is enabled and this idle timeout setting is > 0, memory map-ed index-headers will be automatically released after 'idle timeout' inactivity.").
 		Hidden().Default("5m").Duration()
 
 	webExternalPrefix := cmd.Flag("web.external-prefix", "Static prefix for all HTML links and redirect URLs in the bucket web UI interface. Actual endpoints are still served on / or the web.route-prefix. This allows thanos bucket web UI to be served behind a reverse proxy that strips a URL sub-path.").Default("").String()

--- a/docs/components/store.md
+++ b/docs/components/store.md
@@ -171,6 +171,10 @@ Flags:
                                  before being deleted from bucket. Default is
                                  24h, half of the default value for
                                  --delete-delay on compactor.
+      --store.enable-index-header-lazy-reader
+                                 If true, Store Gateway will lazy memory map
+                                 index-header only once the block is required by
+                                 a query.
       --web.external-prefix=""   Static prefix for all HTML links and redirect
                                  URLs in the bucket web UI interface. Actual
                                  endpoints are still served on / or the

--- a/pkg/block/indexheader/binary_reader.go
+++ b/pkg/block/indexheader/binary_reader.go
@@ -637,8 +637,8 @@ func newBinaryTOCFromByteSlice(bs index.ByteSlice) (*BinaryTOC, error) {
 	}, nil
 }
 
-func (r BinaryReader) IndexVersion() int {
-	return r.indexVersion
+func (r BinaryReader) IndexVersion() (int, error) {
+	return r.indexVersion, nil
 }
 
 // TODO(bwplotka): Get advantage of multi value offset fetch.
@@ -871,7 +871,7 @@ func yoloString(b []byte) string {
 	return *((*string)(unsafe.Pointer(&b)))
 }
 
-func (r BinaryReader) LabelNames() []string {
+func (r BinaryReader) LabelNames() ([]string, error) {
 	allPostingsKeyName, _ := index.AllPostingsKey()
 	labelNames := make([]string, 0, len(r.postings))
 	for name := range r.postings {
@@ -882,7 +882,7 @@ func (r BinaryReader) LabelNames() []string {
 		labelNames = append(labelNames, name)
 	}
 	sort.Strings(labelNames)
-	return labelNames
+	return labelNames, nil
 }
 
 func (r *BinaryReader) Close() error { return r.c.Close() }

--- a/pkg/block/indexheader/header.go
+++ b/pkg/block/indexheader/header.go
@@ -18,7 +18,7 @@ type Reader interface {
 	io.Closer
 
 	// IndexVersion returns version of index.
-	IndexVersion() int
+	IndexVersion() (int, error)
 
 	// PostingsOffset returns start and end offsets of postings for given name and value.
 	// The end offset might be bigger than the actual posting ending, but not larger than the whole index file.
@@ -36,5 +36,5 @@ type Reader interface {
 	LabelValues(name string) ([]string, error)
 
 	// LabelNames returns all label names.
-	LabelNames() []string
+	LabelNames() ([]string, error)
 }

--- a/pkg/block/indexheader/header_test.go
+++ b/pkg/block/indexheader/header_test.go
@@ -178,7 +178,9 @@ func compareIndexToHeader(t *testing.T, indexByteSlice index.ByteSlice, headerRe
 	testutil.Ok(t, err)
 	defer func() { _ = indexReader.Close() }()
 
-	testutil.Equals(t, indexReader.Version(), headerReader.IndexVersion())
+	actVersion, err := headerReader.IndexVersion()
+	testutil.Ok(t, err)
+	testutil.Equals(t, indexReader.Version(), actVersion)
 
 	if indexReader.Version() == index.FormatV2 {
 		// For v2 symbols ref sequential integers 0, 1, 2 etc.
@@ -211,7 +213,9 @@ func compareIndexToHeader(t *testing.T, indexByteSlice index.ByteSlice, headerRe
 
 	expLabelNames, err := indexReader.LabelNames()
 	testutil.Ok(t, err)
-	testutil.Equals(t, expLabelNames, headerReader.LabelNames())
+	actualLabelNames, err := headerReader.LabelNames()
+	testutil.Ok(t, err)
+	testutil.Equals(t, expLabelNames, actualLabelNames)
 
 	expRanges, err := indexReader.PostingsRanges()
 	testutil.Ok(t, err)

--- a/pkg/block/indexheader/header_test.go
+++ b/pkg/block/indexheader/header_test.go
@@ -173,7 +173,7 @@ func TestReaders(t *testing.T) {
 				fn := filepath.Join(tmpDir, id.String(), block.IndexHeaderFilename)
 				testutil.Ok(t, WriteBinary(ctx, bkt, id, fn))
 
-				br, err := NewLazyBinaryReader(ctx, log.NewNopLogger(), nil, tmpDir, id, 3)
+				br, err := NewLazyBinaryReader(ctx, log.NewNopLogger(), nil, tmpDir, id, 3, NewLazyBinaryReaderMetrics(nil))
 				testutil.Ok(t, err)
 
 				defer func() { testutil.Ok(t, br.Close()) }()

--- a/pkg/block/indexheader/header_test.go
+++ b/pkg/block/indexheader/header_test.go
@@ -96,7 +96,7 @@ func TestReaders(t *testing.T) {
 
 			b := realByteSlice(indexFile.Bytes())
 
-			t.Run("binary", func(t *testing.T) {
+			t.Run("binary reader", func(t *testing.T) {
 				fn := filepath.Join(tmpDir, id.String(), block.IndexHeaderFilename)
 				testutil.Ok(t, WriteBinary(ctx, bkt, id, fn))
 
@@ -165,6 +165,18 @@ func TestReaders(t *testing.T) {
 					_, err = br.PostingsOffset("longer-string", "21")
 					testutil.Equals(t, NotFoundRangeErr, err)
 				}
+
+				compareIndexToHeader(t, b, br)
+			})
+
+			t.Run("lazy binary reader", func(t *testing.T) {
+				fn := filepath.Join(tmpDir, id.String(), block.IndexHeaderFilename)
+				testutil.Ok(t, WriteBinary(ctx, bkt, id, fn))
+
+				br, err := NewLazyBinaryReader(ctx, log.NewNopLogger(), nil, tmpDir, id, 3)
+				testutil.Ok(t, err)
+
+				defer func() { testutil.Ok(t, br.Close()) }()
 
 				compareIndexToHeader(t, b, br)
 			})

--- a/pkg/block/indexheader/header_test.go
+++ b/pkg/block/indexheader/header_test.go
@@ -173,7 +173,7 @@ func TestReaders(t *testing.T) {
 				fn := filepath.Join(tmpDir, id.String(), block.IndexHeaderFilename)
 				testutil.Ok(t, WriteBinary(ctx, bkt, id, fn))
 
-				br, err := NewLazyBinaryReader(ctx, log.NewNopLogger(), nil, tmpDir, id, 3, NewLazyBinaryReaderMetrics(nil))
+				br, err := NewLazyBinaryReader(ctx, log.NewNopLogger(), nil, tmpDir, id, 3, NewLazyBinaryReaderMetrics(nil), nil)
 				testutil.Ok(t, err)
 
 				defer func() { testutil.Ok(t, br.Close()) }()

--- a/pkg/block/indexheader/lazy_binary_reader.go
+++ b/pkg/block/indexheader/lazy_binary_reader.go
@@ -1,0 +1,177 @@
+package indexheader
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/oklog/ulid"
+	"github.com/pkg/errors"
+	"github.com/prometheus/prometheus/tsdb/index"
+
+	"github.com/thanos-io/thanos/pkg/block"
+	"github.com/thanos-io/thanos/pkg/objstore"
+)
+
+type LazyBinaryReader struct {
+	ctx                         context.Context
+	logger                      log.Logger
+	bkt                         objstore.BucketReader
+	dir                         string
+	filepath                    string
+	id                          ulid.ULID
+	postingOffsetsInMemSampling int
+
+	readerMx  sync.RWMutex
+	reader    *BinaryReader
+	readerErr error
+}
+
+func NewLazyBinaryReader(ctx context.Context, logger log.Logger, bkt objstore.BucketReader, dir string, id ulid.ULID, postingOffsetsInMemSampling int) (*LazyBinaryReader, error) {
+	filepath := filepath.Join(dir, id.String(), block.IndexHeaderFilename)
+
+	// If the index-header doesn't exist we should download it.
+	if _, err := os.Stat(filepath); err != nil {
+		if !os.IsNotExist(err) {
+			return nil, errors.Wrap(err, "read index header")
+		}
+
+		level.Debug(logger).Log("msg", "the index-header doesn't exist on disk; recreating", "path", filepath)
+
+		start := time.Now()
+		if err := WriteBinary(ctx, bkt, id, filepath); err != nil {
+			return nil, errors.Wrap(err, "write index header")
+		}
+
+		level.Debug(logger).Log("msg", "built index-header file", "path", filepath, "elapsed", time.Since(start))
+	}
+
+	return &LazyBinaryReader{
+		ctx:                         ctx,
+		logger:                      logger,
+		bkt:                         bkt,
+		dir:                         dir,
+		filepath:                    filepath,
+		id:                          id,
+		postingOffsetsInMemSampling: postingOffsetsInMemSampling,
+	}, nil
+}
+
+func (r *LazyBinaryReader) Close() error {
+	r.readerMx.Lock()
+	defer r.readerMx.Unlock()
+
+	if r.reader == nil {
+		return nil
+	}
+
+	if err := r.reader.Close(); err != nil {
+		return err
+	}
+
+	r.reader = nil
+	return nil
+}
+
+func (r *LazyBinaryReader) IndexVersion() (int, error) {
+	r.readerMx.RLock()
+	defer r.readerMx.RUnlock()
+
+	if err := r.open(); err != nil {
+		return 0, err
+	}
+
+	return r.reader.IndexVersion()
+}
+
+func (r *LazyBinaryReader) PostingsOffset(name string, value string) (index.Range, error) {
+	r.readerMx.RLock()
+	defer r.readerMx.RUnlock()
+
+	if err := r.open(); err != nil {
+		return index.Range{}, err
+	}
+
+	return r.reader.PostingsOffset(name, value)
+}
+
+func (r *LazyBinaryReader) LookupSymbol(o uint32) (string, error) {
+	r.readerMx.RLock()
+	defer r.readerMx.RUnlock()
+
+	if err := r.open(); err != nil {
+		return "", err
+	}
+
+	return r.reader.LookupSymbol(o)
+}
+
+func (r *LazyBinaryReader) LabelValues(name string) ([]string, error) {
+	r.readerMx.RLock()
+	defer r.readerMx.RUnlock()
+
+	if err := r.open(); err != nil {
+		return nil, err
+	}
+
+	return r.reader.LabelValues(name)
+}
+
+func (r *LazyBinaryReader) LabelNames() ([]string, error) {
+	r.readerMx.RLock()
+	defer r.readerMx.RUnlock()
+
+	if err := r.open(); err != nil {
+		return nil, err
+	}
+
+	return r.reader.LabelNames()
+}
+
+// open ensure the underlying binary index-header reader has been successfully opened. Returns
+// an error on failure. This function MUST be called with the read lock already acquired.
+func (r *LazyBinaryReader) open() error {
+	// Nothing to do if it's already opened.
+	if r.reader != nil {
+		return nil
+	}
+
+	// If we already tried to open it and it failed, we don't retry again
+	// and we always return the same error.
+	if r.readerErr != nil {
+		return r.readerErr
+	}
+
+	// Take the write lock to ensure we'll try to open it only once. Take again
+	// the read lock once done.
+	r.readerMx.RUnlock()
+	r.readerMx.Lock()
+	defer r.readerMx.RLock()
+	defer r.readerMx.Unlock()
+
+	// Ensure none else tried to open it in the meanwhile.
+	if r.reader != nil {
+		return nil
+	} else if r.readerErr != nil {
+		return r.readerErr
+	}
+
+	level.Debug(r.logger).Log("msg", "lazy loading index-header file", "path", r.filepath)
+	startTime := time.Now()
+
+	reader, err := NewBinaryReader(r.ctx, r.logger, r.bkt, r.dir, r.id, r.postingOffsetsInMemSampling)
+	if err != nil {
+		level.Error(r.logger).Log("msg", "failed to lazy load index-header file", "path", r.filepath, "err", err)
+		r.readerErr = err
+		return err
+	}
+
+	r.reader = reader
+	level.Info(r.logger).Log("msg", "lazy loaded index-header file", "path", r.filepath, "elapsed", time.Since(startTime))
+
+	return nil
+}

--- a/pkg/block/indexheader/lazy_binary_reader.go
+++ b/pkg/block/indexheader/lazy_binary_reader.go
@@ -1,3 +1,6 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
 package indexheader
 
 import (

--- a/pkg/block/indexheader/lazy_binary_reader.go
+++ b/pkg/block/indexheader/lazy_binary_reader.go
@@ -135,14 +135,10 @@ func (r *LazyBinaryReader) LabelNames() ([]string, error) {
 // open ensure the underlying binary index-header reader has been successfully opened. Returns
 // an error on failure. This function MUST be called with the read lock already acquired.
 func (r *LazyBinaryReader) open() error {
-	// Nothing to do if it's already opened.
+	// Nothing to do if we already tried opening it.
 	if r.reader != nil {
 		return nil
-	}
-
-	// If we already tried to open it and it failed, we don't retry again
-	// and we always return the same error.
-	if r.readerErr != nil {
+	} else if r.readerErr != nil {
 		return r.readerErr
 	}
 

--- a/pkg/block/indexheader/lazy_binary_reader.go
+++ b/pkg/block/indexheader/lazy_binary_reader.go
@@ -33,23 +33,23 @@ type LazyBinaryReaderMetrics struct {
 func NewLazyBinaryReaderMetrics(reg prometheus.Registerer) *LazyBinaryReaderMetrics {
 	return &LazyBinaryReaderMetrics{
 		loadCount: promauto.With(reg).NewCounter(prometheus.CounterOpts{
-			Name: "binary_reader_lazy_load_total",
+			Name: "indexheader_lazy_load_total",
 			Help: "Total number of index-header lazy load operations.",
 		}),
 		loadFailedCount: promauto.With(reg).NewCounter(prometheus.CounterOpts{
-			Name: "binary_reader_lazy_load_failed_total",
+			Name: "indexheader_lazy_load_failed_total",
 			Help: "Total number of failed index-header lazy load operations.",
 		}),
 		unloadCount: promauto.With(reg).NewCounter(prometheus.CounterOpts{
-			Name: "binary_reader_lazy_unload_total",
+			Name: "indexheader_lazy_unload_total",
 			Help: "Total number of index-header lazy unload operations.",
 		}),
 		unloadFailedCount: promauto.With(reg).NewCounter(prometheus.CounterOpts{
-			Name: "binary_reader_lazy_unload_failed_total",
+			Name: "indexheader_lazy_unload_failed_total",
 			Help: "Total number of failed index-header lazy unload operations.",
 		}),
 		loadDuration: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
-			Name:    "binary_reader_lazy_load_duration_seconds",
+			Name:    "indexheader_lazy_load_duration_seconds",
 			Help:    "Duration of the index-header lazy loading in seconds.",
 			Buckets: []float64{0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1, 2, 5},
 		}),

--- a/pkg/block/indexheader/lazy_binary_reader.go
+++ b/pkg/block/indexheader/lazy_binary_reader.go
@@ -129,7 +129,6 @@ func NewLazyBinaryReader(
 // Close implements Reader. It unloads the index-header from memory (releasing the mmap
 // area), but a subsequent call to any other Reader function will automatically reload it.
 func (r *LazyBinaryReader) Close() error {
-	// Invoke the callback after having released the lock.
 	if r.onClosed != nil {
 		defer r.onClosed(r)
 	}
@@ -202,7 +201,7 @@ func (r *LazyBinaryReader) LabelNames() ([]string, error) {
 	return r.reader.LabelNames()
 }
 
-// load ensure the underlying binary index-header reader has been successfully loaded. Returns
+// load ensures the underlying binary index-header reader has been successfully loaded. Returns
 // an error on failure. This function MUST be called with the read lock already acquired.
 func (r *LazyBinaryReader) load() error {
 	// Nothing to do if we already tried loading it.

--- a/pkg/block/indexheader/lazy_binary_reader_test.go
+++ b/pkg/block/indexheader/lazy_binary_reader_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
 package indexheader
 
 import (

--- a/pkg/block/indexheader/lazy_binary_reader_test.go
+++ b/pkg/block/indexheader/lazy_binary_reader_test.go
@@ -1,0 +1,143 @@
+package indexheader
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/go-kit/kit/log"
+	"github.com/oklog/ulid"
+	"github.com/prometheus/prometheus/pkg/labels"
+
+	"github.com/thanos-io/thanos/pkg/block"
+	"github.com/thanos-io/thanos/pkg/objstore/filesystem"
+	"github.com/thanos-io/thanos/pkg/testutil"
+	"github.com/thanos-io/thanos/pkg/testutil/e2eutil"
+)
+
+func TestNewLazyBinaryReader_ShouldFailIfUnableToBuildIndexHeader(t *testing.T) {
+	ctx := context.Background()
+
+	tmpDir, err := ioutil.TempDir("", "test-indexheader")
+	testutil.Ok(t, err)
+	defer func() { testutil.Ok(t, os.RemoveAll(tmpDir)) }()
+
+	bkt, err := filesystem.NewBucket(filepath.Join(tmpDir, "bkt"))
+	testutil.Ok(t, err)
+	defer func() { testutil.Ok(t, bkt.Close()) }()
+
+	_, err = NewLazyBinaryReader(ctx, log.NewNopLogger(), bkt, tmpDir, ulid.MustNew(0, nil), 3)
+	testutil.NotOk(t, err)
+}
+
+func TestNewLazyBinaryReader_ShouldBuildIndexHeaderFromBucket(t *testing.T) {
+	ctx := context.Background()
+
+	tmpDir, err := ioutil.TempDir("", "test-indexheader")
+	testutil.Ok(t, err)
+	defer func() { testutil.Ok(t, os.RemoveAll(tmpDir)) }()
+
+	bkt, err := filesystem.NewBucket(filepath.Join(tmpDir, "bkt"))
+	testutil.Ok(t, err)
+	defer func() { testutil.Ok(t, bkt.Close()) }()
+
+	// Create block.
+	blockID, err := e2eutil.CreateBlock(ctx, tmpDir, []labels.Labels{
+		{{Name: "a", Value: "1"}},
+		{{Name: "a", Value: "2"}},
+	}, 100, 0, 1000, labels.Labels{{Name: "ext1", Value: "1"}}, 124)
+	testutil.Ok(t, err)
+	testutil.Ok(t, block.Upload(ctx, log.NewNopLogger(), bkt, filepath.Join(tmpDir, blockID.String())))
+
+	r, err := NewLazyBinaryReader(ctx, log.NewNopLogger(), bkt, tmpDir, blockID, 3)
+	testutil.Ok(t, err)
+	testutil.Assert(t, r.reader == nil)
+
+	// Should lazy load the index upon first usage.
+	v, err := r.IndexVersion()
+	testutil.Ok(t, err)
+	testutil.Equals(t, 2, v)
+	testutil.Assert(t, r.reader != nil)
+
+	labelNames, err := r.LabelNames()
+	testutil.Ok(t, err)
+	testutil.Equals(t, []string{"a"}, labelNames)
+}
+
+func TestNewLazyBinaryReader_ShouldRebuildCorruptedIndexHeader(t *testing.T) {
+	ctx := context.Background()
+
+	tmpDir, err := ioutil.TempDir("", "test-indexheader")
+	testutil.Ok(t, err)
+	defer func() { testutil.Ok(t, os.RemoveAll(tmpDir)) }()
+
+	bkt, err := filesystem.NewBucket(filepath.Join(tmpDir, "bkt"))
+	testutil.Ok(t, err)
+	defer func() { testutil.Ok(t, bkt.Close()) }()
+
+	// Create block.
+	blockID, err := e2eutil.CreateBlock(ctx, tmpDir, []labels.Labels{
+		{{Name: "a", Value: "1"}},
+		{{Name: "a", Value: "2"}},
+	}, 100, 0, 1000, labels.Labels{{Name: "ext1", Value: "1"}}, 124)
+	testutil.Ok(t, err)
+	testutil.Ok(t, block.Upload(ctx, log.NewNopLogger(), bkt, filepath.Join(tmpDir, blockID.String())))
+
+	// Write a corrupted index-header for the block.
+	headerFilename := filepath.Join(tmpDir, blockID.String(), block.IndexHeaderFilename)
+	ioutil.WriteFile(headerFilename, []byte("xxx"), os.ModePerm)
+
+	r, err := NewLazyBinaryReader(ctx, log.NewNopLogger(), bkt, tmpDir, blockID, 3)
+	testutil.Ok(t, err)
+	testutil.Assert(t, r.reader == nil)
+
+	// Ensure it can read data.
+	labelNames, err := r.LabelNames()
+	testutil.Ok(t, err)
+	testutil.Equals(t, []string{"a"}, labelNames)
+}
+
+func TestLazyBinaryReader_ShouldReopenOnUsageAfterClose(t *testing.T) {
+	ctx := context.Background()
+
+	tmpDir, err := ioutil.TempDir("", "test-indexheader")
+	testutil.Ok(t, err)
+	defer func() { testutil.Ok(t, os.RemoveAll(tmpDir)) }()
+
+	bkt, err := filesystem.NewBucket(filepath.Join(tmpDir, "bkt"))
+	testutil.Ok(t, err)
+	defer func() { testutil.Ok(t, bkt.Close()) }()
+
+	// Create block.
+	blockID, err := e2eutil.CreateBlock(ctx, tmpDir, []labels.Labels{
+		{{Name: "a", Value: "1"}},
+		{{Name: "a", Value: "2"}},
+	}, 100, 0, 1000, labels.Labels{{Name: "ext1", Value: "1"}}, 124)
+	testutil.Ok(t, err)
+	testutil.Ok(t, block.Upload(ctx, log.NewNopLogger(), bkt, filepath.Join(tmpDir, blockID.String())))
+
+	r, err := NewLazyBinaryReader(ctx, log.NewNopLogger(), bkt, tmpDir, blockID, 3)
+	testutil.Ok(t, err)
+	testutil.Assert(t, r.reader == nil)
+
+	// Should lazy load the index upon first usage.
+	labelNames, err := r.LabelNames()
+	testutil.Ok(t, err)
+	testutil.Equals(t, []string{"a"}, labelNames)
+
+	// Close it.
+	testutil.Ok(t, r.Close())
+	testutil.Assert(t, r.reader == nil)
+
+	// Should lazy load again upon next usage.
+	labelNames, err = r.LabelNames()
+	testutil.Ok(t, err)
+	testutil.Equals(t, []string{"a"}, labelNames)
+
+	// Closing an already closed lazy reader should be a no-op.
+	for i := 0; i < 2; i++ {
+		testutil.Ok(t, r.Close())
+	}
+}

--- a/pkg/block/indexheader/lazy_binary_reader_test.go
+++ b/pkg/block/indexheader/lazy_binary_reader_test.go
@@ -32,7 +32,7 @@ func TestNewLazyBinaryReader_ShouldFailIfUnableToBuildIndexHeader(t *testing.T) 
 	testutil.Ok(t, err)
 	defer func() { testutil.Ok(t, bkt.Close()) }()
 
-	_, err = NewLazyBinaryReader(ctx, log.NewNopLogger(), bkt, tmpDir, ulid.MustNew(0, nil), 3, NewLazyBinaryReaderMetrics(nil))
+	_, err = NewLazyBinaryReader(ctx, log.NewNopLogger(), bkt, tmpDir, ulid.MustNew(0, nil), 3, NewLazyBinaryReaderMetrics(nil), nil)
 	testutil.NotOk(t, err)
 }
 
@@ -56,7 +56,7 @@ func TestNewLazyBinaryReader_ShouldBuildIndexHeaderFromBucket(t *testing.T) {
 	testutil.Ok(t, block.Upload(ctx, log.NewNopLogger(), bkt, filepath.Join(tmpDir, blockID.String())))
 
 	m := NewLazyBinaryReaderMetrics(nil)
-	r, err := NewLazyBinaryReader(ctx, log.NewNopLogger(), bkt, tmpDir, blockID, 3, m)
+	r, err := NewLazyBinaryReader(ctx, log.NewNopLogger(), bkt, tmpDir, blockID, 3, m, nil)
 	testutil.Ok(t, err)
 	testutil.Assert(t, r.reader == nil)
 	testutil.Equals(t, float64(0), promtestutil.ToFloat64(m.loadCount))
@@ -101,7 +101,7 @@ func TestNewLazyBinaryReader_ShouldRebuildCorruptedIndexHeader(t *testing.T) {
 	testutil.Ok(t, ioutil.WriteFile(headerFilename, []byte("xxx"), os.ModePerm))
 
 	m := NewLazyBinaryReaderMetrics(nil)
-	r, err := NewLazyBinaryReader(ctx, log.NewNopLogger(), bkt, tmpDir, blockID, 3, m)
+	r, err := NewLazyBinaryReader(ctx, log.NewNopLogger(), bkt, tmpDir, blockID, 3, m, nil)
 	testutil.Ok(t, err)
 	testutil.Assert(t, r.reader == nil)
 	testutil.Equals(t, float64(0), promtestutil.ToFloat64(m.loadCount))
@@ -137,7 +137,7 @@ func TestLazyBinaryReader_ShouldReopenOnUsageAfterClose(t *testing.T) {
 	testutil.Ok(t, block.Upload(ctx, log.NewNopLogger(), bkt, filepath.Join(tmpDir, blockID.String())))
 
 	m := NewLazyBinaryReaderMetrics(nil)
-	r, err := NewLazyBinaryReader(ctx, log.NewNopLogger(), bkt, tmpDir, blockID, 3, m)
+	r, err := NewLazyBinaryReader(ctx, log.NewNopLogger(), bkt, tmpDir, blockID, 3, m, nil)
 	testutil.Ok(t, err)
 	testutil.Assert(t, r.reader == nil)
 

--- a/pkg/block/indexheader/reader_pool.go
+++ b/pkg/block/indexheader/reader_pool.go
@@ -1,0 +1,181 @@
+package indexheader
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/oklog/ulid"
+	"github.com/prometheus/prometheus/tsdb/index"
+	"go.uber.org/atomic"
+
+	"github.com/thanos-io/thanos/pkg/objstore"
+)
+
+type ReaderPool struct {
+	lazyReaderEnabled     bool
+	lazyReaderIdleTimeout time.Duration
+	logger                log.Logger
+
+	// Channel used to signal once the pool is closing.
+	close chan struct{}
+
+	// Keep track of all readers managed by the pool.
+	readersMx sync.Mutex
+	readers   map[*readerTracker]struct{}
+}
+
+func NewReaderPool(logger log.Logger, lazyReaderEnabled bool, lazyReaderIdleTimeout time.Duration) *ReaderPool {
+	p := &ReaderPool{
+		logger:                logger,
+		lazyReaderEnabled:     lazyReaderEnabled,
+		lazyReaderIdleTimeout: lazyReaderIdleTimeout,
+		readers:               make(map[*readerTracker]struct{}),
+		close:                 make(chan struct{}),
+	}
+
+	// Start a goroutine to close idle readers (only if required).
+	if p.lazyReaderEnabled && p.lazyReaderIdleTimeout > 0 {
+		checkFreq := p.lazyReaderIdleTimeout / 10
+
+		go func() {
+			for {
+				select {
+				case <-p.close:
+					return
+				case <-time.After(checkFreq):
+					p.closeIdleReaders()
+				}
+			}
+		}()
+	}
+
+	return p
+}
+
+func (p *ReaderPool) NewBinaryReader(ctx context.Context, logger log.Logger, bkt objstore.BucketReader, dir string, id ulid.ULID, postingOffsetsInMemSampling int) (Reader, error) {
+	var reader Reader
+	var err error
+
+	if p.lazyReaderEnabled {
+		reader, err = NewLazyBinaryReader(ctx, logger, bkt, dir, id, postingOffsetsInMemSampling)
+	} else {
+		reader, err = NewBinaryReader(ctx, logger, bkt, dir, id, postingOffsetsInMemSampling)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	// Keep track of lazy readers only if required.
+	if p.lazyReaderEnabled && p.lazyReaderIdleTimeout > 0 {
+		reader = &readerTracker{
+			reader: reader,
+			pool:   p,
+			usedAt: atomic.NewInt64(time.Now().UnixNano()),
+		}
+
+		p.readersMx.Lock()
+		p.readers[reader.(*readerTracker)] = struct{}{}
+		p.readersMx.Unlock()
+	}
+
+	return reader, err
+}
+
+// Close the pool and stop checking for idle readers. No reader tracked by this pool
+// will be closed. It's the caller responsability to close readers.
+func (p *ReaderPool) Close() {
+	close(p.close)
+}
+
+func (p *ReaderPool) closeIdleReaders() {
+	for _, r := range p.getIdleReaders() {
+		// Closing an already closed reader is a no-op, so we close it and just update
+		// the last timestamp on success. If it will be still be idle the next time this
+		// function is called, we'll try to close it again and will just be a no-op.
+		//
+		// Due to concurrency, the current implementation may close a reader which was
+		// use between when the list of idle readers has been computed and now. This is
+		// an edge case we're willing to accept, to not further complicate the logic.
+		if err := r.reader.Close(); err != nil {
+			level.Warn(p.logger).Log("msg", "failed to close idle index-header reader", "err", err)
+		}
+
+		// Update the used timestamp so that we'll not call Close() again until the next
+		// idle timeout is hit.
+		r.usedAt.Store(time.Now().UnixNano())
+	}
+}
+
+func (p *ReaderPool) getIdleReaders() []*readerTracker {
+	p.readersMx.Lock()
+	defer p.readersMx.Unlock()
+
+	var idle []*readerTracker
+	threshold := time.Now().Add(-p.lazyReaderIdleTimeout).UnixNano()
+
+	for r := range p.readers {
+		if r.usedAt.Load() < threshold {
+			idle = append(idle, r)
+		}
+	}
+
+	return idle
+}
+
+func (p *ReaderPool) isTracking(r *readerTracker) bool {
+	p.readersMx.Lock()
+	defer p.readersMx.Unlock()
+
+	_, ok := p.readers[r]
+	return ok
+}
+
+func (p *ReaderPool) onReaderClosed(r *readerTracker) {
+	p.readersMx.Lock()
+	defer p.readersMx.Unlock()
+
+	// When this function is called, it means the reader has been closed NOT because was idle
+	// but because the consumer closed it. By contract, a reader closed by the consumer can't
+	// be used anymore, so we can automatically remove it from the pool.
+	delete(p.readers, r)
+}
+
+type readerTracker struct {
+	reader Reader
+	pool   *ReaderPool
+	usedAt *atomic.Int64
+}
+
+func (r *readerTracker) Close() error {
+	r.pool.onReaderClosed(r)
+	return r.reader.Close()
+}
+
+func (r *readerTracker) IndexVersion() (int, error) {
+	r.usedAt.Store(time.Now().UnixNano())
+	return r.reader.IndexVersion()
+}
+
+func (r *readerTracker) PostingsOffset(name string, value string) (index.Range, error) {
+	r.usedAt.Store(time.Now().UnixNano())
+	return r.reader.PostingsOffset(name, value)
+}
+
+func (r *readerTracker) LookupSymbol(o uint32) (string, error) {
+	r.usedAt.Store(time.Now().UnixNano())
+	return r.reader.LookupSymbol(o)
+}
+
+func (r *readerTracker) LabelValues(name string) ([]string, error) {
+	r.usedAt.Store(time.Now().UnixNano())
+	return r.reader.LabelValues(name)
+}
+
+func (r *readerTracker) LabelNames() ([]string, error) {
+	r.usedAt.Store(time.Now().UnixNano())
+	return r.reader.LabelNames()
+}

--- a/pkg/block/indexheader/reader_pool.go
+++ b/pkg/block/indexheader/reader_pool.go
@@ -1,3 +1,6 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
 package indexheader
 
 import (

--- a/pkg/block/indexheader/reader_pool.go
+++ b/pkg/block/indexheader/reader_pool.go
@@ -15,7 +15,6 @@ import (
 	"github.com/prometheus/prometheus/tsdb/index"
 	"go.uber.org/atomic"
 
-	"github.com/thanos-io/thanos/pkg/extprom"
 	"github.com/thanos-io/thanos/pkg/objstore"
 )
 
@@ -38,7 +37,7 @@ func NewReaderPool(logger log.Logger, lazyReaderEnabled bool, lazyReaderIdleTime
 		logger:                logger,
 		lazyReaderEnabled:     lazyReaderEnabled,
 		lazyReaderIdleTimeout: lazyReaderIdleTimeout,
-		lazyReaderMetrics:     NewLazyBinaryReaderMetrics(extprom.WrapRegistererWithPrefix("indexheader_pool_", reg)),
+		lazyReaderMetrics:     NewLazyBinaryReaderMetrics(reg),
 		readers:               make(map[*readerTracker]struct{}),
 		close:                 make(chan struct{}),
 	}

--- a/pkg/block/indexheader/reader_pool_test.go
+++ b/pkg/block/indexheader/reader_pool_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
 package indexheader
 
 import (

--- a/pkg/block/indexheader/reader_pool_test.go
+++ b/pkg/block/indexheader/reader_pool_test.go
@@ -1,0 +1,125 @@
+package indexheader
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/go-kit/kit/log"
+	"github.com/prometheus/prometheus/pkg/labels"
+
+	"github.com/thanos-io/thanos/pkg/block"
+	"github.com/thanos-io/thanos/pkg/objstore/filesystem"
+	"github.com/thanos-io/thanos/pkg/testutil"
+	"github.com/thanos-io/thanos/pkg/testutil/e2eutil"
+)
+
+func TestReaderPool_NewBinaryReader(t *testing.T) {
+	tests := map[string]struct {
+		lazyReaderEnabled     bool
+		lazyReaderIdleTimeout time.Duration
+	}{
+		"lazy reader is disabled": {
+			lazyReaderEnabled: false,
+		},
+		"lazy reader is enabled but close on idle timeout is disabled": {
+			lazyReaderEnabled:     true,
+			lazyReaderIdleTimeout: 0,
+		},
+		"lazy reader and close on idle timeout are both enabled": {
+			lazyReaderEnabled:     true,
+			lazyReaderIdleTimeout: time.Minute,
+		},
+	}
+
+	ctx := context.Background()
+
+	tmpDir, err := ioutil.TempDir("", "test-indexheader")
+	testutil.Ok(t, err)
+	defer func() { testutil.Ok(t, os.RemoveAll(tmpDir)) }()
+
+	bkt, err := filesystem.NewBucket(filepath.Join(tmpDir, "bkt"))
+	testutil.Ok(t, err)
+	defer func() { testutil.Ok(t, bkt.Close()) }()
+
+	// Create block.
+	blockID, err := e2eutil.CreateBlock(ctx, tmpDir, []labels.Labels{
+		{{Name: "a", Value: "1"}},
+		{{Name: "a", Value: "2"}},
+	}, 100, 0, 1000, labels.Labels{{Name: "ext1", Value: "1"}}, 124)
+	testutil.Ok(t, err)
+	testutil.Ok(t, block.Upload(ctx, log.NewNopLogger(), bkt, filepath.Join(tmpDir, blockID.String())))
+
+	for testName, testData := range tests {
+		t.Run(testName, func(t *testing.T) {
+			pool := NewReaderPool(log.NewNopLogger(), testData.lazyReaderEnabled, testData.lazyReaderIdleTimeout)
+			defer pool.Close()
+
+			r, err := pool.NewBinaryReader(ctx, log.NewNopLogger(), bkt, tmpDir, blockID, 3)
+			testutil.Ok(t, err)
+			defer func() { testutil.Ok(t, r.Close()) }()
+
+			// Ensure it can read data.
+			labelNames, err := r.LabelNames()
+			testutil.Ok(t, err)
+			testutil.Equals(t, []string{"a"}, labelNames)
+		})
+	}
+}
+
+func TestReaderPool_ShouldCloseIdleLazyReaders(t *testing.T) {
+	const idleTimeout = time.Second
+
+	ctx := context.Background()
+
+	tmpDir, err := ioutil.TempDir("", "test-indexheader")
+	testutil.Ok(t, err)
+	defer func() { testutil.Ok(t, os.RemoveAll(tmpDir)) }()
+
+	bkt, err := filesystem.NewBucket(filepath.Join(tmpDir, "bkt"))
+	testutil.Ok(t, err)
+	defer func() { testutil.Ok(t, bkt.Close()) }()
+
+	// Create block.
+	blockID, err := e2eutil.CreateBlock(ctx, tmpDir, []labels.Labels{
+		{{Name: "a", Value: "1"}},
+		{{Name: "a", Value: "2"}},
+	}, 100, 0, 1000, labels.Labels{{Name: "ext1", Value: "1"}}, 124)
+	testutil.Ok(t, err)
+	testutil.Ok(t, block.Upload(ctx, log.NewNopLogger(), bkt, filepath.Join(tmpDir, blockID.String())))
+
+	pool := NewReaderPool(log.NewNopLogger(), true, idleTimeout)
+	defer pool.Close()
+
+	r, err := pool.NewBinaryReader(ctx, log.NewNopLogger(), bkt, tmpDir, blockID, 3)
+	testutil.Ok(t, err)
+	defer func() { testutil.Ok(t, r.Close()) }()
+
+	// Ensure it can read data.
+	labelNames, err := r.LabelNames()
+	testutil.Ok(t, err)
+	testutil.Equals(t, []string{"a"}, labelNames)
+	testutil.Assert(t, r.(*readerTracker).reader.(*LazyBinaryReader).reader != nil)
+
+	// Wait enough time before checking it.
+	time.Sleep(idleTimeout * 2)
+
+	// We expect the reader has been closed, but not released from the pool.
+	testutil.Assert(t, r.(*readerTracker).reader.(*LazyBinaryReader).reader == nil)
+	testutil.Assert(t, pool.isTracking(r.(*readerTracker)))
+
+	// Ensure it can still read data (will be re-opened).
+	labelNames, err = r.LabelNames()
+	testutil.Ok(t, err)
+	testutil.Equals(t, []string{"a"}, labelNames)
+	testutil.Assert(t, r.(*readerTracker).reader.(*LazyBinaryReader).reader != nil)
+	testutil.Assert(t, pool.isTracking(r.(*readerTracker)))
+
+	// We expect an explicit call to Close() to close the reader and release it from the pool too.
+	testutil.Ok(t, r.Close())
+	testutil.Assert(t, r.(*readerTracker).reader.(*LazyBinaryReader).reader == nil)
+	testutil.Assert(t, !pool.isTracking(r.(*readerTracker)))
+}

--- a/pkg/block/indexheader/reader_pool_test.go
+++ b/pkg/block/indexheader/reader_pool_test.go
@@ -113,7 +113,7 @@ func TestReaderPool_ShouldCloseIdleLazyReaders(t *testing.T) {
 	time.Sleep(idleTimeout * 2)
 
 	// We expect the reader has been closed, but not released from the pool.
-	testutil.Assert(t, pool.isTracking(r.(*readerTracker)))
+	testutil.Assert(t, pool.isTracking(r.(*LazyBinaryReader)))
 	testutil.Equals(t, float64(1), promtestutil.ToFloat64(pool.lazyReaderMetrics.loadCount))
 	testutil.Equals(t, float64(1), promtestutil.ToFloat64(pool.lazyReaderMetrics.unloadCount))
 
@@ -121,13 +121,13 @@ func TestReaderPool_ShouldCloseIdleLazyReaders(t *testing.T) {
 	labelNames, err = r.LabelNames()
 	testutil.Ok(t, err)
 	testutil.Equals(t, []string{"a"}, labelNames)
-	testutil.Assert(t, pool.isTracking(r.(*readerTracker)))
+	testutil.Assert(t, pool.isTracking(r.(*LazyBinaryReader)))
 	testutil.Equals(t, float64(2), promtestutil.ToFloat64(pool.lazyReaderMetrics.loadCount))
 	testutil.Equals(t, float64(1), promtestutil.ToFloat64(pool.lazyReaderMetrics.unloadCount))
 
 	// We expect an explicit call to Close() to close the reader and release it from the pool too.
 	testutil.Ok(t, r.Close())
-	testutil.Assert(t, !pool.isTracking(r.(*readerTracker)))
+	testutil.Assert(t, !pool.isTracking(r.(*LazyBinaryReader)))
 	testutil.Equals(t, float64(2), promtestutil.ToFloat64(pool.lazyReaderMetrics.loadCount))
 	testutil.Equals(t, float64(2), promtestutil.ToFloat64(pool.lazyReaderMetrics.unloadCount))
 }

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -40,6 +40,7 @@ import (
 	"github.com/thanos-io/thanos/pkg/block/metadata"
 	"github.com/thanos-io/thanos/pkg/compact/downsample"
 	"github.com/thanos-io/thanos/pkg/component"
+	"github.com/thanos-io/thanos/pkg/extprom"
 	"github.com/thanos-io/thanos/pkg/gate"
 	"github.com/thanos-io/thanos/pkg/model"
 	"github.com/thanos-io/thanos/pkg/objstore"
@@ -324,7 +325,7 @@ func NewBucketStore(
 		fetcher:                     fetcher,
 		dir:                         dir,
 		indexCache:                  indexCache,
-		indexReaderPool:             indexheader.NewReaderPool(logger, lazyIndexReaderEnabled, lazyIndexReaderIdleTimeout),
+		indexReaderPool:             indexheader.NewReaderPool(logger, lazyIndexReaderEnabled, lazyIndexReaderIdleTimeout, extprom.WrapRegistererWithPrefix("thanos_bucket_store_", reg)),
 		chunkPool:                   chunkPool,
 		blocks:                      map[ulid.ULID]*bucketBlock{},
 		blockSets:                   map[uint64]*bucketBlockSet{},

--- a/pkg/store/bucket_e2e_test.go
+++ b/pkg/store/bucket_e2e_test.go
@@ -171,6 +171,8 @@ func prepareStoreWithTestBlocks(t testing.TB, dir string, bkt objstore.Bucket, m
 		true,
 		DefaultPostingOffsetInMemorySampling,
 		true,
+		true,
+		time.Minute,
 	)
 	testutil.Ok(t, err)
 	s.store = store

--- a/pkg/store/bucket_e2e_test.go
+++ b/pkg/store/bucket_e2e_test.go
@@ -175,6 +175,8 @@ func prepareStoreWithTestBlocks(t testing.TB, dir string, bkt objstore.Bucket, m
 		time.Minute,
 	)
 	testutil.Ok(t, err)
+	defer func() { testutil.Ok(t, store.Close()) }()
+
 	s.store = store
 
 	if manyParts {

--- a/pkg/store/bucket_test.go
+++ b/pkg/store/bucket_test.go
@@ -585,6 +585,7 @@ func TestBucketStore_Info(t *testing.T) {
 		0,
 	)
 	testutil.Ok(t, err)
+	defer func() { testutil.Ok(t, bucketStore.Close()) }()
 
 	resp, err := bucketStore.Info(ctx, &storepb.InfoRequest{})
 	testutil.Ok(t, err)
@@ -836,6 +837,7 @@ func testSharding(t *testing.T, reuseDisk string, bkt objstore.Bucket, all ...ul
 				0,
 			)
 			testutil.Ok(t, err)
+			defer func() { testutil.Ok(t, bucketStore.Close()) }()
 
 			testutil.Ok(t, bucketStore.InitialSync(context.Background()))
 
@@ -1617,6 +1619,8 @@ func TestSeries_RequestAndResponseHints(t *testing.T) {
 		0,
 	)
 	testutil.Ok(tb, err)
+	defer func() { testutil.Ok(t, store.Close()) }()
+
 	testutil.Ok(tb, store.SyncBlocks(context.Background()))
 
 	testCases := []*storetestutil.SeriesCase{
@@ -1728,6 +1732,8 @@ func TestSeries_ErrorUnmarshallingRequestHints(t *testing.T) {
 		0,
 	)
 	testutil.Ok(tb, err)
+	defer func() { testutil.Ok(t, store.Close()) }()
+
 	testutil.Ok(tb, store.SyncBlocks(context.Background()))
 
 	// Create a request with invalid hints (uses response hints instead of request hints).
@@ -1963,6 +1969,8 @@ func TestBlockWithLargeChunks(t *testing.T) {
 		0,
 	)
 	testutil.Ok(t, err)
+	defer func() { testutil.Ok(t, store.Close()) }()
+
 	testutil.Ok(t, store.SyncBlocks(context.Background()))
 
 	req := &storepb.SeriesRequest{

--- a/pkg/store/bucket_test.go
+++ b/pkg/store/bucket_test.go
@@ -581,6 +581,8 @@ func TestBucketStore_Info(t *testing.T) {
 		true,
 		DefaultPostingOffsetInMemorySampling,
 		false,
+		false,
+		0,
 	)
 	testutil.Ok(t, err)
 
@@ -830,6 +832,8 @@ func testSharding(t *testing.T, reuseDisk string, bkt objstore.Bucket, all ...ul
 				true,
 				DefaultPostingOffsetInMemorySampling,
 				false,
+				false,
+				0,
 			)
 			testutil.Ok(t, err)
 
@@ -1257,10 +1261,11 @@ func benchBucketSeries(t testutil.TB, skipChunk bool, samplesPerSeries, totalSer
 	}
 
 	store := &BucketStore{
-		bkt:        objstore.WithNoopInstr(bkt),
-		logger:     logger,
-		indexCache: noopCache{},
-		metrics:    newBucketStoreMetrics(nil),
+		bkt:             objstore.WithNoopInstr(bkt),
+		logger:          logger,
+		indexCache:      noopCache{},
+		indexReaderPool: indexheader.NewReaderPool(log.NewNopLogger(), false, 0),
+		metrics:         newBucketStoreMetrics(nil),
 		blockSets: map[uint64]*bucketBlockSet{
 			labels.Labels{{Name: "ext1", Value: "1"}}.Hash(): {blocks: [][]*bucketBlock{blocks}},
 		},
@@ -1468,10 +1473,11 @@ func TestBucketSeries_OneBlock_InMemIndexCacheSegfault(t *testing.T) {
 	}
 
 	store := &BucketStore{
-		bkt:        objstore.WithNoopInstr(bkt),
-		logger:     logger,
-		indexCache: indexCache,
-		metrics:    newBucketStoreMetrics(nil),
+		bkt:             objstore.WithNoopInstr(bkt),
+		logger:          logger,
+		indexCache:      indexCache,
+		indexReaderPool: indexheader.NewReaderPool(log.NewNopLogger(), false, 0),
+		metrics:         newBucketStoreMetrics(nil),
 		blockSets: map[uint64]*bucketBlockSet{
 			labels.Labels{{Name: "ext1", Value: "1"}}.Hash(): {blocks: [][]*bucketBlock{{b1, b2}}},
 		},
@@ -1607,6 +1613,8 @@ func TestSeries_RequestAndResponseHints(t *testing.T) {
 		true,
 		DefaultPostingOffsetInMemorySampling,
 		true,
+		false,
+		0,
 	)
 	testutil.Ok(tb, err)
 	testutil.Ok(tb, store.SyncBlocks(context.Background()))
@@ -1716,6 +1724,8 @@ func TestSeries_ErrorUnmarshallingRequestHints(t *testing.T) {
 		true,
 		DefaultPostingOffsetInMemorySampling,
 		true,
+		false,
+		0,
 	)
 	testutil.Ok(tb, err)
 	testutil.Ok(tb, store.SyncBlocks(context.Background()))
@@ -1949,6 +1959,8 @@ func TestBlockWithLargeChunks(t *testing.T) {
 		true,
 		DefaultPostingOffsetInMemorySampling,
 		true,
+		false,
+		0,
 	)
 	testutil.Ok(t, err)
 	testutil.Ok(t, store.SyncBlocks(context.Background()))

--- a/pkg/store/bucket_test.go
+++ b/pkg/store/bucket_test.go
@@ -1264,7 +1264,7 @@ func benchBucketSeries(t testutil.TB, skipChunk bool, samplesPerSeries, totalSer
 		bkt:             objstore.WithNoopInstr(bkt),
 		logger:          logger,
 		indexCache:      noopCache{},
-		indexReaderPool: indexheader.NewReaderPool(log.NewNopLogger(), false, 0),
+		indexReaderPool: indexheader.NewReaderPool(log.NewNopLogger(), false, 0, nil),
 		metrics:         newBucketStoreMetrics(nil),
 		blockSets: map[uint64]*bucketBlockSet{
 			labels.Labels{{Name: "ext1", Value: "1"}}.Hash(): {blocks: [][]*bucketBlock{blocks}},
@@ -1476,7 +1476,7 @@ func TestBucketSeries_OneBlock_InMemIndexCacheSegfault(t *testing.T) {
 		bkt:             objstore.WithNoopInstr(bkt),
 		logger:          logger,
 		indexCache:      indexCache,
-		indexReaderPool: indexheader.NewReaderPool(log.NewNopLogger(), false, 0),
+		indexReaderPool: indexheader.NewReaderPool(log.NewNopLogger(), false, 0, nil),
 		metrics:         newBucketStoreMetrics(nil),
 		blockSets: map[uint64]*bucketBlockSet{
 			labels.Labels{{Name: "ext1", Value: "1"}}.Hash(): {blocks: [][]*bucketBlock{{b1, b2}}},

--- a/pkg/store/bucket_test.go
+++ b/pkg/store/bucket_test.go
@@ -1822,6 +1822,8 @@ func TestSeries_BlockWithMultipleChunks(t *testing.T) {
 		true,
 		DefaultPostingOffsetInMemorySampling,
 		true,
+		false,
+		0,
 	)
 	testutil.Ok(tb, err)
 	testutil.Ok(tb, store.SyncBlocks(context.Background()))


### PR DESCRIPTION
* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes
As discussed during the Thanos community meeting, I would like to propose to add support for lazy mmaping of index-headers in the store-gateway with the ability to automatically unload them after X time of inactivity. This PR aims to do it.

**Draft** because:
- CHANGELOG is missing

## Verification

Unit tests.
