### PR TITLE
fix index out of bound bug when comparing ZLabelSets

### DIFF
--- a/pkg/queryfrontend/labels_codec.go
+++ b/pkg/queryfrontend/labels_codec.go
@@ -88,23 +88,6 @@ func (c labelsCodec) MergeResponse(responses ...queryrange.Response) (queryrange
 			return responses[0], nil
 		}
 
-		i := 0
-		var resp queryrange.Response
-		for _, response := range responses {
-			if len(response.(*ThanosSeriesResponse).Data) > 0 {
-				i++
-				resp = response
-			}
-			if i > 1 {
-				break
-			}
-		}
-		// Fast path for the case that only one response contains series data and other responses are empty.
-		// We can just return that response to avoid deduplication and sorting.
-		if i == 1 {
-			return resp, nil
-		}
-
 		seriesData := make(labelpb.ZLabelSets, 0)
 		uniqueSeries := make(map[string]struct{})
 		for _, res := range responses {
@@ -304,7 +287,7 @@ func (c labelsCodec) parseLabelsRequest(r *http.Request, op string) (queryrange.
 		return nil, err
 	}
 
-	result.StoreMatchers, err = parseMatchersParam(r.Form[queryv1.StoreMatcherParam], queryv1.StoreMatcherParam)
+	result.StoreMatchers, err = parseMatchersParam(r.Form, queryv1.StoreMatcherParam)
 	if err != nil {
 		return nil, err
 	}
@@ -338,7 +321,7 @@ func (c labelsCodec) parseSeriesRequest(r *http.Request) (queryrange.Request, er
 		return nil, err
 	}
 
-	result.Matchers, err = parseMatchersParam(r.Form[queryv1.MatcherParam], queryv1.MatcherParam)
+	result.Matchers, err = parseMatchersParam(r.Form, queryv1.MatcherParam)
 	if err != nil {
 		return nil, err
 	}
@@ -357,7 +340,7 @@ func (c labelsCodec) parseSeriesRequest(r *http.Request) (queryrange.Request, er
 		result.ReplicaLabels = r.Form[queryv1.ReplicaLabelsParam]
 	}
 
-	result.StoreMatchers, err = parseMatchersParam(r.Form[queryv1.StoreMatcherParam], queryv1.StoreMatcherParam)
+	result.StoreMatchers, err = parseMatchersParam(r.Form, queryv1.StoreMatcherParam)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/queryfrontend/queryrange_codec.go
+++ b/pkg/queryfrontend/queryrange_codec.go
@@ -111,7 +111,7 @@ func (c queryRangeCodec) DecodeRequest(_ context.Context, r *http.Request) (quer
 		result.ReplicaLabels = r.Form[queryv1.ReplicaLabelsParam]
 	}
 
-	result.StoreMatchers, err = parseMatchersParam(r.Form[queryv1.StoreMatcherParam])
+	result.StoreMatchers, err = parseMatchersParam(r.Form[queryv1.StoreMatcherParam], queryv1.StoreMatcherParam)
 	if err != nil {
 		return nil, err
 	}
@@ -221,12 +221,12 @@ func parsePartialResponseParam(s string, defaultEnablePartialResponse bool) (boo
 	return defaultEnablePartialResponse, nil
 }
 
-func parseMatchersParam(ss []string) ([][]*labels.Matcher, error) {
+func parseMatchersParam(ss []string, matcherParam string) ([][]*labels.Matcher, error) {
 	matchers := make([][]*labels.Matcher, 0, len(ss))
 	for _, s := range ss {
 		ms, err := parser.ParseMetricSelector(s)
 		if err != nil {
-			return nil, httpgrpc.Errorf(http.StatusBadRequest, errCannotParse, queryv1.StoreMatcherParam)
+			return nil, httpgrpc.Errorf(http.StatusBadRequest, errCannotParse, matcherParam)
 		}
 		matchers = append(matchers, ms)
 	}

--- a/pkg/queryfrontend/queryrange_codec.go
+++ b/pkg/queryfrontend/queryrange_codec.go
@@ -111,7 +111,7 @@ func (c queryRangeCodec) DecodeRequest(_ context.Context, r *http.Request) (quer
 		result.ReplicaLabels = r.Form[queryv1.ReplicaLabelsParam]
 	}
 
-	result.StoreMatchers, err = parseMatchersParam(r.Form[queryv1.StoreMatcherParam], queryv1.StoreMatcherParam)
+	result.StoreMatchers, err = parseMatchersParam(r.Form, queryv1.StoreMatcherParam)
 	if err != nil {
 		return nil, err
 	}
@@ -221,9 +221,9 @@ func parsePartialResponseParam(s string, defaultEnablePartialResponse bool) (boo
 	return defaultEnablePartialResponse, nil
 }
 
-func parseMatchersParam(ss []string, matcherParam string) ([][]*labels.Matcher, error) {
-	matchers := make([][]*labels.Matcher, 0, len(ss))
-	for _, s := range ss {
+func parseMatchersParam(ss url.Values, matcherParam string) ([][]*labels.Matcher, error) {
+	matchers := make([][]*labels.Matcher, 0, len(ss[matcherParam]))
+	for _, s := range ss[matcherParam] {
 		ms, err := parser.ParseMetricSelector(s)
 		if err != nil {
 			return nil, httpgrpc.Errorf(http.StatusBadRequest, errCannotParse, matcherParam)

--- a/pkg/store/labelpb/label.go
+++ b/pkg/store/labelpb/label.go
@@ -307,7 +307,8 @@ func (z ZLabelSets) Less(i, j int) bool {
 	l := 0
 	r := 0
 	var result int
-	for l < z[i].Size() && r < z[j].Size() {
+	lenI, lenJ := len(z[i].Labels), len(z[j].Labels)
+	for l < lenI && r < lenJ {
 		result = z[i].Labels[l].Compare(z[j].Labels[r])
 		if result == 0 {
 			l++
@@ -317,5 +318,5 @@ func (z ZLabelSets) Less(i, j int) bool {
 		return result < 0
 	}
 
-	return l == z[i].Size()
+	return l == lenI
 }

--- a/pkg/store/labelpb/label_test.go
+++ b/pkg/store/labelpb/label_test.go
@@ -132,6 +132,34 @@ func TestSortZLabelSets(t *testing.T) {
 		{
 			Labels: ZLabelsFromPromLabels(
 				labels.FromMap(map[string]string{
+					"__name__":  "grpc_client_handled_total",
+					"cluster":   "test",
+					"grpc_code": "OK",
+					"aa":        "1",
+					"bb":        "2",
+					"cc":        "3",
+					"dd":        "4",
+					"ee":        "5",
+				}),
+			),
+		},
+		{
+			Labels: ZLabelsFromPromLabels(
+				labels.FromMap(map[string]string{
+					"__name__":  "grpc_client_handled_total",
+					"cluster":   "test",
+					"grpc_code": "OK",
+					"aa":        "1",
+					"bb":        "2",
+					"cc":        "3",
+					"dd":        "4",
+					"ee":        "5",
+				}),
+			),
+		},
+		{
+			Labels: ZLabelsFromPromLabels(
+				labels.FromMap(map[string]string{
 					"__name__":    "grpc_server_handled_total",
 					"cluster":     "test",
 					"grpc_code":   "OK",
@@ -185,6 +213,35 @@ func TestSortZLabelSets(t *testing.T) {
 					"cluster":     "test",
 					"grpc_code":   "OK",
 					"grpc_method": "Info",
+				}),
+			),
+		},
+		{
+			Labels: ZLabelsFromPromLabels(
+				labels.FromMap(map[string]string{
+					"__name__":  "grpc_client_handled_total",
+					"cluster":   "test",
+					"grpc_code": "OK",
+					"aa":        "1",
+					"bb":        "2",
+					"cc":        "3",
+					"dd":        "4",
+					"ee":        "5",
+				}),
+			),
+		},
+		// This label set is the same as the previous one, which should correctly return 0 in Less() function.
+		{
+			Labels: ZLabelsFromPromLabels(
+				labels.FromMap(map[string]string{
+					"cluster":   "test",
+					"__name__":  "grpc_client_handled_total",
+					"grpc_code": "OK",
+					"aa":        "1",
+					"bb":        "2",
+					"cc":        "3",
+					"dd":        "4",
+					"ee":        "5",
 				}),
 			),
 		},


### PR DESCRIPTION
Signed-off-by: Ben Ye <yb532204897@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->
Fixes #3515 

The bug is originated from that I got the label pair length using `Size()` method, it is a stupid mistake :-1:  because it doesn't return the number of label pairs.
Added one test case to ensure no panic for comparing the same label sets.
However, we deduplicate the series before sorting them so the case shouldn't happen. Still investigating the root cause and trying to reproduce this from the query frontend side.

## Verification

<!-- How you tested it? How do you know it works? -->
