### PR TITLE
ui: make old bucket viewer UI work with vanilla blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ We use _breaking :warning:_ to mark changes that are not backward compatible (re
 
 ## Unreleased
 
+### Added
+
+- [#3700](https://github.com/thanos-io/thanos/pull/3700) ui: make old bucket viewer UI work with vanilla Prometheus blocks
+
 ## [v0.18.0](https://github.com/thanos-io/thanos/releases) - Release in progress
 
 ### Added

--- a/pkg/ui/static/js/bucket.js
+++ b/pkg/ui/static/js/bucket.js
@@ -77,10 +77,10 @@ function draw() {
     }
 }
 
-// isThanosBlock eturns true if it is a block that has been processed by Thanos.
+// isThanosBlock returns true if it is a block that has been processed by Thanos.
 function isThanosBlock(d) {
     return d.thanos.labels !== null &&
-        d.thanos.source != ""
+        d.thanos.source !== ""
 }
 
 function stringify(map) {

--- a/pkg/ui/static/js/bucket.js
+++ b/pkg/ui/static/js/bucket.js
@@ -34,6 +34,12 @@ function draw() {
         dataTable.addRows(thanos.blocks
             .sort((a, b) => a.thanos.downsample.resolution - b.thanos.downsample.resolution)
             .map(function(d) {
+                if (!isThanosBlock(d)) {
+                    title = 'Prometheus'
+                    titles['Prometheus blocks with no Thanos data'] = title
+
+                    return [title, `level: ${d.compaction.level}`, generateTooltip(d), new Date(d.minTime), new Date(d.maxTime)]
+                }
                 // Title is the first column of the timeline.
                 //
                 // A unique Prometheus label that identifies each shard is used
@@ -71,6 +77,12 @@ function draw() {
     }
 }
 
+// isThanosBlock eturns true if it is a block that has been processed by Thanos.
+function isThanosBlock(d) {
+    return d.thanos.labels !== null &&
+        d.thanos.source != ""
+}
+
 function stringify(map) {
     var t = "";
     for (let [key, value] of Object.entries(map)) {
@@ -91,15 +103,19 @@ function generateTooltip(block) {
     var info = document.createElement("ul");
     info.className = "list-group list-group-flush";
 
-    var metaInfo = document.createElement("li");
-    metaInfo.className = "list-group-item";
-    metaInfo.innerHTML = "<p><b>Labels</b></p>";
-    var labelTable = document.createElement("table");
-    labelTable.className = "table table-sm mb-0";
-    for (let [key, value] of Object.entries(block.thanos.labels)) {
-        labelTable.innerHTML += `<tr><td>${key}</td><td>${value}</td></tr>`;
+
+    if (isThanosBlock(block)) {
+        var metaInfo = document.createElement("li");
+        metaInfo.className = "list-group-item";
+        metaInfo.innerHTML = "<p><b>Labels</b></p>";
+
+        var labelTable = document.createElement("table");
+        labelTable.className = "table table-sm mb-0";
+        for (let [key, value] of Object.entries(block.thanos.labels)) {
+            labelTable.innerHTML += `<tr><td>${key}</td><td>${value}</td></tr>`;
+        }
+        metaInfo.appendChild(labelTable);
     }
-    metaInfo.appendChild(labelTable);
 
     var dateInfo = document.createElement("li");
     var minTime = new Date(block.minTime);
@@ -114,18 +130,25 @@ function generateTooltip(block) {
     statsInfo.className = "list-group-item";
     statsInfo.innerHTML = generateLine("Series: ", block.stats.numSeries.toLocaleString());
     statsInfo.innerHTML += generateLine("Samples: ", block.stats.numSamples.toLocaleString());
-    statsInfo.innerHTML += generateLine("Chunks: ", block.stats.numChunks.toLocaleString());  
+    statsInfo.innerHTML += generateLine("Chunks: ", block.stats.numChunks.toLocaleString());
 
-    var compactInfo = document.createElement("li");
-    compactInfo.className = "list-group-item";
-    compactInfo.innerHTML = generateLine("Resolution: ", block.thanos.downsample.resolution);
-    compactInfo.innerHTML += generateLine("Level: ", block.compaction.level);
-    compactInfo.innerHTML += generateLine("Source: ", block.thanos.source);
 
-    info.appendChild(metaInfo);
+    if (isThanosBlock(block)) {
+        info.appendChild(metaInfo);
+    }
+
     info.appendChild(dateInfo);
     info.appendChild(statsInfo);
-    info.appendChild(compactInfo);
+
+    if (isThanosBlock(block)) {
+        var compactInfo = document.createElement("li");
+        compactInfo.className = "list-group-item";
+        compactInfo.innerHTML = generateLine("Resolution: ", block.thanos.downsample.resolution);
+        compactInfo.innerHTML += generateLine("Level: ", block.compaction.level);
+        compactInfo.innerHTML += generateLine("Source: ", block.thanos.source);
+
+        info.appendChild(compactInfo);
+    }
 
     tooltip.appendChild(title);
     tooltip.appendChild(info);


### PR DESCRIPTION
Make the old bucket viewer UI work with vanilla Prometheus blocks by
checking whether the `Thanos` part exists before formatting the HTML.

Signed-off-by: Giedrius Statkevičius <giedriuswork@gmail.com>

Only changing the old UI here to solicit responses on whether we should
change the API not to return the `thanos` key if it does not exist. IMHO
we should keep it as is and add checks as in this PR.

Screenshot:
![ss](https://user-images.githubusercontent.com/2377233/103802998-a295c300-5058-11eb-920a-e7b0eec7278b.png)


* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Verification

Built Thanos and ran it with the `FILESYSTEM` bucket on a local Prometheus directory.