### PR TITLE
Query: range query histogram

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ We use _breaking :warning:_ to mark changes that are not backward compatible (re
 
 ## Unreleased
 
+- [#4019](https://github.com/thanos-io/thanos/pull/4019) Query: Adds query range histogram. 
 - [#3350](https://github.com/thanos-io/thanos/pull/3350) Query/Sidecar: Added targets API support. You can now configure you Querier to fetch Prometheus targets from leaf Prometheus-es!
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ We use _breaking :warning:_ to mark changes that are not backward compatible (re
 
 ## Unreleased
 
-- [#4019](https://github.com/thanos-io/thanos/pull/4019) Query: Adds query range histogram. 
+- [#4019](https://github.com/thanos-io/thanos/pull/4019) Query: Adds query range histogram.
 - [#3350](https://github.com/thanos-io/thanos/pull/3350) Query/Sidecar: Added targets API support. You can now configure you Querier to fetch Prometheus targets from leaf Prometheus-es!
 
 ### Added

--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -585,6 +585,7 @@ func runQuery(
 				extprom.WrapRegistererWithPrefix("thanos_query_concurrent_", reg),
 				maxConcurrentQueries,
 			),
+			reg,
 		)
 
 		api.Register(router.WithPrefix("/api/v1"), tracer, logger, ins, logMiddleware)

--- a/pkg/api/query/v1.go
+++ b/pkg/api/query/v1.go
@@ -32,6 +32,8 @@ import (
 	"github.com/go-kit/kit/log"
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/common/route"
 	"github.com/prometheus/prometheus/pkg/labels"
@@ -95,6 +97,8 @@ type QueryAPI struct {
 	defaultRangeQueryStep                  time.Duration
 	defaultInstantQueryMaxSourceResolution time.Duration
 	defaultMetadataTimeRange               time.Duration
+
+	queryRangeHist prometheus.Histogram
 }
 
 // NewQueryAPI returns an initialized QueryAPI type.
@@ -119,6 +123,7 @@ func NewQueryAPI(
 	defaultMetadataTimeRange time.Duration,
 	disableCORS bool,
 	gate gate.Gate,
+	reg *prometheus.Registry,
 ) *QueryAPI {
 	return &QueryAPI{
 		baseAPI:         api.NewBaseAPI(logger, disableCORS, flagsMap),
@@ -142,6 +147,12 @@ func NewQueryAPI(
 		defaultInstantQueryMaxSourceResolution: defaultInstantQueryMaxSourceResolution,
 		defaultMetadataTimeRange:               defaultMetadataTimeRange,
 		disableCORS:                            disableCORS,
+
+		queryRangeHist: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
+			Name:    "query_range_duration_seconds",
+			Help:    "A histogram of the query range window in seconds",
+			Buckets: prometheus.ExponentialBuckets(15*60, 2, 12),
+		}),
 	}
 }
 
@@ -429,6 +440,9 @@ func (qapi *QueryAPI) queryRange(r *http.Request) (interface{}, []error, *api.Ap
 	}
 
 	qe := qapi.queryEngine(maxSourceResolution)
+
+	// Record the query range requested
+	qapi.queryRangeHist.Observe(end.Sub(start).Seconds())
 
 	// We are starting promQL tracing span here, because we have no control over promQL code.
 	span, ctx := tracing.StartSpan(ctx, "promql_range_query")

--- a/pkg/api/query/v1.go
+++ b/pkg/api/query/v1.go
@@ -149,7 +149,7 @@ func NewQueryAPI(
 		disableCORS:                            disableCORS,
 
 		queryRangeHist: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
-			Name:    "query_range_duration_seconds",
+			Name:    "thanos_query_range_requested_timespan_duration_seconds",
 			Help:    "A histogram of the query range window in seconds",
 			Buckets: prometheus.ExponentialBuckets(15*60, 2, 12),
 		}),

--- a/pkg/api/query/v1.go
+++ b/pkg/api/query/v1.go
@@ -441,7 +441,7 @@ func (qapi *QueryAPI) queryRange(r *http.Request) (interface{}, []error, *api.Ap
 
 	qe := qapi.queryEngine(maxSourceResolution)
 
-	// Record the query range requested
+	// Record the query range requested.
 	qapi.queryRangeHist.Observe(end.Sub(start).Seconds())
 
 	// We are starting promQL tracing span here, because we have no control over promQL code.

--- a/pkg/api/query/v1_test.go
+++ b/pkg/api/query/v1_test.go
@@ -32,6 +32,8 @@ import (
 	"time"
 
 	"github.com/go-kit/kit/log"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/common/route"
 	promgate "github.com/prometheus/prometheus/pkg/gate"
 	"github.com/prometheus/prometheus/pkg/labels"
@@ -186,6 +188,9 @@ func TestQueryEndpoints(t *testing.T) {
 		},
 		gate:                  gate.New(nil, 4),
 		defaultRangeQueryStep: time.Second,
+		queryRangeHist: promauto.With(prometheus.NewRegistry()).NewHistogram(prometheus.HistogramOpts{
+			Name: "query_range_hist",
+		}),
 	}
 
 	start := time.Unix(0, 0)
@@ -695,6 +700,9 @@ func TestMetadataEndpoints(t *testing.T) {
 			return qe
 		},
 		gate: gate.New(nil, 4),
+		queryRangeHist: promauto.With(prometheus.NewRegistry()).NewHistogram(prometheus.HistogramOpts{
+			Name: "query_range_hist",
+		}),
 	}
 	apiWithLabelLookback := &QueryAPI{
 		baseAPI: &baseAPI.BaseAPI{
@@ -706,6 +714,9 @@ func TestMetadataEndpoints(t *testing.T) {
 		},
 		gate:                     gate.New(nil, 4),
 		defaultMetadataTimeRange: apiLookbackDelta,
+		queryRangeHist: promauto.With(prometheus.NewRegistry()).NewHistogram(prometheus.HistogramOpts{
+			Name: "query_range_hist",
+		}),
 	}
 
 	var tests = []endpointTestCase{
@@ -1326,6 +1337,9 @@ func TestParseDownsamplingParamMillis(t *testing.T) {
 		api := QueryAPI{
 			enableAutodownsampling: test.enableAutodownsampling,
 			gate:                   gate.New(nil, 4),
+			queryRangeHist: promauto.With(prometheus.NewRegistry()).NewHistogram(prometheus.HistogramOpts{
+				Name: "query_range_hist",
+			}),
 		}
 		v := url.Values{}
 		v.Set(MaxSourceResolutionParam, test.maxSourceResolutionParam)
@@ -1374,6 +1388,9 @@ func TestParseStoreDebugMatchersParam(t *testing.T) {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
 			api := QueryAPI{
 				gate: promgate.New(4),
+				queryRangeHist: promauto.With(prometheus.NewRegistry()).NewHistogram(prometheus.HistogramOpts{
+					Name: "query_range_hist",
+				}),
 			}
 			v := url.Values{}
 			v.Set(StoreMatcherParam, tc.storeMatchers)


### PR DESCRIPTION
Adds a range query histogram that tracks the distribution
of range queries. This can be useful for determining storage
retention requirements.

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

- Adds a range query histogram to the query component.

## Verification

<!-- How you tested it? How do you know it works? -->
