### PR TITLE
pkg/extflag: clarify help for path/content flags

### DIFF
--- a/docs/components/compact.md
+++ b/docs/components/compact.md
@@ -333,9 +333,9 @@ Flags:
                                 See format details:
                                 https://thanos.io/tip/thanos/tracing.md/#configuration
       --tracing.config=<content>
-                                Alternative to 'tracing.config-file' flag (lower
-                                priority). Content of YAML file with tracing
-                                configuration. See format details:
+                                Alternative to 'tracing.config-file' flag
+                                (mutually exclusive). Content of YAML file with
+                                tracing configuration. See format details:
                                 https://thanos.io/tip/thanos/tracing.md/#configuration
       --http-address="0.0.0.0:10902"
                                 Listen host:port for HTTP endpoints.
@@ -349,7 +349,7 @@ Flags:
                                 https://thanos.io/tip/thanos/storage.md/#configuration
       --objstore.config=<content>
                                 Alternative to 'objstore.config-file' flag
-                                (lower priority). Content of YAML file that
+                                (mutually exclusive). Content of YAML file that
                                 contains object store configuration. See format
                                 details:
                                 https://thanos.io/tip/thanos/storage.md/#configuration
@@ -422,10 +422,11 @@ Flags:
                                 https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
       --selector.relabel-config=<content>
                                 Alternative to 'selector.relabel-config-file'
-                                flag (lower priority). Content of YAML file that
-                                contains relabeling configuration that allows
-                                selecting blocks. It follows native Prometheus
-                                relabel-config syntax. See format details:
+                                flag (mutually exclusive). Content of YAML file
+                                that contains relabeling configuration that
+                                allows selecting blocks. It follows native
+                                Prometheus relabel-config syntax. See format
+                                details:
                                 https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
       --web.external-prefix=""  Static prefix for all HTML links and redirect
                                 URLs in the bucket web UI interface. Actual

--- a/docs/components/query-frontend.md
+++ b/docs/components/query-frontend.md
@@ -135,7 +135,7 @@ Flags:
                                  https://thanos.io/tip/thanos/tracing.md/#configuration
       --tracing.config=<content>
                                  Alternative to 'tracing.config-file' flag
-                                 (lower priority). Content of YAML file with
+                                 (mutually exclusive). Content of YAML file with
                                  tracing configuration. See format details:
                                  https://thanos.io/tip/thanos/tracing.md/#configuration
       --http-address="0.0.0.0:10902"
@@ -181,7 +181,7 @@ Flags:
       --query-range.response-cache-config=<content>
                                  Alternative to
                                  'query-range.response-cache-config-file' flag
-                                 (lower priority). Content of YAML file that
+                                 (mutually exclusive). Content of YAML file that
                                  contains response cache configuration.
       --labels.split-interval=24h
                                  Split labels requests by an interval and
@@ -211,9 +211,9 @@ Flags:
                                  configuration.
       --labels.response-cache-config=<content>
                                  Alternative to
-                                 'labels.response-cache-config-file' flag (lower
-                                 priority). Content of YAML file that contains
-                                 response cache configuration.
+                                 'labels.response-cache-config-file' flag
+                                 (mutually exclusive). Content of YAML file that
+                                 contains response cache configuration.
       --cache-compression-type=""
                                  Use compression in results cache. Supported
                                  values are: 'snappy' and ” (disable
@@ -250,7 +250,7 @@ Flags:
                                  https://gist.github.com/yashrsharma44/02f5765c5710dd09ce5d14e854f22825
       --request.logging-config=<content>
                                  Alternative to 'request.logging-config-file'
-                                 flag (lower priority). Content of YAML file
+                                 flag (mutually exclusive). Content of YAML file
                                  with request logging configuration. See format
                                  details:
                                  https://gist.github.com/yashrsharma44/02f5765c5710dd09ce5d14e854f22825

--- a/docs/components/query.md
+++ b/docs/components/query.md
@@ -302,7 +302,7 @@ Flags:
                                  https://thanos.io/tip/thanos/tracing.md/#configuration
       --tracing.config=<content>
                                  Alternative to 'tracing.config-file' flag
-                                 (lower priority). Content of YAML file with
+                                 (mutually exclusive). Content of YAML file with
                                  tracing configuration. See format details:
                                  https://thanos.io/tip/thanos/tracing.md/#configuration
       --http-address="0.0.0.0:10902"
@@ -448,7 +448,7 @@ Flags:
                                  https://gist.github.com/yashrsharma44/02f5765c5710dd09ce5d14e854f22825
       --request.logging-config=<content>
                                  Alternative to 'request.logging-config-file'
-                                 flag (lower priority). Content of YAML file
+                                 flag (mutually exclusive). Content of YAML file
                                  with request logging configuration. See format
                                  details:
                                  https://gist.github.com/yashrsharma44/02f5765c5710dd09ce5d14e854f22825

--- a/docs/components/receive.md
+++ b/docs/components/receive.md
@@ -87,7 +87,7 @@ Flags:
                                  https://thanos.io/tip/thanos/tracing.md/#configuration
       --tracing.config=<content>
                                  Alternative to 'tracing.config-file' flag
-                                 (lower priority). Content of YAML file with
+                                 (mutually exclusive). Content of YAML file with
                                  tracing configuration. See format details:
                                  https://thanos.io/tip/thanos/tracing.md/#configuration
       --http-address="0.0.0.0:10902"
@@ -141,7 +141,7 @@ Flags:
                                  https://thanos.io/tip/thanos/storage.md/#configuration
       --objstore.config=<content>
                                  Alternative to 'objstore.config-file' flag
-                                 (lower priority). Content of YAML file that
+                                 (mutually exclusive). Content of YAML file that
                                  contains object store configuration. See format
                                  details:
                                  https://thanos.io/tip/thanos/storage.md/#configuration
@@ -197,7 +197,7 @@ Flags:
                                  https://gist.github.com/yashrsharma44/02f5765c5710dd09ce5d14e854f22825
       --request.logging-config=<content>
                                  Alternative to 'request.logging-config-file'
-                                 flag (lower priority). Content of YAML file
+                                 flag (mutually exclusive). Content of YAML file
                                  with request logging configuration. See format
                                  details:
                                  https://gist.github.com/yashrsharma44/02f5765c5710dd09ce5d14e854f22825

--- a/docs/components/rule.md
+++ b/docs/components/rule.md
@@ -248,7 +248,7 @@ Flags:
                                  https://thanos.io/tip/thanos/tracing.md/#configuration
       --tracing.config=<content>
                                  Alternative to 'tracing.config-file' flag
-                                 (lower priority). Content of YAML file with
+                                 (mutually exclusive). Content of YAML file with
                                  tracing configuration. See format details:
                                  https://thanos.io/tip/thanos/tracing.md/#configuration
       --http-address="0.0.0.0:10902"
@@ -308,7 +308,7 @@ Flags:
                                  '--alertmanagers.send-timeout' flags.
       --alertmanagers.config=<content>
                                  Alternative to 'alertmanagers.config-file' flag
-                                 (lower priority). Content of YAML file that
+                                 (mutually exclusive). Content of YAML file that
                                  contains alerting configuration. See format
                                  details:
                                  https://thanos.io/tip/components/rule.md/#configuration.
@@ -364,7 +364,7 @@ Flags:
                                  https://thanos.io/tip/thanos/storage.md/#configuration
       --objstore.config=<content>
                                  Alternative to 'objstore.config-file' flag
-                                 (lower priority). Content of YAML file that
+                                 (mutually exclusive). Content of YAML file that
                                  contains object store configuration. See format
                                  details:
                                  https://thanos.io/tip/thanos/storage.md/#configuration
@@ -379,10 +379,10 @@ Flags:
                                  https://thanos.io/tip/components/rule.md/#configuration.
                                  If defined, it takes precedence over the
                                  '--query' and '--query.sd-files' flags.
-      --query.config=<content>   Alternative to 'query.config-file' flag (lower
-                                 priority). Content of YAML file that contains
-                                 query API servers configuration. See format
-                                 details:
+      --query.config=<content>   Alternative to 'query.config-file' flag
+                                 (mutually exclusive). Content of YAML file that
+                                 contains query API servers configuration. See
+                                 format details:
                                  https://thanos.io/tip/components/rule.md/#configuration.
                                  If defined, it takes precedence over the
                                  '--query' and '--query.sd-files' flags.
@@ -408,7 +408,7 @@ Flags:
                                  https://gist.github.com/yashrsharma44/02f5765c5710dd09ce5d14e854f22825
       --request.logging-config=<content>
                                  Alternative to 'request.logging-config-file'
-                                 flag (lower priority). Content of YAML file
+                                 flag (mutually exclusive). Content of YAML file
                                  with request logging configuration. See format
                                  details:
                                  https://gist.github.com/yashrsharma44/02f5765c5710dd09ce5d14e854f22825

--- a/docs/components/sidecar.md
+++ b/docs/components/sidecar.md
@@ -94,7 +94,7 @@ Flags:
                                  https://thanos.io/tip/thanos/tracing.md/#configuration
       --tracing.config=<content>
                                  Alternative to 'tracing.config-file' flag
-                                 (lower priority). Content of YAML file with
+                                 (mutually exclusive). Content of YAML file with
                                  tracing configuration. See format details:
                                  https://thanos.io/tip/thanos/tracing.md/#configuration
       --http-address="0.0.0.0:10902"
@@ -146,7 +146,7 @@ Flags:
                                  https://gist.github.com/yashrsharma44/02f5765c5710dd09ce5d14e854f22825
       --request.logging-config=<content>
                                  Alternative to 'request.logging-config-file'
-                                 flag (lower priority). Content of YAML file
+                                 flag (mutually exclusive). Content of YAML file
                                  with request logging configuration. See format
                                  details:
                                  https://gist.github.com/yashrsharma44/02f5765c5710dd09ce5d14e854f22825
@@ -156,7 +156,7 @@ Flags:
                                  https://thanos.io/tip/thanos/storage.md/#configuration
       --objstore.config=<content>
                                  Alternative to 'objstore.config-file' flag
-                                 (lower priority). Content of YAML file that
+                                 (mutually exclusive). Content of YAML file that
                                  contains object store configuration. See format
                                  details:
                                  https://thanos.io/tip/thanos/storage.md/#configuration

--- a/docs/components/store.md
+++ b/docs/components/store.md
@@ -47,7 +47,7 @@ Flags:
                                  https://thanos.io/tip/thanos/tracing.md/#configuration
       --tracing.config=<content>
                                  Alternative to 'tracing.config-file' flag
-                                 (lower priority). Content of YAML file with
+                                 (mutually exclusive). Content of YAML file with
                                  tracing configuration. See format details:
                                  https://thanos.io/tip/thanos/tracing.md/#configuration
       --http-address="0.0.0.0:10902"
@@ -84,7 +84,7 @@ Flags:
                                  https://thanos.io/tip/components/store.md/#index-cache
       --index-cache.config=<content>
                                  Alternative to 'index-cache.config-file' flag
-                                 (lower priority). Content of YAML file that
+                                 (mutually exclusive). Content of YAML file that
                                  contains index cache configuration. See format
                                  details:
                                  https://thanos.io/tip/components/store.md/#index-cache
@@ -113,7 +113,7 @@ Flags:
                                  https://thanos.io/tip/thanos/storage.md/#configuration
       --objstore.config=<content>
                                  Alternative to 'objstore.config-file' flag
-                                 (lower priority). Content of YAML file that
+                                 (mutually exclusive). Content of YAML file that
                                  contains object store configuration. See format
                                  details:
                                  https://thanos.io/tip/thanos/storage.md/#configuration
@@ -147,7 +147,7 @@ Flags:
                                  https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
       --selector.relabel-config=<content>
                                  Alternative to 'selector.relabel-config-file'
-                                 flag (lower priority). Content of YAML file
+                                 flag (mutually exclusive). Content of YAML file
                                  that contains relabeling configuration that
                                  allows selecting blocks. It follows native
                                  Prometheus relabel-config syntax. See format
@@ -207,7 +207,7 @@ Flags:
                                  https://gist.github.com/yashrsharma44/02f5765c5710dd09ce5d14e854f22825
       --request.logging-config=<content>
                                  Alternative to 'request.logging-config-file'
-                                 flag (lower priority). Content of YAML file
+                                 flag (mutually exclusive). Content of YAML file
                                  with request logging configuration. See format
                                  details:
                                  https://gist.github.com/yashrsharma44/02f5765c5710dd09ce5d14e854f22825

--- a/docs/components/tools.md
+++ b/docs/components/tools.md
@@ -30,8 +30,8 @@ Flags:
                            format details:
                            https://thanos.io/tip/thanos/tracing.md/#configuration
       --tracing.config=<content>
-                           Alternative to 'tracing.config-file' flag (lower
-                           priority). Content of YAML file with tracing
+                           Alternative to 'tracing.config-file' flag (mutually
+                           exclusive). Content of YAML file with tracing
                            configuration. See format details:
                            https://thanos.io/tip/thanos/tracing.md/#configuration
 
@@ -127,8 +127,8 @@ Flags:
                            format details:
                            https://thanos.io/tip/thanos/tracing.md/#configuration
       --tracing.config=<content>
-                           Alternative to 'tracing.config-file' flag (lower
-                           priority). Content of YAML file with tracing
+                           Alternative to 'tracing.config-file' flag (mutually
+                           exclusive). Content of YAML file with tracing
                            configuration. See format details:
                            https://thanos.io/tip/thanos/tracing.md/#configuration
       --objstore.config-file=<file-path>
@@ -136,8 +136,8 @@ Flags:
                            configuration. See format details:
                            https://thanos.io/tip/thanos/storage.md/#configuration
       --objstore.config=<content>
-                           Alternative to 'objstore.config-file' flag (lower
-                           priority). Content of YAML file that contains object
+                           Alternative to 'objstore.config-file' flag (mutually
+                           exclusive). Content of YAML file that contains object
                            store configuration. See format details:
                            https://thanos.io/tip/thanos/storage.md/#configuration
 
@@ -223,9 +223,9 @@ Flags:
                                 See format details:
                                 https://thanos.io/tip/thanos/tracing.md/#configuration
       --tracing.config=<content>
-                                Alternative to 'tracing.config-file' flag (lower
-                                priority). Content of YAML file with tracing
-                                configuration. See format details:
+                                Alternative to 'tracing.config-file' flag
+                                (mutually exclusive). Content of YAML file with
+                                tracing configuration. See format details:
                                 https://thanos.io/tip/thanos/tracing.md/#configuration
       --objstore.config-file=<file-path>
                                 Path to YAML file that contains object store
@@ -233,7 +233,7 @@ Flags:
                                 https://thanos.io/tip/thanos/storage.md/#configuration
       --objstore.config=<content>
                                 Alternative to 'objstore.config-file' flag
-                                (lower priority). Content of YAML file that
+                                (mutually exclusive). Content of YAML file that
                                 contains object store configuration. See format
                                 details:
                                 https://thanos.io/tip/thanos/storage.md/#configuration
@@ -298,8 +298,8 @@ Flags:
                            format details:
                            https://thanos.io/tip/thanos/tracing.md/#configuration
       --tracing.config=<content>
-                           Alternative to 'tracing.config-file' flag (lower
-                           priority). Content of YAML file with tracing
+                           Alternative to 'tracing.config-file' flag (mutually
+                           exclusive). Content of YAML file with tracing
                            configuration. See format details:
                            https://thanos.io/tip/thanos/tracing.md/#configuration
       --objstore.config-file=<file-path>
@@ -307,8 +307,8 @@ Flags:
                            configuration. See format details:
                            https://thanos.io/tip/thanos/storage.md/#configuration
       --objstore.config=<content>
-                           Alternative to 'objstore.config-file' flag (lower
-                           priority). Content of YAML file that contains object
+                           Alternative to 'objstore.config-file' flag (mutually
+                           exclusive). Content of YAML file that contains object
                            store configuration. See format details:
                            https://thanos.io/tip/thanos/storage.md/#configuration
       --objstore-backup.config-file=<file-path>
@@ -319,9 +319,9 @@ Flags:
                            removal.
       --objstore-backup.config=<content>
                            Alternative to 'objstore-backup.config-file' flag
-                           (lower priority). Content of YAML file that contains
-                           object store-backup configuration. See format
-                           details:
+                           (mutually exclusive). Content of YAML file that
+                           contains object store-backup configuration. See
+                           format details:
                            https://thanos.io/tip/thanos/storage.md/#configuration
                            Used for repair logic to backup blocks before
                            removal.
@@ -377,8 +377,8 @@ Flags:
                            format details:
                            https://thanos.io/tip/thanos/tracing.md/#configuration
       --tracing.config=<content>
-                           Alternative to 'tracing.config-file' flag (lower
-                           priority). Content of YAML file with tracing
+                           Alternative to 'tracing.config-file' flag (mutually
+                           exclusive). Content of YAML file with tracing
                            configuration. See format details:
                            https://thanos.io/tip/thanos/tracing.md/#configuration
       --objstore.config-file=<file-path>
@@ -386,8 +386,8 @@ Flags:
                            configuration. See format details:
                            https://thanos.io/tip/thanos/storage.md/#configuration
       --objstore.config=<content>
-                           Alternative to 'objstore.config-file' flag (lower
-                           priority). Content of YAML file that contains object
+                           Alternative to 'objstore.config-file' flag (mutually
+                           exclusive). Content of YAML file that contains object
                            store configuration. See format details:
                            https://thanos.io/tip/thanos/storage.md/#configuration
   -o, --output=""          Optional format in which to print each block's
@@ -424,8 +424,8 @@ Flags:
                              format details:
                              https://thanos.io/tip/thanos/tracing.md/#configuration
       --tracing.config=<content>
-                             Alternative to 'tracing.config-file' flag (lower
-                             priority). Content of YAML file with tracing
+                             Alternative to 'tracing.config-file' flag (mutually
+                             exclusive). Content of YAML file with tracing
                              configuration. See format details:
                              https://thanos.io/tip/thanos/tracing.md/#configuration
       --objstore.config-file=<file-path>
@@ -433,9 +433,10 @@ Flags:
                              configuration. See format details:
                              https://thanos.io/tip/thanos/storage.md/#configuration
       --objstore.config=<content>
-                             Alternative to 'objstore.config-file' flag (lower
-                             priority). Content of YAML file that contains
-                             object store configuration. See format details:
+                             Alternative to 'objstore.config-file' flag
+                             (mutually exclusive). Content of YAML file that
+                             contains object store configuration. See format
+                             details:
                              https://thanos.io/tip/thanos/storage.md/#configuration
   -l, --selector=<name>=\"<value>\" ...
                              Selects blocks based on label, e.g. '-l
@@ -480,7 +481,7 @@ Flags:
                                  https://thanos.io/tip/thanos/tracing.md/#configuration
       --tracing.config=<content>
                                  Alternative to 'tracing.config-file' flag
-                                 (lower priority). Content of YAML file with
+                                 (mutually exclusive). Content of YAML file with
                                  tracing configuration. See format details:
                                  https://thanos.io/tip/thanos/tracing.md/#configuration
       --objstore.config-file=<file-path>
@@ -489,7 +490,7 @@ Flags:
                                  https://thanos.io/tip/thanos/storage.md/#configuration
       --objstore.config=<content>
                                  Alternative to 'objstore.config-file' flag
-                                 (lower priority). Content of YAML file that
+                                 (mutually exclusive). Content of YAML file that
                                  contains object store configuration. See format
                                  details:
                                  https://thanos.io/tip/thanos/storage.md/#configuration
@@ -504,7 +505,7 @@ Flags:
                                  The object storage which replicate data to.
       --objstore-to.config=<content>
                                  Alternative to 'objstore-to.config-file' flag
-                                 (lower priority). Content of YAML file that
+                                 (mutually exclusive). Content of YAML file that
                                  contains object store-to configuration. See
                                  format details:
                                  https://thanos.io/tip/thanos/storage.md/#configuration
@@ -577,18 +578,19 @@ Flags:
                               format details:
                               https://thanos.io/tip/thanos/tracing.md/#configuration
       --tracing.config=<content>
-                              Alternative to 'tracing.config-file' flag (lower
-                              priority). Content of YAML file with tracing
-                              configuration. See format details:
+                              Alternative to 'tracing.config-file' flag
+                              (mutually exclusive). Content of YAML file with
+                              tracing configuration. See format details:
                               https://thanos.io/tip/thanos/tracing.md/#configuration
       --objstore.config-file=<file-path>
                               Path to YAML file that contains object store
                               configuration. See format details:
                               https://thanos.io/tip/thanos/storage.md/#configuration
       --objstore.config=<content>
-                              Alternative to 'objstore.config-file' flag (lower
-                              priority). Content of YAML file that contains
-                              object store configuration. See format details:
+                              Alternative to 'objstore.config-file' flag
+                              (mutually exclusive). Content of YAML file that
+                              contains object store configuration. See format
+                              details:
                               https://thanos.io/tip/thanos/storage.md/#configuration
       --http-address="0.0.0.0:10902"
                               Listen host:port for HTTP endpoints.
@@ -644,8 +646,8 @@ Flags:
                            format details:
                            https://thanos.io/tip/thanos/tracing.md/#configuration
       --tracing.config=<content>
-                           Alternative to 'tracing.config-file' flag (lower
-                           priority). Content of YAML file with tracing
+                           Alternative to 'tracing.config-file' flag (mutually
+                           exclusive). Content of YAML file with tracing
                            configuration. See format details:
                            https://thanos.io/tip/thanos/tracing.md/#configuration
       --objstore.config-file=<file-path>
@@ -653,8 +655,8 @@ Flags:
                            configuration. See format details:
                            https://thanos.io/tip/thanos/storage.md/#configuration
       --objstore.config=<content>
-                           Alternative to 'objstore.config-file' flag (lower
-                           priority). Content of YAML file that contains object
+                           Alternative to 'objstore.config-file' flag (mutually
+                           exclusive). Content of YAML file that contains object
                            store configuration. See format details:
                            https://thanos.io/tip/thanos/storage.md/#configuration
       --id=ID ...          ID (ULID) of the blocks to be marked for deletion
@@ -720,9 +722,9 @@ Flags:
                                 See format details:
                                 https://thanos.io/tip/thanos/tracing.md/#configuration
       --tracing.config=<content>
-                                Alternative to 'tracing.config-file' flag (lower
-                                priority). Content of YAML file with tracing
-                                configuration. See format details:
+                                Alternative to 'tracing.config-file' flag
+                                (mutually exclusive). Content of YAML file with
+                                tracing configuration. See format details:
                                 https://thanos.io/tip/thanos/tracing.md/#configuration
       --objstore.config-file=<file-path>
                                 Path to YAML file that contains object store
@@ -730,7 +732,7 @@ Flags:
                                 https://thanos.io/tip/thanos/storage.md/#configuration
       --objstore.config=<content>
                                 Alternative to 'objstore.config-file' flag
-                                (lower priority). Content of YAML file that
+                                (mutually exclusive). Content of YAML file that
                                 contains object store configuration. See format
                                 details:
                                 https://thanos.io/tip/thanos/storage.md/#configuration
@@ -753,9 +755,9 @@ Flags:
                                 to blocks
       --rewrite.to-delete-config=<content>
                                 Alternative to 'rewrite.to-delete-config-file'
-                                flag (lower priority). Content of YAML file that
-                                contains []metadata.DeletionRequest that will be
-                                applied to blocks
+                                flag (mutually exclusive). Content of YAML file
+                                that contains []metadata.DeletionRequest that
+                                will be applied to blocks
       --rewrite.add-change-log  If specified, all modifications are written to
                                 new block directory. Disable if latency is to
                                 high.
@@ -796,8 +798,8 @@ Flags:
                            format details:
                            https://thanos.io/tip/thanos/tracing.md/#configuration
       --tracing.config=<content>
-                           Alternative to 'tracing.config-file' flag (lower
-                           priority). Content of YAML file with tracing
+                           Alternative to 'tracing.config-file' flag (mutually
+                           exclusive). Content of YAML file with tracing
                            configuration. See format details:
                            https://thanos.io/tip/thanos/tracing.md/#configuration
       --rules=RULES ...    The rule files glob to check (repeated).

--- a/pkg/extflag/pathorcontent.go
+++ b/pkg/extflag/pathorcontent.go
@@ -33,7 +33,7 @@ func RegisterPathOrContent(cmd FlagClause, flagName string, help string, require
 	fileHelp := fmt.Sprintf("Path to %s", help)
 	fileFlag := cmd.Flag(fileFlagName, fileHelp).PlaceHolder("<file-path>").String()
 
-	contentHelp := fmt.Sprintf("Alternative to '%s' flag (lower priority). Content of %s", fileFlagName, help)
+	contentHelp := fmt.Sprintf("Alternative to '%s' flag (mutually exclusive). Content of %s", fileFlagName, help)
 	contentFlag := cmd.Flag(contentFlagName, contentHelp).PlaceHolder("<content>").String()
 
 	return &PathOrContent{
@@ -44,9 +44,11 @@ func RegisterPathOrContent(cmd FlagClause, flagName string, help string, require
 	}
 }
 
-// Content returns the content of the file when given or directly the content that has passed to the flag.
-// Flag that specifies path has priority.
-// It returns error if the content is empty and required flag is set to true.
+// Content returns the content of the file when given or directly the content that has been passed to the flag.
+// It returns an error when:
+// * The file and content flags are both not empty.
+// * The file flag is not empty but the file can't be read.
+// * The content is empty and the flag has been defined as required.
 func (p *PathOrContent) Content() ([]byte, error) {
 	fileFlagName := fmt.Sprintf("%s-file", p.flagName)
 


### PR DESCRIPTION
* [ ] I added CHANGELOG entry for this change.
* [X] Change is not relevant to the end user.

## Changes

The help text stated that both flags could be defined at the same time
with higher priority for the path flag while in practice, they are
mutually exclusive.

## Verification

No functional change.
