### PR TITLE
(bugsbash)fixes gosec warning potential file inclusion via variable

### DIFF
--- a/cmd/thanos/tools.go
+++ b/cmd/thanos/tools.go
@@ -50,7 +50,7 @@ func checkRulesFiles(logger log.Logger, patterns *[]string) error {
 			continue
 		}
 		for _, fn := range matches {
-			level.Info(logger).Log("msg", "checking", "filename", fn)
+			level.Info(logger).Log("msg", "checking", "filename", filepath.Clean(fn))
 			f, er := os.Open(fn)
 			if er != nil {
 				level.Error(logger).Log("result", "FAILED", "error", er)

--- a/pkg/block/indexheader/binary_reader.go
+++ b/pkg/block/indexheader/binary_reader.go
@@ -295,7 +295,7 @@ type FileWriter struct {
 
 // TODO(bwplotka): Added size to method, upstream this.
 func NewFileWriter(name string, size int) (*FileWriter, error) {
-	f, err := os.OpenFile(name, os.O_CREATE|os.O_RDWR, 0666)
+	f, err := os.OpenFile(filepath.Clean(name), os.O_CREATE|os.O_RDWR, 0666)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/block/metadata/hash.go
+++ b/pkg/block/metadata/hash.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 
 	"github.com/go-kit/kit/log"
 	"github.com/pkg/errors"
@@ -40,7 +41,7 @@ func (oh *ObjectHash) Equal(other *ObjectHash) bool {
 func CalculateHash(p string, hf HashFunc, logger log.Logger) (ObjectHash, error) {
 	switch hf {
 	case SHA256Func:
-		f, err := os.Open(p)
+		f, err := os.Open(filepath.Clean(p))
 		if err != nil {
 			return ObjectHash{}, errors.Wrap(err, "opening file")
 		}

--- a/pkg/block/metadata/meta.go
+++ b/pkg/block/metadata/meta.go
@@ -197,7 +197,7 @@ func renameFile(logger log.Logger, from, to string) error {
 
 // ReadFromDir reads the given meta from <dir>/meta.json.
 func ReadFromDir(dir string) (*Meta, error) {
-	f, err := os.Open(filepath.Join(dir, MetaFilename))
+	f, err := os.Open(filepath.Join(dir, filepath.Clean(MetaFilename)))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/objstore/filesystem/filesystem.go
+++ b/pkg/objstore/filesystem/filesystem.go
@@ -145,7 +145,7 @@ func (b *Bucket) GetRange(_ context.Context, name string, off, length int64) (io
 		return nil, errors.Wrapf(err, "stat %s", file)
 	}
 
-	f, err := os.OpenFile(file, os.O_RDONLY, 0666)
+	f, err := os.OpenFile(filepath.Clean(file), os.O_RDONLY, 0666)
 	if err != nil {
 		return nil, err
 	}
@@ -196,7 +196,7 @@ func (b *Bucket) Upload(_ context.Context, name string, r io.Reader) (err error)
 }
 
 func isDirEmpty(name string) (ok bool, err error) {
-	f, err := os.Open(name)
+	f, err := os.Open(filepath.Clean(name))
 	if err != nil {
 		return false, err
 	}

--- a/pkg/objstore/objstore.go
+++ b/pkg/objstore/objstore.go
@@ -194,7 +194,7 @@ func UploadDir(ctx context.Context, logger log.Logger, bkt Bucket, srcdir, dstdi
 // UploadFile uploads the file with the given name to the bucket.
 // It is a caller responsibility to clean partial upload in case of failure.
 func UploadFile(ctx context.Context, logger log.Logger, bkt Bucket, src, dst string) error {
-	r, err := os.Open(src)
+	r, err := os.Open(filepath.Clean(src))
 	if err != nil {
 		return errors.Wrapf(err, "open file %s", src)
 	}

--- a/pkg/query/test.go
+++ b/pkg/query/test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"math"
+	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
@@ -104,7 +105,7 @@ func newTest(t testing.TB, input string) (*test, error) {
 }
 
 func newTestFromFile(t testing.TB, filename string) (*test, error) {
-	content, err := ioutil.ReadFile(filename)
+	content, err := ioutil.ReadFile(filepath.Clean(filename))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/receive/config.go
+++ b/pkg/receive/config.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/go-kit/kit/log"
@@ -267,7 +268,7 @@ func loadConfig(logger log.Logger, path string) ([]HashringConfig, float64, erro
 
 // readFile reads the configuration file and returns content of configuration file.
 func readFile(logger log.Logger, path string) ([]byte, error) {
-	fd, err := os.Open(path)
+	fd, err := os.Open(filepath.Clean(path))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Signed-off-by: aSquare14 <atibhi.a@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

gosec was showing the following warning "Potential file inclusion via variable". This is because we are trying to open files using dynamic variables. Hence, I've cleaned the bad file paths using filepath.Clean()

Another observation, most of the file paths for which the ```gosec``` was showing a warning, they will never have user-inputted filenames, so I think it is sufficient to remove bad file paths. If it is a user inputted file path, having a basePath joined to the incoming path would be better. 

References
[filePath.Clean()](https://golang.org/pkg/path/filepath/#Clean)
[Stackoverflow](https://stackoverflow.com/questions/52320708/how-to-handle-gosec-linter-warning-potential-file-inclusion-via-variable)

