### PR TITLE
Fix staticcheck lint errors in error strings

### DIFF
--- a/pkg/logging/grpc.go
+++ b/pkg/logging/grpc.go
@@ -35,7 +35,7 @@ func checkOptionsConfigEmpty(optcfg OptionsConfig) (bool, error) {
 		return true, nil
 	}
 	if len(optcfg.Level) == 0 && (optcfg.Decision.LogStart || optcfg.Decision.LogEnd) {
-		return false, fmt.Errorf("level field is empty.")
+		return false, fmt.Errorf("level field is empty")
 	}
 	return false, nil
 }
@@ -89,19 +89,19 @@ func getGRPCLoggingOption(logStart bool, logEnd bool) (grpc_logging.Decision, er
 	if logStart && logEnd {
 		return grpc_logging.LogStartAndFinishCall, nil
 	}
-	return -1, fmt.Errorf("log start call is not supported.")
+	return -1, fmt.Errorf("log start call is not supported")
 }
 
 // validateLevel validates the list of level entries.
 // Raise an error if empty or log level not in uppercase.
 func validateLevel(level string) error {
 	if len(level) == 0 {
-		return fmt.Errorf("level field in YAML file is empty.")
+		return fmt.Errorf("level field in YAML file is empty")
 	}
 	if level == "INFO" || level == "DEBUG" || level == "ERROR" || level == "WARNING" {
 		return nil
 	}
-	return fmt.Errorf("The format of level is invalid. Expected INFO/DEBUG/ERROR/WARNING, got this %v", level)
+	return fmt.Errorf("the format of level is invalid. Expected INFO/DEBUG/ERROR/WARNING, got this %v", level)
 }
 
 // NewGRPCOption adds in the config options and returns tags for logging middleware.


### PR DESCRIPTION
Signed-off-by: prateekpandey14 <prateekpandey14@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes
fix [staticcheck lint errors ](https://console.muse.dev/result/thanos-io/thanos/01F4RM4HGH6KVXTB0DQX8N2QY8?t=CustomTool%20%22Staticcheck%22%7CST1005) in Incorrectly formatted error string
