### PR TITLE
store: send data immediately after getting it

### DIFF
--- a/pkg/store/bucket_test.go
+++ b/pkg/store/bucket_test.go
@@ -2392,11 +2392,12 @@ func benchmarkBlockSeriesWithConcurrency(b *testing.B, concurrency int, blockMet
 				indexReader := blk.indexReader(ctx)
 				chunkReader := blk.chunkReader(ctx)
 
-				seriesSet, _, err := blockSeries(nil, indexReader, chunkReader, matchers, chunksLimiter, seriesLimiter, req.SkipChunks, req.MinTime, req.MaxTime, req.Aggregates, h)
+				_, err = blockSeries(nil, indexReader, chunkReader, matchers, chunksLimiter, seriesLimiter, req.SkipChunks, req.MinTime, req.MaxTime, req.Aggregates, h)
 				testutil.Ok(b, err)
 
 				// Ensure at least 1 series has been returned (as expected).
-				testutil.Equals(b, true, seriesSet.Next())
+				element := heap.Pop(h).(*seriesResponseEntry)
+				testutil.Assert(b, element.series != nil)
 
 				testutil.Ok(b, indexReader.Close())
 				testutil.Ok(b, chunkReader.Close())

--- a/pkg/store/bucket_test.go
+++ b/pkg/store/bucket_test.go
@@ -2392,7 +2392,7 @@ func benchmarkBlockSeriesWithConcurrency(b *testing.B, concurrency int, blockMet
 				indexReader := blk.indexReader(ctx)
 				chunkReader := blk.chunkReader(ctx)
 
-				seriesSet, _, err := blockSeries(context.TODO(), nil, indexReader, chunkReader, matchers, chunksLimiter, seriesLimiter, req.SkipChunks, req.MinTime, req.MaxTime, req.Aggregates, h)
+				seriesSet, _, err := blockSeries(nil, indexReader, chunkReader, matchers, chunksLimiter, seriesLimiter, req.SkipChunks, req.MinTime, req.MaxTime, req.Aggregates, h)
 				testutil.Ok(b, err)
 
 				// Ensure at least 1 series has been returned (as expected).


### PR DESCRIPTION
Build a min-heap to immediately send back data to the querier after
getting it. Min heap is needed to maintain the invariant of Series()
that the returned data is sorted by the labels. My anecdotal data shows
that this could shave off a few percent of the total duration of queries
because we aren't doing one sorting pass at the end _after_ getting
_all_ of the data and we can free memory quicker.

I don't think any of the current benchmarks can show this difference?
It's probably the most visible when a Series() comes in which matches a
lot of series.

I have only done minimal testing - that I am still able to query data
via `/api/v1/query_range`.

Signed-off-by: Giedrius Statkevičius <giedrius.statkevicius@vinted.com>

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

What do you think @bwplotka @kakkoyun @yeya24 ? 

