### PR TITLE
Blocks upload: Don't do cleanUp when meta.json fails to upload.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ We use _breaking :warning:_ to mark changes that are not backward compatible (re
 - [#2732](https://github.com/thanos-io/thanos/pull/2732) Swift: Switched to a new library [ncw/swift](https://github.com/ncw/swift) providing large objects support.
    By default, segments will be uploaded to the same container directory `segments/` if the file is bigger than `1GB`.
    To change the defaults see [the docs](./docs/storage.md#openstack-swift).
-
+- [#3626](https://github.com/thanos-io/thanos/pull/3626) Failed upload of `meta.json` file doesn't cause block cleanup anymore. This has a potential to generate corrupted blocks under specific conditions. Partial block is left in bucket for later cleanup.
 
 
 ## [v0.17.2](https://github.com/thanos-io/thanos/releases/tag/v0.17.2) - 2020.12.07

--- a/pkg/block/block.go
+++ b/pkg/block/block.go
@@ -120,6 +120,7 @@ func Upload(ctx context.Context, logger log.Logger, bkt objstore.Bucket, bdir st
 		// Don't call cleanUp here. Despite getting error, meta.json may have been uploaded in certain cases,
 		// and even though cleanUp will not see it yet, meta.json may appear in the bucket later.
 		// (Eg. S3 is known to behave this way when it returns 503 "SlowDown" error).
+		// If meta.json is not uploaded, this will produce partial blocks, but such blocks will be cleaned later.
 		return errors.Wrap(err, "upload meta file")
 	}
 

--- a/pkg/block/block.go
+++ b/pkg/block/block.go
@@ -117,7 +117,10 @@ func Upload(ctx context.Context, logger log.Logger, bkt objstore.Bucket, bdir st
 
 	// Meta.json always need to be uploaded as a last item. This will allow to assume block directories without meta file to be pending uploads.
 	if err := bkt.Upload(ctx, path.Join(id.String(), MetaFilename), &metaEncoded); err != nil {
-		return cleanUp(logger, bkt, id, errors.Wrap(err, "upload meta file"))
+		// Don't call cleanUp here. Despite getting error, meta.json may have been uploaded in certain cases,
+		// and even though cleanUp will not see it yet, meta.json may appear in the bucket later.
+		// (Eg. S3 is known to behave this way when it returns 503 "SlowDown" error).
+		return errors.Wrap(err, "upload meta file")
 	}
 
 	return nil


### PR DESCRIPTION
Under certain conditions, when upload of `meta.json` file fails, it will actually appear on the bucket eventually. S3 has been observed to behave like this when it reports 503 "SlowDown" error. Currently `block.Upload` calls `cleanUp` to delete partially uploaded block, but if `meta.json` can still appear in the bucket later, this actually creates invalid block – with `meta.json` file only, but no index or chunks.

## Changes

This PR removes call to `cleanUp` if only `meta.json` upload fails. If `meta.json` has really failed, this will result into partial block (without `meta.json`) and be eventually removed by other components, or upload will be retried by Shipper. But at least it won't generate corrupted blocks.

For more details, see discussion at https://cloud-native.slack.com/archives/CL25937SP/p1608021430416900.

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Verification

Added unit test.