### PR TITLE
Support max_item_size for query frontend memcached cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ We use _breaking :warning:_ to mark changes that are not backward compatible (re
 - [#3903](https://github.com/thanos-io/thanos/pull/3903) Store: Returning custom grpc code when reaching series/chunk limits.
 - [#3919](https://github.com/thanos-io/thanos/pull/3919) Allow to disable automatically setting CORS headers using `--web.disable-cors` flag in each component that exposes an API.
 - [#3840](https://github.com/thanos-io/thanos/pull/3840) Tools: Added a flag to support rewrite Prometheus TSDB blocks.
+- [#3920](https://github.com/thanos-io/thanos/pull/3920) Query Frontend: Support `max_item_size` in Query frontend Memcached cache.
 
 ### Fixed
 

--- a/docs/components/query-frontend.md
+++ b/docs/components/query-frontend.md
@@ -85,7 +85,9 @@ config:
   expiration: 0s
 ```
 
-`expiration` specifies memcached cache valid time , If set to 0s, so using a default of 24 hours expiration time
+`expiration` specifies memcached cache valid time.  If set to 0s, so using a default of 24 hours expiration time.
+
+If a `set` operation is skipped because of the item size is larger than `max_item_size`, this event is tracked by a counter metric `cortex_memcache_client_set_skip_total`.
 
 Other cache configuration parameters, you can refer to [memcached-index-cache]( https://thanos.io/tip/components/store.md/#memcached-index-cache).
 
@@ -97,6 +99,7 @@ config:
   addresses: [your-memcached-addresses]
   timeout: 500ms
   max_idle_connections: 100
+  max_item_size: 1MiB
   max_async_concurrency: 10
   max_async_buffer_size: 10000
   max_get_multi_concurrency: 100


### PR DESCRIPTION
Signed-off-by: yeya24 <yb532204897@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->
Fixes #3895

This pr upgrades Cortex and support `max_item_size` in query frontend Memcached config.

## Verification

<!-- How you tested it? How do you know it works? -->
