### PR TITLE
Api: Add flag to set default step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ We use _breaking :warning:_ to mark changes that are not backward compatible (re
 
 ### Added
 
+- [#3740](https://github.com/thanos-io/thanos/pull/3740) Query: Added `--query.default-set` flag to set default step.
 - [#3700](https://github.com/thanos-io/thanos/pull/3700) ui: make old bucket viewer UI work with vanilla Prometheus blocks
 - [#2641](https://github.com/thanos-io/thanos/issues/2641) Query Frontend: Added `--query-range.request-downsampled` flag enabling additional queries for downsampled data in case of empty or incomplete response to range request.
 - [#3792](https://github.com/thanos-io/thanos/pull/3792) Receiver: Added `--tsdb.allow-overlapping-blocks` flag to allow overlapping tsdb blocks and enable vertical compaction

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ We use _breaking :warning:_ to mark changes that are not backward compatible (re
 
 ### Added
 
-- [#3740](https://github.com/thanos-io/thanos/pull/3740) Query: Added `--query.default-set` flag to set default step.
+- [#3740](https://github.com/thanos-io/thanos/pull/3740) Query: Added `--query.default-step` flag to set default step.
 - [#3700](https://github.com/thanos-io/thanos/pull/3700) ui: make old bucket viewer UI work with vanilla Prometheus blocks
 - [#2641](https://github.com/thanos-io/thanos/issues/2641) Query Frontend: Added `--query-range.request-downsampled` flag enabling additional queries for downsampled data in case of empty or incomplete response to range request.
 - [#3792](https://github.com/thanos-io/thanos/pull/3792) Receiver: Added `--tsdb.allow-overlapping-blocks` flag to allow overlapping tsdb blocks and enable vertical compaction

--- a/Makefile
+++ b/Makefile
@@ -171,7 +171,7 @@ docs: ## Regenerates flags in docs for all thanos commands.
 docs: $(EMBEDMD) build
 	@echo ">> generating docs"
 	@EMBEDMD_BIN="$(EMBEDMD)" SED_BIN="$(SED)" THANOS_BIN="$(GOBIN)/thanos"  scripts/genflagdocs.sh
-	@echo ">> cleaning whte noise"
+	@echo ">> cleaning white noise"
 	@find . -type f -name "*.md" | SED_BIN="$(SED)" xargs scripts/cleanup-white-noise.sh
 
 .PHONY: check-docs

--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -125,6 +125,9 @@ func registerQuery(app *extkingpin.App) {
 
 	defaultEvaluationInterval := extkingpin.ModelDuration(cmd.Flag("query.default-evaluation-interval", "Set default evaluation interval for sub queries.").Default("1m"))
 
+	defaultRangeQueryStep := extkingpin.ModelDuration(cmd.Flag("query.default-step", "Set default step for range queries").
+		Default("1s"))
+
 	storeResponseTimeout := extkingpin.ModelDuration(cmd.Flag("store.response-timeout", "If a Store doesn't send any data in this specified duration then a Store will be ignored and partial data will be returned if it's enabled. 0 disables timeout.").Default("0ms"))
 
 	cmd.Setup(func(g *run.Group, logger log.Logger, reg *prometheus.Registry, tracer opentracing.Tracer, _ <-chan struct{}, _ bool) error {
@@ -181,6 +184,7 @@ func registerQuery(app *extkingpin.App) {
 			*webPrefixHeaderName,
 			*maxConcurrentQueries,
 			*maxConcurrentSelects,
+			time.Duration(*defaultRangeQueryStep),
 			time.Duration(*queryTimeout),
 			*lookbackDelta,
 			*dynamicLookbackDelta,
@@ -231,6 +235,7 @@ func runQuery(
 	webPrefixHeaderName string,
 	maxConcurrentQueries int,
 	maxConcurrentSelects int,
+	defaultRangeQueryStep time.Duration,
 	queryTimeout time.Duration,
 	lookbackDelta time.Duration,
 	dynamicLookbackDelta bool,
@@ -454,6 +459,7 @@ func runQuery(
 			enableRulePartialResponse,
 			queryReplicaLabels,
 			flagsMap,
+			defaultRangeQueryStep,
 			instantDefaultMaxSourceResolution,
 			defaultMetadataTimeRange,
 			gate.New(

--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -125,7 +125,7 @@ func registerQuery(app *extkingpin.App) {
 
 	defaultEvaluationInterval := extkingpin.ModelDuration(cmd.Flag("query.default-evaluation-interval", "Set default evaluation interval for sub queries.").Default("1m"))
 
-	defaultRangeQueryStep := extkingpin.ModelDuration(cmd.Flag("query.default-step", "Set default step for range queries").
+	defaultRangeQueryStep := extkingpin.ModelDuration(cmd.Flag("query.default-step", "Set default step for range queries. Default step is only used when step is not set in UI. In such cases, Thanos UI will use default step to calculate resolution (resolution = max(rangeSeconds / 250, defaultStep)). This will not work from Grafana, but Grafana has __step variable which can be used.").
 		Default("1s"))
 
 	storeResponseTimeout := extkingpin.ModelDuration(cmd.Flag("store.response-timeout", "If a Store doesn't send any data in this specified duration then a Store will be ignored and partial data will be returned if it's enabled. 0 disables timeout.").Default("0ms"))

--- a/docs/components/query.md
+++ b/docs/components/query.md
@@ -432,7 +432,7 @@ Flags:
                                  step is only used when step is not set in UI.
                                  In such cases, Thanos UI will use default step
                                  to calculate resolution (resolution =
-                                 min(rangeSeconds / 250, defaultStep)). This
+                                 max(rangeSeconds / 250, defaultStep)). This
                                  will not work from Grafana, but Grafana has
                                  __step variable which can be used.
       --store.response-timeout=0ms

--- a/docs/components/query.md
+++ b/docs/components/query.md
@@ -428,6 +428,7 @@ Flags:
       --query.default-evaluation-interval=1m
                                  Set default evaluation interval for sub
                                  queries.
+      --query.default-step=1s    Set default step for range queries
       --store.response-timeout=0ms
                                  If a Store doesn't send any data in this
                                  specified duration then a Store will be ignored

--- a/docs/components/query.md
+++ b/docs/components/query.md
@@ -428,7 +428,13 @@ Flags:
       --query.default-evaluation-interval=1m
                                  Set default evaluation interval for sub
                                  queries.
-      --query.default-step=1s    Set default step for range queries
+      --query.default-step=1s    Set default step for range queries. Default
+                                 step is only used when step is not set in UI.
+                                 In such cases, Thanos UI will use default step
+                                 to calculate resolution (resolution =
+                                 min(rangeSeconds / 250, defaultStep)). This
+                                 will not work from Grafana, but Grafana has
+                                 __step variable which can be used.
       --store.response-timeout=0ms
                                  If a Store doesn't send any data in this
                                  specified duration then a Store will be ignored

--- a/pkg/api/query/v1.go
+++ b/pkg/api/query/v1.go
@@ -77,6 +77,7 @@ type QueryAPI struct {
 	replicaLabels []string
 	storeSet      *query.StoreSet
 
+	defaultRangeQueryStep                  time.Duration
 	defaultInstantQueryMaxSourceResolution time.Duration
 	defaultMetadataTimeRange               time.Duration
 }
@@ -93,6 +94,7 @@ func NewQueryAPI(
 	enableRulePartialResponse bool,
 	replicaLabels []string,
 	flagsMap map[string]string,
+	defaultRangeQueryStep time.Duration,
 	defaultInstantQueryMaxSourceResolution time.Duration,
 	defaultMetadataTimeRange time.Duration,
 	gate gate.Gate,
@@ -110,6 +112,7 @@ func NewQueryAPI(
 		enableRulePartialResponse:              enableRulePartialResponse,
 		replicaLabels:                          replicaLabels,
 		storeSet:                               storeSet,
+		defaultRangeQueryStep:                  defaultRangeQueryStep,
 		defaultInstantQueryMaxSourceResolution: defaultInstantQueryMaxSourceResolution,
 		defaultMetadataTimeRange:               defaultMetadataTimeRange,
 	}
@@ -225,6 +228,19 @@ func (qapi *QueryAPI) parsePartialResponseParam(r *http.Request, defaultEnablePa
 	return defaultEnablePartialResponse, nil
 }
 
+func (qapi *QueryAPI) parseStep(r *http.Request, defaultRangeQueryStep time.Duration) (step time.Duration, _ *api.ApiError) {
+	// Overwrite the cli flag when provided as a query parameter.
+	if val := r.FormValue("step"); val != "" {
+		var err error
+		defaultRangeQueryStep, err = parseDuration(val)
+		if err != nil {
+			return 0, &api.ApiError{Typ: api.ErrorBadData, Err: errors.Wrapf(err, "'%s' parameter", defaultRangeQueryStep)}
+		}
+	}
+
+	return defaultRangeQueryStep, nil
+}
+
 func (qapi *QueryAPI) query(r *http.Request) (interface{}, []error, *api.ApiError) {
 	ts, err := parseTimeParam(r, "time", qapi.baseAPI.Now())
 	if err != nil {
@@ -320,9 +336,9 @@ func (qapi *QueryAPI) queryRange(r *http.Request) (interface{}, []error, *api.Ap
 		return nil, nil, &api.ApiError{Typ: api.ErrorBadData, Err: err}
 	}
 
-	step, err := parseDuration(r.FormValue("step"))
+	step, apiErr := qapi.parseStep(r, qapi.defaultRangeQueryStep)
 	if err != nil {
-		return nil, nil, &api.ApiError{Typ: api.ErrorBadData, Err: errors.Wrap(err, "param step")}
+		return nil, nil, apiErr
 	}
 
 	if step <= 0 {

--- a/pkg/api/query/v1.go
+++ b/pkg/api/query/v1.go
@@ -58,6 +58,7 @@ const (
 	ReplicaLabelsParam       = "replicaLabels[]"
 	MatcherParam             = "match[]"
 	StoreMatcherParam        = "storeMatch[]"
+	Step                     = "step"
 )
 
 // QueryAPI is an API used by Thanos Querier.
@@ -228,17 +229,19 @@ func (qapi *QueryAPI) parsePartialResponseParam(r *http.Request, defaultEnablePa
 	return defaultEnablePartialResponse, nil
 }
 
-func (qapi *QueryAPI) parseStep(r *http.Request, defaultRangeQueryStep time.Duration) (step time.Duration, _ *api.ApiError) {
+func (qapi *QueryAPI) parseStep(r *http.Request, defaultRangeQueryStep time.Duration, rangeSeconds int64) (step time.Duration, _ *api.ApiError) {
 	// Overwrite the cli flag when provided as a query parameter.
-	if val := r.FormValue("step"); val != "" {
+	if val := r.FormValue(Step); val != "" {
 		var err error
 		defaultRangeQueryStep, err = parseDuration(val)
 		if err != nil {
-			return 0, &api.ApiError{Typ: api.ErrorBadData, Err: errors.Wrapf(err, "'%s' parameter", defaultRangeQueryStep)}
+			return 0, &api.ApiError{Typ: api.ErrorBadData, Err: errors.Wrapf(err, "'%s' parameter", Step)}
 		}
 	}
 
-	return defaultRangeQueryStep, nil
+	// Default step is used this way to make it consistent with UI
+	d := time.Duration(math.Max(float64(rangeSeconds/250), float64(defaultRangeQueryStep/time.Second))) * time.Second
+	return d, nil
 }
 
 func (qapi *QueryAPI) query(r *http.Request) (interface{}, []error, *api.ApiError) {
@@ -336,7 +339,7 @@ func (qapi *QueryAPI) queryRange(r *http.Request) (interface{}, []error, *api.Ap
 		return nil, nil, &api.ApiError{Typ: api.ErrorBadData, Err: err}
 	}
 
-	step, apiErr := qapi.parseStep(r, qapi.defaultRangeQueryStep)
+	step, apiErr := qapi.parseStep(r, qapi.defaultRangeQueryStep, int64(end.Sub(start)/time.Second))
 	if err != nil {
 		return nil, nil, apiErr
 	}

--- a/pkg/api/query/v1.go
+++ b/pkg/api/query/v1.go
@@ -229,7 +229,7 @@ func (qapi *QueryAPI) parsePartialResponseParam(r *http.Request, defaultEnablePa
 	return defaultEnablePartialResponse, nil
 }
 
-func (qapi *QueryAPI) parseStep(r *http.Request, defaultRangeQueryStep time.Duration, rangeSeconds int64) (step time.Duration, _ *api.ApiError) {
+func (qapi *QueryAPI) parseStep(r *http.Request, defaultRangeQueryStep time.Duration, rangeSeconds int64) (time.Duration, *api.ApiError) {
 	// Overwrite the cli flag when provided as a query parameter.
 	if val := r.FormValue(Step); val != "" {
 		var err error

--- a/pkg/api/query/v1.go
+++ b/pkg/api/query/v1.go
@@ -239,7 +239,7 @@ func (qapi *QueryAPI) parseStep(r *http.Request, defaultRangeQueryStep time.Dura
 		}
 	}
 
-	// Default step is used this way to make it consistent with UI
+	// Default step is used this way to make it consistent with UI.
 	d := time.Duration(math.Max(float64(rangeSeconds/250), float64(defaultRangeQueryStep/time.Second))) * time.Second
 	return d, nil
 }

--- a/pkg/api/query/v1_test.go
+++ b/pkg/api/query/v1_test.go
@@ -482,7 +482,7 @@ func TestQueryEndpoints(t *testing.T) {
 				},
 			},
 		},
-		// Use default step when missing
+		// Use default step when missing.
 		{
 			endpoint: api.queryRange,
 			query: url.Values{

--- a/pkg/api/query/v1_test.go
+++ b/pkg/api/query/v1_test.go
@@ -184,7 +184,8 @@ func TestQueryEndpoints(t *testing.T) {
 		queryEngine: func(int64) *promql.Engine {
 			return qe
 		},
-		gate: gate.New(nil, 4),
+		gate:                  gate.New(nil, 4),
+		defaultRangeQueryStep: time.Second,
 	}
 
 	start := time.Unix(0, 0)
@@ -481,6 +482,28 @@ func TestQueryEndpoints(t *testing.T) {
 				},
 			},
 		},
+		// Use default step when missing
+		{
+			endpoint: api.queryRange,
+			query: url.Values{
+				"query": []string{"time()"},
+				"start": []string{"0"},
+				"end":   []string{"2"},
+			},
+			response: &queryData{
+				ResultType: parser.ValueTypeMatrix,
+				Result: promql.Matrix{
+					promql.Series{
+						Points: []promql.Point{
+							{V: 0, T: timestamp.FromTime(start)},
+							{V: 1, T: timestamp.FromTime(start.Add(1 * time.Second))},
+							{V: 2, T: timestamp.FromTime(start.Add(2 * time.Second))},
+						},
+						Metric: nil,
+					},
+				},
+			},
+		},
 		// Missing query params in range queries.
 		{
 			endpoint: api.queryRange,
@@ -497,15 +520,6 @@ func TestQueryEndpoints(t *testing.T) {
 				"query": []string{"time()"},
 				"start": []string{"0"},
 				"step":  []string{"1"},
-			},
-			errType: baseAPI.ErrorBadData,
-		},
-		{
-			endpoint: api.queryRange,
-			query: url.Values{
-				"query": []string{"time()"},
-				"start": []string{"0"},
-				"end":   []string{"2"},
 			},
 			errType: baseAPI.ErrorBadData,
 		},

--- a/pkg/ui/react-app/src/pages/flags/Flags.tsx
+++ b/pkg/ui/react-app/src/pages/flags/Flags.tsx
@@ -5,7 +5,7 @@ import { withStatusIndicator } from '../../components/withStatusIndicator';
 import { useFetch } from '../../hooks/useFetch';
 import PathPrefixProps from '../../types/PathPrefixProps';
 
-interface FlagMap {
+export interface FlagMap {
   [key: string]: string;
 }
 

--- a/pkg/ui/react-app/src/pages/graph/Panel.tsx
+++ b/pkg/ui/react-app/src/pages/graph/Panel.tsx
@@ -15,6 +15,7 @@ import QueryStatsView, { QueryStats } from './QueryStatsView';
 import { Store } from '../../thanos/pages/stores/store';
 import PathPrefixProps from '../../types/PathPrefixProps';
 import { QueryParams } from '../../types/types';
+import { parseRange } from '../../utils/index';
 
 interface PanelProps {
   id: string;
@@ -27,6 +28,7 @@ interface PanelProps {
   onExecuteQuery: (query: string) => void;
   stores: Store[];
   enableAutocomplete: boolean;
+  defaultStep: string;
 }
 
 interface PanelState {
@@ -140,7 +142,9 @@ class Panel extends Component<PanelProps & PathPrefixProps, PanelState> {
 
     const endTime = this.getEndTime().valueOf() / 1000; // TODO: shouldn't valueof only work when it's a moment?
     const startTime = endTime - this.props.options.range;
-    const resolution = this.props.options.resolution || Math.max(Math.floor(this.props.options.range / 250), 1);
+    const resolution =
+      this.props.options.resolution ||
+      Math.max(Math.floor(this.props.options.range / 250), parseRange(this.props.defaultStep) as number);
     const params: URLSearchParams = new URLSearchParams({
       query: expr,
       dedup: this.props.options.useDeduplication.toString(),

--- a/pkg/ui/react-app/src/pages/graph/PanelList.tsx
+++ b/pkg/ui/react-app/src/pages/graph/PanelList.tsx
@@ -7,6 +7,7 @@ import Checkbox from '../../components/Checkbox';
 import PathPrefixProps from '../../types/PathPrefixProps';
 import { StoreListProps } from '../../thanos/pages/stores/Stores';
 import { Store } from '../../thanos/pages/stores/store';
+import { FlagMap } from '../flags/Flags';
 import { generateID, decodePanelOptionsFromQueryString, encodePanelOptionsToQueryString, callAll } from '../../utils';
 import { useFetch } from '../../hooks/useFetch';
 import { useLocalStorage } from '../../hooks/useLocalStorage';
@@ -26,6 +27,7 @@ interface PanelListProps extends PathPrefixProps, RouteComponentProps {
   queryHistoryEnabled: boolean;
   stores: StoreListProps;
   enableAutocomplete: boolean;
+  defaultStep: string;
 }
 
 export const PanelListContent: FC<PanelListProps> = ({
@@ -35,6 +37,7 @@ export const PanelListContent: FC<PanelListProps> = ({
   queryHistoryEnabled,
   stores = {},
   enableAutocomplete,
+  defaultStep,
   ...rest
 }) => {
   const [panels, setPanels] = useState(rest.panels);
@@ -117,6 +120,7 @@ export const PanelListContent: FC<PanelListProps> = ({
           pathPrefix={pathPrefix}
           stores={storeData}
           enableAutocomplete={enableAutocomplete}
+          defaultStep={defaultStep}
         />
       ))}
       <Button className="d-block mb-3" color="primary" onClick={addPanel}>
@@ -137,8 +141,10 @@ const PanelList: FC<RouteComponentProps & PathPrefixProps> = ({ pathPrefix = '' 
 
   const { response: metricsRes, error: metricsErr } = useFetch<string[]>(`${pathPrefix}/api/v1/label/__name__/values`);
   const { response: storesRes, error: storesErr, isLoading: storesLoading } = useFetch<StoreListProps>(
-    `${pathPrefix}/api/v1/stores`
-  );
+      `${pathPrefix}/api/v1/stores`
+      );
+  const { response: flagsRes, error: flagsErr, isLoading:flagsLoading } = useFetch<FlagMap>(`${pathPrefix}/api/v1/status/flags`);
+  let defaultStep = flagsRes.data ? flagsRes.data['query.default-step'] : "";
 
   const browserTime = new Date().getTime() / 1000;
   const { response: timeRes, error: timeErr } = useFetch<{ result: number[] }>(`${pathPrefix}/api/v1/query?query=time()`);
@@ -210,6 +216,12 @@ const PanelList: FC<RouteComponentProps & PathPrefixProps> = ({ pathPrefix = '' 
           Error fetching stores list: Unexpected response status when fetching stores: {storesErr.message}
         </UncontrolledAlert>
       )}
+      {flagsErr && (
+        <UncontrolledAlert color="danger">
+          <strong>Warning: </strong>
+          Error fetching flags list: Unexpected response status when fetching flags: {flagsErr.message}
+        </UncontrolledAlert>
+      )}
       <PanelListContentWithIndicator
         panels={decodePanelOptionsFromQueryString(window.location.search)}
         pathPrefix={pathPrefix}
@@ -217,8 +229,9 @@ const PanelList: FC<RouteComponentProps & PathPrefixProps> = ({ pathPrefix = '' 
         metrics={metricsRes.data}
         stores={debugMode ? storesRes.data : {}}
         enableAutocomplete={enableAutocomplete}
+        defaultStep={defaultStep}
         queryHistoryEnabled={enableQueryHistory}
-        isLoading={storesLoading}
+        isLoading={storesLoading || flagsLoading}
       />
     </>
   );

--- a/pkg/ui/react-app/src/pages/graph/PanelList.tsx
+++ b/pkg/ui/react-app/src/pages/graph/PanelList.tsx
@@ -146,7 +146,7 @@ const PanelList: FC<RouteComponentProps & PathPrefixProps> = ({ pathPrefix = '' 
   const { response: flagsRes, error: flagsErr, isLoading: flagsLoading } = useFetch<FlagMap>(
     `${pathPrefix}/api/v1/status/flags`
   );
-  const defaultStep = flagsRes.data && 'query.default-step' in flagsRes.data ? flagsRes.data['query.default-step'] : '1s';
+  const defaultStep = flagsRes?.data?.['query.default-step'] || '1s';
 
   const browserTime = new Date().getTime() / 1000;
   const { response: timeRes, error: timeErr } = useFetch<{ result: number[] }>(`${pathPrefix}/api/v1/query?query=time()`);

--- a/pkg/ui/react-app/src/pages/graph/PanelList.tsx
+++ b/pkg/ui/react-app/src/pages/graph/PanelList.tsx
@@ -146,7 +146,7 @@ const PanelList: FC<RouteComponentProps & PathPrefixProps> = ({ pathPrefix = '' 
   const { response: flagsRes, error: flagsErr, isLoading: flagsLoading } = useFetch<FlagMap>(
     `${pathPrefix}/api/v1/status/flags`
   );
-  const defaultStep = flagsRes.data ? flagsRes.data['query.default-step'] : '';
+  const defaultStep = (flagsRes.data && "query.default-step" in flagsRes.data) ? flagsRes.data['query.default-step'] : '1s';
 
   const browserTime = new Date().getTime() / 1000;
   const { response: timeRes, error: timeErr } = useFetch<{ result: number[] }>(`${pathPrefix}/api/v1/query?query=time()`);

--- a/pkg/ui/react-app/src/pages/graph/PanelList.tsx
+++ b/pkg/ui/react-app/src/pages/graph/PanelList.tsx
@@ -146,7 +146,7 @@ const PanelList: FC<RouteComponentProps & PathPrefixProps> = ({ pathPrefix = '' 
   const { response: flagsRes, error: flagsErr, isLoading: flagsLoading } = useFetch<FlagMap>(
     `${pathPrefix}/api/v1/status/flags`
   );
-  const defaultStep = (flagsRes.data && "query.default-step" in flagsRes.data) ? flagsRes.data['query.default-step'] : '1s';
+  const defaultStep = flagsRes.data && 'query.default-step' in flagsRes.data ? flagsRes.data['query.default-step'] : '1s';
 
   const browserTime = new Date().getTime() / 1000;
   const { response: timeRes, error: timeErr } = useFetch<{ result: number[] }>(`${pathPrefix}/api/v1/query?query=time()`);

--- a/pkg/ui/react-app/src/pages/graph/PanelList.tsx
+++ b/pkg/ui/react-app/src/pages/graph/PanelList.tsx
@@ -141,10 +141,12 @@ const PanelList: FC<RouteComponentProps & PathPrefixProps> = ({ pathPrefix = '' 
 
   const { response: metricsRes, error: metricsErr } = useFetch<string[]>(`${pathPrefix}/api/v1/label/__name__/values`);
   const { response: storesRes, error: storesErr, isLoading: storesLoading } = useFetch<StoreListProps>(
-      `${pathPrefix}/api/v1/stores`
-      );
-  const { response: flagsRes, error: flagsErr, isLoading:flagsLoading } = useFetch<FlagMap>(`${pathPrefix}/api/v1/status/flags`);
-  let defaultStep = flagsRes.data ? flagsRes.data['query.default-step'] : "";
+    `${pathPrefix}/api/v1/stores`
+  );
+  const { response: flagsRes, error: flagsErr, isLoading: flagsLoading } = useFetch<FlagMap>(
+    `${pathPrefix}/api/v1/status/flags`
+  );
+  const defaultStep = flagsRes.data ? flagsRes.data['query.default-step'] : '';
 
   const browserTime = new Date().getTime() / 1000;
   const { response: timeRes, error: timeErr } = useFetch<{ result: number[] }>(`${pathPrefix}/api/v1/query?query=time()`);

--- a/pkg/ui/static/js/graph.js
+++ b/pkg/ui/static/js/graph.js
@@ -308,8 +308,8 @@ Prometheus.Graph.prototype.setDefaultStep = function(el) {
                 if(json.status !== "success") {
                     self.showError("Error querying flags.");
                     return;
-                }
-                el.defaultStep = json.data["query.default-step"];
+                } 
+                el.defaultStep = (json.data && "query.default-stp" in json.data) ? json.data["query.default-stp"] : "1s"
                 
             },
             error: function() {

--- a/pkg/ui/static/js/graph.js
+++ b/pkg/ui/static/js/graph.js
@@ -48,6 +48,8 @@ Prometheus.Graph.prototype.initialize = function() {
 	  self.options.max_source_resolution = "0s";
   }
 
+  self.setDefaultStep(this);
+
   // Draw graph controls and container from Handlebars template.
 
   var options = {
@@ -293,6 +295,27 @@ Prometheus.Graph.prototype.initialize = function() {
   if (self.expr.val()) {
     self.submitQuery();
   }
+};
+
+Prometheus.Graph.prototype.setDefaultStep = function(el) {
+    var self = this;
+    $.ajax({
+        method: "GET",
+        url : PATH_PREFIX + "/api/v1/status/flags",
+        async: false,
+        dataType: "json",
+            success: function(json) {
+                if(json.status !== "success") {
+                    self.showError("Error querying flags.");
+                    return;
+                }
+                el.defaultStep = json.data["query.default-step"];
+                
+            },
+            error: function() {
+                self.showError("Error loading flags.");
+            }
+    })
 };
 
 Prometheus.Graph.prototype.checkTimeDrift = function() {
@@ -545,7 +568,7 @@ Prometheus.Graph.prototype.submitQuery = function() {
 
   var startTime = new Date().getTime();
   var rangeSeconds = self.parseDuration(self.rangeInput.val());
-  var resolution = parseInt(self.queryForm.find("input[name=step_input]").val()) || Math.max(Math.floor(rangeSeconds / 250), 1);
+  var resolution = parseInt(self.queryForm.find("input[name=step_input]").val()) || Math.max(Math.floor(rangeSeconds / 250), self.parseDuration(self.defaultStep));
   var maxSourceResolution = self.maxSourceResolutionInput.val()
   var endDate = self.getEndDate() / 1000;
   var moment = self.getMoment() / 1000;


### PR DESCRIPTION
Signed-off-by: Hitanshu Mehta <hitanshu99amehta@gmail.com>

Fixes : #3651 

This PR Adds a new flag `query.default-step` which allows to set step for range queries. This cli flag will be overwritten when step is provided in request parameter. 

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
