### PR TITLE
query-frontend: inclusive results when start/end are the same

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ We use _breaking :warning:_ to mark changes that are not backward compatible (re
 
 ### Fixed
 
--
+- [#3527](https://github.com/thanos-io/thanos/pull/3527) Query Frontend: Fix query_range behavior when start/end times are the same
 
 ### Changed
 

--- a/pkg/queryfrontend/split_by_interval.go
+++ b/pkg/queryfrontend/split_by_interval.go
@@ -68,13 +68,17 @@ func (s splitByInterval) Do(ctx context.Context, r queryrange.Request) (queryran
 func splitQuery(r queryrange.Request, interval time.Duration) []queryrange.Request {
 	var reqs []queryrange.Request
 	if _, ok := r.(*ThanosQueryRangeRequest); ok {
-		for start := r.GetStart(); start < r.GetEnd(); start = nextIntervalBoundary(start, r.GetStep(), interval) + r.GetStep() {
-			end := nextIntervalBoundary(start, r.GetStep(), interval)
-			if end+r.GetStep() >= r.GetEnd() {
-				end = r.GetEnd()
-			}
+		if start := r.GetStart(); start == r.GetEnd() {
+			reqs = append(reqs, r.WithStartEnd(start, start))
+		} else {
+			for ; start < r.GetEnd(); start = nextIntervalBoundary(start, r.GetStep(), interval) + r.GetStep() {
+				end := nextIntervalBoundary(start, r.GetStep(), interval)
+				if end+r.GetStep() >= r.GetEnd() {
+					end = r.GetEnd()
+				}
 
-			reqs = append(reqs, r.WithStartEnd(start, end))
+				reqs = append(reqs, r.WithStartEnd(start, end))
+			}
 		}
 	} else {
 		dur := int64(interval / time.Millisecond)


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

Verified same way bug report #3526 was tested. When passing start/end with the same value, results are now returned.

```
❯ http --follow "http://localhost:19090/api/v1/query_range?query=up&start=$(gdate +%s)&end=$(gdate +%s)&step=120" | jq '.data.result | length'
14
❯ http --follow "http://localhost:19090/api/v1/query_range?query=up&start=$(gdate --date='5 minutes ago' +%s)&end=$(gdate +%s)&step=120" | jq '.data.result | length'
14
```

<!-- How you tested it? How do you know it works? -->
