### PR TITLE
comment amendment in dns/provider.go

### DIFF
--- a/pkg/discovery/dns/provider.go
+++ b/pkg/discovery/dns/provider.go
@@ -108,7 +108,7 @@ func GetQTypeName(addr string) (qtype string, name string) {
 
 // Resolve stores a list of provided addresses or their DNS records if requested.
 // Addresses prefixed with `dns+` or `dnssrv+` will be resolved through respective DNS lookup (A/AAAA or SRV).
-// defaultPort is used for non-SRV records when a port is not supplied.
+// For non-SRV records, it will return an error if a port is not supplied.
 func (p *Provider) Resolve(ctx context.Context, addrs []string) error {
 	resolvedAddrs := map[string][]string{}
 	errs := errutil.MultiError{}


### PR DESCRIPTION
Signed-off-by: Namanl2001 <namanlakhwani@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

fixes #3187

## Changes

Amended the comment.

## Verification

Verified from the official docs which states that it returns error for non-SRV prefix, when a port is not supplied.
While for SRV prefixes there is no need to specify a port, as the one from the SRV query results will be used.
