### PR TITLE
Fix partial query results

### DIFF
--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -2071,6 +2071,8 @@ func (r *bucketIndexReader) decodeSeriesWithReq(b []byte, lbls *labels.Labels, c
 	for i := 1; i < k; i++ {
 		mint := int64(d.Uvarint64()) + t0
 		maxt := int64(d.Uvarint64()) + mint
+		ref0 += d.Varint64()
+		t0 = maxt
 
 		if maxt < req.MinTime {
 			continue
@@ -2078,9 +2080,6 @@ func (r *bucketIndexReader) decodeSeriesWithReq(b []byte, lbls *labels.Labels, c
 		if mint > req.MaxTime {
 			break
 		}
-
-		ref0 += d.Varint64()
-		t0 = maxt
 
 		if d.Err() != nil {
 			return errors.Wrapf(d.Err(), "read meta for chunk %d", i)


### PR DESCRIPTION
* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user (because not released yet)

## Changes

The PR #3367 introduced a bug causing partial query results. The problem is: in `decodeSeriesWithReq()`, when the condition `if maxt < req.MinTime` is met, the chunk reference `ref0` is not read from the index (and `t0` not updated) and this breaks the decoding of subsequent chunks.

## Verification

Unit and manual tests.
