### PR TITLE
Report errors to caller when Close() fails

### DIFF
--- a/pkg/objstore/swift/swift.go
+++ b/pkg/objstore/swift/swift.go
@@ -282,7 +282,7 @@ func (c *Container) IsObjNotFoundErr(err error) bool {
 }
 
 // Upload writes the contents of the reader as an object into the container.
-func (c *Container) Upload(_ context.Context, name string, r io.Reader) error {
+func (c *Container) Upload(_ context.Context, name string, r io.Reader) (err error) {
 	size, err := objstore.TryToGetSize(r)
 	if err != nil {
 		level.Warn(c.logger).Log("msg", "could not guess file size, using large object to avoid issues if the file is larger than limit", "name", name, "err", err)
@@ -312,7 +312,7 @@ func (c *Container) Upload(_ context.Context, name string, r io.Reader) error {
 			return errors.Wrap(err, "create file")
 		}
 	}
-	defer runutil.CloseWithLogOnErr(c.logger, file, "upload object close")
+	defer runutil.CloseWithErrCapture(&err, file, "upload object close")
 	if _, err := io.Copy(file, r); err != nil {
 		return errors.Wrap(err, "uploading object")
 	}


### PR DESCRIPTION
Resolves #3958

As per NCW Swift's [ObjectCreate():](https://pkg.go.dev/github.com/ncw/swift/v2?utm_source=godoc#Connection.ObjectCreate)

> You MUST call Close() on it and you MUST check the error return from Close().

Signed-off-by: Benjamin Charron <benjamin.charron@ubisoft.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Report failures during Upload() back to the caller so that it can retry the operation

## Verification

- Manual testing with TestObjStore_AcceptanceTest_e2e
