### PR TITLE
Block Viewer: Add the missing `--web.route-prefix` flag

### DIFF
--- a/cmd/thanos/tools_bucket.go
+++ b/cmd/thanos/tools_bucket.go
@@ -327,7 +327,7 @@ func registerBucketWeb(app extkingpin.AppClause, objStoreConfig *extflag.PathOrC
 	webExternalPrefix := cmd.Flag("web.external-prefix", "Static prefix for all HTML links and redirect URLs in the bucket web UI interface. Actual endpoints are still served on / or the web.route-prefix. This allows thanos bucket web UI to be served behind a reverse proxy that strips a URL sub-path.").Default("").String()
 	webPrefixHeaderName := cmd.Flag("web.prefix-header", "Name of HTTP request header used for dynamic prefixing of UI links and redirects. This option is ignored if web.external-prefix argument is set. Security risk: enable this option only if a reverse proxy in front of thanos is resetting the header. The --web.prefix-header=X-Forwarded-Prefix option can be useful, for example, if Thanos UI is served via Traefik reverse proxy with PathPrefixStrip option enabled, which sends the stripped prefix value in X-Forwarded-Prefix header. This allows thanos UI to be served on a sub-path.").Default("").String()
 	webDisableCORS := cmd.Flag("web.disable-cors", "Whether to disable CORS headers to be set by Thanos. By default Thanos sets CORS headers to be allowed by all.").Default("false").Bool()
-	
+
 	interval := cmd.Flag("refresh", "Refresh interval to download metadata from remote storage").Default("30m").Duration()
 	timeout := cmd.Flag("timeout", "Timeout to download metadata from remote storage").Default("5m").Duration()
 	label := cmd.Flag("label", "Prometheus label to use as timeline title").String()

--- a/cmd/thanos/tools_bucket.go
+++ b/cmd/thanos/tools_bucket.go
@@ -321,9 +321,12 @@ func registerBucketInspect(app extkingpin.AppClause, objStoreConfig *extflag.Pat
 func registerBucketWeb(app extkingpin.AppClause, objStoreConfig *extflag.PathOrContent) {
 	cmd := app.Command("web", "Web interface for remote storage bucket.")
 	httpBindAddr, httpGracePeriod := extkingpin.RegisterHTTPFlags(cmd)
+
+	webRoutePrefix := cmd.Flag("web.route-prefix", "Prefix for API and UI endpoints. This allows thanos UI to be served on a sub-path. Defaults to the value of --web.external-prefix. This option is analogous to --web.route-prefix of Prometheus.").Default("").String()
 	webExternalPrefix := cmd.Flag("web.external-prefix", "Static prefix for all HTML links and redirect URLs in the bucket web UI interface. Actual endpoints are still served on / or the web.route-prefix. This allows thanos bucket web UI to be served behind a reverse proxy that strips a URL sub-path.").Default("").String()
 	webPrefixHeaderName := cmd.Flag("web.prefix-header", "Name of HTTP request header used for dynamic prefixing of UI links and redirects. This option is ignored if web.external-prefix argument is set. Security risk: enable this option only if a reverse proxy in front of thanos is resetting the header. The --web.prefix-header=X-Forwarded-Prefix option can be useful, for example, if Thanos UI is served via Traefik reverse proxy with PathPrefixStrip option enabled, which sends the stripped prefix value in X-Forwarded-Prefix header. This allows thanos UI to be served on a sub-path.").Default("").String()
 	webDisableCORS := cmd.Flag("web.disable-cors", "Whether to disable CORS headers to be set by Thanos. By default Thanos sets CORS headers to be allowed by all.").Default("false").Bool()
+	
 	interval := cmd.Flag("refresh", "Refresh interval to download metadata from remote storage").Default("30m").Duration()
 	timeout := cmd.Flag("timeout", "Timeout to download metadata from remote storage").Default("5m").Duration()
 	label := cmd.Flag("label", "Prometheus label to use as timeline title").String()
@@ -341,7 +344,32 @@ func registerBucketWeb(app extkingpin.AppClause, objStoreConfig *extflag.PathOrC
 			httpserver.WithGracePeriod(time.Duration(*httpGracePeriod)),
 		)
 
+
+		if *webRoutePrefix == "" {
+			*webRoutePrefix = *webExternalPrefix
+		}
+
+		if *webRoutePrefix != *webExternalPrefix {
+			level.Warn(logger).Log("msg", "different values for --web.route-prefix and --web.external-prefix detected, web UI may not work without a reverse-proxy.")
+		}
+				
+
 		router := route.New()
+
+		// RoutePrefix must always start with '/'.
+		webRoutePrefix = "/" + strings.Trim(webRoutePrefix, "/")
+
+		// Redirect from / to /webRoutePrefix.
+		if webRoutePrefix != "/" {
+			router.Get("/", func(w http.ResponseWriter, r *http.Request) {
+				http.Redirect(w, r, webRoutePrefix, http.StatusFound)
+			})
+			router.Get(webRoutePrefix, func(w http.ResponseWriter, r *http.Request) {
+				http.Redirect(w, r, webRoutePrefix, http.StatusFound)
+			})
+			router = router.WithPrefix(webRoutePrefix)
+		}		
+		
 		ins := extpromhttp.NewInstrumentationMiddleware(reg, nil)
 
 		bucketUI := ui.NewBucketUI(logger, *label, *webExternalPrefix, *webPrefixHeaderName, "", component.Bucket)

--- a/docs/components/tools.md
+++ b/docs/components/tools.md
@@ -245,7 +245,7 @@ Flags:
                                 thanos UI to be served on a sub-path. Defaults
                                 to the value of --web.external-prefix. This
                                 option is analogous to --web.route-prefix of
-                                Prometheus.                                
+                                Prometheus.
       --web.external-prefix=""  Static prefix for all HTML links and redirect
                                 URLs in the bucket web UI interface. Actual
                                 endpoints are still served on / or the

--- a/docs/components/tools.md
+++ b/docs/components/tools.md
@@ -241,6 +241,11 @@ Flags:
                                 Listen host:port for HTTP endpoints.
       --http-grace-period=2m    Time to wait after an interrupt received for
                                 HTTP Server.
+      --web.route-prefix=""     Prefix for API and UI endpoints. This allows
+                                thanos UI to be served on a sub-path. Defaults
+                                to the value of --web.external-prefix. This
+                                option is analogous to --web.route-prefix of
+                                Prometheus.                                
       --web.external-prefix=""  Static prefix for all HTML links and redirect
                                 URLs in the bucket web UI interface. Actual
                                 endpoints are still served on / or the

--- a/pkg/ui/templates/bucket_menu.html
+++ b/pkg/ui/templates/bucket_menu.html
@@ -11,7 +11,7 @@
                     <a class="nav-link" href="https://thanos.io/tip/thanos/getting-started.md/" target="_blank">Help</a>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link" href="/new/" target="_blank">New UI</a>
+                    <a class="nav-link" href="{{ pathPrefix }}/new/" target="_blank">New UI</a>
                 </li>
             </ul>
         </div>

--- a/test/e2e/e2ethanos/services.go
+++ b/test/e2e/e2ethanos/services.go
@@ -501,7 +501,7 @@ func NewMemcached(name string) *e2e.ConcreteService {
 	return memcached
 }
 
-func NewToolsBucketWeb(sharedDir string, name string, bucketConfig client.BucketConfig, routePrefix, externalPrefix string) (*Service, error) {
+func NewToolsBucketWeb(name string, bucketConfig client.BucketConfig, routePrefix, externalPrefix string) (*Service, error) {
 	bktConfigBytes, err := yaml.Marshal(bucketConfig)
 	if err != nil {
 		return nil, errors.Wrapf(err, "generate tools bucket web config file: %v", bucketConfig)

--- a/test/e2e/e2ethanos/services.go
+++ b/test/e2e/e2ethanos/services.go
@@ -508,10 +508,10 @@ func NewToolsBucketWeb(sharedDir string, name string, bucketConfig client.Bucket
 	}
 
 	args := e2e.BuildArgs(map[string]string{
-		"--debug.name":            fmt.Sprintf("toolsBucketWeb-%s", name),
-		"--http-address":          ":8080",
-		"--log.level":             logLevel,
-		"--objstore.config":       string(bktConfigBytes),
+		"--debug.name":      fmt.Sprintf("toolsBucketWeb-%s", name),
+		"--http-address":    ":8080",
+		"--log.level":       logLevel,
+		"--objstore.config": string(bktConfigBytes),
 	})
 	if routePrefix != "" {
 		args = append(args, "--web.route-prefix="+routePrefix)
@@ -522,7 +522,7 @@ func NewToolsBucketWeb(sharedDir string, name string, bucketConfig client.Bucket
 	}
 
 	args = append([]string{"bucket", "web"}, args...)
-	
+
 	toolsBucketWeb := NewService(
 		fmt.Sprintf("toolsBucketWeb-%s", name),
 		DefaultImage(),

--- a/test/e2e/e2ethanos/services.go
+++ b/test/e2e/e2ethanos/services.go
@@ -510,7 +510,7 @@ func NewToolsBucketWeb(name string, bucketConfig client.BucketConfig, routePrefi
 	args := e2e.BuildArgs(map[string]string{
 		"--debug.name":      fmt.Sprintf("toolsBucketWeb-%s", name),
 		"--http-address":    ":8080",
-		"--log.level":       logLevel,
+		"--log.level":       infoLogLevel,
 		"--objstore.config": string(bktConfigBytes),
 	})
 	if routePrefix != "" {

--- a/test/e2e/tools_bucket_web_test.go
+++ b/test/e2e/tools_bucket_web_test.go
@@ -6,10 +6,12 @@ package e2e_test
 import (
 	"net/http/httptest"
 	"testing"
+
 	"github.com/cortexproject/cortex/integration/e2e"
+	e2edb "github.com/cortexproject/cortex/integration/e2e/db"
+
 	"github.com/thanos-io/thanos/pkg/objstore/client"
 	"github.com/thanos-io/thanos/pkg/objstore/s3"
-	e2edb "github.com/cortexproject/cortex/integration/e2e/db"
 	"github.com/thanos-io/thanos/pkg/testutil"
 	"github.com/thanos-io/thanos/test/e2e/e2ethanos"
 )
@@ -34,8 +36,8 @@ func TestToolsBucketWebExternalPrefixWithoutReverseProxy(t *testing.T) {
 			Endpoint:  m.NetworkHTTPEndpoint(),
 			Insecure:  true,
 		},
-	}	
-	
+	}
+
 	b, err := e2ethanos.NewToolsBucketWeb(
 		s.SharedDir(), "1",
 		svcConfig,
@@ -44,7 +46,7 @@ func TestToolsBucketWebExternalPrefixWithoutReverseProxy(t *testing.T) {
 	)
 	testutil.Ok(t, err)
 	testutil.Ok(t, s.StartAndWaitReady(b))
-	
+
 	checkNetworkRequests(t, "http://"+b.HTTPEndpoint()+"/"+externalPrefix+"/blocks")
 }
 
@@ -69,8 +71,7 @@ func TestToolsBucketWebExternalPrefix(t *testing.T) {
 			Endpoint:  m.NetworkHTTPEndpoint(),
 			Insecure:  true,
 		},
-	}	
-
+	}
 
 	b, err := e2ethanos.NewToolsBucketWeb(
 		s.SharedDir(), "1",
@@ -100,7 +101,7 @@ func TestToolsBucketWebExternalPrefixAndRoutePrefix(t *testing.T) {
 	routePrefix := "test"
 	const bucket = "toolsBucketWeb_test"
 	m := e2edb.NewMinio(8080, bucket)
-	testutil.Ok(t, s.StartAndWaitReady(m))	
+	testutil.Ok(t, s.StartAndWaitReady(m))
 
 	svcConfig := client.BucketConfig{
 		Type: client.S3,
@@ -111,8 +112,8 @@ func TestToolsBucketWebExternalPrefixAndRoutePrefix(t *testing.T) {
 			Endpoint:  m.NetworkHTTPEndpoint(),
 			Insecure:  true,
 		},
-	}		
-	
+	}
+
 	b, err := e2ethanos.NewToolsBucketWeb(
 		s.SharedDir(), "1",
 		svcConfig,

--- a/test/e2e/tools_bucket_web_test.go
+++ b/test/e2e/tools_bucket_web_test.go
@@ -1,0 +1,131 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package e2e_test
+
+import (
+	"net/http/httptest"
+	"testing"
+	"github.com/cortexproject/cortex/integration/e2e"
+	"github.com/thanos-io/thanos/pkg/objstore/client"
+	"github.com/thanos-io/thanos/pkg/objstore/s3"
+	e2edb "github.com/cortexproject/cortex/integration/e2e/db"
+	"github.com/thanos-io/thanos/pkg/testutil"
+	"github.com/thanos-io/thanos/test/e2e/e2ethanos"
+)
+
+func TestToolsBucketWebExternalPrefixWithoutReverseProxy(t *testing.T) {
+	t.Parallel()
+
+	s, err := e2e.NewScenario("e2e_test_tools_bucket_web_route_prefix")
+	testutil.Ok(t, err)
+	t.Cleanup(e2ethanos.CleanScenario(t, s))
+
+	externalPrefix := "thanos"
+	m := e2edb.NewMinio(8080, "thanos")
+	testutil.Ok(t, s.StartAndWaitReady(m))
+
+	svcConfig := client.BucketConfig{
+		Type: client.S3,
+		Config: s3.Config{
+			Bucket:    "thanos",
+			AccessKey: e2edb.MinioAccessKey,
+			SecretKey: e2edb.MinioSecretKey,
+			Endpoint:  m.NetworkHTTPEndpoint(),
+			Insecure:  true,
+		},
+	}	
+	
+	b, err := e2ethanos.NewToolsBucketWeb(
+		s.SharedDir(), "1",
+		svcConfig,
+		"",
+		externalPrefix,
+	)
+	testutil.Ok(t, err)
+	testutil.Ok(t, s.StartAndWaitReady(b))
+	
+	checkNetworkRequests(t, "http://"+b.HTTPEndpoint()+"/"+externalPrefix+"/blocks")
+}
+
+func TestToolsBucketWebExternalPrefix(t *testing.T) {
+	t.Parallel()
+
+	s, err := e2e.NewScenario("e2e_test_tools_bucket_web_external_prefix")
+	testutil.Ok(t, err)
+	t.Cleanup(e2ethanos.CleanScenario(t, s))
+
+	externalPrefix := "thanos"
+	const bucket = "toolsBucketWeb_test"
+	m := e2edb.NewMinio(8080, bucket)
+	testutil.Ok(t, s.StartAndWaitReady(m))
+
+	svcConfig := client.BucketConfig{
+		Type: client.S3,
+		Config: s3.Config{
+			Bucket:    bucket,
+			AccessKey: e2edb.MinioAccessKey,
+			SecretKey: e2edb.MinioSecretKey,
+			Endpoint:  m.NetworkHTTPEndpoint(),
+			Insecure:  true,
+		},
+	}	
+
+
+	b, err := e2ethanos.NewToolsBucketWeb(
+		s.SharedDir(), "1",
+		svcConfig,
+		"",
+		externalPrefix,
+	)
+	testutil.Ok(t, err)
+	testutil.Ok(t, s.StartAndWaitReady(b))
+
+	toolsBucketWebURL := mustURLParse(t, "http://"+b.HTTPEndpoint()+"/"+externalPrefix)
+
+	toolsBucketWebProxy := httptest.NewServer(e2ethanos.NewSingleHostReverseProxy(toolsBucketWebURL, externalPrefix))
+	t.Cleanup(toolsBucketWebProxy.Close)
+
+	checkNetworkRequests(t, toolsBucketWebProxy.URL+"/"+externalPrefix+"/blocks")
+}
+
+func TestToolsBucketWebExternalPrefixAndRoutePrefix(t *testing.T) {
+	t.Parallel()
+
+	s, err := e2e.NewScenario("e2e_test_tools_bucket_web_external_prefix_and_route_prefix")
+	testutil.Ok(t, err)
+	t.Cleanup(e2ethanos.CleanScenario(t, s))
+
+	externalPrefix := "thanos"
+	routePrefix := "test"
+	const bucket = "toolsBucketWeb_test"
+	m := e2edb.NewMinio(8080, bucket)
+	testutil.Ok(t, s.StartAndWaitReady(m))	
+
+	svcConfig := client.BucketConfig{
+		Type: client.S3,
+		Config: s3.Config{
+			Bucket:    bucket,
+			AccessKey: e2edb.MinioAccessKey,
+			SecretKey: e2edb.MinioSecretKey,
+			Endpoint:  m.NetworkHTTPEndpoint(),
+			Insecure:  true,
+		},
+	}		
+	
+	b, err := e2ethanos.NewToolsBucketWeb(
+		s.SharedDir(), "1",
+		svcConfig,
+		"",
+		externalPrefix,
+	)
+	testutil.Ok(t, err)
+	testutil.Ok(t, s.StartAndWaitReady(b))
+
+	toolsBucketWebURL := mustURLParse(t, "http://"+b.HTTPEndpoint()+"/"+routePrefix)
+
+	toolsBucketWebProxy := httptest.NewServer(e2ethanos.NewSingleHostReverseProxy(toolsBucketWebURL, externalPrefix))
+	t.Cleanup(toolsBucketWebProxy.Close)
+
+	checkNetworkRequests(t, toolsBucketWebProxy.URL+"/"+externalPrefix+"/blocks")
+}

--- a/test/e2e/tools_bucket_web_test.go
+++ b/test/e2e/tools_bucket_web_test.go
@@ -39,7 +39,7 @@ func TestToolsBucketWebExternalPrefixWithoutReverseProxy(t *testing.T) {
 	}
 
 	b, err := e2ethanos.NewToolsBucketWeb(
-		s.SharedDir(), "1",
+		"1",
 		svcConfig,
 		"",
 		externalPrefix,
@@ -74,7 +74,7 @@ func TestToolsBucketWebExternalPrefix(t *testing.T) {
 	}
 
 	b, err := e2ethanos.NewToolsBucketWeb(
-		s.SharedDir(), "1",
+		"1",
 		svcConfig,
 		"",
 		externalPrefix,
@@ -115,9 +115,9 @@ func TestToolsBucketWebExternalPrefixAndRoutePrefix(t *testing.T) {
 	}
 
 	b, err := e2ethanos.NewToolsBucketWeb(
-		s.SharedDir(), "1",
+		"1",
 		svcConfig,
-		"",
+		routePrefix,
 		externalPrefix,
 	)
 	testutil.Ok(t, err)

--- a/test/e2e/tools_bucket_web_test.go
+++ b/test/e2e/tools_bucket_web_test.go
@@ -23,7 +23,7 @@ func TestToolsBucketWebExternalPrefixWithoutReverseProxy(t *testing.T) {
 	testutil.Ok(t, err)
 	t.Cleanup(e2ethanos.CleanScenario(t, s))
 
-	externalPrefix := "thanos"
+	externalPrefix := "testThanos"
 	m := e2edb.NewMinio(8080, "thanos")
 	testutil.Ok(t, s.StartAndWaitReady(m))
 
@@ -57,7 +57,7 @@ func TestToolsBucketWebExternalPrefix(t *testing.T) {
 	testutil.Ok(t, err)
 	t.Cleanup(e2ethanos.CleanScenario(t, s))
 
-	externalPrefix := "thanos"
+	externalPrefix := "testThanos"
 	const bucket = "toolsBucketWeb_test"
 	m := e2edb.NewMinio(8080, bucket)
 	testutil.Ok(t, s.StartAndWaitReady(m))
@@ -97,7 +97,7 @@ func TestToolsBucketWebExternalPrefixAndRoutePrefix(t *testing.T) {
 	testutil.Ok(t, err)
 	t.Cleanup(e2ethanos.CleanScenario(t, s))
 
-	externalPrefix := "thanos"
+	externalPrefix := "testThanos"
 	routePrefix := "test"
 	const bucket = "toolsBucketWeb_test"
 	m := e2edb.NewMinio(8080, bucket)


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->
Fixes [#3211](https://github.com/thanos-io/thanos/issues/3211)
<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes
Added the missing route-

1. prefix flag in tools bucket web.
2. External-prefix is handled properly.

<!-- Enumerate changes you made -->

## Verification

1. Tested locally without reverse proxy.
2. Tested behind a reverse proxy using caddy.
3. Wrote 3 e2e test.
    1. Test External Prefix without Reverse Proxy.
    2. Test External Prefix with Reverse Proxy.
    3. Test External Prefix and Route Prefix with Reverse Proxy.


<!-- How you tested it? How do you know it works? -->
