### PR TITLE
Add test scenario for missing A record

### DIFF
--- a/pkg/discovery/dns/resolver_test.go
+++ b/pkg/discovery/dns/resolver_test.go
@@ -129,6 +129,7 @@ var (
 				},
 			},
 		},
+		// Regression test for https://github.com/thanos-io/thanos/issues/3766
 		{
 			testName:       "multiple SRV records from SRV lookup with missing A records",
 			addr:           "_test._tcp.mycompany.com",


### PR DESCRIPTION
Signed-off-by: Michael Okoko <okokomichaels@outlook.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

- Adds a test scenario to check for cases where an SRV record points to a non-existent A record as per #3766.

## Verification

<!-- How you tested it? How do you know it works? -->
