### PR TITLE
Use direct cache in index reader for symbol values

### DIFF
--- a/pkg/block/indexheader/binary_reader.go
+++ b/pkg/block/indexheader/binary_reader.go
@@ -418,6 +418,8 @@ type postingOffset struct {
 	tableOff int
 }
 
+const valueSymbolsCacheSize = 1024
+
 type BinaryReader struct {
 	b   index.ByteSlice
 	toc *BinaryTOC
@@ -432,9 +434,16 @@ type BinaryReader struct {
 	postingsV1 map[string]map[string]index.Range
 
 	// Symbols struct that keeps only 1/postingOffsetsInMemSampling in the memory, then looks up the rest via mmap.
-	symbols     *index.Symbols
-	nameSymbols map[uint32]string // Cache of the label name symbol lookups,
+	symbols *index.Symbols
+	// Cache of the label name symbol lookups,
 	// as there are not many and they are half of all lookups.
+	nameSymbols map[uint32]string
+	// Direct cache of values. This is much faster than an LRU cache and still provides
+	// a reasonable cache hit ratio.
+	valueSymbols [valueSymbolsCacheSize]struct {
+		index  uint32
+		symbol string
+	}
 
 	dec *index.Decoder
 
@@ -801,7 +810,12 @@ func (r BinaryReader) postingsOffset(name string, values ...string) ([]index.Ran
 	return rngs, nil
 }
 
-func (r BinaryReader) LookupSymbol(o uint32) (string, error) {
+func (r *BinaryReader) LookupSymbol(o uint32) (string, error) {
+	cacheIndex := o % valueSymbolsCacheSize
+	if cached := r.valueSymbols[cacheIndex]; cached.index == o && cached.symbol != "" {
+		return cached.symbol, nil
+	}
+
 	if s, ok := r.nameSymbols[o]; ok {
 		return s, nil
 	}
@@ -812,7 +826,13 @@ func (r BinaryReader) LookupSymbol(o uint32) (string, error) {
 		o += headerLen - index.HeaderLen
 	}
 
-	return r.symbols.Lookup(o)
+	s, err := r.symbols.Lookup(o)
+	if err != nil {
+		return s, err
+	}
+	r.valueSymbols[cacheIndex].index = o
+	r.valueSymbols[cacheIndex].symbol = s
+	return s, nil
 }
 
 func (r BinaryReader) LabelValues(name string) ([]string, error) {

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -2108,7 +2108,6 @@ func (r *bucketIndexReader) Close() error {
 func (r *bucketIndexReader) LookupLabelsSymbols(symbolized []symbolizedLabel, lbls *labels.Labels) error {
 	*lbls = (*lbls)[:0]
 	for _, s := range symbolized {
-		// TODO(bwplotka): Cache, it takes majority of query time.
 		ln, err := r.dec.LookupSymbol(s.name)
 		if err != nil {
 			return errors.Wrap(err, "lookup label name")


### PR DESCRIPTION
Signed-off-by: Ben Ye <yb532204897@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

Apply the same improvement as the upstream Prometheus pr https://github.com/prometheus/prometheus/pull/8265.

The benchmark result is great comparing to the current master.

```
name                                                             old time/op    new time/op    delta
TelemeterRealData_Series/alerts2w/01EPXBGA0413QZMTF4XQ0M4Q3E        16.7s ± 0%     11.8s ± 0%  -29.31%
TelemeterRealData_Series/alerts15s/01EPXBGA0413QZMTF4XQ0M4Q3E       3.95s ± 0%     3.93s ± 0%   -0.53%
TelemeterRealData_Series/subssyncs2w/01EPXBGA0413QZMTF4XQ0M4Q3E     2.44s ± 0%     1.18s ± 0%  -51.63%
TelemeterRealData_Series/subs2w/01EPXBGA0413QZMTF4XQ0M4Q3E          14.3s ± 0%      6.3s ± 0%  -56.04%
TelemeterRealData_Series/subs15s/01EPXBGA0413QZMTF4XQ0M4Q3E         2.07s ± 0%     2.11s ± 0%   +2.00%

name                                                             old alloc/op   new alloc/op   delta
TelemeterRealData_Series/alerts2w/01EPXBGA0413QZMTF4XQ0M4Q3E       4.05GB ± 0%    3.50GB ± 0%  -13.54%
TelemeterRealData_Series/alerts15s/01EPXBGA0413QZMTF4XQ0M4Q3E      1.09GB ± 0%    1.08GB ± 0%   -0.37%
TelemeterRealData_Series/subssyncs2w/01EPXBGA0413QZMTF4XQ0M4Q3E     663MB ± 0%     545MB ± 0%  -17.78%
TelemeterRealData_Series/subs2w/01EPXBGA0413QZMTF4XQ0M4Q3E         2.67GB ± 0%    2.22GB ± 0%  -16.99%
TelemeterRealData_Series/subs15s/01EPXBGA0413QZMTF4XQ0M4Q3E         631MB ± 0%     631MB ± 0%   +0.00%

name                                                             old allocs/op  new allocs/op  delta
TelemeterRealData_Series/alerts2w/01EPXBGA0413QZMTF4XQ0M4Q3E        38.7M ± 0%     15.5M ± 0%  -59.85%
TelemeterRealData_Series/alerts15s/01EPXBGA0413QZMTF4XQ0M4Q3E        412k ± 0%      229k ± 0%  -44.43%
TelemeterRealData_Series/subssyncs2w/01EPXBGA0413QZMTF4XQ0M4Q3E     5.85M ± 0%     2.10M ± 0%  -64.20%
TelemeterRealData_Series/subs2w/01EPXBGA0413QZMTF4XQ0M4Q3E          30.4M ± 0%      7.2M ± 0%  -76.31%
TelemeterRealData_Series/subs15s/01EPXBGA0413QZMTF4XQ0M4Q3E         38.4k ± 0%     38.5k ± 0%   +0.28%

```

## Verification

<!-- How you tested it? How do you know it works? -->
