### PR TITLE
mixin: Allow excluding individual components through configuration

### DIFF
--- a/mixin/alerts/bucket_replicate.libsonnet
+++ b/mixin/alerts/bucket_replicate.libsonnet
@@ -6,7 +6,7 @@
     p99LatencyThreshold: 20,
   },
   prometheusAlerts+:: {
-    groups+: [
+    groups+: if thanos.bucket_replicate == null then [] else [
       {
         name: 'thanos-bucket-replicate',
         rules: [

--- a/mixin/alerts/compact.libsonnet
+++ b/mixin/alerts/compact.libsonnet
@@ -6,7 +6,7 @@
     bucketOpsErrorThreshold: 5,
   },
   prometheusAlerts+:: {
-    groups+: [
+    groups+: if thanos.compact == null then [] else [
       {
         name: 'thanos-compact',
         rules: [

--- a/mixin/alerts/query.libsonnet
+++ b/mixin/alerts/query.libsonnet
@@ -9,7 +9,7 @@
     p99QueryRangeLatencyThreshold: 90,
   },
   prometheusAlerts+:: {
-    groups+: [
+    groups+: if thanos.query == null then [] else [
       {
         name: 'thanos-query',
         rules: [

--- a/mixin/alerts/receive.libsonnet
+++ b/mixin/alerts/receive.libsonnet
@@ -8,7 +8,7 @@
     p99LatencyThreshold: 10,
   },
   prometheusAlerts+:: {
-    groups+: [
+    groups+: if thanos.receive == null then [] else [
       {
         name: 'thanos-receive',
         rules: [

--- a/mixin/alerts/rule.libsonnet
+++ b/mixin/alerts/rule.libsonnet
@@ -8,7 +8,7 @@
     evalErrorThreshold: 5,
   },
   prometheusAlerts+:: {
-    groups+: [
+    groups+: if thanos.rule == null then [] else [
       {
         name: 'thanos-rule',
         rules: [

--- a/mixin/alerts/sidecar.libsonnet
+++ b/mixin/alerts/sidecar.libsonnet
@@ -4,7 +4,7 @@
     selector: error 'must provide selector for Thanos Sidecar alerts',
   },
   prometheusAlerts+:: {
-    groups+: [
+    groups+: if thanos.sidecar == null then [] else [
       {
         name: 'thanos-sidecar',
         rules: [

--- a/mixin/alerts/store.libsonnet
+++ b/mixin/alerts/store.libsonnet
@@ -9,7 +9,7 @@
     bucketOpsP99LatencyThreshold: 2,
   },
   prometheusAlerts+:: {
-    groups+: [
+    groups+: if thanos.store == null then [] else [
       {
         name: 'thanos-store',
         rules: [

--- a/mixin/dashboards/bucket_replicate.libsonnet
+++ b/mixin/dashboards/bucket_replicate.libsonnet
@@ -8,7 +8,7 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
     title: error 'must provide title for Thanos Bucket Replicate dashboard',
   },
   grafanaDashboards+:: {
-    'bucket_replicate.json':
+    [if thanos.bucket_replicate != null then 'bucket_replicate.json']:
       g.dashboard(thanos.bucket_replicate.title)
       .addRow(
         g.row('Bucket Replicate Runs')

--- a/mixin/dashboards/compact.libsonnet
+++ b/mixin/dashboards/compact.libsonnet
@@ -8,7 +8,7 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
     title: error 'must provide title for Thanos Compact dashboard',
   },
   grafanaDashboards+:: {
-    'compact.json':
+    [if thanos.compact != null then 'compact.json']:
       g.dashboard(thanos.compact.title)
       .addRow(
         g.row('Group Compaction')

--- a/mixin/dashboards/query.libsonnet
+++ b/mixin/dashboards/query.libsonnet
@@ -8,7 +8,7 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
     title: error 'must provide title for Thanos Query dashboard',
   },
   grafanaDashboards+:: {
-    'query.json':
+    [if thanos.query != null then 'query.json']:
       g.dashboard(thanos.query.title)
       .addRow(
         g.row('Instant Query API')

--- a/mixin/dashboards/receive.libsonnet
+++ b/mixin/dashboards/receive.libsonnet
@@ -8,7 +8,7 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
     title: error 'must provide title for Thanos Receive dashboard',
   },
   grafanaDashboards+:: {
-    'receive.json':
+    [if thanos.receive != null then 'receive.json']:
       g.dashboard(thanos.receive.title)
       .addRow(
         g.row('WRITE - Incoming Request')

--- a/mixin/dashboards/rule.libsonnet
+++ b/mixin/dashboards/rule.libsonnet
@@ -8,7 +8,7 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
     title: error 'must provide title for Thanos Rule dashboard',
   },
   grafanaDashboards+:: {
-    'rule.json':
+    [if thanos.rule != null then 'rule.json']:
       g.dashboard(thanos.rule.title)
       .addRow(
         g.row('Rule Group Evaluations')

--- a/mixin/dashboards/sidecar.libsonnet
+++ b/mixin/dashboards/sidecar.libsonnet
@@ -8,7 +8,7 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
     title: error 'must provide title for Thanos Sidecar dashboard',
   },
   grafanaDashboards+:: {
-    'sidecar.json':
+    [if thanos.sidecar != null then 'sidecar.json']:
       g.dashboard(thanos.sidecar.title)
       .addRow(
         g.row('gRPC (Unary)')

--- a/mixin/dashboards/store.libsonnet
+++ b/mixin/dashboards/store.libsonnet
@@ -8,7 +8,7 @@ local g = import '../lib/thanos-grafana-builder/builder.libsonnet';
     title: error 'must provide title for Thanos Store dashboard',
   },
   grafanaDashboards+:: {
-    'store.json':
+    [if thanos.store != null then 'store.json']:
       g.dashboard(thanos.store.title)
       .addRow(
         g.row('gRPC (Unary)')


### PR DESCRIPTION
* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

Allow excluding individual components alerts/dashboards through mixin configuration.

## Verification

Since by default all should still be included I tested that this is the case by re-generating the examples that are checked into this repo.

@kakkoyun @metalmatze 
