### PR TITLE
Added matchers support to TSDB store

### DIFF
--- a/pkg/store/tsdb.go
+++ b/pkg/store/tsdb.go
@@ -221,7 +221,11 @@ func (s *TSDBStore) LabelValues(ctx context.Context, r *storepb.LabelValuesReque
 	}
 	defer runutil.CloseWithLogOnErr(s.logger, q, "close tsdb querier label values")
 
-	res, _, err := q.LabelValues(r.Label)
+	matchers, err := storepb.MatchersToPromMatchers(r.Matchers...)
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+	res, _, err := q.LabelValues(r.Label, matchers...)
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}

--- a/pkg/store/tsdb_test.go
+++ b/pkg/store/tsdb_test.go
@@ -348,9 +348,6 @@ func TestTSDBStore_LabelValues(t *testing.T) {
 			end: func() int64 {
 				return timestamp.FromTime(maxTime)
 			},
-			Matchers: []storepb.LabelMatcher{
-				{Type: storepb.LabelMatcher_EQ, Name: "foo", Value: "test"},
-			},
 		},
 		{
 			title:          "add another label value",
@@ -366,10 +363,24 @@ func TestTSDBStore_LabelValues(t *testing.T) {
 			},
 		},
 		{
-			title:          "add another label value",
-			addedLabels:    []string{"foo", "test2"},
+			title:          "check label value matcher",
 			queryLabel:     "foo",
-			expectedValues: []string{"test2"},
+			expectedValues: []string{"test1"},
+			timestamp:      now.Unix(),
+			start: func() int64 {
+				return timestamp.FromTime(minTime)
+			},
+			end: func() int64 {
+				return timestamp.FromTime(maxTime)
+			},
+			Matchers: []storepb.LabelMatcher{
+				{Type: storepb.LabelMatcher_EQ, Name: "foo", Value: "test1"},
+			},
+		},
+		{
+			title:          "check another label value matcher",
+			queryLabel:     "foo",
+			expectedValues: []string{},
 			timestamp:      now.Unix(),
 			start: func() int64 {
 				return timestamp.FromTime(minTime)


### PR DESCRIPTION
Fixes Task 1: `Add matchers support to TSDB store` of #3779 
This change improves the performance of the label-values lookup when matchers are specified. With this change, the Queriers won't need to fetch & sort & de-duplicate all the metrics, because they can directly call the `.LabelValues()` method and pass the matchers parameter.
### Verification
Added unit tests.