### PR TITLE
bump codemirror-promql to v0.16.0

### DIFF
--- a/pkg/ui/react-app/package.json
+++ b/pkg/ui/react-app/package.json
@@ -20,7 +20,7 @@
     "@fortawesome/react-fontawesome": "^0.1.14",
     "@reach/router": "^1.3.4",
     "bootstrap": "^4.6.0",
-    "codemirror-promql": "^0.15.0",
+    "codemirror-promql": "^0.16.0",
     "css.escape": "^1.5.1",
     "downshift": "^6.1.0",
     "enzyme-to-json": "^3.6.1",

--- a/pkg/ui/react-app/yarn.lock
+++ b/pkg/ui/react-app/yarn.lock
@@ -3575,12 +3575,12 @@ coa@^2.0.2:
     chalk "^2.4.1"
     q "^1.1.2"
 
-codemirror-promql@^0.15.0:
-  version "0.15.0"
-  resolved "https://registry.yarnpkg.com/codemirror-promql/-/codemirror-promql-0.15.0.tgz#dd6365ea5c2d18421d225cef12b74e64d8cab280"
-  integrity sha512-u5f6Narj8Kx79AHMPlr8vogGUhinZfsZVT00R7wStquDA3kRTvxfEBYK77UtWNNJshxC1B3EZnHzXN2K9RzVXw==
+codemirror-promql@^0.16.0:
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/codemirror-promql/-/codemirror-promql-0.16.0.tgz#c51ca8ce1772a228ebfdbc8431550b2385670d46"
+  integrity sha512-/npytsj103ccWSMWffxibDuS+0p8DFneB7eRdUQULNVOsF+QSif2fqohjz6C9OmM+r58hA5qmdBUdhtogqsvEQ==
   dependencies:
-    lezer-promql "^0.18.0"
+    lezer-promql "^0.19.0"
     lru-cache "^6.0.0"
 
 collection-visit@^1.0.0:
@@ -7651,10 +7651,10 @@ levn@^0.3.0, levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
-lezer-promql@^0.18.0:
-  version "0.18.0"
-  resolved "https://registry.yarnpkg.com/lezer-promql/-/lezer-promql-0.18.0.tgz#7eea8cb02f8203043560415d7a436e9903176ab2"
-  integrity sha512-4ZQGyiU4JoL14rhtuAEmlSKHhu0dcBiLsqjF+RyouZNojUiLh6vyBFwrtPgAdD58s4j8+J21dOO/yUnaJvoGkw==
+lezer-promql@^0.19.0:
+  version "0.19.0"
+  resolved "https://registry.yarnpkg.com/lezer-promql/-/lezer-promql-0.19.0.tgz#0cedaead2d7b3700a25c09e5ae85568979806710"
+  integrity sha512-divgYjuKw4ESDWVCXg7FipH2dF4vq0aWTb0QCyIGz5NHTLx6H+tVC7IlMkQSqsK8t/6qhgxh6A9s6XrE4ZFFJQ==
 
 lezer-tree@^0.13.0, lezer-tree@^0.13.2:
   version "0.13.2"


### PR DESCRIPTION
This PR is increasing the version of codemirror-promql and lezer-promql.

It provides the following interesting (for Prometheus) fixes and enhancements:

* Autocomplete `NaN` and `Inf`
* Fetch series using the HTTP POST method. (The switch was done because some users are reaching the URL limit, which I thought wasn't really possible in the context of this lib)
* Fix the parsing of metric names starting with `Inf` / `NaN` like `infra`

Complete release note is available [here](https://github.com/prometheus-community/codemirror-promql/releases/tag/0.16.0) 