### PR TITLE
don't log.Fatal with a defer cancel/cleanup in the mix

### DIFF
--- a/pkg/runutil/example_test.go
+++ b/pkg/runutil/example_test.go
@@ -24,7 +24,7 @@ func ExampleRepeat() {
 		return nil
 	})
 	if err != nil {
-		log.Fatal(err)
+		log.Print(err.Error())
 	}
 }
 
@@ -39,6 +39,6 @@ func ExampleRetry() {
 		return errors.New("Try to retry")
 	})
 	if err != nil {
-		log.Fatal(err)
+		log.Print(err.Error())
 	}
 }


### PR DESCRIPTION
Signed-off-by: arcolife <archit.py@gmail.com>

* [x] Change is not relevant to the end user.

## Changes

uses a `log.Printf(err.Error())` instead of `log.Fatal` so there are no unclean dangling resources, if any.
Otherwise, in case of failure, `defer` is never called.

## Verification

