### PR TITLE
rule: prevent rule crash from no such host error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ We use _breaking :warning:_ to mark changes that are not backward compatible (re
 
 - [#3527](https://github.com/thanos-io/thanos/pull/3527) Query Frontend: Fix query_range behavior when start/end times are the same
 - [#3560](https://github.com/thanos-io/thanos/pull/3560) query-frontend: Allow separate label cache
+- [#3672](https://github.com/thanos-io/thanos/pull/3672) rule: prevent rule crash from no such host error when using `dnssrv+` or `dnssrvnoa+`.
 
 ### Changed
 

--- a/pkg/discovery/dns/godns/resolver.go
+++ b/pkg/discovery/dns/godns/resolver.go
@@ -1,0 +1,25 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package godns
+
+import (
+	"net"
+
+	"github.com/pkg/errors"
+)
+
+// Resolver is a wrapper for net.Resolver.
+type Resolver struct {
+	*net.Resolver
+}
+
+// IsNotFound checkout if DNS record is not found.
+func (r *Resolver) IsNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	err = errors.Cause(err)
+	dnsErr, ok := err.(*net.DNSError)
+	return ok && dnsErr.IsNotFound
+}

--- a/pkg/discovery/dns/miekgdns/lookup.go
+++ b/pkg/discovery/dns/miekgdns/lookup.go
@@ -11,6 +11,8 @@ import (
 	"github.com/pkg/errors"
 )
 
+var ErrNoSuchHost = errors.New("no such host")
+
 // Copied and slightly adjusted from Prometheus DNS SD:
 // https://github.com/prometheus/prometheus/blob/be3c082539d85908ce03b6d280f83343e7c930eb/discovery/dns/dns.go#L212
 
@@ -68,7 +70,7 @@ func (r *Resolver) lookupWithSearchPath(name string, qtype dns.Type) (*dns.Msg, 
 
 	if len(errs) == 0 {
 		// Outcome 2: everyone says NXDOMAIN.
-		return &dns.Msg{}, nil
+		return &dns.Msg{}, ErrNoSuchHost
 	}
 	// Outcome 3: boned.
 	return nil, errors.Errorf("could not resolve %q: all servers responded with errors to at least one search domain. Errs %s", name, fmtErrs(errs))

--- a/pkg/discovery/dns/miekgdns/resolver.go
+++ b/pkg/discovery/dns/miekgdns/resolver.go
@@ -72,3 +72,7 @@ func (r *Resolver) LookupIPAddr(ctx context.Context, host string) ([]net.IPAddr,
 	}
 	return resp, nil
 }
+
+func (r *Resolver) IsNotFound(err error) bool {
+	return errors.Is(errors.Cause(err), ErrNoSuchHost)
+}

--- a/pkg/discovery/dns/provider.go
+++ b/pkg/discovery/dns/provider.go
@@ -14,6 +14,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 
+	"github.com/thanos-io/thanos/pkg/discovery/dns/godns"
 	"github.com/thanos-io/thanos/pkg/discovery/dns/miekgdns"
 	"github.com/thanos-io/thanos/pkg/errutil"
 	"github.com/thanos-io/thanos/pkg/extprom"
@@ -43,12 +44,12 @@ func (t ResolverType) ToResolver(logger log.Logger) ipLookupResolver {
 	var r ipLookupResolver
 	switch t {
 	case GolangResolverType:
-		r = net.DefaultResolver
+		r = &godns.Resolver{Resolver: net.DefaultResolver}
 	case MiekgdnsResolverType:
 		r = &miekgdns.Resolver{ResolvConf: miekgdns.DefaultResolvConfPath}
 	default:
 		level.Warn(logger).Log("msg", "no such resolver type, defaulting to golang", "type", t)
-		r = net.DefaultResolver
+		r = &godns.Resolver{Resolver: net.DefaultResolver}
 	}
 	return r
 }

--- a/pkg/discovery/dns/resolver_test.go
+++ b/pkg/discovery/dns/resolver_test.go
@@ -35,6 +35,10 @@ func (m mockHostnameResolver) LookupSRV(ctx context.Context, service, proto, nam
 	return "", m.resultSRVs[name], nil
 }
 
+func (m mockHostnameResolver) IsNotFound(err error) bool {
+	return false
+}
+
 type DNSSDTest struct {
 	testName       string
 	addr           string


### PR DESCRIPTION
The rule will crash due to alert managers restart, same with https://github.com/thanos-io/thanos/pull/3257 but I use `dnssrv+`/`dnssrvnoa+`.

Maybe we should make [this line](https://github.com/thanos-io/thanos/blob/3908812e60d1baabf0ba38cd8bf6edf78206d7ab/cmd/thanos/rule.go#L803) fault-tolerant rather than make changes in [pkg/discovery/dns](https://github.com/thanos-io/thanos/tree/master/pkg/discovery/dns).


* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.
