### PR TITLE
Fix the metadata API flaky tests

### DIFF
--- a/pkg/metadata/prometheus_test.go
+++ b/pkg/metadata/prometheus_test.go
@@ -72,8 +72,8 @@ scrape_configs:
 `, p.Addr()))
 	testutil.Ok(t, err)
 
-	// Do a hot reload for load the latest configuration.
-	err = p.Reload(logger)
+	// Do a hot reload for loading the latest configuration.
+	err = p.Reload()
 	testutil.Ok(t, err)
 
 	u, err := url.Parse("http://" + p.Addr())

--- a/pkg/metadata/prometheus_test.go
+++ b/pkg/metadata/prometheus_test.go
@@ -5,7 +5,6 @@ package metadata
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -13,6 +12,7 @@ import (
 	"time"
 
 	"github.com/go-kit/kit/log"
+	"github.com/pkg/errors"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/thanos-io/thanos/pkg/metadata/metadatapb"
 	"github.com/thanos-io/thanos/pkg/promclient"
@@ -30,7 +30,7 @@ func TestPrometheus_Metadata_e2e(t *testing.T) {
 	testutil.Ok(t, err)
 	defer func() { testutil.Ok(t, p.Stop()) }()
 
-	testutil.Ok(t, p.SetConfig(fmt.Sprintf(`
+	p.SetConfig(fmt.Sprintf(`
 global:
   external_labels:
     region: eu-west
@@ -41,7 +41,7 @@ scrape_configs:
   scrape_timeout: 1s
   static_configs:
   - targets: ['%s']
-`, e2eutil.PromAddrPlaceHolder)))
+`, e2eutil.PromAddrPlaceHolder))
 	testutil.Ok(t, p.Start())
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/pkg/metadata/prometheus_test.go
+++ b/pkg/metadata/prometheus_test.go
@@ -5,20 +5,23 @@ package metadata
 
 import (
 	"context"
+	"fmt"
+	"net/http"
 	"net/url"
 	"testing"
 	"time"
 
+	"github.com/go-kit/kit/log"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/thanos-io/thanos/pkg/metadata/metadatapb"
 	"github.com/thanos-io/thanos/pkg/promclient"
+	"github.com/thanos-io/thanos/pkg/runutil"
 	"github.com/thanos-io/thanos/pkg/testutil"
 	"github.com/thanos-io/thanos/pkg/testutil/e2eutil"
-	"go.uber.org/goleak"
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	testutil.TolerantVerifyLeakMain(m)
 }
 
 func TestPrometheus_Metadata_e2e(t *testing.T) {
@@ -26,6 +29,8 @@ func TestPrometheus_Metadata_e2e(t *testing.T) {
 	testutil.Ok(t, err)
 	defer func() { testutil.Ok(t, p.Stop()) }()
 
+	// As we don't know the actual port of the test Prometheus service,
+	// we just use localhost:9090 here.
 	testutil.Ok(t, p.SetConfig(`
 global:
   external_labels:
@@ -36,17 +41,58 @@ scrape_configs:
   scrape_interval: 1s
   scrape_timeout: 1s
   static_configs:
-  - targets: ['localhost:9090','localhost:80']
+  - targets: ['localhost:9090']
 `))
 	testutil.Ok(t, p.Start())
 
-	time.Sleep(10 * time.Second)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	_ = ctx
+
+	upctx, upcancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer upcancel()
+
+	logger := log.NewNopLogger()
+	// Wait for Prometheus up.
+	err = p.WaitPrometheusUp(upctx, logger)
+	testutil.Ok(t, err)
+
+	// Update the scrape configs to the current Prometheus address.
+	err = p.SetConfig(fmt.Sprintf(`
+global:
+  external_labels:
+    region: eu-west
+scrape_configs:
+- job_name: 'myself'
+  # Quick scrapes for test purposes.
+  scrape_interval: 1s
+  scrape_timeout: 1s
+  static_configs:
+  - targets: ['%s']
+`, p.Addr()))
+	testutil.Ok(t, err)
+
+	// Do a hot reload for load the latest configuration.
+	err = p.Reload(logger)
+	testutil.Ok(t, err)
 
 	u, err := url.Parse("http://" + p.Addr())
 	testutil.Ok(t, err)
 
-	prom := NewPrometheus(u, promclient.NewDefaultClient())
+	c := promclient.NewClient(http.DefaultClient, logger, "")
+	prom := NewPrometheus(u, c)
 
+	// Wait metadata response to be ready as Prometheus gets metadata after scrape.
+	testutil.Ok(t, runutil.Retry(3*time.Second, ctx.Done(), func() error {
+		meta, err := c.MetadataInGRPC(ctx, u, "", -1)
+		testutil.Ok(t, err)
+		if len(meta) > 0 {
+			return nil
+		}
+		return fmt.Errorf("empty metadata response from Prometheus")
+	}))
+
+	grpcClient := NewGRPCClient(prom)
 	for _, tcase := range []struct {
 		name         string
 		metric       string
@@ -56,8 +102,9 @@ scrape_configs:
 		{
 			name:  "all metadata return",
 			limit: -1,
+			// We just check two metrics here.
 			expectedFunc: func(m map[string][]metadatapb.Meta) bool {
-				return len(m["thanos_build_info"]) > 0 && len(m["prometheus_build_info"]) > 0
+				return len(m["prometheus_build_info"]) > 0 && len(m["prometheus_engine_query_duration_seconds"]) > 0
 			},
 		},
 		{
@@ -75,19 +122,20 @@ scrape_configs:
 			},
 		},
 		{
-			name:   "only thanos_build_info metadata return",
-			metric: "thanos_build_info",
+			name:   "only prometheus_build_info metadata return",
+			metric: "prometheus_build_info",
 			limit:  1,
 			expectedFunc: func(m map[string][]metadatapb.Meta) bool {
-				return len(m) == 1 && len(m["thanos_build_info"]) > 0
+				return len(m) == 1 && len(m["prometheus_build_info"]) > 0
 			},
 		},
 	} {
 		t.Run(tcase.name, func(t *testing.T) {
-			meta, w, err := NewGRPCClient(prom).Metadata(context.Background(), &metadatapb.MetadataRequest{
+			meta, w, err := grpcClient.Metadata(ctx, &metadatapb.MetadataRequest{
 				Metric: tcase.metric,
 				Limit:  tcase.limit,
 			})
+
 			testutil.Equals(t, storage.Warnings(nil), w)
 			testutil.Ok(t, err)
 			testutil.Assert(t, tcase.expectedFunc(meta))

--- a/pkg/metadata/prometheus_test.go
+++ b/pkg/metadata/prometheus_test.go
@@ -90,7 +90,7 @@ scrape_configs:
 			})
 			testutil.Equals(t, storage.Warnings(nil), w)
 			testutil.Ok(t, err)
-			testutil.Assert(t, true, tcase.expectedFunc(meta))
+			testutil.Assert(t, tcase.expectedFunc(meta))
 		})
 	}
 }

--- a/pkg/promclient/promclient_e2e_test.go
+++ b/pkg/promclient/promclient_e2e_test.go
@@ -38,12 +38,12 @@ func TestIsWALFileAccessible_e2e(t *testing.T) {
 
 func TestExternalLabels_e2e(t *testing.T) {
 	e2eutil.ForeachPrometheus(t, func(t testing.TB, p *e2eutil.Prometheus) {
-		testutil.Ok(t, p.SetConfig(`
+		p.SetConfig(`
 global:
   external_labels:
     region: eu-west
     az: 1
-`))
+`)
 
 		testutil.Ok(t, p.Start())
 

--- a/pkg/rules/prometheus_test.go
+++ b/pkg/rules/prometheus_test.go
@@ -26,7 +26,7 @@ func TestPrometheus_Rules_e2e(t *testing.T) {
 	testutil.Ok(t, err)
 	root := filepath.Join(curr, "../../")
 
-	testutil.Ok(t, p.SetConfig(fmt.Sprintf(`
+	p.SetConfig(fmt.Sprintf(`
 global:
   external_labels:
     region: eu-west
@@ -34,7 +34,7 @@ global:
 rule_files:
   - %s/examples/alerts/alerts.yaml
   - %s/examples/alerts/rules.yaml
-`, root, root)))
+`, root, root))
 	testutil.Ok(t, p.Start())
 
 	u, err := url.Parse(fmt.Sprintf("http://%s", p.Addr()))

--- a/pkg/shipper/shipper_e2e_test.go
+++ b/pkg/shipper/shipper_e2e_test.go
@@ -212,16 +212,17 @@ func TestShipper_SyncBlocksWithMigrating_e2e(t *testing.T) {
 
 		testutil.Ok(t, p.Start())
 
+		logger := log.NewNopLogger()
 		upctx, upcancel := context.WithTimeout(ctx, 10*time.Second)
 		defer upcancel()
-		testutil.Ok(t, p.WaitPrometheusUp(upctx))
+		testutil.Ok(t, p.WaitPrometheusUp(upctx, logger))
 
 		p.DisableCompaction()
 		testutil.Ok(t, p.Restart())
 
 		upctx2, upcancel2 := context.WithTimeout(ctx, 10*time.Second)
 		defer upcancel2()
-		testutil.Ok(t, p.WaitPrometheusUp(upctx2))
+		testutil.Ok(t, p.WaitPrometheusUp(upctx2, logger))
 
 		shipper := New(log.NewLogfmtLogger(os.Stderr), nil, dir, bkt, func() labels.Labels { return extLset }, metadata.TestSource, true, false, metadata.NoneFunc)
 

--- a/pkg/targets/prometheus_test.go
+++ b/pkg/targets/prometheus_test.go
@@ -25,7 +25,7 @@ func TestPrometheus_Targets_e2e(t *testing.T) {
 	testutil.Ok(t, err)
 	defer func() { testutil.Ok(t, p.Stop()) }()
 
-	testutil.Ok(t, p.SetConfig(`
+	p.SetConfig(`
 global:
   external_labels:
     region: eu-west
@@ -41,7 +41,7 @@ scrape_configs:
   - source_labels: ['__address__']
     regex: '^.+:80$'
     action: drop
-`))
+`)
 	testutil.Ok(t, p.Start())
 
 	// For some reason it's better to wait much more than a few scrape intervals.

--- a/pkg/testutil/e2eutil/prometheus.go
+++ b/pkg/testutil/e2eutil/prometheus.go
@@ -282,18 +282,9 @@ func (p *Prometheus) Appender() storage.Appender {
 	return p.db.Appender(context.Background())
 }
 
-// Reload sends a POST request to the reload endpoint for a hot reload.
-func (p *Prometheus) Reload(logger log.Logger) error {
-	r, err := http.Post(fmt.Sprintf("http://%s/-/reload", p.addr), "", nil)
-	if err != nil {
-		return err
-	}
-	defer runutil.ExhaustCloseWithLogOnErr(logger, r.Body, "failed to exhaust and close body")
-
-	if r.StatusCode != 200 {
-		return errors.Errorf("Got non 200 response: %v", r.StatusCode)
-	}
-	return nil
+// Reload sends a SIGHUP to Prometheus for a hot reload.
+func (p *Prometheus) Reload() error {
+	return p.cmd.Process.Signal(syscall.SIGHUP)
 }
 
 // CreateEmptyBlock produces empty block like it was the case before fix: https://github.com/prometheus/tsdb/pull/374.

--- a/pkg/testutil/e2eutil/prometheus.go
+++ b/pkg/testutil/e2eutil/prometheus.go
@@ -181,8 +181,9 @@ func (p *Prometheus) start() error {
 		)
 	}
 	p.addr = fmt.Sprintf("localhost:%d", port)
-	// Update the config template with the actual address.
-	if err := p.SetConfig(strings.ReplaceAll(p.config, PromAddrPlaceHolder, p.addr)); err != nil {
+	// Write the final config to the config file.
+	// The address placeholder will be replaced with the actual address.
+	if err := p.writeConfig(strings.ReplaceAll(p.config, PromAddrPlaceHolder, p.addr)); err != nil {
 		return err
 	}
 	args := append([]string{
@@ -248,16 +249,19 @@ func (p *Prometheus) DisableCompaction() {
 	p.disabledCompaction = true
 }
 
-// SetConfig updates the contents of the config file. By default it is empty.
-func (p *Prometheus) SetConfig(s string) (err error) {
+// SetConfig updates the contents of the config.
+func (p *Prometheus) SetConfig(s string) {
+	p.config = s
+}
+
+// writeConfig writes the Prometheus config to the config file.
+func (p *Prometheus) writeConfig(config string) (err error) {
 	f, err := os.Create(filepath.Join(p.dir, "prometheus.yml"))
 	if err != nil {
 		return err
 	}
 	defer runutil.CloseWithErrCapture(&err, f, "prometheus config")
-
-	p.config = s
-	_, err = f.Write([]byte(s))
+	_, err = f.Write([]byte(config))
 	return err
 }
 

--- a/pkg/testutil/e2eutil/prometheus.go
+++ b/pkg/testutil/e2eutil/prometheus.go
@@ -182,7 +182,6 @@ func (p *Prometheus) start() error {
 		"--web.listen-address=" + p.addr,
 		"--web.route-prefix=" + p.prefix,
 		"--web.enable-admin-api",
-		"--web.enable-lifecycle", // Enable hot reload.
 		"--config.file=" + filepath.Join(p.db.Dir(), "prometheus.yml"),
 	}, extra...)
 

--- a/test/e2e/metadata_api_test.go
+++ b/test/e2e/metadata_api_test.go
@@ -71,11 +71,11 @@ func TestMetadataAPI_Fanout(t *testing.T) {
 
 	promMeta, err := promclient.NewDefaultClient().MetadataInGRPC(ctx, mustURLParse(t, "http://"+prom1.HTTPEndpoint()), "", -1)
 	testutil.Ok(t, err)
-	testutil.Assert(t, true, len(promMeta) > 0)
+	testutil.Assert(t, len(promMeta) > 0, "got empty metadata response from Prometheus")
 
 	thanosMeta, err := promclient.NewDefaultClient().MetadataInGRPC(ctx, mustURLParse(t, "http://"+q.HTTPEndpoint()), "", -1)
 	testutil.Ok(t, err)
-	testutil.Assert(t, true, len(thanosMeta) > 0)
+	testutil.Assert(t, len(thanosMeta) > 0, "got empty metadata response from Thanos")
 
 	// Metadata response from Prometheus and Thanos Querier should be the same after deduplication.
 	metadataEqual(t, thanosMeta, promMeta)
@@ -83,22 +83,22 @@ func TestMetadataAPI_Fanout(t *testing.T) {
 	// We only expect to see one metadata returned.
 	thanosMeta, err = promclient.NewDefaultClient().MetadataInGRPC(ctx, mustURLParse(t, "http://"+q.HTTPEndpoint()), "", 1)
 	testutil.Ok(t, err)
-	testutil.Assert(t, true, len(thanosMeta) == 1)
+	testutil.Assert(t, len(thanosMeta) == 1, "expected 1 metadata from Thanos, got %d", len(thanosMeta))
 
 	// We only expect to see ten metadata returned.
 	thanosMeta, err = promclient.NewDefaultClient().MetadataInGRPC(ctx, mustURLParse(t, "http://"+q.HTTPEndpoint()), "", 10)
 	testutil.Ok(t, err)
-	testutil.Assert(t, true, len(thanosMeta) == 10)
+	testutil.Assert(t, len(thanosMeta) == 10, "expected 10 metadata from Thanos, got %d", len(thanosMeta))
 
 	// No metadata returned.
 	thanosMeta, err = promclient.NewDefaultClient().MetadataInGRPC(ctx, mustURLParse(t, "http://"+q.HTTPEndpoint()), "", 0)
 	testutil.Ok(t, err)
-	testutil.Assert(t, true, len(thanosMeta) == 0)
+	testutil.Assert(t, len(thanosMeta) == 0, "expected 0 metadata from Thanos, got %d", len(thanosMeta))
 
 	// Only prometheus_build_info metric will be returned.
 	thanosMeta, err = promclient.NewDefaultClient().MetadataInGRPC(ctx, mustURLParse(t, "http://"+q.HTTPEndpoint()), "prometheus_build_info", -1)
 	testutil.Ok(t, err)
-	testutil.Assert(t, true, len(thanosMeta) == 1 && len(thanosMeta["prometheus_build_info"]) > 0)
+	testutil.Assert(t, len(thanosMeta) == 1 && len(thanosMeta["prometheus_build_info"]) > 0, "expected one prometheus_build_info metadata from Thanos, got %v", thanosMeta)
 }
 
 func metadataEqual(t *testing.T, meta1, meta2 map[string][]metadatapb.Meta) {
@@ -109,7 +109,7 @@ func metadataEqual(t *testing.T, meta1, meta2 map[string][]metadatapb.Meta) {
 		// Get metadata for the metric.
 		meta1MetricMeta := meta1[metric]
 		meta2MetricMeta, ok := meta2[metric]
-		testutil.Assert(t, true, ok)
+		testutil.Assert(t, ok)
 
 		sort.Slice(meta1MetricMeta, func(i, j int) bool {
 			return meta1MetricMeta[i].Help < meta1MetricMeta[j].Help

--- a/test/e2e/metadata_api_test.go
+++ b/test/e2e/metadata_api_test.go
@@ -117,6 +117,6 @@ func metadataEqual(t *testing.T, meta1, meta2 map[string][]metadatapb.Meta) {
 		sort.Slice(meta2MetricMeta, func(i, j int) bool {
 			return meta2MetricMeta[i].Help < meta2MetricMeta[j].Help
 		})
-		reflect.DeepEqual(meta1MetricMeta, meta2MetricMeta)
+		testutil.Assert(t, reflect.DeepEqual(meta1MetricMeta, meta2MetricMeta), "meta1 %v; meta2 %v", meta1MetricMeta, meta2MetricMeta)
 	}
 }

--- a/test/e2e/metadata_api_test.go
+++ b/test/e2e/metadata_api_test.go
@@ -6,7 +6,6 @@ package e2e_test
 import (
 	"context"
 	"fmt"
-	"reflect"
 	"sort"
 	"testing"
 	"time"
@@ -71,9 +70,7 @@ func TestMetadataAPI_Fanout(t *testing.T) {
 	testutil.Ok(t, q.WaitSumMetricsWithOptions(e2e.Equals(2), []string{"thanos_store_nodes_grpc_connections"}, e2e.WaitMissingMetrics))
 	testutil.Ok(t, q.WaitSumMetricsWithOptions(e2e.Equals(2), []string{"thanos_query_metadata_apis_dns_provider_results"}, e2e.WaitMissingMetrics))
 
-	var (
-		promMeta map[string][]metadatapb.Meta
-	)
+	var promMeta map[string][]metadatapb.Meta
 	// Wait metadata response to be ready as Prometheus gets metadata after scrape.
 	testutil.Ok(t, runutil.Retry(3*time.Second, ctx.Done(), func() error {
 		promMeta, err = promclient.NewDefaultClient().MetadataInGRPC(ctx, mustURLParse(t, "http://"+prom1.HTTPEndpoint()), "", -1)
@@ -94,17 +91,17 @@ func TestMetadataAPI_Fanout(t *testing.T) {
 	// We only expect to see one metadata returned.
 	thanosMeta, err = promclient.NewDefaultClient().MetadataInGRPC(ctx, mustURLParse(t, "http://"+q.HTTPEndpoint()), "", 1)
 	testutil.Ok(t, err)
-	testutil.Assert(t, len(thanosMeta) == 1, "expected 1 metadata from Thanos, got %d", len(thanosMeta))
+	testutil.Equals(t, len(thanosMeta), 1)
 
 	// We only expect to see ten metadata returned.
 	thanosMeta, err = promclient.NewDefaultClient().MetadataInGRPC(ctx, mustURLParse(t, "http://"+q.HTTPEndpoint()), "", 10)
 	testutil.Ok(t, err)
-	testutil.Assert(t, len(thanosMeta) == 10, "expected 10 metadata from Thanos, got %d", len(thanosMeta))
+	testutil.Equals(t, len(thanosMeta), 10)
 
 	// No metadata returned.
 	thanosMeta, err = promclient.NewDefaultClient().MetadataInGRPC(ctx, mustURLParse(t, "http://"+q.HTTPEndpoint()), "", 0)
 	testutil.Ok(t, err)
-	testutil.Assert(t, len(thanosMeta) == 0, "expected 0 metadata from Thanos, got %d", len(thanosMeta))
+	testutil.Equals(t, len(thanosMeta), 0)
 
 	// Only prometheus_build_info metric will be returned.
 	thanosMeta, err = promclient.NewDefaultClient().MetadataInGRPC(ctx, mustURLParse(t, "http://"+q.HTTPEndpoint()), "prometheus_build_info", -1)
@@ -128,6 +125,6 @@ func metadataEqual(t *testing.T, meta1, meta2 map[string][]metadatapb.Meta) {
 		sort.Slice(meta2MetricMeta, func(i, j int) bool {
 			return meta2MetricMeta[i].Help < meta2MetricMeta[j].Help
 		})
-		testutil.Assert(t, reflect.DeepEqual(meta1MetricMeta, meta2MetricMeta), "meta1 %v; meta2 %v", meta1MetricMeta, meta2MetricMeta)
+		testutil.Equals(t, meta1MetricMeta, meta2MetricMeta)
 	}
 }


### PR DESCRIPTION
Signed-off-by: yeya24 <yb532204897@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

Fixes #4012

## Changes

Refactor the metadata E2E test and use `metadataEqual` function to compare the two responses instead of just using reflect.DeepEqual.

In `metadataEqual` function, each entry in the metadata response is first sorted and then compare. This fixes the problem mentioned in https://github.com/thanos-io/thanos/issues/4012#issuecomment-812542755

Update: I also rewrite the unit tests of metadata API.

## Verification

<!-- How you tested it? How do you know it works? -->
