### PR TITLE
s3: Respect SignatureV2 flag for all credential providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ We use _breaking :warning:_ to mark changes that are not backward compatible (re
 
 ### Changed
 
--
+- [#3496](https://github.com/thanos-io/thanos/pull/3496) s3: Respect SignatureV2 flag for all credential providers.
 
 ## [v0.17.0](https://github.com/thanos-io/thanos/releases/tag/v0.17.0) - 2020.11.18
 

--- a/docs/components/tools.md
+++ b/docs/components/tools.md
@@ -66,19 +66,19 @@ Subcommands:
     potentially a noop.
 
   tools bucket rewrite --id=ID [<flags>]
-    Rewrite chosen blocks in the bucket, while deleting or modifying
-    seriesResulted block has modified stats in meta.json. Additionally
-    compaction.sources are altered to not confuse readers of meta.json.Instead
+    Rewrite chosen blocks in the bucket, while deleting or modifying series
+    Resulted block has modified stats in meta.json. Additionally
+    compaction.sources are altered to not confuse readers of meta.json. Instead
     thanos.rewrite section is added with useful info like old sources and
-    deletion requestsNOTE: It's recommended to turn off compactor while doing
+    deletion requests. NOTE: It's recommended to turn off compactor while doing
     this operation. If the compactor is running and touching exactly same block
-    thatis being rewritten, the resulted rewritten block might only cause
-    overlap (mitigated by marking overlapping block manually for deletion)and
+    that is being rewritten, the resulted rewritten block might only cause
+    overlap (mitigated by marking overlapping block manually for deletion) and
     the data you wanted to rewrite could already part of bigger block.
 
     Use FILESYSTEM type of bucket to rewrite block on disk (suitable for vanilla
-    Prometheus)After rewrite, it's caller responsibility to delete or mark
-    source block for deletion to avoid overlaps.WARNING: This procedure is
+    Prometheus) After rewrite, it's caller responsibility to delete or mark
+    source block for deletion to avoid overlaps. WARNING: This procedure is
     *IRREVERSIBLE* after certain time (delete delay), so do backup your blocks
     first.
 
@@ -172,19 +172,19 @@ Subcommands:
     potentially a noop.
 
   tools bucket rewrite --id=ID [<flags>]
-    Rewrite chosen blocks in the bucket, while deleting or modifying
-    seriesResulted block has modified stats in meta.json. Additionally
-    compaction.sources are altered to not confuse readers of meta.json.Instead
+    Rewrite chosen blocks in the bucket, while deleting or modifying series
+    Resulted block has modified stats in meta.json. Additionally
+    compaction.sources are altered to not confuse readers of meta.json. Instead
     thanos.rewrite section is added with useful info like old sources and
-    deletion requestsNOTE: It's recommended to turn off compactor while doing
+    deletion requests. NOTE: It's recommended to turn off compactor while doing
     this operation. If the compactor is running and touching exactly same block
-    thatis being rewritten, the resulted rewritten block might only cause
-    overlap (mitigated by marking overlapping block manually for deletion)and
+    that is being rewritten, the resulted rewritten block might only cause
+    overlap (mitigated by marking overlapping block manually for deletion) and
     the data you wanted to rewrite could already part of bigger block.
 
     Use FILESYSTEM type of bucket to rewrite block on disk (suitable for vanilla
-    Prometheus)After rewrite, it's caller responsibility to delete or mark
-    source block for deletion to avoid overlaps.WARNING: This procedure is
+    Prometheus) After rewrite, it's caller responsibility to delete or mark
+    source block for deletion to avoid overlaps. WARNING: This procedure is
     *IRREVERSIBLE* after certain time (delete delay), so do backup your blocks
     first.
 
@@ -682,19 +682,19 @@ ts=2020-11-09T00:40:13.703322181Z caller=level.go:63 level=info msg="changelog w
 ```$
 usage: thanos tools bucket rewrite --id=ID [<flags>]
 
-Rewrite chosen blocks in the bucket, while deleting or modifying seriesResulted
+Rewrite chosen blocks in the bucket, while deleting or modifying series Resulted
 block has modified stats in meta.json. Additionally compaction.sources are
-altered to not confuse readers of meta.json.Instead thanos.rewrite section is
-added with useful info like old sources and deletion requestsNOTE: It's
+altered to not confuse readers of meta.json. Instead thanos.rewrite section is
+added with useful info like old sources and deletion requests. NOTE: It's
 recommended to turn off compactor while doing this operation. If the compactor
-is running and touching exactly same block thatis being rewritten, the resulted
+is running and touching exactly same block that is being rewritten, the resulted
 rewritten block might only cause overlap (mitigated by marking overlapping block
-manually for deletion)and the data you wanted to rewrite could already part of
+manually for deletion) and the data you wanted to rewrite could already part of
 bigger block.
 
 Use FILESYSTEM type of bucket to rewrite block on disk (suitable for vanilla
-Prometheus)After rewrite, it's caller responsibility to delete or mark source
-block for deletion to avoid overlaps.WARNING: This procedure is *IRREVERSIBLE*
+Prometheus) After rewrite, it's caller responsibility to delete or mark source
+block for deletion to avoid overlaps. WARNING: This procedure is *IRREVERSIBLE*
 after certain time (delete delay), so do backup your blocks first.
 
 Flags:


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Thanos currently only supports V2 signatures when the credentials are statically specified in its configuration. This change supports using signature V2 on other credential sources, too.

## Verification

The object storage appliance is not fully compatible with S3V4 signatures and we are able to run it statically configured with V2. 

As we need to roll over the used accessKey/secretKey regularly we would like to be able to configure it via the `&credentials.IAM{}` chain. 