### PR TITLE
tutorials: fixed some broken links in the lts tutorial

### DIFF
--- a/tutorials/katacoda/thanos/2-lts/step1.md
+++ b/tutorials/katacoda/thanos/2-lts/step1.md
@@ -144,6 +144,6 @@ Similar to previous course let's check if the Querier works as intended. Let's l
 
 This should list the sidecar, including the external labels.
 
-On graph you should also see our 5 series for 1y time, thanks to Prometheus and sidecar StoreAPI: [Graph](https://[[HOST_SUBDOMAIN]]-9091-[[KATACODA_HOST]].environments.katacoda.com/https://2886795307-9091-ollie02.environments.katacoda.com/graph?g0.range_input=1y&g0.max_source_resolution=0s&g0.expr=continuous_app_metric0&g0.tab=0).
+On graph you should also see our 5 series for 1y time, thanks to Prometheus and sidecar StoreAPI: [Graph](https://[[HOST_SUBDOMAIN]]-9091-[[KATACODA_HOST]].environments.katacoda.com/graph?g0.range_input=1y&g0.max_source_resolution=0s&g0.expr=continuous_app_metric0&g0.tab=0).
 
 Click `Continue` to see how we can move this data to much cheaper and easier to operate object storage.

--- a/tutorials/katacoda/thanos/2-lts/step3.md
+++ b/tutorials/katacoda/thanos/2-lts/step3.md
@@ -78,7 +78,7 @@ The potential duplication of data between Prometheus+sidecar results and store G
 
 Another interesting question here is how to ensure if we query the data from bucket only?
 
-We can check this by visitng the [New UI]((https://[[HOST_SUBDOMAIN]]-9091-[[KATACODA_HOST]].environments.katacoda.com/new/graph?g0.expr=&g0.tab=0&g0.stacked=0&g0.range_input=1h&g0.max_source_resolution=0s&g0.deduplicate=1&g0.partial_response=0&g0.store_matches=[])), inserting `continuous_app_metric0` metrics again with 1 year time range of graph,
+We can check this by visitng the [New UI](https://[[HOST_SUBDOMAIN]]-9091-[[KATACODA_HOST]].environments.katacoda.com/new/graph?g0.expr=&g0.tab=0&g0.stacked=0&g0.range_input=1h&g0.max_source_resolution=0s&g0.deduplicate=1&g0.partial_response=0&g0.store_matches=[]), inserting `continuous_app_metric0` metrics again with 1 year time range of graph,
 and click on `Enable Store Filtering`.
 
 This allows us to filter stores and helps in debugging from where we are querying the data exactly.


### PR DESCRIPTION
* [x] Change is not relevant to the end user.

## Changes

Fixed two broken links in the 2-lts tutorial for katacoda, one in step 1 when opening the graph and another in step 3 when opening the New UI.

## Verification

I pushed to my own katacoda environment and manually checked the links.