### PR TITLE
Add `--query-range.request-downsampled` flag to Query Frontend (#2641)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ We use _breaking :warning:_ to mark changes that are not backward compatible (re
 ### Added
 
 - [#3700](https://github.com/thanos-io/thanos/pull/3700) ui: make old bucket viewer UI work with vanilla Prometheus blocks
+- [#2641](https://github.com/thanos-io/thanos/issues/2641) Query Frontend: Added `--query-range.request-downsampled` flag enabling additional queries for downsampled data in case of empty or incomplete response to range request.
 
 ### Changed
 

--- a/cmd/thanos/query_frontend.go
+++ b/cmd/thanos/query_frontend.go
@@ -65,6 +65,9 @@ func registerQueryFrontend(app *extkingpin.App) {
 	cmd.Flag("query-range.align-range-with-step", "Mutate incoming queries to align their start and end with their step for better cache-ability. Note: Grafana dashboards do that by default.").
 		Default("true").BoolVar(&cfg.QueryRangeConfig.AlignRangeWithStep)
 
+	cmd.Flag("query-range.request-downsampled", "Make additional query for downsampled data in case of empty or incomplete response to range request.").
+		Default("true").BoolVar(&cfg.QueryRangeConfig.RequestDownsampled)
+
 	cmd.Flag("query-range.split-interval", "Split query range requests by an interval and execute in parallel, it should be greater than 0 when query-range.response-cache-config is configured.").
 		Default("24h").DurationVar(&cfg.QueryRangeConfig.SplitQueriesByInterval)
 

--- a/docs/components/query-frontend.md
+++ b/docs/components/query-frontend.md
@@ -147,6 +147,10 @@ Flags:
                                  and end with their step for better
                                  cache-ability. Note: Grafana dashboards do that
                                  by default.
+      --query-range.request-downsampled
+                                 Make additional query for downsampled data in
+                                 case of empty or incomplete response to range
+                                 request.
       --query-range.split-interval=24h
                                  Split query range requests by an interval and
                                  execute in parallel, it should be greater than

--- a/pkg/queryfrontend/config.go
+++ b/pkg/queryfrontend/config.go
@@ -162,6 +162,7 @@ type QueryRangeConfig struct {
 	CachePathOrContent extflag.PathOrContent
 
 	AlignRangeWithStep     bool
+	RequestDownsampled     bool
 	SplitQueriesByInterval time.Duration
 	MaxRetries             int
 	Limits                 *cortexvalidation.Limits

--- a/pkg/queryfrontend/downsampled.go
+++ b/pkg/queryfrontend/downsampled.go
@@ -1,0 +1,103 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package queryfrontend
+
+import (
+	"context"
+
+	"github.com/cortexproject/cortex/pkg/querier/queryrange"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/thanos-io/thanos/pkg/compact/downsample"
+)
+
+// DownsampledMiddleware creates a new Middleware that requests downsampled data
+// should response to original request with auto max_source_resolution not contain data points.
+func DownsampledMiddleware(merger queryrange.Merger, registerer prometheus.Registerer) queryrange.Middleware {
+	return queryrange.MiddlewareFunc(func(next queryrange.Handler) queryrange.Handler {
+		return downsampled{
+			next:   next,
+			merger: merger,
+			extraCounter: promauto.With(registerer).NewCounter(prometheus.CounterOpts{
+				Namespace: "thanos",
+				Name:      "frontend_downsampled_extra_queries_total",
+				Help:      "Total number of extra queries for downsampled data",
+			}),
+		}
+	})
+}
+
+type downsampled struct {
+	next   queryrange.Handler
+	merger queryrange.Merger
+
+	// Metrics.
+	extraCounter prometheus.Counter
+}
+
+var resolutions = []int64{downsample.ResLevel1, downsample.ResLevel2}
+
+func (d downsampled) Do(ctx context.Context, req queryrange.Request) (queryrange.Response, error) {
+	tqrr, ok := req.(*ThanosQueryRangeRequest)
+	if !ok || !tqrr.AutoDownsampling {
+		return d.next.Do(ctx, req)
+	}
+
+	var (
+		resps = make([]queryrange.Response, 0)
+		resp  queryrange.Response
+		err   error
+		i     int
+	)
+
+forLoop:
+	for i < len(resolutions) {
+		if i > 0 {
+			d.extraCounter.Inc()
+		}
+		r := *tqrr
+		resp, err = d.next.Do(ctx, &r)
+		if err != nil {
+			return nil, err
+		}
+		resps = append(resps, resp)
+		// Set MaxSourceResolution for next request, if any.
+		for i < len(resolutions) {
+			if tqrr.MaxSourceResolution < resolutions[i] {
+				tqrr.AutoDownsampling = false
+				tqrr.MaxSourceResolution = resolutions[i]
+				break
+			}
+			i++
+		}
+		m := minResponseTime(resp)
+		switch m {
+		case tqrr.Start: // Response not impacted by retention policy.
+			break forLoop
+		case -1: // Empty response, retry with higher MaxSourceResolution.
+			continue
+		default: // Data partially present, query for empty part with higher MaxSourceResolution.
+			tqrr.End = m - tqrr.Step
+		}
+		if tqrr.Start > tqrr.End {
+			break forLoop
+		}
+	}
+	response, err := d.merger.MergeResponse(resps...)
+	if err != nil {
+		return nil, err
+	}
+	return response, nil
+}
+
+func minResponseTime(r queryrange.Response) int64 {
+	var res = r.(*queryrange.PrometheusResponse).Data.Result
+	if len(res) == 0 {
+		return -1
+	}
+	if len(res[0].Samples) == 0 {
+		return -1
+	}
+	return res[0].Samples[0].TimestampMs
+}

--- a/pkg/queryfrontend/downsampled.go
+++ b/pkg/queryfrontend/downsampled.go
@@ -19,10 +19,10 @@ func DownsampledMiddleware(merger queryrange.Merger, registerer prometheus.Regis
 		return downsampled{
 			next:   next,
 			merger: merger,
-			extraCounter: promauto.With(registerer).NewCounter(prometheus.CounterOpts{
+			additionalQueriesCount: promauto.With(registerer).NewCounter(prometheus.CounterOpts{
 				Namespace: "thanos",
 				Name:      "frontend_downsampled_extra_queries_total",
-				Help:      "Total number of extra queries for downsampled data",
+				Help:      "Total number of additional queries for downsampled data",
 			}),
 		}
 	})
@@ -33,7 +33,7 @@ type downsampled struct {
 	merger queryrange.Merger
 
 	// Metrics.
-	extraCounter prometheus.Counter
+	additionalQueriesCount prometheus.Counter
 }
 
 var resolutions = []int64{downsample.ResLevel1, downsample.ResLevel2}
@@ -54,7 +54,7 @@ func (d downsampled) Do(ctx context.Context, req queryrange.Request) (queryrange
 forLoop:
 	for i < len(resolutions) {
 		if i > 0 {
-			d.extraCounter.Inc()
+			d.additionalQueriesCount.Inc()
 		}
 		r := *tqrr
 		resp, err = d.next.Do(ctx, &r)

--- a/pkg/queryfrontend/roundtrip.go
+++ b/pkg/queryfrontend/roundtrip.go
@@ -131,7 +131,7 @@ func getOperation(r *http.Request) string {
 }
 
 // newQueryRangeTripperware returns a Tripperware for range queries configured with middlewares of
-// limit, step align, split by interval, cache requests and retry.
+// limit, step align, downsampled, split by interval, cache requests and retry.
 func newQueryRangeTripperware(
 	config QueryRangeConfig,
 	limits queryrange.Limits,
@@ -148,6 +148,14 @@ func newQueryRangeTripperware(
 			queryRangeMiddleware,
 			queryrange.InstrumentMiddleware("step_align", m),
 			queryrange.StepAlignMiddleware,
+		)
+	}
+
+	if config.RequestDownsampled {
+		queryRangeMiddleware = append(
+			queryRangeMiddleware,
+			queryrange.InstrumentMiddleware("downsampled", m),
+			DownsampledMiddleware(codec, reg),
 		)
 	}
 


### PR DESCRIPTION
Signed-off-by: Vladimir Kononov <krya-kryak@users.noreply.github.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

- [#2641](https://github.com/thanos-io/thanos/issues/2641) Query Frontend: Added `--query-range.request-downsampled` flag enabling additional queries for downsampled data in case of empty or incomplete response to range request.

This is needed to zoom into past, where raw and/or 5m datapoints could be lacking due to retention policies.

Q: Why query-frontend instead of query?
A: Query currently has no concept of modifying queries, while query-frontend does. Secondly, at the moment query seems to have no cortex dependencies, and cortex's matrix merger is a convenient thing.

## Verification

Here are screenshots for the same queries made against the very same underlying thanos-query. Please excuse the quality. For those struggling to make sense of the pixelated mess, all requests are the same, all set to a particular time window in the past, the only difference is downsample picker, set to "Max 5m downsampling", "Max 1h downsampling", "auto downsampling" respectively. 5m points are half-gone at this point due to retention strategy, while 1h points are still present. Note "auto downsampling" actually producing sensible graph preserving maximum amount of infromation: 
![before-after](https://user-images.githubusercontent.com/1035472/104727855-1c0f6e80-5747-11eb-9499-2400f4883780.png)