### PR TITLE
cmd/thanos/query.go: Timeout DNS resolution with refresh interval

### DIFF
--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -391,6 +391,8 @@ func runQuery(
 		ctx, cancel := context.WithCancel(context.Background())
 		g.Add(func() error {
 			return runutil.Repeat(dnsSDInterval, ctx.Done(), func() error {
+				ctx, cancel = context.WithTimeout(ctx, dnsSDInterval)
+				defer cancel()
 				if err := dnsStoreProvider.Resolve(ctx, append(fileSDCache.Addresses(), storeAddrs...)); err != nil {
 					level.Error(logger).Log("msg", "failed to resolve addresses for storeAPIs", "err", err)
 				}


### PR DESCRIPTION
While the context is passed to DNS resolver, no timeout is ever set,
which leaves us in an unpredictable state, as we wait for the resolution
indefinitely. Every interval we repeat the DNS resolution, but don't ever
cancel previous attempts even if they have not finished.

Signed-off-by: Lili Cosic <cosiclili@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes
- Adds timeout DNS resolution with refresh interval
While the context is passed to DNS resolver, no timeout is ever set,
which leaves us in an unpredictable state, as we wait for the resolution
indefinitely. Every interval we repeat the DNS resolution, but don't ever
cancel previous attempts even if they have not finished. 

Note as per https://github.com/thanos-io/thanos/pull/3508#issuecomment-734316160 this only applies to the default DNS resolver. 

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
