### PR TITLE
(bugsbash)Package "prometheus/prometheus/pkg/labels" imported twice

### DIFF
--- a/pkg/promclient/promclient.go
+++ b/pkg/promclient/promclient.go
@@ -26,7 +26,7 @@ import (
 	"github.com/gogo/status"
 	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
-	promlabels "github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/pkg/timestamp"
 	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/promql/parser"
@@ -465,10 +465,10 @@ func (c *Client) PromqlQueryInstant(ctx context.Context, base *url.URL, query st
 	vec := make(promql.Vector, 0, len(vectorResult))
 
 	for _, e := range vectorResult {
-		lset := make(promlabels.Labels, 0, len(e.Metric))
+		lset := make(labels.Labels, 0, len(e.Metric))
 
 		for k, v := range e.Metric {
-			lset = append(lset, promlabels.Label{
+			lset = append(lset, labels.Label{
 				Name:  string(k),
 				Value: string(v),
 			})

--- a/pkg/promclient/promclient.go
+++ b/pkg/promclient/promclient.go
@@ -26,7 +26,6 @@ import (
 	"github.com/gogo/status"
 	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
-	"github.com/prometheus/prometheus/pkg/labels"
 	promlabels "github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/pkg/timestamp"
 	"github.com/prometheus/prometheus/promql"


### PR DESCRIPTION
Signed-off-by: aSquare14 <atibhi.a@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x ] Change is not relevant to the end user.

## Changes
 Fixes ST1019 : package "github.com/prometheus/prometheus/pkg/labels" is being imported more than once
<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
