### PR TITLE
stalebot: Add an exempt label to ignore issue that has a PR

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -10,6 +10,7 @@ exemptLabels:
   # This label is hardcoded on remind bot (https://probot.github.io/apps/reminders/) and is used by remind bot when
   # issue is being reminded.
   - reminder
+  - 'state: someone-working-on-it' 
 
 # Set to true to ignore issues in a project (defaults to false)
 exemptProjects: false


### PR DESCRIPTION
This PR adds an exempt label to stalebot to ignore the issue with active PRs. 
To mark the issue that has an active PR, maintainers should add a specific label: [`state: someone-working-on-it`](https://github.com/thanos-io/thanos/labels/state%3A%20someone-working-on-it)

The idea triggered in https://github.com/thanos-io/thanos/issues/3456

What do you think?
