### PR TITLE
Added a featured blog section

### DIFF
--- a/docs/featured/_index.md
+++ b/docs/featured/_index.md
@@ -1,0 +1,3 @@
+---
+title: "Featured:"
+---

--- a/docs/featured/featured-blogs.md
+++ b/docs/featured/featured-blogs.md
@@ -1,0 +1,19 @@
+---
+title: Featured Blogs
+type: docs
+menu: featured
+---
+
+# Featured Blogs
+
+This page enlists the hand-picked blog-posts from the maintainers, about Thanos and the it's internal workings. Thanos contains lot of documentation about the working and using different components. However, there are some blogposts, which have been written keeping in mind about the user's use case and constraints, which might provide more insight about using Thanos in production, and help you in picturing Thanos as a part of a bigger building block. We chose to feature those posts here, which might provide more insights and help you understand Thanos more better.
+
+We also have enlisted blogs which are helpful while getting started to contribute to Thanos and to the community as a whole, and might help you get unblocked and provide you a seamless experience in setting up Thanos.
+
+<!-- ### Using Thanos in Production
+
+These posts depict their experience of using Thanos in production and how to proceed with setting up a working Thanos setup in short time. -->
+
+### Thanos Contributor's Dev Docs
+
+Although the [contributing docs](https://thanos.io/tip/contributing/contributing.md/) is a great place to start, there are some curated explanation about the internal workings of Thanos, that the previous contributors might have worked earlier. All the internal details about the components of Thanos that have been worked upon, has been discussed in the doc - [Thanos Dev Docs](https://docs.google.com/document/d/1hluKPDKsSdOqcCpOnzr7-4PxLnUtrCl5d4-TVGch_D4/edit) - in more detail. Feel free to add in your detailed explanation about those components, or feature of Thanos which has not been covered in the docs yet.


### PR DESCRIPTION
Added a Featured section for curated blogs that we might want to put up for Thanos.

There are some blog-posts that we might want to keep on the Thanos Website for spotlight purpose - https://www.infracloud.io/blogs/multi-tenancy-monitoring-thanos-receiver/

* This section is useful for putting up links to the posts which are quite useful and demonstrate unique ways of using Thanos in Production. 
* This might be a start for placing company based case-studies that each company might post in their blog posts, we could provide a reference to those which are deemed to be useful for the same. 
* **_This would also cater to common questions that users might have while setting up Thanos, we could just refer them to those posts, rather than maintaining a section for common setup questions, which might need some effort from our side to maintain them._**

More info - [link](https://docs.google.com/document/d/137XnxfOT2p1NcNUq6NWZjwmtlSdA6Wyti86Pd6cyQhs/edit?disco=AAAAH2_C3TA)

For starters, I have added a sub-section for contributors dev docs.

cc @thanos-io/thanos-maintainers 