### PR TITLE
Expose metadata.Read()

### DIFF
--- a/pkg/block/metadata/meta.go
+++ b/pkg/block/metadata/meta.go
@@ -198,10 +198,11 @@ func ReadFromDir(dir string) (*Meta, error) {
 	if err != nil {
 		return nil, err
 	}
-	return read(f)
+	return Read(f)
 }
 
-func read(rc io.ReadCloser) (_ *Meta, err error) {
+// Read the block meta from the given reader.
+func Read(rc io.ReadCloser) (_ *Meta, err error) {
 	defer runutil.ExhaustCloseWithErrCapture(&err, rc, "close meta JSON")
 
 	var m Meta

--- a/pkg/block/metadata/meta_test.go
+++ b/pkg/block/metadata/meta_test.go
@@ -35,7 +35,7 @@ func TestMeta_ReadWrite(t *testing.T) {
 	}
 }
 `, b.String())
-		_, err := read(ioutil.NopCloser(&b))
+		_, err := Read(ioutil.NopCloser(&b))
 		testutil.NotOk(t, err)
 		testutil.Equals(t, "unexpected meta file version 0", err.Error())
 	})
@@ -125,7 +125,7 @@ func TestMeta_ReadWrite(t *testing.T) {
 	}
 }
 `, b.String())
-		retMeta, err := read(ioutil.NopCloser(&b))
+		retMeta, err := Read(ioutil.NopCloser(&b))
 		testutil.Ok(t, err)
 		testutil.Equals(t, m1, *retMeta)
 	})
@@ -203,7 +203,7 @@ func TestMeta_ReadWrite(t *testing.T) {
 	}
 }
 `, b.String())
-		retMeta, err := read(ioutil.NopCloser(&b))
+		retMeta, err := Read(ioutil.NopCloser(&b))
 		testutil.Ok(t, err)
 
 		// We expect map to be empty but allocated.


### PR DESCRIPTION
* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

In Cortex we have the need to parse `meta.json` from a `io.Reader`. Since Thanos already has a function for that, can we expose it, instead of duplicating it?

## Verification

N/A
