### PR TITLE
Fix dashboard: query range should be inside rate function

### DIFF
--- a/examples/alerts/alerts.md
+++ b/examples/alerts/alerts.md
@@ -14,7 +14,7 @@ rules:
       There are {{$value}} '
     runbook_url: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanoscompactmultiplerunning
     summary: Thanos Compact has multiple instances running.
-  expr: sum by (job) (up{job=~"thanos-compact.*"}) > 1
+  expr: sum by (job) (up{job=~".*thanos-compact.*"}) > 1
   for: 5m
   labels:
     severity: warning
@@ -23,7 +23,7 @@ rules:
     description: Thanos Compact {{$labels.job}} has failed to run  and now is halted.
     runbook_url: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanoscompacthalted
     summary: Thanos Compact has failed to run ans is now halted.
-  expr: thanos_compact_halted{job=~"thanos-compact.*"} == 1
+  expr: thanos_compact_halted{job=~".*thanos-compact.*"} == 1
   for: 5m
   labels:
     severity: warning
@@ -35,9 +35,9 @@ rules:
     summary: Thanos Compact is failing to execute compactions.
   expr: |
     (
-      sum by (job) (rate(thanos_compact_group_compactions_failures_total{job=~"thanos-compact.*"}[5m]))
+      sum by (job) (rate(thanos_compact_group_compactions_failures_total{job=~".*thanos-compact.*"}[5m]))
     /
-      sum by (job) (rate(thanos_compact_group_compactions_total{job=~"thanos-compact.*"}[5m]))
+      sum by (job) (rate(thanos_compact_group_compactions_total{job=~".*thanos-compact.*"}[5m]))
     * 100 > 5
     )
   for: 15m
@@ -51,9 +51,9 @@ rules:
     summary: Thanos Compact Bucket is having a high number of operation failures.
   expr: |
     (
-      sum by (job) (rate(thanos_objstore_bucket_operation_failures_total{job=~"thanos-compact.*"}[5m]))
+      sum by (job) (rate(thanos_objstore_bucket_operation_failures_total{job=~".*thanos-compact.*"}[5m]))
     /
-      sum by (job) (rate(thanos_objstore_bucket_operations_total{job=~"thanos-compact.*"}[5m]))
+      sum by (job) (rate(thanos_objstore_bucket_operations_total{job=~".*thanos-compact.*"}[5m]))
     * 100 > 5
     )
   for: 15m
@@ -65,7 +65,7 @@ rules:
       hours.
     runbook_url: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanoscompacthasnotrun
     summary: Thanos Compact has not uploaded anything for last 24 hours.
-  expr: (time() - max by (job) (max_over_time(thanos_objstore_bucket_last_successful_upload_time{job=~"thanos-compact.*"}[24h])))
+  expr: (time() - max by (job) (max_over_time(thanos_objstore_bucket_last_successful_upload_time{job=~".*thanos-compact.*"}[24h])))
     / 60 / 60 > 24
   labels:
     severity: warning
@@ -85,7 +85,7 @@ rules:
     runbook_url: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanosrulequeueisdroppingalerts
     summary: Thanos Rule is failing to queue alerts.
   expr: |
-    sum by (job, instance) (rate(thanos_alert_queue_alerts_dropped_total{job=~"thanos-rule.*"}[5m])) > 0
+    sum by (job, instance) (rate(thanos_alert_queue_alerts_dropped_total{job=~".*thanos-rule.*"}[5m])) > 0
   for: 5m
   labels:
     severity: critical
@@ -95,7 +95,7 @@ rules:
     runbook_url: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanosrulesenderisfailingalerts
     summary: Thanos Rule is failing to send alerts to alertmanager.
   expr: |
-    sum by (job, instance) (rate(thanos_alert_sender_alerts_dropped_total{job=~"thanos-rule.*"}[5m])) > 0
+    sum by (job, instance) (rate(thanos_alert_sender_alerts_dropped_total{job=~".*thanos-rule.*"}[5m])) > 0
   for: 5m
   labels:
     severity: critical
@@ -106,9 +106,9 @@ rules:
     summary: Thanos Rule is failing to evaluate rules.
   expr: |
     (
-      sum by (job, instance) (rate(prometheus_rule_evaluation_failures_total{job=~"thanos-rule.*"}[5m]))
+      sum by (job, instance) (rate(prometheus_rule_evaluation_failures_total{job=~".*thanos-rule.*"}[5m]))
     /
-      sum by (job, instance) (rate(prometheus_rule_evaluations_total{job=~"thanos-rule.*"}[5m]))
+      sum by (job, instance) (rate(prometheus_rule_evaluations_total{job=~".*thanos-rule.*"}[5m]))
     * 100 > 5
     )
   for: 5m
@@ -120,7 +120,7 @@ rules:
     runbook_url: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanosrulehighruleevaluationwarnings
     summary: Thanos Rule has high number of evaluation warnings.
   expr: |
-    sum by (job, instance) (rate(thanos_rule_evaluation_with_warnings_total{job=~"thanos-rule.*"}[5m])) > 0
+    sum by (job, instance) (rate(thanos_rule_evaluation_with_warnings_total{job=~".*thanos-rule.*"}[5m])) > 0
   for: 15m
   labels:
     severity: info
@@ -132,9 +132,9 @@ rules:
     summary: Thanos Rule has high rule evaluation latency.
   expr: |
     (
-      sum by (job, instance, rule_group) (prometheus_rule_group_last_duration_seconds{job=~"thanos-rule.*"})
+      sum by (job, instance, rule_group) (prometheus_rule_group_last_duration_seconds{job=~".*thanos-rule.*"})
     >
-      sum by (job, instance, rule_group) (prometheus_rule_group_interval_seconds{job=~"thanos-rule.*"})
+      sum by (job, instance, rule_group) (prometheus_rule_group_interval_seconds{job=~".*thanos-rule.*"})
     )
   for: 5m
   labels:
@@ -147,9 +147,9 @@ rules:
     summary: Thanos Rule is failing to handle grpc requests.
   expr: |
     (
-      sum by (job, instance) (rate(grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded", job=~"thanos-rule.*"}[5m]))
+      sum by (job, instance) (rate(grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded", job=~".*thanos-rule.*"}[5m]))
     /
-      sum by (job, instance) (rate(grpc_server_started_total{job=~"thanos-rule.*"}[5m]))
+      sum by (job, instance) (rate(grpc_server_started_total{job=~".*thanos-rule.*"}[5m]))
     * 100 > 5
     )
   for: 5m
@@ -160,7 +160,7 @@ rules:
     description: Thanos Rule {{$labels.job}} has not been able to reload its configuration.
     runbook_url: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanosruleconfigreloadfailure
     summary: Thanos Rule has not been able to reload configuration.
-  expr: avg by (job, instance) (thanos_rule_config_last_reload_successful{job=~"thanos-rule.*"})
+  expr: avg by (job, instance) (thanos_rule_config_last_reload_successful{job=~".*thanos-rule.*"})
     != 1
   for: 5m
   labels:
@@ -173,9 +173,9 @@ rules:
     summary: Thanos Rule is having high number of DNS failures.
   expr: |
     (
-      sum by (job, instance) (rate(thanos_rule_query_apis_dns_failures_total{job=~"thanos-rule.*"}[5m]))
+      sum by (job, instance) (rate(thanos_rule_query_apis_dns_failures_total{job=~".*thanos-rule.*"}[5m]))
     /
-      sum by (job, instance) (rate(thanos_rule_query_apis_dns_lookups_total{job=~"thanos-rule.*"}[5m]))
+      sum by (job, instance) (rate(thanos_rule_query_apis_dns_lookups_total{job=~".*thanos-rule.*"}[5m]))
     * 100 > 1
     )
   for: 15m
@@ -189,9 +189,9 @@ rules:
     summary: Thanos Rule is having high number of DNS failures.
   expr: |
     (
-      sum by (job, instance) (rate(thanos_rule_alertmanagers_dns_failures_total{job=~"thanos-rule.*"}[5m]))
+      sum by (job, instance) (rate(thanos_rule_alertmanagers_dns_failures_total{job=~".*thanos-rule.*"}[5m]))
     /
-      sum by (job, instance) (rate(thanos_rule_alertmanagers_dns_lookups_total{job=~"thanos-rule.*"}[5m]))
+      sum by (job, instance) (rate(thanos_rule_alertmanagers_dns_lookups_total{job=~".*thanos-rule.*"}[5m]))
     * 100 > 1
     )
   for: 15m
@@ -204,9 +204,9 @@ rules:
     runbook_url: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanosrulenoevaluationfor10intervals
     summary: Thanos Rule has rule groups that did not evaluate for 10 intervals.
   expr: |
-    time() -  max by (job, instance, group) (prometheus_rule_group_last_evaluation_timestamp_seconds{job=~"thanos-rule.*"})
+    time() -  max by (job, instance, group) (prometheus_rule_group_last_evaluation_timestamp_seconds{job=~".*thanos-rule.*"})
     >
-    10 * max by (job, instance, group) (prometheus_rule_group_interval_seconds{job=~"thanos-rule.*"})
+    10 * max by (job, instance, group) (prometheus_rule_group_interval_seconds{job=~".*thanos-rule.*"})
   for: 5m
   labels:
     severity: info
@@ -217,9 +217,9 @@ rules:
     runbook_url: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanosnoruleevaluations
     summary: Thanos Rule did not perform any rule evaluations.
   expr: |
-    sum by (job, instance) (rate(prometheus_rule_evaluations_total{job=~"thanos-rule.*"}[5m])) <= 0
+    sum by (job, instance) (rate(prometheus_rule_evaluations_total{job=~".*thanos-rule.*"}[5m])) <= 0
       and
-    sum by (job, instance) (thanos_rule_loaded_rules{job=~"thanos-rule.*"}) > 0
+    sum by (job, instance) (thanos_rule_loaded_rules{job=~".*thanos-rule.*"}) > 0
   for: 5m
   labels:
     severity: critical
@@ -239,9 +239,9 @@ rules:
     summary: Thanos Store is failing to handle qrpcd requests.
   expr: |
     (
-      sum by (job) (rate(grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded", job=~"thanos-store.*"}[5m]))
+      sum by (job) (rate(grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded", job=~".*thanos-store.*"}[5m]))
     /
-      sum by (job) (rate(grpc_server_started_total{job=~"thanos-store.*"}[5m]))
+      sum by (job) (rate(grpc_server_started_total{job=~".*thanos-store.*"}[5m]))
     * 100 > 5
     )
   for: 5m
@@ -255,9 +255,9 @@ rules:
     summary: Thanos Store has high latency for store series gate requests.
   expr: |
     (
-      histogram_quantile(0.99, sum by (job, le) (rate(thanos_bucket_store_series_gate_duration_seconds_bucket{job=~"thanos-store.*"}[5m]))) > 2
+      histogram_quantile(0.99, sum by (job, le) (rate(thanos_bucket_store_series_gate_duration_seconds_bucket{job=~".*thanos-store.*"}[5m]))) > 2
     and
-      sum by (job) (rate(thanos_bucket_store_series_gate_duration_seconds_count{job=~"thanos-store.*"}[5m])) > 0
+      sum by (job) (rate(thanos_bucket_store_series_gate_duration_seconds_count{job=~".*thanos-store.*"}[5m])) > 0
     )
   for: 10m
   labels:
@@ -270,9 +270,9 @@ rules:
     summary: Thanos Store Bucket is failing to execute operations.
   expr: |
     (
-      sum by (job) (rate(thanos_objstore_bucket_operation_failures_total{job=~"thanos-store.*"}[5m]))
+      sum by (job) (rate(thanos_objstore_bucket_operation_failures_total{job=~".*thanos-store.*"}[5m]))
     /
-      sum by (job) (rate(thanos_objstore_bucket_operations_total{job=~"thanos-store.*"}[5m]))
+      sum by (job) (rate(thanos_objstore_bucket_operations_total{job=~".*thanos-store.*"}[5m]))
     * 100 > 5
     )
   for: 15m
@@ -286,9 +286,9 @@ rules:
     summary: Thanos Store is having high latency for bucket operations.
   expr: |
     (
-      histogram_quantile(0.99, sum by (job, le) (rate(thanos_objstore_bucket_operation_duration_seconds_bucket{job=~"thanos-store.*"}[5m]))) > 2
+      histogram_quantile(0.99, sum by (job, le) (rate(thanos_objstore_bucket_operation_duration_seconds_bucket{job=~".*thanos-store.*"}[5m]))) > 2
     and
-      sum by (job) (rate(thanos_objstore_bucket_operation_duration_seconds_count{job=~"thanos-store.*"}[5m])) > 0
+      sum by (job) (rate(thanos_objstore_bucket_operation_duration_seconds_count{job=~".*thanos-store.*"}[5m])) > 0
     )
   for: 10m
   labels:
@@ -307,7 +307,7 @@ rules:
     runbook_url: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanossidecarprometheusdown
     summary: Thanos Sidecar cannot connect to Prometheus
   expr: |
-    thanos_sidecar_prometheus_up{job=~"thanos-sidecar.*"} == 0
+    thanos_sidecar_prometheus_up{job=~".*thanos-sidecar.*"} == 0
   for: 5m
   labels:
     severity: critical
@@ -317,7 +317,7 @@ rules:
     runbook_url: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanossidecarbucketoperationsfailed
     summary: Thanos Sidecar bucket operations are failing
   expr: |
-    sum by (job, instance) (rate(thanos_objstore_bucket_operation_failures_total{job=~"thanos-sidecar.*"}[5m])) > 0
+    sum by (job, instance) (rate(thanos_objstore_bucket_operation_failures_total{job=~".*thanos-sidecar.*"}[5m])) > 0
   for: 5m
   labels:
     severity: critical
@@ -327,7 +327,7 @@ rules:
     runbook_url: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanossidecarunhealthy
     summary: Thanos Sidecar is unhealthy.
   expr: |
-    time() - max by (job, instance) (thanos_sidecar_last_heartbeat_success_time_seconds{job=~"thanos-sidecar.*"}) >= 600
+    time() - max by (job, instance) (thanos_sidecar_last_heartbeat_success_time_seconds{job=~".*thanos-sidecar.*"}) >= 600
   labels:
     severity: critical
 ```
@@ -346,9 +346,9 @@ rules:
     summary: Thanos Query is failing to handle requests.
   expr: |
     (
-      sum by (job) (rate(http_requests_total{code=~"5..", job=~"thanos-query.*", handler="query"}[5m]))
+      sum by (job) (rate(http_requests_total{code=~"5..", job=~".*thanos-query.*", handler="query"}[5m]))
     /
-      sum by (job) (rate(http_requests_total{job=~"thanos-query.*", handler="query"}[5m]))
+      sum by (job) (rate(http_requests_total{job=~".*thanos-query.*", handler="query"}[5m]))
     ) * 100 > 5
   for: 5m
   labels:
@@ -361,9 +361,9 @@ rules:
     summary: Thanos Query is failing to handle requests.
   expr: |
     (
-      sum by (job) (rate(http_requests_total{code=~"5..", job=~"thanos-query.*", handler="query_range"}[5m]))
+      sum by (job) (rate(http_requests_total{code=~"5..", job=~".*thanos-query.*", handler="query_range"}[5m]))
     /
-      sum by (job) (rate(http_requests_total{job=~"thanos-query.*", handler="query_range"}[5m]))
+      sum by (job) (rate(http_requests_total{job=~".*thanos-query.*", handler="query_range"}[5m]))
     ) * 100 > 5
   for: 5m
   labels:
@@ -376,9 +376,9 @@ rules:
     summary: Thanos Query is failing to handle requests.
   expr: |
     (
-      sum by (job) (rate(grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded", job=~"thanos-query.*"}[5m]))
+      sum by (job) (rate(grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded", job=~".*thanos-query.*"}[5m]))
     /
-      sum by (job) (rate(grpc_server_started_total{job=~"thanos-query.*"}[5m]))
+      sum by (job) (rate(grpc_server_started_total{job=~".*thanos-query.*"}[5m]))
     * 100 > 5
     )
   for: 5m
@@ -392,9 +392,9 @@ rules:
     summary: Thanos Query is failing to send requests.
   expr: |
     (
-      sum by (job) (rate(grpc_client_handled_total{grpc_code!="OK", job=~"thanos-query.*"}[5m]))
+      sum by (job) (rate(grpc_client_handled_total{grpc_code!="OK", job=~".*thanos-query.*"}[5m]))
     /
-      sum by (job) (rate(grpc_client_started_total{job=~"thanos-query.*"}[5m]))
+      sum by (job) (rate(grpc_client_started_total{job=~".*thanos-query.*"}[5m]))
     ) * 100 > 5
   for: 5m
   labels:
@@ -407,9 +407,9 @@ rules:
     summary: Thanos Query is having high number of DNS failures.
   expr: |
     (
-      sum by (job) (rate(thanos_query_store_apis_dns_failures_total{job=~"thanos-query.*"}[5m]))
+      sum by (job) (rate(thanos_query_store_apis_dns_failures_total{job=~".*thanos-query.*"}[5m]))
     /
-      sum by (job) (rate(thanos_query_store_apis_dns_lookups_total{job=~"thanos-query.*"}[5m]))
+      sum by (job) (rate(thanos_query_store_apis_dns_lookups_total{job=~".*thanos-query.*"}[5m]))
     ) * 100 > 1
   for: 15m
   labels:
@@ -422,9 +422,9 @@ rules:
     summary: Thanos Query has high latency for queries.
   expr: |
     (
-      histogram_quantile(0.99, sum by (job, le) (rate(http_request_duration_seconds_bucket{job=~"thanos-query.*", handler="query"}[5m]))) > 40
+      histogram_quantile(0.99, sum by (job, le) (rate(http_request_duration_seconds_bucket{job=~".*thanos-query.*", handler="query"}[5m]))) > 40
     and
-      sum by (job) (rate(http_request_duration_seconds_bucket{job=~"thanos-query.*", handler="query"}[5m])) > 0
+      sum by (job) (rate(http_request_duration_seconds_bucket{job=~".*thanos-query.*", handler="query"}[5m])) > 0
     )
   for: 10m
   labels:
@@ -437,9 +437,9 @@ rules:
     summary: Thanos Query has high latency for queries.
   expr: |
     (
-      histogram_quantile(0.99, sum by (job, le) (rate(http_request_duration_seconds_bucket{job=~"thanos-query.*", handler="query_range"}[5m]))) > 90
+      histogram_quantile(0.99, sum by (job, le) (rate(http_request_duration_seconds_bucket{job=~".*thanos-query.*", handler="query_range"}[5m]))) > 90
     and
-      sum by (job) (rate(http_request_duration_seconds_count{job=~"thanos-query.*", handler="query_range"}[5m])) > 0
+      sum by (job) (rate(http_request_duration_seconds_count{job=~".*thanos-query.*", handler="query_range"}[5m])) > 0
     )
   for: 10m
   labels:
@@ -460,9 +460,9 @@ rules:
     summary: Thanos Receive is failing to handle requests.
   expr: |
     (
-      sum by (job) (rate(http_requests_total{code=~"5..", job=~"thanos-receive.*", handler="receive"}[5m]))
+      sum by (job) (rate(http_requests_total{code=~"5..", job=~".*thanos-receive.*", handler="receive"}[5m]))
     /
-      sum by (job) (rate(http_requests_total{job=~"thanos-receive.*", handler="receive"}[5m]))
+      sum by (job) (rate(http_requests_total{job=~".*thanos-receive.*", handler="receive"}[5m]))
     ) * 100 > 5
   for: 5m
   labels:
@@ -475,9 +475,9 @@ rules:
     summary: Thanos Receive has high HTTP requests latency.
   expr: |
     (
-      histogram_quantile(0.99, sum by (job, le) (rate(http_request_duration_seconds_bucket{job=~"thanos-receive.*", handler="receive"}[5m]))) > 10
+      histogram_quantile(0.99, sum by (job, le) (rate(http_request_duration_seconds_bucket{job=~".*thanos-receive.*", handler="receive"}[5m]))) > 10
     and
-      sum by (job) (rate(http_request_duration_seconds_count{job=~"thanos-receive.*", handler="receive"}[5m])) > 0
+      sum by (job) (rate(http_request_duration_seconds_count{job=~".*thanos-receive.*", handler="receive"}[5m])) > 0
     )
   for: 10m
   labels:
@@ -493,15 +493,15 @@ rules:
       and
     (
       (
-        sum by (job) (rate(thanos_receive_replications_total{result="error", job=~"thanos-receive.*"}[5m]))
+        sum by (job) (rate(thanos_receive_replications_total{result="error", job=~".*thanos-receive.*"}[5m]))
       /
-        sum by (job) (rate(thanos_receive_replications_total{job=~"thanos-receive.*"}[5m]))
+        sum by (job) (rate(thanos_receive_replications_total{job=~".*thanos-receive.*"}[5m]))
       )
       >
       (
-        max by (job) (floor((thanos_receive_replication_factor{job=~"thanos-receive.*"}+1) / 2))
+        max by (job) (floor((thanos_receive_replication_factor{job=~".*thanos-receive.*"}+1) / 2))
       /
-        max by (job) (thanos_receive_hashring_nodes{job=~"thanos-receive.*"})
+        max by (job) (thanos_receive_hashring_nodes{job=~".*thanos-receive.*"})
       )
     ) * 100
   for: 5m
@@ -515,9 +515,9 @@ rules:
     summary: Thanos Receive is failing to forward requests.
   expr: |
     (
-      sum by (job) (rate(thanos_receive_forward_requests_total{result="error", job=~"thanos-receive.*"}[5m]))
+      sum by (job) (rate(thanos_receive_forward_requests_total{result="error", job=~".*thanos-receive.*"}[5m]))
     /
-      sum by (job) (rate(thanos_receive_forward_requests_total{job=~"thanos-receive.*"}[5m]))
+      sum by (job) (rate(thanos_receive_forward_requests_total{job=~".*thanos-receive.*"}[5m]))
     ) * 100 > 20
   for: 5m
   labels:
@@ -530,9 +530,9 @@ rules:
     summary: Thanos Receive is failing to refresh hasring file.
   expr: |
     (
-      sum by (job) (rate(thanos_receive_hashrings_file_errors_total{job=~"thanos-receive.*"}[5m]))
+      sum by (job) (rate(thanos_receive_hashrings_file_errors_total{job=~".*thanos-receive.*"}[5m]))
     /
-      sum by (job) (rate(thanos_receive_hashrings_file_refreshes_total{job=~"thanos-receive.*"}[5m]))
+      sum by (job) (rate(thanos_receive_hashrings_file_refreshes_total{job=~".*thanos-receive.*"}[5m]))
     > 0
     )
   for: 15m
@@ -544,7 +544,7 @@ rules:
       configurations.
     runbook_url: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanosreceiveconfigreloadfailure
     summary: Thanos Receive has not been able to reload configuration.
-  expr: avg by (job) (thanos_receive_config_last_reload_successful{job=~"thanos-receive.*"})
+  expr: avg by (job) (thanos_receive_config_last_reload_successful{job=~".*thanos-receive.*"})
     != 1
   for: 5m
   labels:
@@ -556,9 +556,9 @@ rules:
     runbook_url: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanosreceivenoupload
     summary: Thanos Receive has not uploaded latest data to object storage.
   expr: |
-    (up{job=~"thanos-receive.*"} - 1)
+    (up{job=~".*thanos-receive.*"} - 1)
     + on (job, instance) # filters to only alert on current instance last 3h
-    (sum by (job, instance) (increase(thanos_shipper_uploads_total{job=~"thanos-receive.*"}[3h])) == 0)
+    (sum by (job, instance) (increase(thanos_shipper_uploads_total{job=~".*thanos-receive.*"}[3h])) == 0)
   for: 3h
   labels:
     severity: critical
@@ -578,9 +578,9 @@ rules:
     summary: Thanose Replicate is failing to run in  .
   expr: |
     (
-      sum by (job) (rate(thanos_replicate_replication_runs_total{result="error", job=~"thanos-bucket-replicate.*"}[5m]))
+      sum by (job) (rate(thanos_replicate_replication_runs_total{result="error", job=~".*thanos-bucket-replicate.*"}[5m]))
     / on (job) group_left
-      sum by (job) (rate(thanos_replicate_replication_runs_total{job=~"thanos-bucket-replicate.*"}[5m]))
+      sum by (job) (rate(thanos_replicate_replication_runs_total{job=~".*thanos-bucket-replicate.*"}[5m]))
     ) * 100 >= 10
   for: 5m
   labels:
@@ -593,9 +593,9 @@ rules:
     summary: Thanos Replicate has a high latency for replicate operations.
   expr: |
     (
-      histogram_quantile(0.99, sum by (job) (rate(thanos_replicate_replication_run_duration_seconds_bucket{job=~"thanos-bucket-replicate.*"}[5m]))) > 20
+      histogram_quantile(0.99, sum by (job) (rate(thanos_replicate_replication_run_duration_seconds_bucket{job=~".*thanos-bucket-replicate.*"}[5m]))) > 20
     and
-      sum by (job) (rate(thanos_replicate_replication_run_duration_seconds_bucket{job=~"thanos-bucket-replicate.*"}[5m])) > 0
+      sum by (job) (rate(thanos_replicate_replication_run_duration_seconds_bucket{job=~".*thanos-bucket-replicate.*"}[5m])) > 0
     )
   for: 5m
   labels:
@@ -617,7 +617,7 @@ rules:
     runbook_url: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanosbucketreplicateisdown
     summary: Thanos component has disappeared.
   expr: |
-    absent(up{job=~"thanos-bucket-replicate.*"} == 1)
+    absent(up{job=~".*thanos-bucket-replicate.*"} == 1)
   for: 5m
   labels:
     severity: critical
@@ -628,7 +628,7 @@ rules:
     runbook_url: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanoscompactisdown
     summary: Thanos component has disappeared.
   expr: |
-    absent(up{job=~"thanos-compact.*"} == 1)
+    absent(up{job=~".*thanos-compact.*"} == 1)
   for: 5m
   labels:
     severity: critical
@@ -639,7 +639,7 @@ rules:
     runbook_url: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanosqueryisdown
     summary: Thanos component has disappeared.
   expr: |
-    absent(up{job=~"thanos-query.*"} == 1)
+    absent(up{job=~".*thanos-query.*"} == 1)
   for: 5m
   labels:
     severity: critical
@@ -650,7 +650,7 @@ rules:
     runbook_url: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanosreceiveisdown
     summary: Thanos component has disappeared.
   expr: |
-    absent(up{job=~"thanos-receive.*"} == 1)
+    absent(up{job=~".*thanos-receive.*"} == 1)
   for: 5m
   labels:
     severity: critical
@@ -661,7 +661,7 @@ rules:
     runbook_url: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanosruleisdown
     summary: Thanos component has disappeared.
   expr: |
-    absent(up{job=~"thanos-rule.*"} == 1)
+    absent(up{job=~".*thanos-rule.*"} == 1)
   for: 5m
   labels:
     severity: critical
@@ -672,7 +672,7 @@ rules:
     runbook_url: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanossidecarisdown
     summary: Thanos component has disappeared.
   expr: |
-    absent(up{job=~"thanos-sidecar.*"} == 1)
+    absent(up{job=~".*thanos-sidecar.*"} == 1)
   for: 5m
   labels:
     severity: critical
@@ -683,7 +683,7 @@ rules:
     runbook_url: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanosstoreisdown
     summary: Thanos component has disappeared.
   expr: |
-    absent(up{job=~"thanos-store.*"} == 1)
+    absent(up{job=~".*thanos-store.*"} == 1)
   for: 5m
   labels:
     severity: critical

--- a/examples/alerts/alerts.yaml
+++ b/examples/alerts/alerts.yaml
@@ -7,7 +7,7 @@ groups:
         once. There are {{$value}} '
       runbook_url: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanoscompactmultiplerunning
       summary: Thanos Compact has multiple instances running.
-    expr: sum by (job) (up{job=~"thanos-compact.*"}) > 1
+    expr: sum by (job) (up{job=~".*thanos-compact.*"}) > 1
     for: 5m
     labels:
       severity: warning
@@ -16,7 +16,7 @@ groups:
       description: Thanos Compact {{$labels.job}} has failed to run  and now is halted.
       runbook_url: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanoscompacthalted
       summary: Thanos Compact has failed to run ans is now halted.
-    expr: thanos_compact_halted{job=~"thanos-compact.*"} == 1
+    expr: thanos_compact_halted{job=~".*thanos-compact.*"} == 1
     for: 5m
     labels:
       severity: warning
@@ -28,9 +28,9 @@ groups:
       summary: Thanos Compact is failing to execute compactions.
     expr: |
       (
-        sum by (job) (rate(thanos_compact_group_compactions_failures_total{job=~"thanos-compact.*"}[5m]))
+        sum by (job) (rate(thanos_compact_group_compactions_failures_total{job=~".*thanos-compact.*"}[5m]))
       /
-        sum by (job) (rate(thanos_compact_group_compactions_total{job=~"thanos-compact.*"}[5m]))
+        sum by (job) (rate(thanos_compact_group_compactions_total{job=~".*thanos-compact.*"}[5m]))
       * 100 > 5
       )
     for: 15m
@@ -44,9 +44,9 @@ groups:
       summary: Thanos Compact Bucket is having a high number of operation failures.
     expr: |
       (
-        sum by (job) (rate(thanos_objstore_bucket_operation_failures_total{job=~"thanos-compact.*"}[5m]))
+        sum by (job) (rate(thanos_objstore_bucket_operation_failures_total{job=~".*thanos-compact.*"}[5m]))
       /
-        sum by (job) (rate(thanos_objstore_bucket_operations_total{job=~"thanos-compact.*"}[5m]))
+        sum by (job) (rate(thanos_objstore_bucket_operations_total{job=~".*thanos-compact.*"}[5m]))
       * 100 > 5
       )
     for: 15m
@@ -58,7 +58,7 @@ groups:
         hours.
       runbook_url: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanoscompacthasnotrun
       summary: Thanos Compact has not uploaded anything for last 24 hours.
-    expr: (time() - max by (job) (max_over_time(thanos_objstore_bucket_last_successful_upload_time{job=~"thanos-compact.*"}[24h])))
+    expr: (time() - max by (job) (max_over_time(thanos_objstore_bucket_last_successful_upload_time{job=~".*thanos-compact.*"}[24h])))
       / 60 / 60 > 24
     labels:
       severity: warning
@@ -72,9 +72,9 @@ groups:
       summary: Thanos Query is failing to handle requests.
     expr: |
       (
-        sum by (job) (rate(http_requests_total{code=~"5..", job=~"thanos-query.*", handler="query"}[5m]))
+        sum by (job) (rate(http_requests_total{code=~"5..", job=~".*thanos-query.*", handler="query"}[5m]))
       /
-        sum by (job) (rate(http_requests_total{job=~"thanos-query.*", handler="query"}[5m]))
+        sum by (job) (rate(http_requests_total{job=~".*thanos-query.*", handler="query"}[5m]))
       ) * 100 > 5
     for: 5m
     labels:
@@ -87,9 +87,9 @@ groups:
       summary: Thanos Query is failing to handle requests.
     expr: |
       (
-        sum by (job) (rate(http_requests_total{code=~"5..", job=~"thanos-query.*", handler="query_range"}[5m]))
+        sum by (job) (rate(http_requests_total{code=~"5..", job=~".*thanos-query.*", handler="query_range"}[5m]))
       /
-        sum by (job) (rate(http_requests_total{job=~"thanos-query.*", handler="query_range"}[5m]))
+        sum by (job) (rate(http_requests_total{job=~".*thanos-query.*", handler="query_range"}[5m]))
       ) * 100 > 5
     for: 5m
     labels:
@@ -102,9 +102,9 @@ groups:
       summary: Thanos Query is failing to handle requests.
     expr: |
       (
-        sum by (job) (rate(grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded", job=~"thanos-query.*"}[5m]))
+        sum by (job) (rate(grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded", job=~".*thanos-query.*"}[5m]))
       /
-        sum by (job) (rate(grpc_server_started_total{job=~"thanos-query.*"}[5m]))
+        sum by (job) (rate(grpc_server_started_total{job=~".*thanos-query.*"}[5m]))
       * 100 > 5
       )
     for: 5m
@@ -118,9 +118,9 @@ groups:
       summary: Thanos Query is failing to send requests.
     expr: |
       (
-        sum by (job) (rate(grpc_client_handled_total{grpc_code!="OK", job=~"thanos-query.*"}[5m]))
+        sum by (job) (rate(grpc_client_handled_total{grpc_code!="OK", job=~".*thanos-query.*"}[5m]))
       /
-        sum by (job) (rate(grpc_client_started_total{job=~"thanos-query.*"}[5m]))
+        sum by (job) (rate(grpc_client_started_total{job=~".*thanos-query.*"}[5m]))
       ) * 100 > 5
     for: 5m
     labels:
@@ -133,9 +133,9 @@ groups:
       summary: Thanos Query is having high number of DNS failures.
     expr: |
       (
-        sum by (job) (rate(thanos_query_store_apis_dns_failures_total{job=~"thanos-query.*"}[5m]))
+        sum by (job) (rate(thanos_query_store_apis_dns_failures_total{job=~".*thanos-query.*"}[5m]))
       /
-        sum by (job) (rate(thanos_query_store_apis_dns_lookups_total{job=~"thanos-query.*"}[5m]))
+        sum by (job) (rate(thanos_query_store_apis_dns_lookups_total{job=~".*thanos-query.*"}[5m]))
       ) * 100 > 1
     for: 15m
     labels:
@@ -148,9 +148,9 @@ groups:
       summary: Thanos Query has high latency for queries.
     expr: |
       (
-        histogram_quantile(0.99, sum by (job, le) (rate(http_request_duration_seconds_bucket{job=~"thanos-query.*", handler="query"}[5m]))) > 40
+        histogram_quantile(0.99, sum by (job, le) (rate(http_request_duration_seconds_bucket{job=~".*thanos-query.*", handler="query"}[5m]))) > 40
       and
-        sum by (job) (rate(http_request_duration_seconds_bucket{job=~"thanos-query.*", handler="query"}[5m])) > 0
+        sum by (job) (rate(http_request_duration_seconds_bucket{job=~".*thanos-query.*", handler="query"}[5m])) > 0
       )
     for: 10m
     labels:
@@ -163,9 +163,9 @@ groups:
       summary: Thanos Query has high latency for queries.
     expr: |
       (
-        histogram_quantile(0.99, sum by (job, le) (rate(http_request_duration_seconds_bucket{job=~"thanos-query.*", handler="query_range"}[5m]))) > 90
+        histogram_quantile(0.99, sum by (job, le) (rate(http_request_duration_seconds_bucket{job=~".*thanos-query.*", handler="query_range"}[5m]))) > 90
       and
-        sum by (job) (rate(http_request_duration_seconds_count{job=~"thanos-query.*", handler="query_range"}[5m])) > 0
+        sum by (job) (rate(http_request_duration_seconds_count{job=~".*thanos-query.*", handler="query_range"}[5m])) > 0
       )
     for: 10m
     labels:
@@ -180,9 +180,9 @@ groups:
       summary: Thanos Receive is failing to handle requests.
     expr: |
       (
-        sum by (job) (rate(http_requests_total{code=~"5..", job=~"thanos-receive.*", handler="receive"}[5m]))
+        sum by (job) (rate(http_requests_total{code=~"5..", job=~".*thanos-receive.*", handler="receive"}[5m]))
       /
-        sum by (job) (rate(http_requests_total{job=~"thanos-receive.*", handler="receive"}[5m]))
+        sum by (job) (rate(http_requests_total{job=~".*thanos-receive.*", handler="receive"}[5m]))
       ) * 100 > 5
     for: 5m
     labels:
@@ -195,9 +195,9 @@ groups:
       summary: Thanos Receive has high HTTP requests latency.
     expr: |
       (
-        histogram_quantile(0.99, sum by (job, le) (rate(http_request_duration_seconds_bucket{job=~"thanos-receive.*", handler="receive"}[5m]))) > 10
+        histogram_quantile(0.99, sum by (job, le) (rate(http_request_duration_seconds_bucket{job=~".*thanos-receive.*", handler="receive"}[5m]))) > 10
       and
-        sum by (job) (rate(http_request_duration_seconds_count{job=~"thanos-receive.*", handler="receive"}[5m])) > 0
+        sum by (job) (rate(http_request_duration_seconds_count{job=~".*thanos-receive.*", handler="receive"}[5m])) > 0
       )
     for: 10m
     labels:
@@ -213,15 +213,15 @@ groups:
         and
       (
         (
-          sum by (job) (rate(thanos_receive_replications_total{result="error", job=~"thanos-receive.*"}[5m]))
+          sum by (job) (rate(thanos_receive_replications_total{result="error", job=~".*thanos-receive.*"}[5m]))
         /
-          sum by (job) (rate(thanos_receive_replications_total{job=~"thanos-receive.*"}[5m]))
+          sum by (job) (rate(thanos_receive_replications_total{job=~".*thanos-receive.*"}[5m]))
         )
         >
         (
-          max by (job) (floor((thanos_receive_replication_factor{job=~"thanos-receive.*"}+1) / 2))
+          max by (job) (floor((thanos_receive_replication_factor{job=~".*thanos-receive.*"}+1) / 2))
         /
-          max by (job) (thanos_receive_hashring_nodes{job=~"thanos-receive.*"})
+          max by (job) (thanos_receive_hashring_nodes{job=~".*thanos-receive.*"})
         )
       ) * 100
     for: 5m
@@ -235,9 +235,9 @@ groups:
       summary: Thanos Receive is failing to forward requests.
     expr: |
       (
-        sum by (job) (rate(thanos_receive_forward_requests_total{result="error", job=~"thanos-receive.*"}[5m]))
+        sum by (job) (rate(thanos_receive_forward_requests_total{result="error", job=~".*thanos-receive.*"}[5m]))
       /
-        sum by (job) (rate(thanos_receive_forward_requests_total{job=~"thanos-receive.*"}[5m]))
+        sum by (job) (rate(thanos_receive_forward_requests_total{job=~".*thanos-receive.*"}[5m]))
       ) * 100 > 20
     for: 5m
     labels:
@@ -250,9 +250,9 @@ groups:
       summary: Thanos Receive is failing to refresh hasring file.
     expr: |
       (
-        sum by (job) (rate(thanos_receive_hashrings_file_errors_total{job=~"thanos-receive.*"}[5m]))
+        sum by (job) (rate(thanos_receive_hashrings_file_errors_total{job=~".*thanos-receive.*"}[5m]))
       /
-        sum by (job) (rate(thanos_receive_hashrings_file_refreshes_total{job=~"thanos-receive.*"}[5m]))
+        sum by (job) (rate(thanos_receive_hashrings_file_refreshes_total{job=~".*thanos-receive.*"}[5m]))
       > 0
       )
     for: 15m
@@ -264,7 +264,7 @@ groups:
         configurations.
       runbook_url: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanosreceiveconfigreloadfailure
       summary: Thanos Receive has not been able to reload configuration.
-    expr: avg by (job) (thanos_receive_config_last_reload_successful{job=~"thanos-receive.*"})
+    expr: avg by (job) (thanos_receive_config_last_reload_successful{job=~".*thanos-receive.*"})
       != 1
     for: 5m
     labels:
@@ -276,9 +276,9 @@ groups:
       runbook_url: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanosreceivenoupload
       summary: Thanos Receive has not uploaded latest data to object storage.
     expr: |
-      (up{job=~"thanos-receive.*"} - 1)
+      (up{job=~".*thanos-receive.*"} - 1)
       + on (job, instance) # filters to only alert on current instance last 3h
-      (sum by (job, instance) (increase(thanos_shipper_uploads_total{job=~"thanos-receive.*"}[3h])) == 0)
+      (sum by (job, instance) (increase(thanos_shipper_uploads_total{job=~".*thanos-receive.*"}[3h])) == 0)
     for: 3h
     labels:
       severity: critical
@@ -290,7 +290,7 @@ groups:
       runbook_url: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanossidecarprometheusdown
       summary: Thanos Sidecar cannot connect to Prometheus
     expr: |
-      thanos_sidecar_prometheus_up{job=~"thanos-sidecar.*"} == 0
+      thanos_sidecar_prometheus_up{job=~".*thanos-sidecar.*"} == 0
     for: 5m
     labels:
       severity: critical
@@ -300,7 +300,7 @@ groups:
       runbook_url: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanossidecarbucketoperationsfailed
       summary: Thanos Sidecar bucket operations are failing
     expr: |
-      sum by (job, instance) (rate(thanos_objstore_bucket_operation_failures_total{job=~"thanos-sidecar.*"}[5m])) > 0
+      sum by (job, instance) (rate(thanos_objstore_bucket_operation_failures_total{job=~".*thanos-sidecar.*"}[5m])) > 0
     for: 5m
     labels:
       severity: critical
@@ -311,7 +311,7 @@ groups:
       runbook_url: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanossidecarunhealthy
       summary: Thanos Sidecar is unhealthy.
     expr: |
-      time() - max by (job, instance) (thanos_sidecar_last_heartbeat_success_time_seconds{job=~"thanos-sidecar.*"}) >= 600
+      time() - max by (job, instance) (thanos_sidecar_last_heartbeat_success_time_seconds{job=~".*thanos-sidecar.*"}) >= 600
     labels:
       severity: critical
 - name: thanos-store
@@ -324,9 +324,9 @@ groups:
       summary: Thanos Store is failing to handle qrpcd requests.
     expr: |
       (
-        sum by (job) (rate(grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded", job=~"thanos-store.*"}[5m]))
+        sum by (job) (rate(grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded", job=~".*thanos-store.*"}[5m]))
       /
-        sum by (job) (rate(grpc_server_started_total{job=~"thanos-store.*"}[5m]))
+        sum by (job) (rate(grpc_server_started_total{job=~".*thanos-store.*"}[5m]))
       * 100 > 5
       )
     for: 5m
@@ -340,9 +340,9 @@ groups:
       summary: Thanos Store has high latency for store series gate requests.
     expr: |
       (
-        histogram_quantile(0.99, sum by (job, le) (rate(thanos_bucket_store_series_gate_duration_seconds_bucket{job=~"thanos-store.*"}[5m]))) > 2
+        histogram_quantile(0.99, sum by (job, le) (rate(thanos_bucket_store_series_gate_duration_seconds_bucket{job=~".*thanos-store.*"}[5m]))) > 2
       and
-        sum by (job) (rate(thanos_bucket_store_series_gate_duration_seconds_count{job=~"thanos-store.*"}[5m])) > 0
+        sum by (job) (rate(thanos_bucket_store_series_gate_duration_seconds_count{job=~".*thanos-store.*"}[5m])) > 0
       )
     for: 10m
     labels:
@@ -355,9 +355,9 @@ groups:
       summary: Thanos Store Bucket is failing to execute operations.
     expr: |
       (
-        sum by (job) (rate(thanos_objstore_bucket_operation_failures_total{job=~"thanos-store.*"}[5m]))
+        sum by (job) (rate(thanos_objstore_bucket_operation_failures_total{job=~".*thanos-store.*"}[5m]))
       /
-        sum by (job) (rate(thanos_objstore_bucket_operations_total{job=~"thanos-store.*"}[5m]))
+        sum by (job) (rate(thanos_objstore_bucket_operations_total{job=~".*thanos-store.*"}[5m]))
       * 100 > 5
       )
     for: 15m
@@ -371,9 +371,9 @@ groups:
       summary: Thanos Store is having high latency for bucket operations.
     expr: |
       (
-        histogram_quantile(0.99, sum by (job, le) (rate(thanos_objstore_bucket_operation_duration_seconds_bucket{job=~"thanos-store.*"}[5m]))) > 2
+        histogram_quantile(0.99, sum by (job, le) (rate(thanos_objstore_bucket_operation_duration_seconds_bucket{job=~".*thanos-store.*"}[5m]))) > 2
       and
-        sum by (job) (rate(thanos_objstore_bucket_operation_duration_seconds_count{job=~"thanos-store.*"}[5m])) > 0
+        sum by (job) (rate(thanos_objstore_bucket_operation_duration_seconds_count{job=~".*thanos-store.*"}[5m])) > 0
       )
     for: 10m
     labels:
@@ -386,7 +386,7 @@ groups:
       runbook_url: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanosrulequeueisdroppingalerts
       summary: Thanos Rule is failing to queue alerts.
     expr: |
-      sum by (job, instance) (rate(thanos_alert_queue_alerts_dropped_total{job=~"thanos-rule.*"}[5m])) > 0
+      sum by (job, instance) (rate(thanos_alert_queue_alerts_dropped_total{job=~".*thanos-rule.*"}[5m])) > 0
     for: 5m
     labels:
       severity: critical
@@ -396,7 +396,7 @@ groups:
       runbook_url: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanosrulesenderisfailingalerts
       summary: Thanos Rule is failing to send alerts to alertmanager.
     expr: |
-      sum by (job, instance) (rate(thanos_alert_sender_alerts_dropped_total{job=~"thanos-rule.*"}[5m])) > 0
+      sum by (job, instance) (rate(thanos_alert_sender_alerts_dropped_total{job=~".*thanos-rule.*"}[5m])) > 0
     for: 5m
     labels:
       severity: critical
@@ -407,9 +407,9 @@ groups:
       summary: Thanos Rule is failing to evaluate rules.
     expr: |
       (
-        sum by (job, instance) (rate(prometheus_rule_evaluation_failures_total{job=~"thanos-rule.*"}[5m]))
+        sum by (job, instance) (rate(prometheus_rule_evaluation_failures_total{job=~".*thanos-rule.*"}[5m]))
       /
-        sum by (job, instance) (rate(prometheus_rule_evaluations_total{job=~"thanos-rule.*"}[5m]))
+        sum by (job, instance) (rate(prometheus_rule_evaluations_total{job=~".*thanos-rule.*"}[5m]))
       * 100 > 5
       )
     for: 5m
@@ -422,7 +422,7 @@ groups:
       runbook_url: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanosrulehighruleevaluationwarnings
       summary: Thanos Rule has high number of evaluation warnings.
     expr: |
-      sum by (job, instance) (rate(thanos_rule_evaluation_with_warnings_total{job=~"thanos-rule.*"}[5m])) > 0
+      sum by (job, instance) (rate(thanos_rule_evaluation_with_warnings_total{job=~".*thanos-rule.*"}[5m])) > 0
     for: 15m
     labels:
       severity: info
@@ -434,9 +434,9 @@ groups:
       summary: Thanos Rule has high rule evaluation latency.
     expr: |
       (
-        sum by (job, instance, rule_group) (prometheus_rule_group_last_duration_seconds{job=~"thanos-rule.*"})
+        sum by (job, instance, rule_group) (prometheus_rule_group_last_duration_seconds{job=~".*thanos-rule.*"})
       >
-        sum by (job, instance, rule_group) (prometheus_rule_group_interval_seconds{job=~"thanos-rule.*"})
+        sum by (job, instance, rule_group) (prometheus_rule_group_interval_seconds{job=~".*thanos-rule.*"})
       )
     for: 5m
     labels:
@@ -449,9 +449,9 @@ groups:
       summary: Thanos Rule is failing to handle grpc requests.
     expr: |
       (
-        sum by (job, instance) (rate(grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded", job=~"thanos-rule.*"}[5m]))
+        sum by (job, instance) (rate(grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded", job=~".*thanos-rule.*"}[5m]))
       /
-        sum by (job, instance) (rate(grpc_server_started_total{job=~"thanos-rule.*"}[5m]))
+        sum by (job, instance) (rate(grpc_server_started_total{job=~".*thanos-rule.*"}[5m]))
       * 100 > 5
       )
     for: 5m
@@ -462,7 +462,7 @@ groups:
       description: Thanos Rule {{$labels.job}} has not been able to reload its configuration.
       runbook_url: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanosruleconfigreloadfailure
       summary: Thanos Rule has not been able to reload configuration.
-    expr: avg by (job, instance) (thanos_rule_config_last_reload_successful{job=~"thanos-rule.*"})
+    expr: avg by (job, instance) (thanos_rule_config_last_reload_successful{job=~".*thanos-rule.*"})
       != 1
     for: 5m
     labels:
@@ -475,9 +475,9 @@ groups:
       summary: Thanos Rule is having high number of DNS failures.
     expr: |
       (
-        sum by (job, instance) (rate(thanos_rule_query_apis_dns_failures_total{job=~"thanos-rule.*"}[5m]))
+        sum by (job, instance) (rate(thanos_rule_query_apis_dns_failures_total{job=~".*thanos-rule.*"}[5m]))
       /
-        sum by (job, instance) (rate(thanos_rule_query_apis_dns_lookups_total{job=~"thanos-rule.*"}[5m]))
+        sum by (job, instance) (rate(thanos_rule_query_apis_dns_lookups_total{job=~".*thanos-rule.*"}[5m]))
       * 100 > 1
       )
     for: 15m
@@ -491,9 +491,9 @@ groups:
       summary: Thanos Rule is having high number of DNS failures.
     expr: |
       (
-        sum by (job, instance) (rate(thanos_rule_alertmanagers_dns_failures_total{job=~"thanos-rule.*"}[5m]))
+        sum by (job, instance) (rate(thanos_rule_alertmanagers_dns_failures_total{job=~".*thanos-rule.*"}[5m]))
       /
-        sum by (job, instance) (rate(thanos_rule_alertmanagers_dns_lookups_total{job=~"thanos-rule.*"}[5m]))
+        sum by (job, instance) (rate(thanos_rule_alertmanagers_dns_lookups_total{job=~".*thanos-rule.*"}[5m]))
       * 100 > 1
       )
     for: 15m
@@ -506,9 +506,9 @@ groups:
       runbook_url: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanosrulenoevaluationfor10intervals
       summary: Thanos Rule has rule groups that did not evaluate for 10 intervals.
     expr: |
-      time() -  max by (job, instance, group) (prometheus_rule_group_last_evaluation_timestamp_seconds{job=~"thanos-rule.*"})
+      time() -  max by (job, instance, group) (prometheus_rule_group_last_evaluation_timestamp_seconds{job=~".*thanos-rule.*"})
       >
-      10 * max by (job, instance, group) (prometheus_rule_group_interval_seconds{job=~"thanos-rule.*"})
+      10 * max by (job, instance, group) (prometheus_rule_group_interval_seconds{job=~".*thanos-rule.*"})
     for: 5m
     labels:
       severity: info
@@ -519,9 +519,9 @@ groups:
       runbook_url: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanosnoruleevaluations
       summary: Thanos Rule did not perform any rule evaluations.
     expr: |
-      sum by (job, instance) (rate(prometheus_rule_evaluations_total{job=~"thanos-rule.*"}[5m])) <= 0
+      sum by (job, instance) (rate(prometheus_rule_evaluations_total{job=~".*thanos-rule.*"}[5m])) <= 0
         and
-      sum by (job, instance) (thanos_rule_loaded_rules{job=~"thanos-rule.*"}) > 0
+      sum by (job, instance) (thanos_rule_loaded_rules{job=~".*thanos-rule.*"}) > 0
     for: 5m
     labels:
       severity: critical
@@ -535,9 +535,9 @@ groups:
       summary: Thanose Replicate is failing to run in  .
     expr: |
       (
-        sum by (job) (rate(thanos_replicate_replication_runs_total{result="error", job=~"thanos-bucket-replicate.*"}[5m]))
+        sum by (job) (rate(thanos_replicate_replication_runs_total{result="error", job=~".*thanos-bucket-replicate.*"}[5m]))
       / on (job) group_left
-        sum by (job) (rate(thanos_replicate_replication_runs_total{job=~"thanos-bucket-replicate.*"}[5m]))
+        sum by (job) (rate(thanos_replicate_replication_runs_total{job=~".*thanos-bucket-replicate.*"}[5m]))
       ) * 100 >= 10
     for: 5m
     labels:
@@ -550,9 +550,9 @@ groups:
       summary: Thanos Replicate has a high latency for replicate operations.
     expr: |
       (
-        histogram_quantile(0.99, sum by (job) (rate(thanos_replicate_replication_run_duration_seconds_bucket{job=~"thanos-bucket-replicate.*"}[5m]))) > 20
+        histogram_quantile(0.99, sum by (job) (rate(thanos_replicate_replication_run_duration_seconds_bucket{job=~".*thanos-bucket-replicate.*"}[5m]))) > 20
       and
-        sum by (job) (rate(thanos_replicate_replication_run_duration_seconds_bucket{job=~"thanos-bucket-replicate.*"}[5m])) > 0
+        sum by (job) (rate(thanos_replicate_replication_run_duration_seconds_bucket{job=~".*thanos-bucket-replicate.*"}[5m])) > 0
       )
     for: 5m
     labels:
@@ -566,7 +566,7 @@ groups:
       runbook_url: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanosbucketreplicateisdown
       summary: Thanos component has disappeared.
     expr: |
-      absent(up{job=~"thanos-bucket-replicate.*"} == 1)
+      absent(up{job=~".*thanos-bucket-replicate.*"} == 1)
     for: 5m
     labels:
       severity: critical
@@ -577,7 +577,7 @@ groups:
       runbook_url: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanoscompactisdown
       summary: Thanos component has disappeared.
     expr: |
-      absent(up{job=~"thanos-compact.*"} == 1)
+      absent(up{job=~".*thanos-compact.*"} == 1)
     for: 5m
     labels:
       severity: critical
@@ -588,7 +588,7 @@ groups:
       runbook_url: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanosqueryisdown
       summary: Thanos component has disappeared.
     expr: |
-      absent(up{job=~"thanos-query.*"} == 1)
+      absent(up{job=~".*thanos-query.*"} == 1)
     for: 5m
     labels:
       severity: critical
@@ -599,7 +599,7 @@ groups:
       runbook_url: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanosreceiveisdown
       summary: Thanos component has disappeared.
     expr: |
-      absent(up{job=~"thanos-receive.*"} == 1)
+      absent(up{job=~".*thanos-receive.*"} == 1)
     for: 5m
     labels:
       severity: critical
@@ -610,7 +610,7 @@ groups:
       runbook_url: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanosruleisdown
       summary: Thanos component has disappeared.
     expr: |
-      absent(up{job=~"thanos-rule.*"} == 1)
+      absent(up{job=~".*thanos-rule.*"} == 1)
     for: 5m
     labels:
       severity: critical
@@ -621,7 +621,7 @@ groups:
       runbook_url: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanossidecarisdown
       summary: Thanos component has disappeared.
     expr: |
-      absent(up{job=~"thanos-sidecar.*"} == 1)
+      absent(up{job=~".*thanos-sidecar.*"} == 1)
     for: 5m
     labels:
       severity: critical
@@ -632,7 +632,7 @@ groups:
       runbook_url: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanosstoreisdown
       summary: Thanos component has disappeared.
     expr: |
-      absent(up{job=~"thanos-store.*"} == 1)
+      absent(up{job=~".*thanos-store.*"} == 1)
     for: 5m
     labels:
       severity: critical

--- a/examples/alerts/rules.yaml
+++ b/examples/alerts/rules.yaml
@@ -3,35 +3,35 @@ groups:
   rules:
   - expr: |
       (
-        sum by (job) (rate(grpc_client_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded", job=~"thanos-query.*", grpc_type="unary"}[5m]))
+        sum by (job) (rate(grpc_client_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded", job=~".*thanos-query.*", grpc_type="unary"}[5m]))
       /
-        sum by (job) (rate(grpc_client_started_total{job=~"thanos-query.*", grpc_type="unary"}[5m]))
+        sum by (job) (rate(grpc_client_started_total{job=~".*thanos-query.*", grpc_type="unary"}[5m]))
       )
     record: :grpc_client_failures_per_unary:sum_rate
   - expr: |
       (
-        sum by (job) (rate(grpc_client_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded", job=~"thanos-query.*", grpc_type="server_stream"}[5m]))
+        sum by (job) (rate(grpc_client_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded", job=~".*thanos-query.*", grpc_type="server_stream"}[5m]))
       /
-        sum by (job) (rate(grpc_client_started_total{job=~"thanos-query.*", grpc_type="server_stream"}[5m]))
+        sum by (job) (rate(grpc_client_started_total{job=~".*thanos-query.*", grpc_type="server_stream"}[5m]))
       )
     record: :grpc_client_failures_per_stream:sum_rate
   - expr: |
       (
-        sum by (job) (rate(thanos_query_store_apis_dns_failures_total{job=~"thanos-query.*"}[5m]))
+        sum by (job) (rate(thanos_query_store_apis_dns_failures_total{job=~".*thanos-query.*"}[5m]))
       /
-        sum by (job) (rate(thanos_query_store_apis_dns_lookups_total{job=~"thanos-query.*"}[5m]))
+        sum by (job) (rate(thanos_query_store_apis_dns_lookups_total{job=~".*thanos-query.*"}[5m]))
       )
     record: :thanos_query_store_apis_dns_failures_per_lookup:sum_rate
   - expr: |
       histogram_quantile(0.99,
-        sum by (job, le) (rate(http_request_duration_seconds_bucket{job=~"thanos-query.*", handler="query"}[5m]))
+        sum by (job, le) (rate(http_request_duration_seconds_bucket{job=~".*thanos-query.*", handler="query"}[5m]))
       )
     labels:
       quantile: "0.99"
     record: :query_duration_seconds:histogram_quantile
   - expr: |
       histogram_quantile(0.99,
-        sum by (job, le) (rate(http_request_duration_seconds_bucket{job=~"thanos-query.*", handler="query_range"}[5m]))
+        sum by (job, le) (rate(http_request_duration_seconds_bucket{job=~".*thanos-query.*", handler="query_range"}[5m]))
       )
     labels:
       quantile: "0.99"
@@ -40,79 +40,79 @@ groups:
   rules:
   - expr: |
       (
-        sum by (job) (rate(grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded", job=~"thanos-receive.*", grpc_type="unary"}[5m]))
+        sum by (job) (rate(grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded", job=~".*thanos-receive.*", grpc_type="unary"}[5m]))
       /
-        sum by (job) (rate(grpc_server_started_total{job=~"thanos-receive.*", grpc_type="unary"}[5m]))
+        sum by (job) (rate(grpc_server_started_total{job=~".*thanos-receive.*", grpc_type="unary"}[5m]))
       )
     record: :grpc_server_failures_per_unary:sum_rate
   - expr: |
       (
-        sum by (job) (rate(grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded", job=~"thanos-receive.*", grpc_type="server_stream"}[5m]))
+        sum by (job) (rate(grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded", job=~".*thanos-receive.*", grpc_type="server_stream"}[5m]))
       /
-        sum by (job) (rate(grpc_server_started_total{job=~"thanos-receive.*", grpc_type="server_stream"}[5m]))
+        sum by (job) (rate(grpc_server_started_total{job=~".*thanos-receive.*", grpc_type="server_stream"}[5m]))
       )
     record: :grpc_server_failures_per_stream:sum_rate
   - expr: |
       (
-        sum by (job) (rate(http_requests_total{handler="receive", job=~"thanos-receive.*", code!~"5.."}[5m]))
+        sum by (job) (rate(http_requests_total{handler="receive", job=~".*thanos-receive.*", code!~"5.."}[5m]))
       /
-        sum by (job) (rate(http_requests_total{handler="receive", job=~"thanos-receive.*"}[5m]))
+        sum by (job) (rate(http_requests_total{handler="receive", job=~".*thanos-receive.*"}[5m]))
       )
     record: :http_failure_per_request:sum_rate
   - expr: |
       histogram_quantile(0.99,
-        sum by (job, le) (rate(http_request_duration_seconds_bucket{handler="receive", job=~"thanos-receive.*"}[5m]))
+        sum by (job, le) (rate(http_request_duration_seconds_bucket{handler="receive", job=~".*thanos-receive.*"}[5m]))
       )
     labels:
       quantile: "0.99"
     record: :http_request_duration_seconds:histogram_quantile
   - expr: |
       (
-        sum by (job) (rate(thanos_receive_replications_total{result="error", job=~"thanos-receive.*"}[5m]))
+        sum by (job) (rate(thanos_receive_replications_total{result="error", job=~".*thanos-receive.*"}[5m]))
       /
-        sum by (job) (rate(thanos_receive_replications_total{job=~"thanos-receive.*"}[5m]))
+        sum by (job) (rate(thanos_receive_replications_total{job=~".*thanos-receive.*"}[5m]))
       )
     record: :thanos_receive_replication_failure_per_requests:sum_rate
   - expr: |
       (
-        sum by (job) (rate(thanos_receive_forward_requests_total{result="error", job=~"thanos-receive.*"}[5m]))
+        sum by (job) (rate(thanos_receive_forward_requests_total{result="error", job=~".*thanos-receive.*"}[5m]))
       /
-        sum by (job) (rate(thanos_receive_forward_requests_total{job=~"thanos-receive.*"}[5m]))
+        sum by (job) (rate(thanos_receive_forward_requests_total{job=~".*thanos-receive.*"}[5m]))
       )
     record: :thanos_receive_forward_failure_per_requests:sum_rate
   - expr: |
       (
-        sum by (job) (rate(thanos_receive_hashrings_file_errors_total{job=~"thanos-receive.*"}[5m]))
+        sum by (job) (rate(thanos_receive_hashrings_file_errors_total{job=~".*thanos-receive.*"}[5m]))
       /
-        sum by (job) (rate(thanos_receive_hashrings_file_refreshes_total{job=~"thanos-receive.*"}[5m]))
+        sum by (job) (rate(thanos_receive_hashrings_file_refreshes_total{job=~".*thanos-receive.*"}[5m]))
       )
     record: :thanos_receive_hashring_file_failure_per_refresh:sum_rate
 - name: thanos-store.rules
   rules:
   - expr: |
       (
-        sum by (job) (rate(grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded", job=~"thanos-store.*", grpc_type="unary"}[5m]))
+        sum by (job) (rate(grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded", job=~".*thanos-store.*", grpc_type="unary"}[5m]))
       /
-        sum by (job) (rate(grpc_server_started_total{job=~"thanos-store.*", grpc_type="unary"}[5m]))
+        sum by (job) (rate(grpc_server_started_total{job=~".*thanos-store.*", grpc_type="unary"}[5m]))
       )
     record: :grpc_server_failures_per_unary:sum_rate
   - expr: |
       (
-        sum by (job) (rate(grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded", job=~"thanos-store.*", grpc_type="server_stream"}[5m]))
+        sum by (job) (rate(grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded", job=~".*thanos-store.*", grpc_type="server_stream"}[5m]))
       /
-        sum by (job) (rate(grpc_server_started_total{job=~"thanos-store.*", grpc_type="server_stream"}[5m]))
+        sum by (job) (rate(grpc_server_started_total{job=~".*thanos-store.*", grpc_type="server_stream"}[5m]))
       )
     record: :grpc_server_failures_per_stream:sum_rate
   - expr: |
       (
-        sum by (job) (rate(thanos_objstore_bucket_operation_failures_total{job=~"thanos-store.*"}[5m]))
+        sum by (job) (rate(thanos_objstore_bucket_operation_failures_total{job=~".*thanos-store.*"}[5m]))
       /
-        sum by (job) (rate(thanos_objstore_bucket_operations_total{job=~"thanos-store.*"}[5m]))
+        sum by (job) (rate(thanos_objstore_bucket_operations_total{job=~".*thanos-store.*"}[5m]))
       )
     record: :thanos_objstore_bucket_failures_per_operation:sum_rate
   - expr: |
       histogram_quantile(0.99,
-        sum by (job, le) (rate(thanos_objstore_bucket_operation_duration_seconds_bucket{job=~"thanos-store.*"}[5m]))
+        sum by (job, le) (rate(thanos_objstore_bucket_operation_duration_seconds_bucket{job=~".*thanos-store.*"}[5m]))
       )
     labels:
       quantile: "0.99"

--- a/examples/dashboards/bucket_replicate.json
+++ b/examples/dashboards/bucket_replicate.json
@@ -467,7 +467,7 @@
             "multi": false,
             "name": "job",
             "options": [ ],
-            "query": "label_values(up{job=~\"thanos-bucket-replicate.*\"}, job)",
+            "query": "label_values(up{job=~\".*thanos-bucket-replicate.*\"}, job)",
             "refresh": 1,
             "regex": "",
             "sort": 2,

--- a/examples/dashboards/bucket_replicate.json
+++ b/examples/dashboards/bucket_replicate.json
@@ -51,7 +51,6 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "error",
-                     "refId": "A",
                      "step": 10
                   }
                ],
@@ -227,7 +226,6 @@
                      "logBase": 10,
                      "max": null,
                      "min": null,
-                     "refId": "A",
                      "step": 10
                   },
                   {
@@ -238,7 +236,6 @@
                      "logBase": 10,
                      "max": null,
                      "min": null,
-                     "refId": "A",
                      "step": 10
                   },
                   {
@@ -249,7 +246,6 @@
                      "logBase": 10,
                      "max": null,
                      "min": null,
-                     "refId": "A",
                      "step": 10
                   }
                ],

--- a/examples/dashboards/compact.json
+++ b/examples/dashboards/compact.json
@@ -1785,7 +1785,7 @@
             "multi": false,
             "name": "job",
             "options": [ ],
-            "query": "label_values(up{job=~\"thanos-compact.*\"}, job)",
+            "query": "label_values(up{job=~\".*thanos-compact.*\"}, job)",
             "refresh": 1,
             "regex": "",
             "sort": 2,

--- a/examples/dashboards/compact.json
+++ b/examples/dashboards/compact.json
@@ -129,7 +129,6 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "error",
-                     "refId": "A",
                      "step": 10
                   }
                ],
@@ -297,7 +296,6 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "error",
-                     "refId": "A",
                      "step": 10
                   }
                ],
@@ -465,7 +463,6 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "error",
-                     "refId": "A",
                      "step": 10
                   }
                ],
@@ -564,7 +561,6 @@
                      "logBase": 10,
                      "max": null,
                      "min": null,
-                     "refId": "A",
                      "step": 10
                   },
                   {
@@ -575,7 +571,6 @@
                      "logBase": 10,
                      "max": null,
                      "min": null,
-                     "refId": "A",
                      "step": 10
                   },
                   {
@@ -586,7 +581,6 @@
                      "logBase": 10,
                      "max": null,
                      "min": null,
-                     "refId": "A",
                      "step": 10
                   }
                ],
@@ -997,7 +991,6 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "error",
-                     "refId": "A",
                      "step": 10
                   }
                ],
@@ -1096,7 +1089,6 @@
                      "logBase": 10,
                      "max": null,
                      "min": null,
-                     "refId": "A",
                      "step": 10
                   },
                   {
@@ -1107,7 +1099,6 @@
                      "logBase": 10,
                      "max": null,
                      "min": null,
-                     "refId": "A",
                      "step": 10
                   },
                   {
@@ -1118,7 +1109,6 @@
                      "logBase": 10,
                      "max": null,
                      "min": null,
-                     "refId": "A",
                      "step": 10
                   }
                ],
@@ -1286,7 +1276,6 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "error",
-                     "refId": "A",
                      "step": 10
                   }
                ],
@@ -1385,7 +1374,6 @@
                      "logBase": 10,
                      "max": null,
                      "min": null,
-                     "refId": "A",
                      "step": 10
                   },
                   {
@@ -1396,7 +1384,6 @@
                      "logBase": 10,
                      "max": null,
                      "min": null,
-                     "refId": "A",
                      "step": 10
                   },
                   {
@@ -1407,7 +1394,6 @@
                      "logBase": 10,
                      "max": null,
                      "min": null,
-                     "refId": "A",
                      "step": 10
                   }
                ],

--- a/examples/dashboards/compact.json
+++ b/examples/dashboards/compact.json
@@ -1507,7 +1507,7 @@
                      "step": 10
                   },
                   {
-                     "expr": "rate(go_memstats_alloc_bytes_total{job=\"$job\"})[30s]",
+                     "expr": "rate(go_memstats_alloc_bytes_total{job=\"$job\"}[30s])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "alloc rate all {{instance}}",
@@ -1515,7 +1515,7 @@
                      "step": 10
                   },
                   {
-                     "expr": "rate(go_memstats_heap_alloc_bytes{job=\"$job\"})[30s]",
+                     "expr": "rate(go_memstats_heap_alloc_bytes{job=\"$job\"}[30s])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "alloc rate heap {{instance}}",

--- a/examples/dashboards/overview.json
+++ b/examples/dashboards/overview.json
@@ -79,7 +79,6 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{job}} {{handler}} {{code}}",
-                     "refId": "A",
                      "step": 10
                   }
                ],
@@ -166,7 +165,6 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "error",
-                     "refId": "A",
                      "step": 10
                   }
                ],
@@ -386,7 +384,6 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{job}} {{handler}} {{code}}",
-                     "refId": "A",
                      "step": 10
                   }
                ],
@@ -473,7 +470,6 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "error",
-                     "refId": "A",
                      "step": 10
                   }
                ],
@@ -745,7 +741,6 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{job}} {{grpc_method}} {{grpc_code}}",
-                     "refId": "A",
                      "step": 10
                   }
                ],
@@ -832,7 +827,6 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "error",
-                     "refId": "A",
                      "step": 10
                   }
                ],
@@ -1104,7 +1098,6 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{job}} {{grpc_method}} {{grpc_code}}",
-                     "refId": "A",
                      "step": 10
                   }
                ],
@@ -1191,7 +1184,6 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "error",
-                     "refId": "A",
                      "step": 10
                   }
                ],
@@ -1411,7 +1403,6 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{job}} {{handler}} {{code}}",
-                     "refId": "A",
                      "step": 10
                   }
                ],
@@ -1498,7 +1489,6 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "error",
-                     "refId": "A",
                      "step": 10
                   }
                ],
@@ -1784,7 +1774,6 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "error",
-                     "refId": "A",
                      "step": 10
                   }
                ],
@@ -2070,7 +2059,6 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "error",
-                     "refId": "A",
                      "step": 10
                   }
                ],

--- a/examples/dashboards/query.json
+++ b/examples/dashboards/query.json
@@ -1573,7 +1573,7 @@
                      "step": 10
                   },
                   {
-                     "expr": "rate(go_memstats_alloc_bytes_total{job=\"$job\"})[30s]",
+                     "expr": "rate(go_memstats_alloc_bytes_total{job=\"$job\"}[30s])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "alloc rate all {{instance}}",
@@ -1581,7 +1581,7 @@
                      "step": 10
                   },
                   {
-                     "expr": "rate(go_memstats_heap_alloc_bytes{job=\"$job\"})[30s]",
+                     "expr": "rate(go_memstats_heap_alloc_bytes{job=\"$job\"}[30s])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "alloc rate heap {{instance}}",

--- a/examples/dashboards/query.json
+++ b/examples/dashboards/query.json
@@ -1851,7 +1851,7 @@
             "multi": false,
             "name": "job",
             "options": [ ],
-            "query": "label_values(up{job=~\"thanos-query.*\"}, job)",
+            "query": "label_values(up{job=~\".*thanos-query.*\"}, job)",
             "refresh": 1,
             "regex": "",
             "sort": 2,

--- a/examples/dashboards/query.json
+++ b/examples/dashboards/query.json
@@ -71,7 +71,6 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{job}} {{handler}} {{code}}",
-                     "refId": "A",
                      "step": 10
                   }
                ],
@@ -150,7 +149,6 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "error",
-                     "refId": "A",
                      "step": 10
                   }
                ],
@@ -249,7 +247,6 @@
                      "logBase": 10,
                      "max": null,
                      "min": null,
-                     "refId": "A",
                      "step": 10
                   },
                   {
@@ -260,7 +257,6 @@
                      "logBase": 10,
                      "max": null,
                      "min": null,
-                     "refId": "A",
                      "step": 10
                   },
                   {
@@ -271,7 +267,6 @@
                      "logBase": 10,
                      "max": null,
                      "min": null,
-                     "refId": "A",
                      "step": 10
                   }
                ],
@@ -381,7 +376,6 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{job}} {{handler}} {{code}}",
-                     "refId": "A",
                      "step": 10
                   }
                ],
@@ -460,7 +454,6 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "error",
-                     "refId": "A",
                      "step": 10
                   }
                ],
@@ -559,7 +552,6 @@
                      "logBase": 10,
                      "max": null,
                      "min": null,
-                     "refId": "A",
                      "step": 10
                   },
                   {
@@ -570,7 +562,6 @@
                      "logBase": 10,
                      "max": null,
                      "min": null,
-                     "refId": "A",
                      "step": 10
                   },
                   {
@@ -581,7 +572,6 @@
                      "logBase": 10,
                      "max": null,
                      "min": null,
-                     "refId": "A",
                      "step": 10
                   }
                ],
@@ -743,7 +733,6 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{job}} {{grpc_method}} {{grpc_code}}",
-                     "refId": "A",
                      "step": 10
                   }
                ],
@@ -822,7 +811,6 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "error",
-                     "refId": "A",
                      "step": 10
                   }
                ],
@@ -921,7 +909,6 @@
                      "logBase": 10,
                      "max": null,
                      "min": null,
-                     "refId": "A",
                      "step": 10
                   },
                   {
@@ -932,7 +919,6 @@
                      "logBase": 10,
                      "max": null,
                      "min": null,
-                     "refId": "A",
                      "step": 10
                   },
                   {
@@ -943,7 +929,6 @@
                      "logBase": 10,
                      "max": null,
                      "min": null,
-                     "refId": "A",
                      "step": 10
                   }
                ],
@@ -1105,7 +1090,6 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{job}} {{grpc_method}} {{grpc_code}}",
-                     "refId": "A",
                      "step": 10
                   }
                ],
@@ -1184,7 +1168,6 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "error",
-                     "refId": "A",
                      "step": 10
                   }
                ],
@@ -1283,7 +1266,6 @@
                      "logBase": 10,
                      "max": null,
                      "min": null,
-                     "refId": "A",
                      "step": 10
                   },
                   {
@@ -1294,7 +1276,6 @@
                      "logBase": 10,
                      "max": null,
                      "min": null,
-                     "refId": "A",
                      "step": 10
                   },
                   {
@@ -1305,7 +1286,6 @@
                      "logBase": 10,
                      "max": null,
                      "min": null,
-                     "refId": "A",
                      "step": 10
                   }
                ],
@@ -1473,7 +1453,6 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "error",
-                     "refId": "A",
                      "step": 10
                   }
                ],

--- a/examples/dashboards/receive.json
+++ b/examples/dashboards/receive.json
@@ -71,7 +71,6 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{job}} {{handler}} {{code}}",
-                     "refId": "A",
                      "step": 10
                   }
                ],
@@ -150,7 +149,6 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "error",
-                     "refId": "A",
                      "step": 10
                   }
                ],
@@ -249,7 +247,6 @@
                      "logBase": 10,
                      "max": null,
                      "min": null,
-                     "refId": "A",
                      "step": 10
                   },
                   {
@@ -260,7 +257,6 @@
                      "logBase": 10,
                      "max": null,
                      "min": null,
-                     "refId": "A",
                      "step": 10
                   },
                   {
@@ -271,7 +267,6 @@
                      "logBase": 10,
                      "max": null,
                      "min": null,
-                     "refId": "A",
                      "step": 10
                   }
                ],
@@ -439,7 +434,6 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "error",
-                     "refId": "A",
                      "step": 10
                   }
                ],
@@ -607,7 +601,6 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "error",
-                     "refId": "A",
                      "step": 10
                   }
                ],
@@ -769,7 +762,6 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{job}} {{grpc_method}} {{grpc_code}}",
-                     "refId": "A",
                      "step": 10
                   }
                ],
@@ -848,7 +840,6 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "error",
-                     "refId": "A",
                      "step": 10
                   }
                ],
@@ -947,7 +938,6 @@
                      "logBase": 10,
                      "max": null,
                      "min": null,
-                     "refId": "A",
                      "step": 10
                   },
                   {
@@ -958,7 +948,6 @@
                      "logBase": 10,
                      "max": null,
                      "min": null,
-                     "refId": "A",
                      "step": 10
                   },
                   {
@@ -969,7 +958,6 @@
                      "logBase": 10,
                      "max": null,
                      "min": null,
-                     "refId": "A",
                      "step": 10
                   }
                ],
@@ -1131,7 +1119,6 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{job}} {{grpc_method}} {{grpc_code}}",
-                     "refId": "A",
                      "step": 10
                   }
                ],
@@ -1210,7 +1197,6 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "error",
-                     "refId": "A",
                      "step": 10
                   }
                ],
@@ -1309,7 +1295,6 @@
                      "logBase": 10,
                      "max": null,
                      "min": null,
-                     "refId": "A",
                      "step": 10
                   },
                   {
@@ -1320,7 +1305,6 @@
                      "logBase": 10,
                      "max": null,
                      "min": null,
-                     "refId": "A",
                      "step": 10
                   },
                   {
@@ -1331,7 +1315,6 @@
                      "logBase": 10,
                      "max": null,
                      "min": null,
-                     "refId": "A",
                      "step": 10
                   }
                ],
@@ -1493,7 +1476,6 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{job}} {{grpc_method}} {{grpc_code}}",
-                     "refId": "A",
                      "step": 10
                   }
                ],
@@ -1572,7 +1554,6 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "error",
-                     "refId": "A",
                      "step": 10
                   }
                ],
@@ -1671,7 +1652,6 @@
                      "logBase": 10,
                      "max": null,
                      "min": null,
-                     "refId": "A",
                      "step": 10
                   },
                   {
@@ -1682,7 +1662,6 @@
                      "logBase": 10,
                      "max": null,
                      "min": null,
-                     "refId": "A",
                      "step": 10
                   },
                   {
@@ -1693,7 +1672,6 @@
                      "logBase": 10,
                      "max": null,
                      "min": null,
-                     "refId": "A",
                      "step": 10
                   }
                ],

--- a/examples/dashboards/receive.json
+++ b/examples/dashboards/receive.json
@@ -2196,7 +2196,7 @@
             "multi": false,
             "name": "job",
             "options": [ ],
-            "query": "label_values(up{job=~\"thanos-receive.*\"}, job)",
+            "query": "label_values(up{job=~\".*thanos-receive.*\"}, job)",
             "refresh": 1,
             "regex": "",
             "sort": 2,

--- a/examples/dashboards/receive.json
+++ b/examples/dashboards/receive.json
@@ -1918,7 +1918,7 @@
                      "step": 10
                   },
                   {
-                     "expr": "rate(go_memstats_alloc_bytes_total{job=\"$job\"})[30s]",
+                     "expr": "rate(go_memstats_alloc_bytes_total{job=\"$job\"}[30s])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "alloc rate all {{instance}}",
@@ -1926,7 +1926,7 @@
                      "step": 10
                   },
                   {
-                     "expr": "rate(go_memstats_heap_alloc_bytes{job=\"$job\"})[30s]",
+                     "expr": "rate(go_memstats_heap_alloc_bytes{job=\"$job\"}[30s])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "alloc rate heap {{instance}}",

--- a/examples/dashboards/rule.json
+++ b/examples/dashboards/rule.json
@@ -446,7 +446,6 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "error",
-                     "refId": "A",
                      "step": 10
                   }
                ],
@@ -545,7 +544,6 @@
                      "logBase": 10,
                      "max": null,
                      "min": null,
-                     "refId": "A",
                      "step": 10
                   },
                   {
@@ -556,7 +554,6 @@
                      "logBase": 10,
                      "max": null,
                      "min": null,
-                     "refId": "A",
                      "step": 10
                   },
                   {
@@ -567,7 +564,6 @@
                      "logBase": 10,
                      "max": null,
                      "min": null,
-                     "refId": "A",
                      "step": 10
                   }
                ],
@@ -735,7 +731,6 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "error",
-                     "refId": "A",
                      "step": 10
                   }
                ],
@@ -897,7 +892,6 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{job}} {{grpc_method}} {{grpc_code}}",
-                     "refId": "A",
                      "step": 10
                   }
                ],
@@ -976,7 +970,6 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "error",
-                     "refId": "A",
                      "step": 10
                   }
                ],
@@ -1075,7 +1068,6 @@
                      "logBase": 10,
                      "max": null,
                      "min": null,
-                     "refId": "A",
                      "step": 10
                   },
                   {
@@ -1086,7 +1078,6 @@
                      "logBase": 10,
                      "max": null,
                      "min": null,
-                     "refId": "A",
                      "step": 10
                   },
                   {
@@ -1097,7 +1088,6 @@
                      "logBase": 10,
                      "max": null,
                      "min": null,
-                     "refId": "A",
                      "step": 10
                   }
                ],
@@ -1259,7 +1249,6 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{job}} {{grpc_method}} {{grpc_code}}",
-                     "refId": "A",
                      "step": 10
                   }
                ],
@@ -1338,7 +1327,6 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "error",
-                     "refId": "A",
                      "step": 10
                   }
                ],
@@ -1437,7 +1425,6 @@
                      "logBase": 10,
                      "max": null,
                      "min": null,
-                     "refId": "A",
                      "step": 10
                   },
                   {
@@ -1448,7 +1435,6 @@
                      "logBase": 10,
                      "max": null,
                      "min": null,
-                     "refId": "A",
                      "step": 10
                   },
                   {
@@ -1459,7 +1445,6 @@
                      "logBase": 10,
                      "max": null,
                      "min": null,
-                     "refId": "A",
                      "step": 10
                   }
                ],

--- a/examples/dashboards/rule.json
+++ b/examples/dashboards/rule.json
@@ -1559,7 +1559,7 @@
                      "step": 10
                   },
                   {
-                     "expr": "rate(go_memstats_alloc_bytes_total{job=\"$job\"})[30s]",
+                     "expr": "rate(go_memstats_alloc_bytes_total{job=\"$job\"}[30s])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "alloc rate all {{instance}}",
@@ -1567,7 +1567,7 @@
                      "step": 10
                   },
                   {
-                     "expr": "rate(go_memstats_heap_alloc_bytes{job=\"$job\"})[30s]",
+                     "expr": "rate(go_memstats_heap_alloc_bytes{job=\"$job\"}[30s])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "alloc rate heap {{instance}}",

--- a/examples/dashboards/rule.json
+++ b/examples/dashboards/rule.json
@@ -1837,7 +1837,7 @@
             "multi": false,
             "name": "job",
             "options": [ ],
-            "query": "label_values(up{job=~\"thanos-rule.*\"}, job)",
+            "query": "label_values(up{job=~\".*thanos-rule.*\"}, job)",
             "refresh": 1,
             "regex": "",
             "sort": 2,

--- a/examples/dashboards/sidecar.json
+++ b/examples/dashboards/sidecar.json
@@ -1195,7 +1195,7 @@
                      "step": 10
                   },
                   {
-                     "expr": "rate(go_memstats_alloc_bytes_total{job=\"$job\"})[30s]",
+                     "expr": "rate(go_memstats_alloc_bytes_total{job=\"$job\"}[30s])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "alloc rate all {{instance}}",
@@ -1203,7 +1203,7 @@
                      "step": 10
                   },
                   {
-                     "expr": "rate(go_memstats_heap_alloc_bytes{job=\"$job\"})[30s]",
+                     "expr": "rate(go_memstats_heap_alloc_bytes{job=\"$job\"}[30s])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "alloc rate heap {{instance}}",

--- a/examples/dashboards/sidecar.json
+++ b/examples/dashboards/sidecar.json
@@ -1473,7 +1473,7 @@
             "multi": false,
             "name": "job",
             "options": [ ],
-            "query": "label_values(up{job=~\"thanos-sidecar.*\"}, job)",
+            "query": "label_values(up{job=~\".*thanos-sidecar.*\"}, job)",
             "refresh": 1,
             "regex": "",
             "sort": 2,

--- a/examples/dashboards/sidecar.json
+++ b/examples/dashboards/sidecar.json
@@ -123,7 +123,6 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{job}} {{grpc_method}} {{grpc_code}}",
-                     "refId": "A",
                      "step": 10
                   }
                ],
@@ -202,7 +201,6 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "error",
-                     "refId": "A",
                      "step": 10
                   }
                ],
@@ -301,7 +299,6 @@
                      "logBase": 10,
                      "max": null,
                      "min": null,
-                     "refId": "A",
                      "step": 10
                   },
                   {
@@ -312,7 +309,6 @@
                      "logBase": 10,
                      "max": null,
                      "min": null,
-                     "refId": "A",
                      "step": 10
                   },
                   {
@@ -323,7 +319,6 @@
                      "logBase": 10,
                      "max": null,
                      "min": null,
-                     "refId": "A",
                      "step": 10
                   }
                ],
@@ -485,7 +480,6 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{job}} {{grpc_method}} {{grpc_code}}",
-                     "refId": "A",
                      "step": 10
                   }
                ],
@@ -563,7 +557,6 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "error",
-                     "refId": "A",
                      "step": 10
                   }
                ],
@@ -662,7 +655,6 @@
                      "logBase": 10,
                      "max": null,
                      "min": null,
-                     "refId": "A",
                      "step": 10
                   },
                   {
@@ -673,7 +665,6 @@
                      "logBase": 10,
                      "max": null,
                      "min": null,
-                     "refId": "A",
                      "step": 10
                   },
                   {
@@ -684,7 +675,6 @@
                      "logBase": 10,
                      "max": null,
                      "min": null,
-                     "refId": "A",
                      "step": 10
                   }
                ],
@@ -975,7 +965,6 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "error",
-                     "refId": "A",
                      "step": 10
                   }
                ],
@@ -1073,7 +1062,6 @@
                      "logBase": 10,
                      "max": null,
                      "min": null,
-                     "refId": "A",
                      "step": 10
                   },
                   {
@@ -1084,7 +1072,6 @@
                      "logBase": 10,
                      "max": null,
                      "min": null,
-                     "refId": "A",
                      "step": 10
                   },
                   {
@@ -1095,7 +1082,6 @@
                      "logBase": 10,
                      "max": null,
                      "min": null,
-                     "refId": "A",
                      "step": 10
                   }
                ],

--- a/examples/dashboards/store.json
+++ b/examples/dashboards/store.json
@@ -2457,7 +2457,7 @@
                      "step": 10
                   },
                   {
-                     "expr": "rate(go_memstats_alloc_bytes_total{job=\"$job\"})[30s]",
+                     "expr": "rate(go_memstats_alloc_bytes_total{job=\"$job\"}[30s])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "alloc rate all {{instance}}",
@@ -2465,7 +2465,7 @@
                      "step": 10
                   },
                   {
-                     "expr": "rate(go_memstats_heap_alloc_bytes{job=\"$job\"})[30s]",
+                     "expr": "rate(go_memstats_heap_alloc_bytes{job=\"$job\"}[30s])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "alloc rate heap {{instance}}",

--- a/examples/dashboards/store.json
+++ b/examples/dashboards/store.json
@@ -123,7 +123,6 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{job}} {{grpc_method}} {{grpc_code}}",
-                     "refId": "A",
                      "step": 10
                   }
                ],
@@ -202,7 +201,6 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "error",
-                     "refId": "A",
                      "step": 10
                   }
                ],
@@ -301,7 +299,6 @@
                      "logBase": 10,
                      "max": null,
                      "min": null,
-                     "refId": "A",
                      "step": 10
                   },
                   {
@@ -312,7 +309,6 @@
                      "logBase": 10,
                      "max": null,
                      "min": null,
-                     "refId": "A",
                      "step": 10
                   },
                   {
@@ -323,7 +319,6 @@
                      "logBase": 10,
                      "max": null,
                      "min": null,
-                     "refId": "A",
                      "step": 10
                   }
                ],
@@ -485,7 +480,6 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{job}} {{grpc_method}} {{grpc_code}}",
-                     "refId": "A",
                      "step": 10
                   }
                ],
@@ -564,7 +558,6 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "error",
-                     "refId": "A",
                      "step": 10
                   }
                ],
@@ -663,7 +656,6 @@
                      "logBase": 10,
                      "max": null,
                      "min": null,
-                     "refId": "A",
                      "step": 10
                   },
                   {
@@ -674,7 +666,6 @@
                      "logBase": 10,
                      "max": null,
                      "min": null,
-                     "refId": "A",
                      "step": 10
                   },
                   {
@@ -685,7 +676,6 @@
                      "logBase": 10,
                      "max": null,
                      "min": null,
-                     "refId": "A",
                      "step": 10
                   }
                ],
@@ -1112,7 +1102,6 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "error",
-                     "refId": "A",
                      "step": 10
                   }
                ],
@@ -1268,7 +1257,6 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "error",
-                     "refId": "A",
                      "step": 10
                   }
                ],
@@ -2093,7 +2081,6 @@
                      "logBase": 10,
                      "max": null,
                      "min": null,
-                     "refId": "A",
                      "step": 10
                   },
                   {
@@ -2104,7 +2091,6 @@
                      "logBase": 10,
                      "max": null,
                      "min": null,
-                     "refId": "A",
                      "step": 10
                   },
                   {
@@ -2115,7 +2101,6 @@
                      "logBase": 10,
                      "max": null,
                      "min": null,
-                     "refId": "A",
                      "step": 10
                   }
                ],
@@ -2214,7 +2199,6 @@
                      "logBase": 10,
                      "max": null,
                      "min": null,
-                     "refId": "A",
                      "step": 10
                   },
                   {
@@ -2225,7 +2209,6 @@
                      "logBase": 10,
                      "max": null,
                      "min": null,
-                     "refId": "A",
                      "step": 10
                   },
                   {
@@ -2236,7 +2219,6 @@
                      "logBase": 10,
                      "max": null,
                      "min": null,
-                     "refId": "A",
                      "step": 10
                   }
                ],
@@ -2335,7 +2317,6 @@
                      "logBase": 10,
                      "max": null,
                      "min": null,
-                     "refId": "A",
                      "step": 10
                   },
                   {
@@ -2346,7 +2327,6 @@
                      "logBase": 10,
                      "max": null,
                      "min": null,
-                     "refId": "A",
                      "step": 10
                   },
                   {
@@ -2357,7 +2337,6 @@
                      "logBase": 10,
                      "max": null,
                      "min": null,
-                     "refId": "A",
                      "step": 10
                   }
                ],

--- a/examples/dashboards/store.json
+++ b/examples/dashboards/store.json
@@ -2735,7 +2735,7 @@
             "multi": false,
             "name": "job",
             "options": [ ],
-            "query": "label_values(up{job=~\"thanos-store.*\"}, job)",
+            "query": "label_values(up{job=~\".*thanos-store.*\"}, job)",
             "refresh": 1,
             "regex": "",
             "sort": 2,

--- a/mixin/README.md
+++ b/mixin/README.md
@@ -85,32 +85,32 @@ This project is intended to be used as a library. You can extend and customize d
     // sum by (cluster, namespace, region, zone, job) (rate(thanos_compact_group_compactions_total{cluster=\"$cluster\", namespace=\"$namespace\", region=\"$region\", zone=\"$zone\", job=\"$job\"}[$interval]))
   },
   query+:: {
-    selector: 'job=~"thanos-query.*"',
+    selector: 'job=~".*thanos-query.*"',
     title: '%(prefix)sQuery' % $.dashboard.prefix,
   },
   store+:: {
-    selector: 'job=~"thanos-store.*"',
+    selector: 'job=~".*thanos-store.*"',
     title: '%(prefix)sStore' % $.dashboard.prefix,
   },
   receive+:: {
-    selector: 'job=~"thanos-receive.*"',
+    selector: 'job=~".*thanos-receive.*"',
     title: '%(prefix)sReceive' % $.dashboard.prefix,
   },
   rule+:: {
-    selector: 'job=~"thanos-rule.*"',
+    selector: 'job=~".*thanos-rule.*"',
     title: '%(prefix)sRule' % $.dashboard.prefix,
   },
   compact+:: {
-    selector: 'job=~"thanos-compact.*"',
+    selector: 'job=~".*thanos-compact.*"',
     title: '%(prefix)sCompact' % $.dashboard.prefix,
   },
   sidecar+:: {
-    selector: 'job=~"thanos-sidecar.*"',
+    selector: 'job=~".*thanos-sidecar.*"',
     title: '%(prefix)sSidecar' % $.dashboard.prefix,
   },
   // TODO(kakkoyun): Fix naming convention: bucketReplicate
   bucket_replicate+:: {
-    selector: 'job=~"thanos-bucket-replicate.*"',
+    selector: 'job=~".*thanos-bucket-replicate.*"',
     title: '%(prefix)sBucketReplicate' % $.dashboard.prefix,
   },
   dashboard+:: {

--- a/mixin/config.libsonnet
+++ b/mixin/config.libsonnet
@@ -25,32 +25,32 @@
     // sum by (cluster, namespace, region, zone, job) (rate(thanos_compact_group_compactions_total{cluster=\"$cluster\", namespace=\"$namespace\", region=\"$region\", zone=\"$zone\", job=\"$job\"}[$interval]))
   },
   query+:: {
-    selector: 'job=~"thanos-query.*"',
+    selector: 'job=~".*thanos-query.*"',
     title: '%(prefix)sQuery' % $.dashboard.prefix,
   },
   store+:: {
-    selector: 'job=~"thanos-store.*"',
+    selector: 'job=~".*thanos-store.*"',
     title: '%(prefix)sStore' % $.dashboard.prefix,
   },
   receive+:: {
-    selector: 'job=~"thanos-receive.*"',
+    selector: 'job=~".*thanos-receive.*"',
     title: '%(prefix)sReceive' % $.dashboard.prefix,
   },
   rule+:: {
-    selector: 'job=~"thanos-rule.*"',
+    selector: 'job=~".*thanos-rule.*"',
     title: '%(prefix)sRule' % $.dashboard.prefix,
   },
   compact+:: {
-    selector: 'job=~"thanos-compact.*"',
+    selector: 'job=~".*thanos-compact.*"',
     title: '%(prefix)sCompact' % $.dashboard.prefix,
   },
   sidecar+:: {
-    selector: 'job=~"thanos-sidecar.*"',
+    selector: 'job=~".*thanos-sidecar.*"',
     title: '%(prefix)sSidecar' % $.dashboard.prefix,
   },
   // TODO(kakkoyun): Fix naming convention: bucketReplicate
   bucket_replicate+:: {
-    selector: 'job=~"thanos-bucket-replicate.*"',
+    selector: 'job=~".*thanos-bucket-replicate.*"',
     title: '%(prefix)sBucketReplicate' % $.dashboard.prefix,
   },
   dashboard+:: {

--- a/mixin/lib/thanos-grafana-builder/builder.libsonnet
+++ b/mixin/lib/thanos-grafana-builder/builder.libsonnet
@@ -136,8 +136,8 @@ local utils = import '../utils.libsonnet';
         [
           'go_memstats_alloc_bytes{%s}' % selector,
           'go_memstats_heap_alloc_bytes{%s}' % selector,
-          'rate(go_memstats_alloc_bytes_total{%s})[30s]' % selector,
-          'rate(go_memstats_heap_alloc_bytes{%s})[30s]' % selector,
+          'rate(go_memstats_alloc_bytes_total{%s}[30s])' % selector,
+          'rate(go_memstats_heap_alloc_bytes{%s}[30s])' % selector,
           'go_memstats_stack_inuse_bytes{%s}' % selector,
           'go_memstats_heap_inuse_bytes{%s}' % selector,
         ],

--- a/mixin/lib/thanos-grafana-builder/builder.libsonnet
+++ b/mixin/lib/thanos-grafana-builder/builder.libsonnet
@@ -53,7 +53,6 @@ local utils = import '../utils.libsonnet';
         logBase: 10,
         min: null,
         max: null,
-        refId: 'A',
         step: 10,
       }
       for percentile in [0.5, 0.9, 0.99]
@@ -93,7 +92,6 @@ local utils = import '../utils.libsonnet';
         format: 'time_series',
         intervalFactor: 2,
         legendFormat: 'error',
-        refId: 'A',
         step: 10,
       },
     ],
@@ -113,7 +111,6 @@ local utils = import '../utils.libsonnet';
         format: 'time_series',
         intervalFactor: 2,
         legendFormat: 'error',
-        refId: 'A',
         step: 10,
       },
       {
@@ -121,7 +118,6 @@ local utils = import '../utils.libsonnet';
         format: 'time_series',
         intervalFactor: 2,
         legendFormat: 'success',
-        refId: 'B',
         step: 10,
       },
     ],

--- a/mixin/lib/thanos-grafana-builder/grpc.libsonnet
+++ b/mixin/lib/thanos-grafana-builder/grpc.libsonnet
@@ -31,7 +31,6 @@ local utils = import '../utils.libsonnet';
         format: 'time_series',
         intervalFactor: 2,
         legendFormat: dimensionsTemplate + ' {{grpc_method}} {{grpc_code}}',
-        refId: 'A',
         step: 10,
       },
     ],

--- a/mixin/lib/thanos-grafana-builder/http.libsonnet
+++ b/mixin/lib/thanos-grafana-builder/http.libsonnet
@@ -19,7 +19,6 @@ local utils = import '../utils.libsonnet';
         format: 'time_series',
         intervalFactor: 2,
         legendFormat: dimensionsTemplate + ' {{handler}} {{code}}',
-        refId: 'A',
         step: 10,
       },
     ],


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->
* Fix `rate(go_memstats_alloc_bytes_total{%s})` query in dashboard, range should be inside rate function.
* Add regex match to account for prefixes in thanos component names, 
so the dashboards should work for components named in the following way: `xxx-thanos-component-xxx`
* Remove hardcoded refIds from panel queries (#3959)


## Verification

<!-- How you tested it? How do you know it works? -->
Yes deployed it [our instance of grafana](https://grafana-route-opf-monitoring.apps.zero.massopen.cloud/dashboards)

Closes #3959 