### PR TITLE
Use iterators to expand chunks when downsample

### DIFF
--- a/pkg/compact/downsample/downsample.go
+++ b/pkg/compact/downsample/downsample.go
@@ -146,7 +146,7 @@ func Downsample(
 				maxt = c.MaxTime
 			}
 
-			numSamples += c.Chunk.NumSamples()
+			numSamples += chks[i].Chunk.NumSamples()
 		}
 
 		// Raw and already downsampled data need different processing.


### PR DESCRIPTION
Signed-off-by: yeya24 <yb532204897@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

Fix #2542 

## Changes

<!-- Enumerate changes you made -->

Use iterators to expand chunks when downsampling is performed.

## Verification

<!-- How you tested it? How do you know it works? -->
Existing tests should still pass since this is just refactoring.