### PR TITLE
Returning custom grpc code when reaching series/chunk limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ We use _breaking :warning:_ to mark changes that are not backward compatible (re
 ## Unreleased
 
 ### Added
+- [#3903](https://github.com/thanos-io/thanos/pull/3903) Store: Returning custom grpc code when reaching series/chunk limits.
 
 ### Fixed
 - [#3204](https://github.com/thanos-io/thanos/pull/3204) Mixin: Use sidecar's metric timestamp for healthcheck.

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -1026,7 +1026,11 @@ func (s *BucketStore) Series(req *storepb.SeriesRequest, srv storepb.Store_Serie
 			err = g.Wait()
 		})
 		if err != nil {
-			return status.Error(codes.Aborted, err.Error())
+			code := codes.Aborted
+			if s, ok := status.FromError(errors.Cause(err)); ok {
+				code = s.Code()
+			}
+			return status.Error(code, err.Error())
 		}
 		stats.blocksQueried = len(res)
 		stats.getAllDuration = time.Since(begin)


### PR DESCRIPTION


<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [X] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes
This change allow to return a different/custom GRPC code - other than the generic `Aborted` - when the limits are hit via `SeriesLimiter` or `ChunksLimiter`.

The reason for this change is that it is hard for the caller to differentiate when the error returned by [Series](https://github.com/thanos-io/thanos/blob/main/pkg/store/bucket.go#L893) method was generated by a `limiter` or if it was a generic/transient error. Propagating the error code generated by the limiter will create the possibility to return any GRPC code on those cases.

* If the error generated by the `SeriesLimiter` and `ChunksLimiter` is a GRPC error, the [Series](https://github.com/thanos-io/thanos/blob/main/pkg/store/bucket.go#L893) will return a GRPC error with the same errorcode.
## Verification

* Unit tests