### PR TITLE
compact: Add concurrency to GatherNoCompactFilter

### DIFF
--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -222,7 +222,7 @@ func runCompact(
 	// This is to make sure compactor will not accidentally perform compactions with gap instead.
 	ignoreDeletionMarkFilter := block.NewIgnoreDeletionMarkFilter(logger, bkt, deleteDelay/2, conf.blockMetaFetchConcurrency)
 	duplicateBlocksFilter := block.NewDeduplicateFilter()
-	noCompactMarkerFilter := compact.NewGatherNoCompactionMarkFilter(logger, bkt)
+	noCompactMarkerFilter := compact.NewGatherNoCompactionMarkFilter(logger, bkt, conf.blockMetaFetchConcurrency)
 	labelShardedMetaFilter := block.NewLabelShardedMetaFilter(relabelConfig)
 	consistencyDelayMetaFilter := block.NewConsistencyDelayMetaFilter(logger, conf.consistencyDelay, extprom.WrapRegistererWithPrefix("thanos_", reg))
 

--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -24,6 +24,7 @@ import (
 	"github.com/prometheus/prometheus/tsdb"
 	"github.com/thanos-io/thanos/pkg/extprom"
 	"github.com/thanos-io/thanos/pkg/runutil"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/thanos-io/thanos/pkg/block"
 	"github.com/thanos-io/thanos/pkg/block/metadata"
@@ -1011,13 +1012,15 @@ type GatherNoCompactionMarkFilter struct {
 	logger             log.Logger
 	bkt                objstore.InstrumentedBucketReader
 	noCompactMarkedMap map[ulid.ULID]*metadata.NoCompactMark
+	concurrency        int
 }
 
 // NewGatherNoCompactionMarkFilter creates GatherNoCompactionMarkFilter.
-func NewGatherNoCompactionMarkFilter(logger log.Logger, bkt objstore.InstrumentedBucketReader) *GatherNoCompactionMarkFilter {
+func NewGatherNoCompactionMarkFilter(logger log.Logger, bkt objstore.InstrumentedBucketReader, concurrency int) *GatherNoCompactionMarkFilter {
 	return &GatherNoCompactionMarkFilter{
-		logger: logger,
-		bkt:    bkt,
+		logger:      logger,
+		bkt:         bkt,
+		concurrency: concurrency,
 	}
 }
 
@@ -1030,21 +1033,67 @@ func (f *GatherNoCompactionMarkFilter) NoCompactMarkedBlocks() map[ulid.ULID]*me
 func (f *GatherNoCompactionMarkFilter) Filter(ctx context.Context, metas map[ulid.ULID]*metadata.Meta, synced *extprom.TxGaugeVec) error {
 	f.noCompactMarkedMap = make(map[ulid.ULID]*metadata.NoCompactMark)
 
+	// Make a copy of block IDs to check, in order to avoid concurrency issues
+	// between the scheduler and workers.
+	blockIDs := make([]ulid.ULID, 0, len(metas))
 	for id := range metas {
-		m := &metadata.NoCompactMark{}
-		// TODO(bwplotka): Hook up bucket cache here + reset API so we don't introduce API calls .
-		if err := metadata.ReadMarker(ctx, f.logger, f.bkt, id.String(), m); err != nil {
-			if errors.Cause(err) == metadata.ErrorMarkerNotFound {
-				continue
-			}
-			if errors.Cause(err) == metadata.ErrorUnmarshalMarker {
-				level.Warn(f.logger).Log("msg", "found partial no-compact-mark.json; if we will see it happening often for the same block, consider manually deleting no-compact-mark.json from the object storage", "block", id, "err", err)
-				continue
-			}
-			return err
-		}
-		synced.WithLabelValues(block.MarkedForNoCompactionMeta).Inc()
-		f.noCompactMarkedMap[id] = m
+		blockIDs = append(blockIDs, id)
 	}
+
+	var (
+		eg  errgroup.Group
+		ch  = make(chan ulid.ULID, f.concurrency)
+		mtx sync.Mutex
+	)
+
+	for i := 0; i < f.concurrency; i++ {
+		eg.Go(func() error {
+			var lastErr error
+			for id := range ch {
+				m := &metadata.NoCompactMark{}
+				// TODO(bwplotka): Hook up bucket cache here + reset API so we don't introduce API calls .
+				if err := metadata.ReadMarker(ctx, f.logger, f.bkt, id.String(), m); err != nil {
+					if errors.Cause(err) == metadata.ErrorMarkerNotFound {
+						continue
+					}
+					if errors.Cause(err) == metadata.ErrorUnmarshalMarker {
+						level.Warn(f.logger).Log("msg", "found partial no-compact-mark.json; if we will see it happening often for the same block, consider manually deleting no-compact-mark.json from the object storage", "block", id, "err", err)
+						continue
+					}
+					// Remember the last error and continue draining the channel.
+					lastErr = err
+					continue
+				}
+
+				mtx.Lock()
+				f.noCompactMarkedMap[id] = m
+				mtx.Unlock()
+				synced.WithLabelValues(block.MarkedForNoCompactionMeta).Inc()
+			}
+
+			return lastErr
+		})
+	}
+
+	// Workers scheduled, distribute blocks.
+	eg.Go(func() error {
+		defer close(ch)
+
+		for _, id := range blockIDs {
+			select {
+			case ch <- id:
+				// Nothing to do.
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
+
+		return nil
+	})
+
+	if err := eg.Wait(); err != nil {
+		return errors.Wrap(err, "filter blocks marked for no compaction")
+	}
+
 	return nil
 }


### PR DESCRIPTION
Follow the pattern used for IgnoreDeletionMarkFilter but instead
of stopping early completely drain the channel and report any of
the errors that occurred.

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

Synced metadata in prod (but we didn't have no compact marked blocks)
<!-- How you tested it? How do you know it works? -->
