### PR TITLE
Aligns versions of protoc-gen-gogofast

### DIFF
--- a/.bingo/Variables.mk
+++ b/.bingo/Variables.mk
@@ -127,11 +127,11 @@ $(PROMU): $(BINGO_DIR)/promu.mod
 	@echo "(re)installing $(GOBIN)/promu-v0.5.0"
 	@cd $(BINGO_DIR) && $(GO) build -mod=mod -modfile=promu.mod -o=$(GOBIN)/promu-v0.5.0 "github.com/prometheus/promu"
 
-PROTOC_GEN_GOGOFAST := $(GOBIN)/protoc-gen-gogofast-v1.3.1
+PROTOC_GEN_GOGOFAST := $(GOBIN)/protoc-gen-gogofast-v1.3.2
 $(PROTOC_GEN_GOGOFAST): $(BINGO_DIR)/protoc-gen-gogofast.mod
 	@# Install binary/ries using Go 1.14+ build command. This is using bwplotka/bingo-controlled, separate go module with pinned dependencies.
-	@echo "(re)installing $(GOBIN)/protoc-gen-gogofast-v1.3.1"
-	@cd $(BINGO_DIR) && $(GO) build -mod=mod -modfile=protoc-gen-gogofast.mod -o=$(GOBIN)/protoc-gen-gogofast-v1.3.1 "github.com/gogo/protobuf/protoc-gen-gogofast"
+	@echo "(re)installing $(GOBIN)/protoc-gen-gogofast-v1.3.2"
+	@cd $(BINGO_DIR) && $(GO) build -mod=mod -modfile=protoc-gen-gogofast.mod -o=$(GOBIN)/protoc-gen-gogofast-v1.3.2 "github.com/gogo/protobuf/protoc-gen-gogofast"
 
 SHFMT := $(GOBIN)/shfmt-v3.1.2
 $(SHFMT): $(BINGO_DIR)/shfmt.mod

--- a/.bingo/variables.env
+++ b/.bingo/variables.env
@@ -44,7 +44,7 @@ PROMTOOL="${GOBIN}/promtool-v1.8.2-0.20200522113006-f4dd45609a05"
 
 PROMU="${GOBIN}/promu-v0.5.0"
 
-PROTOC_GEN_GOGOFAST="${GOBIN}/protoc-gen-gogofast-v1.3.1"
+PROTOC_GEN_GOGOFAST="${GOBIN}/protoc-gen-gogofast-v1.3.2"
 
 SHFMT="${GOBIN}/shfmt-v3.1.2"
 


### PR DESCRIPTION
* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

Aligned versions in .bingo for protoc-gen-gogofast to match #3853

## Verification

```bash
$ make proto
(re)installing /Users/adrian/go/bin/goimports-v0.0.0-20200526224456-8b020aee10d2
go: downloading golang.org/x/tools v0.0.0-20200526224456-8b020aee10d2
>> fetching protoc@3.4.0
>> installing protoc@3.4.0
>> produced /Users/adrian/go/bin/protoc-3.4.0
(re)installing /Users/adrian/go/bin/protoc-gen-gogofast-v1.3.2
generating code
~/go/src/thanos/pkg ~/go/src/thanos
~/go/src/thanos/pkg/store/storepb ~/go/src/thanos/pkg ~/go/src/thanos
~/go/src/thanos/pkg ~/go/src/thanos
~/go/src/thanos/pkg/store/storepb/prompb ~/go/src/thanos/pkg ~/go/src/thanos
~/go/src/thanos/pkg ~/go/src/thanos
~/go/src/thanos/pkg/store/labelpb ~/go/src/thanos/pkg ~/go/src/thanos
~/go/src/thanos/pkg ~/go/src/thanos
~/go/src/thanos/pkg/rules/rulespb ~/go/src/thanos/pkg ~/go/src/thanos
~/go/src/thanos/pkg ~/go/src/thanos
~/go/src/thanos/pkg/store/hintspb ~/go/src/thanos/pkg ~/go/src/thanos
~/go/src/thanos/pkg ~/go/src/thanos
~/go/src/thanos/pkg/queryfrontend ~/go/src/thanos/pkg ~/go/src/thanos
~/go/src/thanos/pkg ~/go/src/thanos
~/go/src/thanos/pkg/metadata/metadatapb ~/go/src/thanos/pkg ~/go/src/thanos
~/go/src/thanos/pkg ~/go/src/thanos
~/go/src/thanos
```