### PR TITLE
Export metadata fetcher metrics

### DIFF
--- a/pkg/block/fetcher.go
+++ b/pkg/block/fetcher.go
@@ -37,32 +37,35 @@ import (
 
 const FetcherConcurrency = 32
 
-type fetcherMetrics struct {
-	syncs        prometheus.Counter
-	syncFailures prometheus.Counter
-	syncDuration prometheus.Histogram
+// FetcherMetrics holds metrics tracked by the metadata fetcher. This struct and its fields are exported
+// to allow depending projects (eg. Cortex) to implement their own custom metadata fetcher while tracking
+// compatible metrics.
+type FetcherMetrics struct {
+	Syncs        prometheus.Counter
+	SyncFailures prometheus.Counter
+	SyncDuration prometheus.Histogram
 
-	synced   *extprom.TxGaugeVec
-	modified *extprom.TxGaugeVec
+	Synced   *extprom.TxGaugeVec
+	Modified *extprom.TxGaugeVec
 }
 
-func (s *fetcherMetrics) submit() {
-	s.synced.Submit()
-	s.modified.Submit()
+func (s *FetcherMetrics) submit() {
+	s.Synced.Submit()
+	s.Modified.Submit()
 }
 
-func (s *fetcherMetrics) resetTx() {
-	s.synced.ResetTx()
-	s.modified.ResetTx()
+func (s *FetcherMetrics) resetTx() {
+	s.Synced.ResetTx()
+	s.Modified.ResetTx()
 }
 
 const (
 	fetcherSubSys = "blocks_meta"
 
-	corruptedMeta = "corrupted-meta-json"
-	noMeta        = "no-meta-json"
-	loadedMeta    = "loaded"
-	failedMeta    = "failed"
+	CorruptedMeta = "corrupted-meta-json"
+	NoMeta        = "no-meta-json"
+	LoadedMeta    = "loaded"
+	FailedMeta    = "failed"
 
 	// Synced label values.
 	labelExcludedMeta = "label-excluded"
@@ -71,7 +74,7 @@ const (
 	duplicateMeta     = "duplicate"
 	// Blocks that are marked for deletion can be loaded as well. This is done to make sure that we load blocks that are meant to be deleted,
 	// but don't have a replacement block yet.
-	markedForDeletionMeta = "marked-for-deletion"
+	MarkedForDeletionMeta = "marked-for-deletion"
 
 	// MarkedForNoCompactionMeta is label for blocks which are loaded but also marked for no compaction. This label is also counted in `loaded` label metric.
 	MarkedForNoCompactionMeta = "marked-for-no-compact"
@@ -80,26 +83,26 @@ const (
 	replicaRemovedMeta = "replica-label-removed"
 )
 
-func newFetcherMetrics(reg prometheus.Registerer) *fetcherMetrics {
-	var m fetcherMetrics
+func NewFetcherMetrics(reg prometheus.Registerer) *FetcherMetrics {
+	var m FetcherMetrics
 
-	m.syncs = promauto.With(reg).NewCounter(prometheus.CounterOpts{
+	m.Syncs = promauto.With(reg).NewCounter(prometheus.CounterOpts{
 		Subsystem: fetcherSubSys,
 		Name:      "syncs_total",
 		Help:      "Total blocks metadata synchronization attempts",
 	})
-	m.syncFailures = promauto.With(reg).NewCounter(prometheus.CounterOpts{
+	m.SyncFailures = promauto.With(reg).NewCounter(prometheus.CounterOpts{
 		Subsystem: fetcherSubSys,
 		Name:      "sync_failures_total",
 		Help:      "Total blocks metadata synchronization failures",
 	})
-	m.syncDuration = promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
+	m.SyncDuration = promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
 		Subsystem: fetcherSubSys,
 		Name:      "sync_duration_seconds",
 		Help:      "Duration of the blocks metadata synchronization in seconds",
 		Buckets:   []float64{0.01, 1, 10, 100, 1000},
 	})
-	m.synced = extprom.NewTxGaugeVec(
+	m.Synced = extprom.NewTxGaugeVec(
 		reg,
 		prometheus.GaugeOpts{
 			Subsystem: fetcherSubSys,
@@ -107,18 +110,18 @@ func newFetcherMetrics(reg prometheus.Registerer) *fetcherMetrics {
 			Help:      "Number of block metadata synced",
 		},
 		[]string{"state"},
-		[]string{corruptedMeta},
-		[]string{noMeta},
-		[]string{loadedMeta},
+		[]string{CorruptedMeta},
+		[]string{NoMeta},
+		[]string{LoadedMeta},
 		[]string{tooFreshMeta},
-		[]string{failedMeta},
+		[]string{FailedMeta},
 		[]string{labelExcludedMeta},
 		[]string{timeExcludedMeta},
 		[]string{duplicateMeta},
-		[]string{markedForDeletionMeta},
+		[]string{MarkedForDeletionMeta},
 		[]string{MarkedForNoCompactionMeta},
 	)
-	m.modified = extprom.NewTxGaugeVec(
+	m.Modified = extprom.NewTxGaugeVec(
 		reg,
 		prometheus.GaugeOpts{
 			Subsystem: fetcherSubSys,
@@ -197,7 +200,7 @@ func NewMetaFetcher(logger log.Logger, concurrency int, bkt objstore.Instrumente
 
 // NewMetaFetcher transforms BaseFetcher into actually usable *MetaFetcher.
 func (f *BaseFetcher) NewMetaFetcher(reg prometheus.Registerer, filters []MetadataFilter, modifiers []MetadataModifier, logTags ...interface{}) *MetaFetcher {
-	return &MetaFetcher{metrics: newFetcherMetrics(reg), wrapped: f, filters: filters, modifiers: modifiers, logger: log.With(f.logger, logTags...)}
+	return &MetaFetcher{metrics: NewFetcherMetrics(reg), wrapped: f, filters: filters, modifiers: modifiers, logger: log.With(f.logger, logTags...)}
 }
 
 var (
@@ -405,15 +408,15 @@ func (f *BaseFetcher) fetchMetadata(ctx context.Context) (interface{}, error) {
 	return resp, nil
 }
 
-func (f *BaseFetcher) fetch(ctx context.Context, metrics *fetcherMetrics, filters []MetadataFilter, modifiers []MetadataModifier) (_ map[ulid.ULID]*metadata.Meta, _ map[ulid.ULID]error, err error) {
+func (f *BaseFetcher) fetch(ctx context.Context, metrics *FetcherMetrics, filters []MetadataFilter, modifiers []MetadataModifier) (_ map[ulid.ULID]*metadata.Meta, _ map[ulid.ULID]error, err error) {
 	start := time.Now()
 	defer func() {
-		metrics.syncDuration.Observe(time.Since(start).Seconds())
+		metrics.SyncDuration.Observe(time.Since(start).Seconds())
 		if err != nil {
-			metrics.syncFailures.Inc()
+			metrics.SyncFailures.Inc()
 		}
 	}()
-	metrics.syncs.Inc()
+	metrics.Syncs.Inc()
 	metrics.resetTx()
 
 	// Run this in thread safe run group.
@@ -433,25 +436,25 @@ func (f *BaseFetcher) fetch(ctx context.Context, metrics *fetcherMetrics, filter
 		metas[id] = m
 	}
 
-	metrics.synced.WithLabelValues(failedMeta).Set(float64(len(resp.metaErrs)))
-	metrics.synced.WithLabelValues(noMeta).Set(resp.noMetas)
-	metrics.synced.WithLabelValues(corruptedMeta).Set(resp.corruptedMetas)
+	metrics.Synced.WithLabelValues(FailedMeta).Set(float64(len(resp.metaErrs)))
+	metrics.Synced.WithLabelValues(NoMeta).Set(resp.noMetas)
+	metrics.Synced.WithLabelValues(CorruptedMeta).Set(resp.corruptedMetas)
 
 	for _, filter := range filters {
 		// NOTE: filter can update synced metric accordingly to the reason of the exclude.
-		if err := filter.Filter(ctx, metas, metrics.synced); err != nil {
+		if err := filter.Filter(ctx, metas, metrics.Synced); err != nil {
 			return nil, nil, errors.Wrap(err, "filter metas")
 		}
 	}
 
 	for _, m := range modifiers {
 		// NOTE: modifier can update modified metric accordingly to the reason of the modification.
-		if err := m.Modify(ctx, metas, metrics.modified); err != nil {
+		if err := m.Modify(ctx, metas, metrics.Modified); err != nil {
 			return nil, nil, errors.Wrap(err, "modify metas")
 		}
 	}
 
-	metrics.synced.WithLabelValues(loadedMeta).Set(float64(len(metas)))
+	metrics.Synced.WithLabelValues(LoadedMeta).Set(float64(len(metas)))
 	metrics.submit()
 
 	if len(resp.metaErrs) > 0 {
@@ -464,7 +467,7 @@ func (f *BaseFetcher) fetch(ctx context.Context, metrics *fetcherMetrics, filter
 
 type MetaFetcher struct {
 	wrapped *BaseFetcher
-	metrics *fetcherMetrics
+	metrics *FetcherMetrics
 
 	filters   []MetadataFilter
 	modifiers []MetadataModifier
@@ -823,7 +826,7 @@ func (f *IgnoreDeletionMarkFilter) Filter(ctx context.Context, metas map[ulid.UL
 				mtx.Lock()
 				f.deletionMarkMap[id] = m
 				if time.Since(time.Unix(m.DeletionTime, 0)).Seconds() > f.delay.Seconds() {
-					synced.WithLabelValues(markedForDeletionMeta).Inc()
+					synced.WithLabelValues(MarkedForDeletionMeta).Inc()
 					delete(metas, id)
 				}
 				mtx.Unlock()


### PR DESCRIPTION
* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

In Cortex we're experimenting with a [per-tenant bucket index](https://cortexmetrics.io/docs/proposals/blocks-storage-bucket-index/) which is a single json indexing blocks and deletion marks, so that queriers and store-gateway only need to periodically fetch the bucket index to discover new/deleted blocks instead of running "list objects" operations. If turns out to work well, it's a pattern we may consider backporting to Thanos too.

To implement it in the Cortex store-gateway, we're writing our own custom `MetadataFetcher` (working with the bucket index instead of scanning the bucket). Would be nice to expose the same metrics in the custom implementation too, so I'm wondering what's the sentiment to export `FetcherMetrics`, so that it could be reused by Cortex too.

## Verification

N/A
