### PR TITLE
Documentation: fix store gateway link in sharding.md

### DIFF
--- a/docs/sharding.md
+++ b/docs/sharding.md
@@ -77,4 +77,4 @@ We can shard by adjusting which labels should be included in the blocks.
 
 For store gateway, we can specify `--min-time` and `--max-time` flags to filter for what blocks store gateway should be responsible for.
 
-More details can refer to "Time based partitioning" chapter in [Store gateway](components/store.md).
+More details can refer to "Time based partitioning" chapter in [Store gateway](../../components/store.md/).


### PR DESCRIPTION
* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Fix broken link (404) from sharding.md to store.md

Store.md link: [components/store.md/](https://thanos.io/tip/components/store.md/)
Sharding.md link: [thanos/sharding.md](https://thanos.io/tip/thanos/sharding.md/)

## Verification

Appending the suggested relative URL to the sharding.md results in [thanos/sharding.md/../../components/store.md/](https://thanos.io/tip/thanos/sharding.md/../../components/store.md/) which redirects to the correct page.