### PR TITLE
[Fix] Replace unsupported %v macro in logs

### DIFF
--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -556,7 +556,7 @@ func removeDuplicateStoreSpecs(logger log.Logger, duplicatedStores prometheus.Co
 	for _, spec := range specs {
 		addr := spec.Addr()
 		if _, ok := set[addr]; ok {
-			level.Warn(logger).Log("msg", "Duplicate store address is provided - %v", addr)
+			level.Warn(logger).Log("msg", "Duplicate store address is provided", "addr", addr)
 			duplicatedStores.Inc()
 		}
 		set[addr] = spec

--- a/cmd/thanos/rule.go
+++ b/cmd/thanos/rule.go
@@ -721,7 +721,7 @@ func removeDuplicateQueryEndpoints(logger log.Logger, duplicatedQueriers prometh
 	deduplicated := make([]*url.URL, 0, len(urls))
 	for _, u := range urls {
 		if _, ok := set[u.String()]; ok {
-			level.Warn(logger).Log("msg", "duplicate query address is provided - %v", u.String())
+			level.Warn(logger).Log("msg", "duplicate query address is provided", "addr", u.String())
 			duplicatedQueriers.Inc()
 			continue
 		}


### PR DESCRIPTION
Signed-off-by: Stéphane Brillant <stephane.brillant@jive.com>

* [ ] Fixed json logging with %v macro

Fixes: https://github.com/thanos-io/thanos/issues/3837#issuecomment-786385400
