### PR TITLE
Add max-query-lookback flag to limit the query start time

### DIFF
--- a/cmd/thanos/query_frontend.go
+++ b/cmd/thanos/query_frontend.go
@@ -79,6 +79,9 @@ func registerQueryFrontend(app *extkingpin.App) {
 	cmd.Flag("query-range.max-query-parallelism", "Maximum number of query range requests will be scheduled in parallel by the Frontend.").
 		Default("14").IntVar(&cfg.QueryRangeConfig.Limits.MaxQueryParallelism)
 
+	cmd.Flag("query-range.max-query-lookback", "Limit how long back data can be queried via query range API. If the requested time range is outside the allowed range, the request will not fail but will be manipulated to only query data within the allowed time range. 0 to disable.").
+		Default("0").DurationVar(&cfg.QueryRangeConfig.Limits.MaxQueryLookback)
+
 	cmd.Flag("query-range.response-cache-max-freshness", "Most recent allowed cacheable result for query range requests, to prevent caching very recent results that might still be in flux.").
 		Default("1m").DurationVar(&cfg.QueryRangeConfig.Limits.MaxCacheFreshness)
 
@@ -105,6 +108,9 @@ func registerQueryFrontend(app *extkingpin.App) {
 
 	cmd.Flag("labels.default-time-range", "The default metadata time range duration for retrieving labels through Labels and Series API when the range parameters are not specified.").
 		Default("24h").DurationVar(&cfg.DefaultTimeRange)
+
+	cmd.Flag("labels.max-query-lookback", "Limit how long back metadata can be queried via series and labels API. If the requested time range is outside the allowed range, the request will not fail but will be manipulated to only query data within the allowed time range. 0 to disable.").
+		Default("0").DurationVar(&cfg.QueryRangeConfig.Limits.MaxQueryLookback)
 
 	cfg.LabelsConfig.CachePathOrContent = *extflag.RegisterPathOrContent(cmd, "labels.response-cache-config", "YAML file that contains response cache configuration.", false)
 

--- a/docs/components/query-frontend.md
+++ b/docs/components/query-frontend.md
@@ -161,6 +161,12 @@ Flags:
       --query-range.max-query-parallelism=14
                                  Maximum number of query range requests will be
                                  scheduled in parallel by the Frontend.
+      --query-range.max-query-lookback=0
+                                 Limit how long back data can be queried via
+                                 query range API. If the requested time range is
+                                 outside the allowed range, the request will not
+                                 fail but will be manipulated to only query data
+                                 within the allowed time range. 0 to disable.
       --query-range.response-cache-max-freshness=1m
                                  Most recent allowed cacheable result for query
                                  range requests, to prevent caching very recent
@@ -201,6 +207,13 @@ Flags:
                                  The default metadata time range duration for
                                  retrieving labels through Labels and Series API
                                  when the range parameters are not specified.
+      --labels.max-query-lookback=0
+                                 Limit how long back metadata can be queried via
+                                 series and labels API. If the requested time
+                                 range is outside the allowed range, the request
+                                 will not fail but will be manipulated to only
+                                 query data within the allowed time range. 0 to
+                                 disable.
       --labels.response-cache-config-file=<file-path>
                                  Path to YAML file that contains response cache
                                  configuration.


### PR DESCRIPTION
Signed-off-by: Ben Ye <yb532204897@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->
Upstream Cortex supports `max-query-lookback` to limit the query start time. I think it is useful to make this a configurable flag.

For how it works, please take a look at https://github.com/cortexproject/cortex/blob/master/pkg/querier/queryrange/limits.go#L61-L85

## Verification

<!-- How you tested it? How do you know it works? -->
