### PR TITLE
Refactor flag parsing and runRule arguments for ruler

### DIFF
--- a/docs/components/compact.md
+++ b/docs/components/compact.md
@@ -453,5 +453,9 @@ Flags:
                                 stripped prefix value in X-Forwarded-Prefix
                                 header. This allows thanos UI to be served on a
                                 sub-path.
+      --web.route-prefix=""     Prefix for API and UI endpoints. This allows
+                                thanos UI to be served on a sub-path. This
+                                option is analogous to --web.route-prefix of
+                                Prometheus.
 
 ```

--- a/docs/components/rule.md
+++ b/docs/components/rule.md
@@ -373,6 +373,12 @@ Flags:
                                  an alert to Alertmanager.
       --rule-file=rules/ ...     Rule files that should be used by rule manager.
                                  Can be in glob format (repeated).
+      --shipper.upload-compacted
+                                 If true shipper will try to upload compacted
+                                 blocks as well. Useful for migration purposes.
+                                 Works only if compaction is disabled on
+                                 Prometheus. Do it once and then disable the
+                                 flag when done.
       --tracing.config=<content>
                                  Alternative to 'tracing.config-file' flag
                                  (mutually exclusive). Content of YAML file with
@@ -393,11 +399,11 @@ Flags:
                                  Thanos. By default Thanos sets CORS headers to
                                  be allowed by all.
       --web.external-prefix=""   Static prefix for all HTML links and redirect
-                                 URLs in the UI query web interface. Actual
+                                 URLs in the bucket web UI interface. Actual
                                  endpoints are still served on / or the
-                                 web.route-prefix. This allows thanos UI to be
-                                 served behind a reverse proxy that strips a URL
-                                 sub-path.
+                                 web.route-prefix. This allows thanos bucket web
+                                 UI to be served behind a reverse proxy that
+                                 strips a URL sub-path.
       --web.prefix-header=""     Name of HTTP request header used for dynamic
                                  prefixing of UI links and redirects. This
                                  option is ignored if web.external-prefix


### PR DESCRIPTION
Signed-off-by: Michael Okoko <okokomichaels@outlook.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->
* [x] Change is not relevant to the end user.

## Changes

- Refactor `runRule` arguments into a config struct which can then be passed to the function instead.
- Create new config structs for flags that are in the same "namespace" e.g `query.*` and `alertmanagers.*`. (As per #2248 and similar to #2267).
