### PR TITLE
pkg/rules: fix deduplication of equal alerts with different labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ We use _breaking :warning:_ to mark changes that are not backward compatible (re
 
 - [#3204](https://github.com/thanos-io/thanos/pull/3204) Mixin: Use sidecar's metric timestamp for healthcheck.
 - [#3922](https://github.com/thanos-io/thanos/pull/3922) Fix panic in http logging middleware.
+- [#3960](https://github.com/thanos-io/thanos/pull/3960) fix deduplication of equal alerts with different labels
 
 ### Changed
 - [#3948](https://github.com/thanos-io/thanos/pull/3948) Receiver: Adjust `http_request_duration_seconds` buckets for low latency requests.

--- a/pkg/rules/rules.go
+++ b/pkg/rules/rules.go
@@ -68,23 +68,22 @@ func dedupRules(rules []*rulespb.Rule, replicaLabels map[string]struct{}) []*rul
 		return rules
 	}
 
-	// Sort each rule's label names such that they are comparable.
+	// Remove replica labels and sort each rule's label names such that they are comparable.
 	for _, r := range rules {
+		removeReplicaLabels(r, replicaLabels)
 		sort.Slice(r.GetLabels(), func(i, j int) bool {
 			return r.GetLabels()[i].Name < r.GetLabels()[j].Name
 		})
 	}
 
-	// Sort rules globally based on synthesized deduplication labels, also considering replica labels and their values.
+	// Sort rules globally.
 	sort.Slice(rules, func(i, j int) bool {
 		return rules[i].Compare(rules[j]) < 0
 	})
 
-	// Remove rules based on synthesized deduplication labels, this time ignoring replica labels and last evaluation.
+	// Remove rules based on synthesized deduplication labels.
 	i := 0
-	removeReplicaLabels(rules[i], replicaLabels)
 	for j := 1; j < len(rules); j++ {
-		removeReplicaLabels(rules[j], replicaLabels)
 		if rules[i].Compare(rules[j]) != 0 {
 			// Effectively retain rules[j] in the resulting slice.
 			i++


### PR DESCRIPTION
Currently, if an alerting rule having the same name with different
severity labels is being returned from different replicas then they
are being treated as separate alerts.

Given the following alerts a1,a2 with severities s1,s2 returned from
replicas r1,2:

a1[s1,r1]
a1[s2,r1]
a1[s1,r2]
a1[s2,r2]

Then, currently, the algorithm deduplicates to:

a1[s1]
a1[s2]
a1[s1]
a1[s2]

Instead of the intendet result:

a1[s1]
a1[s2]

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

This fixes it by removing replica labels before sorting labels for
deduplication.

## Verification

New unit tests have been added which failed without the fix. Existing tests have been modified to consider the changed sorting order.