### PR TITLE
Allowing tls skip verify for the query component

### DIFF
--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -59,6 +59,7 @@ func registerQuery(app *extkingpin.App) {
 	grpcBindAddr, grpcGracePeriod, grpcCert, grpcKey, grpcClientCA := extkingpin.RegisterGRPCFlags(cmd)
 
 	secure := cmd.Flag("grpc-client-tls-secure", "Use TLS when talking to the gRPC server").Default("false").Bool()
+	skipVerify := cmd.Flag("grpc-client-tls-skip-verify", "Disable TLS certificate verification i.e self signed, signed by fake CA").Default("false").Bool()
 	cert := cmd.Flag("grpc-client-tls-cert", "TLS Certificates to use to identify this client to the server").Default("").String()
 	key := cmd.Flag("grpc-client-tls-key", "TLS Key for the client's certificate").Default("").String()
 	caCert := cmd.Flag("grpc-client-tls-ca", "TLS CA Certificates to use to verify gRPC servers").Default("").String()
@@ -200,6 +201,7 @@ func registerQuery(app *extkingpin.App) {
 			*grpcKey,
 			*grpcClientCA,
 			*secure,
+			*skipVerify,
 			*cert,
 			*key,
 			*caCert,
@@ -256,6 +258,7 @@ func runQuery(
 	grpcKey string,
 	grpcClientCA string,
 	secure bool,
+	skipVerify bool,
 	cert string,
 	key string,
 	caCert string,
@@ -299,7 +302,7 @@ func runQuery(
 		Help: "The number of times a duplicated store addresses is detected from the different configs in query",
 	})
 
-	dialOpts, err := extgrpc.StoreClientGRPCOpts(logger, reg, tracer, secure, cert, key, caCert, serverName)
+	dialOpts, err := extgrpc.StoreClientGRPCOpts(logger, reg, tracer, secure, skipVerify, cert, key, caCert, serverName)
 	if err != nil {
 		return errors.Wrap(err, "building gRPC client")
 	}

--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -233,7 +233,7 @@ func runReceive(
 	if err != nil {
 		return err
 	}
-	dialOpts, err := extgrpc.StoreClientGRPCOpts(logger, reg, tracer, rwServerCert != "", rwClientCert, rwClientKey, rwClientServerCA, rwClientServerName)
+	dialOpts, err := extgrpc.StoreClientGRPCOpts(logger, reg, tracer, rwServerCert != "", rwServerClientCA == "", rwClientCert, rwClientKey, rwClientServerCA, rwClientServerName)
 	if err != nil {
 		return err
 	}

--- a/docs/components/query.md
+++ b/docs/components/query.md
@@ -324,6 +324,9 @@ Flags:
                                  CA is specified, there is no client
                                  verification on server side. (tls.NoClientCert)
       --grpc-client-tls-secure   Use TLS when talking to the gRPC server
+      --grpc-client-tls-skip-verify
+                                 Disable TLS certificate verification i.e self signed,
+                                 signed by fake CA
       --grpc-client-tls-cert=""  TLS Certificates to use to identify this client
                                  to the server
       --grpc-client-tls-key=""   TLS Key for the client's certificate

--- a/docs/components/query.md
+++ b/docs/components/query.md
@@ -325,8 +325,8 @@ Flags:
                                  verification on server side. (tls.NoClientCert)
       --grpc-client-tls-secure   Use TLS when talking to the gRPC server
       --grpc-client-tls-skip-verify
-                                 Disable TLS certificate verification i.e self signed,
-                                 signed by fake CA
+                                 Disable TLS certificate verification i.e self
+                                 signed, signed by fake CA
       --grpc-client-tls-cert=""  TLS Certificates to use to identify this client
                                  to the server
       --grpc-client-tls-key=""   TLS Key for the client's certificate

--- a/docs/components/tools.md
+++ b/docs/components/tools.md
@@ -741,7 +741,7 @@ Flags:
                                 https://thanos.io/tip/thanos/storage.md/#configuration
       --id=ID ...               ID (ULID) of the blocks for rewrite (repeated
                                 flag).
-      --tmp.dir="/var/folders/ks/bgbzxvwj7dq4kflwx6346x1c0000gp/T/thanos-rewrite"
+      --tmp.dir="/tmp/thanos-rewrite"
                                 Working directory for temporary files
       --hash-func=              Specify which hash function to use when
                                 calculating the hashes of produced files. If no

--- a/docs/components/tools.md
+++ b/docs/components/tools.md
@@ -741,7 +741,7 @@ Flags:
                                 https://thanos.io/tip/thanos/storage.md/#configuration
       --id=ID ...               ID (ULID) of the blocks for rewrite (repeated
                                 flag).
-      --tmp.dir="/tmp/thanos-rewrite"
+      --tmp.dir="/var/folders/ks/bgbzxvwj7dq4kflwx6346x1c0000gp/T/thanos-rewrite"
                                 Working directory for temporary files
       --hash-func=              Specify which hash function to use when
                                 calculating the hashes of produced files. If no

--- a/pkg/extgrpc/client.go
+++ b/pkg/extgrpc/client.go
@@ -20,7 +20,7 @@ import (
 )
 
 // StoreClientGRPCOpts creates gRPC dial options for connecting to a store client.
-func StoreClientGRPCOpts(logger log.Logger, reg *prometheus.Registry, tracer opentracing.Tracer, secure bool, cert, key, caCert, serverName string) ([]grpc.DialOption, error) {
+func StoreClientGRPCOpts(logger log.Logger, reg *prometheus.Registry, tracer opentracing.Tracer, secure, skipVerify bool, cert, key, caCert, serverName string) ([]grpc.DialOption, error) {
 	grpcMets := grpc_prometheus.NewClientMetrics()
 	grpcMets.EnableClientHandlingTimeHistogram(
 		grpc_prometheus.WithHistogramBuckets([]float64{0.001, 0.01, 0.1, 0.3, 0.6, 1, 3, 6, 9, 20, 30, 60, 90, 120, 240, 360, 720}),
@@ -54,7 +54,7 @@ func StoreClientGRPCOpts(logger log.Logger, reg *prometheus.Registry, tracer ope
 
 	level.Info(logger).Log("msg", "enabling client to server TLS")
 
-	tlsCfg, err := tls.NewClientConfig(logger, cert, key, caCert, serverName)
+	tlsCfg, err := tls.NewClientConfig(logger, cert, key, caCert, serverName, skipVerify)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/tls/options.go
+++ b/pkg/tls/options.go
@@ -61,7 +61,7 @@ func NewServerConfig(logger log.Logger, cert, key, clientCA string) (*tls.Config
 }
 
 // NewClientConfig provides new client TLS configuration.
-func NewClientConfig(logger log.Logger, cert, key, caCert, serverName string) (*tls.Config, error) {
+func NewClientConfig(logger log.Logger, cert, key, caCert, serverName string, skipVerify bool) (*tls.Config, error) {
 	var certPool *x509.CertPool
 	if caCert != "" {
 		caPEM, err := ioutil.ReadFile(caCert)
@@ -89,6 +89,10 @@ func NewClientConfig(logger log.Logger, cert, key, caCert, serverName string) (*
 
 	if serverName != "" {
 		tlsCfg.ServerName = serverName
+	}
+
+	if skipVerify {
+		tlsCfg.InsecureSkipVerify = true
 	}
 
 	if (key != "") != (cert != "") {


### PR DESCRIPTION
Signed-off-by: Srinivas Boga <bseenu@gmail.com>

Fixes: #3719 
## Changes

This change allows the grpc server to run with self signed certificate or certificates which are signed by fake CA's eg: https://letsencrypt.org/docs/staging-environment/

Just adding additional flag to the query endpoint which is disabled by false, and can be enabled to skip verification of the certificate

## Verification

```
bash-3.2$  docker run  quay.io/thanos/thanos:v0.18.0 query --log.level=debug --grpc-client-tls-secure --store=localhost:443
		   level=debug ts=2021-03-20T08:16:37.3579772Z caller=main.go:64 msg="maxprocs: Leaving GOMAXPROCS=[8]: CPU quota undefined"
		   level=info ts=2021-03-20T08:16:37.358575Z caller=client.go:54 msg="enabling client to server TLS"
		   level=info ts=2021-03-20T08:16:37.3700257Z caller=options.go:83 msg="TLS client using system certificate pool"
		   level=debug ts=2021-03-20T08:16:37.3710162Z caller=engine.go:283 msg="Lookback delta is zero, setting to default value" value=5m0s
		   level=info ts=2021-03-20T08:16:37.3722011Z caller=options.go:23 protocol=gRPC msg="disabled TLS, key and cert must be set to enable"
		   level=info ts=2021-03-20T08:16:37.3725596Z caller=query.go:508 msg="starting query node"
		   level=info ts=2021-03-20T08:16:37.3730364Z caller=intrumentation.go:48 msg="changing probe status" status=ready
		   level=debug ts=2021-03-20T08:16:37.37335Z caller=storeset.go:341 component=storeset msg="starting updating storeAPIs" cachedStores=0
		   level=info ts=2021-03-20T08:16:37.3734028Z caller=intrumentation.go:60 msg="changing probe status" status=healthy
		   level=info ts=2021-03-20T08:16:37.3734757Z caller=grpc.go:116 service=gRPC/server component=query msg="listening for serving gRPC" address=0.0.0.0:10901
		   level=info ts=2021-03-20T08:16:37.3734869Z caller=http.go:58 service=http/server component=query msg="listening for requests and metrics" address=0.0.0.0:10902
		   level=warn ts=2021-03-20T08:16:42.3411544Z caller=storeset.go:458 component=storeset msg="update of store node failed" err="getting metadata: fetching store info from localhost:443: rpc error: code = DeadlineExceeded desc = latest balancer error: connection error: desc = \"transport: authentication handshake failed: x509: certificate signed by unknown authority\"" localhost:443
		   level=debug ts=2021-03-20T08:16:42.3413208Z caller=storeset.go:344 component=storeset msg="checked requested storeAPIs" activeStores=0 cachedStores=0
		   level=debug ts=2021-03-20T08:16:42.3414082Z caller=storeset.go:341 component=storeset msg="starting updating storeAPIs" cachedStores=0
		   level=warn ts=2021-03-20T08:16:47.3419962Z caller=storeset.go:458 component=storeset msg="update of store node failed" err="getting metadata: fetching store info from localhost:443: rpc error: code = DeadlineExceeded desc = latest balancer error: connection error: desc = \"transport: authentication handshake failed: x509: certificate signed by unknown authority\"" localhost:443
		   level=debug ts=2021-03-20T08:16:47.342159Z caller=storeset.go:344 component=storeset msg="checked requested storeAPIs" activeStores=0 cachedStores=0
		   level=debug ts=2021-03-20T08:16:47.3422563Z caller=storeset.go:341 component=storeset msg="starting updating storeAPIs" cachedStores=0
		   level=warn ts=2021-03-20T08:16:52.3429689Z caller=storeset.go:458 component=storeset msg="update of store node failed" err="getting metadata: fetching store info from localhost:443: rpc error: code = DeadlineExceeded desc = latest balancer error: connection error: desc = \"transport: authentication handshake failed: x509: certificate signed by unknown authority\"" localhost:443
		   level=debug ts=2021-03-20T08:16:52.3432303Z caller=storeset.go:344 component=storeset msg="checked requested storeAPIs" activeStores=0 cachedStores=0
		   level=debug ts=2021-03-20T08:16:52.3433077Z caller=storeset.go:341 component=storeset msg="starting updating storeAPIs" cachedStores=0
		   ^Clevel=info ts=2021-03-20T08:16:53.1731445Z caller=main.go:167 msg="caught signal. Exiting." signal=interrupt

```

With this diff

```
bash-3.2$ ~/go/bin/thanos query --log.level=debug --grpc-client-tls-secure --grpc-client-tls-skip-verify --store=localhost:443
level=debug ts=2021-03-20T08:21:30.232421Z caller=main.go:64 msg="maxprocs: Leaving GOMAXPROCS=[16]: CPU quota undefined"
level=info ts=2021-03-20T08:21:30.23265Z caller=client.go:55 msg="enabling client to server TLS"
level=info ts=2021-03-20T08:21:30.36002Z caller=options.go:83 msg="TLS client using system certificate pool"
level=debug ts=2021-03-20T08:21:30.360776Z caller=engine.go:292 msg="Lookback delta is zero, setting to default value" value=5m0s
level=info ts=2021-03-20T08:21:30.363021Z caller=options.go:23 protocol=gRPC msg="disabled TLS, key and cert must be set to enable"
level=info ts=2021-03-20T08:21:30.363371Z caller=query.go:571 msg="starting query node"
level=debug ts=2021-03-20T08:21:30.36349Z caller=storeset.go:362 component=storeset msg="starting updating storeAPIs" cachedStores=0
level=info ts=2021-03-20T08:21:30.363514Z caller=intrumentation.go:60 msg="changing probe status" status=healthy
level=debug ts=2021-03-20T08:21:30.363533Z caller=storeset.go:365 component=storeset msg="checked requested storeAPIs" activeStores=0 cachedStores=0
level=info ts=2021-03-20T08:21:30.363545Z caller=http.go:62 service=http/server component=query msg="listening for requests and metrics" address=0.0.0.0:10902
level=info ts=2021-03-20T08:21:30.363563Z caller=intrumentation.go:48 msg="changing probe status" status=ready
level=info ts=2021-03-20T08:21:30.363737Z caller=grpc.go:123 service=gRPC/server component=query msg="listening for serving gRPC" address=0.0.0.0:10901
level=debug ts=2021-03-20T08:21:35.363743Z caller=storeset.go:362 component=storeset msg="starting updating storeAPIs" cachedStores=0
level=debug ts=2021-03-20T08:21:35.693564Z caller=storeset.go:365 component=storeset msg="checked requested storeAPIs" activeStores=1 cachedStores=0
level=info ts=2021-03-20T08:21:35.693671Z caller=storeset.go:408 component=storeset msg="adding new storeAPI to query storeset" address=localhost:443 extLset="{cluster=\"bseenu-test\", region=\"us-west-2\"}"
level=debug ts=2021-03-20T08:21:40.365898Z caller=storeset.go:362 component=storeset msg="starting updating storeAPIs" cachedStores=1
level=debug ts=2021-03-20T08:21:40.408064Z caller=storeset.go:365 component=storeset msg="checked requested storeAPIs" activeStores=1 cachedStores=1
level=debug ts=2021-03-20T08:21:45.368319Z caller=storeset.go:362 component=storeset msg="starting updating storeAPIs" cachedStores=1
level=debug ts=2021-03-20T08:21:45.412497Z caller=storeset.go:365 component=storeset msg="checked requested storeAPIs" activeStores=1 cachedStores=1
level=debug ts=2021-03-20T08:21:50.366771Z caller=storeset.go:362 component=storeset msg="starting updating storeAPIs" cachedStores=1
level=debug ts=2021-03-20T08:21:50.406159Z caller=storeset.go:365 component=storeset msg="checked requested storeAPIs" activeStores=1 cachedStores=1
level=debug ts=2021-03-20T08:21:55.368359Z caller=storeset.go:362 component=storeset msg="starting updating storeAPIs" cachedStores=1
level=debug ts=2021-03-20T08:21:55.416091Z caller=storeset.go:365 component=storeset msg="checked requested storeAPIs" activeStores=1 cachedStores=1
level=debug ts=2021-03-20T08:22:00.36877Z caller=storeset.go:362 component=storeset msg="starting updating storeAPIs" cachedStores=1
level=debug ts=2021-03-20T08:22:00.408067Z caller=storeset.go:365 component=storeset msg="checked requested storeAPIs" activeStores=1 cachedStores=1
```

PS : The actual dns names are replaced by localhost in the above logs