### PR TITLE
docs: update release schedule

### DIFF
--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -31,8 +31,10 @@ Release shepherd responsibilities:
 
 | Release   | Time of first RC         | Shepherd (GitHub handle) |
 |-----------|--------------------------|--------------------------|
-| v0.17.0   | (planned) 2020.11.04     | `@metalmatze`            |
-| v0.16.0   | (planned) 2020.09.23     | `@bwplotka`              |
+| v0.19.0   | (planned) 2021.01.10     | `@bwplotka  `            |
+| v0.18.0   | (planned) 2020.12.30     | `@squat     `            |
+| v0.17.0   | 2020.11.18               | `@metalmatze`            |
+| v0.16.0   | 2020.10.26               | `@bwplotka`              |
 | v0.15.0   | 2020.08.12               | `@kakkoyun`              |
 | v0.14.0   | 2020.07.10               | `@kakkoyun`              |
 | v0.13.0   | 2020.05.13               | `@bwplotka`              |


### PR DESCRIPTION
This commit adds entries for the next two releases to the release
process schedule as well as updates the entries for the previous
releases to match the dates on which they were ultimately released.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>

cc @thanos-io/thanos-maintainers 