### PR TITLE
WIP: Introduce a simple wrapper that wraps a regular bucket with configurable retry backoffs.

### DIFF
--- a/pkg/extkingpin/flags.go
+++ b/pkg/extkingpin/flags.go
@@ -58,6 +58,14 @@ func RegisterCommonObjStoreFlags(cmd FlagClause, suffix string, required bool, e
 	return extflag.RegisterPathOrContent(cmd, fmt.Sprintf("objstore%s.config", suffix), help, required)
 }
 
+// RegisterCommonBackoffFlags register flags to specify backoff retry configuration.
+func RegisterCommonBackoffFlags(cmd FlagClause, suffix string, required bool, extraDesc ...string) *extflag.PathOrContent {
+	help := fmt.Sprintf("YAML file that contains backoff%s configuration.", suffix)
+	help = strings.Join(append([]string{help}, extraDesc...), " ")
+
+	return extflag.RegisterPathOrContent(cmd, fmt.Sprintf("backoff%s.config", suffix), help, required)
+}
+
 // RegisterCommonTracingFlags registers flags to pass a tracing configuration to be used with OpenTracing.
 func RegisterCommonTracingFlags(app FlagClause) *extflag.PathOrContent {
 	return extflag.RegisterPathOrContent(

--- a/pkg/objstore/backoff.go
+++ b/pkg/objstore/backoff.go
@@ -1,0 +1,248 @@
+package objstore
+
+import (
+	"context"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/thanos-io/thanos/pkg/runutil"
+)
+
+type backoffBucket struct {
+	Bucket
+	runutil.Backoff
+	logger        log.Logger
+	ignoreObjects []string
+
+	retries *prometheus.CounterVec
+}
+
+func NewBucketWithBackoff(bkt Bucket, backoff runutil.Backoff, logger log.Logger, reg prometheus.Registerer, ignoreObjects ...string) InstrumentedBucket {
+	b := &backoffBucket{
+		Bucket:        bkt,
+		Backoff:       backoff,
+		logger:        logger,
+		ignoreObjects: ignoreObjects,
+		retries: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name:        "thanos_objstore_bucket_backoff_retries_total",
+			Help:        "Total number of retried operations against a bucket.",
+			ConstLabels: prometheus.Labels{"bucket": bkt.Name()},
+		}, []string{"operation"}),
+	}
+
+	for _, op := range []string{
+		OpGet,
+		OpGetRange,
+		OpExists,
+		OpUpload,
+		OpDelete,
+	} {
+		b.retries.WithLabelValues(op)
+	}
+	return b
+}
+
+func (b *backoffBucket) Get(ctx context.Context, name string) (io.ReadCloser, error) {
+	const op = OpGet
+
+	r, err := b.Bucket.Get(ctx, name)
+	// Don't retry in case of 404 or if it's an object worth ignoring.
+	if err == nil || b.Bucket.IsObjNotFoundErr(err) || b.isIgnoreObject(name) {
+		return r, err
+	}
+
+	for retry := 1; retry <= b.Backoff.Max(); retry++ {
+		select {
+		case <-ctx.Done():
+			return r, err
+		case <-b.Backoff.Done():
+			return r, err
+		case <-time.After(b.Backoff.Duration(retry)):
+			// Retry again after backoff
+		}
+
+		r, err = b.Bucket.Get(ctx, name)
+		// Don't retry in case of 404 or if it's an object worth ignoring.
+		if err == nil || b.Bucket.IsObjNotFoundErr(err) || b.isIgnoreObject(name) {
+			return r, err
+		}
+
+		level.Warn(b.logger).Log("msg", "get failed", "name", name, "retryAttempt", retry, "error", err)
+		b.retries.WithLabelValues(op).Inc()
+	}
+
+	return r, err
+}
+
+func (b *backoffBucket) GetRange(ctx context.Context, name string, off, length int64) (io.ReadCloser, error) {
+	const op = OpGetRange
+
+	r, err := b.Bucket.GetRange(ctx, name, off, length)
+	// Don't retry in case of 404 or if it's an object worth ignoring.
+	if err == nil || b.Bucket.IsObjNotFoundErr(err) || b.isIgnoreObject(name) {
+		return r, err
+	}
+
+	for retry := 1; retry <= b.Backoff.Max(); retry++ {
+		select {
+		case <-ctx.Done():
+			return r, err
+		case <-b.Backoff.Done():
+			return r, err
+		case <-time.After(b.Backoff.Duration(retry)):
+			// Retry again after backoff
+		}
+
+		r, err = b.Bucket.GetRange(ctx, name, off, length)
+		// Don't retry in case of 404 or if it's an object worth ignoring.
+		if err == nil || b.Bucket.IsObjNotFoundErr(err) || b.isIgnoreObject(name) {
+			return r, err
+		}
+
+		level.Warn(b.logger).Log("msg", "get range failed", "name", name, "retryAttempt", retry, "error", err)
+		b.retries.WithLabelValues(op).Inc()
+	}
+
+	return r, err
+}
+
+func (b *backoffBucket) Exists(ctx context.Context, name string) (bool, error) {
+	const op = OpExists
+	exists, err := b.Bucket.Exists(ctx, name)
+	// Don't retry in case of 404 or if it's an object worth ignoring.
+	if err == nil || b.Bucket.IsObjNotFoundErr(err) || b.isIgnoreObject(name) {
+		return exists, err
+	}
+
+	for retry := 1; retry <= b.Backoff.Max(); retry++ {
+		select {
+		case <-ctx.Done():
+			return exists, err
+		case <-b.Backoff.Done():
+			return exists, err
+		case <-time.After(b.Backoff.Duration(retry)):
+			// Retry again after backoff
+		}
+
+		exists, err = b.Bucket.Exists(ctx, name)
+		// Don't retry in case of 404 or if it's an object worth ignoring.
+		if err == nil || b.Bucket.IsObjNotFoundErr(err) || b.isIgnoreObject(name) {
+			return exists, err
+		}
+
+		level.Warn(b.logger).Log("msg", "exists failed", "name", name, "retryAttempt", retry, "error", err)
+		b.retries.WithLabelValues(op).Inc()
+	}
+
+	return exists, err
+}
+
+func (b *backoffBucket) Upload(ctx context.Context, name string, r io.Reader) error {
+	const op = OpUpload
+
+	err := b.Bucket.Upload(ctx, name, r)
+	if err == nil || b.isIgnoreObject(name) {
+		return nil
+	}
+
+	for retry := 1; retry <= b.Backoff.Max(); retry++ {
+		select {
+		case <-ctx.Done():
+			return err
+		case <-b.Backoff.Done():
+			return err
+		case <-time.After(b.Backoff.Duration(retry)):
+			// Retry again after backoff
+		}
+
+		err = b.Bucket.Upload(ctx, name, r)
+		if err == nil || b.isIgnoreObject(name) {
+			return nil
+		}
+
+		level.Warn(b.logger).Log("msg", "upload failed", "name", name, "retryAttempt", retry, "error", err)
+		b.retries.WithLabelValues(op).Inc()
+	}
+
+	return err
+}
+
+func (b *backoffBucket) Delete(ctx context.Context, name string) error {
+	const op = OpDelete
+
+	err := b.Bucket.Delete(ctx, name)
+	if err == nil || b.isIgnoreObject(name) {
+		return nil
+	}
+
+	for retry := 1; retry <= b.Backoff.Max(); retry++ {
+		select {
+		case <-ctx.Done():
+			return err
+		case <-b.Backoff.Done():
+			return err
+		case <-time.After(b.Backoff.Duration(retry)):
+			// Retry again after backoff
+		}
+
+		err = b.Bucket.Delete(ctx, name)
+		if err == nil || b.isIgnoreObject(name) {
+			return nil
+		}
+
+		level.Warn(b.logger).Log("msg", "delete failed", "name", name, "retryAttempt", retry, "error", err)
+		b.retries.WithLabelValues(op).Inc()
+	}
+
+	return err
+}
+
+func (b *backoffBucket) Iter(ctx context.Context, dir string, f func(string) error) error {
+	return b.Bucket.Iter(ctx, dir, f)
+}
+
+func (b *backoffBucket) Attributes(ctx context.Context, name string) (ObjectAttributes, error) {
+	return b.Bucket.Attributes(ctx, name)
+}
+
+func (b *backoffBucket) IsObjNotFoundErr(err error) bool {
+	return b.Bucket.IsObjNotFoundErr(err)
+}
+
+func (b *backoffBucket) Name() string {
+	return b.Bucket.Name()
+}
+
+func (b *backoffBucket) WithExpectedErrs(expectedFunc IsOpFailureExpectedFunc) Bucket {
+	if ib, ok := b.Bucket.(InstrumentedBucket); ok {
+		// Make a copy, but replace bucket with instrumented one.
+		res := &backoffBucket{}
+		*res = *b
+		res.Bucket = ib.WithExpectedErrs(expectedFunc)
+		return res
+	}
+
+	return b
+}
+
+func (b *backoffBucket) ReaderWithExpectedErrs(expectedFunc IsOpFailureExpectedFunc) BucketReader {
+	return b.WithExpectedErrs(expectedFunc)
+}
+
+func (b *backoffBucket) Close() error {
+	return b.Bucket.Close()
+}
+
+func (b *backoffBucket) isIgnoreObject(name string) bool {
+	for _, i := range b.ignoreObjects {
+		if strings.HasSuffix(name, i) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/objstore/tracing.go
+++ b/pkg/objstore/tracing.go
@@ -90,7 +90,7 @@ func (t TracingBucket) Delete(ctx context.Context, name string) (err error) {
 }
 
 func (t TracingBucket) Name() string {
-	return "tracing: " + t.bkt.Name()
+	return t.bkt.Name()
 }
 
 func (t TracingBucket) Close() error {

--- a/pkg/runutil/backoff.go
+++ b/pkg/runutil/backoff.go
@@ -1,0 +1,276 @@
+package runutil
+
+import (
+	"context"
+	"math/rand"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/pkg/errors"
+	"gopkg.in/yaml.v2"
+)
+
+type BackoffType string
+
+const (
+	EXPONENTIAL BackoffType = "EXPONENTIAL"
+	SEQUENCE    BackoffType = "SEQUENCE"
+)
+
+type Config struct {
+	Type   BackoffType `yaml:"type"`
+	Config interface{} `yaml:"config"`
+}
+
+func NewBackoff(ctx context.Context, logger log.Logger, confContentYaml []byte) (Backoff, error) {
+	level.Info(logger).Log("msg", "loading backoff configuration")
+	backoffConf := &Config{}
+	if err := yaml.UnmarshalStrict(confContentYaml, backoffConf); err != nil {
+		return nil, errors.Wrap(err, "parsing config YAML file")
+	}
+
+	config, err := yaml.Marshal(backoffConf.Config)
+	if err != nil {
+		return nil, errors.Wrap(err, "marshal content of backoff configuration")
+	}
+
+	var backoff Backoff
+	switch strings.ToUpper(string(backoffConf.Type)) {
+	case string(EXPONENTIAL):
+		backoff, err = NewExponentialBackoffFromYAML(ctx, config)
+	case string(SEQUENCE):
+		backoff, err = NewSequenceBackoffFromYAML(ctx, config)
+	default:
+		return nil, errors.Errorf("backoff with type %s is not supported", backoffConf.Type)
+	}
+	if err != nil {
+		return nil, errors.Wrapf(err, "create %s backoff", backoffConf.Type)
+	}
+	return backoff, nil
+}
+
+type ExponentialBackoffConfig struct {
+	TimeUnit     string        `yaml:"time_unit"`
+	MaxAttempts  int           `yaml:"max_attempts"`
+	Jitter       float64       `yaml:"jitter"`
+	MaxTimeTotal time.Duration `yaml:"max_time_total"`
+}
+
+func (cfg *ExponentialBackoffConfig) Defaults() {
+	cfg.TimeUnit = "seconds"
+	cfg.MaxAttempts = 10
+	cfg.Jitter = 0.0
+}
+
+type SequenceBackoffConfig struct {
+	TimeUnit     string        `yaml:"time_unit"`
+	Elements     []int         `yaml:"elements"`
+	MaxTimeTotal time.Duration `yaml:"max_time_total"`
+}
+
+func (cfg *SequenceBackoffConfig) Defaults() {
+	cfg.TimeUnit = "seconds"
+	cfg.Elements = []int{0, 1, 3, 10, 30, 60, 300}
+}
+
+type Backoff interface {
+	Duration(n int) time.Duration
+	Max() int
+	Done() <-chan struct{}
+}
+
+type backoff struct {
+	timeUnit time.Duration
+	random   *rand.Rand
+	done     chan struct{}
+}
+
+type randSource struct {
+	mtx sync.Mutex
+	src rand.Source
+}
+
+func (r *randSource) Int63() int64 {
+	r.mtx.Lock()
+	i := r.src.Int63()
+	r.mtx.Unlock()
+	return i
+}
+
+func (r *randSource) Seed(seed int64) {
+	r.mtx.Lock()
+	r.src.Seed(seed)
+	r.mtx.Unlock()
+}
+
+type sequenceBackoff struct {
+	Backoff
+	*backoff
+	elements []int
+}
+
+func newBackoff(ctx context.Context, timeUnit, maxTimeTotal time.Duration) *backoff {
+	b := &backoff{
+		timeUnit: timeUnit,
+		random:   rand.New(&randSource{src: rand.NewSource(time.Now().UTC().UnixNano())}),
+	}
+	if maxTimeTotal > 0 {
+		b.done = make(chan struct{})
+		go func() {
+			t := time.NewTimer(maxTimeTotal)
+			defer func() {
+				t.Stop()
+				close(b.done)
+			}()
+			select {
+			case <-ctx.Done():
+			case <-t.C:
+			}
+		}()
+	}
+
+	return b
+}
+
+func NewSequenceBackoff(ctx context.Context, timeUnit string, maxTimeTotal time.Duration, elements ...int) (Backoff, error) {
+	d, err := unitToDuration(timeUnit)
+	if err != nil {
+		return nil, err
+	}
+	pb := &sequenceBackoff{
+		backoff:  newBackoff(ctx, d, maxTimeTotal),
+		elements: elements,
+	}
+
+	return pb, nil
+}
+
+func NewSequenceBackoffWithConfig(ctx context.Context, conf SequenceBackoffConfig) (Backoff, error) {
+	return NewSequenceBackoff(ctx, conf.TimeUnit, conf.MaxTimeTotal, conf.Elements...)
+}
+
+func NewSequenceBackoffFromYAML(ctx context.Context, yamlConf []byte) (Backoff, error) {
+	config := &SequenceBackoffConfig{}
+	config.Defaults()
+
+	if err := yaml.UnmarshalStrict(yamlConf, config); err != nil {
+		return nil, errors.Wrap(err, "parsing config YAML file")
+	}
+
+	return NewSequenceBackoffWithConfig(ctx, *config)
+}
+
+// Duration returns the time duration of the nth wait cycle in a
+// backoff policy. This is p.elements[n], randomized to avoid thundering
+// herds.
+func (b *sequenceBackoff) Duration(n int) time.Duration {
+	if len(b.elements) == 0 {
+		return 0
+	}
+	if n >= len(b.elements) {
+		n = len(b.elements) - 1
+	}
+	if n < 0 {
+		n = 0
+	}
+
+	return time.Duration(b.jitter(b.elements[n])) * b.timeUnit
+}
+
+func (b *sequenceBackoff) Max() int {
+	return len(b.elements) - 1
+}
+
+func (b *sequenceBackoff) Done() <-chan struct{} {
+	return b.done
+}
+
+// jitter returns a random integer uniformly distributed in the range
+// [0.5 * n .. 1.5 * n]
+func (b *sequenceBackoff) jitter(n int) int {
+	if n == 0 {
+		return 0
+	}
+
+	return n/2 + b.random.Intn(n)
+}
+
+type exponentialBackoff struct {
+	Backoff
+	*backoff
+	maxAttempts int
+	jitter      float64
+}
+
+func NewExponentialBackoff(ctx context.Context, timeUnit string, maxTimeTotal time.Duration, maxAttempts int) (Backoff, error) {
+	d, err := unitToDuration(timeUnit)
+	if err != nil {
+		return nil, err
+	}
+	return &exponentialBackoff{
+		backoff:     newBackoff(ctx, d, maxTimeTotal),
+		maxAttempts: maxAttempts,
+	}, nil
+}
+
+func NewExponentialBackoffWithConfig(ctx context.Context, conf ExponentialBackoffConfig) (Backoff, error) {
+	return NewExponentialBackoff(ctx, conf.TimeUnit, conf.MaxTimeTotal, conf.MaxAttempts)
+}
+
+func NewExponentialBackoffFromYAML(ctx context.Context, yamlConf []byte) (Backoff, error) {
+	config := &ExponentialBackoffConfig{}
+	config.Defaults()
+
+	if err := yaml.UnmarshalStrict(yamlConf, config); err != nil {
+		return nil, errors.Wrap(err, "parsing config YAML file")
+	}
+
+	return NewExponentialBackoffWithConfig(ctx, *config)
+}
+
+func (b *exponentialBackoff) Duration(n int) time.Duration {
+	d := b.timeUnit * time.Duration(1<<uint(n))
+	d -= time.Duration(b.random.Float64() * float64(d) * b.jitter)
+
+	return d
+}
+
+func (b *exponentialBackoff) Max() int {
+	return b.maxAttempts
+}
+
+func (b *exponentialBackoff) Done() <-chan struct{} {
+	return b.done
+}
+
+func unitToDuration(unit string) (time.Duration, error) {
+	var d time.Duration
+	u := strings.ToLower(unit)
+	switch u {
+	case "ns", "nano", "nanosecond", "nanoseconds":
+		d = time.Nanosecond
+		break
+	case "us", "µs", "micro", "microsecond", "microseconds":
+		d = time.Microsecond
+		break
+	case "ms", "milli", "millisecond", "milliseconds":
+		d = time.Millisecond
+		break
+	case "", "s", "sec", "second", "seconds":
+		d = time.Second
+		break
+	case "m", "min", "minute", "minutes":
+		d = time.Minute
+		break
+	case "h", "hour", "hours":
+		d = time.Hour
+		break
+	default:
+		return 0, errors.New("invalid unit")
+	}
+
+	return d, nil
+}

--- a/pkg/store/cache/caching_bucket.go
+++ b/pkg/store/cache/caching_bucket.go
@@ -104,7 +104,7 @@ func NewCachingBucket(b objstore.Bucket, cfg *CachingBucketConfig, logger log.Lo
 }
 
 func (cb *CachingBucket) Name() string {
-	return "caching: " + cb.Bucket.Name()
+	return cb.Bucket.Name()
 }
 
 func (cb *CachingBucket) WithExpectedErrs(expectedFunc objstore.IsOpFailureExpectedFunc) objstore.Bucket {


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

The main motivation for this PR is to better cope with potential rate limits that might be enforced by specific S3 providers. Without the possibility of backoff retries at the level of bucket operations, errors caused by those rate limits (e.g. 503, SlowDown/Service Unavailable) are handled at a "too high" level. More precisely, e.g. the main compaction loop of compact catches this as a retriable error and postpones the whole compaction until the next run interval.
One could also take this one step further and delegate the retries one level lower to the actual S3 client (minio in this case). As a matter of fact minio already performs retries under the hood, but those default values might not suffice and are not really configurable from other packages. There is a [global variable](https://github.com/minio/minio-go/blob/v7.0.2/retry.go#L27) that could be increased, but this might introduce a too tight coupling to this part of the minio package, and this would possibly affect all thanos components that use the client.

This PR is still WIP (tests, comments etc. missing :-) and should rather be considered a design doc with a POC implementation ready for feedback, if this a feasible way to do this?! If not or if the topic is considered "big enough" I could alternatively start with a "proper" design doc?!

Also, credits where credit's due: The actual retry implementations are inspired by this [post](https://blog.gopheracademy.com/advent-2014/backoff/) as well as minio's [retry function](https://github.com/minio/minio-go/blob/master/retry.go#L45).

Unfortunately I didn't completely check other current states of implementations. It looks like https://github.com/thanos-io/thanos/pull/3756 also tries to tackle this in the upload case.

## Verification

Deployed and run in Kubernetes cluster

<sub>Johannes Frey [johannes.frey@daimler.com](mailto:johannes.frey@daimler.com) Daimler TSS GmbH ([Imprint](https://github.com/Daimler/daimler-foss/blob/master/LEGAL_IMPRINT.md))</sub>