### PR TITLE
Fix broken `service-discovery`  link

### DIFF
--- a/docs/components/query.md
+++ b/docs/components/query.md
@@ -60,7 +60,7 @@ Thanos Querier instead pulls the data from both replicas, and deduplicate those 
 Overall QueryAPI exposed by Thanos is guaranteed to be compatible with [Prometheus 2.x. API](https://prometheus.io/docs/prometheus/latest/querying/api/).
 The above diagram shows what Querier does for each Prometheus query request.
 
-See [here](../service-discovery.md) on how to connect Querier with desired StoreAPIs.
+See [here](https://thanos.io/tip/thanos/service-discovery.md/) on how to connect Querier with desired StoreAPIs.
 
 <!--- TODO explain steps  --->
 


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

I fixed a broken link to the `service-discovery` page.

## Verification

<!-- How you tested it? How do you know it works? -->

Now, when you click on that link it brings you to the correct page.