### PR TITLE
Fix rewrite chunk reuse reference

### DIFF
--- a/pkg/compactv2/chunk_series_set.go
+++ b/pkg/compactv2/chunk_series_set.go
@@ -47,16 +47,17 @@ func (s *lazyPopulateChunkSeriesSet) Next() bool {
 			continue
 		}
 
+		chks := make([]chunks.Meta, len(s.bufChks))
+		copy(chks, s.bufChks)
 		for i := range s.bufChks {
-			s.bufChks[i].Chunk = &lazyPopulatableChunk{cr: s.sReader.cr, m: &s.bufChks[i]}
+			chks[i].Chunk = &lazyPopulatableChunk{cr: s.sReader.cr, m: &chks[i]}
 		}
 		s.curr = &storage.ChunkSeriesEntry{
 			Lset: make(labels.Labels, len(s.bufLbls)),
 			ChunkIteratorFn: func() chunks.Iterator {
-				return storage.NewListChunkSeriesIterator(s.bufChks...)
+				return storage.NewListChunkSeriesIterator(chks...)
 			},
 		}
-		// TODO: Do we need to copy this?
 		copy(s.curr.Lset, s.bufLbls)
 		return true
 	}


### PR DESCRIPTION
Signed-off-by: yeya24 <yb532204897@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

Fix buf chunks reuse. 

``` go
s.bufChks[i].Chunk = &lazyPopulatableChunk{cr: s.sReader.cr, m: &s.bufChks[i]}
```

Here `m` is a reference to the buffered chunk, we should use a copy instead.
I can reproduce this problem while adding tests for https://github.com/thanos-io/thanos/pull/3707.

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
