### PR TITLE
pkg/server/http: Allow passing http.ServeMux with a server option

### DIFF
--- a/pkg/server/http/http.go
+++ b/pkg/server/http/http.go
@@ -39,6 +39,10 @@ func New(logger log.Logger, reg *prometheus.Registry, comp component.Component, 
 	}
 
 	mux := http.NewServeMux()
+	if options.mux != nil {
+		mux = options.mux
+	}
+
 	registerMetrics(mux, reg)
 	registerProbes(mux, prober, logger)
 	registerProfiler(mux)

--- a/pkg/server/http/option.go
+++ b/pkg/server/http/option.go
@@ -4,12 +4,14 @@
 package http
 
 import (
+	"net/http"
 	"time"
 )
 
 type options struct {
 	gracePeriod time.Duration
 	listen      string
+	mux         *http.ServeMux
 }
 
 // Option overrides behavior of Server.
@@ -36,5 +38,12 @@ func WithGracePeriod(t time.Duration) Option {
 func WithListen(s string) Option {
 	return optionFunc(func(o *options) {
 		o.listen = s
+	})
+}
+
+// WithMux overrides the the server's default mux.
+func WithMux(mux *http.ServeMux) Option {
+	return optionFunc(func(o *options) {
+		o.mux = mux
 	})
 }


### PR DESCRIPTION

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

This allows to pass a specific mux from the outside that the internal server is added on top of.
Nothing really changes.
