### PR TITLE
store: Make more S3 http.Transport settings configurable.

### DIFF
--- a/docs/storage.md
+++ b/docs/storage.md
@@ -84,6 +84,11 @@ config:
     idle_conn_timeout: 1m30s
     response_header_timeout: 2m
     insecure_skip_verify: false
+    tls_handshake_timeout: 10s
+    expect_continue_timeout: 1s
+    max_idle_conns: 100
+    max_idle_conns_per_host: 100
+    max_conns_per_host: 0
   trace:
     enable: false
   list_objects_version: ""


### PR DESCRIPTION
The http.Transport is not auto-tuning and one size does not seem to fit
all cases. In order to respond to a query a store gateway might need to
fetch a large (thousands) of postings, series and chunks.

While the number of idle connections has been increased recently it can
still be too low or expose bursty (opening, closing) behavior. Allow to
tune most of the http.Transport parameters. I considered embedding the
full Transport but there is already a Transport member.

Signed-off-by: Holger Hans Peter Freyther <holger@freyther.de>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->

I manually started thanos store and used fmt.Printf to see the options, e.g. that MaxIdleConns's default is taken.