### PR TITLE
Support bucket rewrite relabel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ We use _breaking :warning:_ to mark changes that are not backward compatible (re
 - [#4125](https://github.com/thanos-io/thanos/pull/4125) Rule: Add `--alert.relabel-config` / `--alert.relabel-config-file` allowing to specify alert relabel configurations like [Prometheus](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config)
 - [#4211](https://github.com/thanos-io/thanos/pull/4211) Add TLS and basic authentication to Thanos APIs
 - [#4249](https://github.com/thanos-io/thanos/pull/4249) UI: add dark theme
+- [#3707](https://github.com/thanos-io/thanos/pull/3707) Tools: Added `--rewrite.to-relabel-config` to bucket rewrite tool to support series relabel from given blocks.
 
 ### Fixed
 -

--- a/docs/components/tools.md
+++ b/docs/components/tools.md
@@ -769,6 +769,14 @@ Flags:
                                 Path to YAML file that contains
                                 []metadata.DeletionRequest that will be applied
                                 to blocks
+      --rewrite.to-relabel-config=<content>
+                                Alternative to 'rewrite.to-relabel-config-file'
+                                flag (mutually exclusive). Content of YAML file
+                                that contains relabel configs that will be
+                                applied to blocks
+      --rewrite.to-relabel-config-file=<file-path>
+                                Path to YAML file that contains relabel configs
+                                that will be applied to blocks
       --tmp.dir="/tmp/thanos-rewrite"
                                 Working directory for temporary files
       --tracing.config=<content>

--- a/pkg/block/fetcher.go
+++ b/pkg/block/fetcher.go
@@ -879,15 +879,18 @@ var (
 )
 
 // ParseRelabelConfig parses relabel configuration.
+// If supportedActions not specified, all relabel actions are valid.
 func ParseRelabelConfig(contentYaml []byte, supportedActions map[relabel.Action]struct{}) ([]*relabel.Config, error) {
 	var relabelConfig []*relabel.Config
 	if err := yaml.Unmarshal(contentYaml, &relabelConfig); err != nil {
 		return nil, errors.Wrap(err, "parsing relabel configuration")
 	}
 
-	for _, cfg := range relabelConfig {
-		if _, ok := supportedActions[cfg.Action]; !ok {
-			return nil, errors.Errorf("unsupported relabel action: %v", cfg.Action)
+	if supportedActions != nil {
+		for _, cfg := range relabelConfig {
+			if _, ok := supportedActions[cfg.Action]; !ok {
+				return nil, errors.Errorf("unsupported relabel action: %v", cfg.Action)
+			}
 		}
 	}
 

--- a/pkg/block/metadata/meta.go
+++ b/pkg/block/metadata/meta.go
@@ -19,12 +19,14 @@ import (
 	"github.com/oklog/ulid"
 	"github.com/pkg/errors"
 	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/prometheus/pkg/relabel"
 	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/prometheus/prometheus/tsdb"
 	"github.com/prometheus/prometheus/tsdb/fileutil"
 	"github.com/prometheus/prometheus/tsdb/tombstones"
-	"github.com/thanos-io/thanos/pkg/runutil"
 	"gopkg.in/yaml.v3"
+
+	"github.com/thanos-io/thanos/pkg/runutil"
 )
 
 type SourceType string
@@ -95,6 +97,8 @@ type Rewrite struct {
 	Sources []ulid.ULID `json:"sources,omitempty"`
 	// Deletions if applied (in order).
 	DeletionsApplied []DeletionRequest `json:"deletions_applied,omitempty"`
+	// Relabels if applied.
+	RelabelsApplied []*relabel.Config `json:"relabels_applied,omitempty"`
 }
 
 type Matchers []*labels.Matcher

--- a/pkg/compactv2/chunk_series_set.go
+++ b/pkg/compactv2/chunk_series_set.go
@@ -13,6 +13,7 @@ import (
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
 	"github.com/prometheus/prometheus/tsdb/chunks"
 	"github.com/prometheus/prometheus/tsdb/index"
+
 	"github.com/thanos-io/thanos/pkg/block"
 )
 

--- a/pkg/compactv2/compactor_test.go
+++ b/pkg/compactv2/compactor_test.go
@@ -17,12 +17,15 @@ import (
 	"github.com/go-kit/kit/log"
 	"github.com/oklog/ulid"
 	"github.com/pkg/errors"
+	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/prometheus/pkg/relabel"
 	"github.com/prometheus/prometheus/tsdb"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
 	"github.com/prometheus/prometheus/tsdb/chunks"
 	"github.com/prometheus/prometheus/tsdb/index"
 	"github.com/prometheus/prometheus/tsdb/tombstones"
+
 	"github.com/thanos-io/thanos/pkg/block"
 	"github.com/thanos-io/thanos/pkg/block/metadata"
 	"github.com/thanos-io/thanos/pkg/testutil"
@@ -395,6 +398,192 @@ func TestCompactor_WriteSeries_e2e(t *testing.T) {
 				NumSamples: 36,
 				NumSeries:  6,
 				NumChunks:  12,
+			},
+		},
+		{
+			name: "1 block + relabel modifier, separate chunks from the same series are merged",
+			input: [][]seriesSamples{
+				{
+					{lset: labels.Labels{{Name: "a", Value: "1"}},
+						chunks: [][]sample{{{0, 0}, {1, 1}, {2, 2}}, {{10, 10}, {11, 11}, {20, 20}}}},
+				},
+			},
+			// Not used in this test case.
+			modifiers: []Modifier{WithRelabelModifier(
+				&relabel.Config{
+					Action:       relabel.Drop,
+					Regex:        relabel.MustNewRegexp("2"),
+					SourceLabels: model.LabelNames{"a"},
+				},
+			)},
+			expected: []seriesSamples{
+				{lset: labels.Labels{{Name: "a", Value: "1"}},
+					chunks: [][]sample{{{0, 0}, {1, 1}, {2, 2}, {10, 10}, {11, 11}, {20, 20}}}},
+			},
+			expectedStats: tsdb.BlockStats{
+				NumSamples: 6,
+				NumSeries:  1,
+				NumChunks:  1,
+			},
+		},
+		{
+			name: "1 block + relabel modifier, delete first series",
+			input: [][]seriesSamples{
+				{
+					{lset: labels.Labels{{Name: "a", Value: "1"}},
+						chunks: [][]sample{{{0, 0}, {1, 1}, {2, 2}, {10, 10}, {11, 11}, {20, 20}}}},
+					{lset: labels.Labels{{Name: "a", Value: "2"}},
+						chunks: [][]sample{{{0, 0}, {1, 1}, {2, 2}}, {{10, 10}, {11, 11}, {20, 20}, {25, 25}}}},
+					{lset: labels.Labels{{Name: "a", Value: "3"}},
+						chunks: [][]sample{{{0, 0}, {1, 1}, {2, 2}, {10, 13}, {11, 11}, {20, 20}}}},
+				},
+			},
+			modifiers: []Modifier{WithRelabelModifier(
+				&relabel.Config{
+					Action:       relabel.Drop,
+					Regex:        relabel.MustNewRegexp("1"),
+					SourceLabels: model.LabelNames{"a"},
+				},
+			)},
+			expected: []seriesSamples{
+				{lset: labels.Labels{{Name: "a", Value: "2"}},
+					chunks: [][]sample{{{0, 0}, {1, 1}, {2, 2}, {10, 10}, {11, 11}, {20, 20}, {25, 25}}}},
+				{lset: labels.Labels{{Name: "a", Value: "3"}},
+					chunks: [][]sample{{{0, 0}, {1, 1}, {2, 2}, {10, 13}, {11, 11}, {20, 20}}}},
+			},
+			expectedChanges: "Deleted {a=\"1\"} [{0 20}]\n",
+			expectedStats: tsdb.BlockStats{
+				NumSamples: 13,
+				NumSeries:  2,
+				NumChunks:  2,
+			},
+		},
+		{
+			name: "1 block + relabel modifier, series reordered",
+			input: [][]seriesSamples{
+				{
+					{lset: labels.Labels{{Name: "a", Value: "1"}},
+						chunks: [][]sample{{{0, 0}, {1, -1}, {2, -2}, {10, -10}, {11, -11}, {20, -20}}}},
+					{lset: labels.Labels{{Name: "a", Value: "2"}},
+						chunks: [][]sample{{{0, 0}, {1, 1}, {2, 2}}, {{10, 10}, {11, 11}, {20, 20}, {25, 25}}}},
+				},
+			},
+			// {a="1"} will be relabeled to {a="3"} while {a="2"} will be relabeled to {a="0"}.
+			modifiers: []Modifier{WithRelabelModifier(
+				&relabel.Config{
+					Action:       relabel.Replace,
+					Regex:        relabel.MustNewRegexp("1"),
+					SourceLabels: model.LabelNames{"a"},
+					TargetLabel:  "a",
+					Replacement:  "3",
+				},
+				&relabel.Config{
+					Action:       relabel.Replace,
+					Regex:        relabel.MustNewRegexp("2"),
+					SourceLabels: model.LabelNames{"a"},
+					TargetLabel:  "a",
+					Replacement:  "0",
+				},
+			)},
+			expected: []seriesSamples{
+				{lset: labels.Labels{{Name: "a", Value: "0"}},
+					chunks: [][]sample{{{0, 0}, {1, 1}, {2, 2}, {10, 10}, {11, 11}, {20, 20}, {25, 25}}}},
+				{lset: labels.Labels{{Name: "a", Value: "3"}},
+					chunks: [][]sample{{{0, 0}, {1, -1}, {2, -2}, {10, -10}, {11, -11}, {20, -20}}}},
+			},
+			expectedChanges: "Relabelled {a=\"1\"} {a=\"3\"}\nRelabelled {a=\"2\"} {a=\"0\"}\n",
+			expectedStats: tsdb.BlockStats{
+				NumSamples: 13,
+				NumSeries:  2,
+				NumChunks:  2,
+			},
+		},
+		{
+			name: "1 block + relabel modifier, series deleted because of no labels left after relabel",
+			input: [][]seriesSamples{
+				{
+					{lset: labels.Labels{{Name: "a", Value: "1"}},
+						chunks: [][]sample{{{0, 0}, {1, 1}, {2, 2}}, {{10, 10}, {11, 11}, {20, 20}, {25, 25}}}},
+				},
+				{
+					{lset: labels.Labels{{Name: "a", Value: "2"}},
+						chunks: [][]sample{{{0, 0}, {1, 1}, {2, 2}}, {{10, 10}, {11, 11}, {20, 20}, {25, 25}}}},
+				},
+			},
+			// Drop all label name "a".
+			modifiers: []Modifier{WithRelabelModifier(
+				&relabel.Config{
+					Action: relabel.LabelDrop,
+					Regex:  relabel.MustNewRegexp("a"),
+				},
+			)},
+			expected:        nil,
+			expectedChanges: "Deleted {a=\"1\"} [{0 25}]\nDeleted {a=\"2\"} [{0 25}]\n",
+			expectedStats: tsdb.BlockStats{
+				NumSamples: 0,
+				NumSeries:  0,
+				NumChunks:  0,
+			},
+		},
+		{
+			name: "1 block + relabel modifier, series 1 is deleted because of no labels left after relabel",
+			input: [][]seriesSamples{
+				{
+					{lset: labels.Labels{{Name: "a", Value: "1"}},
+						chunks: [][]sample{{{0, 0}, {1, 1}, {2, 2}}, {{10, 10}, {11, 11}, {20, 20}, {25, 25}}}},
+				},
+				{
+					{lset: labels.Labels{{Name: "a", Value: "2"}, {Name: "b", Value: "1"}},
+						chunks: [][]sample{{{0, 0}, {1, 1}, {2, 2}}, {{10, 10}, {11, 11}, {20, 20}, {25, 25}}}},
+				},
+			},
+			// Drop all label name "a".
+			modifiers: []Modifier{WithRelabelModifier(
+				&relabel.Config{
+					Action: relabel.LabelDrop,
+					Regex:  relabel.MustNewRegexp("a"),
+				},
+			)},
+			expected: []seriesSamples{
+				{lset: labels.Labels{{Name: "b", Value: "1"}},
+					chunks: [][]sample{{{0, 0}, {1, 1}, {2, 2}, {10, 10}, {11, 11}, {20, 20}, {25, 25}}}},
+			},
+			expectedChanges: "Deleted {a=\"1\"} [{0 25}]\nRelabelled {a=\"2\", b=\"1\"} {b=\"1\"}\n",
+			expectedStats: tsdb.BlockStats{
+				NumSamples: 7,
+				NumSeries:  1,
+				NumChunks:  1,
+			},
+		},
+		{
+			name: "1 block + relabel modifier, series merged after relabeling",
+			input: [][]seriesSamples{
+				{
+					{lset: labels.Labels{{Name: "a", Value: "1"}},
+						chunks: [][]sample{{{1, 1}, {2, 2}, {10, 10}, {20, 20}}}},
+					{lset: labels.Labels{{Name: "a", Value: "2"}},
+						chunks: [][]sample{{{0, 0}, {2, 2}, {3, 3}}, {{4, 4}, {11, 11}, {20, 20}, {25, 25}}}},
+				},
+			},
+			// Drop all label name "a".
+			modifiers: []Modifier{WithRelabelModifier(
+				&relabel.Config{
+					Action:       relabel.Replace,
+					Regex:        relabel.MustNewRegexp("1|2"),
+					SourceLabels: model.LabelNames{"a"},
+					TargetLabel:  "a",
+					Replacement:  "0",
+				},
+			)},
+			expected: []seriesSamples{
+				{lset: labels.Labels{{Name: "a", Value: "0"}},
+					chunks: [][]sample{{{0, 0}, {1, 1}, {2, 2}, {3, 3}, {4, 4}, {10, 10}, {11, 11}, {20, 20}, {25, 25}}}},
+			},
+			expectedChanges: "Relabelled {a=\"1\"} {a=\"0\"}\nRelabelled {a=\"2\"} {a=\"0\"}\n",
+			expectedStats: tsdb.BlockStats{
+				NumSamples: 9,
+				NumSeries:  1,
+				NumChunks:  1,
 			},
 		},
 	} {

--- a/pkg/compactv2/compactor_test.go
+++ b/pkg/compactv2/compactor_test.go
@@ -401,7 +401,7 @@ func TestCompactor_WriteSeries_e2e(t *testing.T) {
 			},
 		},
 		{
-			name: "1 block + relabel modifier, separate chunks from the same series are merged",
+			name: "1 block + relabel modifier, two chunks from the same series are merged into one larger chunk",
 			input: [][]seriesSamples{
 				{
 					{lset: labels.Labels{{Name: "a", Value: "1"}},
@@ -412,7 +412,7 @@ func TestCompactor_WriteSeries_e2e(t *testing.T) {
 			modifiers: []Modifier{WithRelabelModifier(
 				&relabel.Config{
 					Action:       relabel.Drop,
-					Regex:        relabel.MustNewRegexp("2"),
+					Regex:        relabel.MustNewRegexp("no-match"),
 					SourceLabels: model.LabelNames{"a"},
 				},
 			)},
@@ -565,7 +565,7 @@ func TestCompactor_WriteSeries_e2e(t *testing.T) {
 						chunks: [][]sample{{{0, 0}, {2, 2}, {3, 3}}, {{4, 4}, {11, 11}, {20, 20}, {25, 25}}}},
 				},
 			},
-			// Drop all label name "a".
+			// Replace values of label name "a" with "0".
 			modifiers: []Modifier{WithRelabelModifier(
 				&relabel.Config{
 					Action:       relabel.Replace,


### PR DESCRIPTION
Signed-off-by: yeya24 <yb532204897@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->
Fixes #3069 

Add relabel support to bucket rewrite.

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

Add a `RelabelModifier` for blocks relabeling. Unlike the deletion modifier which is used in a streaming way, `RelabelModifier` cannot do this and the reasons are:

1. Relabeling might add new symbols so I have to modify the symbol set and sort it before returning it. Besides, symbols can be deleted because the whole series might be dropped via relabeling.
2. Series are not ordered as relabeling might change the order of series.

These requirements mean that I have to sort almost all the things in the constructor. It is inefficient but currently I don't find a better way to solve it.

## Verification

<!-- How you tested it? How do you know it works? -->

Unit tests added and manual testing.
