### PR TITLE
Add tracing spans for targets API 

### DIFF
--- a/pkg/targets/targets.go
+++ b/pkg/targets/targets.go
@@ -11,6 +11,7 @@ import (
 	"github.com/prometheus/prometheus/storage"
 	"github.com/thanos-io/thanos/pkg/store/storepb"
 	"github.com/thanos-io/thanos/pkg/targets/targetspb"
+	"github.com/thanos-io/thanos/pkg/tracing"
 )
 
 var _ UnaryClient = &GRPCClient{}
@@ -46,6 +47,9 @@ func NewGRPCClientWithDedup(ts targetspb.TargetsServer, replicaLabels []string) 
 }
 
 func (rr *GRPCClient) Targets(ctx context.Context, req *targetspb.TargetsRequest) (*targetspb.TargetDiscovery, storage.Warnings, error) {
+	span, ctx := tracing.StartSpan(ctx, "targets_request")
+	defer span.Finish()
+
 	resp := &targetsServer{ctx: ctx, targets: &targetspb.TargetDiscovery{
 		ActiveTargets:  make([]*targetspb.ActiveTarget, 0),
 		DroppedTargets: make([]*targetspb.DroppedTarget, 0),


### PR DESCRIPTION
Signed-off-by: ebarped <eduardo.barajas.pedrosa@gmail.com>

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

Add tracing for federated targets API.

Closes [#4129](https://github.com/thanos-io/thanos/issues/4129)

## Verification

- `make build`

