### PR TITLE
Delete deletion-mark.json at last when deleting a block

### DIFF
--- a/pkg/block/block_test.go
+++ b/pkg/block/block_test.go
@@ -231,6 +231,9 @@ func TestDelete(t *testing.T) {
 		testutil.Ok(t, Upload(ctx, log.NewNopLogger(), bkt, path.Join(tmpDir, b1.String())))
 		testutil.Equals(t, 4, len(bkt.Objects()))
 
+		markedForDeletion := prometheus.NewCounter(prometheus.CounterOpts{})
+		testutil.Ok(t, MarkForDeletion(ctx, log.NewNopLogger(), bkt, b1, "", markedForDeletion))
+
 		// Full delete.
 		testutil.Ok(t, Delete(ctx, log.NewNopLogger(), bkt, b1))
 		// Still debug meta entry is expected.

--- a/pkg/block/block_test.go
+++ b/pkg/block/block_test.go
@@ -231,7 +231,7 @@ func TestDelete(t *testing.T) {
 		testutil.Ok(t, Upload(ctx, log.NewNopLogger(), bkt, path.Join(tmpDir, b1.String())))
 		testutil.Equals(t, 4, len(bkt.Objects()))
 
-		markedForDeletion := prometheus.NewCounter(prometheus.CounterOpts{})
+		markedForDeletion := promauto.With(prometheus.NewRegistry()).NewCounter(prometheus.CounterOpts{Name: "test"})
 		testutil.Ok(t, MarkForDeletion(ctx, log.NewNopLogger(), bkt, b1, "", markedForDeletion))
 
 		// Full delete.


### PR DESCRIPTION
* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

In Cortex, we have an extra protection to delete partial blocks only when the `deletion-mark.json` exists (reason is that we don't expect any partial block unless an issue). However, if the block deletion fails, we may end up in a situation where `meta.json` as been deleted (correct), `deletion-mark.json` deleted but few other files still left in the bucket (eg. `index`).

In this PR I'm proposing to delete `deletion-mark.json` at last. The only downside is that we're adding an extra `HEAD object` call to check for existence, but I'm planning to improve in a follow up PR (I would like to propose to change objstore clients `Delete()` contract to be idempotent, but that's a separate discussion https://github.com/thanos-io/thanos/issues/3662).

## Verification

Unit tests.
