### PR TITLE
Fix panic on concurrent index-header lazy reader usage and unload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ We use _breaking :warning:_ to mark changes that are not backward compatible (re
 - [#3527](https://github.com/thanos-io/thanos/pull/3527) Query Frontend: Fix query_range behavior when start/end times are the same
 - [#3560](https://github.com/thanos-io/thanos/pull/3560) query-frontend: Allow separate label cache
 - [#3672](https://github.com/thanos-io/thanos/pull/3672) rule: prevent rule crash from no such host error when using `dnssrv+` or `dnssrvnoa+`.
+- [#3760](https://github.com/thanos-io/thanos/pull/3760) Store: Fix panic caused by a race condition happening on concurrent index-header reader usage and unload, when `--store.enable-index-header-lazy-reader` is enabled.
 
 ### Changed
 

--- a/pkg/block/indexheader/lazy_binary_reader.go
+++ b/pkg/block/indexheader/lazy_binary_reader.go
@@ -276,20 +276,16 @@ func (r *LazyBinaryReader) unloadIfIdleSince(ts int64) error {
 	return nil
 }
 
-// isLoaded returns true if the underlying index-header reader is currently loaded.
-func (r *LazyBinaryReader) isLoaded() bool {
-	r.readerMx.RLock()
-	defer r.readerMx.RUnlock()
-
-	return r.reader != nil
-}
-
 // isIdleSince returns true if the reader is idle since given time (as unix nano).
 func (r *LazyBinaryReader) isIdleSince(ts int64) bool {
 	if r.usedAt.Load() > ts {
 		return false
 	}
 
-	// Do not consider it idle if unloaded.
-	return r.isLoaded()
+	// A reader can be considered idle only if it's loaded.
+	r.readerMx.RLock()
+	loaded := r.reader != nil
+	r.readerMx.RUnlock()
+
+	return loaded
 }

--- a/pkg/block/indexheader/lazy_binary_reader.go
+++ b/pkg/block/indexheader/lazy_binary_reader.go
@@ -138,7 +138,7 @@ func (r *LazyBinaryReader) Close() error {
 	}
 
 	// Unload without checking if idle.
-	return r.unload(0)
+	return r.unloadIfIdleSince(0)
 }
 
 // IndexVersion implements Reader.
@@ -250,9 +250,9 @@ func (r *LazyBinaryReader) load() error {
 	return nil
 }
 
-// unload closes underlying BinaryReader if the reader is idle since idleSince time (as unix nano). If idleSince is 0,
+// unloadIfIdleSince closes underlying BinaryReader if the reader is idle since given time (as unix nano). If idleSince is 0,
 // the check on the last usage is skipped. Calling this function on a already unloaded reader is a no-op.
-func (r *LazyBinaryReader) unload(idleSince int64) error {
+func (r *LazyBinaryReader) unloadIfIdleSince(ts int64) error {
 	r.readerMx.Lock()
 	defer r.readerMx.Unlock()
 
@@ -261,8 +261,8 @@ func (r *LazyBinaryReader) unload(idleSince int64) error {
 		return nil
 	}
 
-	// Do not unload if not idle.
-	if idleSince > 0 && r.usedAt.Load() > idleSince {
+	// Do not unloadIfIdleSince if not idle.
+	if ts > 0 && r.usedAt.Load() > ts {
 		return errNotIdle
 	}
 
@@ -284,9 +284,9 @@ func (r *LazyBinaryReader) isLoaded() bool {
 	return r.reader != nil
 }
 
-// isIdle returns true if the reader is idle since idleSince time (as unix nano).
-func (r *LazyBinaryReader) isIdle(idleSince int64) bool {
-	if r.usedAt.Load() > idleSince {
+// isIdleSince returns true if the reader is idle since given time (as unix nano).
+func (r *LazyBinaryReader) isIdleSince(ts int64) bool {
+	if r.usedAt.Load() > ts {
 		return false
 	}
 

--- a/pkg/block/indexheader/lazy_binary_reader_test.go
+++ b/pkg/block/indexheader/lazy_binary_reader_test.go
@@ -204,14 +204,14 @@ func TestLazyBinaryReader_unload_ShouldReturnErrorIfNotIdle(t *testing.T) {
 	testutil.Equals(t, float64(0), promtestutil.ToFloat64(m.unloadFailedCount))
 
 	// Try to unload but not idle since enough time.
-	testutil.Equals(t, errNotIdle, r.unload(time.Now().Add(-time.Minute).UnixNano()))
+	testutil.Equals(t, errNotIdle, r.unloadIfIdleSince(time.Now().Add(-time.Minute).UnixNano()))
 	testutil.Equals(t, float64(1), promtestutil.ToFloat64(m.loadCount))
 	testutil.Equals(t, float64(0), promtestutil.ToFloat64(m.loadFailedCount))
 	testutil.Equals(t, float64(0), promtestutil.ToFloat64(m.unloadCount))
 	testutil.Equals(t, float64(0), promtestutil.ToFloat64(m.unloadFailedCount))
 
 	// Try to unload and idle since enough time.
-	testutil.Ok(t, r.unload(time.Now().UnixNano()))
+	testutil.Ok(t, r.unloadIfIdleSince(time.Now().UnixNano()))
 	testutil.Equals(t, float64(1), promtestutil.ToFloat64(m.loadCount))
 	testutil.Equals(t, float64(0), promtestutil.ToFloat64(m.loadFailedCount))
 	testutil.Equals(t, float64(1), promtestutil.ToFloat64(m.unloadCount))

--- a/pkg/block/indexheader/reader_pool.go
+++ b/pkg/block/indexheader/reader_pool.go
@@ -99,10 +99,10 @@ func (p *ReaderPool) Close() {
 }
 
 func (p *ReaderPool) closeIdleReaders() {
-	idleSince := time.Now().Add(-p.lazyReaderIdleTimeout).UnixNano()
+	idleTimeoutAgo := time.Now().Add(-p.lazyReaderIdleTimeout).UnixNano()
 
-	for _, r := range p.getIdleReadersSince(idleSince) {
-		if err := r.unloadIfIdleSince(idleSince); err != nil && !errors.Is(err, errNotIdle) {
+	for _, r := range p.getIdleReadersSince(idleTimeoutAgo) {
+		if err := r.unloadIfIdleSince(idleTimeoutAgo); err != nil && !errors.Is(err, errNotIdle) {
 			level.Warn(p.logger).Log("msg", "failed to close idle index-header reader", "err", err)
 		}
 	}

--- a/pkg/block/indexheader/reader_pool.go
+++ b/pkg/block/indexheader/reader_pool.go
@@ -11,6 +11,7 @@ import (
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/oklog/ulid"
+	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/thanos-io/thanos/pkg/objstore"
@@ -98,29 +99,22 @@ func (p *ReaderPool) Close() {
 }
 
 func (p *ReaderPool) closeIdleReaders() {
-	for _, r := range p.getIdleReaders() {
-		// Closing an already closed reader is a no-op, so we close it and just update
-		// the last timestamp on success. If it will be still be idle the next time this
-		// function is called, we'll try to close it again and will just be a no-op.
-		//
-		// Due to concurrency, the current implementation may close a reader which was
-		// use between when the list of idle readers has been computed and now. This is
-		// an edge case we're willing to accept, to not further complicate the logic.
-		if err := r.unload(); err != nil {
+	idleSince := time.Now().Add(-p.lazyReaderIdleTimeout).UnixNano()
+
+	for _, r := range p.getIdleReaders(idleSince) {
+		if err := r.unload(idleSince); err != nil && !errors.Is(err, errNotIdle) {
 			level.Warn(p.logger).Log("msg", "failed to close idle index-header reader", "err", err)
 		}
 	}
 }
 
-func (p *ReaderPool) getIdleReaders() []*LazyBinaryReader {
+func (p *ReaderPool) getIdleReaders(idleSince int64) []*LazyBinaryReader {
 	p.lazyReadersMx.Lock()
 	defer p.lazyReadersMx.Unlock()
 
 	var idle []*LazyBinaryReader
-	threshold := time.Now().Add(-p.lazyReaderIdleTimeout).UnixNano()
-
 	for r := range p.lazyReaders {
-		if r.lastUsedAt() < threshold {
+		if r.isIdle(idleSince) {
 			idle = append(idle, r)
 		}
 	}


### PR DESCRIPTION
* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

The `LazyBinaryReader` can be unloaded at any time. When it gets unloaded, the values returned by its functions (eg. `LabelValues()`) are no more valid because they're yolo strings whose underlying buffer is released (and file unmmaped) on `unload()`.

I would guess this not to be a real issue assuming a long enough idle timeout. For example, if the idle timeout is 20 minutes, the values returned by the `LazyBinaryReader` needs to be around for 20 minutes before it panics, which is currently not the case.

However, the combination of `ReaderPool` and `LazyBinaryReader` doesn't guarantee that `unload()` is always executed on idle readers. It may happen that a reader which is idle gets returned by `ReaderPool.getIdleReaders()` and gets used right before calling `LazyBinaryReader.unload()`, causing a panic like this (line numbers match with Thanos at commit `2f7d37d7368cce61ee028a27c2a4a21f9d8fe552`):

```
unexpected fault address 0x7f3e16fe7905
fatal error: fault
[signal SIGSEGV: segmentation violation code=0x1 addr=0x7f3e16fe7905 pc=0x4020ac]

goroutine 10902586 [running]:
runtime.throw(0x2533220, 0x5)
	/usr/local/go/src/runtime/panic.go:1116 +0x72 fp=0xc0e3094f38 sp=0xc0e3094f08 pc=0x434de2
runtime.sigpanic()
	/usr/local/go/src/runtime/signal_unix.go:702 +0x3cc fp=0xc0e3094f68 sp=0xc0e3094f38 pc=0x44bb8c
cmpbody()
	/usr/local/go/src/internal/bytealg/compare_amd64.s:115 +0xec fp=0xc0e3094f70 sp=0xc0e3094f68 pc=0x4020ac
github.com/thanos-io/thanos/pkg/block/indexheader.BinaryReader.postingsOffset(0x2b73f00, 0xc1182fc5a0, 0xc114ce36d0, 0x2b44ce0, 0xc1182fc560, 0xc0b4452180, 0x0, 0xc0d7977140, 0xc10c1ba420, 0xc353b7c190, ...)
	/__w/cortex/cortex/vendor/github.com/thanos-io/thanos/pkg/block/indexheader/binary_reader.go:696 +0xe54 fp=0xc0e30950e8 sp=0xc0e3094f70 pc=0x18f5b94
github.com/thanos-io/thanos/pkg/block/indexheader.BinaryReader.PostingsOffset(0x2b73f00, 0xc1182fc5a0, 0xc114ce36d0, 0x2b44ce0, 0xc1182fc560, 0xc0b4452180, 0x0, 0xc0d7977140, 0xc10c1ba420, 0xc353b7c190, ...)
	/__w/cortex/cortex/vendor/github.com/thanos-io/thanos/pkg/block/indexheader/binary_reader.go:646 +0xbf fp=0xc0e30951c8 sp=0xc0e30950e8 pc=0x18f4b6f
github.com/thanos-io/thanos/pkg/block/indexheader.(*LazyBinaryReader).PostingsOffset(0xc00bf6d4a0, 0xc020951520, 0x15, 0x7f3e16fe7905, 0x14, 0x0, 0x0, 0x0, 0x0)
	/__w/cortex/cortex/vendor/github.com/thanos-io/thanos/pkg/block/indexheader/lazy_binary_reader.go:162 +0x1b3 fp=0xc0e3095318 sp=0xc0e30951c8 pc=0x18f7db3
github.com/thanos-io/thanos/pkg/store.(*bucketIndexReader).fetchPostings(0xc00b6e1c80, 0xc093896e00, 0x5, 0x8, 0x0, 0x0, 0x0, 0x0, 0x0)
	/__w/cortex/cortex/vendor/github.com/thanos-io/thanos/pkg/store/bucket.go:1783 +0xb01 fp=0xc0e3095578 sp=0xc0e3095318 pc=0x199db71
github.com/thanos-io/thanos/pkg/store.(*bucketIndexReader).ExpandedPostings(0xc00b6e1c80, 0xc00b9642e0, 0x2, 0x2, 0xc182bf6120, 0x253113a, 0x3, 0x2bb7920, 0x0)
	/__w/cortex/cortex/vendor/github.com/thanos-io/thanos/pkg/store/bucket.go:1601 +0x5ac fp=0xc0e3095818 sp=0xc0e3095578 pc=0x199b68c
github.com/thanos-io/thanos/pkg/store.blockSeries(0xc00933edb0, 0xc00b6e1c80, 0xc11d7a3f80, 0xc00b9642e0, 0x2, 0x2, 0xc11d7a2540, 0x2b44f80, 0xc02b22f530, 0x125fde00, ...)
	/__w/cortex/cortex/vendor/github.com/thanos-io/thanos/pkg/store/bucket.go:687 +0x6a fp=0xc0e3095d00 sp=0xc0e3095818 pc=0x19931ba
github.com/thanos-io/thanos/pkg/store.(*BucketStore).Series.func2(0x125ff840, 0x125ff8a0)
	/__w/cortex/cortex/vendor/github.com/thanos-io/thanos/pkg/store/bucket.go:938 +0xbe fp=0xc0e3095f78 sp=0xc0e3095d00 pc=0x19a373e
golang.org/x/sync/errgroup.(*Group).Go.func1(0xc02b22f4d0, 0xc0829de0e0)
	/__w/cortex/cortex/vendor/golang.org/x/sync/errgroup/errgroup.go:57 +0x59 fp=0xc0e3095fd0 sp=0xc0e3095f78 pc=0x997bc9
runtime.goexit()
	/usr/local/go/src/runtime/asm_amd64.s:1373 +0x1 fp=0xc0e3095fd8 sp=0xc0e3095fd0 pc=0x467ca1
created by golang.org/x/sync/errgroup.(*Group).Go
	/__w/cortex/cortex/vendor/golang.org/x/sync/errgroup/errgroup.go:54 +0x66
```

This PR is not a definitive fix, in the sense that the values returned by `LazyIndexHeader` can potentially become invalid any time, but mitigates the issue fixing the race condition between `ReaderPool` and `LazyBinaryReader` guaranteeing that `unload()` is always executed on a idle reader.

## Verification

Unit tests (but this specific race condition is hard to reproduce with a test).
