### PR TITLE
(bugsbash) Fix deferring unsafe method "Close" on type "*os.File" to adhere to styleguide

### DIFF
--- a/pkg/reloader/reloader.go
+++ b/pkg/reloader/reloader.go
@@ -370,7 +370,9 @@ func hashFile(h hash.Hash, fn string) error {
 	if err != nil {
 		return err
 	}
-	defer f.Close()
+	defer func() {
+		f.Close()
+	}()
 
 	if _, err := h.Write([]byte{'\xff'}); err != nil {
 		return err

--- a/pkg/reloader/reloader.go
+++ b/pkg/reloader/reloader.go
@@ -370,9 +370,7 @@ func hashFile(h hash.Hash, fn string) error {
 	if err != nil {
 		return err
 	}
-	defer func() {
-		f.Close()
-	}()
+	defer runutil.CloseWithErrCapture(&err, f, "close file")
 
 	if _, err := h.Write([]byte{'\xff'}); err != nil {
 		return err

--- a/pkg/testutil/e2eutil/copy.go
+++ b/pkg/testutil/e2eutil/copy.go
@@ -40,13 +40,18 @@ func copyRecursive(src, dst string) error {
 		if err != nil {
 			return err
 		}
-		defer source.Close()
+		defer func() {
+			source.Close()
+		}()
 
 		destination, err := os.Create(filepath.Join(dst, relPath))
 		if err != nil {
 			return err
 		}
-		defer destination.Close()
+		defer func() {
+			destination.Close()
+		}()
+
 		_, err = io.Copy(destination, source)
 		return err
 	})

--- a/pkg/testutil/e2eutil/copy.go
+++ b/pkg/testutil/e2eutil/copy.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/pkg/errors"
+	"github.com/thanos-io/thanos/pkg/runutil"
 	"github.com/thanos-io/thanos/pkg/testutil"
 )
 
@@ -40,17 +41,13 @@ func copyRecursive(src, dst string) error {
 		if err != nil {
 			return err
 		}
-		defer func() {
-			source.Close()
-		}()
+		defer runutil.CloseWithErrCapture(&err, source, "close file")
 
 		destination, err := os.Create(filepath.Join(dst, relPath))
 		if err != nil {
 			return err
 		}
-		defer func() {
-			destination.Close()
-		}()
+		defer runutil.CloseWithErrCapture(&err, destination, "close file")
 
 		_, err = io.Copy(destination, source)
 		return err


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes
```go
defer f.Close()
```
to

```go
defer runutil.CloseWithErrCapture(&err, f, "close file")
```
Fixes G307
<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
