### PR TITLE
Temporarily skip flaky test TestTargetsAPI_Fanout

### DIFF
--- a/test/e2e/targets_api_test.go
+++ b/test/e2e/targets_api_test.go
@@ -23,6 +23,8 @@ import (
 )
 
 func TestTargetsAPI_Fanout(t *testing.T) {
+	t.Skip("TODO: Flaky test. See: https://github.com/thanos-io/thanos/issues/4069")
+
 	t.Parallel()
 
 	netName := "e2e_test_targets_fanout"

--- a/test/e2e/targets_api_test.go
+++ b/test/e2e/targets_api_test.go
@@ -107,6 +107,7 @@ func TestTargetsAPI_Fanout(t *testing.T) {
 	})
 }
 
+//nolint:unused
 func targetAndAssert(t *testing.T, ctx context.Context, addr string, state string, want *targetspb.TargetDiscovery) {
 	t.Helper()
 


### PR DESCRIPTION
* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

The `TestTargetsAPI_Fanout` is flaky (see issue https://github.com/thanos-io/thanos/issues/4069) and is currently blocking some PRs from being merged. I would suggest to temporarily skip it to gain more time to investigate and fix it.

## Verification

CI
