### PR TITLE
Tracing: change baggage key to be lower kebab-case for Jaeger compatability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,10 +30,10 @@ We use _breaking :warning:_ to mark changes that are not backward compatible (re
 
 ### Changed
 - [#3929](https://github.com/thanos-io/thanos/pull/3929) Store: Adds the name of the instantiated memcached client to log info
-
 - [#3948](https://github.com/thanos-io/thanos/pull/3948) Receiver: Adjust `http_request_duration_seconds` buckets for low latency requests.
 - [#3856](https://github.com/thanos-io/thanos/pull/3856) Mixin: _breaking :warning:_ Introduce flexible multi-cluster/namespace mode for alerts and dashboards. Removes jobPrefix config option. Removes `namespace` by default.
 - [#3937](https://github.com/thanos-io/thanos/pull/3937) Store: Reduce memory usage for range queries.
+- [#4018](https://github.com/thanos-io/thanos/pull/4018) Tracing: Update "force tracing" baggage header to be lower kebab-case for Jaeger support.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ We use _breaking :warning:_ to mark changes that are not backward compatible (re
 - [#3948](https://github.com/thanos-io/thanos/pull/3948) Receiver: Adjust `http_request_duration_seconds` buckets for low latency requests.
 - [#3856](https://github.com/thanos-io/thanos/pull/3856) Mixin: _breaking :warning:_ Introduce flexible multi-cluster/namespace mode for alerts and dashboards. Removes jobPrefix config option. Removes `namespace` by default.
 - [#3937](https://github.com/thanos-io/thanos/pull/3937) Store: Reduce memory usage for range queries.
-- [#4018](https://github.com/thanos-io/thanos/pull/4018) Tracing: Update "force tracing" baggage header to be lower kebab-case for Jaeger support.
+- [#4018](https://github.com/thanos-io/thanos/pull/4018) Tracing: Update "force tracing" baggage key to be lower kebab-case for Jaeger support.
 
 ### Removed
 

--- a/pkg/tracing/tracing.go
+++ b/pkg/tracing/tracing.go
@@ -10,7 +10,9 @@ import (
 )
 
 // ForceTracingBaggageKey - force sampling header.
-const ForceTracingBaggageKey = "X-Thanos-Force-Tracing"
+// Lower kebab-case for Jaeger support, per documentation:
+// https://www.jaegertracing.io/docs/1.22/client-libraries/#baggage
+const ForceTracingBaggageKey = "x-thanos-force-tracing"
 
 // traceIdResponseHeader - Trace ID response header.
 const traceIDResponseHeader = "X-Thanos-Trace-Id"


### PR DESCRIPTION
Signed-off-by: Conor Evans <coevans@tcd.ie>

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

Closes #3951 

## Changes

Make baggage key lowercase for Jaeger support. Per [Jaeger documentation](https://www.jaegertracing.io/docs/1.22/client-libraries/#baggage):

> Limitation: since HTTP headers don’t preserve the case, Jaeger recommends baggage keys to be lowercase-kebab-case, e.g. my-baggage-key-1.

## Verification

Since this is a one-line const change, no tests have been added. I also did not feel terribly inclined to spin up a local Thanos+Jaeger set-up, though I can do so for completeness if desired.
