### PR TITLE
Allow to customise S3 SSE on a per-request basis

### DIFF
--- a/pkg/objstore/s3/s3_test.go
+++ b/pkg/objstore/s3/s3_test.go
@@ -4,8 +4,12 @@
 package s3
 
 import (
+	"context"
 	"testing"
 	"time"
+
+	"github.com/go-kit/kit/log"
+	"github.com/minio/minio-go/v7/pkg/encrypt"
 
 	"github.com/thanos-io/thanos/pkg/testutil"
 )
@@ -255,4 +259,41 @@ list_objects_version: "abcd"`)
 	if cfg2.ListObjectsVersion != "abcd" {
 		t.Errorf("parsing of list_objects_version failed: got %v, expected %v", cfg.ListObjectsVersion, "abcd")
 	}
+}
+
+func TestBucket_getServerSideEncryption(t *testing.T) {
+	// Default config should return no SSE config.
+	cfg := DefaultConfig
+	cfg.Endpoint = "localhost:80"
+	bkt, err := NewBucketWithConfig(log.NewNopLogger(), cfg, "test")
+	testutil.Ok(t, err)
+
+	sse, err := bkt.getServerSideEncryption(context.Background())
+	testutil.Ok(t, err)
+	testutil.Equals(t, nil, sse)
+
+	// If SSE is configured in the client config it should be used.
+	cfg = DefaultConfig
+	cfg.Endpoint = "localhost:80"
+	cfg.SSEConfig = SSEConfig{Type: SSES3}
+	bkt, err = NewBucketWithConfig(log.NewNopLogger(), cfg, "test")
+	testutil.Ok(t, err)
+
+	sse, err = bkt.getServerSideEncryption(context.Background())
+	testutil.Ok(t, err)
+	testutil.Equals(t, encrypt.S3, sse.Type())
+
+	// If SSE is configured in the context it should win.
+	cfg = DefaultConfig
+	cfg.Endpoint = "localhost:80"
+	cfg.SSEConfig = SSEConfig{Type: SSES3}
+	override, err := encrypt.NewSSEKMS("test", nil)
+	testutil.Ok(t, err)
+
+	bkt, err = NewBucketWithConfig(log.NewNopLogger(), cfg, "test")
+	testutil.Ok(t, err)
+
+	sse, err = bkt.getServerSideEncryption(context.WithValue(context.Background(), SSEConfigKey, override))
+	testutil.Ok(t, err)
+	testutil.Equals(t, encrypt.KMS, sse.Type())
 }

--- a/pkg/objstore/s3/s3_test.go
+++ b/pkg/objstore/s3/s3_test.go
@@ -293,7 +293,7 @@ func TestBucket_getServerSideEncryption(t *testing.T) {
 	bkt, err = NewBucketWithConfig(log.NewNopLogger(), cfg, "test")
 	testutil.Ok(t, err)
 
-	sse, err = bkt.getServerSideEncryption(context.WithValue(context.Background(), SSEConfigKey, override))
+	sse, err = bkt.getServerSideEncryption(context.WithValue(context.Background(), sseConfigKey, override))
 	testutil.Ok(t, err)
 	testutil.Equals(t, encrypt.KMS, sse.Type())
 }


### PR DESCRIPTION
* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

In this PR I'm proposing to introduce a context key to allow downstream projects (Cortex in this case) to inject custom SSE config on a per-request basis.

Fixes #3781.

## Verification

Unit test.
