### PR TITLE
Fix race condition in pool.BucketedBytes

### DIFF
--- a/pkg/pool/pool.go
+++ b/pkg/pool/pool.go
@@ -112,11 +112,12 @@ func (p *BucketedBytes) Put(b *[]byte) {
 			continue
 		}
 		*b = (*b)[:0]
-		p.mtx.Lock()
-		defer p.mtx.Unlock()
 		p.buckets[i].Put(b)
 		break
 	}
+
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
 
 	// We could assume here that our users will not make the slices larger
 	// but lets be on the safe side to avoid an underflow of p.usedTotal.


### PR DESCRIPTION
* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

We're reviewing #3937 and we found a race condition introduced in `pool.BucketedBytes.Put()`. If the input buffer is larger than the largest bucket size, then `p.usedTotal` is modified outside the lock.

In this PR I'm rolling back the change done in #3937 which I think was unnecessary. Before the lock only `p.sizes` and `p.buckets[i]` are accessed: `p.sizes` doesn't change and `p.buckets[i]` (which is a `sync.Pool`) is thread safe.

## Verification

N/A
