### PR TITLE
Mixin: Make runbookURL anchor lowercasing optional

### DIFF
--- a/mixin/README.md
+++ b/mixin/README.md
@@ -113,6 +113,16 @@ This project is intended to be used as a library. You can extend and customize d
     selector: 'job=~".*thanos-bucket-replicate.*"',
     title: '%(prefix)sBucketReplicate' % $.dashboard.prefix,
   },
+
+  //_config+:: {
+  //  // The Base URL for your runbooks.
+  //  runbookURLPattern: 'http://yourRunbookUrlPlace.biz/runbook#%s',
+  //  // Whether you want runbook URL anchors as lowercase for runbooks
+  //  // e.g. ThanosCompactMultipleRunning -> thanoscompactmultiplerunning
+  //  // Set to `false` if you have a wiki that supports CamelCase url anchors
+  //  runbookURLToLower: true
+  //},
+
   dashboard+:: {
     prefix: 'Thanos / ',
     tags: ['thanos-mixin'],

--- a/mixin/README.md
+++ b/mixin/README.md
@@ -119,8 +119,9 @@ This project is intended to be used as a library. You can extend and customize d
   //  runbookURLPattern: 'http://yourRunbookUrlPlace.biz/runbook#%s',
   //  // Whether you want runbook URL anchors as lowercase for runbooks
   //  // e.g. ThanosCompactMultipleRunning -> thanoscompactmultiplerunning
-  //  // Set to `false` if you have a wiki that supports CamelCase url anchors
-  //  runbookURLToLower: true
+  //  // Set to `false` if your runbook hosting of choice supports CamelCase 
+  //  // url anchors
+  //  runbookURLAnchorsToLowercase: true
   //},
 
   dashboard+:: {

--- a/mixin/README.md
+++ b/mixin/README.md
@@ -113,17 +113,6 @@ This project is intended to be used as a library. You can extend and customize d
     selector: 'job=~".*thanos-bucket-replicate.*"',
     title: '%(prefix)sBucketReplicate' % $.dashboard.prefix,
   },
-
-  //_config+:: {
-  //  // The Base URL for your runbooks.
-  //  runbookURLPattern: 'http://yourRunbookUrlPlace.biz/runbook#%s',
-  //  // Whether you want runbook URL anchors as lowercase for runbooks
-  //  // e.g. ThanosCompactMultipleRunning -> thanoscompactmultiplerunning
-  //  // Set to `false` if your runbook hosting of choice supports CamelCase 
-  //  // url anchors
-  //  runbookURLAnchorsToLowercase: true
-  //},
-
   dashboard+:: {
     prefix: 'Thanos / ',
     tags: ['thanos-mixin'],

--- a/mixin/alerts/add_runbook_links.libsonnet
+++ b/mixin/alerts/add_runbook_links.libsonnet
@@ -11,7 +11,7 @@ local lower(x) =
 {
   _config+:: {
     runbookURLPattern: 'https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-%s',
-    runbookURLAnchorsToLowercase: true
+    runbookURLAnchorsToLowercase: true,
   },
 
   prometheusAlerts+::

--- a/mixin/alerts/add_runbook_links.libsonnet
+++ b/mixin/alerts/add_runbook_links.libsonnet
@@ -11,13 +11,13 @@ local lower(x) =
 {
   _config+:: {
     runbookURLPattern: 'https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-%s',
-    runbookURLToLower: true
+    runbookURLAnchorsToLowercase: true
   },
 
   prometheusAlerts+::
     local addRunbookURL(rule) = rule {
       [if 'alert' in rule && !('runbook_url' in rule.annotations) then 'annotations']+: {
-        runbook_url: if $._config.runbookURLToLower then $._config.runbookURLPattern % lower(rule.alert) else $._config.runbookURLPattern % rule.alert,
+        runbook_url: if $._config.runbookURLAnchorsToLowercase then $._config.runbookURLPattern % lower(rule.alert) else $._config.runbookURLPattern % rule.alert,
       },
     };
     utils.mapRuleGroups(addRunbookURL),

--- a/mixin/alerts/add_runbook_links.libsonnet
+++ b/mixin/alerts/add_runbook_links.libsonnet
@@ -11,12 +11,13 @@ local lower(x) =
 {
   _config+:: {
     runbookURLPattern: 'https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-%s',
+    runbookURLToLower: true
   },
 
   prometheusAlerts+::
     local addRunbookURL(rule) = rule {
       [if 'alert' in rule && !('runbook_url' in rule.annotations) then 'annotations']+: {
-        runbook_url: $._config.runbookURLPattern % lower(rule.alert),
+        runbook_url: if $._config.runbookURLToLower then $._config.runbookURLPattern % lower(rule.alert) else $._config.runbookURLPattern % rule.alert,
       },
     };
     utils.mapRuleGroups(addRunbookURL),


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

Resolves #4261

## Changes

- Adds `runbookURLAnchorsToLowercase` that allows one to opt out of lowercasing runbook URL anchors.

## Verification

