### PR TITLE
Query: Add a new Metric (Gauge) to keep track of whether a given store is up or down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ We use _breaking :warning:_ to mark changes that are not backward compatible (re
 
 - [#4107](https://github.com/thanos-io/thanos/pull/4107) Store: `LabelNames` and `LabelValues` now support label matchers.
 - [#4171](https://github.com/thanos-io/thanos/pull/4171) Docker: Busybox image updated to latest (1.33.1)
+- [#4169](https://github.com/thanos-io/thanos/pull/4169) Query: Add Gauge metric to keep track of whether a given store is up or down
 
 ### Fixed
 -

--- a/pkg/query/storeset.go
+++ b/pkg/query/storeset.go
@@ -274,8 +274,8 @@ func NewStoreSet(
 
 		upStatus: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
 			Name: "thanos_store_status",
-			Help: "Status of a given store node address.",
-		}, []string{"addr"}),
+			Help: "Status of a given Store API. A value of 1 means store API available for Querier",
+		}, []string{"external_labels", "store_type"}),
 	}
 	return ss
 }
@@ -630,9 +630,9 @@ func (s *StoreSet) updateStoreStatus(store *storeRef, err error) {
 		status.MinTime = mint
 		status.MaxTime = maxt
 		status.LastError = nil
-		s.upStatus.WithLabelValues(store.addr).Set(1)
+		s.upStatus.WithLabelValues(labelpb.PromLabelSetsToString(store.LabelSets()), store.StoreType().String()).Set(1)
 	} else {
-		s.upStatus.WithLabelValues(store.addr).Set(0)
+		s.upStatus.WithLabelValues(labelpb.PromLabelSetsToString(store.LabelSets()), store.StoreType().String()).Set(0)
 		status.LastError = &stringError{originalErr: err}
 	}
 

--- a/pkg/query/storeset_test.go
+++ b/pkg/query/storeset_test.go
@@ -1064,6 +1064,10 @@ func TestUpdateStoreStateLastError(t *testing.T) {
 	for _, tc := range tcs {
 		mockStoreSet := &StoreSet{
 			storeStatuses: map[string]*StoreStatus{},
+			upStatus: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+				Name: "thanos_store_status",
+				Help: "Status of a given store node address.",
+			}, []string{"addr"}),
 		}
 		mockStoreRef := &storeRef{
 			addr: "mockedStore",
@@ -1080,6 +1084,10 @@ func TestUpdateStoreStateLastError(t *testing.T) {
 func TestUpdateStoreStateForgetsPreviousErrors(t *testing.T) {
 	mockStoreSet := &StoreSet{
 		storeStatuses: map[string]*StoreStatus{},
+		upStatus: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "thanos_store_status",
+			Help: "Status of a given store node address.",
+		}, []string{"addr"}),
 	}
 	mockStoreRef := &storeRef{
 		addr: "mockedStore",

--- a/pkg/query/storeset_test.go
+++ b/pkg/query/storeset_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -186,7 +187,8 @@ func TestStoreSet_Update(t *testing.T) {
 
 	// Testing if duplicates can cause weird results.
 	discoveredStoreAddr = append(discoveredStoreAddr, discoveredStoreAddr[0])
-	storeSet := NewStoreSet(nil, nil,
+	metrics := prometheus.NewRegistry()
+	storeSet := NewStoreSet(nil, metrics,
 		func() (specs []StoreSpec) {
 			for _, addr := range discoveredStoreAddr {
 				specs = append(specs, NewGRPCStoreSpec(addr, false))
@@ -546,7 +548,8 @@ func TestStoreSet_Update_NoneAvailable(t *testing.T) {
 	st.CloseOne(initialStoreAddr[0])
 	st.CloseOne(initialStoreAddr[1])
 
-	storeSet := NewStoreSet(nil, nil,
+	metrics := prometheus.NewRegistry()
+	storeSet := NewStoreSet(nil, metrics,
 		func() (specs []StoreSpec) {
 			for _, addr := range initialStoreAddr {
 				specs = append(specs, NewGRPCStoreSpec(addr, false))
@@ -634,7 +637,8 @@ func TestQuerierStrict(t *testing.T) {
 
 	staticStoreAddr := st.StoreAddresses()[0]
 	slowStaticStoreAddr := st.StoreAddresses()[2]
-	storeSet := NewStoreSet(nil, nil, func() (specs []StoreSpec) {
+	metrics := prometheus.NewRegistry()
+	storeSet := NewStoreSet(nil, metrics, func() (specs []StoreSpec) {
 		return []StoreSpec{
 			NewGRPCStoreSpec(st.StoreAddresses()[0], true),
 			NewGRPCStoreSpec(st.StoreAddresses()[1], false),
@@ -796,7 +800,8 @@ func TestStoreSet_Update_Rules(t *testing.T) {
 			expectedRules:  2,
 		},
 	} {
-		storeSet := NewStoreSet(nil, nil,
+		metrics := prometheus.NewRegistry()
+		storeSet := NewStoreSet(nil, metrics,
 			tc.storeSpecs,
 			tc.ruleSpecs,
 			func() []TargetSpec { return nil },
@@ -958,8 +963,8 @@ func TestStoreSet_Rules_Discovery(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			currentState := 0
-
-			storeSet := NewStoreSet(nil, nil,
+			metrics := prometheus.NewRegistry()
+			storeSet := NewStoreSet(nil, metrics,
 				func() []StoreSpec {
 					if tc.states[currentState].storeSpecs == nil {
 						return nil


### PR DESCRIPTION
Signed-off-by: David Grizzanti <david_grizzanti@comcast.com>

Fixes #4124 

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

- Added a new gauge Metric to track the up/down status of a given store address as discussed in #4124 
- Primarily intended to track when a given store goes down for an extended period of time and is removed from the active store list

## Verification

I haven't added any unit tests around instrumentation as it seems that is not always done but wasn't sure if there is something I should/could add to e2e tests.

- Validated gauge value is `1` for a given store address when store is shown on the Stores page
- Validated gauge value is `0` for a given store address when store is not accessible/removed from the Stores page
