### PR TITLE
receiver: fix the calculation logic of minimum number of replicas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ We use _breaking :warning:_ to mark changes that are not backward compatible (re
 - [#3937](https://github.com/thanos-io/thanos/pull/3937) Store: Fix race condition in chunk pool.
 - [#4017](https://github.com/thanos-io/thanos/pull/4017) Query Frontend: fix downsampling iterator returning duplicate samples.
 - [#4017](https://github.com/thanos-io/thanos/pull/4041) Logging: fix the HTTP logger
+- [#4053](https://github.com/thanos-io/thanos/pull/4053) receiver: fix the calculation logic of minimum number of successful replicas
 
 ### Changed
 - [#3929](https://github.com/thanos-io/thanos/pull/3929) Store: Adds the name of the instantiated memcached client to log info

--- a/pkg/receive/handler.go
+++ b/pkg/receive/handler.go
@@ -395,7 +395,7 @@ func (h *Handler) forward(ctx context.Context, tenant string, r replica, wreq *p
 
 // writeQuorum returns minimum number of replicas that has to confirm write success before claiming replication success.
 func (h *Handler) writeQuorum() int {
-	return int((h.options.ReplicationFactor / 2) + 1)
+	return int(((h.options.ReplicationFactor - 1) / 2) + 1)
 }
 
 // fanoutForward fans out concurrently given set of write requests. It returns status immediately when quorum of


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes
I modified the pattern to `int(((h.options.ReplicationFactor - 1) / 2) + 1)`.
The original pattern is `int((h.options.ReplicationFactor / 2) + 1)`. there will be a issue when the `ReplicationFactor` is even numbers.
if the `ReplicationFactor` is `2`. the value of the pattern would be `(2/2+1)=2`. therefore, both replicas must be successfull to return success to prometheus. 
if the `ReplicationFactor` is `4`, the value of the pattern would be `(4/2+1)=3`. therefore, there need to be 3 successful replicas to return success to prometheus.

Recently we alter the replicas from 1 to 2, but all the receivers would be stuck if one receiver was crashed. 
It works after alter this pattern.


## Verification
![image](https://user-images.githubusercontent.com/5546200/114595795-5a261b00-9cc1-11eb-84c5-8d35866dd0cd.png)

<!-- How you tested it? How do you know it works? -->
