### PR TITLE
Compaction group concurrency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ We use _breaking :warning:_ to mark changes that are not backward compatible (re
 - [#3903](https://github.com/thanos-io/thanos/pull/3903) Store: Returning custom grpc code when reaching series/chunk limits.
 - [#3919](https://github.com/thanos-io/thanos/pull/3919) Allow to disable automatically setting CORS headers using `--web.disable-cors` flag in each component that exposes an API.
 - [#3840](https://github.com/thanos-io/thanos/pull/3840) Tools: Added a flag to support rewrite Prometheus TSDB blocks.
+- [#3807](https://github.com/thanos-io/thanos/pull/3807) Compact: Added experimental feature, compaction group concurrency, which allows a single group to run multiple compactions concurrently.
 
 ### Fixed
 


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes
- Planner is moved out of compaction code and instead the grouper uses the planner to recursively call planner for each group, returning a new set of groups, 1 group for each plan available
- Grouper now depends on planner

## Verification

We have a dev cortex cluster using block storage that was 60 days behind, an ideal situation for testing this code. I was able to catch up 40 times faster as I ran this with group concurrency set to 40. Everything looks good so far.