### PR TITLE
Skip making reload request when `--watch-interval` == `0`

### DIFF
--- a/pkg/reloader/reloader.go
+++ b/pkg/reloader/reloader.go
@@ -341,6 +341,9 @@ func (r *Reloader) apply(ctx context.Context) error {
 	}
 
 	if err := runutil.RetryWithLog(r.logger, r.retryInterval, ctx.Done(), func() error {
+		if r.watchInterval == 0 {
+			return nil
+		}
 		r.reloads.Inc()
 		if err := r.triggerReload(ctx); err != nil {
 			r.reloadErrors.Inc()


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [X] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Related to https://github.com/prometheus-operator/prometheus-operator/pull/3955 when trying to fix https://github.com/prometheus-operator/prometheus-operator/issues/3061#issuecomment-619812179

<!-- Enumerate changes you made -->
- Skip make reload request when --watch-interval equals zero; which avoid retrial error when :9090/-/-reload is not ready

## Verification

<!-- How you tested it? How do you know it works? -->

Updated unit test by checking reload atom equals 0 for reload request skipped. 