### PR TITLE
e2e: Resolved Flaky tests

### DIFF
--- a/test/e2e/query_test.go
+++ b/test/e2e/query_test.go
@@ -368,7 +368,7 @@ func checkNetworkRequests(t *testing.T, addr string) {
 	ctx, cancel := chromedp.NewContext(context.Background())
 	t.Cleanup(cancel)
 
-	testutil.Ok(t, runutil.Retry(1*time.Minute, ctx.Done(), func() error {	
+	testutil.Ok(t, runutil.Retry(1*time.Minute, ctx.Done(), func() error {
 		var networkErrors []string
 
 		err := chromedp.Run(ctx,
@@ -376,26 +376,26 @@ func checkNetworkRequests(t *testing.T, addr string) {
 			chromedp.Navigate(addr),
 			chromedp.WaitVisible(`body`),
 		)
-		
+
 		if err != nil {
 			return err
 		}
-		
+
 		// Listen for failed network requests and push them to an array.
 		chromedp.ListenTarget(ctx, func(ev interface{}) {
 			switch ev := ev.(type) {
 			case *network.EventLoadingFailed:
 				networkErrors = append(networkErrors, ev.ErrorText)
 			}
-		})		
-		
+		})
+
 		err = func() error {
 			if len(networkErrors) > 0 {
 				return fmt.Errorf("some network requests failed: %s", strings.Join(networkErrors, "; "))
 			}
 			return nil
 		}()
-		return err;
+		return err
 	}))
 }
 


### PR DESCRIPTION
Signed-off-by: Abhishek357 <abhisheksinghchauhan357@gmail.com>
Fixes: #3412
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->
Tests are retried using the Retry function in runutil which executes the function(which makes it flaky) every interval until timeout or no error is returned.
## Verification

<!-- How you tested it? How do you know it works? -->
Tested Locally
