### PR TITLE
Upgrade Cortex into Thanos

### DIFF
--- a/cmd/thanos/query_frontend.go
+++ b/cmd/thanos/query_frontend.go
@@ -45,7 +45,6 @@ func registerQueryFrontend(app *extkingpin.App) {
 	cmd := app.Command(comp.String(), "query frontend")
 	cfg := &queryFrontendConfig{
 		Config: queryfrontend.Config{
-			CortexFrontendConfig: &cortexfrontendv1.Config{},
 			// Max body size is 10 MiB.
 			CortexHandlerConfig: &transport.HandlerConfig{
 				MaxBodySize: 10 * 1024 * 1024,
@@ -169,7 +168,7 @@ func runQueryFrontend(
 		return errors.Wrap(err, "error validating the config")
 	}
 
-	fe, err := cortexfrontendv1.New(*cfg.CortexFrontendConfig, nil, logger, reg)
+	fe, err := cortexfrontendv1.New(cortexfrontendv1.Config{}, nil, logger, reg)
 	if err != nil {
 		return errors.Wrap(err, "setup query frontend")
 	}

--- a/cmd/thanos/query_frontend.go
+++ b/cmd/thanos/query_frontend.go
@@ -8,7 +8,9 @@ import (
 	"time"
 
 	"github.com/NYTimes/gziphandler"
-	cortexfrontend "github.com/cortexproject/cortex/pkg/querier/frontend"
+	cortexfrontend "github.com/cortexproject/cortex/pkg/frontend"
+	"github.com/cortexproject/cortex/pkg/frontend/transport"
+	cortexfrontendv1 "github.com/cortexproject/cortex/pkg/frontend/v1"
 	"github.com/cortexproject/cortex/pkg/querier/queryrange"
 	cortexvalidation "github.com/cortexproject/cortex/pkg/util/validation"
 	"github.com/go-kit/kit/log"
@@ -43,8 +45,11 @@ func registerQueryFrontend(app *extkingpin.App) {
 	cmd := app.Command(comp.String(), "query frontend")
 	cfg := &queryFrontendConfig{
 		Config: queryfrontend.Config{
+			CortexFrontendConfig: &cortexfrontendv1.Config{},
 			// Max body size is 10 MiB.
-			CortexFrontendConfig: &cortexfrontend.Config{MaxBodySize: 10 * 1024 * 1024},
+			CortexHandlerConfig: &transport.HandlerConfig{
+				MaxBodySize: 10 * 1024 * 1024,
+			},
 			QueryRangeConfig: queryfrontend.QueryRangeConfig{
 				Limits:             &cortexvalidation.Limits{},
 				ResultsCacheConfig: &queryrange.ResultsCacheConfig{},
@@ -107,13 +112,13 @@ func registerQueryFrontend(app *extkingpin.App) {
 		Default("").StringVar(&cfg.CacheCompression)
 
 	cmd.Flag("query-frontend.downstream-url", "URL of downstream Prometheus Query compatible API.").
-		Default("http://localhost:9090").StringVar(&cfg.CortexFrontendConfig.DownstreamURL)
+		Default("http://localhost:9090").StringVar(&cfg.DownstreamURL)
 
 	cmd.Flag("query-frontend.compress-responses", "Compress HTTP responses.").
-		Default("false").BoolVar(&cfg.CortexFrontendConfig.CompressResponses)
+		Default("false").BoolVar(&cfg.CompressResponses)
 
 	cmd.Flag("query-frontend.log-queries-longer-than", "Log queries that are slower than the specified duration. "+
-		"Set to 0 to disable. Set to < 0 to enable on all queries.").Default("0").DurationVar(&cfg.CortexFrontendConfig.LogQueriesLongerThan)
+		"Set to 0 to disable. Set to < 0 to enable on all queries.").Default("0").DurationVar(&cfg.CortexHandlerConfig.LogQueriesLongerThan)
 
 	cmd.Flag("log.request.decision", "Request Logging for logging the start and end of requests. LogFinishCall is enabled by default. LogFinishCall : Logs the finish call of the requests. LogStartAndFinishCall : Logs the start and finish call of the requests. NoLogCall : Disable request logging.").Default("LogFinishCall").EnumVar(&cfg.RequestLoggingDecision, "NoLogCall", "LogFinishCall", "LogStartAndFinishCall")
 
@@ -164,7 +169,7 @@ func runQueryFrontend(
 		return errors.Wrap(err, "error validating the config")
 	}
 
-	fe, err := cortexfrontend.New(*cfg.CortexFrontendConfig, nil, logger, reg)
+	fe, err := cortexfrontendv1.New(*cfg.CortexFrontendConfig, nil, logger, reg)
 	if err != nil {
 		return errors.Wrap(err, "setup query frontend")
 	}
@@ -175,7 +180,20 @@ func runQueryFrontend(
 		return errors.Wrap(err, "setup tripperwares")
 	}
 
-	fe.Wrap(tripperWare)
+	// Create a downstream roundtripper.
+	roundTripper, err := cortexfrontend.NewDownstreamRoundTripper(cfg.DownstreamURL)
+	if err != nil {
+		return errors.Wrap(err, "setup downstream roundtripper")
+	}
+
+	// Wrap the downstream RoundTripper into query frontend Tripperware.
+	roundTripper = tripperWare(roundTripper)
+
+	// Create the query frontend transport.
+	handler := transport.NewHandler(*cfg.CortexHandlerConfig, roundTripper, logger)
+	if cfg.CompressResponses {
+		handler = gziphandler.GzipHandler(handler)
+	}
 
 	httpProbe := prober.NewHTTP()
 	statusProber := prober.Combine(
@@ -217,7 +235,7 @@ func runQueryFrontend(
 			})
 			return hf
 		}
-		srv.Handle("/", instr(fe.Handler().ServeHTTP))
+		srv.Handle("/", instr(handler.ServeHTTP))
 
 		g.Add(func() error {
 			statusProber.Healthy()

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/cespare/xxhash v1.1.0
 	github.com/chromedp/cdproto v0.0.0-20200424080200-0de008e41fa0
 	github.com/chromedp/chromedp v0.5.3
-	github.com/cortexproject/cortex v1.4.1-0.20201030080541-83ad6df2abea
+	github.com/cortexproject/cortex v1.5.1-0.20201111110551-ba512881b076
 	github.com/davecgh/go-spew v1.1.1
 	github.com/facette/natsort v0.0.0-20181210072756-2cd4dd1e2dcb
 	github.com/fatih/structtag v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -226,6 +226,8 @@ github.com/cortexproject/cortex v1.2.1-0.20200805064754-d8edc95e2c91/go.mod h1:P
 github.com/cortexproject/cortex v1.3.1-0.20200923145333-8587ea61fe17/go.mod h1:dJ9gpW7dzQ7z09cKtNN9PfebumgyO4dtNdFQ6eQEed0=
 github.com/cortexproject/cortex v1.4.1-0.20201030080541-83ad6df2abea h1:AT8j9cojU1ena5hSyjdgAShH4Ut3JY7HLMKurR7RHm4=
 github.com/cortexproject/cortex v1.4.1-0.20201030080541-83ad6df2abea/go.mod h1:kXo5F3jlF7Ky3+I31jt/bXTzOlQjl2X/vGDpy0RY1gU=
+github.com/cortexproject/cortex v1.5.1-0.20201111110551-ba512881b076 h1:SxwQL+Tdo2RlSOZUJVvR5jXuprDRglABtjbHnNA8y9M=
+github.com/cortexproject/cortex v1.5.1-0.20201111110551-ba512881b076/go.mod h1:zFBGVsvRBfVp6ARXZ7pmiLaGlbjda5ZnA4Y6qSJyrQg=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/cznic/b v0.0.0-20180115125044-35e9bbe41f07/go.mod h1:URriBxXwVq5ijiJ12C7iIZqlA69nTlI+LgI6/pwftG8=
@@ -1065,6 +1067,7 @@ github.com/thanos-io/thanos v0.8.1-0.20200109203923-552ffa4c1a0d/go.mod h1:usT/T
 github.com/thanos-io/thanos v0.13.1-0.20200731083140-69b87607decf/go.mod h1:G8caR6G7pSDreRDvFm9wFuyjEBztmr8Ag3kBYpa/fEc=
 github.com/thanos-io/thanos v0.13.1-0.20200807203500-9b578afb4763/go.mod h1:KyW0a93tsh7v4hXAwo2CVAIRYuZT1Kkf4e04gisQjAg=
 github.com/thanos-io/thanos v0.13.1-0.20201019130456-f41940581d9a/go.mod h1:A3qUEEbsVkplJnxyDLwuIuvTDaJPByTH+hMdTl9ujAA=
+github.com/thanos-io/thanos v0.13.1-0.20201030101306-47f9a225cc52/go.mod h1:OqqX4x21cg5N5MMHd/yGQAc/V3wg8a7Do4Jk8HfaFZQ=
 github.com/themihai/gomemcache v0.0.0-20180902122335-24332e2d58ab h1:7ZR3hmisBWw77ZpO1/o86g+JV3VKlk3d48jopJxzTjU=
 github.com/themihai/gomemcache v0.0.0-20180902122335-24332e2d58ab/go.mod h1:eheTFp954zcWZXCU8d0AT76ftsQOTo4DTqkN/h3k1MY=
 github.com/tidwall/pretty v0.0.0-20180105212114-65a9db5fad51/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=

--- a/pkg/queryfrontend/config.go
+++ b/pkg/queryfrontend/config.go
@@ -8,13 +8,14 @@ import (
 	"time"
 
 	cortexcache "github.com/cortexproject/cortex/pkg/chunk/cache"
+	"github.com/cortexproject/cortex/pkg/frontend/transport"
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/thanos-io/thanos/pkg/cacheutil"
 	"github.com/thanos-io/thanos/pkg/extflag"
 	"gopkg.in/yaml.v2"
 
-	cortexfrontend "github.com/cortexproject/cortex/pkg/querier/frontend"
+	cortexfrontend "github.com/cortexproject/cortex/pkg/frontend/v1"
 	"github.com/cortexproject/cortex/pkg/querier/queryrange"
 	cortexvalidation "github.com/cortexproject/cortex/pkg/util/validation"
 	"github.com/pkg/errors"
@@ -146,8 +147,11 @@ type Config struct {
 	LabelsConfig
 
 	CortexFrontendConfig   *cortexfrontend.Config
+	CortexHandlerConfig    *transport.HandlerConfig
+	CompressResponses      bool
 	CacheCompression       string
 	RequestLoggingDecision string
+	DownstreamURL          string
 }
 
 // QueryRangeConfig holds the config for query range tripperware.
@@ -205,7 +209,7 @@ func (cfg *Config) Validate() error {
 		return errors.New("labels.default-time-range cannot be set to 0")
 	}
 
-	if len(cfg.CortexFrontendConfig.DownstreamURL) == 0 {
+	if len(cfg.DownstreamURL) == 0 {
 		return errors.New("downstream URL should be configured")
 	}
 

--- a/pkg/queryfrontend/config.go
+++ b/pkg/queryfrontend/config.go
@@ -15,7 +15,6 @@ import (
 	"github.com/thanos-io/thanos/pkg/extflag"
 	"gopkg.in/yaml.v2"
 
-	cortexfrontend "github.com/cortexproject/cortex/pkg/frontend/v1"
 	"github.com/cortexproject/cortex/pkg/querier/queryrange"
 	cortexvalidation "github.com/cortexproject/cortex/pkg/util/validation"
 	"github.com/pkg/errors"
@@ -146,7 +145,6 @@ type Config struct {
 	QueryRangeConfig
 	LabelsConfig
 
-	CortexFrontendConfig   *cortexfrontend.Config
 	CortexHandlerConfig    *transport.HandlerConfig
 	CompressResponses      bool
 	CacheCompression       string

--- a/pkg/queryfrontend/roundtrip.go
+++ b/pkg/queryfrontend/roundtrip.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/cortexproject/cortex/pkg/querier/frontend"
 	"github.com/cortexproject/cortex/pkg/querier/queryrange"
 	"github.com/cortexproject/cortex/pkg/util/validation"
 
@@ -29,7 +28,7 @@ const (
 )
 
 // NewTripperware returns a Tripperware which sends requests to different sub tripperwares based on the query type.
-func NewTripperware(config Config, reg prometheus.Registerer, logger log.Logger) (frontend.Tripperware, error) {
+func NewTripperware(config Config, reg prometheus.Registerer, logger log.Logger) (queryrange.Tripperware, error) {
 	var (
 		queryRangeLimits, labelsLimits queryrange.Limits
 		err                            error
@@ -139,8 +138,8 @@ func newQueryRangeTripperware(
 	codec *queryRangeCodec,
 	reg prometheus.Registerer,
 	logger log.Logger,
-) (frontend.Tripperware, error) {
-	queryRangeMiddleware := []queryrange.Middleware{queryrange.LimitsMiddleware(limits)}
+) (queryrange.Tripperware, error) {
+	queryRangeMiddleware := []queryrange.Middleware{queryrange.NewLimitsMiddleware(limits)}
 	m := queryrange.NewInstrumentMiddlewareMetrics(reg)
 
 	// step align middleware.
@@ -197,7 +196,7 @@ func newQueryRangeTripperware(
 
 	return func(next http.RoundTripper) http.RoundTripper {
 		rt := queryrange.NewRoundTripper(next, codec, queryRangeMiddleware...)
-		return frontend.RoundTripFunc(func(r *http.Request) (*http.Response, error) {
+		return queryrange.RoundTripFunc(func(r *http.Request) (*http.Response, error) {
 			return rt.RoundTrip(r)
 		})
 	}, nil
@@ -211,7 +210,7 @@ func newLabelsTripperware(
 	codec *labelsCodec,
 	reg prometheus.Registerer,
 	logger log.Logger,
-) (frontend.Tripperware, error) {
+) (queryrange.Tripperware, error) {
 	labelsMiddleware := []queryrange.Middleware{}
 	m := queryrange.NewInstrumentMiddlewareMetrics(reg)
 
@@ -259,7 +258,7 @@ func newLabelsTripperware(
 	}
 	return func(next http.RoundTripper) http.RoundTripper {
 		rt := queryrange.NewRoundTripper(next, codec, labelsMiddleware...)
-		return frontend.RoundTripFunc(func(r *http.Request) (*http.Response, error) {
+		return queryrange.RoundTripFunc(func(r *http.Request) (*http.Response, error) {
 			return rt.RoundTrip(r)
 		})
 	}, nil


### PR DESCRIPTION
* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

We recently refactored the query-frontend in Cortex, in order to introduce the support for a new component (query-scheduler used by query-frontend v2). The "old" query-frontend logic (v1) has been left untouched, a part from some package refactoring. Also the v1 doesn't handle the downstream, slow query logging and response compression anymore, but they're available as pluggable middlewares.

In this PR I've upgraded Cortex and done the required changes 🤞 

_Note: this upgrade has the nice side effect that Thanos will not vendor anymore Cortex `pkg/storegateway`, thus unblocking the PR #3431._

## Verification

Existing tests.
