### PR TITLE
cmd/thanos/receive.go: Receive client infers TLS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ We use _breaking :warning:_ to mark changes that are not backward compatible (re
 - [#3814](https://github.com/thanos-io/thanos/pull/3814) Store: Decreased memory utilisation while fetching block's chunks.
 - [#3815](https://github.com/thanos-io/thanos/pull/3815) Receive: Improve handling of empty time series from clients
 - [#3795](https://github.com/thanos-io/thanos/pull/3795) s3: A truncated "get object" response is reported as error.
+- [#3899](https://github.com/thanos-io/thanos/pull/3899) Receive: Correct the inference of client gRPC configuration.
 
 ### Changed
 

--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -55,7 +55,7 @@ func registerReceive(app *extkingpin.App) {
 	rwClientCert := cmd.Flag("remote-write.client-tls-cert", "TLS Certificates to use to identify this client to the server.").Default("").String()
 	rwClientKey := cmd.Flag("remote-write.client-tls-key", "TLS Key for the client's certificate.").Default("").String()
 	rwClientServerCA := cmd.Flag("remote-write.client-tls-ca", "TLS CA Certificates to use to verify servers.").Default("").String()
-	rwClientServerName := cmd.Flag("remote-write.client-server-name", "Server name to verify the hostname on the returned gRPC certificates. See https://tools.ietf.org/html/rfc4366#section-3.1").Default("").String()
+	rwClientServerName := cmd.Flag("remote-write.client-server-name", "Server name to verify the hostname on the returned TLS certificates. See https://tools.ietf.org/html/rfc4366#section-3.1").Default("").String()
 
 	dataDir := cmd.Flag("tsdb.path", "Data directory of TSDB.").
 		Default("./data").String()
@@ -220,7 +220,7 @@ func runReceive(
 	if err != nil {
 		return err
 	}
-	dialOpts, err := extgrpc.StoreClientGRPCOpts(logger, reg, tracer, rwServerCert != "", rwClientCert, rwClientKey, rwClientServerCA, rwClientServerName)
+	dialOpts, err := extgrpc.StoreClientGRPCOpts(logger, reg, tracer, grpcCert != "", rwClientCert, rwClientKey, rwClientServerCA, rwClientServerName)
 	if err != nil {
 		return err
 	}

--- a/docs/components/receive.md
+++ b/docs/components/receive.md
@@ -129,7 +129,7 @@ Flags:
                                  TLS CA Certificates to use to verify servers.
       --remote-write.client-server-name=""
                                  Server name to verify the hostname on the
-                                 returned gRPC certificates. See
+                                 returned TLS certificates. See
                                  https://tools.ietf.org/html/rfc4366#section-3.1
       --tsdb.path="./data"       Data directory of TSDB.
       --label=key="value" ...    External labels to announce. This flag will be


### PR DESCRIPTION
Currently, the thanos Receiver infers whether it should use TLS for
the gRPC clients that forwards time series to other receivers based on
whether the remote-write HTTP server uses TLS. This is not correct, as
the HTTP server may use TLS without the gRPC server using TLS. This
commit fixes the inference.

Longer-term, this will be taken care of by the receive/router split.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>

Fixes: https://github.com/thanos-io/thanos/issues/3898

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

cc @thanos-io/thanos-maintainers 