### PR TITLE
Create a remote-write Appender for a stateless Ruler

### DIFF
--- a/cmd/thanos/rule.go
+++ b/cmd/thanos/rule.go
@@ -383,7 +383,14 @@ func runRule(
 	)
 
 	if remoteWrite {
-		rw := &thanosrules.RemoteWrite{}
+		remoteWriteConfig, err := thanosrules.LoadRemoteWriteConfig(remoteWriteConfigYAML)
+		if err != nil {
+			return err
+		}
+
+		rw := &thanosrules.RemoteWrite{
+			RemoteWriteConfig: remoteWriteConfig,
+		}
 
 		appendable = rw
 		queryable = rw

--- a/pkg/rules/proxy.go
+++ b/pkg/rules/proxy.go
@@ -10,12 +10,13 @@ import (
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/pkg/errors"
-	"github.com/thanos-io/thanos/pkg/rules/rulespb"
-	"github.com/thanos-io/thanos/pkg/store/storepb"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	"github.com/thanos-io/thanos/pkg/rules/rulespb"
+	"github.com/thanos-io/thanos/pkg/store/storepb"
 )
 
 // Proxy implements rulespb.Rules gRPC that fanouts requests to given rulespb.Rules and deduplication on the way.

--- a/pkg/rules/remote_write.go
+++ b/pkg/rules/remote_write.go
@@ -1,0 +1,112 @@
+package rules
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"sync"
+
+	"github.com/gogo/protobuf/proto"
+	"github.com/golang/snappy"
+	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/prometheus/prompb"
+	"github.com/prometheus/prometheus/storage"
+)
+
+type RemoteWrite struct{}
+
+func (r *RemoteWrite) Appender(ctx context.Context) storage.Appender {
+	return &RemoteWriteAppender{mu: &sync.Mutex{}}
+}
+
+func (r *RemoteWrite) Querier(ctx context.Context, mint, maxt int64) (storage.Querier, error) {
+	return &RemoteWriteQueryable{}, nil
+}
+
+type RemoteWriteAppender struct {
+	mu  *sync.Mutex
+	req prompb.WriteRequest
+}
+
+func (r *RemoteWriteAppender) Add(l labels.Labels, t int64, v float64) (uint64, error) {
+	// TODO: Maybe there's a way of type casting this?
+	var reqLabels []prompb.Label
+	for _, label := range l {
+		reqLabels = append(reqLabels, prompb.Label{
+			Name:  label.Name,
+			Value: label.Value,
+		})
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.req.Timeseries = append(r.req.Timeseries, prompb.TimeSeries{
+		Labels: reqLabels,
+		Samples: []prompb.Sample{{
+			Timestamp: t,
+			Value:     v,
+		}},
+	})
+
+	return uint64(t), nil
+}
+
+func (r *RemoteWriteAppender) AddFast(ref uint64, t int64, v float64) error {
+	fmt.Printf("Appender AddFast: %d, %d, %2.f\n", ref, t, v)
+	return nil
+}
+
+func (r *RemoteWriteAppender) Commit() error {
+	payload, err := proto.Marshal(&r.req)
+	if err != nil {
+		return fmt.Errorf("failed to marshal proto remote write request: %w", err)
+	}
+
+	payloadCompressed := snappy.Encode(nil, payload)
+
+	req, err := http.NewRequest(http.MethodPost, "http://localhost:10908/api/v1/receive", bytes.NewBuffer(payloadCompressed))
+	if err != nil {
+		return fmt.Errorf("failed to create HTTP remote-write request: %w", err)
+	}
+	//TODO: Add THANOS-TENANT header
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to make remote-write request: %w", err)
+	}
+
+	if resp.StatusCode/100 != 2 {
+		return fmt.Errorf("remote write requests didn't return with 200 OK: %d", resp.StatusCode)
+	}
+
+	return nil
+}
+
+func (r *RemoteWriteAppender) Rollback() error {
+	fmt.Println("Appender Rollback")
+	return nil
+}
+
+type RemoteWriteQueryable struct{}
+
+func (r *RemoteWriteQueryable) LabelValues(name string) ([]string, storage.Warnings, error) {
+	fmt.Printf("Queryable LabelValues: %s\n", name)
+	return nil, nil, nil
+}
+
+func (r *RemoteWriteQueryable) LabelNames() ([]string, storage.Warnings, error) {
+	fmt.Printf("Queryable LabelNames\n")
+	return nil, nil, nil
+}
+
+func (r *RemoteWriteQueryable) Close() error {
+	fmt.Println("Queryable Close")
+	return nil
+}
+
+func (r *RemoteWriteQueryable) Select(sortSeries bool, hints *storage.SelectHints, matchers ...*labels.Matcher) storage.SeriesSet {
+	fmt.Printf("Queryable Select: %t, %v, %v\n", sortSeries, hints, matchers)
+	return nil
+}

--- a/scripts/quickstart.sh
+++ b/scripts/quickstart.sh
@@ -78,6 +78,12 @@ cat >data/rules.yml <<-EOF
 	      expr: sum(go_threads) by (job)
 EOF
 
+# Setup optional remote-write config for Thanos Ruler.
+cat >data/rule-remote-write.yaml <<-EOF
+name: thanos-receivers
+url: http://127.0.0.1:10908/api/v1/receive
+EOF
+
 STORES=""
 
 # Start three Prometheus servers monitoring themselves.


### PR DESCRIPTION
Still WIP :)
I need to pass down the configuration and reuse a proper HTTP client. But overall it works and I can already remote-write into receivers.

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
