### PR TITLE
Add TLS and basic auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ We use _breaking :warning:_ to mark changes that are not backward compatible (re
 - [#4175](https://github.com/thanos-io/thanos/pull/4175) Added Tag Configuration Support Lightstep Tracing
 - [#4176](https://github.com/thanos-io/thanos/pull/4176) Query API: Adds optional `Stats param` to return stats for query APIs
 - [#4125](https://github.com/thanos-io/thanos/pull/4125) Rule: Add `--alert.relabel-config` / `--alert.relabel-config-file` allowing to specify alert relabel configurations like [Prometheus](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config)
+- [#4211](https://github.com/thanos-io/thanos/pull/4211) Add TLS and basic authentication to Thanos APIs
+
 ### Fixed
 -
 ### Changed

--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -177,6 +177,7 @@ func runCompact(
 	srv := httpserver.New(logger, reg, component, httpProbe,
 		httpserver.WithListen(conf.http.bindAddress),
 		httpserver.WithGracePeriod(time.Duration(conf.http.gracePeriod)),
+		httpserver.WithTLSConfig(conf.http.tlsConfig),
 	)
 
 	g.Add(func() error {

--- a/cmd/thanos/config.go
+++ b/cmd/thanos/config.go
@@ -57,7 +57,7 @@ func (hc *httpConfig) registerFlag(cmd extkingpin.FlagClause) *httpConfig {
 		Default("2m").SetValue(&hc.gracePeriod)
 	cmd.Flag(
 		"http-tls-config",
-		"[EXPERIMENTAL] Path to configuration file that can enable TLS or authentication.",
+		"[EXPERIMENTAL] Path to the configuration file that can enable TLS or authentication for all HTTP endpoints.",
 	).Default("").StringVar(&hc.tlsConfig)
 	return hc
 }

--- a/cmd/thanos/config.go
+++ b/cmd/thanos/config.go
@@ -56,7 +56,7 @@ func (hc *httpConfig) registerFlag(cmd extkingpin.FlagClause) *httpConfig {
 		"Time to wait after an interrupt received for HTTP Server.").
 		Default("2m").SetValue(&hc.gracePeriod)
 	cmd.Flag(
-		"http-tls-config",
+		"http.config",
 		"[EXPERIMENTAL] Path to the configuration file that can enable TLS or authentication for all HTTP endpoints.",
 	).Default("").StringVar(&hc.tlsConfig)
 	return hc

--- a/cmd/thanos/config.go
+++ b/cmd/thanos/config.go
@@ -44,6 +44,7 @@ func (gc *grpcConfig) registerFlag(cmd extkingpin.FlagClause) *grpcConfig {
 
 type httpConfig struct {
 	bindAddress string
+	tlsConfig   string
 	gracePeriod model.Duration
 }
 
@@ -54,6 +55,10 @@ func (hc *httpConfig) registerFlag(cmd extkingpin.FlagClause) *httpConfig {
 	cmd.Flag("http-grace-period",
 		"Time to wait after an interrupt received for HTTP Server.").
 		Default("2m").SetValue(&hc.gracePeriod)
+	cmd.Flag(
+		"http-tls-config",
+		"[EXPERIMENTAL] Path to configuration file that can enable TLS or authentication.",
+	).Default("").StringVar(&hc.tlsConfig)
 	return hc
 }
 

--- a/cmd/thanos/downsample.go
+++ b/cmd/thanos/downsample.go
@@ -58,6 +58,7 @@ func RunDownsample(
 	logger log.Logger,
 	reg *prometheus.Registry,
 	httpBindAddr string,
+	httpTLSConfig string,
 	httpGracePeriod time.Duration,
 	dataDir string,
 	objStoreConfig *extflag.PathOrContent,
@@ -136,6 +137,7 @@ func RunDownsample(
 	srv := httpserver.New(logger, reg, comp, httpProbe,
 		httpserver.WithListen(httpBindAddr),
 		httpserver.WithGracePeriod(httpGracePeriod),
+		httpserver.WithTLSConfig(httpTLSConfig),
 	)
 
 	g.Add(func() error {

--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -57,7 +57,7 @@ func registerQuery(app *extkingpin.App) {
 	comp := component.Query
 	cmd := app.Command(comp.String(), "Query node exposing PromQL enabled Query API with data retrieved from multiple store nodes.")
 
-	httpBindAddr, httpGracePeriod := extkingpin.RegisterHTTPFlags(cmd)
+	httpBindAddr, httpGracePeriod, httpTLSConfig := extkingpin.RegisterHTTPFlags(cmd)
 	grpcBindAddr, grpcGracePeriod, grpcCert, grpcKey, grpcClientCA := extkingpin.RegisterGRPCFlags(cmd)
 
 	secure := cmd.Flag("grpc-client-tls-secure", "Use TLS when talking to the gRPC server").Default("false").Bool()
@@ -227,6 +227,7 @@ func registerQuery(app *extkingpin.App) {
 			*caCert,
 			*serverName,
 			*httpBindAddr,
+			*httpTLSConfig,
 			time.Duration(*httpGracePeriod),
 			*webRoutePrefix,
 			*webExternalPrefix,
@@ -287,6 +288,7 @@ func runQuery(
 	caCert string,
 	serverName string,
 	httpBindAddr string,
+	httpTLSConfig string,
 	httpGracePeriod time.Duration,
 	webRoutePrefix string,
 	webExternalPrefix string,
@@ -593,6 +595,7 @@ func runQuery(
 		srv := httpserver.New(logger, reg, comp, httpProbe,
 			httpserver.WithListen(httpBindAddr),
 			httpserver.WithGracePeriod(httpGracePeriod),
+			httpserver.WithTLSConfig(httpTLSConfig),
 		)
 		srv.Handle("/", router)
 

--- a/cmd/thanos/query_frontend.go
+++ b/cmd/thanos/query_frontend.go
@@ -220,6 +220,7 @@ func runQueryFrontend(
 		srv := httpserver.New(logger, reg, comp, httpProbe,
 			httpserver.WithListen(cfg.http.bindAddress),
 			httpserver.WithGracePeriod(time.Duration(cfg.http.gracePeriod)),
+			httpserver.WithTLSConfig(cfg.http.tlsConfig),
 		)
 
 		instr := func(f http.HandlerFunc) http.HandlerFunc {

--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -47,9 +47,8 @@ import (
 func registerReceive(app *extkingpin.App) {
 	cmd := app.Command(component.Receive.String(), "Accept Prometheus remote write API requests and write to local tsdb.")
 
-	httpBindAddr, httpGracePeriod := extkingpin.RegisterHTTPFlags(cmd)
+	httpBindAddr, httpGracePeriod, httpTLSConfig := extkingpin.RegisterHTTPFlags(cmd)
 	grpcBindAddr, grpcGracePeriod, grpcCert, grpcKey, grpcClientCA := extkingpin.RegisterGRPCFlags(cmd)
-
 	rwAddress := cmd.Flag("remote-write.address", "Address to listen on for remote write requests.").
 		Default("0.0.0.0:19291").String()
 	rwServerCert := cmd.Flag("remote-write.server-tls-cert", "TLS Certificate for HTTP server, leave blank to disable TLS.").Default("").String()
@@ -155,6 +154,7 @@ func registerReceive(app *extkingpin.App) {
 			*grpcKey,
 			*grpcClientCA,
 			*httpBindAddr,
+			*httpTLSConfig,
 			time.Duration(*httpGracePeriod),
 			*rwAddress,
 			*rwServerCert,
@@ -199,6 +199,7 @@ func runReceive(
 	grpcKey string,
 	grpcClientCA string,
 	httpBindAddr string,
+	httpTLSConfig string,
 	httpGracePeriod time.Duration,
 	rwAddress string,
 	rwServerCert string,
@@ -478,6 +479,7 @@ func runReceive(
 	srv := httpserver.New(logger, reg, comp, httpProbe,
 		httpserver.WithListen(httpBindAddr),
 		httpserver.WithGracePeriod(httpGracePeriod),
+		httpserver.WithTLSConfig(httpTLSConfig),
 	)
 	g.Add(func() error {
 		statusProber.Healthy()

--- a/cmd/thanos/rule.go
+++ b/cmd/thanos/rule.go
@@ -573,6 +573,7 @@ func runRule(
 		srv := httpserver.New(logger, reg, comp, httpProbe,
 			httpserver.WithListen(conf.http.bindAddress),
 			httpserver.WithGracePeriod(time.Duration(conf.http.gracePeriod)),
+			httpserver.WithTLSConfig(conf.http.tlsConfig),
 		)
 		srv.Handle("/", router)
 

--- a/cmd/thanos/sidecar.go
+++ b/cmd/thanos/sidecar.go
@@ -118,6 +118,7 @@ func runSidecar(
 	srv := httpserver.New(logger, reg, comp, httpProbe,
 		httpserver.WithListen(conf.http.bindAddress),
 		httpserver.WithGracePeriod(time.Duration(conf.http.gracePeriod)),
+		httpserver.WithTLSConfig(conf.http.tlsConfig),
 	)
 
 	g.Add(func() error {

--- a/cmd/thanos/store.go
+++ b/cmd/thanos/store.go
@@ -221,6 +221,7 @@ func runStore(
 	srv := httpserver.New(logger, reg, conf.component, httpProbe,
 		httpserver.WithListen(conf.httpConfig.bindAddress),
 		httpserver.WithGracePeriod(time.Duration(conf.httpConfig.gracePeriod)),
+		httpserver.WithTLSConfig(conf.httpConfig.tlsConfig),
 	)
 
 	g.Add(func() error {

--- a/cmd/thanos/tools_bucket.go
+++ b/cmd/thanos/tools_bucket.go
@@ -321,8 +321,7 @@ func registerBucketInspect(app extkingpin.AppClause, objStoreConfig *extflag.Pat
 // registerBucketWeb exposes a web interface for the state of remote store like `pprof web`.
 func registerBucketWeb(app extkingpin.AppClause, objStoreConfig *extflag.PathOrContent) {
 	cmd := app.Command("web", "Web interface for remote storage bucket.")
-	httpBindAddr, httpGracePeriod := extkingpin.RegisterHTTPFlags(cmd)
-
+	httpBindAddr, httpGracePeriod, httpTLSConfig := extkingpin.RegisterHTTPFlags(cmd)
 	webRoutePrefix := cmd.Flag("web.route-prefix", "Prefix for API and UI endpoints. This allows thanos UI to be served on a sub-path. Defaults to the value of --web.external-prefix. This option is analogous to --web.route-prefix of Prometheus.").Default("").String()
 	webExternalPrefix := cmd.Flag("web.external-prefix", "Static prefix for all HTML links and redirect URLs in the bucket web UI interface. Actual endpoints are still served on / or the web.route-prefix. This allows thanos bucket web UI to be served behind a reverse proxy that strips a URL sub-path.").Default("").String()
 	webPrefixHeaderName := cmd.Flag("web.prefix-header", "Name of HTTP request header used for dynamic prefixing of UI links and redirects. This option is ignored if web.external-prefix argument is set. Security risk: enable this option only if a reverse proxy in front of thanos is resetting the header. The --web.prefix-header=X-Forwarded-Prefix option can be useful, for example, if Thanos UI is served via Traefik reverse proxy with PathPrefixStrip option enabled, which sends the stripped prefix value in X-Forwarded-Prefix header. This allows thanos UI to be served on a sub-path.").Default("").String()
@@ -343,6 +342,7 @@ func registerBucketWeb(app extkingpin.AppClause, objStoreConfig *extflag.PathOrC
 		srv := httpserver.New(logger, reg, comp, httpProbe,
 			httpserver.WithListen(*httpBindAddr),
 			httpserver.WithGracePeriod(time.Duration(*httpGracePeriod)),
+			httpserver.WithTLSConfig(*httpTLSConfig),
 		)
 
 		if *webRoutePrefix == "" {
@@ -462,7 +462,7 @@ func listResLevel() []string {
 
 func registerBucketReplicate(app extkingpin.AppClause, objStoreConfig *extflag.PathOrContent) {
 	cmd := app.Command("replicate", fmt.Sprintf("Replicate data from one object storage to another. NOTE: Currently it works only with Thanos blocks (%v has to have Thanos metadata).", block.MetaFilename))
-	httpBindAddr, httpGracePeriod := extkingpin.RegisterHTTPFlags(cmd)
+	httpBindAddr, httpGracePeriod, httpTLSConfig := extkingpin.RegisterHTTPFlags(cmd)
 	toObjStoreConfig := extkingpin.RegisterCommonObjStoreFlags(cmd, "-to", false, "The object storage which replicate data to.")
 	resolutions := cmd.Flag("resolution", "Only blocks with these resolutions will be replicated. Repeated flag.").Default("0s", "5m", "1h").HintAction(listResLevel).DurationList()
 	compactions := cmd.Flag("compaction", "Only blocks with these compaction levels will be replicated. Repeated flag.").Default("1", "2", "3", "4").Ints()
@@ -500,6 +500,7 @@ func registerBucketReplicate(app extkingpin.AppClause, objStoreConfig *extflag.P
 			reg,
 			tracer,
 			*httpBindAddr,
+			*httpTLSConfig,
 			time.Duration(*httpGracePeriod),
 			matchers,
 			resolutionLevels,
@@ -516,14 +517,14 @@ func registerBucketReplicate(app extkingpin.AppClause, objStoreConfig *extflag.P
 
 func registerBucketDownsample(app extkingpin.AppClause, objStoreConfig *extflag.PathOrContent) {
 	cmd := app.Command(component.Downsample.String(), "Continuously downsamples blocks in an object store bucket.")
-	httpAddr, httpGracePeriod := extkingpin.RegisterHTTPFlags(cmd)
+	httpAddr, httpGracePeriod, httpTLSConfig := extkingpin.RegisterHTTPFlags(cmd)
 	dataDir := cmd.Flag("data-dir", "Data directory in which to cache blocks and process downsamplings.").
 		Default("./data").String()
 	hashFunc := cmd.Flag("hash-func", "Specify which hash function to use when calculating the hashes of produced files. If no function has been specified, it does not happen. This permits avoiding downloading some files twice albeit at some performance cost. Possible values are: \"\", \"SHA256\".").
 		Default("").Enum("SHA256", "")
 
 	cmd.Setup(func(g *run.Group, logger log.Logger, reg *prometheus.Registry, tracer opentracing.Tracer, _ <-chan struct{}, _ bool) error {
-		return RunDownsample(g, logger, reg, *httpAddr, time.Duration(*httpGracePeriod), *dataDir, objStoreConfig, component.Downsample, metadata.HashFunc(*hashFunc))
+		return RunDownsample(g, logger, reg, *httpAddr, *httpTLSConfig, time.Duration(*httpGracePeriod), *dataDir, objStoreConfig, component.Downsample, metadata.HashFunc(*hashFunc))
 	})
 }
 

--- a/docs/components/compact.md
+++ b/docs/components/compact.md
@@ -377,7 +377,7 @@ Flags:
                                 Listen host:port for HTTP endpoints.
       --http-grace-period=2m    Time to wait after an interrupt received for
                                 HTTP Server.
-      --http-tls-config=""      [EXPERIMENTAL] Path to the configuration file
+      --http.config=""          [EXPERIMENTAL] Path to the configuration file
                                 that can enable TLS or authentication for all
                                 HTTP endpoints.
       --log.format=logfmt       Log format to use. Possible options: logfmt or

--- a/docs/components/compact.md
+++ b/docs/components/compact.md
@@ -377,6 +377,8 @@ Flags:
                                 Listen host:port for HTTP endpoints.
       --http-grace-period=2m    Time to wait after an interrupt received for
                                 HTTP Server.
+      --http-tls-config=""      [EXPERIMENTAL] Path to configuration file that
+                                can enable TLS or authentication.
       --log.format=logfmt       Log format to use. Possible options: logfmt or
                                 json.
       --log.level=info          Log filtering level.

--- a/docs/components/compact.md
+++ b/docs/components/compact.md
@@ -377,8 +377,9 @@ Flags:
                                 Listen host:port for HTTP endpoints.
       --http-grace-period=2m    Time to wait after an interrupt received for
                                 HTTP Server.
-      --http-tls-config=""      [EXPERIMENTAL] Path to configuration file that
-                                can enable TLS or authentication.
+      --http-tls-config=""      [EXPERIMENTAL] Path to the configuration file
+                                that can enable TLS or authentication for all
+                                HTTP endpoints.
       --log.format=logfmt       Log format to use. Possible options: logfmt or
                                 json.
       --log.level=info          Log filtering level.

--- a/docs/components/query-frontend.md
+++ b/docs/components/query-frontend.md
@@ -136,8 +136,9 @@ Flags:
                                  Listen host:port for HTTP endpoints.
       --http-grace-period=2m     Time to wait after an interrupt received for
                                  HTTP Server.
-      --http-tls-config=""       [EXPERIMENTAL] Path to configuration file that
-                                 can enable TLS or authentication.
+      --http-tls-config=""       [EXPERIMENTAL] Path to the configuration file
+                                 that can enable TLS or authentication for all
+                                 HTTP endpoints.
       --labels.default-time-range=24h
                                  The default metadata time range duration for
                                  retrieving labels through Labels and Series API

--- a/docs/components/query-frontend.md
+++ b/docs/components/query-frontend.md
@@ -136,6 +136,8 @@ Flags:
                                  Listen host:port for HTTP endpoints.
       --http-grace-period=2m     Time to wait after an interrupt received for
                                  HTTP Server.
+      --http-tls-config=""       [EXPERIMENTAL] Path to configuration file that
+                                 can enable TLS or authentication.
       --labels.default-time-range=24h
                                  The default metadata time range duration for
                                  retrieving labels through Labels and Series API

--- a/docs/components/query-frontend.md
+++ b/docs/components/query-frontend.md
@@ -136,7 +136,7 @@ Flags:
                                  Listen host:port for HTTP endpoints.
       --http-grace-period=2m     Time to wait after an interrupt received for
                                  HTTP Server.
-      --http-tls-config=""       [EXPERIMENTAL] Path to the configuration file
+      --http.config=""           [EXPERIMENTAL] Path to the configuration file
                                  that can enable TLS or authentication for all
                                  HTTP endpoints.
       --labels.default-time-range=24h

--- a/docs/components/query.md
+++ b/docs/components/query.md
@@ -323,7 +323,7 @@ Flags:
                                  Listen host:port for HTTP endpoints.
       --http-grace-period=2m     Time to wait after an interrupt received for
                                  HTTP Server.
-      --http-tls-config=""       [EXPERIMENTAL] Path to the configuration file
+      --http.config=""           [EXPERIMENTAL] Path to the configuration file
                                  that can enable TLS or authentication for all
                                  HTTP endpoints.
       --log.format=logfmt        Log format to use. Possible options: logfmt or

--- a/docs/components/query.md
+++ b/docs/components/query.md
@@ -323,6 +323,8 @@ Flags:
                                  Listen host:port for HTTP endpoints.
       --http-grace-period=2m     Time to wait after an interrupt received for
                                  HTTP Server.
+      --http-tls-config=""       [EXPERIMENTAL] Path to configuration file that
+                                 can enable TLS or authentication.
       --log.format=logfmt        Log format to use. Possible options: logfmt or
                                  json.
       --log.level=info           Log filtering level.

--- a/docs/components/query.md
+++ b/docs/components/query.md
@@ -323,8 +323,9 @@ Flags:
                                  Listen host:port for HTTP endpoints.
       --http-grace-period=2m     Time to wait after an interrupt received for
                                  HTTP Server.
-      --http-tls-config=""       [EXPERIMENTAL] Path to configuration file that
-                                 can enable TLS or authentication.
+      --http-tls-config=""       [EXPERIMENTAL] Path to the configuration file
+                                 that can enable TLS or authentication for all
+                                 HTTP endpoints.
       --log.format=logfmt        Log format to use. Possible options: logfmt or
                                  json.
       --log.level=info           Log filtering level.

--- a/docs/components/receive.md
+++ b/docs/components/receive.md
@@ -101,8 +101,9 @@ Flags:
                                  Listen host:port for HTTP endpoints.
       --http-grace-period=2m     Time to wait after an interrupt received for
                                  HTTP Server.
-      --http-tls-config=""       [EXPERIMENTAL] Path to configuration file that
-                                 can enable TLS or authentication.
+      --http-tls-config=""       [EXPERIMENTAL] Path to the configuration file
+                                 that can enable TLS or authentication for all
+                                 HTTP endpoints.
       --label=key="value" ...    External labels to announce. This flag will be
                                  removed in the future when handling multiple
                                  tsdb instances is added.

--- a/docs/components/receive.md
+++ b/docs/components/receive.md
@@ -101,7 +101,7 @@ Flags:
                                  Listen host:port for HTTP endpoints.
       --http-grace-period=2m     Time to wait after an interrupt received for
                                  HTTP Server.
-      --http-tls-config=""       [EXPERIMENTAL] Path to the configuration file
+      --http.config=""           [EXPERIMENTAL] Path to the configuration file
                                  that can enable TLS or authentication for all
                                  HTTP endpoints.
       --label=key="value" ...    External labels to announce. This flag will be

--- a/docs/components/receive.md
+++ b/docs/components/receive.md
@@ -101,6 +101,8 @@ Flags:
                                  Listen host:port for HTTP endpoints.
       --http-grace-period=2m     Time to wait after an interrupt received for
                                  HTTP Server.
+      --http-tls-config=""       [EXPERIMENTAL] Path to configuration file that
+                                 can enable TLS or authentication.
       --label=key="value" ...    External labels to announce. This flag will be
                                  removed in the future when handling multiple
                                  tsdb instances is added.

--- a/docs/components/rule.md
+++ b/docs/components/rule.md
@@ -311,7 +311,7 @@ Flags:
                                  Listen host:port for HTTP endpoints.
       --http-grace-period=2m     Time to wait after an interrupt received for
                                  HTTP Server.
-      --http-tls-config=""       [EXPERIMENTAL] Path to the configuration file
+      --http.config=""           [EXPERIMENTAL] Path to the configuration file
                                  that can enable TLS or authentication for all
                                  HTTP endpoints.
       --label=<name>="<value>" ...

--- a/docs/components/rule.md
+++ b/docs/components/rule.md
@@ -311,8 +311,9 @@ Flags:
                                  Listen host:port for HTTP endpoints.
       --http-grace-period=2m     Time to wait after an interrupt received for
                                  HTTP Server.
-      --http-tls-config=""       [EXPERIMENTAL] Path to configuration file that
-                                 can enable TLS or authentication.
+      --http-tls-config=""       [EXPERIMENTAL] Path to the configuration file
+                                 that can enable TLS or authentication for all
+                                 HTTP endpoints.
       --label=<name>="<value>" ...
                                  Labels to be applied to all generated metrics
                                  (repeated). Similar to external labels for

--- a/docs/components/rule.md
+++ b/docs/components/rule.md
@@ -311,6 +311,8 @@ Flags:
                                  Listen host:port for HTTP endpoints.
       --http-grace-period=2m     Time to wait after an interrupt received for
                                  HTTP Server.
+      --http-tls-config=""       [EXPERIMENTAL] Path to configuration file that
+                                 can enable TLS or authentication.
       --label=<name>="<value>" ...
                                  Labels to be applied to all generated metrics
                                  (repeated). Similar to external labels for

--- a/docs/components/sidecar.md
+++ b/docs/components/sidecar.md
@@ -108,8 +108,9 @@ Flags:
                                  Listen host:port for HTTP endpoints.
       --http-grace-period=2m     Time to wait after an interrupt received for
                                  HTTP Server.
-      --http-tls-config=""       [EXPERIMENTAL] Path to configuration file that
-                                 can enable TLS or authentication.
+      --http-tls-config=""       [EXPERIMENTAL] Path to the configuration file
+                                 that can enable TLS or authentication for all
+                                 HTTP endpoints.
       --log.format=logfmt        Log format to use. Possible options: logfmt or
                                  json.
       --log.level=info           Log filtering level.

--- a/docs/components/sidecar.md
+++ b/docs/components/sidecar.md
@@ -108,6 +108,8 @@ Flags:
                                  Listen host:port for HTTP endpoints.
       --http-grace-period=2m     Time to wait after an interrupt received for
                                  HTTP Server.
+      --http-tls-config=""       [EXPERIMENTAL] Path to configuration file that
+                                 can enable TLS or authentication.
       --log.format=logfmt        Log format to use. Possible options: logfmt or
                                  json.
       --log.level=info           Log filtering level.

--- a/docs/components/sidecar.md
+++ b/docs/components/sidecar.md
@@ -108,7 +108,7 @@ Flags:
                                  Listen host:port for HTTP endpoints.
       --http-grace-period=2m     Time to wait after an interrupt received for
                                  HTTP Server.
-      --http-tls-config=""       [EXPERIMENTAL] Path to the configuration file
+      --http.config=""           [EXPERIMENTAL] Path to the configuration file
                                  that can enable TLS or authentication for all
                                  HTTP endpoints.
       --log.format=logfmt        Log format to use. Possible options: logfmt or

--- a/docs/components/store.md
+++ b/docs/components/store.md
@@ -75,8 +75,9 @@ Flags:
                                  Listen host:port for HTTP endpoints.
       --http-grace-period=2m     Time to wait after an interrupt received for
                                  HTTP Server.
-      --http-tls-config=""       [EXPERIMENTAL] Path to configuration file that
-                                 can enable TLS or authentication.
+      --http-tls-config=""       [EXPERIMENTAL] Path to the configuration file
+                                 that can enable TLS or authentication for all
+                                 HTTP endpoints.
       --ignore-deletion-marks-delay=24h
                                  Duration after which the blocks marked for
                                  deletion will be filtered out while fetching

--- a/docs/components/store.md
+++ b/docs/components/store.md
@@ -75,7 +75,7 @@ Flags:
                                  Listen host:port for HTTP endpoints.
       --http-grace-period=2m     Time to wait after an interrupt received for
                                  HTTP Server.
-      --http-tls-config=""       [EXPERIMENTAL] Path to the configuration file
+      --http.config=""           [EXPERIMENTAL] Path to the configuration file
                                  that can enable TLS or authentication for all
                                  HTTP endpoints.
       --ignore-deletion-marks-delay=24h

--- a/docs/components/store.md
+++ b/docs/components/store.md
@@ -75,6 +75,8 @@ Flags:
                                  Listen host:port for HTTP endpoints.
       --http-grace-period=2m     Time to wait after an interrupt received for
                                  HTTP Server.
+      --http-tls-config=""       [EXPERIMENTAL] Path to configuration file that
+                                 can enable TLS or authentication.
       --ignore-deletion-marks-delay=24h
                                  Duration after which the blocks marked for
                                  deletion will be filtered out while fetching

--- a/docs/components/tools.md
+++ b/docs/components/tools.md
@@ -218,6 +218,8 @@ Flags:
                                 Listen host:port for HTTP endpoints.
       --http-grace-period=2m    Time to wait after an interrupt received for
                                 HTTP Server.
+      --http-tls-config=""      [EXPERIMENTAL] Path to configuration file that
+                                can enable TLS or authentication.
       --label=LABEL             Prometheus label to use as timeline title
       --log.format=logfmt       Log format to use. Possible options: logfmt or
                                 json.
@@ -485,6 +487,8 @@ Flags:
                                  Listen host:port for HTTP endpoints.
       --http-grace-period=2m     Time to wait after an interrupt received for
                                  HTTP Server.
+      --http-tls-config=""       [EXPERIMENTAL] Path to configuration file that
+                                 can enable TLS or authentication.
       --id=ID ...                Block to be replicated to the destination
                                  bucket. IDs will be used to match blocks and
                                  other matchers will be ignored. When specified,
@@ -589,6 +593,8 @@ Flags:
                               Listen host:port for HTTP endpoints.
       --http-grace-period=2m  Time to wait after an interrupt received for HTTP
                               Server.
+      --http-tls-config=""    [EXPERIMENTAL] Path to configuration file that can
+                              enable TLS or authentication.
       --log.format=logfmt     Log format to use. Possible options: logfmt or
                               json.
       --log.level=info        Log filtering level.

--- a/docs/components/tools.md
+++ b/docs/components/tools.md
@@ -218,7 +218,7 @@ Flags:
                                 Listen host:port for HTTP endpoints.
       --http-grace-period=2m    Time to wait after an interrupt received for
                                 HTTP Server.
-      --http-tls-config=""      [EXPERIMENTAL] Path to the configuration file
+      --http.config=""          [EXPERIMENTAL] Path to the configuration file
                                 that can enable TLS or authentication for all
                                 HTTP endpoints.
       --label=LABEL             Prometheus label to use as timeline title
@@ -488,7 +488,7 @@ Flags:
                                  Listen host:port for HTTP endpoints.
       --http-grace-period=2m     Time to wait after an interrupt received for
                                  HTTP Server.
-      --http-tls-config=""       [EXPERIMENTAL] Path to the configuration file
+      --http.config=""           [EXPERIMENTAL] Path to the configuration file
                                  that can enable TLS or authentication for all
                                  HTTP endpoints.
       --id=ID ...                Block to be replicated to the destination
@@ -595,7 +595,7 @@ Flags:
                               Listen host:port for HTTP endpoints.
       --http-grace-period=2m  Time to wait after an interrupt received for HTTP
                               Server.
-      --http-tls-config=""    [EXPERIMENTAL] Path to the configuration file that
+      --http.config=""        [EXPERIMENTAL] Path to the configuration file that
                               can enable TLS or authentication for all HTTP
                               endpoints.
       --log.format=logfmt     Log format to use. Possible options: logfmt or

--- a/docs/components/tools.md
+++ b/docs/components/tools.md
@@ -218,8 +218,9 @@ Flags:
                                 Listen host:port for HTTP endpoints.
       --http-grace-period=2m    Time to wait after an interrupt received for
                                 HTTP Server.
-      --http-tls-config=""      [EXPERIMENTAL] Path to configuration file that
-                                can enable TLS or authentication.
+      --http-tls-config=""      [EXPERIMENTAL] Path to the configuration file
+                                that can enable TLS or authentication for all
+                                HTTP endpoints.
       --label=LABEL             Prometheus label to use as timeline title
       --log.format=logfmt       Log format to use. Possible options: logfmt or
                                 json.
@@ -487,8 +488,9 @@ Flags:
                                  Listen host:port for HTTP endpoints.
       --http-grace-period=2m     Time to wait after an interrupt received for
                                  HTTP Server.
-      --http-tls-config=""       [EXPERIMENTAL] Path to configuration file that
-                                 can enable TLS or authentication.
+      --http-tls-config=""       [EXPERIMENTAL] Path to the configuration file
+                                 that can enable TLS or authentication for all
+                                 HTTP endpoints.
       --id=ID ...                Block to be replicated to the destination
                                  bucket. IDs will be used to match blocks and
                                  other matchers will be ignored. When specified,
@@ -593,8 +595,9 @@ Flags:
                               Listen host:port for HTTP endpoints.
       --http-grace-period=2m  Time to wait after an interrupt received for HTTP
                               Server.
-      --http-tls-config=""    [EXPERIMENTAL] Path to configuration file that can
-                              enable TLS or authentication.
+      --http-tls-config=""    [EXPERIMENTAL] Path to the configuration file that
+                              can enable TLS or authentication for all HTTP
+                              endpoints.
       --log.format=logfmt     Log format to use. Possible options: logfmt or
                               json.
       --log.level=info        Log filtering level.

--- a/docs/operating/https.md
+++ b/docs/operating/https.md
@@ -1,0 +1,92 @@
+---
+title: Running Thanos with HTTPS and basic auth
+type: docs
+menu: operating
+---
+
+# HTTPS and authentication
+
+Thanos supports basic authentication and TLS. This is **experimental** and might change in the future.
+
+To specify which HTTP TLS configuration file to load, use the `--http-tls-config` flag.
+The file is written in [YAML format](https://en.wikipedia.org/wiki/YAML), defined by the scheme described below.
+
+## Scheme
+
+Brackets indicate that a parameter is optional. For non-list parameters the value is set to the specified default.
+The file is read upon every http request, such as any change in the configuration and the certificates is picked up immediately.
+
+Generic placeholders are defined as follows:
+
+- `<boolean>`: a boolean that can take the values `true` or `false`
+- `<filename>`: a valid path in the current working directory
+- `<secret>`: a regular string that is a secret, such as a password
+- `<string>`: a regular string
+
+```yaml
+tls_server_config:
+  # Certificate and key files for server to use to authenticate to client.
+  cert_file: <filename>
+  key_file: <filename>
+
+  # Server policy for client authentication. Maps to ClientAuth Policies.
+  # For more detail on clientAuth options:
+  # https://golang.org/pkg/crypto/tls/#ClientAuthType
+  [ client_auth_type: <string> | default = "NoClientCert" ]
+
+  # CA certificate for client certificate authentication to the server.
+  [ client_ca_file: <filename> ]
+
+  # Minimum TLS version that is acceptable.
+  [ min_version: <string> | default = "TLS12" ]
+
+  # Maximum TLS version that is acceptable.
+  [ max_version: <string> | default = "TLS13" ]
+
+  # List of supported cipher suites for TLS versions up to TLS 1.2. If empty,
+  # Go default cipher suites are used. Available cipher suites are documented
+  # in the go documentation:
+  # https://golang.org/pkg/crypto/tls/#pkg-constants
+  [ cipher_suites:
+    [ - <string> ] ]
+
+  # prefer_server_cipher_suites controls whether the server selects the
+  # client's most preferred ciphersuite, or the server's most preferred
+  # ciphersuite. If true then the server's preference, as expressed in
+  # the order of elements in cipher_suites, is used.
+  [ prefer_server_cipher_suites: <bool> | default = true ]
+
+  # Elliptic curves that will be used in an ECDHE handshake, in preference
+  # order. Available curves are documented in the go documentation:
+  # https://golang.org/pkg/crypto/tls/#CurveID
+  [ curve_preferences:
+    [ - <string> ] ]
+
+http_server_config:
+  # Enable HTTP/2 support. Note that HTTP/2 is only supported with TLS.
+  # This can not be changed on the fly.
+  [ http2: <boolean> | default = true ]
+
+# Usernames and hashed passwords that have full access to the web
+# server via basic authentication. If empty, no basic authentication is
+# required. Passwords are hashed with bcrypt.
+basic_auth_users:
+  [ <string>: <secret> ... ]
+```
+
+## Example
+
+An example configuration file is provided below,
+
+```yaml
+# A certificate and a key file are needed.
+tls_server_config:
+  cert_file: server.crt
+  key_file: server.key
+
+# Usernames and passwords required to connect to Thanos.
+# Passwords are hashed with bcrypt.
+basic_auth_users:
+  alice: $2y$10$mDwo.lAisC94iLAyP81MCesa29IzH37oigHC/42V2pdJlUprsJPze
+  bob: $2y$10$hLqFl9jSjoAAy95Z/zw8Ye8wkdMBM8c5Bn1ptYqP/AXyV0.oy0S8m
+```

--- a/docs/operating/https.md
+++ b/docs/operating/https.md
@@ -8,7 +8,7 @@ menu: operating
 
 Thanos supports basic authentication and TLS. This is **experimental** and might change in the future.
 
-To specify which HTTP TLS configuration file to load, use the `--http-tls-config` flag.
+To specify which HTTP TLS configuration file to load, use the `--http.config` flag.
 The file is written in [YAML format](https://en.wikipedia.org/wiki/YAML), defined by the scheme described below.
 
 ## Scheme

--- a/go.mod
+++ b/go.mod
@@ -51,6 +51,7 @@ require (
 	github.com/prometheus/client_golang v1.10.0
 	github.com/prometheus/client_model v0.2.0
 	github.com/prometheus/common v0.21.0
+	github.com/prometheus/exporter-toolkit v0.5.1
 	github.com/prometheus/prometheus v1.8.2-0.20210421143221-52df5ef7a3be
 	github.com/uber/jaeger-client-go v2.25.0+incompatible
 	github.com/uber/jaeger-lib v2.4.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -1099,6 +1099,7 @@ github.com/prometheus/common v0.20.0/go.mod h1:U+gB1OBLb1lF3O42bTCL+FK18tX9Oar16
 github.com/prometheus/common v0.21.0 h1:SMvI2JVldvfUvRVlP64jkIJEC6WiGHJcN2e5tB+ztF8=
 github.com/prometheus/common v0.21.0/go.mod h1:U+gB1OBLb1lF3O42bTCL+FK18tX9Oar16Clt/msog/s=
 github.com/prometheus/exporter-toolkit v0.5.0/go.mod h1:OCkM4805mmisBhLmVFw858QYi3v0wKdY6/UxrT0pZVg=
+github.com/prometheus/exporter-toolkit v0.5.1 h1:9eqgis5er9xN613ZSADjypCJaDGj9ZlcWBvsIHa8/3c=
 github.com/prometheus/exporter-toolkit v0.5.1/go.mod h1:OCkM4805mmisBhLmVFw858QYi3v0wKdY6/UxrT0pZVg=
 github.com/prometheus/node_exporter v1.0.0-rc.0.0.20200428091818-01054558c289 h1:dTUS1vaLWq+Y6XKOTnrFpoVsQKLCbCp1OLj24TDi7oM=
 github.com/prometheus/node_exporter v1.0.0-rc.0.0.20200428091818-01054558c289/go.mod h1:FGbBv5OPKjch+jNUJmEQpMZytIdyW0NdBtWFcfSKusc=

--- a/pkg/extkingpin/flags.go
+++ b/pkg/extkingpin/flags.go
@@ -43,11 +43,14 @@ func RegisterGRPCFlags(cmd FlagClause) (
 }
 
 // RegisterCommonObjStoreFlags register flags commonly used to configure http servers with.
-func RegisterHTTPFlags(cmd FlagClause) (httpBindAddr *string, httpGracePeriod *model.Duration) {
+func RegisterHTTPFlags(cmd FlagClause) (httpBindAddr *string, httpGracePeriod *model.Duration, httpTLSConfig *string) {
 	httpBindAddr = cmd.Flag("http-address", "Listen host:port for HTTP endpoints.").Default("0.0.0.0:10902").String()
 	httpGracePeriod = ModelDuration(cmd.Flag("http-grace-period", "Time to wait after an interrupt received for HTTP Server.").Default("2m")) // by default it's the same as query.timeout.
-
-	return httpBindAddr, httpGracePeriod
+	httpTLSConfig = cmd.Flag(
+		"http-tls-config",
+		"[EXPERIMENTAL] Path to configuration file that can enable TLS or authentication.",
+	).Default("").String()
+	return httpBindAddr, httpGracePeriod, httpTLSConfig
 }
 
 // RegisterCommonObjStoreFlags register flags to specify object storage configuration.

--- a/pkg/extkingpin/flags.go
+++ b/pkg/extkingpin/flags.go
@@ -48,7 +48,7 @@ func RegisterHTTPFlags(cmd FlagClause) (httpBindAddr *string, httpGracePeriod *m
 	httpGracePeriod = ModelDuration(cmd.Flag("http-grace-period", "Time to wait after an interrupt received for HTTP Server.").Default("2m")) // by default it's the same as query.timeout.
 	httpTLSConfig = cmd.Flag(
 		"http-tls-config",
-		"[EXPERIMENTAL] Path to configuration file that can enable TLS or authentication.",
+		"[EXPERIMENTAL] Path to the configuration file that can enable TLS or authentication for all HTTP endpoints.",
 	).Default("").String()
 	return httpBindAddr, httpGracePeriod, httpTLSConfig
 }

--- a/pkg/extkingpin/flags.go
+++ b/pkg/extkingpin/flags.go
@@ -47,7 +47,7 @@ func RegisterHTTPFlags(cmd FlagClause) (httpBindAddr *string, httpGracePeriod *m
 	httpBindAddr = cmd.Flag("http-address", "Listen host:port for HTTP endpoints.").Default("0.0.0.0:10902").String()
 	httpGracePeriod = ModelDuration(cmd.Flag("http-grace-period", "Time to wait after an interrupt received for HTTP Server.").Default("2m")) // by default it's the same as query.timeout.
 	httpTLSConfig = cmd.Flag(
-		"http-tls-config",
+		"http.config",
 		"[EXPERIMENTAL] Path to the configuration file that can enable TLS or authentication for all HTTP endpoints.",
 	).Default("").String()
 	return httpBindAddr, httpGracePeriod, httpTLSConfig

--- a/pkg/replicate/replicator.go
+++ b/pkg/replicate/replicator.go
@@ -75,6 +75,7 @@ func RunReplicate(
 	reg *prometheus.Registry,
 	_ opentracing.Tracer,
 	httpBindAddr string,
+	httpTLSConfig string,
 	httpGracePeriod time.Duration,
 	labelSelector labels.Selector,
 	resolutions []compact.ResolutionLevel,
@@ -98,6 +99,7 @@ func RunReplicate(
 	s := http.New(logger, reg, component.Replicate, httpProbe,
 		http.WithListen(httpBindAddr),
 		http.WithGracePeriod(httpGracePeriod),
+		http.WithTLSConfig(httpTLSConfig),
 	)
 
 	g.Add(func() error {

--- a/pkg/server/http/http.go
+++ b/pkg/server/http/http.go
@@ -14,6 +14,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	toolkit_web "github.com/prometheus/exporter-toolkit/web"
 
 	"github.com/thanos-io/thanos/pkg/component"
 	"github.com/thanos-io/thanos/pkg/prober"
@@ -60,7 +61,12 @@ func New(logger log.Logger, reg *prometheus.Registry, comp component.Component, 
 // ListenAndServe listens on the TCP network address and handles requests on incoming connections.
 func (s *Server) ListenAndServe() error {
 	level.Info(s.logger).Log("msg", "listening for requests and metrics", "address", s.opts.listen)
-	return errors.Wrap(s.srv.ListenAndServe(), "serve HTTP and metrics")
+	err := toolkit_web.Validate(s.opts.tlsConfigPath)
+	if err != nil {
+		level.Error(s.logger).Log("msg", "server could not be started", "err", err)
+		return errors.Wrap(err, "server could not be started")
+	}
+	return errors.Wrap(toolkit_web.ListenAndServe(s.srv, s.opts.tlsConfigPath, s.logger), "serve HTTP and metrics")
 }
 
 // Shutdown gracefully shuts down the server by waiting,

--- a/pkg/server/http/http.go
+++ b/pkg/server/http/http.go
@@ -63,7 +63,6 @@ func (s *Server) ListenAndServe() error {
 	level.Info(s.logger).Log("msg", "listening for requests and metrics", "address", s.opts.listen)
 	err := toolkit_web.Validate(s.opts.tlsConfigPath)
 	if err != nil {
-		level.Error(s.logger).Log("msg", "server could not be started", "err", err)
 		return errors.Wrap(err, "server could not be started")
 	}
 	return errors.Wrap(toolkit_web.ListenAndServe(s.srv, s.opts.tlsConfigPath, s.logger), "serve HTTP and metrics")

--- a/pkg/server/http/option.go
+++ b/pkg/server/http/option.go
@@ -9,9 +9,10 @@ import (
 )
 
 type options struct {
-	gracePeriod time.Duration
-	listen      string
-	mux         *http.ServeMux
+	gracePeriod   time.Duration
+	listen        string
+	tlsConfigPath string
+	mux           *http.ServeMux
 }
 
 // Option overrides behavior of Server.
@@ -38,6 +39,12 @@ func WithGracePeriod(t time.Duration) Option {
 func WithListen(s string) Option {
 	return optionFunc(func(o *options) {
 		o.listen = s
+	})
+}
+
+func WithTLSConfig(tls string) Option {
+	return optionFunc(func(o *options) {
+		o.tlsConfigPath = tls
 	})
 }
 


### PR DESCRIPTION
* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

This PR adds in TLS and basic auth to Thanos HTTP APIs using [exporter-toolkit](https://github.com/prometheus/exporter-toolkit). Configuration follows a similar pattern to Prometheus, where a file containing [TLS configuration](https://github.com/prometheus/prometheus/blob/main/docs/configuration/https.md) is provided using `http-tls-config` flag.
Addresses issue #4168 

## Verification

Tested locally.