### PR TITLE
tools: Fix partial and empty matchers in rewrite

### DIFF
--- a/pkg/compactv2/compactor_test.go
+++ b/pkg/compactv2/compactor_test.go
@@ -344,6 +344,59 @@ func TestCompactor_WriteSeries_e2e(t *testing.T) {
 				NumChunks:  3,
 			},
 		},
+		{
+			name: "1 blocks + delete modifier. Deletion request contains non-equal matchers.",
+			input: [][]seriesSamples{
+				{
+					{lset: labels.Labels{{Name: "a", Value: "1"}},
+						chunks: [][]sample{{{0, 0}, {1, 1}, {2, 2}}, {{10, 11}, {11, 11}, {20, 20}}}},
+					{lset: labels.Labels{{Name: "a", Value: "2"}},
+						chunks: [][]sample{{{0, 0}, {1, 1}, {2, 2}}, {{10, 11}, {11, 11}, {20, 20}}}},
+					{lset: labels.Labels{{Name: "a", Value: "2"}, {Name: "foo", Value: "1"}},
+						chunks: [][]sample{{{0, 0}, {1, 1}, {2, 2}}, {{10, 11}, {11, 11}, {20, 20}}}},
+					{lset: labels.Labels{{Name: "a", Value: "2"}, {Name: "foo", Value: "bar"}},
+						chunks: [][]sample{{{0, 0}, {1, 1}, {2, 2}}, {{10, 11}, {11, 11}, {20, 20}}}},
+					{lset: labels.Labels{{Name: "a", Value: "3"}, {Name: "foo", Value: "baz"}},
+						chunks: [][]sample{{{0, 0}, {1, 1}, {2, 2}}, {{10, 11}, {11, 11}, {20, 20}}}},
+					{lset: labels.Labels{{Name: "foo", Value: "bat"}},
+						chunks: [][]sample{{{0, 0}, {1, 1}, {2, 2}}, {{10, 11}, {11, 11}, {20, 20}}}},
+
+					// Label a is present but with an empty value.
+					{lset: labels.Labels{{Name: "a", Value: ""}, {Name: "foo", Value: "bat"}},
+						chunks: [][]sample{{{0, 0}, {1, 1}, {2, 2}}, {{10, 11}, {11, 11}, {20, 20}}}},
+					// Series with unrelated labels.
+					{lset: labels.Labels{{Name: "c", Value: "1"}},
+						chunks: [][]sample{{{0, 0}, {1, 1}, {2, 2}}, {{10, 11}, {11, 11}, {20, 20}}}},
+				},
+			},
+			modifiers: []Modifier{WithDeletionModifier(
+				metadata.DeletionRequest{
+					Matchers: []*labels.Matcher{
+						labels.MustNewMatcher(labels.MatchNotEqual, "a", "1"),
+						labels.MustNewMatcher(labels.MatchRegexp, "foo", "^ba.$"),
+					},
+				})},
+			expected: []seriesSamples{
+				{lset: labels.Labels{{Name: "a", Value: ""}, {Name: "foo", Value: "bat"}},
+					chunks: [][]sample{{{0, 0}, {1, 1}, {2, 2}}, {{10, 11}, {11, 11}, {20, 20}}}},
+				{lset: labels.Labels{{Name: "a", Value: "1"}},
+					chunks: [][]sample{{{0, 0}, {1, 1}, {2, 2}}, {{10, 11}, {11, 11}, {20, 20}}}},
+				{lset: labels.Labels{{Name: "a", Value: "2"}},
+					chunks: [][]sample{{{0, 0}, {1, 1}, {2, 2}}, {{10, 11}, {11, 11}, {20, 20}}}},
+				{lset: labels.Labels{{Name: "a", Value: "2"}, {Name: "foo", Value: "1"}},
+					chunks: [][]sample{{{0, 0}, {1, 1}, {2, 2}}, {{10, 11}, {11, 11}, {20, 20}}}},
+				{lset: labels.Labels{{Name: "c", Value: "1"}},
+					chunks: [][]sample{{{0, 0}, {1, 1}, {2, 2}}, {{10, 11}, {11, 11}, {20, 20}}}},
+				{lset: labels.Labels{{Name: "foo", Value: "bat"}},
+					chunks: [][]sample{{{0, 0}, {1, 1}, {2, 2}}, {{10, 11}, {11, 11}, {20, 20}}}},
+			},
+			expectedChanges: "Deleted {a=\"2\", foo=\"bar\"} [{0 20}]\nDeleted {a=\"3\", foo=\"baz\"} [{0 20}]\n",
+			expectedStats: tsdb.BlockStats{
+				NumSamples: 36,
+				NumSeries:  6,
+				NumChunks:  12,
+			},
+		},
 	} {
 		t.Run(tcase.name, func(t *testing.T) {
 			tmpDir, err := ioutil.TempDir("", "test-series-writer")

--- a/pkg/compactv2/modifiers.go
+++ b/pkg/compactv2/modifiers.go
@@ -62,12 +62,9 @@ SeriesLoop:
 		for _, deletions := range d.d.deletions {
 			for _, m := range deletions.Matchers {
 				v := lbls.Get(m.Name)
-				if v == "" {
-					continue
-				}
 
 				// Only if all matchers in the deletion request are matched can we proceed to deletion.
-				if !m.Matches(v) {
+				if v == "" || !m.Matches(v) {
 					continue DeletionsLoop
 				}
 			}


### PR DESCRIPTION
Signed-off-by: yeya24 <yb532204897@gmail.com>

Follow-up of #3886.

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

Require full matchers matching when processing deletion requests. Only partial match or empty label is not allowed.

Let's say a deletion request is `{a="1", b="2"}`, so the series we want to delete must at least matches `{a="1", b="2"}`. It can contain other unrelated labels and it doesn't matter.

We don't want to delete series that have an empty label value of the matchers like `{c="1"}` or series that only has partial matches like `{a="1"}` or `{b="2"}`.


<!-- How you tested it? How do you know it works? -->
