### PR TITLE
scripts/quickstart: add external label for Thanos Rule

### DIFF
--- a/scripts/quickstart.sh
+++ b/scripts/quickstart.sh
@@ -259,6 +259,7 @@ ${THANOS_EXECUTABLE} rule \
   --query "http://0.0.0.0:10914" \
   --http-address="0.0.0.0:19999" \
   --grpc-address="0.0.0.0:19998" \
+  --label 'rule="true"' \
   ${OBJSTORECFG} &
 
 STORES="${STORES} --store 127.0.0.1:19998"


### PR DESCRIPTION
Add an external label for Thanos Rule akin to Thanos Receive:
```
--label 'receive="true"' \
```

In the same fashion, let's add `rule=true`. This enables uploading
blocks for Thanos Rule as Thanos blocks must have at least one external
label.

Signed-off-by: Giedrius Statkevičius <giedriuswork@gmail.com>


## Verification

`./scripts/quickstart.sh` works as expected
