### PR TITLE
query-frontend: Allow separate label cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ We use _breaking :warning:_ to mark changes that are not backward compatible (re
 ### Fixed
 
 - [#3527](https://github.com/thanos-io/thanos/pull/3527) Query Frontend: Fix query_range behavior when start/end times are the same
+- [#3560](https://github.com/thanos-io/thanos/pull/3560) query-frontend: Allow separate label cache
 
 ### Changed
 

--- a/cmd/thanos/query_frontend.go
+++ b/cmd/thanos/query_frontend.go
@@ -158,7 +158,7 @@ func runQueryFrontend(
 		return err
 	}
 	if len(labelsCacheConfContentYaml) > 0 {
-		cacheConfig, err := queryfrontend.NewCacheConfig(logger, queryRangeCacheConfContentYaml)
+		cacheConfig, err := queryfrontend.NewCacheConfig(logger, labelsCacheConfContentYaml)
 		if err != nil {
 			return errors.Wrap(err, "initializing the labels cache config")
 		}


### PR DESCRIPTION
Instead of using the cache config from the query-range.

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

Fixed a bug in which the cache config from the query frontend's query range cache was passed to the label cache. This made it impossible to use a label cache on its own, because invalid empty yaml (from the query range cache) would be passed to the label cache config builder.

Any users who are attempting to use separate label and query range caches today should find that the query range one is being used for both. If this is merged and upgraded to, it will cause the label cache to become used instead.

## Verification

<!-- How you tested it? How do you know it works? -->

I've only done some very basic testing, by running the thanos binary locally and verifying whether the different config combinations cause an error on startup with or without this fix.

The error I see from master is:

```
{"caller":"main.go:131","err":"response cache with type  is not supported\ngithub.com/thanos-io/thanos/pkg/queryfrontend.NewCacheConfig\n\t/go/src/github.com/thanos-io/thanos/pkg/queryfrontend/config.go:139\nmain.runQueryFrontend\n\t/go/src/github.com/thanos-io/thanos/cmd/thanos/query_frontend.go:161\nmain.registerQueryFrontend.func1\n\t/go/src/github.com/thanos-io/thanos/cmd/thanos/query_frontend.go:129\nmain.main\n\t/go/src/github.com/thanos-io/thanos/cmd/thanos/main.go:129\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:204\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_amd64.s:1374\ninitializing the labels cache config\nmain.runQueryFrontend\n\t/go/src/github.com/thanos-io/thanos/cmd/thanos/query_frontend.go:163\nmain.registerQueryFrontend.func1\n\t/go/src/github.com/thanos-io/thanos/cmd/thanos/query_frontend.go:129\nmain.main\n\t/go/src/github.com/thanos-io/thanos/cmd/thanos/main.go:129\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:204\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_amd64.s:1374\npreparing query-frontend command failed\nmain.main\n\t/go/src/github.com/thanos-io/thanos/cmd/thanos/main.go:131\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:204\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_amd64.s:1374","level":"error","ts":"2020-12-10T11:20:32.8017198Z"}
```