### PR TITLE
Fix IsObjNotFoundErr() for wrapped errors

### DIFF
--- a/pkg/objstore/cos/cos.go
+++ b/pkg/objstore/cos/cos.go
@@ -205,7 +205,7 @@ func (b *Bucket) Exists(ctx context.Context, name string) (bool, error) {
 
 // IsObjNotFoundErr returns true if error means that object is not found. Relevant to Get operations.
 func (b *Bucket) IsObjNotFoundErr(err error) bool {
-	switch tmpErr := err.(type) {
+	switch tmpErr := errors.Cause(err).(type) {
 	case *cos.ErrorResponse:
 		if tmpErr.Code == "NoSuchKey" ||
 			(tmpErr.Response != nil && tmpErr.Response.StatusCode == http.StatusNotFound) {

--- a/pkg/objstore/gcs/gcs.go
+++ b/pkg/objstore/gcs/gcs.go
@@ -183,7 +183,7 @@ func (b *Bucket) Delete(ctx context.Context, name string) error {
 
 // IsObjNotFoundErr returns true if error means that object is not found. Relevant to Get operations.
 func (b *Bucket) IsObjNotFoundErr(err error) bool {
-	return err == storage.ErrObjectNotExist
+	return errors.Is(err, storage.ErrObjectNotExist)
 }
 
 func (b *Bucket) Close() error {

--- a/pkg/objstore/inmem.go
+++ b/pkg/objstore/inmem.go
@@ -197,7 +197,7 @@ func (b *InMemBucket) Delete(_ context.Context, name string) error {
 
 // IsObjNotFoundErr returns true if error means that object is not found. Relevant to Get operations.
 func (b *InMemBucket) IsObjNotFoundErr(err error) bool {
-	return errors.Cause(err) == errNotFound
+	return errors.Is(err, errNotFound)
 }
 
 func (b *InMemBucket) Close() error { return nil }

--- a/pkg/objstore/oss/oss.go
+++ b/pkg/objstore/oss/oss.go
@@ -354,7 +354,7 @@ func (b *Bucket) Exists(ctx context.Context, name string) (bool, error) {
 
 // IsObjNotFoundErr returns true if error means that object is not found. Relevant to Get operations.
 func (b *Bucket) IsObjNotFoundErr(err error) bool {
-	switch aliErr := err.(type) {
+	switch aliErr := errors.Cause(err).(type) {
 	case alioss.ServiceError:
 		if aliErr.StatusCode == http.StatusNotFound {
 			return true

--- a/pkg/objstore/s3/s3.go
+++ b/pkg/objstore/s3/s3.go
@@ -492,7 +492,7 @@ func (b *Bucket) Delete(ctx context.Context, name string) error {
 
 // IsObjNotFoundErr returns true if error means that object is not found. Relevant to Get operations.
 func (b *Bucket) IsObjNotFoundErr(err error) bool {
-	return minio.ToErrorResponse(err).Code == "NoSuchKey"
+	return minio.ToErrorResponse(errors.Cause(err)).Code == "NoSuchKey"
 }
 
 func (b *Bucket) Close() error { return nil }


### PR DESCRIPTION

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

We have cases in Cortex where we may pass a wrapped error to `IsObjNotFoundErr()`. In this PR I'm proposing to check the error cause in `IsObjNotFoundErr()` so that it can work for wrapped errors too.

I checked all `IsObjNotFoundErr()` implementations and changed only the ones which weren't using `errors.Cause()` or `errors.Is()` yet.

## Verification

N/A
