### PR TITLE
Docs: fix broken links in website and github

### DIFF
--- a/docs/contributing/how-to-contribute-to-docs.md
+++ b/docs/contributing/how-to-contribute-to-docs.md
@@ -87,7 +87,7 @@ and create PR against Thanos `main` branch.
 
 ## White noise
 
-We want all docs to not have any white noise. To achieve it, we provide cleanup-white-noise.sh under `scripts` to check.
+We want all docs to not have any white noise. To achieve it, we provide [cleanup-white-noise.sh](https://github.com/thanos-io/thanos/blob/main/scripts/cleanup-white-noise.sh) under `scripts` to check.
 You can call it before a pull request, also PR test would call it too.
 
 ## Testing

--- a/docs/contributing/mentorship.md
+++ b/docs/contributing/mentorship.md
@@ -12,7 +12,7 @@ Both Thanos and Prometheus projects participate in various, periodic mentoring p
 
 Programs we participated / are participating:
 
-- [CommunityBridge](https://github.com/cncf/mentoring/tree/master/communitybridge)
+- [LFX Mentorship](https://github.com/cncf/mentoring/tree/master/lfx-mentorship)
 - [Google Summer of Code](https://github.com/cncf/mentoring/tree/master/summerofcode)
 - [Red Hat Beyond](https://research.redhat.com/blog/2020/05/24/open-source-development-course-and-devops-methodology/)
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -78,7 +78,7 @@ A store node acts as a gateway to block data that is stored in an object storage
 It continuously synchronizes which blocks exist in the bucket and translates requests for metric data into object storage requests. It implements various strategies to minimize the number of requests to the object storage such as filtering relevant blocks by their metadata (e.g. time range and labels) and caching frequent index lookups.
 
 The Prometheus 2.0 storage layout is optimized for minimal read amplification. For example, sample data for the same time series is sequentially aligned in a [chunk file](design.md/#chunk-file). Similarly, series for the same metric name is sequentially aligned as well.
-The store node is aware of the files' layout and translates data requests into a plan of a minimum amount of object storage request. Each request may fetch up to hundreds of thousands of [chunks](design.md/#Note) at once. This is essential to satisfy even big queries with a limited amount of requests to the object storage.
+The store node is aware of the files' layout and translates data requests into a plan of a minimum amount of object storage request. Each request may fetch up to hundreds of thousands of [chunks](design.md/#chunk) at once. This is essential to satisfy even big queries with a limited amount of requests to the object storage.
 
 Currently, only index data is cached. [Chunk](design.md/#chunk) data could be cached but is orders of magnitude larger in size. In the current state, fetching chunk data from the object storage already only accounts for a small fraction of end-to-end latency. Thus, there's currently no incentive to increase the store nodes resource requirements/limit its scalability by adding chunk caching.
 

--- a/docs/operating/use-cases.md
+++ b/docs/operating/use-cases.md
@@ -6,7 +6,7 @@ menu: operating
 
 # Overview
 
-There are many great use cases of [Thanos](thanos.io), we collect them here for others to refer to.
+There are many great use cases of [Thanos](https://thanos.io/), we collect them here for others to refer to.
 
 ## Horizontal scaleable Prometheus Scraping with Kvass
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -108,14 +108,14 @@ separate what have changed between release candidates.
     1. If there were any changes then update the relevant alerting rules and/or dashboards since `thanos-mixin` is part
        of the repository now
 
-1. Update website's [hugo.yaml](../website/hugo.yaml) to have correct links for new release (
+1. Update website's [hugo.yaml](https://github.com/thanos-io/thanos/blob/main/website/hugo.yaml) to have correct links for new release (
    add `0.y.z: "/:sections/:filename.md"`).
 
 1. Update tutorials:
 
     1. Update the Thanos version used in the [tutorials](../tutorials) manifests.
     1. In case of any breaking changes or necessary updates adjust the manifests so the tutorial stays up to date.
-    1. Update the [scripts/quickstart.sh](../scripts/quickstart.sh) script if needed.
+    1. Update the [scripts/quickstart.sh](https://github.com/thanos-io/thanos/blob/main/scripts/quickstart.sh) script if needed.
 
 1. After review, merge the PR and immediately after this tag a version:
 

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -607,7 +607,7 @@ Example meta.json file:
 }
 ```
 
-Format in Go code can be found [here](../pkg/block/metadata/meta.go).
+Format in Go code can be found [here](https://github.com/thanos-io/thanos/blob/main/pkg/block/metadata/meta.go).
 
 ##### External Labels
 


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->
- Fixed broken links
- Ensured that links are working in GitHub markdown files as well as the Thanos documentation website

**Note**: Rest of the broken links are due to different directory structure in GitHub and in the Thanos website which will be fixed by #3081 and this PR is not a fix for that.

## Verification

<!-- How you tested it? How do you know it works? -->
Manual checking of all links
