### PR TITLE
sidecar: Mark sidecar as unhealthy if bucket upload fails

### DIFF
--- a/cmd/thanos/sidecar.go
+++ b/cmd/thanos/sidecar.go
@@ -275,6 +275,9 @@ func runSidecar(
 			return runutil.Repeat(30*time.Second, ctx.Done(), func() error {
 				if uploaded, err := s.Sync(ctx); err != nil {
 					level.Warn(logger).Log("err", err, "uploaded", uploaded)
+					statusProber.NotHealthy(err)
+				} else {
+					statusProber.Healthy()
 				}
 
 				minTime, _, err := s.Timestamps()


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.

## Changes

Health probe flips to unhealthy if sidecar upload to a bucket fails. This would enable restarting the sidecar with liveliness probe in a containerised environment and reload config on restart.

## Verification

TODO

Fixes: https://github.com/thanos-io/thanos/issues/985
