### PR TITLE
mixin/alerts: remove .rules suffix from alert groups

### DIFF
--- a/examples/alerts/alerts.md
+++ b/examples/alerts/alerts.md
@@ -6,7 +6,7 @@ Here are some example alerts configured for Kubernetes environment.
 
 [embedmd]:# (../tmp/thanos-compact.yaml yaml)
 ```yaml
-name: thanos-compact.rules
+name: thanos-compact
 rules:
 - alert: ThanosCompactMultipleRunning
   annotations:
@@ -76,7 +76,7 @@ For Thanos Ruler we run some alerts in local Prometheus, to make sure that Thano
 
 [embedmd]:# (../tmp/thanos-rule.yaml yaml)
 ```yaml
-name: thanos-rule.rules
+name: thanos-rule
 rules:
 - alert: ThanosRuleQueueIsDroppingAlerts
   annotations:
@@ -231,7 +231,7 @@ rules:
 
 [embedmd]:# (../tmp/thanos-store.yaml yaml)
 ```yaml
-name: thanos-store.rules
+name: thanos-store
 rules:
 - alert: ThanosStoreGrpcErrorRate
   annotations:
@@ -301,7 +301,7 @@ rules:
 
 [embedmd]:# (../tmp/thanos-sidecar.yaml yaml)
 ```yaml
-name: thanos-sidecar.rules
+name: thanos-sidecar
 rules:
 - alert: ThanosSidecarPrometheusDown
   annotations:
@@ -330,7 +330,7 @@ rules:
 
 [embedmd]:# (../tmp/thanos-query.yaml yaml)
 ```yaml
-name: thanos-query.rules
+name: thanos-query
 rules:
 - alert: ThanosQueryHttpRequestQueryErrorRateHigh
   annotations:
@@ -444,7 +444,7 @@ rules:
 
 [embedmd]:# (../tmp/thanos-receive.yaml yaml)
 ```yaml
-name: thanos-receive.rules
+name: thanos-receive
 rules:
 - alert: ThanosReceiveHttpRequestErrorRateHigh
   annotations:
@@ -562,7 +562,7 @@ rules:
 
 [embedmd]:# (../tmp/thanos-bucket-replicate.yaml yaml)
 ```yaml
-name: thanos-bucket-replicate.rules
+name: thanos-bucket-replicate
 rules:
 - alert: ThanosBucketReplicateIsDown
   annotations:
@@ -612,7 +612,7 @@ rules:
 
 [embedmd]:# (../tmp/thanos-component-absent.yaml yaml)
 ```yaml
-name: thanos-component-absent.rules
+name: thanos-component-absent
 rules:
 - alert: ThanosBucketReplicateIsDown
   annotations:

--- a/examples/alerts/alerts.md
+++ b/examples/alerts/alerts.md
@@ -4,7 +4,7 @@ Here are some example alerts configured for Kubernetes environment.
 
 ## Compaction
 
-[embedmd]:# (../tmp/thanos-compact.rules.yaml yaml)
+[embedmd]:# (../tmp/thanos-compact.yaml yaml)
 ```yaml
 name: thanos-compact.rules
 rules:
@@ -74,7 +74,7 @@ rules:
 
 For Thanos Ruler we run some alerts in local Prometheus, to make sure that Thanos Ruler is working:
 
-[embedmd]:# (../tmp/thanos-rule.rules.yaml yaml)
+[embedmd]:# (../tmp/thanos-rule.yaml yaml)
 ```yaml
 name: thanos-rule.rules
 rules:
@@ -229,7 +229,7 @@ rules:
 
 ## Store Gateway
 
-[embedmd]:# (../tmp/thanos-store.rules.yaml yaml)
+[embedmd]:# (../tmp/thanos-store.yaml yaml)
 ```yaml
 name: thanos-store.rules
 rules:
@@ -299,7 +299,7 @@ rules:
 
 ## Sidecar
 
-[embedmd]:# (../tmp/thanos-sidecar.rules.yaml yaml)
+[embedmd]:# (../tmp/thanos-sidecar.yaml yaml)
 ```yaml
 name: thanos-sidecar.rules
 rules:
@@ -328,7 +328,7 @@ rules:
 
 ## Query
 
-[embedmd]:# (../tmp/thanos-query.rules.yaml yaml)
+[embedmd]:# (../tmp/thanos-query.yaml yaml)
 ```yaml
 name: thanos-query.rules
 rules:
@@ -442,7 +442,7 @@ rules:
 
 ## Receive
 
-[embedmd]:# (../tmp/thanos-receive.rules.yaml yaml)
+[embedmd]:# (../tmp/thanos-receive.yaml yaml)
 ```yaml
 name: thanos-receive.rules
 rules:
@@ -560,7 +560,7 @@ rules:
 
 ## Replicate
 
-[embedmd]:# (../tmp/thanos-bucket-replicate.rules.yaml yaml)
+[embedmd]:# (../tmp/thanos-bucket-replicate.yaml yaml)
 ```yaml
 name: thanos-bucket-replicate.rules
 rules:
@@ -610,7 +610,7 @@ rules:
 
 ### Absent Rules
 
-[embedmd]:# (../tmp/thanos-component-absent.rules.yaml yaml)
+[embedmd]:# (../tmp/thanos-component-absent.yaml yaml)
 ```yaml
 name: thanos-component-absent.rules
 rules:

--- a/examples/alerts/alerts.yaml
+++ b/examples/alerts/alerts.yaml
@@ -1,5 +1,5 @@
 groups:
-- name: thanos-compact.rules
+- name: thanos-compact
   rules:
   - alert: ThanosCompactMultipleRunning
     annotations:
@@ -62,7 +62,7 @@ groups:
       / 60 / 60 > 24
     labels:
       severity: warning
-- name: thanos-query.rules
+- name: thanos-query
   rules:
   - alert: ThanosQueryHttpRequestQueryErrorRateHigh
     annotations:
@@ -170,7 +170,7 @@ groups:
     for: 10m
     labels:
       severity: critical
-- name: thanos-receive.rules
+- name: thanos-receive
   rules:
   - alert: ThanosReceiveHttpRequestErrorRateHigh
     annotations:
@@ -282,7 +282,7 @@ groups:
     for: 3h
     labels:
       severity: critical
-- name: thanos-sidecar.rules
+- name: thanos-sidecar
   rules:
   - alert: ThanosSidecarPrometheusDown
     annotations:
@@ -305,7 +305,7 @@ groups:
       time() - max(thanos_sidecar_last_heartbeat_success_time_seconds{job=~"thanos-sidecar.*"}) by (job, pod) >= 600
     labels:
       severity: critical
-- name: thanos-store.rules
+- name: thanos-store
   rules:
   - alert: ThanosStoreGrpcErrorRate
     annotations:
@@ -369,7 +369,7 @@ groups:
     for: 10m
     labels:
       severity: warning
-- name: thanos-rule.rules
+- name: thanos-rule
   rules:
   - alert: ThanosRuleQueueIsDroppingAlerts
     annotations:
@@ -519,7 +519,7 @@ groups:
     for: 3m
     labels:
       severity: critical
-- name: thanos-bucket-replicate.rules
+- name: thanos-bucket-replicate
   rules:
   - alert: ThanosBucketReplicateIsDown
     annotations:
@@ -561,7 +561,7 @@ groups:
     for: 5m
     labels:
       severity: critical
-- name: thanos-component-absent.rules
+- name: thanos-component-absent
   rules:
   - alert: ThanosBucketReplicateIsDown
     annotations:

--- a/mixin/alerts/absent.libsonnet
+++ b/mixin/alerts/absent.libsonnet
@@ -13,7 +13,7 @@ local titlize(str) = std.join('', std.map(capitalize, std.split(str, '_')));
   prometheusAlerts+:: {
     groups+: [
       {
-        name: 'thanos-component-absent.rules',
+        name: 'thanos-component-absent',
         rules: [
           {
             alert: '%sIsDown' % name,

--- a/mixin/alerts/bucket_replicate.libsonnet
+++ b/mixin/alerts/bucket_replicate.libsonnet
@@ -8,7 +8,7 @@
   prometheusAlerts+:: {
     groups+: [
       {
-        name: 'thanos-bucket-replicate.rules',
+        name: 'thanos-bucket-replicate',
         rules: [
           {
             alert: 'ThanosBucketReplicateIsDown',

--- a/mixin/alerts/compact.libsonnet
+++ b/mixin/alerts/compact.libsonnet
@@ -8,7 +8,7 @@
   prometheusAlerts+:: {
     groups+: [
       {
-        name: 'thanos-compact.rules',
+        name: 'thanos-compact',
         rules: [
           {
             alert: 'ThanosCompactMultipleRunning',

--- a/mixin/alerts/query.libsonnet
+++ b/mixin/alerts/query.libsonnet
@@ -11,7 +11,7 @@
   prometheusAlerts+:: {
     groups+: [
       {
-        name: 'thanos-query.rules',
+        name: 'thanos-query',
         rules: [
           {
             alert: 'ThanosQueryHttpRequestQueryErrorRateHigh',

--- a/mixin/alerts/receive.libsonnet
+++ b/mixin/alerts/receive.libsonnet
@@ -10,7 +10,7 @@
   prometheusAlerts+:: {
     groups+: [
       {
-        name: 'thanos-receive.rules',
+        name: 'thanos-receive',
         rules: [
           {
             alert: 'ThanosReceiveHttpRequestErrorRateHigh',

--- a/mixin/alerts/rule.libsonnet
+++ b/mixin/alerts/rule.libsonnet
@@ -10,7 +10,7 @@
   prometheusAlerts+:: {
     groups+: [
       {
-        name: 'thanos-rule.rules',
+        name: 'thanos-rule',
         rules: [
           {
             alert: 'ThanosRuleQueueIsDroppingAlerts',

--- a/mixin/alerts/sidecar.libsonnet
+++ b/mixin/alerts/sidecar.libsonnet
@@ -6,7 +6,7 @@
   prometheusAlerts+:: {
     groups+: [
       {
-        name: 'thanos-sidecar.rules',
+        name: 'thanos-sidecar',
         rules: [
           {
             alert: 'ThanosSidecarPrometheusDown',

--- a/mixin/alerts/store.libsonnet
+++ b/mixin/alerts/store.libsonnet
@@ -11,7 +11,7 @@
   prometheusAlerts+:: {
     groups+: [
       {
-        name: 'thanos-store.rules',
+        name: 'thanos-store',
         rules: [
           {
             alert: 'ThanosStoreGrpcErrorRate',

--- a/pkg/rules/rules_test.go
+++ b/pkg/rules/rules_test.go
@@ -34,28 +34,28 @@ func testRulesAgainstExamples(t *testing.T, dir string, server rulespb.RulesServ
 
 	expected := []*rulespb.RuleGroup{
 		{
-			Name:                    "thanos-bucket-replicate.rules",
+			Name:                    "thanos-bucket-replicate",
 			File:                    filepath.Join(dir, "alerts.yaml"),
 			Rules:                   []*rulespb.Rule{someAlert, someAlert, someAlert},
 			Interval:                60,
 			PartialResponseStrategy: storepb.PartialResponseStrategy_ABORT,
 		},
 		{
-			Name:                    "thanos-compact.rules",
+			Name:                    "thanos-compact",
 			File:                    filepath.Join(dir, "alerts.yaml"),
 			Rules:                   []*rulespb.Rule{someAlert, someAlert, someAlert, someAlert, someAlert},
 			Interval:                60,
 			PartialResponseStrategy: storepb.PartialResponseStrategy_ABORT,
 		},
 		{
-			Name:                    "thanos-component-absent.rules",
+			Name:                    "thanos-component-absent",
 			File:                    filepath.Join(dir, "alerts.yaml"),
 			Rules:                   []*rulespb.Rule{someAlert, someAlert, someAlert, someAlert, someAlert, someAlert, someAlert},
 			Interval:                60,
 			PartialResponseStrategy: storepb.PartialResponseStrategy_ABORT,
 		},
 		{
-			Name: "thanos-query.rules",
+			Name: "thanos-query",
 			File: filepath.Join(dir, "alerts.yaml"),
 			Rules: []*rulespb.Rule{
 				someAlert, someAlert, someAlert, someAlert, someAlert, someAlert, someAlert,
@@ -64,7 +64,7 @@ func testRulesAgainstExamples(t *testing.T, dir string, server rulespb.RulesServ
 			PartialResponseStrategy: storepb.PartialResponseStrategy_ABORT,
 		},
 		{
-			Name: "thanos-receive.rules",
+			Name: "thanos-receive",
 			File: filepath.Join(dir, "alerts.yaml"),
 			Rules: []*rulespb.Rule{
 				someAlert, someAlert, someAlert, someAlert, someAlert, someAlert, someAlert,
@@ -73,21 +73,21 @@ func testRulesAgainstExamples(t *testing.T, dir string, server rulespb.RulesServ
 			PartialResponseStrategy: storepb.PartialResponseStrategy_ABORT,
 		},
 		{
-			Name:                    "thanos-rule.rules",
+			Name:                    "thanos-rule",
 			File:                    filepath.Join(dir, "alerts.yaml"),
 			Rules:                   []*rulespb.Rule{someAlert, someAlert, someAlert, someAlert, someAlert, someAlert, someAlert, someAlert, someAlert, someAlert, someAlert},
 			Interval:                60,
 			PartialResponseStrategy: storepb.PartialResponseStrategy_ABORT,
 		},
 		{
-			Name:                    "thanos-sidecar.rules",
+			Name:                    "thanos-sidecar",
 			File:                    filepath.Join(dir, "alerts.yaml"),
 			Rules:                   []*rulespb.Rule{someAlert, someAlert},
 			Interval:                60,
 			PartialResponseStrategy: storepb.PartialResponseStrategy_ABORT,
 		},
 		{
-			Name: "thanos-store.rules",
+			Name: "thanos-store",
 			File: filepath.Join(dir, "alerts.yaml"),
 			Rules: []*rulespb.Rule{
 				someAlert, someAlert, someAlert, someAlert,


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->
Removed `.rules` suffix from alert groups in thanos mixin. This is similar to how node_exporter handles alert groups.

## Verification

<!-- How you tested it? How do you know it works? -->
Run `make examples` and look at output.

Fixes #3347

/cc @kakkoyun 
