### PR TITLE
Add ReaderWithSize that allows readers to report size of object directly

### DIFF
--- a/pkg/objstore/objstore.go
+++ b/pkg/objstore/objstore.go
@@ -145,29 +145,27 @@ func TryToGetSize(r io.Reader) (int64, error) {
 		return int64(f.Len()), nil
 	case *strings.Reader:
 		return f.Size(), nil
-	case Sizer:
-		return f.Size()
+	case ObjectSizer:
+		return f.ObjectSize()
 	}
 	return 0, errors.Errorf("unsupported type of io.Reader: %T", r)
 }
 
-// Sizer can return size of data.
-type Sizer interface {
-	// Size returns length of the data, or error, if it is not available.
-	// It is best to call Size before calling other methods on the type, as some io.Reader implementations may only return
-	// length of unread data.
-	Size() (int64, error)
+// ObjectSizer can return size of object.
+type ObjectSizer interface {
+	// ObjectSize returns the size of the object in bytes, or error if it is not available.
+	ObjectSize() (int64, error)
 }
 
-type nopCloserWithSize struct{ io.Reader }
+type nopCloserWithObjectSize struct{ io.Reader }
 
-func (nopCloserWithSize) Close() error           { return nil }
-func (n nopCloserWithSize) Size() (int64, error) { return TryToGetSize(n.Reader) }
+func (nopCloserWithObjectSize) Close() error                 { return nil }
+func (n nopCloserWithObjectSize) ObjectSize() (int64, error) { return TryToGetSize(n.Reader) }
 
 // NopCloserWithSize returns a ReadCloser with a no-op Close method wrapping
 // the provided Reader r. Returned ReadCloser also implements Size method.
 func NopCloserWithSize(r io.Reader) io.ReadCloser {
-	return nopCloserWithSize{r}
+	return nopCloserWithObjectSize{r}
 }
 
 // UploadDir uploads all files in srcdir to the bucket with into a top-level directory

--- a/pkg/objstore/objstore.go
+++ b/pkg/objstore/objstore.go
@@ -151,12 +151,12 @@ func TryToGetSize(r io.Reader) (int64, error) {
 	return 0, errors.Errorf("unsupported type of io.Reader: %T", r)
 }
 
-// ReaderWithSize is a Reader that can also return size of the read object.
+// ReaderWithSize is a Reader that can also return size of the read data.
 type ReaderWithSize interface {
 	io.Reader
 
-	// Size returns size of the object read by this reader, or error, if size is not available.
-	// It is best to call Size before reading the object, as some implementations may only return
+	// Size returns length of the data read by this reader, or error, if it is not available.
+	// It is best to call Size before using the Reader, as some implementations may only return
 	// length of unread data.
 	Size() (int64, error)
 }

--- a/pkg/objstore/objstore.go
+++ b/pkg/objstore/objstore.go
@@ -145,18 +145,16 @@ func TryToGetSize(r io.Reader) (int64, error) {
 		return int64(f.Len()), nil
 	case *strings.Reader:
 		return f.Size(), nil
-	case ReaderWithSize:
+	case Sizer:
 		return f.Size()
 	}
 	return 0, errors.Errorf("unsupported type of io.Reader: %T", r)
 }
 
-// ReaderWithSize is a Reader that can also return size of the read data.
-type ReaderWithSize interface {
-	io.Reader
-
-	// Size returns length of the data read by this reader, or error, if it is not available.
-	// It is best to call Size before using the Reader, as some implementations may only return
+// Sizer can return size of data.
+type Sizer interface {
+	// Size returns length of the data, or error, if it is not available.
+	// It is best to call Size before calling other methods on the type, as some io.Reader implementations may only return
 	// length of unread data.
 	Size() (int64, error)
 }

--- a/pkg/objstore/objstore_test.go
+++ b/pkg/objstore/objstore_test.go
@@ -5,6 +5,7 @@ package objstore
 
 import (
 	"bytes"
+	"io"
 	"testing"
 
 	promtest "github.com/prometheus/client_golang/prometheus/testutil"
@@ -66,11 +67,22 @@ func TestMetricBucket_Close(t *testing.T) {
 }
 
 func TestTracingReader(t *testing.T) {
-	r := bytes.NewBuffer([]byte("hello"))
-	tr := &tracingReadCloser{r: NopCloserWithSize(r)}
+	r := bytes.NewReader([]byte("hello world"))
+	tr := newTracingReadCloser(NopCloserWithSize(r), nil)
 
 	size, err := TryToGetSize(tr)
 
 	testutil.Ok(t, err)
-	testutil.Equals(t, int64(5), size)
+	testutil.Equals(t, int64(11), size)
+
+	smallBuf := make([]byte, 4)
+	n, err := io.ReadFull(tr, smallBuf)
+	testutil.Ok(t, err)
+	testutil.Equals(t, 4, n)
+
+	// Verify that size is still the same, after reading 4 bytes.
+	size, err = TryToGetSize(tr)
+
+	testutil.Ok(t, err)
+	testutil.Equals(t, int64(11), size)
 }

--- a/pkg/objstore/objstore_test.go
+++ b/pkg/objstore/objstore_test.go
@@ -4,6 +4,7 @@
 package objstore
 
 import (
+	"bytes"
 	"testing"
 
 	promtest "github.com/prometheus/client_golang/prometheus/testutil"
@@ -62,4 +63,14 @@ func TestMetricBucket_Close(t *testing.T) {
 	testutil.Equals(t, 7, promtest.CollectAndCount(bkt.opsFailures))
 	testutil.Equals(t, 7, promtest.CollectAndCount(bkt.opsDuration))
 	testutil.Assert(t, promtest.ToFloat64(bkt.lastSuccessfulUploadTime) > lastUpload)
+}
+
+func TestTracingReader(t *testing.T) {
+	r := bytes.NewBuffer([]byte("hello"))
+	tr := &tracingReadCloser{r: NopCloserWithSize(r)}
+
+	size, err := TryToGetSize(tr)
+
+	testutil.Ok(t, err)
+	testutil.Equals(t, int64(5), size)
 }

--- a/pkg/objstore/tracing.go
+++ b/pkg/objstore/tracing.go
@@ -118,6 +118,10 @@ type tracingReadCloser struct {
 	read int
 }
 
+func (t *tracingReadCloser) Size() (int64, error) {
+	return TryToGetSize(t.r)
+}
+
 func (t *tracingReadCloser) Read(p []byte) (int, error) {
 	n, err := t.r.Read(p)
 	if n > 0 {

--- a/pkg/objstore/tracing.go
+++ b/pkg/objstore/tracing.go
@@ -118,7 +118,8 @@ type tracingReadCloser struct {
 	read int
 }
 
-func (t *tracingReadCloser) Size() (int64, error) {
+func (t *tracingReadCloser) ObjectSize() (int64, error) {
+	// Note that TryToGetSize returns size of unread data only, which may not be the full object size.
 	return TryToGetSize(t.r)
 }
 

--- a/pkg/objstore/tracing.go
+++ b/pkg/objstore/tracing.go
@@ -40,7 +40,7 @@ func (t TracingBucket) Get(ctx context.Context, name string) (io.ReadCloser, err
 		return nil, err
 	}
 
-	return &tracingReadCloser{r: r, s: span}, nil
+	return newTracingReadCloser(r, span), nil
 }
 
 func (t TracingBucket) GetRange(ctx context.Context, name string, off, length int64) (io.ReadCloser, error) {
@@ -54,7 +54,7 @@ func (t TracingBucket) GetRange(ctx context.Context, name string, off, length in
 		return nil, err
 	}
 
-	return &tracingReadCloser{r: r, s: span}, nil
+	return newTracingReadCloser(r, span), nil
 }
 
 func (t TracingBucket) Exists(ctx context.Context, name string) (exists bool, err error) {
@@ -113,14 +113,25 @@ func (t TracingBucket) ReaderWithExpectedErrs(expectedFunc IsOpFailureExpectedFu
 }
 
 type tracingReadCloser struct {
-	r    io.ReadCloser
-	s    opentracing.Span
+	r io.ReadCloser
+	s opentracing.Span
+
+	objSize    int64
+	objSizeErr error
+
 	read int
 }
 
+func newTracingReadCloser(r io.ReadCloser, span opentracing.Span) io.ReadCloser {
+	// Since TryToGetSize can only reliably return size before doing any read calls,
+	// we call during "construction" and remember the results.
+	objSize, objSizeErr := TryToGetSize(r)
+
+	return &tracingReadCloser{r: r, s: span, objSize: objSize, objSizeErr: objSizeErr}
+}
+
 func (t *tracingReadCloser) ObjectSize() (int64, error) {
-	// Note that TryToGetSize returns size of unread data only, which may not be the full object size.
-	return TryToGetSize(t.r)
+	return t.objSize, t.objSizeErr
 }
 
 func (t *tracingReadCloser) Read(p []byte) (int, error) {

--- a/pkg/store/cache/caching_bucket.go
+++ b/pkg/store/cache/caching_bucket.go
@@ -224,7 +224,7 @@ func (cb *CachingBucket) Get(ctx context.Context, name string) (io.ReadCloser, e
 	hits := cfg.cache.Fetch(ctx, []string{contentKey, existsKey})
 	if hits[contentKey] != nil {
 		cb.operationHits.WithLabelValues(objstore.OpGet, cfgName).Inc()
-		return ioutil.NopCloser(bytes.NewReader(hits[contentKey])), nil
+		return objstore.NopCloserWithSize(bytes.NewBuffer(hits[contentKey])), nil
 	}
 
 	// If we know that file doesn't exist, we can return that. Useful for deletion marks.


### PR DESCRIPTION
This PR makes following changes:
- Add `ReaderWithSize` interface that extends Reader with support to report the size of object directly
- Make `tracingReadCloser` implement `ReaderWithSize`.
- Also added `NopCloserWithSize` that can be used instead of `ioutil.NopCloser`.
- Support for `*bytes.Reader` when getting size.

Especially `ReaderWithSize` should make it simpler to avoid warnings with unknown object size during uploads.