### PR TITLE
Mixin: exclude rule generation if component has been excluded

### DIFF
--- a/mixin/rules/bucket_replicate.libsonnet
+++ b/mixin/rules/bucket_replicate.libsonnet
@@ -4,7 +4,7 @@
     selector: error 'must provide selector for Thanos Bucket Replicate dashboard',
   },
   prometheusRules+:: {
-    groups+: [
+    groups+: if thanos.bucket_replicate == null then [] else [
       {
         name: 'thanos-bucket-replicate.rules',
         rules: [],

--- a/mixin/rules/query.libsonnet
+++ b/mixin/rules/query.libsonnet
@@ -5,7 +5,7 @@
     dimensions: std.join(', ', std.objectFields(thanos.targetGroups) + ['job']),
   },
   prometheusRules+:: {
-    groups+: [
+    groups+: if thanos.query == null then [] else [
       {
         name: 'thanos-query.rules',
         rules: [

--- a/mixin/rules/receive.libsonnet
+++ b/mixin/rules/receive.libsonnet
@@ -5,7 +5,7 @@
     dimensions: std.join(', ', std.objectFields(thanos.targetGroups) + ['job']),
   },
   prometheusRules+:: {
-    groups+: [
+    groups+: if thanos.receive == null then [] else [
       {
         name: 'thanos-receive.rules',
         rules: [

--- a/mixin/rules/store.libsonnet
+++ b/mixin/rules/store.libsonnet
@@ -5,7 +5,7 @@
     dimensions: std.join(', ', std.objectFields(thanos.targetGroups) + ['job']),
   },
   prometheusRules+:: {
-    groups+: [
+    groups+: if thanos.store == null then [] else [
       {
         name: 'thanos-store.rules',
         rules: [


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

Following on from #3883, if a components is excluded via configuration you can't create rules for it. Resolves #4260

## Verification

Tested it locally by turning off `receive` via our own mixins (using thanos as a mixin library). Since `receive`'s object is now `null` there are no `dimensions` or `selector`s variables and we get an error during generation:

```
RUNTIME ERROR: Not enough values to format: 1, expected more than 1
        std.jsonnet:710:15-103  thunk <val>
        std.jsonnet:715:27-30   thunk <val>
        std.jsonnet:585:22-25   thunk <a>
        std.jsonnet:36:17
        std.jsonnet:36:8-19     thunk <a>
        std.jsonnet:36:8-31     function <anonymous>
        std.jsonnet:36:8-31     function <anonymous>
        std.jsonnet:585:9-26    function <format_code>
        std.jsonnet:715:15-60   thunk <s>
        std.jsonnet:720:24      thunk <str>
        ...
        std.jsonnet:1002:33-72  thunk <array_element>
        std.jsonnet:1006:11-42  function <aux>
        std.jsonnet:1030:59-98  thunk <array_element>
        std.jsonnet:1034:11-42  function <aux>
        std.jsonnet:1002:33-72  thunk <array_element>
        std.jsonnet:1006:11-42  function <aux>
        std.jsonnet:1030:59-98  thunk <array_element>
        std.jsonnet:1034:11-42  function <aux>
        std.jsonnet:1035:5-23   function <anonymous>
        ./service/thanos/prometheus_rules.jsonnet:(1:1)-(6:2)
```

