### PR TITLE
Update E2E test Prometheus image to 2.26.0

### DIFF
--- a/test/e2e/e2ethanos/services.go
+++ b/test/e2e/e2ethanos/services.go
@@ -38,7 +38,7 @@ var defaultBackoffConfig = util.BackoffConfig{
 
 // TODO(bwplotka): Run against multiple?
 func DefaultPrometheusImage() string {
-	return "quay.io/prometheus/prometheus:v2.19.3"
+	return "quay.io/prometheus/prometheus:v2.26.0"
 }
 
 func DefaultAlertmanagerImage() string {

--- a/test/e2e/rules_api_test.go
+++ b/test/e2e/rules_api_test.go
@@ -16,7 +16,9 @@ import (
 	"github.com/cortexproject/cortex/integration/e2e"
 	"github.com/pkg/errors"
 
+	http_util "github.com/thanos-io/thanos/pkg/http"
 	"github.com/thanos-io/thanos/pkg/promclient"
+	"github.com/thanos-io/thanos/pkg/query"
 	"github.com/thanos-io/thanos/pkg/rules/rulespb"
 	"github.com/thanos-io/thanos/pkg/runutil"
 	"github.com/thanos-io/thanos/pkg/store/labelpb"
@@ -33,16 +35,22 @@ func TestRulesAPI_Fanout(t *testing.T) {
 	testutil.Ok(t, err)
 	t.Cleanup(e2ethanos.CleanScenario(t, s))
 
-	rulesSubDir := filepath.Join("rules")
-	testutil.Ok(t, os.MkdirAll(filepath.Join(s.SharedDir(), rulesSubDir), os.ModePerm))
-	createRuleFiles(t, filepath.Join(s.SharedDir(), rulesSubDir))
+	promRulesSubDir := filepath.Join("rules")
+	testutil.Ok(t, os.MkdirAll(filepath.Join(s.SharedDir(), promRulesSubDir), os.ModePerm))
+	// Create the abort_on_partial_response alert for Prometheus.
+	// We don't create the warn_on_partial_response alert as Prometheus has strict yaml unmarshalling.
+	createRuleFile(t, filepath.Join(s.SharedDir(), promRulesSubDir, "rules.yaml"), testAlertRuleAbortOnPartialResponse)
+
+	thanosRulesSubDir := filepath.Join("thanos-rules")
+	testutil.Ok(t, os.MkdirAll(filepath.Join(s.SharedDir(), thanosRulesSubDir), os.ModePerm))
+	createRuleFiles(t, filepath.Join(s.SharedDir(), thanosRulesSubDir))
 
 	// 2x Prometheus.
 	prom1, sidecar1, err := e2ethanos.NewPrometheusWithSidecar(
 		s.SharedDir(),
 		netName,
 		"prom1",
-		defaultPromConfig("ha", 0, "", filepath.Join(e2e.ContainerSharedDir, rulesSubDir, "*.yaml")),
+		defaultPromConfig("ha", 0, "", filepath.Join(e2e.ContainerSharedDir, promRulesSubDir, "*.yaml")),
 		e2ethanos.DefaultPrometheusImage(),
 	)
 	testutil.Ok(t, err)
@@ -50,25 +58,19 @@ func TestRulesAPI_Fanout(t *testing.T) {
 		s.SharedDir(),
 		netName,
 		"prom2",
-		defaultPromConfig("ha", 1, "", filepath.Join(e2e.ContainerSharedDir, rulesSubDir, "*.yaml")),
+		defaultPromConfig("ha", 1, "", filepath.Join(e2e.ContainerSharedDir, promRulesSubDir, "*.yaml")),
 		e2ethanos.DefaultPrometheusImage(),
 	)
 	testutil.Ok(t, err)
 	testutil.Ok(t, s.StartAndWaitReady(prom1, sidecar1, prom2, sidecar2))
 
-	// 2x Rulers.
-	r1, err := e2ethanos.NewRuler(s.SharedDir(), "rule1", rulesSubDir, nil, nil)
-	testutil.Ok(t, err)
-	r2, err := e2ethanos.NewRuler(s.SharedDir(), "rule2", rulesSubDir, nil, nil)
-	testutil.Ok(t, err)
-	testutil.Ok(t, s.StartAndWaitReady(r1, r2))
-
 	q, err := e2ethanos.NewQuerier(
 		s.SharedDir(),
 		"query",
-		[]string{sidecar1.GRPCNetworkEndpoint(), sidecar2.GRPCNetworkEndpoint(), r1.GRPCNetworkEndpoint(), r2.GRPCNetworkEndpoint()},
+		// TODO(yeya24): stop hardcoding the GRPC endpoints for rulers.
+		[]string{sidecar1.GRPCNetworkEndpoint(), sidecar2.GRPCNetworkEndpoint(), "rule-rule1:9091", "rule-rule2:9091"},
 		nil,
-		[]string{sidecar1.GRPCNetworkEndpoint(), sidecar2.GRPCNetworkEndpoint(), r1.GRPCNetworkEndpoint(), r2.GRPCNetworkEndpoint()},
+		[]string{sidecar1.GRPCNetworkEndpoint(), sidecar2.GRPCNetworkEndpoint(), "rule-rule1:9091", "rule-rule2:9091"},
 		nil,
 		nil,
 		nil,
@@ -79,6 +81,21 @@ func TestRulesAPI_Fanout(t *testing.T) {
 	testutil.Ok(t, err)
 	testutil.Ok(t, s.StartAndWaitReady(q))
 
+	queryCfg := []query.Config{
+		{
+			EndpointsConfig: http_util.EndpointsConfig{
+				StaticAddresses: []string{q.NetworkHTTPEndpoint()},
+				Scheme:          "http",
+			},
+		},
+	}
+	// 2x Rulers.
+	r1, err := e2ethanos.NewRuler(s.SharedDir(), "rule1", thanosRulesSubDir, nil, queryCfg)
+	testutil.Ok(t, err)
+	r2, err := e2ethanos.NewRuler(s.SharedDir(), "rule2", thanosRulesSubDir, nil, queryCfg)
+	testutil.Ok(t, err)
+	testutil.Ok(t, s.StartAndWaitReady(r1, r2))
+
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
 	t.Cleanup(cancel)
 
@@ -87,7 +104,7 @@ func TestRulesAPI_Fanout(t *testing.T) {
 	ruleAndAssert(t, ctx, q.HTTPEndpoint(), "", []*rulespb.RuleGroup{
 		{
 			Name: "example_abort",
-			File: "/shared/rules/rules-0.yaml",
+			File: "/shared/rules/rules.yaml",
 			Rules: []*rulespb.Rule{
 				rulespb.NewAlertingRule(&rulespb.Alert{
 					Name:  "TestAlert_AbortOnPartialResponse",
@@ -98,8 +115,15 @@ func TestRulesAPI_Fanout(t *testing.T) {
 						{Name: "severity", Value: "page"},
 					}},
 				}),
+			},
+		},
+		{
+			Name: "example_abort",
+			File: "/shared/thanos-rules/rules-0.yaml",
+			Rules: []*rulespb.Rule{
 				rulespb.NewAlertingRule(&rulespb.Alert{
 					Name:  "TestAlert_AbortOnPartialResponse",
+					State: rulespb.AlertState_FIRING,
 					Query: "absent(some_metric)",
 					Labels: labelpb.ZLabelSet{Labels: []labelpb.ZLabel{
 						{Name: "severity", Value: "page"},
@@ -109,19 +133,11 @@ func TestRulesAPI_Fanout(t *testing.T) {
 		},
 		{
 			Name: "example_warn",
-			File: "/shared/rules/rules-1.yaml",
+			File: "/shared/thanos-rules/rules-1.yaml",
 			Rules: []*rulespb.Rule{
 				rulespb.NewAlertingRule(&rulespb.Alert{
 					Name:  "TestAlert_WarnOnPartialResponse",
 					State: rulespb.AlertState_FIRING,
-					Query: "absent(some_metric)",
-					Labels: labelpb.ZLabelSet{Labels: []labelpb.ZLabel{
-						{Name: "prometheus", Value: "ha"},
-						{Name: "severity", Value: "page"},
-					}},
-				}),
-				rulespb.NewAlertingRule(&rulespb.Alert{
-					Name:  "TestAlert_WarnOnPartialResponse",
 					Query: "absent(some_metric)",
 					Labels: labelpb.ZLabelSet{Labels: []labelpb.ZLabel{
 						{Name: "severity", Value: "page"},


### PR DESCRIPTION
Signed-off-by: yeya24 <yb532204897@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

Update E2E Prometheus image to 2.26.0 to enable some tests on new features like Exemplars.

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.


## Changes

<!-- Enumerate changes you made -->

This upgrade breaks the rules API test because Prometheus has strict unmarshalling.

This pr updates the original test case:
1. Remove one of the rule files that Prometheus uses in the test case
2. Use a separate rules dir for Thanos Rulers and enable Rulers for rules evaluation
3. Update the response


## Verification

<!-- How you tested it? How do you know it works? -->
