### PR TITLE
Handle external labels in Store's labels API

### DIFF
--- a/pkg/store/prometheus.go
+++ b/pkg/store/prometheus.go
@@ -484,6 +484,11 @@ func (p *PrometheusStore) encodeChunk(ss []prompb.Sample) (storepb.Chunk_Encodin
 
 // LabelNames returns all known label names.
 func (p *PrometheusStore) LabelNames(ctx context.Context, r *storepb.LabelNamesRequest) (*storepb.LabelNamesResponse, error) {
+	mint, maxt := p.timestamps()
+	if r.Start > maxt || r.End <= mint {
+		return &storepb.LabelNamesResponse{Names: []string{}}, nil
+	}
+
 	lbls, err := p.client.LabelNamesInGRPC(ctx, p.base, nil, r.Start, r.End)
 	if err != nil {
 		return nil, err
@@ -500,6 +505,11 @@ func (p *PrometheusStore) LabelNames(ctx context.Context, r *storepb.LabelNamesR
 
 // LabelValues returns all known label values for a given label name.
 func (p *PrometheusStore) LabelValues(ctx context.Context, r *storepb.LabelValuesRequest) (*storepb.LabelValuesResponse, error) {
+	mint, maxt := p.timestamps()
+	if r.Start > maxt || r.End <= mint {
+		return &storepb.LabelValuesResponse{Values: []string{}}, nil
+	}
+
 	vals, err := p.client.LabelValuesInGRPC(ctx, p.base, r.Label, nil, r.Start, r.End)
 	if err != nil {
 		return nil, err

--- a/pkg/store/prometheus.go
+++ b/pkg/store/prometheus.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/thanos-io/thanos/pkg/strutil"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -29,7 +28,6 @@ import (
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/storage/remote"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
-	"github.com/thanos-io/thanos/pkg/store/labelpb"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -37,8 +35,10 @@ import (
 	thanoshttp "github.com/thanos-io/thanos/pkg/http"
 	"github.com/thanos-io/thanos/pkg/promclient"
 	"github.com/thanos-io/thanos/pkg/runutil"
+	"github.com/thanos-io/thanos/pkg/store/labelpb"
 	"github.com/thanos-io/thanos/pkg/store/storepb"
 	"github.com/thanos-io/thanos/pkg/store/storepb/prompb"
+	"github.com/thanos-io/thanos/pkg/strutil"
 	"github.com/thanos-io/thanos/pkg/tracing"
 )
 

--- a/pkg/store/prometheus_test.go
+++ b/pkg/store/prometheus_test.go
@@ -377,7 +377,8 @@ func TestPrometheusStore_LabelNames_e2e(t *testing.T) {
 	u, err := url.Parse(fmt.Sprintf("http://%s", p.Addr()))
 	testutil.Ok(t, err)
 
-	proxy, err := NewPrometheusStore(nil, nil, promclient.NewDefaultClient(), u, component.Sidecar, getExternalLabels, nil)
+	proxy, err := NewPrometheusStore(nil, nil, promclient.NewDefaultClient(), u, component.Sidecar,
+		getExternalLabels, func() (int64, int64) { return 0, 1000 })
 	testutil.Ok(t, err)
 
 	resp, err := proxy.LabelNames(ctx, &storepb.LabelNamesRequest{
@@ -389,13 +390,14 @@ func TestPrometheusStore_LabelNames_e2e(t *testing.T) {
 	testutil.Equals(t, []string{"a", "ext_a", "ext_b"}, resp.Names)
 
 	// Outside time range.
+	// External labels will not be injected if the time range doesn't match.
 	resp, err = proxy.LabelNames(ctx, &storepb.LabelNamesRequest{
 		Start: timestamp.FromTime(maxTime.Add(-time.Second)),
 		End:   timestamp.FromTime(maxTime),
 	})
 	testutil.Ok(t, err)
 	testutil.Equals(t, []string(nil), resp.Warnings)
-	testutil.Equals(t, []string{"ext_a", "ext_b"}, resp.Names)
+	testutil.Equals(t, []string{}, resp.Names)
 }
 
 func TestPrometheusStore_LabelValues_e2e(t *testing.T) {
@@ -422,7 +424,8 @@ func TestPrometheusStore_LabelValues_e2e(t *testing.T) {
 	u, err := url.Parse(fmt.Sprintf("http://%s", p.Addr()))
 	testutil.Ok(t, err)
 
-	proxy, err := NewPrometheusStore(nil, nil, promclient.NewDefaultClient(), u, component.Sidecar, getExternalLabels, nil)
+	proxy, err := NewPrometheusStore(nil, nil, promclient.NewDefaultClient(), u, component.Sidecar,
+		getExternalLabels, func() (int64, int64) { return 0, 1000 })
 	testutil.Ok(t, err)
 
 	resp, err := proxy.LabelValues(ctx, &storepb.LabelValuesRequest{
@@ -468,21 +471,24 @@ func TestPrometheusStore_ExternalLabelValues_e2e(t *testing.T) {
 	u, err := url.Parse(fmt.Sprintf("http://%s", p.Addr()))
 	testutil.Ok(t, err)
 
-	proxy, err := NewPrometheusStore(nil, nil, promclient.NewDefaultClient(), u, component.Sidecar, getExternalLabels, nil)
+	proxy, err := NewPrometheusStore(nil, nil, promclient.NewDefaultClient(), u, component.Sidecar,
+		getExternalLabels, func() (int64, int64) { return 0, 1000 })
 	testutil.Ok(t, err)
 
 	resp, err := proxy.LabelValues(ctx, &storepb.LabelValuesRequest{
 		Label: "ext_a",
+		Start: timestamp.FromTime(minTime),
+		End:   timestamp.FromTime(maxTime),
 	})
 	testutil.Ok(t, err)
-
 	testutil.Equals(t, []string{"a", "b"}, resp.Values)
 
 	resp, err = proxy.LabelValues(ctx, &storepb.LabelValuesRequest{
 		Label: "a",
+		Start: timestamp.FromTime(minTime),
+		End:   timestamp.FromTime(maxTime),
 	})
 	testutil.Ok(t, err)
-
 	testutil.Equals(t, []string{"b"}, resp.Values)
 }
 

--- a/pkg/store/prometheus_test.go
+++ b/pkg/store/prometheus_test.go
@@ -386,7 +386,7 @@ func TestPrometheusStore_LabelNames_e2e(t *testing.T) {
 	})
 	testutil.Ok(t, err)
 	testutil.Equals(t, []string(nil), resp.Warnings)
-	testutil.Equals(t, []string{"a"}, resp.Names)
+	testutil.Equals(t, []string{"a", "ext_a", "ext_b"}, resp.Names)
 
 	// Outside time range.
 	resp, err = proxy.LabelNames(ctx, &storepb.LabelNamesRequest{
@@ -395,7 +395,7 @@ func TestPrometheusStore_LabelNames_e2e(t *testing.T) {
 	})
 	testutil.Ok(t, err)
 	testutil.Equals(t, []string(nil), resp.Warnings)
-	testutil.Equals(t, []string{}, resp.Names)
+	testutil.Equals(t, []string{"ext_a", "ext_b"}, resp.Names)
 }
 
 func TestPrometheusStore_LabelValues_e2e(t *testing.T) {
@@ -476,7 +476,7 @@ func TestPrometheusStore_ExternalLabelValues_e2e(t *testing.T) {
 	})
 	testutil.Ok(t, err)
 
-	testutil.Equals(t, []string{"a"}, resp.Values)
+	testutil.Equals(t, []string{"a", "b"}, resp.Values)
 
 	resp, err = proxy.LabelValues(ctx, &storepb.LabelValuesRequest{
 		Label: "a",

--- a/pkg/store/tsdb.go
+++ b/pkg/store/tsdb.go
@@ -5,7 +5,6 @@ package store
 
 import (
 	"context"
-	"github.com/thanos-io/thanos/pkg/strutil"
 	"io"
 	"math"
 
@@ -22,6 +21,7 @@ import (
 	"github.com/thanos-io/thanos/pkg/component"
 	"github.com/thanos-io/thanos/pkg/runutil"
 	"github.com/thanos-io/thanos/pkg/store/storepb"
+	"github.com/thanos-io/thanos/pkg/strutil"
 )
 
 const RemoteReadFrameLimit = 1048576

--- a/pkg/store/tsdb_test.go
+++ b/pkg/store/tsdb_test.go
@@ -218,9 +218,10 @@ func TestTSDBStore_LabelNames(t *testing.T) {
 		end           func() int64
 	}{
 		{
-			title:     "no label in tsdb",
-			labels:    []string{},
-			timestamp: now.Unix(),
+			title:         "no label in tsdb",
+			labels:        []string{},
+			expectedNames: []string{"region"},
+			timestamp:     now.Unix(),
 			start: func() int64 {
 				return timestamp.FromTime(minTime)
 			},
@@ -231,7 +232,7 @@ func TestTSDBStore_LabelNames(t *testing.T) {
 		{
 			title:         "add one label",
 			labels:        []string{"foo", "foo"},
-			expectedNames: []string{"foo"},
+			expectedNames: []string{"foo", "region"},
 			timestamp:     now.Unix(),
 			start: func() int64 {
 				return timestamp.FromTime(minTime)
@@ -244,7 +245,7 @@ func TestTSDBStore_LabelNames(t *testing.T) {
 			title:  "add another label",
 			labels: []string{"bar", "bar"},
 			// We will get two labels here.
-			expectedNames: []string{"bar", "foo"},
+			expectedNames: []string{"bar", "foo", "region"},
 			timestamp:     now.Unix(),
 			start: func() int64 {
 				return timestamp.FromTime(minTime)
@@ -254,9 +255,10 @@ func TestTSDBStore_LabelNames(t *testing.T) {
 			},
 		},
 		{
-			title:     "query range outside tsdb head",
-			labels:    []string{},
-			timestamp: now.Unix(),
+			title:         "query range outside tsdb head",
+			labels:        []string{},
+			expectedNames: []string{"region"},
+			timestamp:     now.Unix(),
 			start: func() int64 {
 				return timestamp.FromTime(minTime)
 			},
@@ -267,7 +269,7 @@ func TestTSDBStore_LabelNames(t *testing.T) {
 		{
 			title:         "get all labels",
 			labels:        []string{"buz", "buz"},
-			expectedNames: []string{"bar", "buz", "foo"},
+			expectedNames: []string{"bar", "buz", "foo", "region"},
 			timestamp:     now.Unix(),
 			start: func() int64 {
 				return timestamp.FromTime(minTime)

--- a/test/e2e/query_test.go
+++ b/test/e2e/query_test.go
@@ -289,12 +289,12 @@ func TestQueryLabelNames(t *testing.T) {
 
 	// Outside time range.
 	labelNames(t, ctx, q.HTTPEndpoint(), nil, timestamp.FromTime(now.Add(-24*time.Hour)), timestamp.FromTime(now.Add(-23*time.Hour)), func(res []string) bool {
-		return len(res) == 0
+		return len(res) == 2
 	})
 
 	labelNames(t, ctx, q.HTTPEndpoint(), []storepb.LabelMatcher{{Type: storepb.LabelMatcher_EQ, Name: "__name__", Value: "up"}},
 		timestamp.FromTime(now.Add(-time.Hour)), timestamp.FromTime(now.Add(time.Hour)), func(res []string) bool {
-			// Expected result: [__name__, instance, job, prometheus, replica]
+			// Expected result: [__name__, instance, job, prometheus, receive, replica, tenant_id]
 			return len(res) == 7
 		},
 	)


### PR DESCRIPTION
Signed-off-by: Ben Ye <yb532204897@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

Fixes #3639

This pr unifies the behavior of handling external labels on labels API for different stores.

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
