### PR TITLE
Docs: Adds caching doc and moved caching specific information to this page.

### DIFF
--- a/docs/caching.md
+++ b/docs/caching.md
@@ -1,0 +1,290 @@
+
+---
+title: Caching
+type: docs
+menu: thanos
+---
+
+# Background
+
+Thanos can implement caching layers on multiple components. In general this should speed-up certain processes. There is no definitive guide on how one should setup an entire Thanos stack as each cluster and use-case is different. Especially what KPI's<sup>1</sup>, SLO's<sup>2</sup> and SLI's<sup>3</sup> matter to you, your customers and/or your stack should have influence on the setup.
+
+However it is possible to give guidance on what each component tries to achieve, what it is used for and how you could configure this.
+
+<sub>
+<sup>1</sup> service level agreement
+<sup>2</sup> service level objective
+<sup>3</sup> service level indicator
+</sub>
+
+# Types of cache
+
+| Caching type                                                                                           | Component           | Backends             | Configuration | Extra             |
+| -------------------------------------------------------------------------------------------------- | ------------------ | --------------------- | ----------------- | ----------------------- |
+| Index cache | [Store gateway](components/store.md) | `in_memory` and `memcached` | base configuration | Enabled by default `in_memory`
+| Bucket cache | [Store gateway](components/store.md) | `in_memory` and `memcached` | base configuration + specific bucket cache extra's | Has extra metadata and chunk configuration options
+| Query frontend cache | [Query-frontend](components/query-frontend.md)  | `in_memory` and `memcached` | base configuration + extra field `expiration` | 
+
+
+## Index cache
+
+Thanos Store Gateway supports an index cache to speed up postings and series lookups from TSDB blocks indexes
+
+## Bucket cache
+
+Thanos Store Gateway supports a “caching bucket” with chunks and metadata caching to speed up loading of chunks from TSDB blocks.
+
+## Query frontend cache
+
+Query Frontend supports caching query results and label requests. Query results are reuses on subsequent queries. If the cached results are incomplete, Query Frontend calculates the required subqueries and executes them in parallel on downstream queriers. Query Frontend can optionally align queries with their step parameter to improve the cacheability of the query results.
+
+# Configurations for memcached
+
+## [memcached] Base configuration
+
+When using memcached, there is a base configuration that is consistent in every other caching component using memcached. Per component specific there may be additions to the configuration. Such as the `expiration: 0s` for the frontend cache component.
+
+[embedmd]:# (flags/config_index_cache_memcached.txt yaml)
+```yaml
+type: MEMCACHED
+config:
+  addresses: []
+  timeout: 0s
+  max_idle_connections: 0
+  max_async_concurrency: 0
+  max_async_buffer_size: 0
+  max_get_multi_concurrency: 0
+  max_item_size: 0
+  max_get_multi_batch_size: 0
+  dns_provider_update_interval: 0s
+```
+
+## [memcached] Index cache
+
+The index cache has no exceptions on the [base configuration](caching.md/#memcached-base-configuration).
+
+The `memcached` index cache allows to use [Memcached](https://memcached.org) as cache backend. This cache type is configured using `--index-cache.config-file` to reference to the configuration file or `--index-cache.config` to put yaml config directly
+
+Full example:
+
+[embedmd]:# (flags/config_index_cache_memcached.txt yaml)
+```yaml
+type: MEMCACHED
+config:
+  addresses: []
+  timeout: 0s
+  max_idle_connections: 0
+  max_async_concurrency: 0
+  max_async_buffer_size: 0
+  max_get_multi_concurrency: 0
+  max_item_size: 0
+  max_get_multi_batch_size: 0
+  dns_provider_update_interval: 0s
+```
+
+
+## [memcached] Caching bucket
+
+Uses the [base configuration](caching.md/#memcached-base-configuration).
+
+Additional options to configure various aspects of [chunks](../design.md/#chunk) cache are available:
+
+
+[embedmd]:# (flags/config_bucket_cache_memcached.txt yaml)
+```yaml
+type: MEMCACHED
+config:
+  addresses: []
+  timeout: 0s
+  max_idle_connections: 0
+  max_async_concurrency: 0
+  max_async_buffer_size: 0
+  max_get_multi_concurrency: 0
+  max_item_size: 0
+  max_get_multi_batch_size: 0
+  dns_provider_update_interval: 0s
+chunk_subrange_size: 0
+max_chunks_get_range_requests: 0
+chunk_object_attrs_ttl: 0s
+chunk_subrange_ttl: 0s
+blocks_iter_ttl: 0s
+metafile_exists_ttl: 0s
+metafile_doesnt_exist_ttl: 0s
+metafile_content_ttl: 0s
+metafile_max_size: 0
+```
+
+## [memcached] Query frontend
+
+Uses the [base configuration](caching.md/#memcached-base-configuration) with an extra option:
+
+`expiration` specifies how long memcached itself keeps items. After that time, memcached evicts those items. `0s` means the default duration of `24h`.
+
+[embedmd]:# (flags/config_response_cache_memcached.txt yaml)
+```yaml
+type: MEMCACHED
+config:
+  addresses: []
+  timeout: 0s
+  max_idle_connections: 0
+  max_async_concurrency: 0
+  max_async_buffer_size: 0
+  max_get_multi_concurrency: 0
+  max_item_size: 0
+  max_get_multi_batch_size: 0
+  dns_provider_update_interval: 0s
+  expiration: 0s 
+ ``` 
+
+# Configurations for in-memory
+
+## [in-memory] Base configuration 
+
+[embedmd]:# (flags/config_bucket_cache_in_memory.txt yaml)
+```yaml
+type: IN-MEMORY
+config:
+  max_size: 0
+  max_item_size: 0
+```
+
+
+## [in-memory] Index cache
+
+The index cache has no exceptions on the [base configuration](caching.md/#in-memory-base-configuration).
+
+[embedmd]:# (flags/config_bucket_cache_in_memory.txt yaml)
+```yaml
+type: IN-MEMORY
+config:
+  max_size: 0
+  max_item_size: 0
+```
+
+## [in-memory] Bucket cache
+
+Uses the [base configuration](caching.md/#in-memory-base-configuration).
+
+Additional options to configure various aspects of [chunks](../design.md/#chunk) cache are available:
+
+[embedmd]:# (flags/config_bucket_cache_in_memory.txt yaml)
+```yaml
+type: IN-MEMORY
+config:
+  max_size: 0
+  max_item_size: 0
+chunk_subrange_size: 0
+max_chunks_get_range_requests: 0
+chunk_object_attrs_ttl: 0s
+chunk_subrange_ttl: 0s
+blocks_iter_ttl: 0s
+metafile_exists_ttl: 0s
+metafile_doesnt_exist_ttl: 0s
+metafile_content_ttl: 0s
+metafile_max_size: 0
+```
+
+## [in-memory] Query frontend
+
+Uses the [base configuration](caching.md/#in-memory-base-configuration) with an extra option:
+
+`validity` specifies cache valid time , If set to 0s, so using a default of 24 hours expiration time.
+
+[embedmd]:# (flags/config_response_cache_in_memory.txt yaml)
+```yaml
+type: IN-MEMORY
+config:
+  max_size: 0
+  max_item_size: 0
+  validity: 0s
+```
+
+
+# Notes about Memcached configuration
+
+When implementing memcached as caching backend, one should be familiar with such setup. There are some key points to understand when configuring for memcached
+
+## How to implement memcached node addresses
+
+The `addresses` is an array configuration option. Such as:
+
+```yaml
+  addresses:
+    - localhost:11211
+```
+
+or
+
+```yaml
+  addresses:
+    - redis-1:11211
+    - redis-2:11211
+```
+
+The Thanos memcached client does **not** support autodiscovery of memcached instances. Therefore it is vital to either define each memcached host by itself or via `dnssrv`. 
+
+## Do not use a Loadbalancer as address
+
+If a loadbalancer is used, or for example the cluster endpoint of a cloud service, round-robins will happen. This causes that data has to be posted for each node and your cache-hit rate and performance will suffer.
+
+Therefore one should always use `node` endpoints and not `cluster` endpoints for memcached. On Kubernetes one could implement a `headless` service and use `dnssrv` to fetch each node endpoint. For example:
+
+```yaml
+  addresses:
+    - dnssrv+_grpc._tcp.my-memcached.memcached.cluster.local
+```
+
+Syntax:
+
+```
+dnssrv+_{service-port-name}._{service-protocol}.{service-name}.{namespace}.cluster.local
+```
+
+A Kubernetes headless service would look like this:
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: memcached-service
+  namespace: caching
+spec:
+  clusterIP: None
+  selector:
+    app: memcached
+  ports:
+    - name: memcached
+      protocol: TCP
+      port: 11211
+      targetPort: 11211
+```
+
+Which would result in the following address:
+
+`dnssrv+_memcached._tcp.memcached-service.memcached.cluster.local`
+
+
+## Max item size
+
+The Thanos configuration option: ` max_item_size` such as:
+
+```yaml
+ max_item_size: 1MiB
+```
+should be lower or equal to the max item size that memcached allows. 
+
+Memcached can be configured to allow larger items sizes than the default `1MiB` by setting the `-I` flag, such as `-I 16M` to allow up to `16MiB`
+
+It is not required to increase this, as Thanos simply ignores larger objects. This however decreases the cache hitrate. One could use the metric `thanos_memcached_operation_skipped_total` to observe this behaviour.
+
+## One or multiple memcached instances?
+
+There is no technical limit on using just one instance as backend for all the Thanos caching components. However it might be useful to spread the load over seperated instances to lower the impact in case of incidents. 
+
+It however is not possible to use one memcached instance for multiple store backends as this provides conflicts on index keys.
+
+
+# In-memory versus memcached
+
+- In-memory causes each replica to have it's own cache. If multiple replica's are required it could be more logical by cost/benefit to implement memcached. 
+- Memcached adds extra complexity which should be used in consideration.

--- a/docs/caching.md
+++ b/docs/caching.md
@@ -20,9 +20,9 @@ However it is possible to give guidance on what each component tries to achieve,
 
 | Caching type                                                                                           | Component           | Backends             | Configuration | Extra             |
 | -------------------------------------------------------------------------------------------------- | ------------------ | --------------------- | ----------------- | ----------------------- |
-| Index cache | [Store gateway](components/store.md) | `in_memory` and `memcached` | base configuration | Enabled by default `in_memory`
-| Bucket cache | [Store gateway](components/store.md) | `in_memory` and `memcached` | base configuration + specific bucket cache extra's | Has extra metadata and chunk configuration options
-| Query frontend cache | [Query-frontend](components/query-frontend.md)  | `in_memory` and `memcached` | base configuration + extra field `expiration` |
+| Index cache | [Store gateway](../components/store.md) | `in_memory` and `memcached` | base configuration | Enabled by default `in_memory`
+| Bucket cache | [Store gateway](../components/store.md) | `in_memory` and `memcached` | base configuration + specific bucket cache extra's | Has extra metadata and chunk configuration options
+| Query frontend cache | [Query-frontend](../components/query-frontend.md)  | `in_memory` and `memcached` | base configuration + extra field `expiration` |
 
 ## Index cache
 
@@ -80,6 +80,8 @@ config:
   dns_provider_update_interval: 0s
 ```
 
+Please refer to [Memcached index cache](../components/store.md/#memcached-index-cache) for more information about flags and configuration definitions.
+
 
 ## [memcached] Caching bucket
 
@@ -112,6 +114,8 @@ metafile_content_ttl: 0s
 metafile_max_size: 0
 ```
 
+Please refer to [Memcached caching bucket](../components/store.md/#memcached-caching-bucket) and [Options for the caching bucket](../components/store.md/#options-for-the-caching-bucket) for more information about flags and configuration definitions.
+
 ## [memcached] Query frontend
 
 Uses the [base configuration](caching.md/#memcached-base-configuration) with an extra option:
@@ -125,6 +129,8 @@ config:
   max_size: 0
   max_item_size: 0
 ```
+
+Please refer to [Memcached Query frontend](../components/query-frontend.md/#memcached) for more information about flags and configuration definitions.
 
 # Configurations for in-memory
 
@@ -151,6 +157,8 @@ config:
   max_item_size: 0
 ```
 
+Please refer to [In-memory index cache](../components/store.md/#in-memory-index-cache) for more information about flags and configuration definitions.
+
 ## [in-memory] Bucket cache
 
 Uses the [base configuration](caching.md/#in-memory-base-configuration).
@@ -174,6 +182,8 @@ metafile_content_ttl: 0s
 metafile_max_size: 0
 ```
 
+Please refer to [In-memory caching bucket](../components/store.md/#in-memory-caching-bucket) and [Options for the caching bucket](../components/store.md/#options-for-the-caching-bucket) for more information about flags and configuration definitions.
+
 ## [in-memory] Query frontend
 
 Uses the [base configuration](caching.md/#in-memory-base-configuration) with an extra option:
@@ -189,8 +199,9 @@ config:
   validity: 0s
 ```
 
+Please refer to [In-memory Query frontend](../components/query-frontend.md/#in-memory) for more information about flags and configuration definitions.
 
-# Notes about Memcached configuration
+# Tips & Tricks
 
 When implementing memcached as caching backend, one should be familiar with such setup. There are some key points to understand when configuring for memcached
 

--- a/docs/caching.md
+++ b/docs/caching.md
@@ -1,4 +1,3 @@
-
 ---
 title: Caching
 type: docs
@@ -23,8 +22,7 @@ However it is possible to give guidance on what each component tries to achieve,
 | -------------------------------------------------------------------------------------------------- | ------------------ | --------------------- | ----------------- | ----------------------- |
 | Index cache | [Store gateway](components/store.md) | `in_memory` and `memcached` | base configuration | Enabled by default `in_memory`
 | Bucket cache | [Store gateway](components/store.md) | `in_memory` and `memcached` | base configuration + specific bucket cache extra's | Has extra metadata and chunk configuration options
-| Query frontend cache | [Query-frontend](components/query-frontend.md)  | `in_memory` and `memcached` | base configuration + extra field `expiration` | 
-
+| Query frontend cache | [Query-frontend](components/query-frontend.md)  | `in_memory` and `memcached` | base configuration + extra field `expiration` |
 
 ## Index cache
 
@@ -120,27 +118,19 @@ Uses the [base configuration](caching.md/#memcached-base-configuration) with an 
 
 `expiration` specifies how long memcached itself keeps items. After that time, memcached evicts those items. `0s` means the default duration of `24h`.
 
-[embedmd]:# (flags/config_response_cache_memcached.txt yaml)
+[embedmd]:# (flags/config_index_cache_in_memory.txt yaml)
 ```yaml
-type: MEMCACHED
+type: IN-MEMORY
 config:
-  addresses: []
-  timeout: 0s
-  max_idle_connections: 0
-  max_async_concurrency: 0
-  max_async_buffer_size: 0
-  max_get_multi_concurrency: 0
+  max_size: 0
   max_item_size: 0
-  max_get_multi_batch_size: 0
-  dns_provider_update_interval: 0s
-  expiration: 0s 
- ``` 
+```
 
 # Configurations for in-memory
 
-## [in-memory] Base configuration 
+## [in-memory] Base configuration
 
-[embedmd]:# (flags/config_bucket_cache_in_memory.txt yaml)
+[embedmd]:# (flags/config_index_cache_in_memory.txt yaml)
 ```yaml
 type: IN-MEMORY
 config:
@@ -153,7 +143,7 @@ config:
 
 The index cache has no exceptions on the [base configuration](caching.md/#in-memory-base-configuration).
 
-[embedmd]:# (flags/config_bucket_cache_in_memory.txt yaml)
+[embedmd]:# (flags/config_index_cache_in_memory.txt yaml)
 ```yaml
 type: IN-MEMORY
 config:
@@ -194,8 +184,8 @@ Uses the [base configuration](caching.md/#in-memory-base-configuration) with an 
 ```yaml
 type: IN-MEMORY
 config:
-  max_size: 0
-  max_item_size: 0
+  max_size: ""
+  max_size_items: 0
   validity: 0s
 ```
 
@@ -221,7 +211,7 @@ or
     - redis-2:11211
 ```
 
-The Thanos memcached client does **not** support autodiscovery of memcached instances. Therefore it is vital to either define each memcached host by itself or via `dnssrv`. 
+The Thanos memcached client does **not** support autodiscovery of memcached instances. Therefore it is vital to either define each memcached host by itself or via `dnssrv`.
 
 ## Do not use a Loadbalancer as address
 
@@ -236,7 +226,7 @@ Therefore one should always use `node` endpoints and not `cluster` endpoints for
 
 Syntax:
 
-```
+```yaml
 dnssrv+_{service-port-name}._{service-protocol}.{service-name}.{namespace}.cluster.local
 ```
 
@@ -263,15 +253,15 @@ Which would result in the following address:
 
 `dnssrv+_memcached._tcp.memcached-service.memcached.cluster.local`
 
-
 ## Max item size
 
-The Thanos configuration option: ` max_item_size` such as:
+The Thanos configuration option: `max_item_size` such as:
 
 ```yaml
  max_item_size: 1MiB
 ```
-should be lower or equal to the max item size that memcached allows. 
+
+should be lower or equal to the max item size that memcached allows.
 
 Memcached can be configured to allow larger items sizes than the default `1MiB` by setting the `-I` flag, such as `-I 16M` to allow up to `16MiB`
 
@@ -279,12 +269,11 @@ It is not required to increase this, as Thanos simply ignores larger objects. Th
 
 ## One or multiple memcached instances?
 
-There is no technical limit on using just one instance as backend for all the Thanos caching components. However it might be useful to spread the load over seperated instances to lower the impact in case of incidents. 
+There is no technical limit on using just one instance as backend for all the Thanos caching components. However it might be useful to spread the load over seperated instances to lower the impact in case of incidents.
 
 It however is not possible to use one memcached instance for multiple store backends as this provides conflicts on index keys.
 
+## In-memory versus memcached
 
-# In-memory versus memcached
-
-- In-memory causes each replica to have it's own cache. If multiple replica's are required it could be more logical by cost/benefit to implement memcached. 
+- In-memory causes each replica to have it's own cache. If multiple replica's are required it could be more logical by cost/benefit to implement memcached.
 - Memcached adds extra complexity which should be used in consideration.

--- a/docs/components/query-frontend.md
+++ b/docs/components/query-frontend.md
@@ -43,70 +43,13 @@ Query Frontend supports a retry mechanism to retry query when HTTP requests are 
 
 ### Caching
 
-Query Frontend supports caching query results and reuses them on subsequent queries. If the cached results are incomplete,
-Query Frontend calculates the required subqueries and executes them in parallel on downstream queriers.
-Query Frontend can optionally align queries with their step parameter to improve the cacheability of the query results.
-Currently, in-memory cache (fifo cache) and memcached are supported.
+The Query Frontend component allows `in-memory` or `memcached` caching types for `query-range` and `labels` caching. Please refer to [Query frontend cache](../thanos/caching.md/#query-frontend-cache) to read more about caching in Thanos.
 
-#### In-memory
+Caching can be configured using `--labels.response-cache-config-file` and `--query-range.response-cache-config-file` to reference to the configuration file or `--labels.response-cache-config` and `--query-range.response-cache-config` to insert the yaml config directly
 
-[embedmd]:# (../flags/config_response_cache_in_memory.txt yaml)
-```yaml
-type: IN-MEMORY
-config:
-  max_size: ""
-  max_size_items: 0
-  validity: 0s
-```
-`max_size: ` Maximum memory size of the cache in bytes. A unit suffix (KB, MB, GB) may be applied.
-
-**_NOTE:** If both `max_size` and `max_size_items` are not set, then the *cache* would not be created.
-
-If either of `max_size` or `max_size_items` is set, then there is not limit on other field.
-For example - only set `max_size_item` to 1000, then `max_size` is unlimited. Similarly, if only `max_size` is set, then `max_size_items` is unlimited.
-
-Example configuration: [kube-thanos](https://github.com/thanos-io/kube-thanos/blob/master/examples/all/manifests/thanos-query-frontend-deployment.yaml#L50-L54)
-
-#### Memcached
-
-[embedmd]:# (../flags/config_response_cache_memcached.txt yaml)
-```yaml
-type: MEMCACHED
-config:
-  addresses: []
-  timeout: 0s
-  max_idle_connections: 0
-  max_async_concurrency: 0
-  max_async_buffer_size: 0
-  max_get_multi_concurrency: 0
-  max_item_size: 0
-  max_get_multi_batch_size: 0
-  dns_provider_update_interval: 0s
-  expiration: 0s
-```
-
-`expiration` specifies memcached cache valid time.  If set to 0s, so using a default of 24 hours expiration time.
-
-If a `set` operation is skipped because of the item size is larger than `max_item_size`, this event is tracked by a counter metric `cortex_memcache_client_set_skip_total`.
-
-Other cache configuration parameters, you can refer to [memcached-index-cache]( https://thanos.io/tip/components/store.md/#memcached-index-cache).
-
-The default memcached config is:
-
-```yaml
-type: MEMCACHED
-config:
-  addresses: [your-memcached-addresses]
-  timeout: 500ms
-  max_idle_connections: 100
-  max_item_size: 1MiB
-  max_async_concurrency: 10
-  max_async_buffer_size: 10000
-  max_get_multi_concurrency: 100
-  max_get_multi_batch_size: 0
-  dns_provider_update_interval: 10s
-  expiration: 24h
-```
+Caching configuration:
+- [Memcached Query Frontend](../thanos/caching.md/#memcached-query-frontend)
+- [In-memory Query Frontend](../thanos/caching.md/#in-memory-query-frontend)
 
 ### Slow Query Log
 

--- a/docs/components/store.md
+++ b/docs/components/store.md
@@ -313,27 +313,28 @@ Thanos Store Gateway supports a "caching bucket" with [chunks](../design.md/#chu
 
 Both memcached and in-memory cache "backend"s are supported:
 
+[embedmd]:# (../flags/config_bucket_cache_memcached.txt yaml)
 ```yaml
-type: MEMCACHED # Case-insensitive
+type: MEMCACHED
 config:
   addresses: []
-  timeout: 500ms
-  max_idle_connections: 100
-  max_async_concurrency: 20
-  max_async_buffer_size: 10000
-  max_item_size: 1MiB
-  max_get_multi_concurrency: 100
+  timeout: 0s
+  max_idle_connections: 0
+  max_async_concurrency: 0
+  max_async_buffer_size: 0
+  max_get_multi_concurrency: 0
+  max_item_size: 0
   max_get_multi_batch_size: 0
-  dns_provider_update_interval: 10s
-chunk_subrange_size: 16000
-max_chunks_get_range_requests: 3
-chunk_object_attrs_ttl: 24h
-chunk_subrange_ttl: 24h
-blocks_iter_ttl: 5m
-metafile_exists_ttl: 2h
-metafile_doesnt_exist_ttl: 15m
-metafile_content_ttl: 24h
-metafile_max_size: 1MiB
+  dns_provider_update_interval: 0s
+chunk_subrange_size: 0
+max_chunks_get_range_requests: 0
+chunk_object_attrs_ttl: 0s
+chunk_subrange_ttl: 0s
+blocks_iter_ttl: 0s
+metafile_exists_ttl: 0s
+metafile_doesnt_exist_ttl: 0s
+metafile_content_ttl: 0s
+metafile_max_size: 0
 ```
 
 `config` field for memcached supports all the same configuration as memcached for [index cache](#memcached-index-cache). `addresses` in the config field is a **required** setting

--- a/docs/components/store.md
+++ b/docs/components/store.md
@@ -313,6 +313,8 @@ Thanos Store Gateway supports a "caching bucket" with [chunks](../design.md/#chu
 
 Both memcached and in-memory cache "backend"s are supported:
 
+### Memcached Caching Bucket
+
 [embedmd]:# (../flags/config_bucket_cache_memcached.txt yaml)
 ```yaml
 type: MEMCACHED
@@ -336,6 +338,27 @@ metafile_doesnt_exist_ttl: 0s
 metafile_content_ttl: 0s
 metafile_max_size: 0
 ```
+
+### In-memory Caching Bucket
+
+[embedmd]:# (../flags/config_bucket_cache_in_memory.txt yaml)
+```yaml
+type: IN-MEMORY
+config:
+  max_size: 0
+  max_item_size: 0
+chunk_subrange_size: 0
+max_chunks_get_range_requests: 0
+chunk_object_attrs_ttl: 0s
+chunk_subrange_ttl: 0s
+blocks_iter_ttl: 0s
+metafile_exists_ttl: 0s
+metafile_doesnt_exist_ttl: 0s
+metafile_content_ttl: 0s
+metafile_max_size: 0
+```
+
+### Options for the Caching Bucket
 
 `config` field for memcached supports all the same configuration as memcached for [index cache](#memcached-index-cache). `addresses` in the config field is a **required** setting
 

--- a/docs/components/tools.md
+++ b/docs/components/tools.md
@@ -760,7 +760,7 @@ Flags:
                                 Path to YAML file that contains
                                 []metadata.DeletionRequest that will be applied
                                 to blocks
-      --tmp.dir="/var/folders/7q/nd_xkppx783clb5nc5zzts6c0000gn/T/thanos-rewrite"
+      --tmp.dir="/tmp/thanos-rewrite"
                                 Working directory for temporary files
       --tracing.config=<content>
                                 Alternative to 'tracing.config-file' flag

--- a/docs/components/tools.md
+++ b/docs/components/tools.md
@@ -760,7 +760,7 @@ Flags:
                                 Path to YAML file that contains
                                 []metadata.DeletionRequest that will be applied
                                 to blocks
-      --tmp.dir="/tmp/thanos-rewrite"
+      --tmp.dir="/var/folders/7q/nd_xkppx783clb5nc5zzts6c0000gn/T/thanos-rewrite"
                                 Working directory for temporary files
       --tracing.config=<content>
                                 Alternative to 'tracing.config-file' flag

--- a/scripts/cfggen/main.go
+++ b/scripts/cfggen/main.go
@@ -62,6 +62,11 @@ var (
 		storecache.MEMCACHED: cacheutil.MemcachedClientConfig{},
 	}
 
+	bucketCacheConfigs = map[storecache.BucketCacheProvider]interface{}{
+		storecache.InMemoryBucketCacheProvider:  storecache.InMemoryIndexCacheConfig{},
+		storecache.MemcachedBucketCacheProvider: cacheutil.MemcachedClientConfig{},
+	}
+
 	queryfrontendCacheConfigs = map[queryfrontend.ResponseCacheProvider]interface{}{
 		queryfrontend.INMEMORY:  queryfrontend.InMemoryResponseCacheConfig{},
 		queryfrontend.MEMCACHED: queryfrontend.MemcachedResponseCacheConfig{},
@@ -101,6 +106,13 @@ func main() {
 
 	for typ, config := range indexCacheConfigs {
 		if err := generate(storecache.IndexCacheConfig{Type: typ, Config: config}, generateName("index_cache_", string(typ)), *outputDir); err != nil {
+			level.Error(logger).Log("msg", "failed to generate", "type", typ, "err", err)
+			os.Exit(1)
+		}
+	}
+
+	for typ, config := range bucketCacheConfigs {
+		if err := generate(storecache.CachingWithBackendConfig{Type: typ, BackendConfig: config}, generateName("bucket_cache_", string(typ)), *outputDir); err != nil {
 			level.Error(logger).Log("msg", "failed to generate", "type", typ, "err", err)
 			os.Exit(1)
 		}


### PR DESCRIPTION

* [x] Change is not relevant to the end user.

Relates to this issue: https://github.com/thanos-io/thanos/issues/3888

## Changes

- Creates a new page 'caching'. This contains generic information about caching in Thanos. It also provides specific information on what the options are per component. Finally it contains some tips & tricks.
- Adds functionality to auto-generate `bucketCacheConfigs` - This is needed to give bucket cache examples
- Moved all caching related configuration & documentation to the caching page (so from Store + Frontend -> Caching). 

The last part might be trivial. The reason is that it makes the docs more clean and easier to understand (I hope). 
One can now see all the related **flags** per component, and then can find more information about for example caching, on the caching page. The same we do with tracing: https://thanos.io/tip/thanos/tracing.md/#tracing 

## Verification

make docs, make check-docs

Screenshot of the table of contents:

![image](https://user-images.githubusercontent.com/5786097/117470152-cc072280-af56-11eb-86fd-f22c6951d688.png)



