### PR TITLE
Don't add replica labels to exemplar labels, only to its series labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,9 @@ We use _breaking :warning:_ to mark changes that are not backward compatible (re
 ### Fixed
 -
 ### Changed
--
+
+- [#4223](https://github.com/thanos-io/thanos/pull/4223) Query: federated exemplars API only add replica labels to series labels, not to exemplar labels.
+
 ### Removed
 -
 

--- a/pkg/exemplars/exemplars_test.go
+++ b/pkg/exemplars/exemplars_test.go
@@ -15,7 +15,7 @@ func TestMain(m *testing.M) {
 	testutil.TolerantVerifyLeakMain(m)
 }
 
-func TestDedupExemplarsData(t *testing.T) {
+func TestDedupExemplarsSeriesLabels(t *testing.T) {
 	for _, tc := range []struct {
 		name            string
 		exemplars, want []*exemplarspb.ExemplarData
@@ -135,128 +135,7 @@ func TestDedupExemplarsData(t *testing.T) {
 			for _, lbl := range tc.replicaLabels {
 				replicaLabels[lbl] = struct{}{}
 			}
-			testutil.Equals(t, tc.want, dedupExemplarsData(tc.exemplars, replicaLabels))
-		})
-	}
-}
-
-func TestDedupExemplars(t *testing.T) {
-	for _, tc := range []struct {
-		name            string
-		exemplars, want []*exemplarspb.Exemplar
-		replicaLabels   []string
-	}{
-		{
-			name:      "nil slice",
-			exemplars: nil,
-			want:      nil,
-		},
-		{
-			name:      "empty exemplars slice",
-			exemplars: []*exemplarspb.Exemplar{},
-			want:      []*exemplarspb.Exemplar{},
-		},
-		{
-			name: "duplicate exemplars",
-			exemplars: []*exemplarspb.Exemplar{
-				{
-					Labels: labelpb.ZLabelSet{Labels: []labelpb.ZLabel{
-						{Name: "traceID", Value: "EpTxMJ40fUus7aGY"},
-					}},
-					Value: 19,
-					Ts:    1600096955479,
-				},
-				{
-					Labels: labelpb.ZLabelSet{Labels: []labelpb.ZLabel{
-						{Name: "traceID", Value: "EpTxMJ40fUus7aGY"},
-					}},
-					Value: 19,
-					Ts:    1600096955479,
-				},
-			},
-			want: []*exemplarspb.Exemplar{
-				{
-					Labels: labelpb.ZLabelSet{Labels: []labelpb.ZLabel{
-						{Name: "traceID", Value: "EpTxMJ40fUus7aGY"},
-					}},
-					Value: 19,
-					Ts:    1600096955479,
-				},
-			},
-		},
-		{
-			name: "distinct exemplars",
-			exemplars: []*exemplarspb.Exemplar{
-				{
-					Labels: labelpb.ZLabelSet{Labels: []labelpb.ZLabel{
-						{Name: "traceID", Value: "EpTxMJ40fUus7aGY"},
-					}},
-					Value: 19,
-					Ts:    1600096955479,
-				},
-				{
-					Labels: labelpb.ZLabelSet{Labels: []labelpb.ZLabel{
-						{Name: "traceID", Value: "EpTxMJ40fUus7aGY"},
-					}},
-					Value: 20,
-					Ts:    1600096955479,
-				},
-			},
-			want: []*exemplarspb.Exemplar{
-				{
-					Labels: labelpb.ZLabelSet{Labels: []labelpb.ZLabel{
-						{Name: "traceID", Value: "EpTxMJ40fUus7aGY"},
-					}},
-					Value: 19,
-					Ts:    1600096955479,
-				},
-				{
-					Labels: labelpb.ZLabelSet{Labels: []labelpb.ZLabel{
-						{Name: "traceID", Value: "EpTxMJ40fUus7aGY"},
-					}},
-					Value: 20,
-					Ts:    1600096955479,
-				},
-			},
-		},
-		{
-			name:          "exemplars with replica labels",
-			replicaLabels: []string{"replica"},
-			exemplars: []*exemplarspb.Exemplar{
-				{
-					Labels: labelpb.ZLabelSet{Labels: []labelpb.ZLabel{
-						{Name: "traceID", Value: "EpTxMJ40fUus7aGY"},
-						{Name: "replica", Value: "0"},
-					}},
-					Value: 19,
-					Ts:    1600096955479,
-				},
-				{
-					Labels: labelpb.ZLabelSet{Labels: []labelpb.ZLabel{
-						{Name: "traceID", Value: "EpTxMJ40fUus7aGY"},
-						{Name: "replica", Value: "1"},
-					}},
-					Value: 19,
-					Ts:    1600096955479,
-				},
-			},
-			want: []*exemplarspb.Exemplar{
-				{
-					Labels: labelpb.ZLabelSet{Labels: []labelpb.ZLabel{
-						{Name: "traceID", Value: "EpTxMJ40fUus7aGY"},
-					}},
-					Value: 19,
-					Ts:    1600096955479,
-				},
-			},
-		},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			replicaLabels := make(map[string]struct{})
-			for _, lbl := range tc.replicaLabels {
-				replicaLabels[lbl] = struct{}{}
-			}
-			testutil.Equals(t, tc.want, dedupExemplars(tc.exemplars, replicaLabels))
+			testutil.Equals(t, tc.want, dedupExemplarsSeriesLabels(tc.exemplars, replicaLabels))
 		})
 	}
 }

--- a/pkg/exemplars/exemplarspb/custom.go
+++ b/pkg/exemplars/exemplarspb/custom.go
@@ -66,6 +66,7 @@ func NewWarningExemplarsResponse(warning error) *ExemplarsResponse {
 	}
 }
 
+// Compare only compares the series labels of two exemplar data.
 func (s1 *ExemplarData) Compare(s2 *ExemplarData) int {
 	return labels.Compare(s1.SeriesLabels.PromLabels(), s2.SeriesLabels.PromLabels())
 }
@@ -80,26 +81,17 @@ func (s *ExemplarData) SetSeriesLabels(ls labels.Labels) {
 	s.SeriesLabels = result
 }
 
-func (e *Exemplar) SetLabels(ls labels.Labels) {
-	var result labelpb.ZLabelSet
-
-	if len(ls) > 0 {
-		result = labelpb.ZLabelSet{Labels: labelpb.ZLabelsFromPromLabels(ls)}
+// Compare is used for sorting and comparing exemplars. Start from timestamp, then labels, finally values.
+func (e1 *Exemplar) Compare(e2 *Exemplar) int {
+	if e1.Ts < e2.Ts {
+		return -1
+	}
+	if e1.Ts > e2.Ts {
+		return 1
 	}
 
-	e.Labels = result
-}
-
-func (e1 *Exemplar) Compare(e2 *Exemplar) int {
 	if d := labels.Compare(e1.Labels.PromLabels(), e2.Labels.PromLabels()); d != 0 {
 		return d
 	}
-	if e1.Ts < e2.Ts {
-		return 1
-	}
-	if e1.Ts > e2.Ts {
-		return -1
-	}
-
 	return big.NewFloat(e1.Value).Cmp(big.NewFloat(e2.Value))
 }


### PR DESCRIPTION
Signed-off-by: yeya24 <yb532204897@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

Fixes #4222 

This pr removes the step of adding replica labels to exemplars. Only adding replica labels to exemplars' series labels.

## Verification

<!-- How you tested it? How do you know it works? -->
