### PR TITLE
Sort flags alphabetically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ We use _breaking :warning:_ to mark changes that are not backward compatible (re
 - [#3948](https://github.com/thanos-io/thanos/pull/3948) Receiver: Adjust `http_request_duration_seconds` buckets for low latency requests.
 - [#3856](https://github.com/thanos-io/thanos/pull/3856) Mixin: _breaking :warning:_ Introduce flexible multi-cluster/namespace mode for alerts and dashboards. Removes jobPrefix config option. Removes `namespace` by default.
 - [#3937](https://github.com/thanos-io/thanos/pull/3937) Store: Reduce memory usage for range queries.
+- [#4062](https://github.com/thanos-io/thanos/pull/4062) Flags: Sort flags alphabetically
 
 ### Removed
 

--- a/docs/components/compact.md
+++ b/docs/components/compact.md
@@ -322,73 +322,19 @@ usage: thanos compact [<flags>]
 Continuously compacts blocks in an object store bucket.
 
 Flags:
-  -h, --help                    Show context-sensitive help (also try
-                                --help-long and --help-man).
-      --version                 Show application version.
-      --log.level=info          Log filtering level.
-      --log.format=logfmt       Log format to use. Possible options: logfmt or
-                                json.
-      --tracing.config-file=<file-path>
-                                Path to YAML file with tracing configuration.
-                                See format details:
-                                https://thanos.io/tip/thanos/tracing.md/#configuration
-      --tracing.config=<content>
-                                Alternative to 'tracing.config-file' flag
-                                (mutually exclusive). Content of YAML file with
-                                tracing configuration. See format details:
-                                https://thanos.io/tip/thanos/tracing.md/#configuration
-      --http-address="0.0.0.0:10902"
-                                Listen host:port for HTTP endpoints.
-      --http-grace-period=2m    Time to wait after an interrupt received for
-                                HTTP Server.
-      --data-dir="./data"       Data directory in which to cache blocks and
-                                process compactions.
-      --objstore.config-file=<file-path>
-                                Path to YAML file that contains object store
-                                configuration. See format details:
-                                https://thanos.io/tip/thanos/storage.md/#configuration
-      --objstore.config=<content>
-                                Alternative to 'objstore.config-file' flag
-                                (mutually exclusive). Content of YAML file that
-                                contains object store configuration. See format
-                                details:
-                                https://thanos.io/tip/thanos/storage.md/#configuration
-      --consistency-delay=30m   Minimum age of fresh (non-compacted) blocks
-                                before they are being processed. Malformed
-                                blocks older than the maximum of
-                                consistency-delay and 48h0m0s will be removed.
-      --retention.resolution-raw=0d
-                                How long to retain raw samples in bucket.
-                                Setting this to 0d will retain samples of this
-                                resolution forever
-      --retention.resolution-5m=0d
-                                How long to retain samples of resolution 1 (5
-                                minutes) in bucket. Setting this to 0d will
-                                retain samples of this resolution forever
-      --retention.resolution-1h=0d
-                                How long to retain samples of resolution 2 (1
-                                hour) in bucket. Setting this to 0d will retain
-                                samples of this resolution forever
-  -w, --wait                    Do not exit after all compactions have been
-                                processed and wait for new work.
-      --wait-interval=5m        Wait interval between consecutive compaction
-                                runs and bucket refreshes. Only works when
-                                --wait flag specified.
-      --downsampling.disable    Disables downsampling. This is not recommended
-                                as querying long time ranges without
-                                non-downsampled data is not efficient and useful
-                                e.g it is not possible to render all samples for
-                                a human eye anyway
-      --block-sync-concurrency=20
-                                Number of goroutines to use when syncing block
-                                metadata from object storage.
       --block-meta-fetch-concurrency=32
                                 Number of goroutines to use when fetching block
+                                metadata from object storage.
+      --block-sync-concurrency=20
+                                Number of goroutines to use when syncing block
                                 metadata from object storage.
       --block-viewer.global.sync-block-interval=1m
                                 Repeat interval for syncing the blocks between
                                 local and remote view for /global Block Viewer
                                 UI.
+      --bucket-web-label=BUCKET-WEB-LABEL
+                                Prometheus label to use as timeline title in the
+                                bucket web UI
       --compact.cleanup-interval=5m
                                 How often we should clean up partially uploaded
                                 blocks and blocks with deletion mark in the
@@ -397,6 +343,12 @@ Flags:
                                 happen at the end of an iteration.
       --compact.concurrency=1   Number of goroutines to use when compacting
                                 groups.
+      --consistency-delay=30m   Minimum age of fresh (non-compacted) blocks
+                                before they are being processed. Malformed
+                                blocks older than the maximum of
+                                consistency-delay and 48h0m0s will be removed.
+      --data-dir="./data"       Data directory in which to cache blocks and
+                                process compactions.
       --delete-delay=48h        Time before a block marked for deletion is
                                 deleted from bucket. If delete-delay is non
                                 zero, blocks will be marked for deletion and
@@ -408,18 +360,48 @@ Flags:
                                 loaded, or compactor is ignoring the deletion
                                 because it's compacting the block at the same
                                 time.
+      --downsampling.disable    Disables downsampling. This is not recommended
+                                as querying long time ranges without
+                                non-downsampled data is not efficient and useful
+                                e.g it is not possible to render all samples for
+                                a human eye anyway
       --hash-func=              Specify which hash function to use when
                                 calculating the hashes of produced files. If no
                                 function has been specified, it does not happen.
                                 This permits avoiding downloading some files
                                 twice albeit at some performance cost. Possible
                                 values are: "", "SHA256".
-      --selector.relabel-config-file=<file-path>
-                                Path to YAML file that contains relabeling
-                                configuration that allows selecting blocks. It
-                                follows native Prometheus relabel-config syntax.
-                                See format details:
-                                https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
+  -h, --help                    Show context-sensitive help (also try
+                                --help-long and --help-man).
+      --http-address="0.0.0.0:10902"
+                                Listen host:port for HTTP endpoints.
+      --http-grace-period=2m    Time to wait after an interrupt received for
+                                HTTP Server.
+      --log.format=logfmt       Log format to use. Possible options: logfmt or
+                                json.
+      --log.level=info          Log filtering level.
+      --objstore.config=<content>
+                                Alternative to 'objstore.config-file' flag
+                                (mutually exclusive). Content of YAML file that
+                                contains object store configuration. See format
+                                details:
+                                https://thanos.io/tip/thanos/storage.md/#configuration
+      --objstore.config-file=<file-path>
+                                Path to YAML file that contains object store
+                                configuration. See format details:
+                                https://thanos.io/tip/thanos/storage.md/#configuration
+      --retention.resolution-1h=0d
+                                How long to retain samples of resolution 2 (1
+                                hour) in bucket. Setting this to 0d will retain
+                                samples of this resolution forever
+      --retention.resolution-5m=0d
+                                How long to retain samples of resolution 1 (5
+                                minutes) in bucket. Setting this to 0d will
+                                retain samples of this resolution forever
+      --retention.resolution-raw=0d
+                                How long to retain raw samples in bucket.
+                                Setting this to 0d will retain samples of this
+                                resolution forever
       --selector.relabel-config=<content>
                                 Alternative to 'selector.relabel-config-file'
                                 flag (mutually exclusive). Content of YAML file
@@ -428,6 +410,30 @@ Flags:
                                 Prometheus relabel-config syntax. See format
                                 details:
                                 https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
+      --selector.relabel-config-file=<file-path>
+                                Path to YAML file that contains relabeling
+                                configuration that allows selecting blocks. It
+                                follows native Prometheus relabel-config syntax.
+                                See format details:
+                                https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
+      --tracing.config=<content>
+                                Alternative to 'tracing.config-file' flag
+                                (mutually exclusive). Content of YAML file with
+                                tracing configuration. See format details:
+                                https://thanos.io/tip/thanos/tracing.md/#configuration
+      --tracing.config-file=<file-path>
+                                Path to YAML file with tracing configuration.
+                                See format details:
+                                https://thanos.io/tip/thanos/tracing.md/#configuration
+      --version                 Show application version.
+  -w, --wait                    Do not exit after all compactions have been
+                                processed and wait for new work.
+      --wait-interval=5m        Wait interval between consecutive compaction
+                                runs and bucket refreshes. Only works when
+                                --wait flag specified.
+      --web.disable-cors        Whether to disable CORS headers to be set by
+                                Thanos. By default Thanos sets CORS headers to
+                                be allowed by all.
       --web.external-prefix=""  Static prefix for all HTML links and redirect
                                 URLs in the bucket web UI interface. Actual
                                 endpoints are still served on / or the
@@ -447,11 +453,5 @@ Flags:
                                 stripped prefix value in X-Forwarded-Prefix
                                 header. This allows thanos UI to be served on a
                                 sub-path.
-      --web.disable-cors        Whether to disable CORS headers to be set by
-                                Thanos. By default Thanos sets CORS headers to
-                                be allowed by all.
-      --bucket-web-label=BUCKET-WEB-LABEL
-                                Prometheus label to use as timeline title in the
-                                bucket web UI
 
 ```

--- a/docs/components/query-frontend.md
+++ b/docs/components/query-frontend.md
@@ -123,109 +123,64 @@ Query frontend command implements a service deployed in front of queriers to
 improve query parallelization and caching.
 
 Flags:
+      --cache-compression-type=""
+                                 Use compression in results cache. Supported
+                                 values are: 'snappy' and ” (disable
+                                 compression).
   -h, --help                     Show context-sensitive help (also try
                                  --help-long and --help-man).
-      --version                  Show application version.
-      --log.level=info           Log filtering level.
-      --log.format=logfmt        Log format to use. Possible options: logfmt or
-                                 json.
-      --tracing.config-file=<file-path>
-                                 Path to YAML file with tracing configuration.
-                                 See format details:
-                                 https://thanos.io/tip/thanos/tracing.md/#configuration
-      --tracing.config=<content>
-                                 Alternative to 'tracing.config-file' flag
-                                 (mutually exclusive). Content of YAML file with
-                                 tracing configuration. See format details:
-                                 https://thanos.io/tip/thanos/tracing.md/#configuration
       --http-address="0.0.0.0:10902"
                                  Listen host:port for HTTP endpoints.
       --http-grace-period=2m     Time to wait after an interrupt received for
                                  HTTP Server.
-      --web.disable-cors         Whether to disable CORS headers to be set by
-                                 Thanos. By default Thanos sets CORS headers to
-                                 be allowed by all.
-      --query-range.align-range-with-step
-                                 Mutate incoming queries to align their start
-                                 and end with their step for better
-                                 cache-ability. Note: Grafana dashboards do that
-                                 by default.
-      --query-range.request-downsampled
-                                 Make additional query for downsampled data in
-                                 case of empty or incomplete response to range
-                                 request.
-      --query-range.split-interval=24h
-                                 Split query range requests by an interval and
-                                 execute in parallel, it should be greater than
-                                 0 when query-range.response-cache-config is
-                                 configured.
-      --query-range.max-retries-per-request=5
-                                 Maximum number of retries for a single query
-                                 range request; beyond this, the downstream
-                                 error is returned.
-      --query-range.max-query-length=0
-                                 Limit the query time range (end - start time)
-                                 in the query-frontend, 0 disables it.
-      --query-range.max-query-parallelism=14
-                                 Maximum number of query range requests will be
-                                 scheduled in parallel by the Frontend.
-      --query-range.response-cache-max-freshness=1m
-                                 Most recent allowed cacheable result for query
-                                 range requests, to prevent caching very recent
-                                 results that might still be in flux.
-      --query-range.partial-response
-                                 Enable partial response for query range
-                                 requests if no partial_response param is
-                                 specified. --no-query-range.partial-response
-                                 for disabling.
-      --query-range.response-cache-config-file=<file-path>
-                                 Path to YAML file that contains response cache
-                                 configuration.
-      --query-range.response-cache-config=<content>
-                                 Alternative to
-                                 'query-range.response-cache-config-file' flag
-                                 (mutually exclusive). Content of YAML file that
-                                 contains response cache configuration.
-      --labels.split-interval=24h
-                                 Split labels requests by an interval and
-                                 execute in parallel, it should be greater than
-                                 0 when labels.response-cache-config is
-                                 configured.
-      --labels.max-retries-per-request=5
-                                 Maximum number of retries for a single
-                                 label/series API request; beyond this, the
-                                 downstream error is returned.
-      --labels.max-query-parallelism=14
-                                 Maximum number of labels requests will be
-                                 scheduled in parallel by the Frontend.
-      --labels.response-cache-max-freshness=1m
-                                 Most recent allowed cacheable result for labels
-                                 requests, to prevent caching very recent
-                                 results that might still be in flux.
-      --labels.partial-response  Enable partial response for labels requests if
-                                 no partial_response param is specified.
-                                 --no-labels.partial-response for disabling.
       --labels.default-time-range=24h
                                  The default metadata time range duration for
                                  retrieving labels through Labels and Series API
                                  when the range parameters are not specified.
-      --labels.response-cache-config-file=<file-path>
-                                 Path to YAML file that contains response cache
-                                 configuration.
+      --labels.max-query-parallelism=14
+                                 Maximum number of labels requests will be
+                                 scheduled in parallel by the Frontend.
+      --labels.max-retries-per-request=5
+                                 Maximum number of retries for a single
+                                 label/series API request; beyond this, the
+                                 downstream error is returned.
+      --labels.partial-response  Enable partial response for labels requests if
+                                 no partial_response param is specified.
+                                 --no-labels.partial-response for disabling.
       --labels.response-cache-config=<content>
                                  Alternative to
                                  'labels.response-cache-config-file' flag
                                  (mutually exclusive). Content of YAML file that
                                  contains response cache configuration.
-      --cache-compression-type=""
-                                 Use compression in results cache. Supported
-                                 values are: 'snappy' and ” (disable
-                                 compression).
+      --labels.response-cache-config-file=<file-path>
+                                 Path to YAML file that contains response cache
+                                 configuration.
+      --labels.response-cache-max-freshness=1m
+                                 Most recent allowed cacheable result for labels
+                                 requests, to prevent caching very recent
+                                 results that might still be in flux.
+      --labels.split-interval=24h
+                                 Split labels requests by an interval and
+                                 execute in parallel, it should be greater than
+                                 0 when labels.response-cache-config is
+                                 configured.
+      --log.format=logfmt        Log format to use. Possible options: logfmt or
+                                 json.
+      --log.level=info           Log filtering level.
+      --log.request.decision=    Deprecation Warning - This flag would be soon
+                                 deprecated, and replaced with
+                                 `request.logging-config`. Request Logging for
+                                 logging the start and end of requests. By
+                                 default this flag is disabled. LogFinishCall :
+                                 Logs the finish call of the requests.
+                                 LogStartAndFinishCall : Logs the start and
+                                 finish call of the requests. NoLogCall :
+                                 Disable request logging.
+      --query-frontend.compress-responses
+                                 Compress HTTP responses.
       --query-frontend.downstream-url="http://localhost:9090"
                                  URL of downstream Prometheus Query compatible
                                  API.
-      --query-frontend.compress-responses
-                                 Compress HTTP responses.
       --query-frontend.log-queries-longer-than=0
                                  Log queries that are slower than the specified
                                  duration. Set to 0 to disable. Set to < 0 to
@@ -238,24 +193,69 @@ Flags:
                                  headers match the request, the first matching
                                  arg specified will take precedence. If no
                                  headers match 'anonymous' will be used.
-      --log.request.decision=    Deprecation Warning - This flag would be soon
-                                 deprecated, and replaced with
-                                 `request.logging-config`. Request Logging for
-                                 logging the start and end of requests. By
-                                 default this flag is disabled. LogFinishCall :
-                                 Logs the finish call of the requests.
-                                 LogStartAndFinishCall : Logs the start and
-                                 finish call of the requests. NoLogCall :
-                                 Disable request logging.
-      --request.logging-config-file=<file-path>
-                                 Path to YAML file with request logging
-                                 configuration. See format details:
-                                 https://gist.github.com/yashrsharma44/02f5765c5710dd09ce5d14e854f22825
+      --query-range.align-range-with-step
+                                 Mutate incoming queries to align their start
+                                 and end with their step for better
+                                 cache-ability. Note: Grafana dashboards do that
+                                 by default.
+      --query-range.max-query-length=0
+                                 Limit the query time range (end - start time)
+                                 in the query-frontend, 0 disables it.
+      --query-range.max-query-parallelism=14
+                                 Maximum number of query range requests will be
+                                 scheduled in parallel by the Frontend.
+      --query-range.max-retries-per-request=5
+                                 Maximum number of retries for a single query
+                                 range request; beyond this, the downstream
+                                 error is returned.
+      --query-range.partial-response
+                                 Enable partial response for query range
+                                 requests if no partial_response param is
+                                 specified. --no-query-range.partial-response
+                                 for disabling.
+      --query-range.request-downsampled
+                                 Make additional query for downsampled data in
+                                 case of empty or incomplete response to range
+                                 request.
+      --query-range.response-cache-config=<content>
+                                 Alternative to
+                                 'query-range.response-cache-config-file' flag
+                                 (mutually exclusive). Content of YAML file that
+                                 contains response cache configuration.
+      --query-range.response-cache-config-file=<file-path>
+                                 Path to YAML file that contains response cache
+                                 configuration.
+      --query-range.response-cache-max-freshness=1m
+                                 Most recent allowed cacheable result for query
+                                 range requests, to prevent caching very recent
+                                 results that might still be in flux.
+      --query-range.split-interval=24h
+                                 Split query range requests by an interval and
+                                 execute in parallel, it should be greater than
+                                 0 when query-range.response-cache-config is
+                                 configured.
       --request.logging-config=<content>
                                  Alternative to 'request.logging-config-file'
                                  flag (mutually exclusive). Content of YAML file
                                  with request logging configuration. See format
                                  details:
                                  https://gist.github.com/yashrsharma44/02f5765c5710dd09ce5d14e854f22825
+      --request.logging-config-file=<file-path>
+                                 Path to YAML file with request logging
+                                 configuration. See format details:
+                                 https://gist.github.com/yashrsharma44/02f5765c5710dd09ce5d14e854f22825
+      --tracing.config=<content>
+                                 Alternative to 'tracing.config-file' flag
+                                 (mutually exclusive). Content of YAML file with
+                                 tracing configuration. See format details:
+                                 https://thanos.io/tip/thanos/tracing.md/#configuration
+      --tracing.config-file=<file-path>
+                                 Path to YAML file with tracing configuration.
+                                 See format details:
+                                 https://thanos.io/tip/thanos/tracing.md/#configuration
+      --version                  Show application version.
+      --web.disable-cors         Whether to disable CORS headers to be set by
+                                 Thanos. By default Thanos sets CORS headers to
+                                 be allowed by all.
 
 ```

--- a/docs/components/query.md
+++ b/docs/components/query.md
@@ -290,57 +290,150 @@ Query node exposing PromQL enabled Query API with data retrieved from multiple
 store nodes.
 
 Flags:
-  -h, --help                     Show context-sensitive help (also try
-                                 --help-long and --help-man).
-      --version                  Show application version.
-      --log.level=info           Log filtering level.
-      --log.format=logfmt        Log format to use. Possible options: logfmt or
-                                 json.
-      --tracing.config-file=<file-path>
-                                 Path to YAML file with tracing configuration.
-                                 See format details:
-                                 https://thanos.io/tip/thanos/tracing.md/#configuration
-      --tracing.config=<content>
-                                 Alternative to 'tracing.config-file' flag
-                                 (mutually exclusive). Content of YAML file with
-                                 tracing configuration. See format details:
-                                 https://thanos.io/tip/thanos/tracing.md/#configuration
-      --http-address="0.0.0.0:10902"
-                                 Listen host:port for HTTP endpoints.
-      --http-grace-period=2m     Time to wait after an interrupt received for
-                                 HTTP Server.
       --grpc-address="0.0.0.0:10901"
                                  Listen ip:port address for gRPC endpoints
                                  (StoreAPI). Make sure this address is routable
                                  from other components.
+      --grpc-client-server-name=""
+                                 Server name to verify the hostname on the
+                                 returned gRPC certificates. See
+                                 https://tools.ietf.org/html/rfc4366#section-3.1
+      --grpc-client-tls-ca=""    TLS CA Certificates to use to verify gRPC
+                                 servers
+      --grpc-client-tls-cert=""  TLS Certificates to use to identify this client
+                                 to the server
+      --grpc-client-tls-key=""   TLS Key for the client's certificate
+      --grpc-client-tls-secure   Use TLS when talking to the gRPC server
+      --grpc-client-tls-skip-verify
+                                 Disable TLS certificate verification i.e self
+                                 signed, signed by fake CA
       --grpc-grace-period=2m     Time to wait after an interrupt received for
                                  GRPC Server.
       --grpc-server-tls-cert=""  TLS Certificate for gRPC server, leave blank to
-                                 disable TLS
-      --grpc-server-tls-key=""   TLS Key for the gRPC server, leave blank to
                                  disable TLS
       --grpc-server-tls-client-ca=""
                                  TLS CA to verify clients against. If no client
                                  CA is specified, there is no client
                                  verification on server side. (tls.NoClientCert)
-      --grpc-client-tls-secure   Use TLS when talking to the gRPC server
-      --grpc-client-tls-skip-verify
-                                 Disable TLS certificate verification i.e self
-                                 signed, signed by fake CA
-      --grpc-client-tls-cert=""  TLS Certificates to use to identify this client
-                                 to the server
-      --grpc-client-tls-key=""   TLS Key for the client's certificate
-      --grpc-client-tls-ca=""    TLS CA Certificates to use to verify gRPC
-                                 servers
-      --grpc-client-server-name=""
-                                 Server name to verify the hostname on the
-                                 returned gRPC certificates. See
-                                 https://tools.ietf.org/html/rfc4366#section-3.1
-      --web.route-prefix=""      Prefix for API and UI endpoints. This allows
-                                 thanos UI to be served on a sub-path. Defaults
-                                 to the value of --web.external-prefix. This
-                                 option is analogous to --web.route-prefix of
-                                 Prometheus.
+      --grpc-server-tls-key=""   TLS Key for the gRPC server, leave blank to
+                                 disable TLS
+  -h, --help                     Show context-sensitive help (also try
+                                 --help-long and --help-man).
+      --http-address="0.0.0.0:10902"
+                                 Listen host:port for HTTP endpoints.
+      --http-grace-period=2m     Time to wait after an interrupt received for
+                                 HTTP Server.
+      --log.format=logfmt        Log format to use. Possible options: logfmt or
+                                 json.
+      --log.level=info           Log filtering level.
+      --log.request.decision=    Deprecation Warning - This flag would be soon
+                                 deprecated, and replaced with
+                                 `request.logging-config`. Request Logging for
+                                 logging the start and end of requests. By
+                                 default this flag is disabled. LogFinishCall:
+                                 Logs the finish call of the requests.
+                                 LogStartAndFinishCall: Logs the start and
+                                 finish call of the requests. NoLogCall: Disable
+                                 request logging.
+      --query.auto-downsampling  Enable automatic adjustment (step / 5) to what
+                                 source of data should be used in store gateways
+                                 if no max_source_resolution param is specified.
+      --query.default-evaluation-interval=1m
+                                 Set default evaluation interval for sub
+                                 queries.
+      --query.default-step=1s    Set default step for range queries. Default
+                                 step is only used when step is not set in UI.
+                                 In such cases, Thanos UI will use default step
+                                 to calculate resolution (resolution =
+                                 max(rangeSeconds / 250, defaultStep)). This
+                                 will not work from Grafana, but Grafana has
+                                 __step variable which can be used.
+      --query.lookback-delta=QUERY.LOOKBACK-DELTA
+                                 The maximum lookback duration for retrieving
+                                 metrics during expression evaluations. PromQL
+                                 always evaluates the query for the certain
+                                 timestamp (query range timestamps are deduced
+                                 by step). Since scrape intervals might be
+                                 different, PromQL looks back for given amount
+                                 of time to get latest sample. If it exceeds the
+                                 maximum lookback delta it assumes series is
+                                 stale and returns none (a gap). This is why
+                                 lookback delta should be set to at least 2
+                                 times of the slowest scrape interval. If unset
+                                 it will use the promql default of 5m.
+      --query.max-concurrent=20  Maximum number of queries processed
+                                 concurrently by query node.
+      --query.max-concurrent-select=4
+                                 Maximum number of select requests made
+                                 concurrently per a query.
+      --query.metadata.default-time-range=0s
+                                 The default metadata time range duration for
+                                 retrieving labels through Labels and Series API
+                                 when the range parameters are not specified.
+                                 The zero value means range covers the time
+                                 since the beginning.
+      --query.partial-response   Enable partial response for queries if no
+                                 partial_response param is specified.
+                                 --no-query.partial-response for disabling.
+      --query.replica-label=QUERY.REPLICA-LABEL ...
+                                 Labels to treat as a replica indicator along
+                                 which data is deduplicated. Still you will be
+                                 able to query without deduplication using
+                                 'dedup=false' parameter. Data includes time
+                                 series, recording rules, and alerting rules.
+      --query.timeout=2m         Maximum time to process query by query node.
+      --request.logging-config=<content>
+                                 Alternative to 'request.logging-config-file'
+                                 flag (mutually exclusive). Content of YAML file
+                                 with request logging configuration. See format
+                                 details:
+                                 https://gist.github.com/yashrsharma44/02f5765c5710dd09ce5d14e854f22825
+      --request.logging-config-file=<file-path>
+                                 Path to YAML file with request logging
+                                 configuration. See format details:
+                                 https://gist.github.com/yashrsharma44/02f5765c5710dd09ce5d14e854f22825
+      --selector-label=<name>="<value>" ...
+                                 Query selector labels that will be exposed in
+                                 info endpoint (repeated).
+      --store=<store> ...        Addresses of statically configured store API
+                                 servers (repeatable). The scheme may be
+                                 prefixed with 'dns+' or 'dnssrv+' to detect
+                                 store API servers through respective DNS
+                                 lookups.
+      --store-strict=<staticstore> ...
+                                 Addresses of only statically configured store
+                                 API servers that are always used, even if the
+                                 health check fails. Useful if you have a
+                                 caching layer on top.
+      --store.response-timeout=0ms
+                                 If a Store doesn't send any data in this
+                                 specified duration then a Store will be ignored
+                                 and partial data will be returned if it's
+                                 enabled. 0 disables timeout.
+      --store.sd-dns-interval=30s
+                                 Interval between DNS resolutions.
+      --store.sd-files=<path> ...
+                                 Path to files that contain addresses of store
+                                 API servers. The path can be a glob pattern
+                                 (repeatable).
+      --store.sd-interval=5m     Refresh interval to re-read file SD files. It
+                                 is used as a resync fallback.
+      --store.unhealthy-timeout=5m
+                                 Timeout before an unhealthy store is cleaned
+                                 from the store UI page.
+      --tracing.config=<content>
+                                 Alternative to 'tracing.config-file' flag
+                                 (mutually exclusive). Content of YAML file with
+                                 tracing configuration. See format details:
+                                 https://thanos.io/tip/thanos/tracing.md/#configuration
+      --tracing.config-file=<file-path>
+                                 Path to YAML file with tracing configuration.
+                                 See format details:
+                                 https://thanos.io/tip/thanos/tracing.md/#configuration
+      --version                  Show application version.
+      --web.disable-cors         Whether to disable CORS headers to be set by
+                                 Thanos. By default Thanos sets CORS headers to
+                                 be allowed by all.
       --web.external-prefix=""   Static prefix for all HTML links and redirect
                                  URLs in the UI query web interface. Actual
                                  endpoints are still served on / or the
@@ -360,103 +453,10 @@ Flags:
                                  stripped prefix value in X-Forwarded-Prefix
                                  header. This allows thanos UI to be served on a
                                  sub-path.
-      --web.disable-cors         Whether to disable CORS headers to be set by
-                                 Thanos. By default Thanos sets CORS headers to
-                                 be allowed by all.
-      --log.request.decision=    Deprecation Warning - This flag would be soon
-                                 deprecated, and replaced with
-                                 `request.logging-config`. Request Logging for
-                                 logging the start and end of requests. By
-                                 default this flag is disabled. LogFinishCall:
-                                 Logs the finish call of the requests.
-                                 LogStartAndFinishCall: Logs the start and
-                                 finish call of the requests. NoLogCall: Disable
-                                 request logging.
-      --query.timeout=2m         Maximum time to process query by query node.
-      --query.max-concurrent=20  Maximum number of queries processed
-                                 concurrently by query node.
-      --query.lookback-delta=QUERY.LOOKBACK-DELTA
-                                 The maximum lookback duration for retrieving
-                                 metrics during expression evaluations. PromQL
-                                 always evaluates the query for the certain
-                                 timestamp (query range timestamps are deduced
-                                 by step). Since scrape intervals might be
-                                 different, PromQL looks back for given amount
-                                 of time to get latest sample. If it exceeds the
-                                 maximum lookback delta it assumes series is
-                                 stale and returns none (a gap). This is why
-                                 lookback delta should be set to at least 2
-                                 times of the slowest scrape interval. If unset
-                                 it will use the promql default of 5m.
-      --query.max-concurrent-select=4
-                                 Maximum number of select requests made
-                                 concurrently per a query.
-      --query.replica-label=QUERY.REPLICA-LABEL ...
-                                 Labels to treat as a replica indicator along
-                                 which data is deduplicated. Still you will be
-                                 able to query without deduplication using
-                                 'dedup=false' parameter. Data includes time
-                                 series, recording rules, and alerting rules.
-      --query.metadata.default-time-range=0s
-                                 The default metadata time range duration for
-                                 retrieving labels through Labels and Series API
-                                 when the range parameters are not specified.
-                                 The zero value means range covers the time
-                                 since the beginning.
-      --selector-label=<name>="<value>" ...
-                                 Query selector labels that will be exposed in
-                                 info endpoint (repeated).
-      --store=<store> ...        Addresses of statically configured store API
-                                 servers (repeatable). The scheme may be
-                                 prefixed with 'dns+' or 'dnssrv+' to detect
-                                 store API servers through respective DNS
-                                 lookups.
-      --store-strict=<staticstore> ...
-                                 Addresses of only statically configured store
-                                 API servers that are always used, even if the
-                                 health check fails. Useful if you have a
-                                 caching layer on top.
-      --store.sd-files=<path> ...
-                                 Path to files that contain addresses of store
-                                 API servers. The path can be a glob pattern
-                                 (repeatable).
-      --store.sd-interval=5m     Refresh interval to re-read file SD files. It
-                                 is used as a resync fallback.
-      --store.sd-dns-interval=30s
-                                 Interval between DNS resolutions.
-      --store.unhealthy-timeout=5m
-                                 Timeout before an unhealthy store is cleaned
-                                 from the store UI page.
-      --query.auto-downsampling  Enable automatic adjustment (step / 5) to what
-                                 source of data should be used in store gateways
-                                 if no max_source_resolution param is specified.
-      --query.partial-response   Enable partial response for queries if no
-                                 partial_response param is specified.
-                                 --no-query.partial-response for disabling.
-      --query.default-evaluation-interval=1m
-                                 Set default evaluation interval for sub
-                                 queries.
-      --query.default-step=1s    Set default step for range queries. Default
-                                 step is only used when step is not set in UI.
-                                 In such cases, Thanos UI will use default step
-                                 to calculate resolution (resolution =
-                                 max(rangeSeconds / 250, defaultStep)). This
-                                 will not work from Grafana, but Grafana has
-                                 __step variable which can be used.
-      --store.response-timeout=0ms
-                                 If a Store doesn't send any data in this
-                                 specified duration then a Store will be ignored
-                                 and partial data will be returned if it's
-                                 enabled. 0 disables timeout.
-      --request.logging-config-file=<file-path>
-                                 Path to YAML file with request logging
-                                 configuration. See format details:
-                                 https://gist.github.com/yashrsharma44/02f5765c5710dd09ce5d14e854f22825
-      --request.logging-config=<content>
-                                 Alternative to 'request.logging-config-file'
-                                 flag (mutually exclusive). Content of YAML file
-                                 with request logging configuration. See format
-                                 details:
-                                 https://gist.github.com/yashrsharma44/02f5765c5710dd09ce5d14e854f22825
+      --web.route-prefix=""      Prefix for API and UI endpoints. This allows
+                                 thanos UI to be served on a sub-path. Defaults
+                                 to the value of --web.external-prefix. This
+                                 option is analogous to --web.route-prefix of
+                                 Prometheus.
 
 ```

--- a/docs/components/receive.md
+++ b/docs/components/receive.md
@@ -75,25 +75,6 @@ usage: thanos receive [<flags>]
 Accept Prometheus remote write API requests and write to local tsdb.
 
 Flags:
-  -h, --help                     Show context-sensitive help (also try
-                                 --help-long and --help-man).
-      --version                  Show application version.
-      --log.level=info           Log filtering level.
-      --log.format=logfmt        Log format to use. Possible options: logfmt or
-                                 json.
-      --tracing.config-file=<file-path>
-                                 Path to YAML file with tracing configuration.
-                                 See format details:
-                                 https://thanos.io/tip/thanos/tracing.md/#configuration
-      --tracing.config=<content>
-                                 Alternative to 'tracing.config-file' flag
-                                 (mutually exclusive). Content of YAML file with
-                                 tracing configuration. See format details:
-                                 https://thanos.io/tip/thanos/tracing.md/#configuration
-      --http-address="0.0.0.0:10902"
-                                 Listen host:port for HTTP endpoints.
-      --http-grace-period=2m     Time to wait after an interrupt received for
-                                 HTTP Server.
       --grpc-address="0.0.0.0:10901"
                                  Listen ip:port address for gRPC endpoints
                                  (StoreAPI). Make sure this address is routable
@@ -102,60 +83,52 @@ Flags:
                                  GRPC Server.
       --grpc-server-tls-cert=""  TLS Certificate for gRPC server, leave blank to
                                  disable TLS
-      --grpc-server-tls-key=""   TLS Key for the gRPC server, leave blank to
-                                 disable TLS
       --grpc-server-tls-client-ca=""
                                  TLS CA to verify clients against. If no client
                                  CA is specified, there is no client
                                  verification on server side. (tls.NoClientCert)
-      --remote-write.address="0.0.0.0:19291"
-                                 Address to listen on for remote write requests.
-      --remote-write.server-tls-cert=""
-                                 TLS Certificate for HTTP server, leave blank to
-                                 disable TLS.
-      --remote-write.server-tls-key=""
-                                 TLS Key for the HTTP server, leave blank to
-                                 disable TLS.
-      --remote-write.server-tls-client-ca=""
-                                 TLS CA to verify clients against. If no client
-                                 CA is specified, there is no client
-                                 verification on server side. (tls.NoClientCert)
-      --remote-write.client-tls-cert=""
-                                 TLS Certificates to use to identify this client
-                                 to the server.
-      --remote-write.client-tls-key=""
-                                 TLS Key for the client's certificate.
-      --remote-write.client-tls-ca=""
-                                 TLS CA Certificates to use to verify servers.
-      --remote-write.client-server-name=""
-                                 Server name to verify the hostname on the
-                                 returned TLS certificates. See
-                                 https://tools.ietf.org/html/rfc4366#section-3.1
-      --tsdb.path="./data"       Data directory of TSDB.
+      --grpc-server-tls-key=""   TLS Key for the gRPC server, leave blank to
+                                 disable TLS
+      --hash-func=               Specify which hash function to use when
+                                 calculating the hashes of produced files. If no
+                                 function has been specified, it does not
+                                 happen. This permits avoiding downloading some
+                                 files twice albeit at some performance cost.
+                                 Possible values are: "", "SHA256".
+  -h, --help                     Show context-sensitive help (also try
+                                 --help-long and --help-man).
+      --http-address="0.0.0.0:10902"
+                                 Listen host:port for HTTP endpoints.
+      --http-grace-period=2m     Time to wait after an interrupt received for
+                                 HTTP Server.
       --label=key="value" ...    External labels to announce. This flag will be
                                  removed in the future when handling multiple
                                  tsdb instances is added.
-      --objstore.config-file=<file-path>
-                                 Path to YAML file that contains object store
-                                 configuration. See format details:
-                                 https://thanos.io/tip/thanos/storage.md/#configuration
+      --log.format=logfmt        Log format to use. Possible options: logfmt or
+                                 json.
+      --log.level=info           Log filtering level.
       --objstore.config=<content>
                                  Alternative to 'objstore.config-file' flag
                                  (mutually exclusive). Content of YAML file that
                                  contains object store configuration. See format
                                  details:
                                  https://thanos.io/tip/thanos/storage.md/#configuration
-      --tsdb.retention=15d       How long to retain raw samples on local
-                                 storage. 0d - disables this retention.
+      --objstore.config-file=<file-path>
+                                 Path to YAML file that contains object store
+                                 configuration. See format details:
+                                 https://thanos.io/tip/thanos/storage.md/#configuration
+      --receive.default-tenant-id="default-tenant"
+                                 Default tenant ID to use when none is provided
+                                 via a header.
+      --receive.hashrings=<content>
+                                 Alternative to 'receive.hashrings-file' flag
+                                 (lower priority). Content of file that contains
+                                 the hashring configuration.
       --receive.hashrings-file=<path>
                                  Path to file that contains the hashring
                                  configuration. A watcher is initialized to
                                  watch changes and update the hashring
                                  dynamically.
-      --receive.hashrings=<content>
-                                 Alternative to 'receive.hashrings-file' flag
-                                 (lower priority). Content of file that contains
-                                 the hashring configuration.
       --receive.hashrings-file-refresh-interval=5m
                                  Refresh interval to re-read the hashring
                                  configuration file. (used as a fallback)
@@ -163,43 +136,70 @@ Flags:
                                  Endpoint of local receive node. Used to
                                  identify the local node in the hashring
                                  configuration.
-      --receive.tenant-header="THANOS-TENANT"
-                                 HTTP header to determine tenant for write
-                                 requests.
-      --receive.default-tenant-id="default-tenant"
-                                 Default tenant ID to use when none is provided
-                                 via a header.
-      --receive.tenant-label-name="tenant_id"
-                                 Label name through which the tenant will be
-                                 announced.
       --receive.replica-header="THANOS-REPLICA"
                                  HTTP header specifying the replica number of a
                                  write request.
       --receive.replication-factor=1
                                  How many times to replicate incoming write
                                  requests.
-      --tsdb.allow-overlapping-blocks
-                                 Allow overlapping blocks, which in turn enables
-                                 vertical compaction and vertical query merge.
-      --tsdb.wal-compression     Compress the tsdb WAL.
-      --tsdb.no-lockfile         Do not create lockfile in TSDB data directory.
-                                 In any case, the lockfiles will be deleted on
-                                 next startup.
-      --hash-func=               Specify which hash function to use when
-                                 calculating the hashes of produced files. If no
-                                 function has been specified, it does not
-                                 happen. This permits avoiding downloading some
-                                 files twice albeit at some performance cost.
-                                 Possible values are: "", "SHA256".
-      --request.logging-config-file=<file-path>
-                                 Path to YAML file with request logging
-                                 configuration. See format details:
-                                 https://gist.github.com/yashrsharma44/02f5765c5710dd09ce5d14e854f22825
+      --receive.tenant-header="THANOS-TENANT"
+                                 HTTP header to determine tenant for write
+                                 requests.
+      --receive.tenant-label-name="tenant_id"
+                                 Label name through which the tenant will be
+                                 announced.
+      --remote-write.address="0.0.0.0:19291"
+                                 Address to listen on for remote write requests.
+      --remote-write.client-server-name=""
+                                 Server name to verify the hostname on the
+                                 returned TLS certificates. See
+                                 https://tools.ietf.org/html/rfc4366#section-3.1
+      --remote-write.client-tls-ca=""
+                                 TLS CA Certificates to use to verify servers.
+      --remote-write.client-tls-cert=""
+                                 TLS Certificates to use to identify this client
+                                 to the server.
+      --remote-write.client-tls-key=""
+                                 TLS Key for the client's certificate.
+      --remote-write.server-tls-cert=""
+                                 TLS Certificate for HTTP server, leave blank to
+                                 disable TLS.
+      --remote-write.server-tls-client-ca=""
+                                 TLS CA to verify clients against. If no client
+                                 CA is specified, there is no client
+                                 verification on server side. (tls.NoClientCert)
+      --remote-write.server-tls-key=""
+                                 TLS Key for the HTTP server, leave blank to
+                                 disable TLS.
       --request.logging-config=<content>
                                  Alternative to 'request.logging-config-file'
                                  flag (mutually exclusive). Content of YAML file
                                  with request logging configuration. See format
                                  details:
                                  https://gist.github.com/yashrsharma44/02f5765c5710dd09ce5d14e854f22825
+      --request.logging-config-file=<file-path>
+                                 Path to YAML file with request logging
+                                 configuration. See format details:
+                                 https://gist.github.com/yashrsharma44/02f5765c5710dd09ce5d14e854f22825
+      --tracing.config=<content>
+                                 Alternative to 'tracing.config-file' flag
+                                 (mutually exclusive). Content of YAML file with
+                                 tracing configuration. See format details:
+                                 https://thanos.io/tip/thanos/tracing.md/#configuration
+      --tracing.config-file=<file-path>
+                                 Path to YAML file with tracing configuration.
+                                 See format details:
+                                 https://thanos.io/tip/thanos/tracing.md/#configuration
+      --tsdb.allow-overlapping-blocks
+                                 Allow overlapping blocks, which in turn enables
+                                 vertical compaction and vertical query merge.
+      --tsdb.no-lockfile         Do not create lockfile in TSDB data directory.
+                                 In any case, the lockfiles will be deleted on
+                                 next startup.
+      --tsdb.path="./data"       Data directory of TSDB.
+      --tsdb.retention=15d       How long to retain raw samples on local
+                                 storage. 0d - disables this retention.
+      --tsdb.wal-compression     Compress the tsdb WAL.
+      --version                  Show application version.
 
 ```

--- a/docs/components/rule.md
+++ b/docs/components/rule.md
@@ -236,56 +236,35 @@ Ruler evaluating Prometheus rules against given Query nodes, exposing Store API
 and storing old blocks in bucket.
 
 Flags:
-  -h, --help                     Show context-sensitive help (also try
-                                 --help-long and --help-man).
-      --version                  Show application version.
-      --log.level=info           Log filtering level.
-      --log.format=logfmt        Log format to use. Possible options: logfmt or
-                                 json.
-      --tracing.config-file=<file-path>
-                                 Path to YAML file with tracing configuration.
-                                 See format details:
-                                 https://thanos.io/tip/thanos/tracing.md/#configuration
-      --tracing.config=<content>
-                                 Alternative to 'tracing.config-file' flag
-                                 (mutually exclusive). Content of YAML file with
-                                 tracing configuration. See format details:
-                                 https://thanos.io/tip/thanos/tracing.md/#configuration
-      --http-address="0.0.0.0:10902"
-                                 Listen host:port for HTTP endpoints.
-      --http-grace-period=2m     Time to wait after an interrupt received for
-                                 HTTP Server.
-      --grpc-address="0.0.0.0:10901"
-                                 Listen ip:port address for gRPC endpoints
-                                 (StoreAPI). Make sure this address is routable
-                                 from other components.
-      --grpc-grace-period=2m     Time to wait after an interrupt received for
-                                 GRPC Server.
-      --grpc-server-tls-cert=""  TLS Certificate for gRPC server, leave blank to
-                                 disable TLS
-      --grpc-server-tls-key=""   TLS Key for the gRPC server, leave blank to
-                                 disable TLS
-      --grpc-server-tls-client-ca=""
-                                 TLS CA to verify clients against. If no client
-                                 CA is specified, there is no client
-                                 verification on server side. (tls.NoClientCert)
-      --label=<name>="<value>" ...
-                                 Labels to be applied to all generated metrics
-                                 (repeated). Similar to external labels for
-                                 Prometheus, used to identify ruler and its
-                                 blocks as unique source.
-      --data-dir="data/"         data directory
-      --rule-file=rules/ ...     Rule files that should be used by rule manager.
-                                 Can be in glob format (repeated).
-      --resend-delay=1m          Minimum amount of time to wait before resending
-                                 an alert to Alertmanager.
-      --eval-interval=30s        The default evaluation interval to use.
-      --tsdb.block-duration=2h   Block duration for TSDB block.
-      --tsdb.retention=48h       Block retention time on local disk.
-      --tsdb.no-lockfile         Do not create lockfile in TSDB data directory.
-                                 In any case, the lockfiles will be deleted on
-                                 next startup.
-      --tsdb.wal-compression     Compress the tsdb WAL.
+      --alert.label-drop=ALERT.LABEL-DROP ...
+                                 Labels by name to drop before sending to
+                                 alertmanager. This allows alert to be
+                                 deduplicated on replica label (repeated).
+                                 Similar Prometheus alert relabelling
+      --alert.query-url=ALERT.QUERY-URL
+                                 The external Thanos Query URL that would be set
+                                 in all alerts 'Source' field
+      --alertmanagers.config=<content>
+                                 Alternative to 'alertmanagers.config-file' flag
+                                 (mutually exclusive). Content of YAML file that
+                                 contains alerting configuration. See format
+                                 details:
+                                 https://thanos.io/tip/components/rule.md/#configuration.
+                                 If defined, it takes precedence over the
+                                 '--alertmanagers.url' and
+                                 '--alertmanagers.send-timeout' flags.
+      --alertmanagers.config-file=<file-path>
+                                 Path to YAML file that contains alerting
+                                 configuration. See format details:
+                                 https://thanos.io/tip/components/rule.md/#configuration.
+                                 If defined, it takes precedence over the
+                                 '--alertmanagers.url' and
+                                 '--alertmanagers.send-timeout' flags.
+      --alertmanagers.sd-dns-interval=30s
+                                 Interval between DNS resolutions of
+                                 Alertmanager hosts.
+      --alertmanagers.send-timeout=10s
+                                 Timeout for sending alerts to Alertmanager
       --alertmanagers.url=ALERTMANAGERS.URL ...
                                  Alertmanager replica URLs to push firing
                                  alerts. Ruler claims success if push to at
@@ -297,39 +276,122 @@ Flags:
                                  lookups. The port defaults to 9093 or the SRV
                                  record's value. The URL path is used as a
                                  prefix for the regular Alertmanager API path.
-      --alertmanagers.send-timeout=10s
-                                 Timeout for sending alerts to Alertmanager
-      --alertmanagers.config-file=<file-path>
-                                 Path to YAML file that contains alerting
-                                 configuration. See format details:
-                                 https://thanos.io/tip/components/rule.md/#configuration.
-                                 If defined, it takes precedence over the
-                                 '--alertmanagers.url' and
-                                 '--alertmanagers.send-timeout' flags.
-      --alertmanagers.config=<content>
-                                 Alternative to 'alertmanagers.config-file' flag
+      --data-dir="data/"         data directory
+      --eval-interval=30s        The default evaluation interval to use.
+      --grpc-address="0.0.0.0:10901"
+                                 Listen ip:port address for gRPC endpoints
+                                 (StoreAPI). Make sure this address is routable
+                                 from other components.
+      --grpc-grace-period=2m     Time to wait after an interrupt received for
+                                 GRPC Server.
+      --grpc-server-tls-cert=""  TLS Certificate for gRPC server, leave blank to
+                                 disable TLS
+      --grpc-server-tls-client-ca=""
+                                 TLS CA to verify clients against. If no client
+                                 CA is specified, there is no client
+                                 verification on server side. (tls.NoClientCert)
+      --grpc-server-tls-key=""   TLS Key for the gRPC server, leave blank to
+                                 disable TLS
+      --hash-func=               Specify which hash function to use when
+                                 calculating the hashes of produced files. If no
+                                 function has been specified, it does not
+                                 happen. This permits avoiding downloading some
+                                 files twice albeit at some performance cost.
+                                 Possible values are: "", "SHA256".
+  -h, --help                     Show context-sensitive help (also try
+                                 --help-long and --help-man).
+      --http-address="0.0.0.0:10902"
+                                 Listen host:port for HTTP endpoints.
+      --http-grace-period=2m     Time to wait after an interrupt received for
+                                 HTTP Server.
+      --label=<name>="<value>" ...
+                                 Labels to be applied to all generated metrics
+                                 (repeated). Similar to external labels for
+                                 Prometheus, used to identify ruler and its
+                                 blocks as unique source.
+      --log.format=logfmt        Log format to use. Possible options: logfmt or
+                                 json.
+      --log.level=info           Log filtering level.
+      --log.request.decision=    Deprecation Warning - This flag would be soon
+                                 deprecated, and replaced with
+                                 `request.logging-config`. Request Logging for
+                                 logging the start and end of requests. By
+                                 default this flag is disabled. LogFinishCall:
+                                 Logs the finish call of the requests.
+                                 LogStartAndFinishCall: Logs the start and
+                                 finish call of the requests. NoLogCall: Disable
+                                 request logging.
+      --objstore.config=<content>
+                                 Alternative to 'objstore.config-file' flag
                                  (mutually exclusive). Content of YAML file that
-                                 contains alerting configuration. See format
+                                 contains object store configuration. See format
                                  details:
+                                 https://thanos.io/tip/thanos/storage.md/#configuration
+      --objstore.config-file=<file-path>
+                                 Path to YAML file that contains object store
+                                 configuration. See format details:
+                                 https://thanos.io/tip/thanos/storage.md/#configuration
+      --query=<query> ...        Addresses of statically configured query API
+                                 servers (repeatable). The scheme may be
+                                 prefixed with 'dns+' or 'dnssrv+' to detect
+                                 query API servers through respective DNS
+                                 lookups.
+      --query.config=<content>   Alternative to 'query.config-file' flag
+                                 (mutually exclusive). Content of YAML file that
+                                 contains query API servers configuration. See
+                                 format details:
                                  https://thanos.io/tip/components/rule.md/#configuration.
                                  If defined, it takes precedence over the
-                                 '--alertmanagers.url' and
-                                 '--alertmanagers.send-timeout' flags.
-      --alertmanagers.sd-dns-interval=30s
-                                 Interval between DNS resolutions of
-                                 Alertmanager hosts.
-      --alert.query-url=ALERT.QUERY-URL
-                                 The external Thanos Query URL that would be set
-                                 in all alerts 'Source' field
-      --alert.label-drop=ALERT.LABEL-DROP ...
-                                 Labels by name to drop before sending to
-                                 alertmanager. This allows alert to be
-                                 deduplicated on replica label (repeated).
-                                 Similar Prometheus alert relabelling
-      --web.route-prefix=""      Prefix for API and UI endpoints. This allows
-                                 thanos UI to be served on a sub-path. This
-                                 option is analogous to --web.route-prefix of
-                                 Prometheus.
+                                 '--query' and '--query.sd-files' flags.
+      --query.config-file=<file-path>
+                                 Path to YAML file that contains query API
+                                 servers configuration. See format details:
+                                 https://thanos.io/tip/components/rule.md/#configuration.
+                                 If defined, it takes precedence over the
+                                 '--query' and '--query.sd-files' flags.
+      --query.http-method=POST   HTTP method to use when sending queries.
+                                 Possible options: [GET, POST]
+      --query.sd-dns-interval=30s
+                                 Interval between DNS resolutions.
+      --query.sd-files=<path> ...
+                                 Path to file that contains addresses of query
+                                 API servers. The path can be a glob pattern
+                                 (repeatable).
+      --query.sd-interval=5m     Refresh interval to re-read file SD files.
+                                 (used as a fallback)
+      --request.logging-config=<content>
+                                 Alternative to 'request.logging-config-file'
+                                 flag (mutually exclusive). Content of YAML file
+                                 with request logging configuration. See format
+                                 details:
+                                 https://gist.github.com/yashrsharma44/02f5765c5710dd09ce5d14e854f22825
+      --request.logging-config-file=<file-path>
+                                 Path to YAML file with request logging
+                                 configuration. See format details:
+                                 https://gist.github.com/yashrsharma44/02f5765c5710dd09ce5d14e854f22825
+      --resend-delay=1m          Minimum amount of time to wait before resending
+                                 an alert to Alertmanager.
+      --rule-file=rules/ ...     Rule files that should be used by rule manager.
+                                 Can be in glob format (repeated).
+      --tracing.config=<content>
+                                 Alternative to 'tracing.config-file' flag
+                                 (mutually exclusive). Content of YAML file with
+                                 tracing configuration. See format details:
+                                 https://thanos.io/tip/thanos/tracing.md/#configuration
+      --tracing.config-file=<file-path>
+                                 Path to YAML file with tracing configuration.
+                                 See format details:
+                                 https://thanos.io/tip/thanos/tracing.md/#configuration
+      --tsdb.block-duration=2h   Block duration for TSDB block.
+      --tsdb.no-lockfile         Do not create lockfile in TSDB data directory.
+                                 In any case, the lockfiles will be deleted on
+                                 next startup.
+      --tsdb.retention=48h       Block retention time on local disk.
+      --tsdb.wal-compression     Compress the tsdb WAL.
+      --version                  Show application version.
+      --web.disable-cors         Whether to disable CORS headers to be set by
+                                 Thanos. By default Thanos sets CORS headers to
+                                 be allowed by all.
       --web.external-prefix=""   Static prefix for all HTML links and redirect
                                  URLs in the UI query web interface. Actual
                                  endpoints are still served on / or the
@@ -349,72 +411,10 @@ Flags:
                                  stripped prefix value in X-Forwarded-Prefix
                                  header. This allows thanos UI to be served on a
                                  sub-path.
-      --web.disable-cors         Whether to disable CORS headers to be set by
-                                 Thanos. By default Thanos sets CORS headers to
-                                 be allowed by all.
-      --log.request.decision=    Deprecation Warning - This flag would be soon
-                                 deprecated, and replaced with
-                                 `request.logging-config`. Request Logging for
-                                 logging the start and end of requests. By
-                                 default this flag is disabled. LogFinishCall:
-                                 Logs the finish call of the requests.
-                                 LogStartAndFinishCall: Logs the start and
-                                 finish call of the requests. NoLogCall: Disable
-                                 request logging.
-      --objstore.config-file=<file-path>
-                                 Path to YAML file that contains object store
-                                 configuration. See format details:
-                                 https://thanos.io/tip/thanos/storage.md/#configuration
-      --objstore.config=<content>
-                                 Alternative to 'objstore.config-file' flag
-                                 (mutually exclusive). Content of YAML file that
-                                 contains object store configuration. See format
-                                 details:
-                                 https://thanos.io/tip/thanos/storage.md/#configuration
-      --query=<query> ...        Addresses of statically configured query API
-                                 servers (repeatable). The scheme may be
-                                 prefixed with 'dns+' or 'dnssrv+' to detect
-                                 query API servers through respective DNS
-                                 lookups.
-      --query.config-file=<file-path>
-                                 Path to YAML file that contains query API
-                                 servers configuration. See format details:
-                                 https://thanos.io/tip/components/rule.md/#configuration.
-                                 If defined, it takes precedence over the
-                                 '--query' and '--query.sd-files' flags.
-      --query.config=<content>   Alternative to 'query.config-file' flag
-                                 (mutually exclusive). Content of YAML file that
-                                 contains query API servers configuration. See
-                                 format details:
-                                 https://thanos.io/tip/components/rule.md/#configuration.
-                                 If defined, it takes precedence over the
-                                 '--query' and '--query.sd-files' flags.
-      --query.sd-files=<path> ...
-                                 Path to file that contains addresses of query
-                                 API servers. The path can be a glob pattern
-                                 (repeatable).
-      --query.sd-interval=5m     Refresh interval to re-read file SD files.
-                                 (used as a fallback)
-      --query.sd-dns-interval=30s
-                                 Interval between DNS resolutions.
-      --query.http-method=POST   HTTP method to use when sending queries.
-                                 Possible options: [GET, POST]
-      --hash-func=               Specify which hash function to use when
-                                 calculating the hashes of produced files. If no
-                                 function has been specified, it does not
-                                 happen. This permits avoiding downloading some
-                                 files twice albeit at some performance cost.
-                                 Possible values are: "", "SHA256".
-      --request.logging-config-file=<file-path>
-                                 Path to YAML file with request logging
-                                 configuration. See format details:
-                                 https://gist.github.com/yashrsharma44/02f5765c5710dd09ce5d14e854f22825
-      --request.logging-config=<content>
-                                 Alternative to 'request.logging-config-file'
-                                 flag (mutually exclusive). Content of YAML file
-                                 with request logging configuration. See format
-                                 details:
-                                 https://gist.github.com/yashrsharma44/02f5765c5710dd09ce5d14e854f22825
+      --web.route-prefix=""      Prefix for API and UI endpoints. This allows
+                                 thanos UI to be served on a sub-path. This
+                                 option is analogous to --web.route-prefix of
+                                 Prometheus.
 
 ```
 

--- a/docs/components/sidecar.md
+++ b/docs/components/sidecar.md
@@ -82,25 +82,6 @@ usage: thanos sidecar [<flags>]
 Sidecar for Prometheus server.
 
 Flags:
-  -h, --help                     Show context-sensitive help (also try
-                                 --help-long and --help-man).
-      --version                  Show application version.
-      --log.level=info           Log filtering level.
-      --log.format=logfmt        Log format to use. Possible options: logfmt or
-                                 json.
-      --tracing.config-file=<file-path>
-                                 Path to YAML file with tracing configuration.
-                                 See format details:
-                                 https://thanos.io/tip/thanos/tracing.md/#configuration
-      --tracing.config=<content>
-                                 Alternative to 'tracing.config-file' flag
-                                 (mutually exclusive). Content of YAML file with
-                                 tracing configuration. See format details:
-                                 https://thanos.io/tip/thanos/tracing.md/#configuration
-      --http-address="0.0.0.0:10902"
-                                 Listen host:port for HTTP endpoints.
-      --http-grace-period=2m     Time to wait after an interrupt received for
-                                 HTTP Server.
       --grpc-address="0.0.0.0:10901"
                                  Listen ip:port address for gRPC endpoints
                                  (StoreAPI). Make sure this address is routable
@@ -109,69 +90,27 @@ Flags:
                                  GRPC Server.
       --grpc-server-tls-cert=""  TLS Certificate for gRPC server, leave blank to
                                  disable TLS
-      --grpc-server-tls-key=""   TLS Key for the gRPC server, leave blank to
-                                 disable TLS
       --grpc-server-tls-client-ca=""
                                  TLS CA to verify clients against. If no client
                                  CA is specified, there is no client
                                  verification on server side. (tls.NoClientCert)
-      --prometheus.url=http://localhost:9090
-                                 URL at which to reach Prometheus's API. For
-                                 better performance use local network.
-      --prometheus.ready_timeout=10m
-                                 Maximum time to wait for the Prometheus
-                                 instance to start up
-      --receive.connection-pool-size=RECEIVE.CONNECTION-POOL-SIZE
-                                 Controls the http MaxIdleConns. Default is 0,
-                                 which is unlimited
-      --receive.connection-pool-size-per-host=100
-                                 Controls the http MaxIdleConnsPerHost
-      --tsdb.path="./data"       Data directory of TSDB.
-      --reloader.config-file=""  Config file watched by the reloader.
-      --reloader.config-envsubst-file=""
-                                 Output file for environment variable
-                                 substituted config file.
-      --reloader.rule-dir=RELOADER.RULE-DIR ...
-                                 Rule directories for the reloader to refresh
-                                 (repeated field).
-      --reloader.watch-interval=3m
-                                 Controls how often reloader re-reads config and
-                                 rules.
-      --reloader.retry-interval=5s
-                                 Controls how often reloader retries config
-                                 reload in case of error.
-      --request.logging-config-file=<file-path>
-                                 Path to YAML file with request logging
-                                 configuration. See format details:
-                                 https://gist.github.com/yashrsharma44/02f5765c5710dd09ce5d14e854f22825
-      --request.logging-config=<content>
-                                 Alternative to 'request.logging-config-file'
-                                 flag (mutually exclusive). Content of YAML file
-                                 with request logging configuration. See format
-                                 details:
-                                 https://gist.github.com/yashrsharma44/02f5765c5710dd09ce5d14e854f22825
-      --objstore.config-file=<file-path>
-                                 Path to YAML file that contains object store
-                                 configuration. See format details:
-                                 https://thanos.io/tip/thanos/storage.md/#configuration
-      --objstore.config=<content>
-                                 Alternative to 'objstore.config-file' flag
-                                 (mutually exclusive). Content of YAML file that
-                                 contains object store configuration. See format
-                                 details:
-                                 https://thanos.io/tip/thanos/storage.md/#configuration
-      --shipper.upload-compacted
-                                 If true shipper will try to upload compacted
-                                 blocks as well. Useful for migration purposes.
-                                 Works only if compaction is disabled on
-                                 Prometheus. Do it once and then disable the
-                                 flag when done.
+      --grpc-server-tls-key=""   TLS Key for the gRPC server, leave blank to
+                                 disable TLS
       --hash-func=               Specify which hash function to use when
                                  calculating the hashes of produced files. If no
                                  function has been specified, it does not
                                  happen. This permits avoiding downloading some
                                  files twice albeit at some performance cost.
                                  Possible values are: "", "SHA256".
+  -h, --help                     Show context-sensitive help (also try
+                                 --help-long and --help-man).
+      --http-address="0.0.0.0:10902"
+                                 Listen host:port for HTTP endpoints.
+      --http-grace-period=2m     Time to wait after an interrupt received for
+                                 HTTP Server.
+      --log.format=logfmt        Log format to use. Possible options: logfmt or
+                                 json.
+      --log.level=info           Log filtering level.
       --min-time=0000-01-01T00:00:00Z
                                  Start of time range limit to serve. Thanos
                                  sidecar will serve only metrics, which happened
@@ -179,5 +118,66 @@ Flags:
                                  time in RFC3339 format or time duration
                                  relative to current time, such as -1d or 2h45m.
                                  Valid duration units are ms, s, m, h, d, w, y.
+      --objstore.config=<content>
+                                 Alternative to 'objstore.config-file' flag
+                                 (mutually exclusive). Content of YAML file that
+                                 contains object store configuration. See format
+                                 details:
+                                 https://thanos.io/tip/thanos/storage.md/#configuration
+      --objstore.config-file=<file-path>
+                                 Path to YAML file that contains object store
+                                 configuration. See format details:
+                                 https://thanos.io/tip/thanos/storage.md/#configuration
+      --prometheus.ready_timeout=10m
+                                 Maximum time to wait for the Prometheus
+                                 instance to start up
+      --prometheus.url=http://localhost:9090
+                                 URL at which to reach Prometheus's API. For
+                                 better performance use local network.
+      --receive.connection-pool-size=RECEIVE.CONNECTION-POOL-SIZE
+                                 Controls the http MaxIdleConns. Default is 0,
+                                 which is unlimited
+      --receive.connection-pool-size-per-host=100
+                                 Controls the http MaxIdleConnsPerHost
+      --reloader.config-envsubst-file=""
+                                 Output file for environment variable
+                                 substituted config file.
+      --reloader.config-file=""  Config file watched by the reloader.
+      --reloader.retry-interval=5s
+                                 Controls how often reloader retries config
+                                 reload in case of error.
+      --reloader.rule-dir=RELOADER.RULE-DIR ...
+                                 Rule directories for the reloader to refresh
+                                 (repeated field).
+      --reloader.watch-interval=3m
+                                 Controls how often reloader re-reads config and
+                                 rules.
+      --request.logging-config=<content>
+                                 Alternative to 'request.logging-config-file'
+                                 flag (mutually exclusive). Content of YAML file
+                                 with request logging configuration. See format
+                                 details:
+                                 https://gist.github.com/yashrsharma44/02f5765c5710dd09ce5d14e854f22825
+      --request.logging-config-file=<file-path>
+                                 Path to YAML file with request logging
+                                 configuration. See format details:
+                                 https://gist.github.com/yashrsharma44/02f5765c5710dd09ce5d14e854f22825
+      --shipper.upload-compacted
+                                 If true shipper will try to upload compacted
+                                 blocks as well. Useful for migration purposes.
+                                 Works only if compaction is disabled on
+                                 Prometheus. Do it once and then disable the
+                                 flag when done.
+      --tracing.config=<content>
+                                 Alternative to 'tracing.config-file' flag
+                                 (mutually exclusive). Content of YAML file with
+                                 tracing configuration. See format details:
+                                 https://thanos.io/tip/thanos/tracing.md/#configuration
+      --tracing.config-file=<file-path>
+                                 Path to YAML file with tracing configuration.
+                                 See format details:
+                                 https://thanos.io/tip/thanos/tracing.md/#configuration
+      --tsdb.path="./data"       Data directory of TSDB.
+      --version                  Show application version.
 
 ```

--- a/docs/components/store.md
+++ b/docs/components/store.md
@@ -35,25 +35,26 @@ Store node giving access to blocks in a bucket provider. Now supported GCS, S3,
 Azure, Swift, Tencent COS and Aliyun OSS.
 
 Flags:
-  -h, --help                     Show context-sensitive help (also try
-                                 --help-long and --help-man).
-      --version                  Show application version.
-      --log.level=info           Log filtering level.
-      --log.format=logfmt        Log format to use. Possible options: logfmt or
-                                 json.
-      --tracing.config-file=<file-path>
-                                 Path to YAML file with tracing configuration.
-                                 See format details:
-                                 https://thanos.io/tip/thanos/tracing.md/#configuration
-      --tracing.config=<content>
-                                 Alternative to 'tracing.config-file' flag
-                                 (mutually exclusive). Content of YAML file with
-                                 tracing configuration. See format details:
-                                 https://thanos.io/tip/thanos/tracing.md/#configuration
-      --http-address="0.0.0.0:10902"
-                                 Listen host:port for HTTP endpoints.
-      --http-grace-period=2m     Time to wait after an interrupt received for
-                                 HTTP Server.
+      --block-meta-fetch-concurrency=32
+                                 Number of goroutines to use when fetching block
+                                 metadata from object storage.
+      --block-sync-concurrency=20
+                                 Number of goroutines to use when constructing
+                                 index-cache.json blocks from object storage.
+      --chunk-pool-size=2GB      Maximum size of concurrently allocatable bytes
+                                 reserved strictly to reuse for chunks in
+                                 memory.
+      --consistency-delay=0s     Minimum age of all blocks before they are being
+                                 read. Set it to safe value (e.g 30m) if your
+                                 object storage is eventually consistent. GCS
+                                 and S3 are (roughly) strongly consistent.
+      --data-dir="./data"        Local data directory used for caching purposes
+                                 (index-header, in-mem cache items and
+                                 meta.jsons). If removed, no data will be lost,
+                                 just store will have to rebuild the cache.
+                                 NOTE: Putting raw blocks here will not cause
+                                 the store to read them. For such use cases use
+                                 Prometheus + sidecar.
       --grpc-address="0.0.0.0:10901"
                                  Listen ip:port address for gRPC endpoints
                                  (StoreAPI). Make sure this address is routable
@@ -62,101 +63,18 @@ Flags:
                                  GRPC Server.
       --grpc-server-tls-cert=""  TLS Certificate for gRPC server, leave blank to
                                  disable TLS
-      --grpc-server-tls-key=""   TLS Key for the gRPC server, leave blank to
-                                 disable TLS
       --grpc-server-tls-client-ca=""
                                  TLS CA to verify clients against. If no client
                                  CA is specified, there is no client
                                  verification on server side. (tls.NoClientCert)
-      --data-dir="./data"        Local data directory used for caching purposes
-                                 (index-header, in-mem cache items and
-                                 meta.jsons). If removed, no data will be lost,
-                                 just store will have to rebuild the cache.
-                                 NOTE: Putting raw blocks here will not cause
-                                 the store to read them. For such use cases use
-                                 Prometheus + sidecar.
-      --index-cache-size=250MB   Maximum size of items held in the in-memory
-                                 index cache. Ignored if --index-cache.config or
-                                 --index-cache.config-file option is specified.
-      --index-cache.config-file=<file-path>
-                                 Path to YAML file that contains index cache
-                                 configuration. See format details:
-                                 https://thanos.io/tip/components/store.md/#index-cache
-      --index-cache.config=<content>
-                                 Alternative to 'index-cache.config-file' flag
-                                 (mutually exclusive). Content of YAML file that
-                                 contains index cache configuration. See format
-                                 details:
-                                 https://thanos.io/tip/components/store.md/#index-cache
-      --chunk-pool-size=2GB      Maximum size of concurrently allocatable bytes
-                                 reserved strictly to reuse for chunks in
-                                 memory.
-      --store.grpc.series-sample-limit=0
-                                 Maximum amount of samples returned via a single
-                                 Series call. The Series call fails if this
-                                 limit is exceeded. 0 means no limit. NOTE: For
-                                 efficiency the limit is internally implemented
-                                 as 'chunks limit' considering each chunk
-                                 contains 120 samples (it's the max number of
-                                 samples each chunk can contain), so the actual
-                                 number of samples might be lower, even though
-                                 the maximum could be hit.
-      --store.grpc.touched-series-limit=0
-                                 Maximum amount of touched series returned via a
-                                 single Series call. The Series call fails if
-                                 this limit is exceeded. 0 means no limit.
-      --store.grpc.series-max-concurrency=20
-                                 Maximum number of concurrent Series calls.
-      --objstore.config-file=<file-path>
-                                 Path to YAML file that contains object store
-                                 configuration. See format details:
-                                 https://thanos.io/tip/thanos/storage.md/#configuration
-      --objstore.config=<content>
-                                 Alternative to 'objstore.config-file' flag
-                                 (mutually exclusive). Content of YAML file that
-                                 contains object store configuration. See format
-                                 details:
-                                 https://thanos.io/tip/thanos/storage.md/#configuration
-      --sync-block-duration=3m   Repeat interval for syncing the blocks between
-                                 local and remote view.
-      --block-sync-concurrency=20
-                                 Number of goroutines to use when constructing
-                                 index-cache.json blocks from object storage.
-      --block-meta-fetch-concurrency=32
-                                 Number of goroutines to use when fetching block
-                                 metadata from object storage.
-      --min-time=0000-01-01T00:00:00Z
-                                 Start of time range limit to serve. Thanos
-                                 Store will serve only metrics, which happened
-                                 later than this value. Option can be a constant
-                                 time in RFC3339 format or time duration
-                                 relative to current time, such as -1d or 2h45m.
-                                 Valid duration units are ms, s, m, h, d, w, y.
-      --max-time=9999-12-31T23:59:59Z
-                                 End of time range limit to serve. Thanos Store
-                                 will serve only blocks, which happened earlier
-                                 than this value. Option can be a constant time
-                                 in RFC3339 format or time duration relative to
-                                 current time, such as -1d or 2h45m. Valid
-                                 duration units are ms, s, m, h, d, w, y.
-      --selector.relabel-config-file=<file-path>
-                                 Path to YAML file that contains relabeling
-                                 configuration that allows selecting blocks. It
-                                 follows native Prometheus relabel-config
-                                 syntax. See format details:
-                                 https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
-      --selector.relabel-config=<content>
-                                 Alternative to 'selector.relabel-config-file'
-                                 flag (mutually exclusive). Content of YAML file
-                                 that contains relabeling configuration that
-                                 allows selecting blocks. It follows native
-                                 Prometheus relabel-config syntax. See format
-                                 details:
-                                 https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
-      --consistency-delay=0s     Minimum age of all blocks before they are being
-                                 read. Set it to safe value (e.g 30m) if your
-                                 object storage is eventually consistent. GCS
-                                 and S3 are (roughly) strongly consistent.
+      --grpc-server-tls-key=""   TLS Key for the gRPC server, leave blank to
+                                 disable TLS
+  -h, --help                     Show context-sensitive help (also try
+                                 --help-long and --help-man).
+      --http-address="0.0.0.0:10902"
+                                 Listen host:port for HTTP endpoints.
+      --http-grace-period=2m     Time to wait after an interrupt received for
+                                 HTTP Server.
       --ignore-deletion-marks-delay=24h
                                  Duration after which the blocks marked for
                                  deletion will be filtered out while fetching
@@ -178,10 +96,105 @@ Flags:
                                  before being deleted from bucket. Default is
                                  24h, half of the default value for
                                  --delete-delay on compactor.
+      --index-cache-size=250MB   Maximum size of items held in the in-memory
+                                 index cache. Ignored if --index-cache.config or
+                                 --index-cache.config-file option is specified.
+      --index-cache.config=<content>
+                                 Alternative to 'index-cache.config-file' flag
+                                 (mutually exclusive). Content of YAML file that
+                                 contains index cache configuration. See format
+                                 details:
+                                 https://thanos.io/tip/components/store.md/#index-cache
+      --index-cache.config-file=<file-path>
+                                 Path to YAML file that contains index cache
+                                 configuration. See format details:
+                                 https://thanos.io/tip/components/store.md/#index-cache
+      --log.format=logfmt        Log format to use. Possible options: logfmt or
+                                 json.
+      --log.level=info           Log filtering level.
+      --max-time=9999-12-31T23:59:59Z
+                                 End of time range limit to serve. Thanos Store
+                                 will serve only blocks, which happened earlier
+                                 than this value. Option can be a constant time
+                                 in RFC3339 format or time duration relative to
+                                 current time, such as -1d or 2h45m. Valid
+                                 duration units are ms, s, m, h, d, w, y.
+      --min-time=0000-01-01T00:00:00Z
+                                 Start of time range limit to serve. Thanos
+                                 Store will serve only metrics, which happened
+                                 later than this value. Option can be a constant
+                                 time in RFC3339 format or time duration
+                                 relative to current time, such as -1d or 2h45m.
+                                 Valid duration units are ms, s, m, h, d, w, y.
+      --objstore.config=<content>
+                                 Alternative to 'objstore.config-file' flag
+                                 (mutually exclusive). Content of YAML file that
+                                 contains object store configuration. See format
+                                 details:
+                                 https://thanos.io/tip/thanos/storage.md/#configuration
+      --objstore.config-file=<file-path>
+                                 Path to YAML file that contains object store
+                                 configuration. See format details:
+                                 https://thanos.io/tip/thanos/storage.md/#configuration
+      --request.logging-config=<content>
+                                 Alternative to 'request.logging-config-file'
+                                 flag (mutually exclusive). Content of YAML file
+                                 with request logging configuration. See format
+                                 details:
+                                 https://gist.github.com/yashrsharma44/02f5765c5710dd09ce5d14e854f22825
+      --request.logging-config-file=<file-path>
+                                 Path to YAML file with request logging
+                                 configuration. See format details:
+                                 https://gist.github.com/yashrsharma44/02f5765c5710dd09ce5d14e854f22825
+      --selector.relabel-config=<content>
+                                 Alternative to 'selector.relabel-config-file'
+                                 flag (mutually exclusive). Content of YAML file
+                                 that contains relabeling configuration that
+                                 allows selecting blocks. It follows native
+                                 Prometheus relabel-config syntax. See format
+                                 details:
+                                 https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
+      --selector.relabel-config-file=<file-path>
+                                 Path to YAML file that contains relabeling
+                                 configuration that allows selecting blocks. It
+                                 follows native Prometheus relabel-config
+                                 syntax. See format details:
+                                 https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
       --store.enable-index-header-lazy-reader
                                  If true, Store Gateway will lazy memory map
                                  index-header only once the block is required by
                                  a query.
+      --store.grpc.series-max-concurrency=20
+                                 Maximum number of concurrent Series calls.
+      --store.grpc.series-sample-limit=0
+                                 Maximum amount of samples returned via a single
+                                 Series call. The Series call fails if this
+                                 limit is exceeded. 0 means no limit. NOTE: For
+                                 efficiency the limit is internally implemented
+                                 as 'chunks limit' considering each chunk
+                                 contains 120 samples (it's the max number of
+                                 samples each chunk can contain), so the actual
+                                 number of samples might be lower, even though
+                                 the maximum could be hit.
+      --store.grpc.touched-series-limit=0
+                                 Maximum amount of touched series returned via a
+                                 single Series call. The Series call fails if
+                                 this limit is exceeded. 0 means no limit.
+      --sync-block-duration=3m   Repeat interval for syncing the blocks between
+                                 local and remote view.
+      --tracing.config=<content>
+                                 Alternative to 'tracing.config-file' flag
+                                 (mutually exclusive). Content of YAML file with
+                                 tracing configuration. See format details:
+                                 https://thanos.io/tip/thanos/tracing.md/#configuration
+      --tracing.config-file=<file-path>
+                                 Path to YAML file with tracing configuration.
+                                 See format details:
+                                 https://thanos.io/tip/thanos/tracing.md/#configuration
+      --version                  Show application version.
+      --web.disable-cors         Whether to disable CORS headers to be set by
+                                 Thanos. By default Thanos sets CORS headers to
+                                 be allowed by all.
       --web.external-prefix=""   Static prefix for all HTML links and redirect
                                  URLs in the bucket web UI interface. Actual
                                  endpoints are still served on / or the
@@ -201,19 +214,6 @@ Flags:
                                  stripped prefix value in X-Forwarded-Prefix
                                  header. This allows thanos UI to be served on a
                                  sub-path.
-      --web.disable-cors         Whether to disable CORS headers to be set by
-                                 Thanos. By default Thanos sets CORS headers to
-                                 be allowed by all.
-      --request.logging-config-file=<file-path>
-                                 Path to YAML file with request logging
-                                 configuration. See format details:
-                                 https://gist.github.com/yashrsharma44/02f5765c5710dd09ce5d14e854f22825
-      --request.logging-config=<content>
-                                 Alternative to 'request.logging-config-file'
-                                 flag (mutually exclusive). Content of YAML file
-                                 with request logging configuration. See format
-                                 details:
-                                 https://gist.github.com/yashrsharma44/02f5765c5710dd09ce5d14e854f22825
 
 ```
 

--- a/docs/components/tools.md
+++ b/docs/components/tools.md
@@ -22,18 +22,18 @@ Tools utility commands
 Flags:
   -h, --help               Show context-sensitive help (also try --help-long and
                            --help-man).
-      --version            Show application version.
-      --log.level=info     Log filtering level.
       --log.format=logfmt  Log format to use. Possible options: logfmt or json.
-      --tracing.config-file=<file-path>
-                           Path to YAML file with tracing configuration. See
-                           format details:
-                           https://thanos.io/tip/thanos/tracing.md/#configuration
+      --log.level=info     Log filtering level.
       --tracing.config=<content>
                            Alternative to 'tracing.config-file' flag (mutually
                            exclusive). Content of YAML file with tracing
                            configuration. See format details:
                            https://thanos.io/tip/thanos/tracing.md/#configuration
+      --tracing.config-file=<file-path>
+                           Path to YAML file with tracing configuration. See
+                           format details:
+                           https://thanos.io/tip/thanos/tracing.md/#configuration
+      --version            Show application version.
 
 Subcommands:
   tools bucket verify [<flags>]
@@ -119,27 +119,27 @@ Bucket utility commands
 Flags:
   -h, --help               Show context-sensitive help (also try --help-long and
                            --help-man).
-      --version            Show application version.
-      --log.level=info     Log filtering level.
       --log.format=logfmt  Log format to use. Possible options: logfmt or json.
-      --tracing.config-file=<file-path>
-                           Path to YAML file with tracing configuration. See
-                           format details:
-                           https://thanos.io/tip/thanos/tracing.md/#configuration
-      --tracing.config=<content>
-                           Alternative to 'tracing.config-file' flag (mutually
-                           exclusive). Content of YAML file with tracing
-                           configuration. See format details:
-                           https://thanos.io/tip/thanos/tracing.md/#configuration
-      --objstore.config-file=<file-path>
-                           Path to YAML file that contains object store
-                           configuration. See format details:
-                           https://thanos.io/tip/thanos/storage.md/#configuration
+      --log.level=info     Log filtering level.
       --objstore.config=<content>
                            Alternative to 'objstore.config-file' flag (mutually
                            exclusive). Content of YAML file that contains object
                            store configuration. See format details:
                            https://thanos.io/tip/thanos/storage.md/#configuration
+      --objstore.config-file=<file-path>
+                           Path to YAML file that contains object store
+                           configuration. See format details:
+                           https://thanos.io/tip/thanos/storage.md/#configuration
+      --tracing.config=<content>
+                           Alternative to 'tracing.config-file' flag (mutually
+                           exclusive). Content of YAML file with tracing
+                           configuration. See format details:
+                           https://thanos.io/tip/thanos/tracing.md/#configuration
+      --tracing.config-file=<file-path>
+                           Path to YAML file with tracing configuration. See
+                           format details:
+                           https://thanos.io/tip/thanos/tracing.md/#configuration
+      --version            Show application version.
 
 Subcommands:
   tools bucket verify [<flags>]
@@ -214,38 +214,40 @@ Web interface for remote storage bucket.
 Flags:
   -h, --help                    Show context-sensitive help (also try
                                 --help-long and --help-man).
-      --version                 Show application version.
-      --log.level=info          Log filtering level.
+      --http-address="0.0.0.0:10902"
+                                Listen host:port for HTTP endpoints.
+      --http-grace-period=2m    Time to wait after an interrupt received for
+                                HTTP Server.
+      --label=LABEL             Prometheus label to use as timeline title
       --log.format=logfmt       Log format to use. Possible options: logfmt or
                                 json.
-      --tracing.config-file=<file-path>
-                                Path to YAML file with tracing configuration.
-                                See format details:
-                                https://thanos.io/tip/thanos/tracing.md/#configuration
-      --tracing.config=<content>
-                                Alternative to 'tracing.config-file' flag
-                                (mutually exclusive). Content of YAML file with
-                                tracing configuration. See format details:
-                                https://thanos.io/tip/thanos/tracing.md/#configuration
-      --objstore.config-file=<file-path>
-                                Path to YAML file that contains object store
-                                configuration. See format details:
-                                https://thanos.io/tip/thanos/storage.md/#configuration
+      --log.level=info          Log filtering level.
       --objstore.config=<content>
                                 Alternative to 'objstore.config-file' flag
                                 (mutually exclusive). Content of YAML file that
                                 contains object store configuration. See format
                                 details:
                                 https://thanos.io/tip/thanos/storage.md/#configuration
-      --http-address="0.0.0.0:10902"
-                                Listen host:port for HTTP endpoints.
-      --http-grace-period=2m    Time to wait after an interrupt received for
-                                HTTP Server.
-      --web.route-prefix=""     Prefix for API and UI endpoints. This allows
-                                thanos UI to be served on a sub-path. Defaults
-                                to the value of --web.external-prefix. This
-                                option is analogous to --web.route-prefix of
-                                Prometheus.
+      --objstore.config-file=<file-path>
+                                Path to YAML file that contains object store
+                                configuration. See format details:
+                                https://thanos.io/tip/thanos/storage.md/#configuration
+      --refresh=30m             Refresh interval to download metadata from
+                                remote storage
+      --timeout=5m              Timeout to download metadata from remote storage
+      --tracing.config=<content>
+                                Alternative to 'tracing.config-file' flag
+                                (mutually exclusive). Content of YAML file with
+                                tracing configuration. See format details:
+                                https://thanos.io/tip/thanos/tracing.md/#configuration
+      --tracing.config-file=<file-path>
+                                Path to YAML file with tracing configuration.
+                                See format details:
+                                https://thanos.io/tip/thanos/tracing.md/#configuration
+      --version                 Show application version.
+      --web.disable-cors        Whether to disable CORS headers to be set by
+                                Thanos. By default Thanos sets CORS headers to
+                                be allowed by all.
       --web.external-prefix=""  Static prefix for all HTML links and redirect
                                 URLs in the bucket web UI interface. Actual
                                 endpoints are still served on / or the
@@ -265,13 +267,11 @@ Flags:
                                 stripped prefix value in X-Forwarded-Prefix
                                 header. This allows thanos UI to be served on a
                                 sub-path.
-      --web.disable-cors        Whether to disable CORS headers to be set by
-                                Thanos. By default Thanos sets CORS headers to
-                                be allowed by all.
-      --refresh=30m             Refresh interval to download metadata from
-                                remote storage
-      --timeout=5m              Timeout to download metadata from remote storage
-      --label=LABEL             Prometheus label to use as timeline title
+      --web.route-prefix=""     Prefix for API and UI endpoints. This allows
+                                thanos UI to be served on a sub-path. Defaults
+                                to the value of --web.external-prefix. This
+                                option is analogous to --web.route-prefix of
+                                Prometheus.
 
 ```
 
@@ -296,53 +296,6 @@ issue this might take time and will need downloading all specified blocks to
 disk.
 
 Flags:
-  -h, --help               Show context-sensitive help (also try --help-long and
-                           --help-man).
-      --version            Show application version.
-      --log.level=info     Log filtering level.
-      --log.format=logfmt  Log format to use. Possible options: logfmt or json.
-      --tracing.config-file=<file-path>
-                           Path to YAML file with tracing configuration. See
-                           format details:
-                           https://thanos.io/tip/thanos/tracing.md/#configuration
-      --tracing.config=<content>
-                           Alternative to 'tracing.config-file' flag (mutually
-                           exclusive). Content of YAML file with tracing
-                           configuration. See format details:
-                           https://thanos.io/tip/thanos/tracing.md/#configuration
-      --objstore.config-file=<file-path>
-                           Path to YAML file that contains object store
-                           configuration. See format details:
-                           https://thanos.io/tip/thanos/storage.md/#configuration
-      --objstore.config=<content>
-                           Alternative to 'objstore.config-file' flag (mutually
-                           exclusive). Content of YAML file that contains object
-                           store configuration. See format details:
-                           https://thanos.io/tip/thanos/storage.md/#configuration
-      --objstore-backup.config-file=<file-path>
-                           Path to YAML file that contains object store-backup
-                           configuration. See format details:
-                           https://thanos.io/tip/thanos/storage.md/#configuration
-                           Used for repair logic to backup blocks before
-                           removal.
-      --objstore-backup.config=<content>
-                           Alternative to 'objstore-backup.config-file' flag
-                           (mutually exclusive). Content of YAML file that
-                           contains object store-backup configuration. See
-                           format details:
-                           https://thanos.io/tip/thanos/storage.md/#configuration
-                           Used for repair logic to backup blocks before
-                           removal.
-  -r, --repair             Attempt to repair blocks for which issues were
-                           detected
-  -i, --issues=index_known_issues... ...
-                           Issues to verify (and optionally repair). Possible
-                           issue to verify, without repair: [overlapped_blocks];
-                           Possible issue to verify and repair:
-                           [index_known_issues duplicated_compaction]
-      --id=ID ...          Block IDs to verify (and optionally repair) only. If
-                           none is specified, all blocks will be verified.
-                           Repeated field
       --delete-delay=0s    Duration after which blocks marked for deletion would
                            be deleted permanently from source bucket by
                            compactor component. If delete-delay is non zero,
@@ -355,6 +308,53 @@ Flags:
                            gateway still has the block loaded, or compactor is
                            ignoring the deletion because it's compacting the
                            block at the same time.
+  -h, --help               Show context-sensitive help (also try --help-long and
+                           --help-man).
+      --id=ID ...          Block IDs to verify (and optionally repair) only. If
+                           none is specified, all blocks will be verified.
+                           Repeated field
+  -i, --issues=index_known_issues... ...
+                           Issues to verify (and optionally repair). Possible
+                           issue to verify, without repair: [overlapped_blocks];
+                           Possible issue to verify and repair:
+                           [index_known_issues duplicated_compaction]
+      --log.format=logfmt  Log format to use. Possible options: logfmt or json.
+      --log.level=info     Log filtering level.
+      --objstore-backup.config=<content>
+                           Alternative to 'objstore-backup.config-file' flag
+                           (mutually exclusive). Content of YAML file that
+                           contains object store-backup configuration. See
+                           format details:
+                           https://thanos.io/tip/thanos/storage.md/#configuration
+                           Used for repair logic to backup blocks before
+                           removal.
+      --objstore-backup.config-file=<file-path>
+                           Path to YAML file that contains object store-backup
+                           configuration. See format details:
+                           https://thanos.io/tip/thanos/storage.md/#configuration
+                           Used for repair logic to backup blocks before
+                           removal.
+      --objstore.config=<content>
+                           Alternative to 'objstore.config-file' flag (mutually
+                           exclusive). Content of YAML file that contains object
+                           store configuration. See format details:
+                           https://thanos.io/tip/thanos/storage.md/#configuration
+      --objstore.config-file=<file-path>
+                           Path to YAML file that contains object store
+                           configuration. See format details:
+                           https://thanos.io/tip/thanos/storage.md/#configuration
+  -r, --repair             Attempt to repair blocks for which issues were
+                           detected
+      --tracing.config=<content>
+                           Alternative to 'tracing.config-file' flag (mutually
+                           exclusive). Content of YAML file with tracing
+                           configuration. See format details:
+                           https://thanos.io/tip/thanos/tracing.md/#configuration
+      --tracing.config-file=<file-path>
+                           Path to YAML file with tracing configuration. See
+                           format details:
+                           https://thanos.io/tip/thanos/tracing.md/#configuration
+      --version            Show application version.
 
 ```
 
@@ -377,30 +377,30 @@ List all blocks in the bucket.
 Flags:
   -h, --help               Show context-sensitive help (also try --help-long and
                            --help-man).
-      --version            Show application version.
-      --log.level=info     Log filtering level.
       --log.format=logfmt  Log format to use. Possible options: logfmt or json.
-      --tracing.config-file=<file-path>
-                           Path to YAML file with tracing configuration. See
-                           format details:
-                           https://thanos.io/tip/thanos/tracing.md/#configuration
-      --tracing.config=<content>
-                           Alternative to 'tracing.config-file' flag (mutually
-                           exclusive). Content of YAML file with tracing
-                           configuration. See format details:
-                           https://thanos.io/tip/thanos/tracing.md/#configuration
-      --objstore.config-file=<file-path>
-                           Path to YAML file that contains object store
-                           configuration. See format details:
-                           https://thanos.io/tip/thanos/storage.md/#configuration
+      --log.level=info     Log filtering level.
       --objstore.config=<content>
                            Alternative to 'objstore.config-file' flag (mutually
                            exclusive). Content of YAML file that contains object
                            store configuration. See format details:
                            https://thanos.io/tip/thanos/storage.md/#configuration
+      --objstore.config-file=<file-path>
+                           Path to YAML file that contains object store
+                           configuration. See format details:
+                           https://thanos.io/tip/thanos/storage.md/#configuration
   -o, --output=""          Optional format in which to print each block's
                            information. Options are 'json', 'wide' or a custom
                            template.
+      --tracing.config=<content>
+                           Alternative to 'tracing.config-file' flag (mutually
+                           exclusive). Content of YAML file with tracing
+                           configuration. See format details:
+                           https://thanos.io/tip/thanos/tracing.md/#configuration
+      --tracing.config-file=<file-path>
+                           Path to YAML file with tracing configuration. See
+                           format details:
+                           https://thanos.io/tip/thanos/tracing.md/#configuration
+      --version            Show application version.
 
 ```
 
@@ -423,28 +423,18 @@ Inspect all blocks in the bucket in detailed, table-like way.
 Flags:
   -h, --help                 Show context-sensitive help (also try --help-long
                              and --help-man).
-      --version              Show application version.
-      --log.level=info       Log filtering level.
       --log.format=logfmt    Log format to use. Possible options: logfmt or
                              json.
-      --tracing.config-file=<file-path>
-                             Path to YAML file with tracing configuration. See
-                             format details:
-                             https://thanos.io/tip/thanos/tracing.md/#configuration
-      --tracing.config=<content>
-                             Alternative to 'tracing.config-file' flag (mutually
-                             exclusive). Content of YAML file with tracing
-                             configuration. See format details:
-                             https://thanos.io/tip/thanos/tracing.md/#configuration
-      --objstore.config-file=<file-path>
-                             Path to YAML file that contains object store
-                             configuration. See format details:
-                             https://thanos.io/tip/thanos/storage.md/#configuration
+      --log.level=info       Log filtering level.
       --objstore.config=<content>
                              Alternative to 'objstore.config-file' flag
                              (mutually exclusive). Content of YAML file that
                              contains object store configuration. See format
                              details:
+                             https://thanos.io/tip/thanos/storage.md/#configuration
+      --objstore.config-file=<file-path>
+                             Path to YAML file that contains object store
+                             configuration. See format details:
                              https://thanos.io/tip/thanos/storage.md/#configuration
   -l, --selector=<name>=\"<value>\" ...
                              Selects blocks based on label, e.g. '-l
@@ -455,6 +445,16 @@ Flags:
                              UNTIL'. I.e., if the 'FROM' value is equal the rows
                              are then further sorted by the 'UNTIL' value.
       --timeout=5m           Timeout to download metadata from remote storage
+      --tracing.config=<content>
+                             Alternative to 'tracing.config-file' flag (mutually
+                             exclusive). Content of YAML file with tracing
+                             configuration. See format details:
+                             https://thanos.io/tip/thanos/tracing.md/#configuration
+      --tracing.config-file=<file-path>
+                             Path to YAML file with tracing configuration. See
+                             format details:
+                             https://thanos.io/tip/thanos/tracing.md/#configuration
+      --version              Show application version.
 
 ```
 
@@ -477,62 +477,24 @@ Replicate data from one object storage to another. NOTE: Currently it works only
 with Thanos blocks (meta.json has to have Thanos metadata).
 
 Flags:
+      --compaction=1... ...      Only blocks with these compaction levels will
+                                 be replicated. Repeated flag.
   -h, --help                     Show context-sensitive help (also try
                                  --help-long and --help-man).
-      --version                  Show application version.
-      --log.level=info           Log filtering level.
-      --log.format=logfmt        Log format to use. Possible options: logfmt or
-                                 json.
-      --tracing.config-file=<file-path>
-                                 Path to YAML file with tracing configuration.
-                                 See format details:
-                                 https://thanos.io/tip/thanos/tracing.md/#configuration
-      --tracing.config=<content>
-                                 Alternative to 'tracing.config-file' flag
-                                 (mutually exclusive). Content of YAML file with
-                                 tracing configuration. See format details:
-                                 https://thanos.io/tip/thanos/tracing.md/#configuration
-      --objstore.config-file=<file-path>
-                                 Path to YAML file that contains object store
-                                 configuration. See format details:
-                                 https://thanos.io/tip/thanos/storage.md/#configuration
-      --objstore.config=<content>
-                                 Alternative to 'objstore.config-file' flag
-                                 (mutually exclusive). Content of YAML file that
-                                 contains object store configuration. See format
-                                 details:
-                                 https://thanos.io/tip/thanos/storage.md/#configuration
       --http-address="0.0.0.0:10902"
                                  Listen host:port for HTTP endpoints.
       --http-grace-period=2m     Time to wait after an interrupt received for
                                  HTTP Server.
-      --objstore-to.config-file=<file-path>
-                                 Path to YAML file that contains object store-to
-                                 configuration. See format details:
-                                 https://thanos.io/tip/thanos/storage.md/#configuration
-                                 The object storage which replicate data to.
-      --objstore-to.config=<content>
-                                 Alternative to 'objstore-to.config-file' flag
-                                 (mutually exclusive). Content of YAML file that
-                                 contains object store-to configuration. See
-                                 format details:
-                                 https://thanos.io/tip/thanos/storage.md/#configuration
-                                 The object storage which replicate data to.
-      --resolution=0s... ...     Only blocks with these resolutions will be
-                                 replicated. Repeated flag.
-      --compaction=1... ...      Only blocks with these compaction levels will
-                                 be replicated. Repeated flag.
+      --id=ID ...                Block to be replicated to the destination
+                                 bucket. IDs will be used to match blocks and
+                                 other matchers will be ignored. When specified,
+                                 this command will be run only once after
+                                 successful replication. Repeated field
+      --log.format=logfmt        Log format to use. Possible options: logfmt or
+                                 json.
+      --log.level=info           Log filtering level.
       --matcher=key="value" ...  Only blocks whose external labels exactly match
                                  this matcher will be replicated.
-      --single-run               Run replication only one time, then exit.
-      --min-time=0000-01-01T00:00:00Z
-                                 Start of time range limit to replicate. Thanos
-                                 Replicate will replicate only metrics, which
-                                 happened later than this value. Option can be a
-                                 constant time in RFC3339 format or time
-                                 duration relative to current time, such as -1d
-                                 or 2h45m. Valid duration units are ms, s, m, h,
-                                 d, w, y.
       --max-time=9999-12-31T23:59:59Z
                                  End of time range limit to replicate. Thanos
                                  Replicate will replicate only metrics, which
@@ -541,11 +503,49 @@ Flags:
                                  duration relative to current time, such as -1d
                                  or 2h45m. Valid duration units are ms, s, m, h,
                                  d, w, y.
-      --id=ID ...                Block to be replicated to the destination
-                                 bucket. IDs will be used to match blocks and
-                                 other matchers will be ignored. When specified,
-                                 this command will be run only once after
-                                 successful replication. Repeated field
+      --min-time=0000-01-01T00:00:00Z
+                                 Start of time range limit to replicate. Thanos
+                                 Replicate will replicate only metrics, which
+                                 happened later than this value. Option can be a
+                                 constant time in RFC3339 format or time
+                                 duration relative to current time, such as -1d
+                                 or 2h45m. Valid duration units are ms, s, m, h,
+                                 d, w, y.
+      --objstore-to.config=<content>
+                                 Alternative to 'objstore-to.config-file' flag
+                                 (mutually exclusive). Content of YAML file that
+                                 contains object store-to configuration. See
+                                 format details:
+                                 https://thanos.io/tip/thanos/storage.md/#configuration
+                                 The object storage which replicate data to.
+      --objstore-to.config-file=<file-path>
+                                 Path to YAML file that contains object store-to
+                                 configuration. See format details:
+                                 https://thanos.io/tip/thanos/storage.md/#configuration
+                                 The object storage which replicate data to.
+      --objstore.config=<content>
+                                 Alternative to 'objstore.config-file' flag
+                                 (mutually exclusive). Content of YAML file that
+                                 contains object store configuration. See format
+                                 details:
+                                 https://thanos.io/tip/thanos/storage.md/#configuration
+      --objstore.config-file=<file-path>
+                                 Path to YAML file that contains object store
+                                 configuration. See format details:
+                                 https://thanos.io/tip/thanos/storage.md/#configuration
+      --resolution=0s... ...     Only blocks with these resolutions will be
+                                 replicated. Repeated flag.
+      --single-run               Run replication only one time, then exit.
+      --tracing.config=<content>
+                                 Alternative to 'tracing.config-file' flag
+                                 (mutually exclusive). Content of YAML file with
+                                 tracing configuration. See format details:
+                                 https://thanos.io/tip/thanos/tracing.md/#configuration
+      --tracing.config-file=<file-path>
+                                 Path to YAML file with tracing configuration.
+                                 See format details:
+                                 https://thanos.io/tip/thanos/tracing.md/#configuration
+      --version                  Show application version.
 
 ```
 
@@ -575,35 +575,6 @@ usage: thanos tools bucket downsample [<flags>]
 Continuously downsamples blocks in an object store bucket.
 
 Flags:
-  -h, --help                  Show context-sensitive help (also try --help-long
-                              and --help-man).
-      --version               Show application version.
-      --log.level=info        Log filtering level.
-      --log.format=logfmt     Log format to use. Possible options: logfmt or
-                              json.
-      --tracing.config-file=<file-path>
-                              Path to YAML file with tracing configuration. See
-                              format details:
-                              https://thanos.io/tip/thanos/tracing.md/#configuration
-      --tracing.config=<content>
-                              Alternative to 'tracing.config-file' flag
-                              (mutually exclusive). Content of YAML file with
-                              tracing configuration. See format details:
-                              https://thanos.io/tip/thanos/tracing.md/#configuration
-      --objstore.config-file=<file-path>
-                              Path to YAML file that contains object store
-                              configuration. See format details:
-                              https://thanos.io/tip/thanos/storage.md/#configuration
-      --objstore.config=<content>
-                              Alternative to 'objstore.config-file' flag
-                              (mutually exclusive). Content of YAML file that
-                              contains object store configuration. See format
-                              details:
-                              https://thanos.io/tip/thanos/storage.md/#configuration
-      --http-address="0.0.0.0:10902"
-                              Listen host:port for HTTP endpoints.
-      --http-grace-period=2m  Time to wait after an interrupt received for HTTP
-                              Server.
       --data-dir="./data"     Data directory in which to cache blocks and
                               process downsamplings.
       --hash-func=            Specify which hash function to use when
@@ -612,6 +583,35 @@ Flags:
                               This permits avoiding downloading some files twice
                               albeit at some performance cost. Possible values
                               are: "", "SHA256".
+  -h, --help                  Show context-sensitive help (also try --help-long
+                              and --help-man).
+      --http-address="0.0.0.0:10902"
+                              Listen host:port for HTTP endpoints.
+      --http-grace-period=2m  Time to wait after an interrupt received for HTTP
+                              Server.
+      --log.format=logfmt     Log format to use. Possible options: logfmt or
+                              json.
+      --log.level=info        Log filtering level.
+      --objstore.config=<content>
+                              Alternative to 'objstore.config-file' flag
+                              (mutually exclusive). Content of YAML file that
+                              contains object store configuration. See format
+                              details:
+                              https://thanos.io/tip/thanos/storage.md/#configuration
+      --objstore.config-file=<file-path>
+                              Path to YAML file that contains object store
+                              configuration. See format details:
+                              https://thanos.io/tip/thanos/storage.md/#configuration
+      --tracing.config=<content>
+                              Alternative to 'tracing.config-file' flag
+                              (mutually exclusive). Content of YAML file with
+                              tracing configuration. See format details:
+                              https://thanos.io/tip/thanos/tracing.md/#configuration
+      --tracing.config-file=<file-path>
+                              Path to YAML file with tracing configuration. See
+                              format details:
+                              https://thanos.io/tip/thanos/tracing.md/#configuration
+      --version               Show application version.
 
 ```
 
@@ -644,33 +644,33 @@ currently running compacting same block, this operation would be potentially a
 noop.
 
 Flags:
+      --details=DETAILS    Human readable details to be put into marker.
   -h, --help               Show context-sensitive help (also try --help-long and
                            --help-man).
-      --version            Show application version.
-      --log.level=info     Log filtering level.
+      --id=ID ...          ID (ULID) of the blocks to be marked for deletion
+                           (repeated flag)
       --log.format=logfmt  Log format to use. Possible options: logfmt or json.
-      --tracing.config-file=<file-path>
-                           Path to YAML file with tracing configuration. See
-                           format details:
-                           https://thanos.io/tip/thanos/tracing.md/#configuration
-      --tracing.config=<content>
-                           Alternative to 'tracing.config-file' flag (mutually
-                           exclusive). Content of YAML file with tracing
-                           configuration. See format details:
-                           https://thanos.io/tip/thanos/tracing.md/#configuration
-      --objstore.config-file=<file-path>
-                           Path to YAML file that contains object store
-                           configuration. See format details:
-                           https://thanos.io/tip/thanos/storage.md/#configuration
+      --log.level=info     Log filtering level.
+      --marker=MARKER      Marker to be put.
       --objstore.config=<content>
                            Alternative to 'objstore.config-file' flag (mutually
                            exclusive). Content of YAML file that contains object
                            store configuration. See format details:
                            https://thanos.io/tip/thanos/storage.md/#configuration
-      --id=ID ...          ID (ULID) of the blocks to be marked for deletion
-                           (repeated flag)
-      --marker=MARKER      Marker to be put.
-      --details=DETAILS    Human readable details to be put into marker.
+      --objstore.config-file=<file-path>
+                           Path to YAML file that contains object store
+                           configuration. See format details:
+                           https://thanos.io/tip/thanos/storage.md/#configuration
+      --tracing.config=<content>
+                           Alternative to 'tracing.config-file' flag (mutually
+                           exclusive). Content of YAML file with tracing
+                           configuration. See format details:
+                           https://thanos.io/tip/thanos/tracing.md/#configuration
+      --tracing.config-file=<file-path>
+                           Path to YAML file with tracing configuration. See
+                           format details:
+                           https://thanos.io/tip/thanos/tracing.md/#configuration
+      --version            Show application version.
 
 ```
 
@@ -719,59 +719,59 @@ block for deletion to avoid overlaps. WARNING: This procedure is *IRREVERSIBLE*
 after certain time (delete delay), so do backup your blocks first.
 
 Flags:
-  -h, --help                    Show context-sensitive help (also try
-                                --help-long and --help-man).
-      --version                 Show application version.
-      --log.level=info          Log filtering level.
-      --log.format=logfmt       Log format to use. Possible options: logfmt or
-                                json.
-      --tracing.config-file=<file-path>
-                                Path to YAML file with tracing configuration.
-                                See format details:
-                                https://thanos.io/tip/thanos/tracing.md/#configuration
-      --tracing.config=<content>
-                                Alternative to 'tracing.config-file' flag
-                                (mutually exclusive). Content of YAML file with
-                                tracing configuration. See format details:
-                                https://thanos.io/tip/thanos/tracing.md/#configuration
-      --objstore.config-file=<file-path>
-                                Path to YAML file that contains object store
-                                configuration. See format details:
-                                https://thanos.io/tip/thanos/storage.md/#configuration
-      --objstore.config=<content>
-                                Alternative to 'objstore.config-file' flag
-                                (mutually exclusive). Content of YAML file that
-                                contains object store configuration. See format
-                                details:
-                                https://thanos.io/tip/thanos/storage.md/#configuration
-      --id=ID ...               ID (ULID) of the blocks for rewrite (repeated
-                                flag).
-      --tmp.dir="/tmp/thanos-rewrite"
-                                Working directory for temporary files
+      --dry-run                 Prints the series changes instead of doing them.
+                                Defaults to true, for user to double check. (:
+                                Pass --no-dry-run to skip this.
       --hash-func=              Specify which hash function to use when
                                 calculating the hashes of produced files. If no
                                 function has been specified, it does not happen.
                                 This permits avoiding downloading some files
                                 twice albeit at some performance cost. Possible
                                 values are: "", "SHA256".
-      --dry-run                 Prints the series changes instead of doing them.
-                                Defaults to true, for user to double check. (:
-                                Pass --no-dry-run to skip this.
-      --rewrite.to-delete-config-file=<file-path>
-                                Path to YAML file that contains
-                                []metadata.DeletionRequest that will be applied
-                                to blocks
+  -h, --help                    Show context-sensitive help (also try
+                                --help-long and --help-man).
+      --id=ID ...               ID (ULID) of the blocks for rewrite (repeated
+                                flag).
+      --log.format=logfmt       Log format to use. Possible options: logfmt or
+                                json.
+      --log.level=info          Log filtering level.
+      --objstore.config=<content>
+                                Alternative to 'objstore.config-file' flag
+                                (mutually exclusive). Content of YAML file that
+                                contains object store configuration. See format
+                                details:
+                                https://thanos.io/tip/thanos/storage.md/#configuration
+      --objstore.config-file=<file-path>
+                                Path to YAML file that contains object store
+                                configuration. See format details:
+                                https://thanos.io/tip/thanos/storage.md/#configuration
+      --prom-blocks             If specified, we assume the blocks to be
+                                uploaded are only used with Prometheus so we
+                                don't check external labels in this case.
+      --rewrite.add-change-log  If specified, all modifications are written to
+                                new block directory. Disable if latency is to
+                                high.
       --rewrite.to-delete-config=<content>
                                 Alternative to 'rewrite.to-delete-config-file'
                                 flag (mutually exclusive). Content of YAML file
                                 that contains []metadata.DeletionRequest that
                                 will be applied to blocks
-      --rewrite.add-change-log  If specified, all modifications are written to
-                                new block directory. Disable if latency is to
-                                high.
-      --prom-blocks             If specified, we assume the blocks to be
-                                uploaded are only used with Prometheus so we
-                                don't check external labels in this case.
+      --rewrite.to-delete-config-file=<file-path>
+                                Path to YAML file that contains
+                                []metadata.DeletionRequest that will be applied
+                                to blocks
+      --tmp.dir="/var/folders/7q/nd_xkppx783clb5nc5zzts6c0000gn/T/thanos-rewrite"
+                                Working directory for temporary files
+      --tracing.config=<content>
+                                Alternative to 'tracing.config-file' flag
+                                (mutually exclusive). Content of YAML file with
+                                tracing configuration. See format details:
+                                https://thanos.io/tip/thanos/tracing.md/#configuration
+      --tracing.config-file=<file-path>
+                                Path to YAML file with tracing configuration.
+                                See format details:
+                                https://thanos.io/tip/thanos/tracing.md/#configuration
+      --version                 Show application version.
 
 ```
 
@@ -801,19 +801,19 @@ Check if the rule files are valid or not.
 Flags:
   -h, --help               Show context-sensitive help (also try --help-long and
                            --help-man).
-      --version            Show application version.
-      --log.level=info     Log filtering level.
       --log.format=logfmt  Log format to use. Possible options: logfmt or json.
-      --tracing.config-file=<file-path>
-                           Path to YAML file with tracing configuration. See
-                           format details:
-                           https://thanos.io/tip/thanos/tracing.md/#configuration
+      --log.level=info     Log filtering level.
+      --rules=RULES ...    The rule files glob to check (repeated).
       --tracing.config=<content>
                            Alternative to 'tracing.config-file' flag (mutually
                            exclusive). Content of YAML file with tracing
                            configuration. See format details:
                            https://thanos.io/tip/thanos/tracing.md/#configuration
-      --rules=RULES ...    The rule files glob to check (repeated).
+      --tracing.config-file=<file-path>
+                           Path to YAML file with tracing configuration. See
+                           format details:
+                           https://thanos.io/tip/thanos/tracing.md/#configuration
+      --version            Show application version.
 
 ```
 

--- a/docs/components/tools.md
+++ b/docs/components/tools.md
@@ -760,7 +760,7 @@ Flags:
                                 Path to YAML file that contains
                                 []metadata.DeletionRequest that will be applied
                                 to blocks
-      --tmp.dir="/var/folders/7q/nd_xkppx783clb5nc5zzts6c0000gn/T/thanos-rewrite"
+      --tmp.dir="/tmp/thanos-rewrite"
                                 Working directory for temporary files
       --tracing.config=<content>
                                 Alternative to 'tracing.config-file' flag

--- a/go.mod
+++ b/go.mod
@@ -85,6 +85,9 @@ replace (
 	github.com/sercand/kuberesolver => github.com/sercand/kuberesolver v2.4.0+incompatible
 	google.golang.org/grpc => google.golang.org/grpc v1.29.1
 
+	// Overriding to use latest commit
+	gopkg.in/alecthomas/kingpin.v2 => github.com/alecthomas/kingpin v1.3.8-0.20210301060133-17f40c25f497
+
 	// From Prometheus.
 	k8s.io/klog => github.com/simonpasquier/klog-gokit v0.3.0
 	k8s.io/klog/v2 => github.com/simonpasquier/klog-gokit/v2 v2.0.1

--- a/go.sum
+++ b/go.sum
@@ -121,6 +121,8 @@ github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/
 github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5/go.mod h1:SkGFH1ia65gfNATL8TAiHDNxPzPdmEL5uirI2Uyuz6c=
 github.com/agnivade/levenshtein v1.0.1/go.mod h1:CURSv5d9Uaml+FovSIICkLbAUZ9S4RqaHDIsdSBg7lM=
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
+github.com/alecthomas/kingpin v1.3.8-0.20210301060133-17f40c25f497 h1:aDITxVUQ/3KBhpVWX57Vo9ntGTxoRw1F0T6/x/tRzNU=
+github.com/alecthomas/kingpin v1.3.8-0.20210301060133-17f40c25f497/go.mod h1:b6br6/pDFSfMkBgC96TbpOji05q5pa+v5rIlS0Y6XtI=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 h1:JYp7IbQjafoB+tBA3gMyHYHrpOtNuDiK/uB5uXxq5wM=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
@@ -1765,8 +1767,6 @@ google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGj
 google.golang.org/protobuf v1.25.0 h1:Ejskq+SyPohKW+1uil0JJMtmHCgJPJ/qWTxr8qp+R4c=
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 gopkg.in/airbrake/gobrake.v2 v2.0.9/go.mod h1:/h5ZAUhDkGaJfjzjKLSjv6zCL6O0LLBxU4K+aSYdM/U=
-gopkg.in/alecthomas/kingpin.v2 v2.2.6 h1:jMFz6MfLP0/4fUyZle81rXUoxOBFi19VUFKVDOQfozc=
-gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/pkg/extkingpin/app.go
+++ b/pkg/extkingpin/app.go
@@ -46,7 +46,7 @@ usage: {{.App.Name}}{{template "FormatUsage" .App}}
 {{end}}\
 {{if .Context.Flags}}\
 Flags:
-{{alphabetical .Context.Flags|FlagsToTwoColumns|FormatTwoColumns}}
+{{alphabeticalSort .Context.Flags|FlagsToTwoColumns|FormatTwoColumns}}
 {{end}}\
 {{if .Context.Args}}\
 Args:
@@ -89,7 +89,7 @@ func NewApp(app *kingpin.Application) *App {
 	app.HelpFlag.Short('h')
 	app.UsageTemplate(UsageTemplate)
 	app.UsageFuncs(template.FuncMap{
-		"alphabetical": func(data []*kingpin.FlagModel) []*kingpin.FlagModel {
+		"alphabeticalSort": func(data []*kingpin.FlagModel) []*kingpin.FlagModel {
 			sort.Slice(data, func(i, j int) bool { return data[i].Name < data[j].Name })
 			return data
 		},

--- a/pkg/extkingpin/app.go
+++ b/pkg/extkingpin/app.go
@@ -6,6 +6,8 @@ package extkingpin
 import (
 	"fmt"
 	"os"
+	"sort"
+	"text/template"
 
 	"github.com/go-kit/kit/log"
 	"github.com/oklog/run"
@@ -14,6 +16,52 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"gopkg.in/alecthomas/kingpin.v2"
 )
+
+const UsageTemplate = `{{define "FormatCommand"}}\
+{{if .FlagSummary}} {{.FlagSummary}}{{end}}\
+{{range .Args}} {{if not .Required}}[{{end}}<{{.Name}}>{{if .Value|IsCumulative}}...{{end}}{{if not .Required}}]{{end}}{{end}}\
+{{end}}\
+
+{{define "FormatCommands"}}\
+{{range .FlattenedCommands}}\
+{{if not .Hidden}}\
+  {{.FullCommand}}{{if .Default}}*{{end}}{{template "FormatCommand" .}}
+{{.Help|Wrap 4}}
+{{end}}\
+{{end}}\
+{{end}}\
+
+{{define "FormatUsage"}}\
+{{template "FormatCommand" .}}{{if .Commands}} <command> [<args> ...]{{end}}
+{{if .Help}}
+{{.Help|Wrap 0}}\
+{{end}}\
+
+{{end}}\
+
+{{if .Context.SelectedCommand}}\
+usage: {{.App.Name}} {{.Context.SelectedCommand}}{{template "FormatUsage" .Context.SelectedCommand}}
+{{else}}\
+usage: {{.App.Name}}{{template "FormatUsage" .App}}
+{{end}}\
+{{if .Context.Flags}}\
+Flags:
+{{alphabetical .Context.Flags|FlagsToTwoColumns|FormatTwoColumns}}
+{{end}}\
+{{if .Context.Args}}\
+Args:
+{{.Context.Args|ArgsToTwoColumns|FormatTwoColumns}}
+{{end}}\
+{{if .Context.SelectedCommand}}\
+{{if len .Context.SelectedCommand.Commands}}\
+Subcommands:
+{{template "FormatCommands" .Context.SelectedCommand}}
+{{end}}\
+{{else if .App.Commands}}\
+Commands:
+{{template "FormatCommands" .App}}
+{{end}}\
+`
 
 type FlagClause interface {
 	Flag(name, help string) *kingpin.FlagClause
@@ -39,6 +87,13 @@ type App struct {
 // NewApp returns new App.
 func NewApp(app *kingpin.Application) *App {
 	app.HelpFlag.Short('h')
+	app.UsageTemplate(UsageTemplate)
+	app.UsageFuncs(template.FuncMap{
+		"alphabetical": func(data []*kingpin.FlagModel) []*kingpin.FlagModel {
+			sort.Slice(data, func(i, j int) bool { return data[i].Name < data[j].Name })
+			return data
+		},
+	})
 	return &App{
 		app:        app,
 		FlagClause: app,


### PR DESCRIPTION
Signed-off-by: Wiard van Rij <wiard@outlook.com>

Relates to https://github.com/thanos-io/thanos/issues/4034

It sorts the flags alphabetical

* [x] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

The latest release of the kingpin package is from 17 Dec 2017. It was missing any method to do some funky stuff to get this done. That is, unless we want to manually order all flags in the code. So;

* Replaced v2.2.6 of kingpin with latest commit on their master branch so `UsageFuncs` becomes available
* Used the default template with an extra function call before the flag output 
* Added a function that does a sort on flag name

I think this might fall under "it's not stupid if it works" but this change felt nasty lol. Open for review anyway, LMK.

## Verification

<!-- How you tested it? How do you know it works? -->

Locally tested. 
Will update further if this is the way to go...
