### PR TITLE
Add more granularity to block_meta_sync_duration_seconds metric

### DIFF
--- a/pkg/block/fetcher.go
+++ b/pkg/block/fetcher.go
@@ -102,7 +102,7 @@ func NewFetcherMetrics(reg prometheus.Registerer, syncedExtraLabels, modifiedExt
 		Subsystem: fetcherSubSys,
 		Name:      "sync_duration_seconds",
 		Help:      "Duration of the blocks metadata synchronization in seconds",
-		Buckets:   []float64{0.01, 1, 10, 100, 1000},
+		Buckets:   []float64{0.01, 1, 10, 100, 300, 600, 1000},
 	})
 	m.Synced = extprom.NewTxGaugeVec(
 		reg,


### PR DESCRIPTION
* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

We're seeing the following when querying `block_meta_sync_duration_seconds` metric:

![Screenshot 2021-03-24 at 10 00 47](https://user-images.githubusercontent.com/1701904/112282899-d8297000-8c87-11eb-9707-f84bcae4c730.png)

The sync is actually taking less than 16.67s, but the displayed value is due to the bucket granularity. In this PR I'm proposing to add a couple of more buckets (5m and 10m) to have a better granularity.

## Verification

N/A
