### PR TITLE
Add Protofile for info service

### DIFF
--- a/pkg/info/infopb/rpc.proto
+++ b/pkg/info/infopb/rpc.proto
@@ -1,0 +1,64 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+syntax = "proto3";
+package thanos;
+
+import "store/labelpb/types.proto";
+import "store/storepb/rpc.proto";
+import "gogoproto/gogo.proto";
+
+option go_package = "infopb";
+
+option (gogoproto.sizer_all) = true;
+option (gogoproto.marshaler_all) = true;
+option (gogoproto.unmarshaler_all) = true;
+option (gogoproto.goproto_getters_all) = false;
+
+// Do not generate XXX fields to reduce memory footprint and opening a door
+// for zero-copy casts to/from prometheus data types.
+option (gogoproto.goproto_unkeyed_all) = false;
+option (gogoproto.goproto_unrecognized_all) = false;
+option (gogoproto.goproto_sizecache_all) = false;
+
+// Info represents the API that is responsible for gather metadata about the all APIs supported by the component.
+service Info {
+    // Info returns the metadata (Eg. LabelSets, Min/Max time) about all the APIs the component supports.
+    rpc Info(InfoRequest) returns (InfoResponse);
+}
+
+message InfoRequest {}
+
+message InfoResponse {
+    repeated ZLabelSet label_sets = 1 [(gogoproto.nullable) = false];
+    StoreType storeType  = 2; // Maybe rename to ComponentType
+    
+    StoreInfo storeInfo = 3;
+    RulesInfo rulesInfo = 4;
+    MetadataInfo metadataInfo = 5;
+    ExemplarsInfo exemplarsInfo = 6;
+    
+    // Deprecated. Use label_sets instead.
+    repeated Label labels = 7 [(gogoproto.nullable) = false, (gogoproto.customtype) = "github.com/thanos-io/thanos/pkg/store/labelpb.ZLabel"];
+
+}
+
+message StoreInfo {
+    int64 min_time = 1;
+    int64 max_time = 2;
+}
+
+message RulesInfo {
+    int64 min_time = 1;
+    int64 max_time = 2;
+}
+
+message MetadataInfo {
+    int64 min_time = 1;
+    int64 max_time = 2;
+}
+
+message ExemplarsInfo {
+    int64 min_time = 1;
+    int64 max_time = 2;
+}

--- a/pkg/info/infopb/rpc.proto
+++ b/pkg/info/infopb/rpc.proto
@@ -5,7 +5,6 @@ syntax = "proto3";
 package thanos;
 
 import "store/labelpb/types.proto";
-import "store/storepb/rpc.proto";
 import "gogoproto/gogo.proto";
 
 option go_package = "infopb";
@@ -29,18 +28,25 @@ service Info {
 
 message InfoRequest {}
 
+enum ComponentType {
+    UNKNOWN = 0;
+    QUERY = 1;
+    RULE = 2;
+    SIDECAR = 3;
+    STORE = 4;
+    RECEIVE = 5;
+    // DEBUG represents some debug StoreAPI components e.g. thanos tools store-api-serve.
+    DEBUG = 6;
+  }
+
 message InfoResponse {
     repeated ZLabelSet label_sets = 1 [(gogoproto.nullable) = false];
-    StoreType storeType  = 2; // Maybe rename to ComponentType
+    ComponentType ComponentType  = 2;
     
     StoreInfo storeInfo = 3;
     RulesInfo rulesInfo = 4;
     MetadataInfo metadataInfo = 5;
     ExemplarsInfo exemplarsInfo = 6;
-    
-    // Deprecated. Use label_sets instead.
-    repeated Label labels = 7 [(gogoproto.nullable) = false, (gogoproto.customtype) = "github.com/thanos-io/thanos/pkg/store/labelpb.ZLabel"];
-
 }
 
 message StoreInfo {

--- a/pkg/info/infopb/rpc.proto
+++ b/pkg/info/infopb/rpc.proto
@@ -32,14 +32,14 @@ message InfoResponse {
     repeated ZLabelSet label_sets = 1 [(gogoproto.nullable) = false];
     string ComponentType          = 2;
     
-    StoreInfo store               = 3;
+    StoresInfo stores             = 3;
     RulesInfo rules               = 4;
     MetadataInfo metadata         = 5;
     TargetsInfo targets           = 6;
     ExemplarsInfo exemplars       = 7;
 }
 
-message StoreInfo {
+message StoresInfo {
     int64 min_time = 1;
     int64 max_time = 2;
 }

--- a/pkg/info/infopb/rpc.proto
+++ b/pkg/info/infopb/rpc.proto
@@ -30,15 +30,27 @@ message InfoRequest {}
 
 message InfoResponse {
     repeated ZLabelSet label_sets = 1 [(gogoproto.nullable) = false];
-    string ComponentType  = 2;
+    string ComponentType          = 2;
     
-    StoreInfo store = 3;
-    ExemplarsInfo exemplars = 4;
+    StoreInfo store               = 3;
+    RulesInfo rules               = 4;
+    MetadataInfo metadata         = 5;
+    TargetsInfo targets           = 6;
+    ExemplarsInfo exemplars       = 7;
 }
 
 message StoreInfo {
     int64 min_time = 1;
     int64 max_time = 2;
+}
+
+message RulesInfo {
+}
+
+message MetadataInfo {
+}
+
+message TargetsInfo {
 }
 
 message ExemplarsInfo {

--- a/pkg/info/infopb/rpc.proto
+++ b/pkg/info/infopb/rpc.proto
@@ -20,7 +20,7 @@ option (gogoproto.goproto_unkeyed_all) = false;
 option (gogoproto.goproto_unrecognized_all) = false;
 option (gogoproto.goproto_sizecache_all) = false;
 
-// Info represents the API that is responsible for gather metadata about the all APIs supported by the component.
+// Info represents the API that is responsible for gathering metadata about the all APIs supported by the component.
 service Info {
     // Info returns the metadata (Eg. LabelSets, Min/Max time) about all the APIs the component supports.
     rpc Info(InfoRequest) returns (InfoResponse);

--- a/pkg/info/infopb/rpc.proto
+++ b/pkg/info/infopb/rpc.proto
@@ -44,10 +44,7 @@ message InfoResponse {
     ComponentType ComponentType  = 2;
     
     StoreInfo storeInfo = 3;
-    RulesInfo rulesInfo = 4;
-    MetadataInfo metadataInfo = 5;
-    ExemplarsInfo exemplarsInfo = 6;
-    TargetsInfo targetsInfo = 7;
+    ExemplarsInfo exemplarsInfo = 4;
 }
 
 message StoreInfo {
@@ -55,16 +52,7 @@ message StoreInfo {
     int64 max_time = 2;
 }
 
-message RulesInfo {
-}
-
-message MetadataInfo {
-}
-
 message ExemplarsInfo {
     int64 min_time = 1;
     int64 max_time = 2;
-}
-
-message TargetsInfo {
 }

--- a/pkg/info/infopb/rpc.proto
+++ b/pkg/info/infopb/rpc.proto
@@ -56,13 +56,9 @@ message StoreInfo {
 }
 
 message RulesInfo {
-    int64 min_time = 1;
-    int64 max_time = 2;
 }
 
 message MetadataInfo {
-    int64 min_time = 1;
-    int64 max_time = 2;
 }
 
 message ExemplarsInfo {
@@ -71,6 +67,4 @@ message ExemplarsInfo {
 }
 
 message TargetsInfo {
-    int64 min_time = 1;
-    int64 max_time = 2;
 }

--- a/pkg/info/infopb/rpc.proto
+++ b/pkg/info/infopb/rpc.proto
@@ -20,39 +20,53 @@ option (gogoproto.goproto_unkeyed_all) = false;
 option (gogoproto.goproto_unrecognized_all) = false;
 option (gogoproto.goproto_sizecache_all) = false;
 
-// Info represents the API that is responsible for gathering metadata about the all APIs supported by the component.
+/// Info represents the API that is responsible for gathering metadata about the all APIs supported by the component.
 service Info {
-    // Info returns the metadata (Eg. LabelSets, Min/Max time) about all the APIs the component supports.
+    /// Info returns the metadata (Eg. LabelSets, Min/Max time) about all the APIs the component supports.
     rpc Info(InfoRequest) returns (InfoResponse);
 }
 
 message InfoRequest {}
 
 message InfoResponse {
-    repeated ZLabelSet label_sets = 1 [(gogoproto.nullable) = false];
-    string ComponentType          = 2;
+    repeated ZLabelSet label_sets      = 1 [(gogoproto.nullable) = false];
+    string ComponentType               = 2;
     
-    StoresInfo stores             = 3;
-    RulesInfo rules               = 4;
-    MetadataInfo metadata         = 5;
-    TargetsInfo targets           = 6;
-    ExemplarsInfo exemplars       = 7;
+    /// StoreInfo holds the metadata related to Store API if exposed by the component otherwise it will be null.
+    StoreInfo store                    = 3;    
+
+    /// RulesInfo holds the metadata related to Rules API if exposed by the component otherwise it will be null.
+    RulesInfo rules                    = 4;
+    
+    /// MetricMetadataInfo holds the metadata related to Metadata API if exposed by the component otherwise it will be null.
+    MetricMetadataInfo metric_metadata = 5;
+    
+    /// TargetsInfo holds the metadata related to Targets API if exposed by the component otherwise it will be null.
+    TargetsInfo targets                = 6;
+    
+    /// ExemplarsInfo holds the metadata related to Exemplars API if exposed by the component otherwise it will be null.
+    ExemplarsInfo exemplars            = 7;
 }
 
-message StoresInfo {
+/// StoreInfo holds the metadata related to Store API exposed by the component.
+message StoreInfo {
     int64 min_time = 1;
     int64 max_time = 2;
 }
 
+/// RulesInfo holds the metadata related to Rules API exposed by the component.
 message RulesInfo {
 }
 
-message MetadataInfo {
+/// MetricMetadataInfo holds the metadata related to Metadata API exposed by the component.
+message MetricMetadataInfo {
 }
 
+/// TargetsInfo holds the metadata related to Targets API exposed by the component.
 message TargetsInfo {
 }
 
+/// EXemplarsInfo holds the metadata related to Exemplars API exposed by the component.
 message ExemplarsInfo {
     int64 min_time = 1;
     int64 max_time = 2;

--- a/pkg/info/infopb/rpc.proto
+++ b/pkg/info/infopb/rpc.proto
@@ -47,6 +47,7 @@ message InfoResponse {
     RulesInfo rulesInfo = 4;
     MetadataInfo metadataInfo = 5;
     ExemplarsInfo exemplarsInfo = 6;
+    TargetsInfo targetsInfo = 7;
 }
 
 message StoreInfo {
@@ -65,6 +66,11 @@ message MetadataInfo {
 }
 
 message ExemplarsInfo {
+    int64 min_time = 1;
+    int64 max_time = 2;
+}
+
+message TargetsInfo {
     int64 min_time = 1;
     int64 max_time = 2;
 }

--- a/pkg/info/infopb/rpc.proto
+++ b/pkg/info/infopb/rpc.proto
@@ -43,8 +43,8 @@ message InfoResponse {
     repeated ZLabelSet label_sets = 1 [(gogoproto.nullable) = false];
     ComponentType ComponentType  = 2;
     
-    StoreInfo storeInfo = 3;
-    ExemplarsInfo exemplarsInfo = 4;
+    StoreInfo store = 3;
+    ExemplarsInfo exemplars = 4;
 }
 
 message StoreInfo {

--- a/pkg/info/infopb/rpc.proto
+++ b/pkg/info/infopb/rpc.proto
@@ -28,20 +28,9 @@ service Info {
 
 message InfoRequest {}
 
-enum ComponentType {
-    UNKNOWN = 0;
-    QUERY = 1;
-    RULE = 2;
-    SIDECAR = 3;
-    STORE = 4;
-    RECEIVE = 5;
-    // DEBUG represents some debug StoreAPI components e.g. thanos tools store-api-serve.
-    DEBUG = 6;
-  }
-
 message InfoResponse {
     repeated ZLabelSet label_sets = 1 [(gogoproto.nullable) = false];
-    ComponentType ComponentType  = 2;
+    string ComponentType  = 2;
     
     StoreInfo store = 3;
     ExemplarsInfo exemplars = 4;

--- a/scripts/genproto.sh
+++ b/scripts/genproto.sh
@@ -25,7 +25,7 @@ PATH=${PATH}:/tmp/protobin
 GOGOPROTO_ROOT="$(GO111MODULE=on go list -modfile=.bingo/protoc-gen-gogofast.mod -f '{{ .Dir }}' -m github.com/gogo/protobuf)"
 GOGOPROTO_PATH="${GOGOPROTO_ROOT}:${GOGOPROTO_ROOT}/protobuf"
 
-DIRS="store/storepb/ store/storepb/prompb/ store/labelpb rules/rulespb targets/targetspb store/hintspb queryfrontend metadata/metadatapb exemplars/exemplarspb"
+DIRS="store/storepb/ store/storepb/prompb/ store/labelpb rules/rulespb targets/targetspb store/hintspb queryfrontend metadata/metadatapb exemplars/exemplarspb info/infopb"
 echo "generating code"
 pushd "pkg"
 for dir in ${DIRS}; do


### PR DESCRIPTION
This is the protofile for the Info service we are planning to add as part of [unified endpoint discovery](https://thanos.io/tip/proposals/202101_endpoint_discovery.md/) proposal.

### Open questions
1. Can there be disjoint labelsets (i.e. different external labels for different APIs) for the components exposing multiple APIs?
2. Is there any other metadata for any API?