### PR TITLE
UI: Upgrade hosted-git-info to address a CVE-2021-23362

### DIFF
--- a/pkg/ui/react-app/package.json
+++ b/pkg/ui/react-app/package.json
@@ -35,6 +35,7 @@
     "downshift": "^6.1.0",
     "enzyme-to-json": "^3.6.1",
     "fuzzy": "^0.1.3",
+    "hosted-git-info": "2.8.9",
     "i": "^0.3.6",
     "jquery": "^3.5.1",
     "jquery.flot.tooltip": "^0.9.0",

--- a/pkg/ui/react-app/yarn.lock
+++ b/pkg/ui/react-app/yarn.lock
@@ -6081,7 +6081,7 @@ hoist-non-react-statics@^3.3.1:
   dependencies:
     react-is "^16.7.0"
 
-hosted-git-info@^2.1.4:
+hosted-git-info@2.8.9, hosted-git-info@^2.1.4:
   version "2.8.9"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.9.tgz#dffc0bf9a21c02209090f2aa69429e1414daf3f9"
   integrity sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==


### PR DESCRIPTION
Signed-off-by: Kemal Akkoyun <kakkoyun@gmail.com>

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Verification

* `yarn test`
