### PR TITLE
(bugsbash)value of ctx is never used

### DIFF
--- a/pkg/queryfrontend/labels_codec.go
+++ b/pkg/queryfrontend/labels_codec.go
@@ -197,7 +197,7 @@ func (c labelsCodec) DecodeResponse(ctx context.Context, r *http.Response, req q
 		body, _ := ioutil.ReadAll(r.Body)
 		return nil, httpgrpc.Errorf(r.StatusCode, string(body))
 	}
-	log, ctx := spanlogger.New(ctx, "ParseQueryResponse") //nolint:ineffassign,staticcheck
+	log, _ := spanlogger.New(ctx, "ParseQueryResponse") //nolint:ineffassign,staticcheck
 	defer log.Finish()
 
 	buf, err := ioutil.ReadAll(r.Body)


### PR DESCRIPTION
Signed-off-by: aSquare14 <atibhi.a@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes
```go
log, ctx := spanlogger.New(ctx, "ParseQueryResponse")
```
to

```go
log, _ := spanlogger.New(ctx, "ParseQueryResponse")
```

Fixes SA4006

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
