### PR TITLE
(bugsbash) Error string should not be captilazed in options.go

### DIFF
--- a/pkg/logging/options.go
+++ b/pkg/logging/options.go
@@ -175,7 +175,7 @@ func ParseHTTPOptions(flagDecision string, reqLogConfig *extflag.PathOrContent) 
 
 	// Check if the user enables request logging through flags and YAML.
 	if len(configYAML) != 0 && len(flagDecision) != 0 {
-		return logOpts, fmt.Errorf("both log.request.decision and request.logging has been enabled, please use only one of the flags")
+		return logOpts, fmt.Errorf("both log.request.decision and request.logging have been enabled, please use only one of the flags")
 	}
 	// If old flag is enabled.
 	if len(flagDecision) > 0 {

--- a/pkg/logging/options.go
+++ b/pkg/logging/options.go
@@ -175,7 +175,7 @@ func ParseHTTPOptions(flagDecision string, reqLogConfig *extflag.PathOrContent) 
 
 	// Check if the user enables request logging through flags and YAML.
 	if len(configYAML) != 0 && len(flagDecision) != 0 {
-		return logOpts, fmt.Errorf("both log.request.decision and request.logging has been enabled. Please use one of the flags")
+		return logOpts, fmt.Errorf("both log.request.decision and request.logging has been enabled, please use only one of the flags")
 	}
 	// If old flag is enabled.
 	if len(flagDecision) > 0 {

--- a/pkg/logging/options.go
+++ b/pkg/logging/options.go
@@ -201,7 +201,7 @@ func ParsegRPCOptions(flagDecision string, reqLogConfig *extflag.PathOrContent) 
 
 	// Check if the user enables request logging through flags and YAML.
 	if len(configYAML) != 0 && len(flagDecision) != 0 {
-		return []tags.Option{}, logOpts, fmt.Errorf("both log.request.decision and request.logging-config has been enabled. please use one of the flags")
+		return []tags.Option{}, logOpts, fmt.Errorf("both log.request.decision and request.logging-config have been enabled, please use only one of the flags")
 	}
 
 	// If the old flag is empty, use the new YAML config.

--- a/pkg/logging/options.go
+++ b/pkg/logging/options.go
@@ -175,7 +175,7 @@ func ParseHTTPOptions(flagDecision string, reqLogConfig *extflag.PathOrContent) 
 
 	// Check if the user enables request logging through flags and YAML.
 	if len(configYAML) != 0 && len(flagDecision) != 0 {
-		return logOpts, fmt.Errorf("Both log.request.decision and request.logging has been enabled. Please use one of the flags!")
+		return logOpts, fmt.Errorf("both log.request.decision and request.logging has been enabled. Please use one of the flags")
 	}
 	// If old flag is enabled.
 	if len(flagDecision) > 0 {
@@ -201,7 +201,7 @@ func ParsegRPCOptions(flagDecision string, reqLogConfig *extflag.PathOrContent) 
 
 	// Check if the user enables request logging through flags and YAML.
 	if len(configYAML) != 0 && len(flagDecision) != 0 {
-		return []tags.Option{}, logOpts, fmt.Errorf("Both log.request.decision and request.logging-config has been enabled. Please use one of the flags!")
+		return []tags.Option{}, logOpts, fmt.Errorf("both log.request.decision and request.logging-config has been enabled. Please use one of the flags")
 	}
 
 	// If the old flag is empty, use the new YAML config.

--- a/pkg/logging/options.go
+++ b/pkg/logging/options.go
@@ -201,7 +201,7 @@ func ParsegRPCOptions(flagDecision string, reqLogConfig *extflag.PathOrContent) 
 
 	// Check if the user enables request logging through flags and YAML.
 	if len(configYAML) != 0 && len(flagDecision) != 0 {
-		return []tags.Option{}, logOpts, fmt.Errorf("both log.request.decision and request.logging-config has been enabled. Please use one of the flags")
+		return []tags.Option{}, logOpts, fmt.Errorf("both log.request.decision and request.logging-config has been enabled. please use one of the flags")
 	}
 
 	// If the old flag is empty, use the new YAML config.


### PR DESCRIPTION
Signed-off-by: aSquare14 <atibhi.a@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes
Fixes ST1005 : Error string should not be capitalized and should not end with punctuation or a newline
<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
