### PR TITLE
Fix typo in query component documentation for store api link

### DIFF
--- a/docs/components/query.md
+++ b/docs/components/query.md
@@ -8,7 +8,7 @@ menu: components
 
 The `thanos query` command (also known as "Querier") implements the [Prometheus HTTP v1 API](https://prometheus.io/docs/prometheus/latest/querying/api/) to query data in a Thanos cluster via PromQL.
 
-In short, it gathers the data needed to evaluate the query from underlying [StoreAPIs](/pkg/store/storepb/rpc.proto), evaluates the query and returns the result.
+In short, it gathers the data needed to evaluate the query from underlying [StoreAPIs](https://github.com/thanos-io/thanos/blob/master/pkg/store/storepb/rpc.proto), evaluates the query and returns the result.
 
 Querier is fully stateless and horizontally scalable.
 

--- a/docs/components/query.md
+++ b/docs/components/query.md
@@ -8,7 +8,7 @@ menu: components
 
 The `thanos query` command (also known as "Querier") implements the [Prometheus HTTP v1 API](https://prometheus.io/docs/prometheus/latest/querying/api/) to query data in a Thanos cluster via PromQL.
 
-In short, it gathers the data needed to evaluate the query from underlying [StoreAPIs](../../pkg/store/storepb/rpc.proto), evaluates the query and returns the result.
+In short, it gathers the data needed to evaluate the query from underlying [StoreAPIs](/pkg/store/storepb/rpc.proto), evaluates the query and returns the result.
 
 Querier is fully stateless and horizontally scalable.
 


### PR DESCRIPTION
Signed-off-by: Junyoung, Sung <junyoung.sung@navercorp.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->
Fix typo in query component documentation.
Previous page is not found because it is relative path for docs


![image](https://user-images.githubusercontent.com/16697306/103199350-023ff000-492e-11eb-8309-a81745896880.png)
![image](https://user-images.githubusercontent.com/16697306/103199307-eb999900-492d-11eb-9631-495c63c5a27b.png)

## Verification

<!-- How you tested it? How do you know it works? -->
