### PR TITLE
Tools: rewrite delete can delete series only if it matches all matchers

### DIFF
--- a/pkg/compactv2/modifiers.go
+++ b/pkg/compactv2/modifiers.go
@@ -68,7 +68,7 @@ SeriesLoop:
 
 				// Only if all matchers in the deletion request are matched can we proceed to deletion.
 				if !m.Matches(v) {
-					break DeletionsLoop
+					continue DeletionsLoop
 				}
 			}
 			if len(deletions.Intervals) > 0 {


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->
Fixes #3885.
For all matchers in a single deletion request, we should use `AND` between matchers instead of `OR`.

## Verification

<!-- How you tested it? How do you know it works? -->

One test case added.
