### PR TITLE
Cherry-pick of pkg/rules: fix deduplication of equal alerts with different labels (#3960)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,8 @@ We use _breaking :warning:_ to mark changes that are not backward compatible (re
 - [#3815](https://github.com/thanos-io/thanos/pull/3815) Receive: Improve handling of empty time series from clients
 - [#3795](https://github.com/thanos-io/thanos/pull/3795) s3: A truncated "get object" response is reported as error.
 - [#3899](https://github.com/thanos-io/thanos/pull/3899) Receive: Correct the inference of client gRPC configuration.
-- [#3943](https://github.com/thanos-io/thanos/pull/3943): Receive: Fixed memory regression introduced in v0.17.0.
+- [#3943](https://github.com/thanos-io/thanos/pull/3943) Receive: Fixed memory regression introduced in v0.17.0.
+- [#3960](https://github.com/thanos-io/thanos/pull/3960) Query: Fixed deduplication of equal alerts with different labels.
 
 ### Changed
 

--- a/pkg/rules/rules.go
+++ b/pkg/rules/rules.go
@@ -68,23 +68,22 @@ func dedupRules(rules []*rulespb.Rule, replicaLabels map[string]struct{}) []*rul
 		return rules
 	}
 
-	// Sort each rule's label names such that they are comparable.
+	// Remove replica labels and sort each rule's label names such that they are comparable.
 	for _, r := range rules {
+		removeReplicaLabels(r, replicaLabels)
 		sort.Slice(r.GetLabels(), func(i, j int) bool {
 			return r.GetLabels()[i].Name < r.GetLabels()[j].Name
 		})
 	}
 
-	// Sort rules globally based on synthesized deduplication labels, also considering replica labels and their values.
+	// Sort rules globally.
 	sort.Slice(rules, func(i, j int) bool {
 		return rules[i].Compare(rules[j]) < 0
 	})
 
-	// Remove rules based on synthesized deduplication labels, this time ignoring replica labels and last evaluation.
+	// Remove rules based on synthesized deduplication labels.
 	i := 0
-	removeReplicaLabels(rules[i], replicaLabels)
 	for j := 1; j < len(rules); j++ {
-		removeReplicaLabels(rules[j], replicaLabels)
 		if rules[i].Compare(rules[j]) != 0 {
 			// Effectively retain rules[j] in the resulting slice.
 			i++


### PR DESCRIPTION

Currently, if an alerting rule having the same name with different
severity labels is being returned from different replicas then they
are being treated as separate alerts.

Given the following alerts a1,a2 with severities s1,s2 returned from
replicas r1,2:

a1[s1,r1]
a1[s2,r1]
a1[s1,r2]
a1[s2,r2]

Then, currently, the algorithm deduplicates to:

a1[s1]
a1[s2]
a1[s1]
a1[s2]

Instead of the intendet result:

a1[s1]
a1[s2]

This fixes it by removing replica labels before sorting labels for
deduplication.

Signed-off-by: Sergiusz Urbaniak <sergiusz.urbaniak@gmail.com>
# Conflicts:
#	CHANGELOG.md

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
