### PR TITLE
CHANGELOG.md: add v0.16.0 link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,7 +96,7 @@ We use _breaking :warning:_ to mark changes that are not backward compatible (re
   - `thanos_replicate_origin_partial_meta_reads_total` can be replaced by `blocks_meta_synced{state="failed"}`.
 - [#3309](https://github.com/thanos-io/thanos/pull/3309) Compact: _breaking :warning:_ Rename metrics to match naming convention. This includes metrics starting with `thanos_compactor` to `thanos_compact`, `thanos_querier` to `thanos_query` and `thanos_ruler` to `thanos_rule`.
 
-## [v0.16.0](https://github.com/thanos-io/thanos/releases) - 2020.10.26
+## [v0.16.0](https://github.com/thanos-io/thanos/releases/tag/v0.16.0) - 2020.10.26
 
 Highlights:
 


### PR DESCRIPTION
This small commit fixes the changelog entry for release v0.16.0 so that
the section title includes a link to the actual release.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com