### PR TITLE
Receive: Improve handling of empty time series from clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ We use _breaking :warning:_ to mark changes that are not backward compatible (re
 
 - [#3773](https://github.com/thanos-io/thanos/pull/3773) Compact: Pad compaction planner size check
 - [#3796](https://github.com/thanos-io/thanos/pull/3796) Store: Decreased memory allocations while fetching block's chunks.
+- [#XXXX](https://github.com/thanos-io/thanos/pull/XXXX) Receive: Improve handling of empty time series from clients
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ We use _breaking :warning:_ to mark changes that are not backward compatible (re
 
 - [#3773](https://github.com/thanos-io/thanos/pull/3773) Compact: Pad compaction planner size check
 - [#3796](https://github.com/thanos-io/thanos/pull/3796) Store: Decreased memory allocations while fetching block's chunks.
-- [#XXXX](https://github.com/thanos-io/thanos/pull/XXXX) Receive: Improve handling of empty time series from clients
+- [#3815](https://github.com/thanos-io/thanos/pull/3815) Receive: Improve handling of empty time series from clients
 
 ### Changed
 

--- a/pkg/receive/handler.go
+++ b/pkg/receive/handler.go
@@ -310,6 +310,12 @@ func (h *Handler) receiveHTTP(w http.ResponseWriter, r *http.Request) {
 		tenant = h.options.DefaultTenantID
 	}
 
+	// exit early if the request contained no data
+	if 0 == len(wreq.Timeseries) {
+		level.Info(h.logger).Log("msg", "empty timeseries from client", "tenant", tenant)
+		return
+	}
+
 	err = h.handleRequest(ctx, rep, tenant, &wreq)
 	if err != nil {
 		level.Debug(h.logger).Log("msg", "failed to handle request", "err", err)

--- a/pkg/receive/handler.go
+++ b/pkg/receive/handler.go
@@ -311,7 +311,7 @@ func (h *Handler) receiveHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// exit early if the request contained no data
-	if 0 == len(wreq.Timeseries) {
+	if len(wreq.Timeseries) == 0 {
 		level.Info(h.logger).Log("msg", "empty timeseries from client", "tenant", tenant)
 		return
 	}


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->
If an empty write request is passed into `fanoutForward`, no messages will be sent on the error channel (`ec`) causing the return value to be an empty/default initialised `MultiError`. The error is translated into an "internal server error" at the http handler.

This patch checks that the incoming time series contains data and if not returns immediately.

As to why newer prometheus versions have this behaviour, I'm not currently sure. I believe this will help with #3772.

## Verification

<!-- How you tested it? How do you know it works? -->

We've been running this in our staging environment for a week or so and we no longer see the internal error message being logged and in its place the info message instead.