### PR TITLE
logging: fix the HTTP logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ We use _breaking :warning:_ to mark changes that are not backward compatible (re
 - [#3960](https://github.com/thanos-io/thanos/pull/3960) fix deduplication of equal alerts with different labels
 - [#3937](https://github.com/thanos-io/thanos/pull/3937) Store: Fix race condition in chunk pool.
 - [#4017](https://github.com/thanos-io/thanos/pull/4017) Query Frontend: fix downsampling iterator returning duplicate samples.
+- [#4017](https://github.com/thanos-io/thanos/pull/4041) Logging: fix the HTTP logger
 
 ### Changed
 - [#3929](https://github.com/thanos-io/thanos/pull/3929) Store: Adds the name of the instantiated memcached client to log info

--- a/pkg/logging/http.go
+++ b/pkg/logging/http.go
@@ -39,7 +39,11 @@ func (m *HTTPServerMiddleware) HTTPMiddleware(name string, next http.Handler) ht
 	return func(w http.ResponseWriter, r *http.Request) {
 		wrapped := httputil.WrapResponseWriterWithStatus(w)
 		start := time.Now()
-		_, port, err := net.SplitHostPort(r.Host)
+		hostPort := r.Host
+		if hostPort == "" {
+			hostPort = r.URL.Host
+		}
+		_, port, err := net.SplitHostPort(hostPort)
 		if err != nil {
 			level.Error(m.logger).Log("msg", "failed to parse host port for http log decision", "err", err)
 			next.ServeHTTP(w, r)

--- a/pkg/logging/http_test.go
+++ b/pkg/logging/http_test.go
@@ -29,7 +29,7 @@ func TestHTTPServerMiddleware(t *testing.T) {
 	}
 	hm := m.HTTPMiddleware("test", http.HandlerFunc(handler))
 
-	// Cortex way:
+	// Regression test for Cortex way - https://github.com/thanos-io/thanos/pull/4041
 	u, err := url.Parse("http://example.com:5555/foo")
 	testutil.Ok(t, err)
 	req := &http.Request{

--- a/pkg/logging/http_test.go
+++ b/pkg/logging/http_test.go
@@ -4,10 +4,13 @@
 package logging
 
 import (
+	"bytes"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/go-kit/kit/log"
@@ -15,23 +18,50 @@ import (
 )
 
 func TestHTTPServerMiddleware(t *testing.T) {
-	m := NewHTTPServerMiddleware(log.NewNopLogger())
+	b := bytes.Buffer{}
+
+	m := NewHTTPServerMiddleware(log.NewLogfmtLogger(io.Writer(&b)))
 	handler := func(w http.ResponseWriter, r *http.Request) {
 		_, err := io.WriteString(w, "Test Works")
 		if err != nil {
-			t.Log(err)
+			testutil.Ok(t, err)
 		}
 	}
 	hm := m.HTTPMiddleware("test", http.HandlerFunc(handler))
 
-	req := httptest.NewRequest("GET", "http://example.com/foo", nil)
+	// Cortex way:
+	u, err := url.Parse("http://example.com:5555/foo")
+	testutil.Ok(t, err)
+	req := &http.Request{
+		Method: "GET",
+		URL:    u,
+		Body:   nil,
+	}
+
 	w := httptest.NewRecorder()
 
 	hm(w, req)
 
 	resp := w.Result()
-	body, _ := ioutil.ReadAll(resp.Body)
+	body, err := ioutil.ReadAll(resp.Body)
+	testutil.Ok(t, err)
 
 	testutil.Equals(t, 200, resp.StatusCode)
 	testutil.Equals(t, "Test Works", string(body))
+	testutil.Assert(t, !strings.Contains(b.String(), "err="))
+
+	// Typical way:
+	req = httptest.NewRequest("GET", "http://example.com:5555/foo", nil)
+	b.Reset()
+
+	w = httptest.NewRecorder()
+	hm(w, req)
+
+	resp = w.Result()
+	body, err = ioutil.ReadAll(resp.Body)
+	testutil.Ok(t, err)
+
+	testutil.Equals(t, 200, resp.StatusCode)
+	testutil.Equals(t, "Test Works", string(body))
+	testutil.Assert(t, !strings.Contains(b.String(), "err="))
 }


### PR DESCRIPTION
Fix the HTTP logger so that it would take a look at the `url.URL` as
well if `r.Host` is empty. Without this, the logging functionality doesn't quite work
as Cortex uses `url.URL`:

https://github.com/cortexproject/cortex/blob/faf92e8f3dbedfa769fbd6a3ff6e0fbd127694f5/pkg/frontend/downstream_roundtripper.go#L16-L23

Add a test to ensure that this works as expected in both ways.

Without this, the user only sees in the logs:

```
level=error ts=2021-04-09T10:22:05.3319924Z caller=http.go:44 protocol=http http.component=server msg="failed to parse host port for http log decision" err="address foo.bar: missing port in address"
```

Signed-off-by: Giedrius Statkevičius <giedrius.statkevicius@vinted.com>

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

