### PR TITLE
Mixin: make timezone dynamic

### DIFF
--- a/mixin/README.md
+++ b/mixin/README.md
@@ -116,6 +116,7 @@ This project is intended to be used as a library. You can extend and customize d
   dashboard+:: {
     prefix: 'Thanos / ',
     tags: ['thanos-mixin'],
+    timezone: 'UTC',
     selector: ['%s="$%s"' % [level, level] for level in std.objectFields(thanos.targetGroups)],
     dimensions: ['%s' % level for level in std.objectFields(thanos.targetGroups)],
 

--- a/mixin/config.libsonnet
+++ b/mixin/config.libsonnet
@@ -56,6 +56,7 @@
   dashboard+:: {
     prefix: 'Thanos / ',
     tags: ['thanos-mixin'],
+    timezone: 'UTC',
     selector: ['%s="$%s"' % [level, level] for level in std.objectFields(thanos.targetGroups)],
     dimensions: ['%s' % level for level in std.objectFields(thanos.targetGroups)],
 

--- a/mixin/dashboards/defaults.libsonnet
+++ b/mixin/dashboards/defaults.libsonnet
@@ -7,7 +7,7 @@
   dashboard:: {
     prefix: 'Thanos / ',
     tags: error 'must provide dashboard tags',
-    timezone: 'UTC'
+    timezone: 'UTC',
   },
 
   // Automatically add a uid to each dashboard based on the base64 encoding

--- a/mixin/dashboards/defaults.libsonnet
+++ b/mixin/dashboards/defaults.libsonnet
@@ -7,6 +7,7 @@
   dashboard:: {
     prefix: 'Thanos / ',
     tags: error 'must provide dashboard tags',
+    timezone: 'UTC'
   },
 
   // Automatically add a uid to each dashboard based on the base64 encoding
@@ -15,7 +16,7 @@
     local component = std.split(filename, '.')[0],
     [filename]: grafanaDashboards[filename] {
       uid: std.md5(filename),
-      timezone: 'UTC',
+      timezone: thanos.dashboard.timezone,
       tags: thanos.dashboard.tags,
 
       // Modify tooltip to only show a single value


### PR DESCRIPTION
Signed-off-by: Wiard van Rij <wiard@outlook.com>

## Changes

This keeps the default timezone for dashboards to 'UTC' but allows to override it in an easier way.