### PR TITLE
ui: Fix state sharing between windows

### DIFF
--- a/pkg/ui/static/js/graph.js
+++ b/pkg/ui/static/js/graph.js
@@ -33,17 +33,17 @@ Prometheus.Graph.stepValues = [
 ];
 
 // Get id of last panel and increment.
-let num = 0;
+let num = -1;
 Object.entries(localStorage).map(([key]) => {
-  if (key.includes("enable-dedup") && num < parseInt(key[key.length - 1], 10)) {
-    num = parseInt(key[key.length - 1], 10);
+  if (key.includes("enable-dedup") && num < Number(key[key.length - 1])) {
+    num = Number(key[key.length - 1]);
   }
 });
-Prometheus.Graph.numGraphs = num;
+Prometheus.Graph.numGraphs = num + 1;
 
 Prometheus.Graph.prototype.initialize = function() {
   var self = this;
-  self.id = ++Prometheus.Graph.numGraphs;
+  self.id = Prometheus.Graph.numGraphs++;
 
   // Set default options.
   self.options.id = self.id;

--- a/pkg/ui/static/js/graph.js
+++ b/pkg/ui/static/js/graph.js
@@ -32,11 +32,18 @@ Prometheus.Graph.stepValues = [
   "1w", "2w", "4w", "8w", "1y", "2y"
 ];
 
-Prometheus.Graph.numGraphs = 0;
+// Get id of last panel and increment.
+let num = 0;
+Object.entries(localStorage).map(([key]) => {
+  if (key.includes("enable-dedup") && num < parseInt(key[key.length - 1], 10)) {
+    num = parseInt(key[key.length - 1], 10);
+  }
+});
+Prometheus.Graph.numGraphs = num;
 
 Prometheus.Graph.prototype.initialize = function() {
   var self = this;
-  self.id = Prometheus.Graph.numGraphs++;
+  self.id = ++Prometheus.Graph.numGraphs;
 
   // Set default options.
   self.options.id = self.id;


### PR DESCRIPTION
* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes
Attempts to fix #4004. With this fix, new window graph panels don't start from `id` 0 but from the last recorded index in `localStorage`. This ensures there is no mismatch between query result and the options selected even with multiple windows open.
For e.g, browser tab A is opened and 3 graph panels are added then `localStorage` is,
![Screenshot 2021-04-03 at 1 33 32 PM](https://user-images.githubusercontent.com/51132453/113472841-530e3a00-9483-11eb-8e02-2df36a9decf7.png)
![Screenshot 2021-04-03 at 1 33 43 PM](https://user-images.githubusercontent.com/51132453/113472844-56a1c100-9483-11eb-87e5-f1b018bad7fe.png)
Then browser tab B is opened and 2 graph panels are added, resulting in the following `localStorage`,
![Screenshot 2021-04-03 at 1 34 32 PM](https://user-images.githubusercontent.com/51132453/113472875-89e45000-9483-11eb-9fe3-31fe651e3cb8.png)
![Screenshot 2021-04-03 at 1 34 40 PM](https://user-images.githubusercontent.com/51132453/113472878-9072c780-9483-11eb-8b87-8ba10a3a8399.png)


## Verification
Tested locally.
<!-- How you tested it? How do you know it works? -->
