### PR TITLE
UI: Fix styling bug for target labels with special names 

### DIFF
--- a/pkg/ui/react-app/src/pages/targets/TargetLabels.test.tsx
+++ b/pkg/ui/react-app/src/pages/targets/TargetLabels.test.tsx
@@ -23,7 +23,7 @@ describe('targetLabels', () => {
   const targetLabels = shallow(<TargetLabels {...defaultProps} />);
 
   it('renders a div of series labels', () => {
-    const div = targetLabels.find('div').filterWhere(elem => elem.hasClass('series-labels-container'));
+    const div = targetLabels.find('div').filterWhere((elem) => elem.hasClass('series-labels-container'));
     expect(div).toHaveLength(1);
     expect(div.prop('id')).toEqual('series-labels-cortex/node-exporter_group/0-1');
   });
@@ -33,7 +33,7 @@ describe('targetLabels', () => {
     Object.keys(l).forEach((labelName: string): void => {
       const badge = targetLabels
         .find(Badge)
-        .filterWhere(badge => badge.children().text() === `${labelName}="${l[labelName]}"`);
+        .filterWhere((badge) => badge.children().text() === `${labelName}="${l[labelName]}"`);
       expect(badge).toHaveLength(1);
     });
     expect(targetLabels.find(Badge)).toHaveLength(3);

--- a/pkg/ui/react-app/src/pages/targets/TargetLabels.test.tsx
+++ b/pkg/ui/react-app/src/pages/targets/TargetLabels.test.tsx
@@ -23,7 +23,7 @@ describe('targetLabels', () => {
   const targetLabels = shallow(<TargetLabels {...defaultProps} />);
 
   it('renders a div of series labels', () => {
-    const div = targetLabels.find('div').filterWhere((elem) => elem.hasClass('series-labels-container'));
+    const div = targetLabels.find('div').filterWhere(elem => elem.hasClass('series-labels-container'));
     expect(div).toHaveLength(1);
     expect(div.prop('id')).toEqual('series-labels-cortex/node-exporter_group/0-1');
   });
@@ -31,8 +31,10 @@ describe('targetLabels', () => {
   it('wraps each label in a label badge', () => {
     const l: { [key: string]: string } = defaultProps.labels;
     Object.keys(l).forEach((labelName: string): void => {
-      const badge = targetLabels.find(Badge).filterWhere((badge) => badge.hasClass(labelName));
-      expect(badge.children().text()).toEqual(`${labelName}="${l[labelName]}"`);
+      const badge = targetLabels
+        .find(Badge)
+        .filterWhere(badge => badge.children().text() === `${labelName}="${l[labelName]}"`);
+      expect(badge).toHaveLength(1);
     });
     expect(targetLabels.find(Badge)).toHaveLength(3);
   });

--- a/pkg/ui/react-app/src/pages/targets/TargetLabels.tsx
+++ b/pkg/ui/react-app/src/pages/targets/TargetLabels.tsx
@@ -27,7 +27,7 @@ const TargetLabels: FC<TargetLabelsProps> = ({ discoveredLabels, labels, idx, sc
       <div id={id} className="series-labels-container">
         {Object.keys(labels).map((labelName) => {
           return (
-            <Badge color="primary" className={`mr-1 ${labelName}`} key={labelName}>
+            <Badge color="primary" className="mr-1" key={labelName}>
               {`${labelName}="${labels[labelName]}"`}
             </Badge>
           );

--- a/pkg/ui/react-app/src/pages/targets/__snapshots__/TargetLabels.test.tsx.snap
+++ b/pkg/ui/react-app/src/pages/targets/__snapshots__/TargetLabels.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`targetLabels renders discovered labels 1`] = `
     id="series-labels-cortex/node-exporter_group/0-1"
   >
     <Badge
-      className="mr-1 instance"
+      className="mr-1"
       color="primary"
       key="instance"
       pill={false}
@@ -16,7 +16,7 @@ exports[`targetLabels renders discovered labels 1`] = `
       instance="localhost:9100"
     </Badge>
     <Badge
-      className="mr-1 job"
+      className="mr-1"
       color="primary"
       key="job"
       pill={false}
@@ -25,7 +25,7 @@ exports[`targetLabels renders discovered labels 1`] = `
       job="node_exporter"
     </Badge>
     <Badge
-      className="mr-1 foo"
+      className="mr-1"
       color="primary"
       key="foo"
       pill={false}


### PR DESCRIPTION
Signed-off-by: Namanl2001 <namanlakhwani@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

Fixes a subissue `Fix styling bug for target labels with special names.` in #3541 



<!-- Enumerate changes you made -->



<!-- How you tested it? How do you know it works? -->
