### PR TITLE
Fixed compactor logs

### DIFF
--- a/pkg/block/metadata/meta.go
+++ b/pkg/block/metadata/meta.go
@@ -10,6 +10,7 @@ package metadata
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -49,6 +50,10 @@ type Meta struct {
 	tsdb.BlockMeta
 
 	Thanos Thanos `json:"thanos"`
+}
+
+func (m *Meta) String() string {
+	return fmt.Sprintf("%s (min time: %d, max time: %d)", m.ULID, m.MinTime, m.MaxTime)
 }
 
 // Thanos holds block meta information specific to Thanos.


### PR DESCRIPTION
* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

A recent refactoring in the compactor made log messages hard to read because the planned blocks are logged as pointers. This should PR fix it.

Before:
```
compaction available and planned; downloading blocks" plan="[0xc001820d20 0xc0028afb30 0xc0018cbef0 0xc00152e960 0xc001940f00 0xc001940a50 0xc0028af770 0xc00152e5a0 0xc002b2e1e0 0xc001735d10 0xc002b2e000 0xc0028af590 0xc001735b30 0xc0018cb1d0 0xc001735950 0xc0019405a0 0xc001940c30 0xc00152e3c0 0xc001940870 0xc0018caff0 0xc00152e1e0 0xc0028af2c0 0xc0017354a0 0xc0017352c0 0xc001e2fef0 0xc001e2f860 0xc0018cae10 0xc001735770 0xc001e2f680]
```

After (different set of blocks in the example log):
```
compaction available and planned; downloading blocks" plan="[01EGQB46JTK4AWAV0Y5J4RA871 (min time: 1598277600000, max time: 1598284800000) 01EJ6NYRNQNPWTV0GY05QK925A (min time: 1598457600000, max time: 1598464800000)]
```

## Verification

Existing tests.
