### PR TITLE
Query-frontend: use detailed text description for cmd

### DIFF
--- a/cmd/thanos/query_frontend.go
+++ b/cmd/thanos/query_frontend.go
@@ -43,7 +43,7 @@ type queryFrontendConfig struct {
 
 func registerQueryFrontend(app *extkingpin.App) {
 	comp := component.QueryFrontend
-	cmd := app.Command(comp.String(), "query frontend")
+	cmd := app.Command(comp.String(), "query frontend command implements a service deployed in front of queriers to improve query parallelization and caching.")
 	cfg := &queryFrontendConfig{
 		Config: queryfrontend.Config{
 			// Max body size is 10 MiB.

--- a/docs/components/query-frontend.md
+++ b/docs/components/query-frontend.md
@@ -119,7 +119,8 @@ Naming is hard :) Please check [here](https://github.com/thanos-io/thanos/pull/2
 ```$
 usage: thanos query-frontend [<flags>]
 
-query frontend
+query frontend command implements a service deployed in front of queriers to
+improve query parallelization and caching.
 
 Flags:
   -h, --help                     Show context-sensitive help (also try


### PR DESCRIPTION
# Description:

this is a minor PR fix I just fund out when doing some exploratory usage of thanos.

The text is copied from upstream documentation, feel free to suggest changes if you think it could be improved. :sake: 


## Changes

- add more text description for the command

## Verification:
#### Before:
```
  query-frontend [<flags>]
    query frontend
```

#### After:
```
  query-frontend [<flags>]
    query frontend command implements a service that can be put in front of Thanos Queriers to improve the read path. It is based on the Cortex Query Frontend component so you can find some common features like Splitting and Results
    Caching. Query Frontend is fully stateless and horizontally scalable.
```
