### PR TITLE
docs: add Jaeger client parameter link to documentation

### DIFF
--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -76,6 +76,8 @@ config:
   agent_port: 0
 ```
 
+More informations on Jaeger client parmeters can be found in [Jaeger client features](https://www.jaegertracing.io/docs/1.21/client-features/)
+
 ### Stackdriver
 
 Client for https://cloud.google.com/trace/ tracing.


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

I would like to add a link to Jaeger official documentation in Thanos tracing documentation to help newcomers to understand how to fill in tracing configuration.

## Verification

<!-- How you tested it? How do you know it works? -->
