### PR TITLE
Fix DeleteAll() on non-existing directory

### DIFF
--- a/pkg/runutil/runutil.go
+++ b/pkg/runutil/runutil.go
@@ -166,6 +166,9 @@ func ExhaustCloseWithErrCapture(err *error, r io.ReadCloser, format string, a ..
 // NOTE: DeleteAll is not idempotent.
 func DeleteAll(dir string, ignoreDirs ...string) error {
 	entries, err := ioutil.ReadDir(dir)
+	if os.IsNotExist(err) {
+		return nil
+	}
 	if err != nil {
 		return errors.Wrap(err, "read dir")
 	}

--- a/pkg/runutil/runutil.go
+++ b/pkg/runutil/runutil.go
@@ -163,7 +163,6 @@ func ExhaustCloseWithErrCapture(err *error, r io.ReadCloser, format string, a ..
 
 // DeleteAll deletes all files and directories inside the given
 // dir except for the ignoreDirs directories.
-// NOTE: DeleteAll is not idempotent.
 func DeleteAll(dir string, ignoreDirs ...string) error {
 	entries, err := ioutil.ReadDir(dir)
 	if os.IsNotExist(err) {

--- a/pkg/runutil/runutil_test.go
+++ b/pkg/runutil/runutil_test.go
@@ -165,3 +165,12 @@ func TestDeleteAll(t *testing.T) {
 	_, err = os.Stat(filepath.Join(dir, "c", "innerc"))
 	testutil.Ok(t, err)
 }
+
+func TestDeleteAll_ShouldReturnNoErrorIfDirectoryDoesNotExists(t *testing.T) {
+	dir, err := ioutil.TempDir("", "example")
+	testutil.Ok(t, err)
+	testutil.Ok(t, os.RemoveAll(dir))
+
+	// Calling DeleteAll() on a non-existent directory should return no error.
+	testutil.Ok(t, DeleteAll(dir))
+}


### PR DESCRIPTION
* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

We're upgrading Thanos in Cortex and we noticed the compactor logs "failed deleting non-compaction group directories/files, some disk space usage might have leaked". The reason is that, under some conditions, the directory doesn't exist at all. I suggest to consider that case as a non-error.

## Verification

N/A
