### PR TITLE
query: Be pessimistic about strict stores

### DIFF
--- a/pkg/query/storeset.go
+++ b/pkg/query/storeset.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
 	"sort"
 	"sync"
 	"time"
@@ -439,6 +440,9 @@ func (s *StoreSet) getActiveStores(ctx context.Context, stores map[string]*store
 				}
 
 				st = &storeRef{StoreClient: storepb.NewStoreClient(conn), storeType: component.UnknownStoreAPI, cc: conn, addr: addr, logger: s.logger}
+				if spec.StrictStatic() {
+					st.maxTime = math.MaxInt64
+				}
 			}
 
 			var rule rulespb.RulesClient
@@ -496,6 +500,10 @@ func (s *StoreSet) updateStoreStatus(store *storeRef, err error) {
 	prev, ok := s.storeStatuses[store.addr]
 	if ok {
 		status = *prev
+	} else {
+		mint, maxt := store.TimeRange()
+		status.MinTime = mint
+		status.MaxTime = maxt
 	}
 
 	if err == nil {


### PR DESCRIPTION
We want queries with ?partial_response=0 to be sound and complete.
Unfortunately today many queries can succeed without an error while the
system is heavily degraded.

Make strict stores cover a long time range by default until the right
time range has been discovered. We might need to extend this to labels
too. Also on many consecutive Metadata failures we should revert to a
default minTime and maxTime.

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

StoreSet
* Initialize storeRef maxTime to the maximum possible value
* The first time we set the status, initialize minTime and maxTime to the provided values. This is for initializing with an error case.


## Verification

<!-- How you tested it? How do you know it works? -->

go test ./pkg/query only so far