### PR TITLE
Avoid go-routines with fails outside of testcases.

### DIFF
--- a/pkg/store/tsdb_test.go
+++ b/pkg/store/tsdb_test.go
@@ -522,11 +522,11 @@ func TestTSDBStore_SeriesAccessWithDelegateClosing(t *testing.T) {
 		}
 	})
 
-	flushDone := make(chan struct{})
+	flushDone := make(chan error)
 	t.Run("flush WAL and access results", func(t *testing.T) {
 		go func() {
 			// This should block until all queries are closed.
-			testutil.Ok(t, db.FlushWAL(tmpDir))
+			flushDone <- db.FlushWAL(tmpDir)
 			close(flushDone)
 		}()
 		// All chunks should be still accessible for read, but not necessarily for write.
@@ -544,18 +544,18 @@ func TestTSDBStore_SeriesAccessWithDelegateClosing(t *testing.T) {
 		}
 	})
 	select {
-	case _, ok := <-flushDone:
+	case err, ok := <-flushDone:
 		if !ok {
-			t.Fatal("expected flush to be blocked, but it seems it completed.")
+			t.Fatalf("expected flush to be blocked, but it seems it completed. Result: %v", err)
 		}
 	default:
 	}
 
-	closeDone := make(chan struct{})
+	closeDone := make(chan error)
 	t.Run("close db with block readers and access results", func(t *testing.T) {
 		go func() {
 			// This should block until all queries are closed.
-			testutil.Ok(t, db.Close())
+			closeDone <- db.Close()
 			db = nil
 			close(closeDone)
 		}()
@@ -576,7 +576,8 @@ func TestTSDBStore_SeriesAccessWithDelegateClosing(t *testing.T) {
 	select {
 	case _, ok := <-closeDone:
 		if !ok {
-			t.Fatal("expected db to be closed, but it seems it completed.")
+			t.Fatalf("expected db cloe to be blocked, but it seems it completed. Result: %v", err)
+
 		}
 	default:
 	}
@@ -586,9 +587,9 @@ func TestTSDBStore_SeriesAccessWithDelegateClosing(t *testing.T) {
 		testutil.Equals(t, 1, len(csrv.closers))
 		testutil.Ok(t, csrv.closers[0].Close())
 
-		// Expect flush and close to be unblocked.
-		<-flushDone
-		<-closeDone
+		// Expect flush and close to be unblocked and without errors.
+		testutil.Ok(t, <-flushDone)
+		testutil.Ok(t, <-closeDone)
 
 		// Expect segfault on read and write.
 		t.Run("non delegatable", func(t *testing.T) {


### PR DESCRIPTION
This was hiding actual errors as we can see in https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_thanos/52/pull-ci-openshift-thanos-release-4.7-test-local/1376872767521034240

Signed-off-by: Bartlomiej Plotka <bwplotka@gmail.com>

Fixing flake https://app.circleci.com/pipelines/github/thanos-io/thanos/5562/workflows/994df1b2-6d4f-4c15-918f-9bf9315f2f40/jobs/14318

cc @s-urbaniak 

Also fixing flake: https://app.circleci.com/pipelines/github/thanos-io/thanos/5562/workflows/994df1b2-6d4f-4c15-918f-9bf9315f2f40/jobs/14318