### PR TITLE
UI: Fix conflicts in dependencies

### DIFF
--- a/pkg/ui/react-app/package.json
+++ b/pkg/ui/react-app/package.json
@@ -19,7 +19,6 @@
     "@fortawesome/free-solid-svg-icons": "^5.15.2",
     "@fortawesome/react-fontawesome": "^0.1.14",
     "@reach/router": "^1.3.4",
-    "@testing-library/react-hooks": "^5.0.3",
     "@types/jest": "^26.0.20",
     "@types/jquery": "^3.5.5",
     "@types/node": "^14.14.30",
@@ -37,10 +36,10 @@
     "enzyme-to-json": "^3.6.1",
     "fuzzy": "^0.1.3",
     "i": "^0.3.6",
-    "jest-fetch-mock": "^3.0.3",
     "jquery": "^3.5.1",
     "jquery.flot.tooltip": "^0.9.0",
     "jsdom": "^16.4.0",
+    "lezer": "^0.13.4",
     "moment": "^2.29.1",
     "moment-timezone": "^0.5.33",
     "popper.js": "^1.16.1",
@@ -81,7 +80,7 @@
     "not op_mini all"
   ],
   "devDependencies": {
-    "@testing-library/react-hooks": "^3.1.1",
+    "@testing-library/react-hooks": "^5.0.3",
     "@types/enzyme": "^3.10.8",
     "@types/enzyme-adapter-react-16": "^1.0.6",
     "@types/flot": "^0.0.31",
@@ -102,7 +101,7 @@
     "eslint-plugin-prettier": "^3.3.1",
     "eslint-plugin-react": "^7.22.0",
     "eslint-plugin-react-hooks": "^4.2.0",
-    "jest-fetch-mock": "^2.1.2",
+    "jest-fetch-mock": "^3.0.3",
     "mutationobserver-shim": "^0.3.7",
     "prettier": "^2.2.1",
     "sinon": "^9.2.4"


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes
- Some dependencies were present in both `dependencies` and `devDependencies` section. I kep them in `devDependencies` (since both of them are related to tests) to avoid conflicts.
- I also explicitly added `lezer` as a dependency since it is required as a peer dependency by `codemirror-promql`.


## Verification
`yarn test`

