### PR TITLE
Add a flag to not check external labels using bucket rewrite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@ We use _breaking :warning:_ to mark changes that are not backward compatible (re
 
 - [#3977](https://github.com/thanos-io/thanos/pull/3903) Expose exemplars for `http_request_duration_seconds` histogram if tracing is enabled.
 - [#3903](https://github.com/thanos-io/thanos/pull/3903) Store: Returning custom grpc code when reaching series/chunk limits.
-- [3919](https://github.com/thanos-io/thanos/pull/3919) Allow to disable automatically setting CORS headers using `--web.disable-cors` flag in each component that exposes an API.
+- [#3919](https://github.com/thanos-io/thanos/pull/3919) Allow to disable automatically setting CORS headers using `--web.disable-cors` flag in each component that exposes an API.
+- [#3840](https://github.com/thanos-io/thanos/pull/3840) Tools: Added a flag to support rewrite Prometheus TSDB blocks.
 
 ### Fixed
 

--- a/docs/components/tools.md
+++ b/docs/components/tools.md
@@ -764,6 +764,9 @@ Flags:
       --rewrite.add-change-log  If specified, all modifications are written to
                                 new block directory. Disable if latency is to
                                 high.
+      --prom-blocks             If specified, we assume the blocks to be
+                                uploaded are only used with Prometheus so we
+                                don't check external labels in this case.
 
 ```
 

--- a/pkg/block/block_test.go
+++ b/pkg/block/block_test.go
@@ -210,6 +210,23 @@ func TestUpload(t *testing.T) {
 		testutil.Equals(t, "empty external labels are not allowed for Thanos block.", err.Error())
 		testutil.Equals(t, 4, len(bkt.Objects()))
 	}
+	{
+		// No external labels with UploadPromBlocks.
+		b2, err := e2eutil.CreateBlock(ctx, tmpDir, []labels.Labels{
+			{{Name: "a", Value: "1"}},
+			{{Name: "a", Value: "2"}},
+			{{Name: "a", Value: "3"}},
+			{{Name: "a", Value: "4"}},
+			{{Name: "b", Value: "1"}},
+		}, 100, 0, 1000, nil, 124, metadata.NoneFunc)
+		testutil.Ok(t, err)
+		err = UploadPromBlock(ctx, log.NewNopLogger(), bkt, path.Join(tmpDir, b2.String()), metadata.NoneFunc)
+		testutil.Ok(t, err)
+		testutil.Equals(t, 8, len(bkt.Objects()))
+		testutil.Equals(t, 3736, len(bkt.Objects()[path.Join(b2.String(), ChunksDirname, "000001")]))
+		testutil.Equals(t, 401, len(bkt.Objects()[path.Join(b2.String(), IndexFilename)]))
+		testutil.Equals(t, 525, len(bkt.Objects()[path.Join(b2.String(), MetaFilename)]))
+	}
 }
 
 func TestDelete(t *testing.T) {


### PR DESCRIPTION

Signed-off-by: yeya24 <yb532204897@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

Fixes #3706 

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

Adapt the second approach mentioned in https://github.com/thanos-io/thanos/issues/3706#issuecomment-768598478.

Add a new flag to not check Thanos external labels when uploading blocks to obj store.

## Verification

<!-- How you tested it? How do you know it works? -->

Tested with a local prometheus tsdb block.

Before rewrite:

```
./promtool tsdb analyze data 01EYV86TDESNRQNT2NN0WK6QC9   --limit=100 |grep build_info
1 prometheus_build_info
```

Rewrite block with the command below:
```
thanos tools bucket rewrite --rewrite.to-delete-config-file test.yaml --id 01EYV86TDESNRQNT2NN0WK6QC9  --objstore.config-file /home/yeya24/b.yaml --no-dry-run --prom-blocks
level=info ts=2021-02-26T04:28:21.275951558Z caller=factory.go:46 msg="loading bucket configuration"
level=info ts=2021-02-26T04:28:21.276586951Z caller=tools_bucket.go:836 msg="downloading block" source=01EYV86TDESNRQNT2NN0WK6QC9
level=info ts=2021-02-26T04:28:21.277412002Z caller=tools_bucket.go:872 msg="changelog will be available" file=/tmp/thanos-rewrite/01EZE9GFWXJ1ACN42V72YJ7S7C/change.log
level=info ts=2021-02-26T04:28:21.280528395Z caller=tools_bucket.go:887 msg="starting rewrite for block" source=01EYV86TDESNRQNT2NN0WK6QC9 new=01EZE9GFWXJ1ACN42V72YJ7S7C toDelete="- matchers: \"{__name__=\\\"prometheus_build_info\\\"}\"\n"
level=info ts=2021-02-26T04:28:21.284137549Z caller=compactor.go:41 msg="processed 9.89% of 374 series"
level=info ts=2021-02-26T04:28:21.284549508Z caller=compactor.go:41 msg="processed 19.79% of 374 series"
level=info ts=2021-02-26T04:28:21.284942365Z caller=compactor.go:41 msg="processed 29.68% of 374 series"
level=info ts=2021-02-26T04:28:21.285297219Z caller=compactor.go:41 msg="processed 39.57% of 374 series"
level=info ts=2021-02-26T04:28:21.285640116Z caller=compactor.go:41 msg="processed 49.47% of 374 series"
level=info ts=2021-02-26T04:28:21.285977354Z caller=compactor.go:41 msg="processed 59.36% of 374 series"
level=info ts=2021-02-26T04:28:21.286304648Z caller=compactor.go:41 msg="processed 69.25% of 374 series"
level=info ts=2021-02-26T04:28:21.286629152Z caller=compactor.go:41 msg="processed 79.14% of 374 series"
level=info ts=2021-02-26T04:28:21.286944944Z caller=compactor.go:41 msg="processed 89.04% of 374 series"
level=info ts=2021-02-26T04:28:21.287248931Z caller=compactor.go:41 msg="processed 98.93% of 374 series"
level=info ts=2021-02-26T04:28:21.287294998Z caller=tools_bucket.go:897 msg="wrote new block after modifications; flushing" source=01EYV86TDESNRQNT2NN0WK6QC9 new=01EZE9GFWXJ1ACN42V72YJ7S7C
level=info ts=2021-02-26T04:28:21.298739241Z caller=tools_bucket.go:906 msg="uploading new block" source=01EYV86TDESNRQNT2NN0WK6QC9 new=01EZE9GFWXJ1ACN42V72YJ7S7C
level=info ts=2021-02-26T04:28:21.299116007Z caller=tools_bucket.go:916 msg=uploaded source=01EYV86TDESNRQNT2NN0WK6QC9 new=01EZE9GFWXJ1ACN42V72YJ7S7C
level=info ts=2021-02-26T04:28:21.299130425Z caller=tools_bucket.go:918 msg="rewrite done" IDs=01EYV86TDESNRQNT2NN0WK6QC9
level=info ts=2021-02-26T04:28:21.299161779Z caller=main.go:159 msg=exiting
```

config:
```yaml
- matchers: "{__name__=\"prometheus_build_info\"}"
```

Check the new block, there is no `prometheus_build_info` metric.
```
./promtool tsdb analyze data 01EZE9GFWXJ1ACN42V72YJ7S7C --limit=100 | grep build
```