### PR TITLE
cmd/thanos: fix DNS resolution when ctx is canceled

### DIFF
--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -391,12 +391,12 @@ func runQuery(
 		ctx, cancel := context.WithCancel(context.Background())
 		g.Add(func() error {
 			return runutil.Repeat(dnsSDInterval, ctx.Done(), func() error {
-				ctx, cancel = context.WithTimeout(ctx, dnsSDInterval)
-				defer cancel()
-				if err := dnsStoreProvider.Resolve(ctx, append(fileSDCache.Addresses(), storeAddrs...)); err != nil {
+				resolveCtx, resolveCancel := context.WithTimeout(ctx, dnsSDInterval)
+				defer resolveCancel()
+				if err := dnsStoreProvider.Resolve(resolveCtx, append(fileSDCache.Addresses(), storeAddrs...)); err != nil {
 					level.Error(logger).Log("msg", "failed to resolve addresses for storeAPIs", "err", err)
 				}
-				if err := dnsRuleProvider.Resolve(ctx, ruleAddrs); err != nil {
+				if err := dnsRuleProvider.Resolve(resolveCtx, ruleAddrs); err != nil {
 					level.Error(logger).Log("msg", "failed to resolve addresses for rulesAPIs", "err", err)
 				}
 				return nil


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [X] Change is not relevant to the end user.

## Changes

c21337e5 introduced a subtle bug: when the DNS resolution context
expires, all subsequent resolutions will fail with 'operation was
canceled' because the function overwrites the global context instead of
creating child context. To make it more obvious, we use different
variable names for the parent and child contexts.

## Verification

Here is a minimal reproducer:
https://play.golang.org/p/Gw9B1cU3mtL
