### PR TITLE
Mixin: Remove dependency on the rule dashboard from compact dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ We use _breaking :warning:_ to mark changes that are not backward compatible (re
 
 ## Unreleased
 
+- [#4029](https://github.com/thanos-io/thanos/pull/4029) Mixin: Remove dependency on the rule dashboard when generating the compact dashboard
 - [#4019](https://github.com/thanos-io/thanos/pull/4019) Query: Adds query range histogram.
 - [#3350](https://github.com/thanos-io/thanos/pull/3350) Query/Sidecar: Added targets API support. You can now configure you Querier to fetch Prometheus targets from leaf Prometheus-es!
 

--- a/mixin/dashboards/compact.libsonnet
+++ b/mixin/dashboards/compact.libsonnet
@@ -35,7 +35,7 @@ local utils = import '../lib/utils.libsonnet';
           g.qpsErrTotalPanel(
             'thanos_compact_group_compactions_failures_total{%(selector)s}' % thanos.compact.dashboard.selector,
             'thanos_compact_group_compactions_total{%(selector)s}' % thanos.compact.dashboard.selector,
-            thanos.rule.dashboard.dimensions
+            thanos.compact.dashboard.dimensions
           )
         )
       )
@@ -57,7 +57,7 @@ local utils = import '../lib/utils.libsonnet';
           g.qpsErrTotalPanel(
             'thanos_compact_downsample_failed_total{%(selector)s}' % thanos.compact.dashboard.selector,
             'thanos_compact_downsample_total{%(selector)s}' % thanos.compact.dashboard.selector,
-            thanos.rule.dashboard.dimensions
+            thanos.compact.dashboard.dimensions
           )
         )
       )
@@ -79,12 +79,12 @@ local utils = import '../lib/utils.libsonnet';
           g.qpsErrTotalPanel(
             'thanos_compact_garbage_collection_failures_total{%(selector)s}' % thanos.compact.dashboard.selector,
             'thanos_compact_garbage_collection_total{%(selector)s}' % thanos.compact.dashboard.selector,
-            thanos.rule.dashboard.dimensions
+            thanos.compact.dashboard.dimensions
           )
         )
         .addPanel(
           g.panel('Duration', 'Shows how long has it taken to execute garbage collection in quantiles.') +
-          g.latencyPanel('thanos_compact_garbage_collection_duration_seconds', thanos.rule.dashboard.selector, thanos.rule.dashboard.dimensions)
+          g.latencyPanel('thanos_compact_garbage_collection_duration_seconds', thanos.compact.dashboard.selector, thanos.compact.dashboard.dimensions)
         )
       )
       .addRow(
@@ -139,12 +139,12 @@ local utils = import '../lib/utils.libsonnet';
           g.qpsErrTotalPanel(
             'thanos_blocks_meta_sync_failures_total{%(selector)s}' % thanos.compact.dashboard.selector,
             'thanos_blocks_meta_syncs_total{%(selector)s}' % thanos.compact.dashboard.selector,
-            thanos.rule.dashboard.dimensions
+            thanos.compact.dashboard.dimensions
           )
         )
         .addPanel(
           g.panel('Duration', 'Shows how long has it taken to execute meta file sync, in quantiles.') +
-          g.latencyPanel('thanos_blocks_meta_sync_duration_seconds', thanos.rule.dashboard.selector, thanos.rule.dashboard.dimensions)
+          g.latencyPanel('thanos_blocks_meta_sync_duration_seconds', thanos.compact.dashboard.selector, thanos.compact.dashboard.dimensions)
         )
       )
       .addRow(
@@ -162,16 +162,16 @@ local utils = import '../lib/utils.libsonnet';
           g.qpsErrTotalPanel(
             'thanos_objstore_bucket_operation_failures_total{%(selector)s}' % thanos.compact.dashboard.selector,
             'thanos_objstore_bucket_operations_total{%(selector)s}' % thanos.compact.dashboard.selector,
-            thanos.rule.dashboard.dimensions
+            thanos.compact.dashboard.dimensions
           )
         )
         .addPanel(
           g.panel('Duration', 'Shows how long has it taken to execute operations against the bucket, in quantiles.') +
-          g.latencyPanel('thanos_objstore_bucket_operation_duration_seconds', thanos.rule.dashboard.selector, thanos.rule.dashboard.dimensions)
+          g.latencyPanel('thanos_objstore_bucket_operation_duration_seconds', thanos.compact.dashboard.selector, thanos.compact.dashboard.dimensions)
         )
       )
       .addRow(
-        g.resourceUtilizationRow(thanos.rule.dashboard.selector, thanos.rule.dashboard.dimensions)
+        g.resourceUtilizationRow(thanos.compact.dashboard.selector, thanos.compact.dashboard.dimensions)
       ),
 
     __overviewRows__+:: [
@@ -196,7 +196,7 @@ local utils = import '../lib/utils.libsonnet';
         g.qpsErrTotalPanel(
           'thanos_compact_group_compactions_failures_total{%(selector)s}' % thanos.dashboard.overview.selector,
           'thanos_compact_group_compactions_total{%(selector)s}' % thanos.dashboard.overview.selector,
-          thanos.rule.dashboard.dimensions
+          thanos.compact.dashboard.dimensions
         ) +
         g.addDashboardLink(thanos.compact.title)
       ) +


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

This change will remove the dependency between the rule dashboard and the compact dashboard mixins to be able to only generate the compact dashboard without defining the rule dashboard.

## Verification

The compact dashboard has been generated and imported to Grafana with and without the included change. No visible differences found.
