### PR TITLE
Redirect feature requests from Issues to Discussions

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -7,37 +7,7 @@ assignees: ''
 
 ---
 
-### Is your proposal related to a problem?
+We are now using GitHub Discussions for Thanos feature requests:
+https://github.com/thanos-io/thanos/discussions
 
-<!--
-  Provide a clear and concise description of what the problem is.
-  For example, "I'm always frustrated when..."
-  Alternatively, an issue can also be linked here.
--->
-
-(Write your answer here.)
-
-### Describe the solution you'd like
-
-<!--
-  Provide a clear and concise description of what you want to happen.
--->
-
-(Describe your proposed solution here.)
-
-### Describe alternatives you've considered
-
-<!--
-  Let us know about other solutions you've tried or researched.
--->
-
-(Write your answer here.)
-
-### Additional context
-
-<!--
-  Is there anything else you can add about the proposal?
-  You might want to link to related issues here, if you haven't already.
--->
-
-(Write your answer here.)
+Please create a new discussion to discuss more open-ended feature requests there.


### PR DESCRIPTION
* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

Sadly the Discussions don't see to support templates like these just yet.
I've commented on a discussions on discussions for our discussions. :joy: 

https://github.com/github/feedback/discussions/2838#discussioncomment-193944