### PR TITLE
store: Be pessimistic and check how many bytes got copied

### DIFF
--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -1479,7 +1479,7 @@ func (b *bucketBlock) readChunkRange(ctx context.Context, seq int, off, length i
 	}
 	if copied != length {
 		b.chunkPool.Put(c)
-		return nil, errors.Errorf("Read less than specified wanted=%v got=%v", length, copied)
+		return nil, errors.Errorf("read %v bytes but got %v", length, copied)
 	}
 	internalBuf := buf.Bytes()
 	return &internalBuf, nil


### PR DESCRIPTION
I have seen a panic in loadChunks and the first thing that came to mind
that the getRange query might not give the result we would like to have.
Check the right number of bytes were copied into the destination.

Signed-off-by: Holger Hans Peter Freyther <holger@freyther.de>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

Not yet. Soliciting feedback of how defensive we want to be.
<!-- How you tested it? How do you know it works? -->
