### PR TITLE
objstore: Provide the correct underlying size in more cases

### DIFF
--- a/pkg/objstore/objstore.go
+++ b/pkg/objstore/objstore.go
@@ -117,6 +117,10 @@ func TryToGetSize(r io.Reader) (int64, error) {
 		return int64(f.Len()), nil
 	case *strings.Reader:
 		return f.Size(), nil
+	case *tracingReadCloser:
+		return TryToGetSize(f.r)
+	case *timingReadCloser:
+		return TryToGetSize(f.ReadCloser)
 	}
 	return 0, errors.Errorf("unsupported type of io.Reader: %T", r)
 }

--- a/pkg/objstore/objstore.go
+++ b/pkg/objstore/objstore.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
+	"github.com/minio/minio-go/v7"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -121,6 +122,12 @@ func TryToGetSize(r io.Reader) (int64, error) {
 		return TryToGetSize(f.r)
 	case *timingReadCloser:
 		return TryToGetSize(f.ReadCloser)
+	case *minio.Object:
+		s, err := f.Stat()
+		if err != nil {
+			return 0, errors.Wrap(err, "minio.Object.Stat()")
+		}
+		return s.Size, nil
 	}
 	return 0, errors.Errorf("unsupported type of io.Reader: %T", r)
 }


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

Uploads of the shipper (and thanos tool bucket replicate) showed that the filesize could not be guessed. Look into the timing and tracing wrappers and optionally look into the S3 object as well to get the underlying size.

## Verification

<!-- How you tested it? How do you know it works? -->

Minimal checking with replicate and looking at the uploaded chunks.