### PR TITLE
Checking sampled traces to create exemplar

### DIFF
--- a/pkg/extprom/http/instrument_server.go
+++ b/pkg/extprom/http/instrument_server.go
@@ -118,7 +118,7 @@ func (ins *defaultInstrumentationMiddleware) NewHandler(handlerName string, hand
 					span := opentracing.SpanFromContext(r.Context())
 					if span != nil {
 						spanCtx, ok := span.Context().(jaeger.SpanContext)
-						if ok {
+						if ok && spanCtx.IsSampled() {
 							observer.(prometheus.ExemplarObserver).ObserveWithExemplar(
 								time.Since(now).Seconds(),
 								prometheus.Labels{


### PR DESCRIPTION
Signed-off-by: Namanl2001 <namanlakhwani@gmail.com>

Fixes: #4186 

If a trace is not sampled, then it is unnecessary to create an exemplar.

## Changes

```
if ok && spanCtx.IsSampled() 
```