### PR TITLE
Allow downstream projects to customise the Partitioner

### DIFF
--- a/pkg/store/bucket_e2e_test.go
+++ b/pkg/store/bucket_e2e_test.go
@@ -473,10 +473,10 @@ func TestBucketStore_e2e(t *testing.T) {
 
 type naivePartitioner struct{}
 
-func (g naivePartitioner) Partition(length int, rng func(int) (uint64, uint64)) (parts []part) {
+func (g naivePartitioner) Partition(length int, rng func(int) (uint64, uint64)) (parts []Part) {
 	for i := 0; i < length; i++ {
 		s, e := rng(i)
-		parts = append(parts, part{start: s, end: e, elemRng: [2]int{i, i + 1}})
+		parts = append(parts, Part{Start: s, End: e, ElemRng: [2]int{i, i + 1}})
 	}
 	return parts
 }

--- a/pkg/store/bucket_test.go
+++ b/pkg/store/bucket_test.go
@@ -501,15 +501,15 @@ func TestGapBasedPartitioner_Partition(t *testing.T) {
 
 	for _, c := range []struct {
 		input    [][2]int
-		expected []part
+		expected []Part
 	}{
 		{
 			input:    [][2]int{{1, 10}},
-			expected: []part{{start: 1, end: 10, elemRng: [2]int{0, 1}}},
+			expected: []Part{{Start: 1, End: 10, ElemRng: [2]int{0, 1}}},
 		},
 		{
 			input:    [][2]int{{1, 2}, {3, 5}, {7, 10}},
-			expected: []part{{start: 1, end: 10, elemRng: [2]int{0, 3}}},
+			expected: []Part{{Start: 1, End: 10, ElemRng: [2]int{0, 3}}},
 		},
 		{
 			input: [][2]int{
@@ -518,9 +518,9 @@ func TestGapBasedPartitioner_Partition(t *testing.T) {
 				{20, 30},
 				{maxGapSize + 31, maxGapSize + 32},
 			},
-			expected: []part{
-				{start: 1, end: 30, elemRng: [2]int{0, 3}},
-				{start: maxGapSize + 31, end: maxGapSize + 32, elemRng: [2]int{3, 4}},
+			expected: []Part{
+				{Start: 1, End: 30, ElemRng: [2]int{0, 3}},
+				{Start: maxGapSize + 31, End: maxGapSize + 32, ElemRng: [2]int{3, 4}},
 			},
 		},
 		// Overlapping ranges.
@@ -532,9 +532,9 @@ func TestGapBasedPartitioner_Partition(t *testing.T) {
 				{maxGapSize + 31, maxGapSize + 32},
 				{maxGapSize + 31, maxGapSize + 40},
 			},
-			expected: []part{
-				{start: 1, end: 30, elemRng: [2]int{0, 3}},
-				{start: maxGapSize + 31, end: maxGapSize + 40, elemRng: [2]int{3, 5}},
+			expected: []Part{
+				{Start: 1, End: 30, ElemRng: [2]int{0, 3}},
+				{Start: maxGapSize + 31, End: maxGapSize + 40, ElemRng: [2]int{3, 5}},
 			},
 		},
 		{
@@ -544,7 +544,7 @@ func TestGapBasedPartitioner_Partition(t *testing.T) {
 				{1, maxGapSize + 100},
 				{maxGapSize + 31, maxGapSize + 40},
 			},
-			expected: []part{{start: 1, end: maxGapSize + 100, elemRng: [2]int{0, 3}}},
+			expected: []Part{{Start: 1, End: maxGapSize + 100, ElemRng: [2]int{0, 3}}},
 		},
 	} {
 		res := gapBasedPartitioner{maxGapSize: maxGapSize}.Partition(len(c.input), func(i int) (uint64, uint64) {


### PR DESCRIPTION
* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

In https://github.com/thanos-io/thanos/pull/3802 I've exposed `Partitioner` to let Cortex trying to experiment with a different algorithm (in case we find anything interesting we'll upstream it to Thanos then). But `part` is still unexposed, which makes impossible to customise it.

## Verification

N/A
