### PR TITLE
pkg/logging: Fix HTTP logging middleware panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ We use _breaking :warning:_ to mark changes that are not backward compatible (re
 
 ### Fixed
 - [#3204](https://github.com/thanos-io/thanos/pull/3204) Mixin: Use sidecar's metric timestamp for healthcheck.
+- [#3922](https://github.com/thanos-io/thanos/pull/3922) Fix panic in http logging middleware.
 
 ### Changed
 

--- a/pkg/logging/http_test.go
+++ b/pkg/logging/http_test.go
@@ -1,0 +1,37 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package logging
+
+import (
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-kit/kit/log"
+	"github.com/thanos-io/thanos/pkg/testutil"
+)
+
+func TestHTTPServerMiddleware(t *testing.T) {
+	m := NewHTTPServerMiddleware(log.NewNopLogger())
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		_, err := io.WriteString(w, "Test Works")
+		if err != nil {
+			t.Log(err)
+		}
+	}
+	hm := m.HTTPMiddleware("test", http.HandlerFunc(handler))
+
+	req := httptest.NewRequest("GET", "http://example.com/foo", nil)
+	w := httptest.NewRecorder()
+
+	hm(w, req)
+
+	resp := w.Result()
+	body, _ := ioutil.ReadAll(resp.Body)
+
+	testutil.Equals(t, 200, resp.StatusCode)
+	testutil.Equals(t, "Test Works", string(body))
+}


### PR DESCRIPTION
* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Use `net.SplitHostPort` instead of `strings.Split` with a direct slice access, which caused panics when the `Host` header is not available or doesn't contain a port.

## Verification

Added a unit test that without this patch paniced.

Fixes #3921

@thanos-io/thanos-maintainers 
