### PR TITLE
downsample: ensure consistent order

### DIFF
--- a/cmd/thanos/downsample.go
+++ b/cmd/thanos/downsample.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"sort"
 	"time"
 
 	"github.com/go-kit/kit/log"
@@ -194,7 +195,17 @@ func downsampleBucket(
 		}
 	}
 
-	for _, m := range metas {
+	metasULIDS := make([]ulid.ULID, 0, len(metas))
+	for k := range metas {
+		metasULIDS = append(metasULIDS, k)
+	}
+	sort.Slice(metasULIDS, func(i, j int) bool {
+		return metasULIDS[i].Compare(metasULIDS[j]) < 0
+	})
+
+	for _, mk := range metasULIDS {
+		m := metas[mk]
+
 		switch m.Thanos.Downsample.Resolution {
 		case downsample.ResLevel0:
 			missing := false


### PR DESCRIPTION
Ensure that we have a consistent order of blocks that we are going to
downsample. `range` over maps doesn't enforce any particular order on
purpose.

This is needed for https://github.com/thanos-io/thanos/pull/3031/files.
ATM in that PR before downsampling we delete all directories which do
not match blocks ULIDs in the remote object storage. Ideally, we should
only keep around the files of a block which we are about to downsample.

It is impossible to do that properly ATM if during another iteration
we'd start from a different block. Thus, let's have a consistent order.

Signed-off-by: Giedrius Statkevičius <giedriuswork@gmail.com>

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

Added sorting for block ULIDs before attempting to possibly downsample them.

## Verification

Tests still pass.
