### PR TITLE
Fix `make docker`

### DIFF
--- a/Dockerfile.multi-stage
+++ b/Dockerfile.multi-stage
@@ -1,3 +1,5 @@
+# By default we pin to amd64 sha. Use make docker to automatically adjust for arm64 versions.
+ARG SHA="fca3819d670cdaee0d785499fda202ea01c0640ca0803d26ae6dbf2a1c8c041c"
 FROM golang:1.15-alpine3.12 as builder
 
 WORKDIR $GOPATH/src/github.com/thanos-io/thanos
@@ -14,8 +16,6 @@ RUN git update-index --refresh; make build
 
 # -----------------------------------------------------------------------------
 
-# By default we pin to amd64 sha. Use make docker to automatically adjust for arm64 versions.
-ARG SHA="fca3819d670cdaee0d785499fda202ea01c0640ca0803d26ae6dbf2a1c8c041c"
 FROM quay.io/prometheus/busybox@sha256:${SHA}
 LABEL maintainer="The Thanos Authors"
 


### PR DESCRIPTION
## Pertaining Issues
#3955 

## Changes
Currently, the `make docker` command uses `Dockerfile` when the kernel is `linux_x86_64` and `Dockerfile.multi-stage` for everything else for e.g macOS (`darwin_x86_64`).  However, in case of the `Dockerfile.multi-stage` the `SHA` build argument goes out of scope when the first stage finishes as it's treated as part of the first stage. This results in the error below,
```
.
.
Step 7/10 : FROM quay.io/prometheus/busybox@sha256:${SHA}
invalid reference format
make: *** [docker-multi-stage] Error 1
```
By defining the build arg, `SHA`, before the first stage, we can ensure that it never goes out of scope and the docker image can be built and tagged successfully. More info can be found [here](https://docs.docker.com/engine/reference/builder/#scope) and [here](https://stackoverflow.com/questions/48324659/docker-multistage-build-fails-with-multiple-build-arg).
## Verification
Now, on running `make docker`, image builds successfully,
```
Removing intermediate container ad87b4d7643d
 ---> 6fe986b3524e
Step 7/10 : FROM quay.io/prometheus/busybox@sha256:${SHA}
quay.io/prometheus/busybox@sha256:14d68ca3d69fceaa6224250c83d81d935c053fb13594c811038c461194599973: Pulling from prometheus/busybox
e5d9363303dd: Pull complete 
3430c2c42129: Pull complete 
Digest: sha256:14d68ca3d69fceaa6224250c83d81d935c053fb13594c811038c461194599973
Status: Downloaded newer image for quay.io/prometheus/busybox@sha256:14d68ca3d69fceaa6224250c83d81d935c053fb13594c811038c461194599973
 ---> 14d98f19c979
Step 8/10 : LABEL maintainer="The Thanos Authors"
 ---> Running in ff3d7adbbad9
Removing intermediate container ff3d7adbbad9
 ---> 3e8d6c49b46a
Step 9/10 : COPY --from=builder /go/bin/thanos /bin/thanos
 ---> 1b342c6b5055
Step 10/10 : ENTRYPOINT [ "/bin/thanos" ]
 ---> Running in e40aea9cd020
Removing intermediate container e40aea9cd020
 ---> adaf6e773e5e
Successfully built adaf6e773e5e
Successfully tagged thanos:latest
```
