### PR TITLE
receiver: Move the Flags for receiver to a separate struct

### DIFF
--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -51,7 +51,7 @@ func registerReceive(app *extkingpin.App) {
 	conf.registerFlag(cmd)
 
 	cmd.Setup(func(g *run.Group, logger log.Logger, reg *prometheus.Registry, tracer opentracing.Tracer, _ <-chan struct{}, _ bool) error {
-		lset, err := parseFlagLabels(*conf.labelStrs)
+		lset, err := parseFlagLabels(conf.labelStrs)
 		if err != nil {
 			return errors.Wrap(err, "parse labels")
 		}
@@ -576,7 +576,7 @@ type receiveConfig struct {
 	rwClientServerName string
 
 	dataDir   string
-	labelStrs *[]string
+	labelStrs []string
 
 	objStoreConfig *extflag.PathOrContent
 	retention      *model.Duration
@@ -632,7 +632,7 @@ func (rc *receiveConfig) registerFlag(cmd extkingpin.FlagClause) {
 	cmd.Flag("tsdb.path", "Data directory of TSDB.").
 		Default("./data").StringVar(&rc.dataDir)
 
-	cmd.Flag("label", "External labels to announce. This flag will be removed in the future when handling multiple tsdb instances is added.").PlaceHolder("key=\"value\"").StringsVar(rc.labelStrs)
+	cmd.Flag("label", "External labels to announce. This flag will be removed in the future when handling multiple tsdb instances is added.").PlaceHolder("key=\"value\"").StringsVar(&rc.labelStrs)
 
 	rc.objStoreConfig = extkingpin.RegisterCommonObjStoreFlags(cmd, "", false)
 

--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -24,8 +24,8 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/tsdb"
-	"github.com/thanos-io/thanos/pkg/block/metadata"
 
+	"github.com/thanos-io/thanos/pkg/block/metadata"
 	"github.com/thanos-io/thanos/pkg/extkingpin"
 	"github.com/thanos-io/thanos/pkg/logging"
 
@@ -47,67 +47,11 @@ import (
 func registerReceive(app *extkingpin.App) {
 	cmd := app.Command(component.Receive.String(), "Accept Prometheus remote write API requests and write to local tsdb.")
 
-	httpBindAddr, httpGracePeriod, httpTLSConfig := extkingpin.RegisterHTTPFlags(cmd)
-	grpcBindAddr, grpcGracePeriod, grpcCert, grpcKey, grpcClientCA := extkingpin.RegisterGRPCFlags(cmd)
-	rwAddress := cmd.Flag("remote-write.address", "Address to listen on for remote write requests.").
-		Default("0.0.0.0:19291").String()
-	rwServerCert := cmd.Flag("remote-write.server-tls-cert", "TLS Certificate for HTTP server, leave blank to disable TLS.").Default("").String()
-	rwServerKey := cmd.Flag("remote-write.server-tls-key", "TLS Key for the HTTP server, leave blank to disable TLS.").Default("").String()
-	rwServerClientCA := cmd.Flag("remote-write.server-tls-client-ca", "TLS CA to verify clients against. If no client CA is specified, there is no client verification on server side. (tls.NoClientCert)").Default("").String()
-	rwClientCert := cmd.Flag("remote-write.client-tls-cert", "TLS Certificates to use to identify this client to the server.").Default("").String()
-	rwClientKey := cmd.Flag("remote-write.client-tls-key", "TLS Key for the client's certificate.").Default("").String()
-	rwClientServerCA := cmd.Flag("remote-write.client-tls-ca", "TLS CA Certificates to use to verify servers.").Default("").String()
-	rwClientServerName := cmd.Flag("remote-write.client-server-name", "Server name to verify the hostname on the returned TLS certificates. See https://tools.ietf.org/html/rfc4366#section-3.1").Default("").String()
-
-	dataDir := cmd.Flag("tsdb.path", "Data directory of TSDB.").
-		Default("./data").String()
-
-	labelStrs := cmd.Flag("label", "External labels to announce. This flag will be removed in the future when handling multiple tsdb instances is added.").PlaceHolder("key=\"value\"").Strings()
-
-	objStoreConfig := extkingpin.RegisterCommonObjStoreFlags(cmd, "", false)
-
-	retention := extkingpin.ModelDuration(cmd.Flag("tsdb.retention", "How long to retain raw samples on local storage. 0d - disables this retention.").Default("15d"))
-
-	hashringsFilePath := cmd.Flag("receive.hashrings-file", "Path to file that contains the hashring configuration. A watcher is initialized to watch changes and update the hashring dynamically.").PlaceHolder("<path>").String()
-	hashringsFileContent := cmd.Flag("receive.hashrings", "Alternative to 'receive.hashrings-file' flag (lower priority). Content of file that contains the hashring configuration.").PlaceHolder("<content>").String()
-
-	refreshInterval := extkingpin.ModelDuration(cmd.Flag("receive.hashrings-file-refresh-interval", "Refresh interval to re-read the hashring configuration file. (used as a fallback)").
-		Default("5m"))
-
-	localEndpoint := cmd.Flag("receive.local-endpoint", "Endpoint of local receive node. Used to identify the local node in the hashring configuration.").String()
-
-	tenantHeader := cmd.Flag("receive.tenant-header", "HTTP header to determine tenant for write requests.").Default(receive.DefaultTenantHeader).String()
-
-	defaultTenantID := cmd.Flag("receive.default-tenant-id", "Default tenant ID to use when none is provided via a header.").Default(receive.DefaultTenant).String()
-
-	tenantLabelName := cmd.Flag("receive.tenant-label-name", "Label name through which the tenant will be announced.").Default(receive.DefaultTenantLabel).String()
-
-	replicaHeader := cmd.Flag("receive.replica-header", "HTTP header specifying the replica number of a write request.").Default(receive.DefaultReplicaHeader).String()
-
-	replicationFactor := cmd.Flag("receive.replication-factor", "How many times to replicate incoming write requests.").Default("1").Uint64()
-
-	forwardTimeout := extkingpin.ModelDuration(cmd.Flag("receive-forward-timeout", "Timeout for each forward request.").Default("5s").Hidden())
-
-	tsdbMinBlockDuration := extkingpin.ModelDuration(cmd.Flag("tsdb.min-block-duration", "Min duration for local TSDB blocks").Default("2h").Hidden())
-	tsdbMaxBlockDuration := extkingpin.ModelDuration(cmd.Flag("tsdb.max-block-duration", "Max duration for local TSDB blocks").Default("2h").Hidden())
-	tsdbAllowOverlappingBlocks := cmd.Flag("tsdb.allow-overlapping-blocks", "Allow overlapping blocks, which in turn enables vertical compaction and vertical query merge.").Default("false").Bool()
-	walCompression := cmd.Flag("tsdb.wal-compression", "Compress the tsdb WAL.").Default("true").Bool()
-	noLockFile := cmd.Flag("tsdb.no-lockfile", "Do not create lockfile in TSDB data directory. In any case, the lockfiles will be deleted on next startup.").Default("false").Bool()
-
-	hashFunc := cmd.Flag("hash-func", "Specify which hash function to use when calculating the hashes of produced files. If no function has been specified, it does not happen. This permits avoiding downloading some files twice albeit at some performance cost. Possible values are: \"\", \"SHA256\".").
-		Default("").Enum("SHA256", "")
-
-	ignoreBlockSize := cmd.Flag("shipper.ignore-unequal-block-size", "If true receive will not require min and max block size flags to be set to the same value. Only use this if you want to keep long retention and compaction enabled, as in the worst case it can result in ~2h data loss for your Thanos bucket storage.").Default("false").Hidden().Bool()
-	allowOutOfOrderUpload := cmd.Flag("shipper.allow-out-of-order-uploads",
-		"If true, shipper will skip failed block uploads in the given iteration and retry later. This means that some newer blocks might be uploaded sooner than older blocks."+
-			"This can trigger compaction without those blocks and as a result will create an overlap situation. Set it to true if you have vertical compaction enabled and wish to upload blocks as soon as possible without caring"+
-			"about order.").
-		Default("false").Hidden().Bool()
-
-	reqLogConfig := extkingpin.RegisterRequestLoggingFlags(cmd)
+	conf := &receiveConfig{}
+	conf.registerFlag(cmd)
 
 	cmd.Setup(func(g *run.Group, logger log.Logger, reg *prometheus.Registry, tracer opentracing.Tracer, _ <-chan struct{}, _ bool) error {
-		lset, err := parseFlagLabels(*labelStrs)
+		lset, err := parseFlagLabels(*conf.labelStrs)
 		if err != nil {
 			return errors.Wrap(err, "parse labels")
 		}
@@ -116,30 +60,30 @@ func registerReceive(app *extkingpin.App) {
 			return errors.New("no external labels configured for receive, uniquely identifying external labels must be configured (ideally with `receive_` prefix); see https://thanos.io/tip/thanos/storage.md#external-labels for details.")
 		}
 
-		tagOpts, grpcLogOpts, err := logging.ParsegRPCOptions("", reqLogConfig)
+		tagOpts, grpcLogOpts, err := logging.ParsegRPCOptions("", conf.reqLogConfig)
 		if err != nil {
 			return errors.Wrap(err, "error while parsing config for request logging")
 		}
 
 		tsdbOpts := &tsdb.Options{
-			MinBlockDuration:       int64(time.Duration(*tsdbMinBlockDuration) / time.Millisecond),
-			MaxBlockDuration:       int64(time.Duration(*tsdbMaxBlockDuration) / time.Millisecond),
-			RetentionDuration:      int64(time.Duration(*retention) / time.Millisecond),
-			NoLockfile:             *noLockFile,
-			WALCompression:         *walCompression,
-			AllowOverlappingBlocks: *tsdbAllowOverlappingBlocks,
+			MinBlockDuration:       int64(time.Duration(*conf.tsdbMinBlockDuration) / time.Millisecond),
+			MaxBlockDuration:       int64(time.Duration(*conf.tsdbMaxBlockDuration) / time.Millisecond),
+			RetentionDuration:      int64(time.Duration(*conf.retention) / time.Millisecond),
+			NoLockfile:             conf.noLockFile,
+			WALCompression:         conf.walCompression,
+			AllowOverlappingBlocks: conf.tsdbAllowOverlappingBlocks,
 		}
 
 		// Local is empty, so try to generate a local endpoint
 		// based on the hostname and the listening port.
-		if *localEndpoint == "" {
+		if conf.endpoint == "" {
 			hostname, err := os.Hostname()
 			if hostname == "" || err != nil {
 				return errors.New("--receive.local-endpoint is empty and host could not be determined.")
 			}
-			parts := strings.Split(*grpcBindAddr, ":")
+			parts := strings.Split(*conf.grpcBindAddr, ":")
 			port := parts[len(parts)-1]
-			*localEndpoint = net.JoinHostPort(hostname, port)
+			conf.endpoint = net.JoinHostPort(hostname, port)
 		}
 
 		return runReceive(
@@ -148,40 +92,11 @@ func registerReceive(app *extkingpin.App) {
 			reg,
 			tracer,
 			grpcLogOpts, tagOpts,
-			*grpcBindAddr,
-			time.Duration(*grpcGracePeriod),
-			*grpcCert,
-			*grpcKey,
-			*grpcClientCA,
-			*httpBindAddr,
-			*httpTLSConfig,
-			time.Duration(*httpGracePeriod),
-			*rwAddress,
-			*rwServerCert,
-			*rwServerKey,
-			*rwServerClientCA,
-			*rwClientCert,
-			*rwClientKey,
-			*rwClientServerCA,
-			*rwClientServerName,
-			*dataDir,
-			objStoreConfig,
 			tsdbOpts,
-			*ignoreBlockSize,
 			lset,
-			*hashringsFilePath,
-			*hashringsFileContent,
-			refreshInterval,
-			*localEndpoint,
-			*tenantHeader,
-			*defaultTenantID,
-			*tenantLabelName,
-			*replicaHeader,
-			*replicationFactor,
-			time.Duration(*forwardTimeout),
-			*allowOutOfOrderUpload,
 			component.Receive,
-			metadata.HashFunc(*hashFunc),
+			metadata.HashFunc(conf.hashFunc),
+			conf,
 		)
 	})
 }
@@ -193,44 +108,15 @@ func runReceive(
 	tracer opentracing.Tracer,
 	grpcLogOpts []grpc_logging.Option,
 	tagOpts []tags.Option,
-	grpcBindAddr string,
-	grpcGracePeriod time.Duration,
-	grpcCert string,
-	grpcKey string,
-	grpcClientCA string,
-	httpBindAddr string,
-	httpTLSConfig string,
-	httpGracePeriod time.Duration,
-	rwAddress string,
-	rwServerCert string,
-	rwServerKey string,
-	rwServerClientCA string,
-	rwClientCert string,
-	rwClientKey string,
-	rwClientServerCA string,
-	rwClientServerName string,
-	dataDir string,
-	objStoreConfig *extflag.PathOrContent,
 	tsdbOpts *tsdb.Options,
-	ignoreBlockSize bool,
 	lset labels.Labels,
-	hashringsFilePath string,
-	hashringsFileContent string,
-	refreshInterval *model.Duration,
-	endpoint string,
-	tenantHeader string,
-	defaultTenantID string,
-	tenantLabelName string,
-	replicaHeader string,
-	replicationFactor uint64,
-	forwardTimeout time.Duration,
-	allowOutOfOrderUpload bool,
 	comp component.SourceStoreAPI,
 	hashFunc metadata.HashFunc,
+	conf *receiveConfig,
 ) error {
 	logger = log.With(logger, "component", "receive")
 	level.Warn(logger).Log("msg", "setting up receive")
-	rwTLSConfig, err := tls.NewServerConfig(log.With(logger, "protocol", "HTTP"), rwServerCert, rwServerKey, rwServerClientCA)
+	rwTLSConfig, err := tls.NewServerConfig(log.With(logger, "protocol", "HTTP"), conf.rwServerCert, conf.rwServerKey, conf.rwServerClientCA)
 	if err != nil {
 		return err
 	}
@@ -238,26 +124,26 @@ func runReceive(
 		logger,
 		reg,
 		tracer,
-		rwServerCert != "",
-		rwServerClientCA == "",
-		rwClientCert,
-		rwClientKey,
-		rwClientServerCA,
-		rwClientServerName,
+		conf.rwServerCert != "",
+		conf.rwServerClientCA == "",
+		conf.rwClientCert,
+		conf.rwClientKey,
+		conf.rwClientServerCA,
+		conf.rwClientServerName,
 	)
 	if err != nil {
 		return err
 	}
 
 	var bkt objstore.Bucket
-	confContentYaml, err := objStoreConfig.Content()
+	confContentYaml, err := conf.objStoreConfig.Content()
 	if err != nil {
 		return err
 	}
 	upload := len(confContentYaml) > 0
 	if upload {
 		if tsdbOpts.MinBlockDuration != tsdbOpts.MaxBlockDuration {
-			if !ignoreBlockSize {
+			if !conf.ignoreBlockSize {
 				return errors.Errorf("found that TSDB Max time is %d and Min time is %d. "+
 					"Compaction needs to be disabled (tsdb.min-block-duration = tsdb.max-block-duration)", tsdbOpts.MaxBlockDuration, tsdbOpts.MinBlockDuration)
 			}
@@ -275,35 +161,35 @@ func runReceive(
 
 	// TODO(brancz): remove after a couple of versions
 	// Migrate non-multi-tsdb capable storage to multi-tsdb disk layout.
-	if err := migrateLegacyStorage(logger, dataDir, defaultTenantID); err != nil {
-		return errors.Wrapf(err, "migrate legacy storage in %v to default tenant %v", dataDir, defaultTenantID)
+	if err := migrateLegacyStorage(logger, conf.dataDir, conf.defaultTenantID); err != nil {
+		return errors.Wrapf(err, "migrate legacy storage in %v to default tenant %v", conf.dataDir, conf.defaultTenantID)
 	}
 
 	dbs := receive.NewMultiTSDB(
-		dataDir,
+		conf.dataDir,
 		logger,
 		reg,
 		tsdbOpts,
 		lset,
-		tenantLabelName,
+		conf.tenantLabelName,
 		bkt,
-		allowOutOfOrderUpload,
+		conf.allowOutOfOrderUpload,
 		hashFunc,
 	)
 	writer := receive.NewWriter(log.With(logger, "component", "receive-writer"), dbs)
 	webHandler := receive.NewHandler(log.With(logger, "component", "receive-handler"), &receive.Options{
 		Writer:            writer,
-		ListenAddress:     rwAddress,
+		ListenAddress:     conf.rwAddress,
 		Registry:          reg,
-		Endpoint:          endpoint,
-		TenantHeader:      tenantHeader,
-		DefaultTenantID:   defaultTenantID,
-		ReplicaHeader:     replicaHeader,
-		ReplicationFactor: replicationFactor,
+		Endpoint:          conf.endpoint,
+		TenantHeader:      conf.tenantHeader,
+		DefaultTenantID:   conf.defaultTenantID,
+		ReplicaHeader:     conf.replicaHeader,
+		ReplicationFactor: conf.replicationFactor,
 		Tracer:            tracer,
 		TLSConfig:         rwTLSConfig,
 		DialOpts:          dialOpts,
-		ForwardTimeout:    forwardTimeout,
+		ForwardTimeout:    time.Duration(*conf.forwardTimeout),
 	})
 
 	grpcProbe := prober.NewGRPC()
@@ -405,8 +291,8 @@ func runReceive(
 		updates := make(chan receive.Hashring, 1)
 
 		// The Hashrings config file path is given initializing config watcher.
-		if hashringsFilePath != "" {
-			cw, err := receive.NewConfigWatcher(log.With(logger, "component", "config-watcher"), reg, hashringsFilePath, *refreshInterval)
+		if conf.hashringsFilePath != "" {
+			cw, err := receive.NewConfigWatcher(log.With(logger, "component", "config-watcher"), reg, conf.hashringsFilePath, *conf.refreshInterval)
 			if err != nil {
 				return errors.Wrap(err, "failed to initialize config watcher")
 			}
@@ -428,8 +314,8 @@ func runReceive(
 		} else {
 			var ring receive.Hashring
 			// The Hashrings config file content given initialize configuration from content.
-			if len(hashringsFileContent) > 0 {
-				ring, err = receive.HashringFromConfig(hashringsFileContent)
+			if len(conf.hashringsFileContent) > 0 {
+				ring, err = receive.HashringFromConfig(conf.hashringsFileContent)
 				if err != nil {
 					close(updates)
 					return errors.Wrap(err, "failed to validate hashring configuration file")
@@ -437,7 +323,7 @@ func runReceive(
 				level.Info(logger).Log("msg", "the hashring initialized directly with the given content through the flag.")
 			} else {
 				level.Info(logger).Log("msg", "the hashring file is not specified use single node hashring.")
-				ring = receive.SingleNodeHashring(endpoint)
+				ring = receive.SingleNodeHashring(conf.endpoint)
 			}
 
 			cancel := make(chan struct{})
@@ -477,9 +363,9 @@ func runReceive(
 
 	level.Debug(logger).Log("msg", "setting up http server")
 	srv := httpserver.New(logger, reg, comp, httpProbe,
-		httpserver.WithListen(httpBindAddr),
-		httpserver.WithGracePeriod(httpGracePeriod),
-		httpserver.WithTLSConfig(httpTLSConfig),
+		httpserver.WithListen(*conf.httpBindAddr),
+		httpserver.WithGracePeriod(time.Duration(*conf.httpGracePeriod)),
+		httpserver.WithTLSConfig(*conf.httpTLSConfig),
 	)
 	g.Add(func() error {
 		statusProber.Healthy()
@@ -499,7 +385,7 @@ func runReceive(
 		g.Add(func() error {
 			defer close(startGRPC)
 
-			tlsCfg, err := tls.NewServerConfig(log.With(logger, "protocol", "gRPC"), grpcCert, grpcKey, grpcClientCA)
+			tlsCfg, err := tls.NewServerConfig(log.With(logger, "protocol", "gRPC"), *conf.grpcCert, *conf.grpcKey, *conf.grpcClientCA)
 			if err != nil {
 				return errors.Wrap(err, "setup gRPC server")
 			}
@@ -522,8 +408,8 @@ func runReceive(
 				s = grpcserver.New(logger, &receive.UnRegisterer{Registerer: reg}, tracer, grpcLogOpts, tagOpts, comp, grpcProbe,
 					grpcserver.WithServer(store.RegisterStoreServer(rw)),
 					grpcserver.WithServer(store.RegisterWritableStoreServer(rw)),
-					grpcserver.WithListen(grpcBindAddr),
-					grpcserver.WithGracePeriod(grpcGracePeriod),
+					grpcserver.WithListen(*conf.grpcBindAddr),
+					grpcserver.WithGracePeriod(time.Duration(*conf.grpcGracePeriod)),
 					grpcserver.WithTLSConfig(tlsCfg),
 				)
 				startGRPC <- struct{}{}
@@ -537,7 +423,7 @@ func runReceive(
 		// whenever the DB changes, thus it needs its own run group.
 		g.Add(func() error {
 			for range startGRPC {
-				level.Info(logger).Log("msg", "listening for StoreAPI and WritableStoreAPI gRPC", "address", grpcBindAddr)
+				level.Info(logger).Log("msg", "listening for StoreAPI and WritableStoreAPI gRPC", "address", *conf.grpcBindAddr)
 				if err := s.ListenAndServe(); err != nil {
 					return errors.Wrap(err, "serve gRPC")
 				}
@@ -667,4 +553,132 @@ func migrateLegacyStorage(logger log.Logger, dataDir, defaultTenantID string) er
 	}
 
 	return nil
+}
+
+type receiveConfig struct {
+	httpBindAddr    *string
+	httpGracePeriod *model.Duration
+	httpTLSConfig   *string
+
+	grpcBindAddr    *string
+	grpcGracePeriod *model.Duration
+	grpcCert        *string
+	grpcKey         *string
+	grpcClientCA    *string
+
+	rwAddress          string
+	rwServerCert       string
+	rwServerKey        string
+	rwServerClientCA   string
+	rwClientCert       string
+	rwClientKey        string
+	rwClientServerCA   string
+	rwClientServerName string
+
+	dataDir   string
+	labelStrs *[]string
+
+	objStoreConfig *extflag.PathOrContent
+	retention      *model.Duration
+
+	hashringsFilePath    string
+	hashringsFileContent string
+
+	refreshInterval   *model.Duration
+	endpoint          string
+	tenantHeader      string
+	defaultTenantID   string
+	tenantLabelName   string
+	replicaHeader     string
+	replicationFactor uint64
+	forwardTimeout    *model.Duration
+
+	tsdbMinBlockDuration       *model.Duration
+	tsdbMaxBlockDuration       *model.Duration
+	tsdbAllowOverlappingBlocks bool
+
+	walCompression bool
+	noLockFile     bool
+
+	hashFunc string
+
+	ignoreBlockSize       bool
+	allowOutOfOrderUpload bool
+
+	reqLogConfig *extflag.PathOrContent
+}
+
+func (rc *receiveConfig) registerFlag(cmd extkingpin.FlagClause) {
+	rc.httpBindAddr, rc.httpGracePeriod, rc.httpTLSConfig = extkingpin.RegisterHTTPFlags(cmd)
+	rc.grpcBindAddr, rc.grpcGracePeriod, rc.grpcCert, rc.grpcKey, rc.grpcClientCA = extkingpin.RegisterGRPCFlags(cmd)
+
+	cmd.Flag("remote-write.address", "Address to listen on for remote write requests.").
+		Default("0.0.0.0:19291").StringVar(&rc.rwAddress)
+
+	cmd.Flag("remote-write.server-tls-cert", "TLS Certificate for HTTP server, leave blank to disable TLS.").Default("").StringVar(&rc.rwServerCert)
+
+	cmd.Flag("remote-write.server-tls-key", "TLS Key for the HTTP server, leave blank to disable TLS.").Default("").StringVar(&rc.rwServerKey)
+
+	cmd.Flag("remote-write.server-tls-client-ca", "TLS CA to verify clients against. If no client CA is specified, there is no client verification on server side. (tls.NoClientCert)").Default("").StringVar(&rc.rwServerClientCA)
+
+	cmd.Flag("remote-write.client-tls-cert", "TLS Certificates to use to identify this client to the server.").Default("").StringVar(&rc.rwClientCert)
+
+	cmd.Flag("remote-write.client-tls-key", "TLS Key for the client's certificate.").Default("").StringVar(&rc.rwClientKey)
+
+	cmd.Flag("remote-write.client-tls-ca", "TLS CA Certificates to use to verify servers.").Default("").StringVar(&rc.rwClientServerCA)
+
+	cmd.Flag("remote-write.client-server-name", "Server name to verify the hostname on the returned TLS certificates. See https://tools.ietf.org/html/rfc4366#section-3.1").Default("").StringVar(&rc.rwClientServerName)
+
+	cmd.Flag("tsdb.path", "Data directory of TSDB.").
+		Default("./data").StringVar(&rc.dataDir)
+
+	cmd.Flag("label", "External labels to announce. This flag will be removed in the future when handling multiple tsdb instances is added.").PlaceHolder("key=\"value\"").StringsVar(rc.labelStrs)
+
+	rc.objStoreConfig = extkingpin.RegisterCommonObjStoreFlags(cmd, "", false)
+
+	rc.retention = extkingpin.ModelDuration(cmd.Flag("tsdb.retention", "How long to retain raw samples on local storage. 0d - disables this retention.").Default("15d"))
+
+	cmd.Flag("receive.hashrings-file", "Path to file that contains the hashring configuration. A watcher is initialized to watch changes and update the hashring dynamically.").PlaceHolder("<path>").StringVar(&rc.hashringsFilePath)
+
+	cmd.Flag("receive.hashrings", "Alternative to 'receive.hashrings-file' flag (lower priority). Content of file that contains the hashring configuration.").PlaceHolder("<content>").StringVar(&rc.hashringsFileContent)
+
+	rc.refreshInterval = extkingpin.ModelDuration(cmd.Flag("receive.hashrings-file-refresh-interval", "Refresh interval to re-read the hashring configuration file. (used as a fallback)").
+		Default("5m"))
+
+	cmd.Flag("receive.local-endpoint", "Endpoint of local receive node. Used to identify the local node in the hashring configuration.").StringVar(&rc.endpoint)
+
+	cmd.Flag("receive.tenant-header", "HTTP header to determine tenant for write requests.").Default(receive.DefaultTenantHeader).StringVar(&rc.tenantHeader)
+
+	cmd.Flag("receive.default-tenant-id", "Default tenant ID to use when none is provided via a header.").Default(receive.DefaultTenant).StringVar(&rc.defaultTenantID)
+
+	cmd.Flag("receive.tenant-label-name", "Label name through which the tenant will be announced.").Default(receive.DefaultTenantLabel).StringVar(&rc.tenantLabelName)
+
+	cmd.Flag("receive.replica-header", "HTTP header specifying the replica number of a write request.").Default(receive.DefaultReplicaHeader).StringVar(&rc.replicaHeader)
+
+	cmd.Flag("receive.replication-factor", "How many times to replicate incoming write requests.").Default("1").Uint64Var(&rc.replicationFactor)
+
+	rc.forwardTimeout = extkingpin.ModelDuration(cmd.Flag("receive-forward-timeout", "Timeout for each forward request.").Default("5s").Hidden())
+
+	rc.tsdbMinBlockDuration = extkingpin.ModelDuration(cmd.Flag("tsdb.min-block-duration", "Min duration for local TSDB blocks").Default("2h").Hidden())
+
+	rc.tsdbMaxBlockDuration = extkingpin.ModelDuration(cmd.Flag("tsdb.max-block-duration", "Max duration for local TSDB blocks").Default("2h").Hidden())
+
+	cmd.Flag("tsdb.allow-overlapping-blocks", "Allow overlapping blocks, which in turn enables vertical compaction and vertical query merge.").Default("false").BoolVar(&rc.tsdbAllowOverlappingBlocks)
+
+	cmd.Flag("tsdb.wal-compression", "Compress the tsdb WAL.").Default("true").BoolVar(&rc.walCompression)
+
+	cmd.Flag("tsdb.no-lockfile", "Do not create lockfile in TSDB data directory. In any case, the lockfiles will be deleted on next startup.").Default("false").BoolVar(&rc.noLockFile)
+
+	cmd.Flag("hash-func", "Specify which hash function to use when calculating the hashes of produced files. If no function has been specified, it does not happen. This permits avoiding downloading some files twice albeit at some performance cost. Possible values are: \"\", \"SHA256\".").
+		Default("").EnumVar(&rc.hashFunc, "SHA256", "")
+
+	cmd.Flag("shipper.ignore-unequal-block-size", "If true receive will not require min and max block size flags to be set to the same value. Only use this if you want to keep long retention and compaction enabled, as in the worst case it can result in ~2h data loss for your Thanos bucket storage.").Default("false").Hidden().BoolVar(&rc.ignoreBlockSize)
+
+	cmd.Flag("shipper.allow-out-of-order-uploads",
+		"If true, shipper will skip failed block uploads in the given iteration and retry later. This means that some newer blocks might be uploaded sooner than older blocks."+
+			"This can trigger compaction without those blocks and as a result will create an overlap situation. Set it to true if you have vertical compaction enabled and wish to upload blocks as soon as possible without caring"+
+			"about order.").
+		Default("false").Hidden().BoolVar(&rc.allowOutOfOrderUpload)
+
+	rc.reqLogConfig = extkingpin.RegisterRequestLoggingFlags(cmd)
 }


### PR DESCRIPTION
Signed-off-by: Yash Sharma <yashrsharma44@gmail.com>

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes
Moved all the flags for registration for the receiver to a new struct, for improving readability and reduce cognitive load.

## Verification
Let's wait for the CI to turn green :)

Related Issue: #2248 