### PR TITLE
Receiver: e2e test

### DIFF
--- a/test/e2e/receive_test.go
+++ b/test/e2e/receive_test.go
@@ -141,7 +141,7 @@ func TestReceive(t *testing.T) {
 	t.Run("hashring with config watcher", func(t *testing.T) {
 		t.Parallel()
 
-		s, err := e2e.NewScenario("e2e_test_receive_hashring")
+		s, err := e2e.NewScenario("e2e_test_receive_hashring_config_watcher")
 		testutil.Ok(t, err)
 		t.Cleanup(e2ethanos.CleanScenario(t, s))
 


### PR DESCRIPTION
Signed-off-by: Abhishek357 <abhisheksinghchauhan357@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.
Fixes #4257 
## Changes
Changed the network name for `hashring with config watcher` e2e test for receive.
The network name for two tests (`hashring` and `hashring with config watcher`) for receive are same.
<!-- Enumerate changes you made -->

## Verification
`go test -run TestReceive/hashring ./test/e2e/...`
<!-- How you tested it? How do you know it works? -->
