### PR TITLE
Set replicate status prober to ready

### DIFF
--- a/pkg/replicate/replicator.go
+++ b/pkg/replicate/replicator.go
@@ -213,6 +213,7 @@ func RunReplicate(
 		defer runutil.CloseWithLogOnErr(logger, fromBkt, "from bucket client")
 		defer runutil.CloseWithLogOnErr(logger, toBkt, "to bucket client")
 
+		statusProber.Ready()
 		if singleRun || len(blockIDs) > 0 {
 			return replicateFn()
 		}


### PR DESCRIPTION
Signed-off-by: yeya24 <yb532204897@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

The ready status prober is missing for bucket tool replicate.

## Verification

<!-- How you tested it? How do you know it works? -->
