### PR TITLE
Add CircleCI Go orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,9 @@
 # NOTE: Current plan gives 1500 build minutes per month.
 version: 2.1
 
+orbs:
+  go: circleci/go@1.5.0
+
 executors:
   golang:
     docker:
@@ -17,6 +20,7 @@ jobs:
       GO111MODULE: 'on'
     steps:
       - checkout
+      - go/mod-download-cached
       - setup_remote_docker:
           version: 17.07.0-ce
       - run:
@@ -68,6 +72,7 @@ jobs:
     executor: golang
     steps:
       - checkout
+      - go/mod-download-cached
       - setup_remote_docker:
           version: 17.07.0-ce
       - attach_workspace:
@@ -85,6 +90,7 @@ jobs:
     executor: golang
     steps:
       - checkout
+      - go/mod-download-cached
       - setup_remote_docker:
           version: 17.07.0-ce
       - attach_workspace:


### PR DESCRIPTION
Add CircleCI orb for Go, use go mod download caching.

Signed-off-by: Ben Kochie <superq@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
