### PR TITLE
Add alert relabelling for Thanos Rule based on Prometheus' logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ We use _breaking :warning:_ to mark changes that are not backward compatible (re
 - [#4171](https://github.com/thanos-io/thanos/pull/4171) Docker: Busybox image updated to latest (1.33.1)
 - [#4175](https://github.com/thanos-io/thanos/pull/4175) Added Tag Configuration Support Lightstep Tracing
 - [#4176](https://github.com/thanos-io/thanos/pull/4176) Query API: Adds optional `Stats param` to return stats for query APIs
-
+- [#4125](https://github.com/thanos-io/thanos/pull/4125) Rule: Add `--alert.relabel-config` / `--alert.relabel-config-file` allowing to specify alert relabel configurations like [Prometheus](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config)
 ### Fixed
 -
 ### Changed

--- a/cmd/thanos/config.go
+++ b/cmd/thanos/config.go
@@ -202,6 +202,7 @@ type alertMgrConfig struct {
 	alertmgrsDNSSDInterval time.Duration
 	alertExcludeLabels     []string
 	alertQueryURL          *string
+	alertRelabelConfigPath *extflag.PathOrContent
 }
 
 func (ac *alertMgrConfig) registerFlag(cmd extflag.FlagClause) *alertMgrConfig {
@@ -215,5 +216,6 @@ func (ac *alertMgrConfig) registerFlag(cmd extflag.FlagClause) *alertMgrConfig {
 	ac.alertQueryURL = cmd.Flag("alert.query-url", "The external Thanos Query URL that would be set in all alerts 'Source' field").String()
 	cmd.Flag("alert.label-drop", "Labels by name to drop before sending to alertmanager. This allows alert to be deduplicated on replica label (repeated). Similar Prometheus alert relabelling").
 		StringsVar(&ac.alertExcludeLabels)
+	ac.alertRelabelConfigPath = extflag.RegisterPathOrContent(cmd, "alert.relabel-config", "YAML file that contains alert relabelling configuration.", false)
 	return ac
 }

--- a/cmd/thanos/rule.go
+++ b/cmd/thanos/rule.go
@@ -15,8 +15,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/prometheus/prometheus/pkg/relabel"
-
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	grpc_logging "github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/logging"
@@ -29,6 +27,7 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/common/route"
 	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/prometheus/pkg/relabel"
 	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/rules"
 	"github.com/prometheus/prometheus/tsdb"

--- a/cmd/thanos/rule.go
+++ b/cmd/thanos/rule.go
@@ -15,6 +15,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/prometheus/prometheus/pkg/relabel"
+
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	grpc_logging "github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/logging"
@@ -69,9 +71,10 @@ type ruleConfig struct {
 	query           queryConfig
 	queryConfigYAML []byte
 
-	alertmgr            alertMgrConfig
-	alertmgrsConfigYAML []byte
-	alertQueryURL       *url.URL
+	alertmgr               alertMgrConfig
+	alertmgrsConfigYAML    []byte
+	alertQueryURL          *url.URL
+	alertRelabelConfigYAML []byte
 
 	resendDelay    time.Duration
 	evalInterval   time.Duration
@@ -170,6 +173,11 @@ func registerRule(app *extkingpin.App) {
 		}
 		if len(conf.alertmgrsConfigYAML) != 0 && len(conf.alertmgr.alertmgrURLs) != 0 {
 			return errors.New("--alertmanagers.url and --alertmanagers.config* parameters cannot be defined at the same time")
+		}
+
+		conf.alertRelabelConfigYAML, err = conf.alertmgr.alertRelabelConfigPath.Content()
+		if err != nil {
+			return err
 		}
 
 		httpLogOpts, err := logging.ParseHTTPOptions(*reqLogDecision, reqLogConfig)
@@ -352,6 +360,14 @@ func runRule(
 		level.Warn(logger).Log("msg", "no alertmanager configured")
 	}
 
+	var alertRelabelConfigs []*relabel.Config
+	if len(conf.alertRelabelConfigYAML) > 0 {
+		alertRelabelConfigs, err = alert.LoadRelabelConfigs(conf.alertRelabelConfigYAML)
+		if err != nil {
+			return err
+		}
+	}
+
 	amProvider := dns.NewProvider(
 		logger,
 		extprom.WrapRegistererWithPrefix("thanos_rule_alertmanagers_", reg),
@@ -377,7 +393,7 @@ func runRule(
 
 	var (
 		ruleMgr *thanosrules.Manager
-		alertQ  = alert.NewQueue(logger, reg, 10000, 100, labelsTSDBToProm(conf.lset), conf.alertmgr.alertExcludeLabels)
+		alertQ  = alert.NewQueue(logger, reg, 10000, 100, labelsTSDBToProm(conf.lset), conf.alertmgr.alertExcludeLabels, alertRelabelConfigs)
 	)
 	{
 		// Run rule evaluation and alert notifications.

--- a/docs/components/rule.md
+++ b/docs/components/rule.md
@@ -244,6 +244,13 @@ Flags:
       --alert.query-url=ALERT.QUERY-URL
                                  The external Thanos Query URL that would be set
                                  in all alerts 'Source' field
+      --alert.relabel-config=<content>
+                                 Alternative to 'alert.relabel-config-file' flag
+                                 (mutually exclusive). Content of YAML file that
+                                 contains alert relabelling configuration.
+      --alert.relabel-config-file=<file-path>
+                                 Path to YAML file that contains alert
+                                 relabelling configuration.
       --alertmanagers.config=<content>
                                  Alternative to 'alertmanagers.config-file' flag
                                  (mutually exclusive). Content of YAML file that

--- a/pkg/alert/alert.go
+++ b/pkg/alert/alert.go
@@ -16,8 +16,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/prometheus/prometheus/pkg/relabel"
-
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/go-openapi/strfmt"
@@ -26,6 +24,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/prometheus/pkg/relabel"
 	"go.uber.org/atomic"
 
 	"github.com/thanos-io/thanos/pkg/runutil"

--- a/pkg/alert/alert.go
+++ b/pkg/alert/alert.go
@@ -16,6 +16,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/prometheus/prometheus/pkg/relabel"
+
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/go-openapi/strfmt"
@@ -85,11 +87,12 @@ func (a *Alert) ResolvedAt(ts time.Time) bool {
 // Queue is a queue of alert notifications waiting to be sent. The queue is consumed in batches
 // and entries are dropped at the front if it runs full.
 type Queue struct {
-	logger          log.Logger
-	maxBatchSize    int
-	capacity        int
-	toAddLset       labels.Labels
-	toExcludeLabels labels.Labels
+	logger              log.Logger
+	maxBatchSize        int
+	capacity            int
+	toAddLset           labels.Labels
+	toExcludeLabels     labels.Labels
+	alertRelabelConfigs []*relabel.Config
 
 	mtx   sync.Mutex
 	queue []*Alert
@@ -120,19 +123,20 @@ func relabelLabels(lset labels.Labels, excludeLset []string) (toAdd labels.Label
 
 // NewQueue returns a new queue. The given label set is attached to all alerts pushed to the queue.
 // The given exclude label set tells what label names to drop including external labels.
-func NewQueue(logger log.Logger, reg prometheus.Registerer, capacity, maxBatchSize int, externalLset labels.Labels, excludeLabels []string) *Queue {
+func NewQueue(logger log.Logger, reg prometheus.Registerer, capacity, maxBatchSize int, externalLset labels.Labels, excludeLabels []string, alertRelabelConfigs []*relabel.Config) *Queue {
 	toAdd, toExclude := relabelLabels(externalLset, excludeLabels)
 
 	if logger == nil {
 		logger = log.NewNopLogger()
 	}
 	q := &Queue{
-		logger:          logger,
-		capacity:        capacity,
-		morec:           make(chan struct{}, 1),
-		maxBatchSize:    maxBatchSize,
-		toAddLset:       toAdd,
-		toExcludeLabels: toExclude,
+		logger:              logger,
+		capacity:            capacity,
+		morec:               make(chan struct{}, 1),
+		maxBatchSize:        maxBatchSize,
+		toAddLset:           toAdd,
+		toExcludeLabels:     toExclude,
+		alertRelabelConfigs: alertRelabelConfigs,
 
 		dropped: promauto.With(reg).NewCounter(prometheus.CounterOpts{
 			Name: "thanos_alert_queue_alerts_dropped_total",
@@ -214,7 +218,6 @@ func (q *Queue) Push(alerts []*Alert) {
 	q.pushed.Add(float64(len(alerts)))
 
 	// Attach external labels and drop excluded labels before sending.
-	// TODO(bwplotka): User proper relabelling with https://github.com/thanos-io/thanos/issues/660.
 	for _, a := range alerts {
 		lb := labels.NewBuilder(labels.Labels{})
 		for _, l := range a.Labels {
@@ -226,7 +229,7 @@ func (q *Queue) Push(alerts []*Alert) {
 		for _, l := range q.toAddLset {
 			lb.Set(l.Name, l.Value)
 		}
-		a.Labels = lb.Labels()
+		a.Labels = relabel.Process(lb.Labels(), q.alertRelabelConfigs...)
 	}
 
 	// Queue capacity should be significantly larger than a single alert

--- a/pkg/alert/alert_test.go
+++ b/pkg/alert/alert_test.go
@@ -12,11 +12,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/prometheus/common/model"
-	"github.com/prometheus/prometheus/pkg/relabel"
-
 	"github.com/pkg/errors"
+	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/prometheus/pkg/relabel"
 
 	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/thanos-io/thanos/pkg/testutil"

--- a/pkg/alert/config.go
+++ b/pkg/alert/config.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/prometheus/prometheus/pkg/relabel"
+
 	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
 	"gopkg.in/yaml.v2"
@@ -129,4 +131,13 @@ func BuildAlertmanagerConfig(address string, timeout time.Duration) (Alertmanage
 		Timeout:    model.Duration(timeout),
 		APIVersion: APIv1,
 	}, nil
+}
+
+// LoadRelabelConfigs loads a list of relabel.Config from YAML data.
+func LoadRelabelConfigs(confYaml []byte) ([]*relabel.Config, error) {
+	var cfg []*relabel.Config
+	if err := yaml.UnmarshalStrict(confYaml, &cfg); err != nil {
+		return nil, err
+	}
+	return cfg, nil
 }

--- a/pkg/alert/config.go
+++ b/pkg/alert/config.go
@@ -10,10 +10,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/prometheus/prometheus/pkg/relabel"
-
 	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/pkg/relabel"
 	"gopkg.in/yaml.v2"
 
 	"github.com/thanos-io/thanos/pkg/discovery/dns"


### PR DESCRIPTION
Signed-off-by: Christian Schulz <trutty3@gmail.com>

Fixes https://github.com/thanos-io/thanos/issues/4122

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->
Add Prometheus' alert relabelling features to Thanos Rule.
Add command line flag to supply the configuration via YAML or file.

## Verification

<!-- How you tested it? How do you know it works? -->
Tested locally with a unit test.
The relabelling logic itself is also tested within Prometheus.
