### PR TITLE
Reduce memory allocations in bucketBlock.readChunkRange()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,10 +21,7 @@ We use _breaking :warning:_ to mark changes that are not backward compatible (re
 ### Fixed
 
 - [#3773](https://github.com/thanos-io/thanos/pull/3773) Compact: Pad compaction planner size check
-
-### Fixed
-
-- [#3773](https://github.com/thanos-io/thanos/pull/3773) Compact: Pad compaction planner size check
+- [#3796](https://github.com/thanos-io/thanos/pull/3796) Store: Decreased memory allocations while fetching block's chunks.
 
 ### Changed
 

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -1470,7 +1470,9 @@ func (b *bucketBlock) readChunkRange(ctx context.Context, seq int, off, length i
 		return nil, errors.Errorf("unknown segment file for index %d", seq)
 	}
 
-	c, err := b.chunkPool.Get(int(length))
+	// Request bytes.MinRead extra space to ensure the copy operation will not trigger
+	// a memory reallocation.
+	c, err := b.chunkPool.Get(int(length) + bytes.MinRead)
 	if err != nil {
 		return nil, errors.Wrap(err, "allocate chunk bytes")
 	}


### PR DESCRIPTION
* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

We're running the Cortex blocks storage at an increasingly large scale. We're currently investigating how to reduce the memory utilisation in the store-gateway and a low hanging fruit I've noticed is that `bucketBlock.readChunkRange()` waste memory allocations to grow the buffer if the requested length is larger than the largest bucket in the chunk pool (which is 32MB):

![Screenshot 2021-02-12 at 18 34 31](https://user-images.githubusercontent.com/1701904/107801895-f6cf4980-6d60-11eb-88de-447eb5581c77.png)

The reason is that to ensure that `io.Copy()` doesn't grow the buffer, the buffer needs to be at least `bytes.MinRead` larger than the actual size to write.

This PR fixes it.

I've also added a benchmark, comparing it with `master`:

```
benchmark                                  old ns/op     new ns/op     delta
BenchmarkBucketBlock_readChunkRange-12     89789         70651         -21.31%

benchmark                                  old allocs     new allocs     delta
BenchmarkBucketBlock_readChunkRange-12     12             12             +0.00%

benchmark                                  old bytes     new bytes     delta
BenchmarkBucketBlock_readChunkRange-12     296676        204791        -30.97%
```

## Verification

Bencharmk.
