### PR TITLE
Introduce "allow overlapping blocks" flag for Thanos receiver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ We use _breaking :warning:_ to mark changes that are not backward compatible (re
 
 - [#3700](https://github.com/thanos-io/thanos/pull/3700) ui: make old bucket viewer UI work with vanilla Prometheus blocks
 - [#2641](https://github.com/thanos-io/thanos/issues/2641) Query Frontend: Added `--query-range.request-downsampled` flag enabling additional queries for downsampled data in case of empty or incomplete response to range request.
-
+- [#3792](https://github.com/thanos-io/thanos/pull/3792) Receiver: Added `--tsdb.allow-overlapping-blocks` flag to allow overlapping tsdb blocks and enable vertical compaction
 ### Changed
 
 - [#3705](https://github.com/thanos-io/thanos/pull/3705) Store: Fix race condition leading to failing queries or possibly incorrect query results.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ We use _breaking :warning:_ to mark changes that are not backward compatible (re
 - [#3700](https://github.com/thanos-io/thanos/pull/3700) ui: make old bucket viewer UI work with vanilla Prometheus blocks
 - [#2641](https://github.com/thanos-io/thanos/issues/2641) Query Frontend: Added `--query-range.request-downsampled` flag enabling additional queries for downsampled data in case of empty or incomplete response to range request.
 - [#3792](https://github.com/thanos-io/thanos/pull/3792) Receiver: Added `--tsdb.allow-overlapping-blocks` flag to allow overlapping tsdb blocks and enable vertical compaction
+
+### Fixed
+
+- [#3773](https://github.com/thanos-io/thanos/pull/3773) Compact: Pad compaction planner size check
+
 ### Changed
 
 - [#3705](https://github.com/thanos-io/thanos/pull/3705) Store: Fix race condition leading to failing queries or possibly incorrect query results.

--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -87,8 +87,8 @@ func registerReceive(app *extkingpin.App) {
 
 	tsdbMinBlockDuration := extkingpin.ModelDuration(cmd.Flag("tsdb.min-block-duration", "Min duration for local TSDB blocks").Default("2h").Hidden())
 	tsdbMaxBlockDuration := extkingpin.ModelDuration(cmd.Flag("tsdb.max-block-duration", "Max duration for local TSDB blocks").Default("2h").Hidden())
-    tsdbAllowOverlappingBlocks := cmd.Flag("tsdb.allow-overlapping-blocks", "Allow overlapping blocks, which in turn enables vertical compaction and vertical query merge.").Default("false").Bool()
-    walCompression := cmd.Flag("tsdb.wal-compression", "Compress the tsdb WAL.").Default("true").Bool()
+	tsdbAllowOverlappingBlocks := cmd.Flag("tsdb.allow-overlapping-blocks", "Allow overlapping blocks, which in turn enables vertical compaction and vertical query merge.").Default("false").Bool()
+	walCompression := cmd.Flag("tsdb.wal-compression", "Compress the tsdb WAL.").Default("true").Bool()
 	noLockFile := cmd.Flag("tsdb.no-lockfile", "Do not create lockfile in TSDB data directory. In any case, the lockfiles will be deleted on next startup.").Default("false").Bool()
 
 	ignoreBlockSize := cmd.Flag("shipper.ignore-unequal-block-size", "If true receive will not require min and max block size flags to be set to the same value. Only use this if you want to keep long retention and compaction enabled, as in the worst case it can result in ~2h data loss for your Thanos bucket storage.").Default("false").Hidden().Bool()
@@ -109,12 +109,12 @@ func registerReceive(app *extkingpin.App) {
 		}
 
 		tsdbOpts := &tsdb.Options{
-			MinBlockDuration:  int64(time.Duration(*tsdbMinBlockDuration) / time.Millisecond),
-			MaxBlockDuration:  int64(time.Duration(*tsdbMaxBlockDuration) / time.Millisecond),
-			RetentionDuration: int64(time.Duration(*retention) / time.Millisecond),
-			NoLockfile:        *noLockFile,
-			WALCompression:    *walCompression,
-            AllowOverlappingBlocks: *tsdbAllowOverlappingBlocks,
+			MinBlockDuration:       int64(time.Duration(*tsdbMinBlockDuration) / time.Millisecond),
+			MaxBlockDuration:       int64(time.Duration(*tsdbMaxBlockDuration) / time.Millisecond),
+			RetentionDuration:      int64(time.Duration(*retention) / time.Millisecond),
+			NoLockfile:             *noLockFile,
+			WALCompression:         *walCompression,
+			AllowOverlappingBlocks: *tsdbAllowOverlappingBlocks,
 		}
 
 		// Local is empty, so try to generate a local endpoint

--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -87,7 +87,8 @@ func registerReceive(app *extkingpin.App) {
 
 	tsdbMinBlockDuration := extkingpin.ModelDuration(cmd.Flag("tsdb.min-block-duration", "Min duration for local TSDB blocks").Default("2h").Hidden())
 	tsdbMaxBlockDuration := extkingpin.ModelDuration(cmd.Flag("tsdb.max-block-duration", "Max duration for local TSDB blocks").Default("2h").Hidden())
-	walCompression := cmd.Flag("tsdb.wal-compression", "Compress the tsdb WAL.").Default("true").Bool()
+    tsdbAllowOverlappingBlocks := cmd.Flag("tsdb.allow-overlapping-blocks", "Allow overlapping blocks, which in turn enables vertical compaction and vertical query merge.").Default("false").Bool()
+    walCompression := cmd.Flag("tsdb.wal-compression", "Compress the tsdb WAL.").Default("true").Bool()
 	noLockFile := cmd.Flag("tsdb.no-lockfile", "Do not create lockfile in TSDB data directory. In any case, the lockfiles will be deleted on next startup.").Default("false").Bool()
 
 	ignoreBlockSize := cmd.Flag("shipper.ignore-unequal-block-size", "If true receive will not require min and max block size flags to be set to the same value. Only use this if you want to keep long retention and compaction enabled, as in the worst case it can result in ~2h data loss for your Thanos bucket storage.").Default("false").Hidden().Bool()
@@ -113,6 +114,7 @@ func registerReceive(app *extkingpin.App) {
 			RetentionDuration: int64(time.Duration(*retention) / time.Millisecond),
 			NoLockfile:        *noLockFile,
 			WALCompression:    *walCompression,
+            AllowOverlappingBlocks: *tsdbAllowOverlappingBlocks,
 		}
 
 		// Local is empty, so try to generate a local endpoint

--- a/docs/components/receive.md
+++ b/docs/components/receive.md
@@ -182,5 +182,7 @@ Flags:
       --tsdb.no-lockfile         Do not create lockfile in TSDB data directory.
                                  In any case, the lockfiles will be deleted on
                                  next startup.
-
+      --tsdb.allow-overlapping-blocks         
+                                 Allow overlapping blocks, which in turn enables 
+                                 vertical compaction and vertical query merge.
 ```

--- a/docs/components/receive.md
+++ b/docs/components/receive.md
@@ -182,7 +182,7 @@ Flags:
       --tsdb.no-lockfile         Do not create lockfile in TSDB data directory.
                                  In any case, the lockfiles will be deleted on
                                  next startup.
-      --tsdb.allow-overlapping-blocks         
-                                 Allow overlapping blocks, which in turn enables 
+      --tsdb.allow-overlapping-blocks
+                                 Allow overlapping blocks, which in turn enables
                                  vertical compaction and vertical query merge.
 ```

--- a/docs/components/receive.md
+++ b/docs/components/receive.md
@@ -178,12 +178,12 @@ Flags:
       --receive.replication-factor=1
                                  How many times to replicate incoming write
                                  requests.
+      --tsdb.allow-overlapping-blocks
+                                 Allow overlapping blocks, which in turn enables
+                                 vertical compaction and vertical query merge.
       --tsdb.wal-compression     Compress the tsdb WAL.
       --tsdb.no-lockfile         Do not create lockfile in TSDB data directory.
                                  In any case, the lockfiles will be deleted on
                                  next startup.
-      --tsdb.allow-overlapping-blocks
-                                 Allow overlapping blocks, which in turn enables
-                                 vertical compaction and vertical query merge.
 
 ```

--- a/docs/components/receive.md
+++ b/docs/components/receive.md
@@ -185,4 +185,5 @@ Flags:
       --tsdb.allow-overlapping-blocks
                                  Allow overlapping blocks, which in turn enables
                                  vertical compaction and vertical query merge.
+
 ```


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

This change enables the "allow-overlapping-blocks" flag to be passed down to the TSDB on the Thanos Receive component. 

This overlap can occur where there is a backlog of metrics waiting to be pushed to Thanos and a compaction event happens. The Receiver TSDB will write out the WAL to a TSDB block and start a new block. If the first metric has a time that is earlier than the end of the previous block, these blocks will overlap and cause issues when the next compaction event happens. 

By adding and enabling this flag it allows the receive component to vertically compact these blocks and deal with the overlap. 

This is related to: https://github.com/prometheus/prometheus/issues/8055 

## Verification

I built the image and observed vertical compaction happening on the receivers when the overlap issue occurred by monitoring the `prometheus_tsdb_vertical_compactions_total` metric.
