### PR TITLE
receive: Enable exemplars ingestion and querying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ We use _breaking :warning:_ to mark changes that are not backward compatible (re
 - [#4299](https://github.com/thanos-io/thanos/pull/4299) Tracing: Add tracing to exemplar APIs.
 - [#4327](https://github.com/thanos-io/thanos/pull/4327) Add environment variable substitution to all YAML configuration flags.
 - [#4239](https://github.com/thanos-io/thanos/pull/4239) Add penalty based deduplication mode for compactor.
+- [#4292](https://github.com/thanos-io/thanos/pull/4292) Receive: Enable exemplars ingestion and querying.
 
 ### Fixed
 

--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -24,6 +24,7 @@ import (
 	"github.com/prometheus/prometheus/tsdb"
 
 	"github.com/thanos-io/thanos/pkg/block/metadata"
+	"github.com/thanos-io/thanos/pkg/exemplars"
 	"github.com/thanos-io/thanos/pkg/extkingpin"
 	"github.com/thanos-io/thanos/pkg/logging"
 
@@ -320,6 +321,7 @@ func setupAndRunGRPCServer(g *run.Group,
 			s = grpcserver.New(logger, &receive.UnRegisterer{Registerer: reg}, tracer, grpcLogOpts, tagOpts, comp, grpcProbe,
 				grpcserver.WithServer(store.RegisterStoreServer(rw)),
 				grpcserver.WithServer(store.RegisterWritableStoreServer(rw)),
+				grpcserver.WithServer(exemplars.RegisterExemplarsServer(exemplars.NewMultiTSDB(dbs.TSDBExemplars))),
 				grpcserver.WithListen(*conf.grpcBindAddr),
 				grpcserver.WithGracePeriod(time.Duration(*conf.grpcGracePeriod)),
 				grpcserver.WithTLSConfig(tlsCfg),

--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -764,7 +764,11 @@ func (rc *receiveConfig) registerFlag(cmd extkingpin.FlagClause) {
 
 	cmd.Flag("tsdb.no-lockfile", "Do not create lockfile in TSDB data directory. In any case, the lockfiles will be deleted on next startup.").Default("false").BoolVar(&rc.noLockFile)
 
-	cmd.Flag("tsdb.max-exemplars", "Enables support for ingesting exemplars and set the maximum number that will be stored. 0 (or less) disables exemplars storage.").Default("0").IntVar(&rc.tsdbMaxExemplars)
+	cmd.Flag("tsdb.max-exemplars",
+		"Enables support for ingesting exemplars and sets the maximum number of exemplars that will be stored per tenant."+
+			" In case the exemplar storage becomes full (number of stored exemplars becomes equal to max-exemplars),"+
+			" ingesting a new exemplar will evict the oldest exemplar from storage. 0 (or less) value of this flag disables exemplars storage.").
+		Default("0").IntVar(&rc.tsdbMaxExemplars)
 
 	cmd.Flag("hash-func", "Specify which hash function to use when calculating the hashes of produced files. If no function has been specified, it does not happen. This permits avoiding downloading some files twice albeit at some performance cost. Possible values are: \"\", \"SHA256\".").
 		Default("").EnumVar(&rc.hashFunc, "SHA256", "")

--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -70,6 +70,7 @@ func registerReceive(app *extkingpin.App) {
 			NoLockfile:             conf.noLockFile,
 			WALCompression:         conf.walCompression,
 			AllowOverlappingBlocks: conf.tsdbAllowOverlappingBlocks,
+			MaxExemplars:           conf.tsdbMaxExemplars,
 		}
 
 		// Enable ingestion if endpoint is specified or if both the hashrings configs are empty.
@@ -687,6 +688,7 @@ type receiveConfig struct {
 	tsdbMinBlockDuration       *model.Duration
 	tsdbMaxBlockDuration       *model.Duration
 	tsdbAllowOverlappingBlocks bool
+	tsdbMaxExemplars           int
 
 	walCompression bool
 	noLockFile     bool
@@ -759,6 +761,8 @@ func (rc *receiveConfig) registerFlag(cmd extkingpin.FlagClause) {
 	cmd.Flag("tsdb.wal-compression", "Compress the tsdb WAL.").Default("true").BoolVar(&rc.walCompression)
 
 	cmd.Flag("tsdb.no-lockfile", "Do not create lockfile in TSDB data directory. In any case, the lockfiles will be deleted on next startup.").Default("false").BoolVar(&rc.noLockFile)
+
+	cmd.Flag("tsdb.max-exemplars", "Enables support for ingesting exemplars and set the maximum number that will be stored. 0 (or less) disables exemplars storage.").Default("0").IntVar(&rc.tsdbMaxExemplars)
 
 	cmd.Flag("hash-func", "Specify which hash function to use when calculating the hashes of produced files. If no function has been specified, it does not happen. This permits avoiding downloading some files twice albeit at some performance cost. Possible values are: \"\", \"SHA256\".").
 		Default("").EnumVar(&rc.hashFunc, "SHA256", "")

--- a/docs/components/receive.md
+++ b/docs/components/receive.md
@@ -12,12 +12,14 @@ We recommend this component to users who can only push into a Thanos due to air-
 
 Thanos Receive supports multi-tenancy by using labels. See [Multitenancy documentation here](../operating/multi-tenancy.md).
 
+Thanos Receive supports ingesting [exemplars](https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#exemplars) via remote-write. By default, the exemplars are silently discarded as `--tsdb.max-exemplars` is set to `0`. To enable exemplars storage, set the `--tsdb.max-exemplars` flag to a non-zero value. It exposes the ExemplarsAPI so that the [Thanos Queriers](./query.md) can query the stored exemplars. Take a look at the documentation for [exemplars storage in Prometheus](https://prometheus.io/docs/prometheus/latest/disabled_features/#exemplars-storage) to know more about it.
+
 For more information please check out [initial design proposal](../proposals/201812_thanos-remote-receive.md).
 For further information on tuning Prometheus Remote Write [see remote write tuning document](https://prometheus.io/docs/practices/remote_write/).
 
 > NOTE: As the block producer it's important to set correct "external labels" that will identify data block across Thanos clusters. See [external labels](../storage.md#external-labels) docs for details.
 
-# Example
+## Example
 
 ```bash
 thanos receive \

--- a/docs/components/receive.md
+++ b/docs/components/receive.md
@@ -196,9 +196,14 @@ Flags:
       --tsdb.allow-overlapping-blocks
                                  Allow overlapping blocks, which in turn enables
                                  vertical compaction and vertical query merge.
-      --tsdb.max-exemplars=0     Enables support for ingesting exemplars and set
-                                 the maximum number that will be stored. 0 (or
-                                 less) disables exemplars storage.
+      --tsdb.max-exemplars=0     Enables support for ingesting exemplars and
+                                 sets the maximum number of exemplars that will
+                                 be stored per tenant. In case the exemplar
+                                 storage becomes full (number of stored
+                                 exemplars becomes equal to max-exemplars),
+                                 ingesting a new exemplar will evict the oldest
+                                 exemplar from storage. 0 (or less) value of
+                                 this flag disables exemplars storage.
       --tsdb.no-lockfile         Do not create lockfile in TSDB data directory.
                                  In any case, the lockfiles will be deleted on
                                  next startup.

--- a/docs/components/receive.md
+++ b/docs/components/receive.md
@@ -196,6 +196,9 @@ Flags:
       --tsdb.allow-overlapping-blocks
                                  Allow overlapping blocks, which in turn enables
                                  vertical compaction and vertical query merge.
+      --tsdb.max-exemplars=0     Enables support for ingesting exemplars and set
+                                 the maximum number that will be stored. 0 (or
+                                 less) disables exemplars storage.
       --tsdb.no-lockfile         Do not create lockfile in TSDB data directory.
                                  In any case, the lockfiles will be deleted on
                                  next startup.

--- a/pkg/exemplars/exemplarspb/custom.go
+++ b/pkg/exemplars/exemplarspb/custom.go
@@ -8,6 +8,7 @@ import (
 	"math/big"
 
 	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/pkg/exemplar"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/thanos-io/thanos/pkg/store/labelpb"
 )
@@ -94,4 +95,16 @@ func (e1 *Exemplar) Compare(e2 *Exemplar) int {
 		return d
 	}
 	return big.NewFloat(e1.Value).Cmp(big.NewFloat(e2.Value))
+}
+
+func ExemplarsFromPromExemplars(exemplars []exemplar.Exemplar) []*Exemplar {
+	ex := make([]*Exemplar, 0, len(exemplars))
+	for _, e := range exemplars {
+		ex = append(ex, &Exemplar{
+			Labels: labelpb.ZLabelSet{Labels: labelpb.ZLabelsFromPromLabels(e.Labels)},
+			Value:  e.Value,
+			Ts:     e.Ts,
+		})
+	}
+	return ex
 }

--- a/pkg/exemplars/multitsdb.go
+++ b/pkg/exemplars/multitsdb.go
@@ -1,0 +1,35 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package exemplars
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+
+	"github.com/thanos-io/thanos/pkg/exemplars/exemplarspb"
+)
+
+// MultiTSDB implements exemplarspb.ExemplarsServer that allows to fetch exemplars a MultiTSDB instance.
+type MultiTSDB struct {
+	tsdbExemplarsServers func() map[string]exemplarspb.ExemplarsServer
+}
+
+// NewMultiTSDB creates new exemplars.MultiTSDB.
+func NewMultiTSDB(tsdbExemplarsServers func() map[string]exemplarspb.ExemplarsServer) *MultiTSDB {
+	return &MultiTSDB{
+		tsdbExemplarsServers: tsdbExemplarsServers,
+	}
+}
+
+// Exemplars returns all specified exemplars from a MultiTSDB instance.
+func (m *MultiTSDB) Exemplars(r *exemplarspb.ExemplarsRequest, s exemplarspb.Exemplars_ExemplarsServer) error {
+	fmt.Println("meer paas request aayi", m.tsdbExemplarsServers())
+	for tenant, es := range m.tsdbExemplarsServers() {
+		if err := es.Exemplars(r, s); err != nil {
+			return errors.Wrapf(err, "get info for tenant %s", tenant)
+		}
+	}
+	return nil
+}

--- a/pkg/exemplars/multitsdb.go
+++ b/pkg/exemplars/multitsdb.go
@@ -5,6 +5,8 @@ package exemplars
 
 import (
 	"github.com/pkg/errors"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/thanos-io/thanos/pkg/exemplars/exemplarspb"
 )
@@ -25,7 +27,7 @@ func NewMultiTSDB(tsdbExemplarsServers func() map[string]exemplarspb.ExemplarsSe
 func (m *MultiTSDB) Exemplars(r *exemplarspb.ExemplarsRequest, s exemplarspb.Exemplars_ExemplarsServer) error {
 	for tenant, es := range m.tsdbExemplarsServers() {
 		if err := es.Exemplars(r, s); err != nil {
-			return errors.Wrapf(err, "get exemplars for tenant %s", tenant)
+			return status.Error(codes.Aborted, errors.Wrapf(err, "get exemplars for tenant %s", tenant).Error())
 		}
 	}
 	return nil

--- a/pkg/exemplars/multitsdb.go
+++ b/pkg/exemplars/multitsdb.go
@@ -4,8 +4,6 @@
 package exemplars
 
 import (
-	"fmt"
-
 	"github.com/pkg/errors"
 
 	"github.com/thanos-io/thanos/pkg/exemplars/exemplarspb"
@@ -25,10 +23,9 @@ func NewMultiTSDB(tsdbExemplarsServers func() map[string]exemplarspb.ExemplarsSe
 
 // Exemplars returns all specified exemplars from a MultiTSDB instance.
 func (m *MultiTSDB) Exemplars(r *exemplarspb.ExemplarsRequest, s exemplarspb.Exemplars_ExemplarsServer) error {
-	fmt.Println("meer paas request aayi", m.tsdbExemplarsServers())
 	for tenant, es := range m.tsdbExemplarsServers() {
 		if err := es.Exemplars(r, s); err != nil {
-			return errors.Wrapf(err, "get info for tenant %s", tenant)
+			return errors.Wrapf(err, "get exemplars for tenant %s", tenant)
 		}
 	}
 	return nil

--- a/pkg/exemplars/tsdb.go
+++ b/pkg/exemplars/tsdb.go
@@ -1,0 +1,61 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package exemplars
+
+import (
+	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/prometheus/prometheus/storage"
+
+	"github.com/thanos-io/thanos/pkg/exemplars/exemplarspb"
+	"github.com/thanos-io/thanos/pkg/store/labelpb"
+)
+
+// TSDB implements exemplarspb.Exemplars that allows to fetch exemplars from a TSDB instance.
+type TSDB struct {
+	db        storage.ExemplarQueryable
+	extLabels labels.Labels
+}
+
+// NewTSDB creates new exemplars.TSDB.
+func NewTSDB(db storage.ExemplarQueryable, extLabels labels.Labels) *TSDB {
+	return &TSDB{
+		db:        db,
+		extLabels: extLabels,
+	}
+}
+
+// Exemplars returns all specified exemplars from a TSDB instance.
+func (t *TSDB) Exemplars(r *exemplarspb.ExemplarsRequest, s exemplarspb.Exemplars_ExemplarsServer) error {
+	eq, err := t.db.ExemplarQuerier(s.Context())
+	if err != nil {
+		return err
+	}
+
+	expr, err := parser.ParseExpr(r.Query)
+	if err != nil {
+		return err
+	}
+
+	matchers := parser.ExtractSelectors(expr)
+
+	exemplars, err := eq.Select(r.Start, r.End, matchers...)
+	if err != nil {
+		return err
+	}
+
+	for _, e := range exemplars {
+		exd := exemplarspb.ExemplarData{
+			SeriesLabels: labelpb.ZLabelSet{
+				Labels: labelpb.ZLabelsFromPromLabels(
+					labelpb.ExtendSortedLabels(e.SeriesLabels, t.extLabels),
+				),
+			},
+		}
+		if err := s.Send(&exemplarspb.ExemplarsResponse{Result: &exemplarspb.ExemplarsResponse_Data{Data: &exd}}); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/exemplars/tsdb.go
+++ b/pkg/exemplars/tsdb.go
@@ -52,8 +52,9 @@ func (t *TSDB) Exemplars(r *exemplarspb.ExemplarsRequest, s exemplarspb.Exemplar
 					labelpb.ExtendSortedLabels(e.SeriesLabels, t.extLabels),
 				),
 			},
+			Exemplars: exemplarspb.ExemplarsFromPromExemplars(e.Exemplars),
 		}
-		if err := s.Send(&exemplarspb.ExemplarsResponse{Result: &exemplarspb.ExemplarsResponse_Data{Data: &exd}}); err != nil {
+		if err := s.Send(exemplarspb.NewExemplarsResponse(&exd)); err != nil {
 			return err
 		}
 	}

--- a/pkg/exemplars/tsdb.go
+++ b/pkg/exemplars/tsdb.go
@@ -4,9 +4,12 @@
 package exemplars
 
 import (
+	"github.com/gogo/status"
+	"github.com/pkg/errors"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/prometheus/prometheus/storage"
+	"google.golang.org/grpc/codes"
 
 	"github.com/thanos-io/thanos/pkg/exemplars/exemplarspb"
 	"github.com/thanos-io/thanos/pkg/store/labelpb"
@@ -28,35 +31,59 @@ func NewTSDB(db storage.ExemplarQueryable, extLabels labels.Labels) *TSDB {
 
 // Exemplars returns all specified exemplars from a TSDB instance.
 func (t *TSDB) Exemplars(r *exemplarspb.ExemplarsRequest, s exemplarspb.Exemplars_ExemplarsServer) error {
-	eq, err := t.db.ExemplarQuerier(s.Context())
-	if err != nil {
-		return err
-	}
-
 	expr, err := parser.ParseExpr(r.Query)
 	if err != nil {
-		return err
+		return status.Error(codes.Internal, err.Error())
 	}
 
-	matchers := parser.ExtractSelectors(expr)
+	match, selectors := selectorsMatchesExternalLabels(parser.ExtractSelectors(expr), t.extLabels)
 
-	exemplars, err := eq.Select(r.Start, r.End, matchers...)
+	if !match {
+		return nil
+	}
+
+	if len(selectors) == 0 {
+		return status.Error(codes.InvalidArgument, errors.New("no matchers specified (excluding external labels)").Error())
+	}
+
+	eq, err := t.db.ExemplarQuerier(s.Context())
 	if err != nil {
-		return err
+		return status.Error(codes.Internal, err.Error())
+	}
+
+	exemplars, err := eq.Select(r.Start, r.End, selectors...)
+	if err != nil {
+		return status.Error(codes.Internal, err.Error())
 	}
 
 	for _, e := range exemplars {
 		exd := exemplarspb.ExemplarData{
 			SeriesLabels: labelpb.ZLabelSet{
-				Labels: labelpb.ZLabelsFromPromLabels(
-					labelpb.ExtendSortedLabels(e.SeriesLabels, t.extLabels),
-				),
+				Labels: labelpb.ZLabelsFromPromLabels(labelpb.ExtendSortedLabels(e.SeriesLabels, t.extLabels)),
 			},
 			Exemplars: exemplarspb.ExemplarsFromPromExemplars(e.Exemplars),
 		}
 		if err := s.Send(exemplarspb.NewExemplarsResponse(&exd)); err != nil {
-			return err
+			return status.Error(codes.Aborted, err.Error())
 		}
 	}
 	return nil
+}
+
+// selectorsMatchesExternalLabels returns false if none of the selectors matches the external labels.
+// If true, it also returns an array of non-empty Prometheus matchers.
+func selectorsMatchesExternalLabels(selectors [][]*labels.Matcher, externalLabels labels.Labels) (bool, [][]*labels.Matcher) {
+	matchedOnce := false
+
+	var newSelectors [][]*labels.Matcher
+	for _, m := range selectors {
+		match, m := matchesExternalLabels(m, externalLabels)
+
+		matchedOnce = matchedOnce || match
+		if match && len(m) > 0 {
+			newSelectors = append(newSelectors, m)
+		}
+	}
+
+	return matchedOnce, newSelectors
 }

--- a/pkg/exemplars/tsdb_test.go
+++ b/pkg/exemplars/tsdb_test.go
@@ -1,0 +1,95 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package exemplars
+
+import (
+	"testing"
+
+	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/thanos-io/thanos/pkg/testutil"
+)
+
+func TestSelectorsMatchExternalLabels(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		selectors         [][]*labels.Matcher
+		extLabels         labels.Labels
+		shouldMatch       bool
+		expectedSelectors [][]*labels.Matcher
+	}{
+		"should return true for matching labels": {
+			selectors: [][]*labels.Matcher{
+				{
+					labels.MustNewMatcher(labels.MatchEqual, "code", "200"),
+					labels.MustNewMatcher(labels.MatchEqual, "receive", "true"),
+				},
+			},
+			extLabels:   labels.FromStrings("receive", "true"),
+			shouldMatch: true,
+			expectedSelectors: [][]*labels.Matcher{
+				{
+					labels.MustNewMatcher(labels.MatchEqual, "code", "200"),
+				},
+			},
+		},
+		"should return true when the external labels are not present in input at all": {
+			selectors: [][]*labels.Matcher{
+				{
+					labels.MustNewMatcher(labels.MatchEqual, "code", "200"),
+				},
+			},
+			extLabels:   labels.FromStrings("receive", "true"),
+			shouldMatch: true,
+			expectedSelectors: [][]*labels.Matcher{
+				{
+					labels.MustNewMatcher(labels.MatchEqual, "code", "200"),
+				},
+			},
+		},
+		"should return true when only some of matchers slice are matching": {
+			selectors: [][]*labels.Matcher{
+				{
+					labels.MustNewMatcher(labels.MatchEqual, "code", "200"),
+					labels.MustNewMatcher(labels.MatchRegexp, "receive", "false"),
+				},
+				{
+					labels.MustNewMatcher(labels.MatchEqual, "code", "500"),
+					labels.MustNewMatcher(labels.MatchRegexp, "receive", "true"),
+				},
+			},
+			extLabels:   labels.FromStrings("receive", "true", "replica", "0"),
+			shouldMatch: true,
+			expectedSelectors: [][]*labels.Matcher{
+				{
+					labels.MustNewMatcher(labels.MatchEqual, "code", "500"),
+				},
+			},
+		},
+		"should return false when the external labels are not matching": {
+			selectors: [][]*labels.Matcher{
+				{
+					labels.MustNewMatcher(labels.MatchEqual, "code", "200"),
+					labels.MustNewMatcher(labels.MatchNotEqual, "replica", "1"),
+				},
+				{
+					labels.MustNewMatcher(labels.MatchEqual, "op", "get"),
+					labels.MustNewMatcher(labels.MatchEqual, "replica", "0"),
+				},
+			},
+			extLabels:         labels.FromStrings("replica", "1"),
+			shouldMatch:       false,
+			expectedSelectors: nil,
+		},
+	}
+
+	for name, tdata := range tests {
+		t.Run(name, func(t *testing.T) {
+			match, selectors := selectorsMatchesExternalLabels(tdata.selectors, tdata.extLabels)
+			testutil.Equals(t, tdata.shouldMatch, match)
+
+			testutil.Equals(t, tdata.expectedSelectors, selectors)
+		})
+	}
+}

--- a/pkg/receive/handler.go
+++ b/pkg/receive/handler.go
@@ -325,7 +325,7 @@ func (h *Handler) receiveHTTP(w http.ResponseWriter, r *http.Request) {
 		tenant = h.options.DefaultTenantID
 	}
 
-	// TODO(yeya24): handle remote write metadata and exemplars.
+	// TODO(yeya24): handle remote write metadata.
 	// exit early if the request contained no data
 	if len(wreq.Timeseries) == 0 {
 		level.Debug(h.logger).Log("msg", "empty timeseries from client", "tenant", tenant)

--- a/pkg/receive/multitsdb.go
+++ b/pkg/receive/multitsdb.go
@@ -22,7 +22,6 @@ import (
 	"github.com/thanos-io/thanos/pkg/component"
 	"github.com/thanos-io/thanos/pkg/errutil"
 	"github.com/thanos-io/thanos/pkg/exemplars"
-	"github.com/thanos-io/thanos/pkg/exemplars/exemplarspb"
 	"github.com/thanos-io/thanos/pkg/objstore"
 	"github.com/thanos-io/thanos/pkg/shipper"
 	"github.com/thanos-io/thanos/pkg/store"
@@ -276,11 +275,11 @@ func (t *MultiTSDB) TSDBStores() map[string]storepb.StoreServer {
 	return res
 }
 
-func (t *MultiTSDB) TSDBExemplars() map[string]exemplarspb.ExemplarsServer {
+func (t *MultiTSDB) TSDBExemplars() map[string]*exemplars.TSDB {
 	t.mtx.RLock()
 	defer t.mtx.RUnlock()
 
-	res := make(map[string]exemplarspb.ExemplarsServer, len(t.tenants))
+	res := make(map[string]*exemplars.TSDB, len(t.tenants))
 	for k, tenant := range t.tenants {
 		e := tenant.exemplars()
 		if e != nil {
@@ -457,19 +456,11 @@ func (a adapter) StartTime() (int64, error) {
 }
 
 func (a adapter) Querier(ctx context.Context, mint, maxt int64) (storage.Querier, error) {
-	q, err := a.db.Querier(ctx, mint, maxt)
-	if err != nil {
-		return nil, err
-	}
-	return q, nil
+	return a.db.Querier(ctx, mint, maxt)
 }
 
 func (a adapter) ExemplarQuerier(ctx context.Context) (storage.ExemplarQuerier, error) {
-	q, err := a.db.ExemplarQuerier(ctx)
-	if err != nil {
-		return nil, err
-	}
-	return q, nil
+	return a.db.ExemplarQuerier(ctx)
 }
 
 // Appender returns a new appender against the storage.

--- a/pkg/receive/multitsdb.go
+++ b/pkg/receive/multitsdb.go
@@ -21,6 +21,8 @@ import (
 	"github.com/thanos-io/thanos/pkg/block/metadata"
 	"github.com/thanos-io/thanos/pkg/component"
 	"github.com/thanos-io/thanos/pkg/errutil"
+	"github.com/thanos-io/thanos/pkg/exemplars"
+	"github.com/thanos-io/thanos/pkg/exemplars/exemplarspb"
 	"github.com/thanos-io/thanos/pkg/objstore"
 	"github.com/thanos-io/thanos/pkg/shipper"
 	"github.com/thanos-io/thanos/pkg/store"
@@ -78,9 +80,10 @@ func NewMultiTSDB(
 }
 
 type tenant struct {
-	readyS    *ReadyStorage
-	storeTSDB *store.TSDBStore
-	ship      *shipper.Shipper
+	readyS        *ReadyStorage
+	storeTSDB     *store.TSDBStore
+	exemplarsTSDB *exemplars.TSDB
+	ship          *shipper.Shipper
 
 	mtx *sync.RWMutex
 }
@@ -102,17 +105,24 @@ func (t *tenant) store() *store.TSDBStore {
 	return t.storeTSDB
 }
 
+func (t *tenant) exemplars() *exemplars.TSDB {
+	t.mtx.RLock()
+	defer t.mtx.RUnlock()
+	return t.exemplarsTSDB
+}
+
 func (t *tenant) shipper() *shipper.Shipper {
 	t.mtx.RLock()
 	defer t.mtx.RUnlock()
 	return t.ship
 }
 
-func (t *tenant) set(storeTSDB *store.TSDBStore, tenantTSDB *tsdb.DB, ship *shipper.Shipper) {
+func (t *tenant) set(storeTSDB *store.TSDBStore, tenantTSDB *tsdb.DB, ship *shipper.Shipper, exemplarsTSDB *exemplars.TSDB) {
 	t.readyS.Set(tenantTSDB)
 	t.mtx.Lock()
 	t.storeTSDB = storeTSDB
 	t.ship = ship
+	t.exemplarsTSDB = exemplarsTSDB
 	t.mtx.Unlock()
 }
 
@@ -266,6 +276,20 @@ func (t *MultiTSDB) TSDBStores() map[string]storepb.StoreServer {
 	return res
 }
 
+func (t *MultiTSDB) TSDBExemplars() map[string]exemplarspb.ExemplarsServer {
+	t.mtx.RLock()
+	defer t.mtx.RUnlock()
+
+	res := make(map[string]exemplarspb.ExemplarsServer, len(t.tenants))
+	for k, tenant := range t.tenants {
+		e := tenant.exemplars()
+		if e != nil {
+			res[k] = e
+		}
+	}
+	return res
+}
+
 func (t *MultiTSDB) startTSDB(logger log.Logger, tenantID string, tenant *tenant) error {
 	reg := prometheus.WrapRegistererWith(prometheus.Labels{"tenant": tenantID}, t.reg)
 	lset := labelpb.ExtendSortedLabels(t.labels, labels.FromStrings(t.tenantLabelName, tenantID))
@@ -299,7 +323,7 @@ func (t *MultiTSDB) startTSDB(logger log.Logger, tenantID string, tenant *tenant
 			t.hashFunc,
 		)
 	}
-	tenant.set(store.NewTSDBStore(logger, s, component.Receive, lset), s, ship)
+	tenant.set(store.NewTSDBStore(logger, s, component.Receive, lset), s, ship, exemplars.NewTSDB(s, lset))
 	level.Info(logger).Log("msg", "TSDB is now ready")
 	return nil
 }
@@ -398,6 +422,14 @@ func (s *ReadyStorage) Querier(ctx context.Context, mint, maxt int64) (storage.Q
 	return nil, ErrNotReady
 }
 
+// ExemplarQuerier implements the Storage interface.
+func (s *ReadyStorage) ExemplarQuerier(ctx context.Context) (storage.ExemplarQuerier, error) {
+	if x := s.get(); x != nil {
+		return x.ExemplarQuerier(ctx)
+	}
+	return nil, ErrNotReady
+}
+
 // Appender implements the Storage interface.
 func (s *ReadyStorage) Appender(ctx context.Context) (storage.Appender, error) {
 	if x := s.get(); x != nil {
@@ -426,6 +458,14 @@ func (a adapter) StartTime() (int64, error) {
 
 func (a adapter) Querier(ctx context.Context, mint, maxt int64) (storage.Querier, error) {
 	q, err := a.db.Querier(ctx, mint, maxt)
+	if err != nil {
+		return nil, err
+	}
+	return q, nil
+}
+
+func (a adapter) ExemplarQuerier(ctx context.Context) (storage.ExemplarQuerier, error) {
+	q, err := a.db.ExemplarQuerier(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/receive/multitsdb_test.go
+++ b/pkg/receive/multitsdb_test.go
@@ -398,10 +398,10 @@ func (s *exemplarsServer) Context() context.Context {
 
 func checkExemplarsResponse(t *testing.T, expected []exemplarspb.ExemplarData, data []exemplarspb.ExemplarData) {
 	testutil.Equals(t, len(expected), len(data))
-	for i, _ := range data {
+	for i := range data {
 		testutil.Equals(t, expected[i].SeriesLabels, data[i].SeriesLabels)
 		testutil.Equals(t, len(expected[i].Exemplars), len(data[i].Exemplars))
-		for j, _ := range data[i].Exemplars {
+		for j := range data[i].Exemplars {
 			testutil.Equals(t, *expected[i].Exemplars[j], *data[i].Exemplars[j])
 		}
 	}

--- a/pkg/receive/multitsdb_test.go
+++ b/pkg/receive/multitsdb_test.go
@@ -311,11 +311,12 @@ func testMulitTSDBExemplars(t *testing.T, m *MultiTSDB) {
 
 		g.Go(func() error {
 			srv := newExemplarsServer(context.Background())
-			if err := s["foo"].Exemplars(&exemplarspb.ExemplarsRequest{
-				Query: `{a="1"}`,
-				Start: 0,
-				End:   10,
-			}, srv); err != nil {
+			if err := s["foo"].Exemplars(
+				[][]*labels.Matcher{{labels.MustNewMatcher(labels.MatchEqual, "a", "1")}},
+				0,
+				10,
+				srv,
+			); err != nil {
 				return err
 			}
 			respFoo <- srv.Data
@@ -323,11 +324,12 @@ func testMulitTSDBExemplars(t *testing.T, m *MultiTSDB) {
 		})
 		g.Go(func() error {
 			srv := newExemplarsServer(context.Background())
-			if err := s["bar"].Exemplars(&exemplarspb.ExemplarsRequest{
-				Query: `{a="1"}`,
-				Start: 0,
-				End:   10,
-			}, srv); err != nil {
+			if err := s["bar"].Exemplars(
+				[][]*labels.Matcher{{labels.MustNewMatcher(labels.MatchEqual, "a", "1")}},
+				0,
+				10,
+				srv,
+			); err != nil {
 				return err
 			}
 			respBar <- srv.Data

--- a/pkg/receive/multitsdb_test.go
+++ b/pkg/receive/multitsdb_test.go
@@ -20,6 +20,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/thanos-io/thanos/pkg/block/metadata"
+	"github.com/thanos-io/thanos/pkg/exemplars/exemplarspb"
 	"github.com/thanos-io/thanos/pkg/runutil"
 	"github.com/thanos-io/thanos/pkg/store/labelpb"
 	"github.com/thanos-io/thanos/pkg/store/storepb"
@@ -72,11 +73,11 @@ func TestMultiTSDB(t *testing.T) {
 		testutil.Ok(t, err)
 
 		// Test exemplars.
-		_, err = a.AppendExemplar(ref, labels.FromStrings("a", "1", "b", "2"), exemplar.Exemplar{Value: 1})
+		_, err = a.AppendExemplar(ref, labels.FromStrings("a", "1", "b", "2"), exemplar.Exemplar{Value: 1, Ts: 1, HasTs: true})
 		testutil.Ok(t, err)
-		_, err = a.AppendExemplar(ref, labels.FromStrings("a", "1", "b", "2"), exemplar.Exemplar{Value: 2.1212})
+		_, err = a.AppendExemplar(ref, labels.FromStrings("a", "1", "b", "2"), exemplar.Exemplar{Value: 2.1212, Ts: 2, HasTs: true})
 		testutil.Ok(t, err)
-		_, err = a.AppendExemplar(ref, labels.FromStrings("a", "1", "b", "2"), exemplar.Exemplar{Value: 3.1313})
+		_, err = a.AppendExemplar(ref, labels.FromStrings("a", "1", "b", "2"), exemplar.Exemplar{Value: 3.1313, Ts: 3, HasTs: true})
 		testutil.Ok(t, err)
 		testutil.Ok(t, a.Commit())
 
@@ -103,11 +104,19 @@ func TestMultiTSDB(t *testing.T) {
 		testutil.Ok(t, err)
 		_, err = a.Append(0, labels.FromStrings("a", "1", "b", "2"), 2, 30.41241)
 		testutil.Ok(t, err)
-		_, err = a.Append(0, labels.FromStrings("a", "1", "b", "2"), 3, 40.41241)
+		ref, err = a.Append(0, labels.FromStrings("a", "1", "b", "2"), 3, 40.41241)
+		testutil.Ok(t, err)
+
+		_, err = a.AppendExemplar(ref, labels.FromStrings("a", "1", "b", "2"), exemplar.Exemplar{Value: 11, Ts: 1, HasTs: true, Labels: labels.FromStrings("traceID", "abc")})
+		testutil.Ok(t, err)
+		_, err = a.AppendExemplar(ref, labels.FromStrings("a", "1", "b", "2"), exemplar.Exemplar{Value: 22.1212, Ts: 2, HasTs: true, Labels: labels.FromStrings("traceID", "def")})
+		testutil.Ok(t, err)
+		_, err = a.AppendExemplar(ref, labels.FromStrings("a", "1", "b", "2"), exemplar.Exemplar{Value: 33.1313, Ts: 3, HasTs: true, Labels: labels.FromStrings("traceID", "ghi")})
 		testutil.Ok(t, err)
 		testutil.Ok(t, a.Commit())
 
 		testMulitTSDBSeries(t, m)
+		testMulitTSDBExemplars(t, m)
 	})
 	t.Run("run on existing storage", func(t *testing.T) {
 		m := NewMultiTSDB(
@@ -267,6 +276,135 @@ func (s *storeSeriesServer) Send(r *storepb.SeriesResponse) error {
 
 func (s *storeSeriesServer) Context() context.Context {
 	return s.ctx
+}
+
+var (
+	expectedFooRespExemplars = []exemplarspb.ExemplarData{
+		{
+			SeriesLabels: labelpb.ZLabelSet{Labels: []labelpb.ZLabel{{Name: "a", Value: "1"}, {Name: "b", Value: "2"}, {Name: "replica", Value: "01"}, {Name: "tenant_id", Value: "foo"}}},
+			Exemplars: []*exemplarspb.Exemplar{
+				{Value: 1, Ts: 1},
+				{Value: 2.1212, Ts: 2},
+				{Value: 3.1313, Ts: 3},
+			},
+		},
+	}
+	expectedBarRespExemplars = []exemplarspb.ExemplarData{
+		{
+			SeriesLabels: labelpb.ZLabelSet{Labels: []labelpb.ZLabel{{Name: "a", Value: "1"}, {Name: "b", Value: "2"}, {Name: "replica", Value: "01"}, {Name: "tenant_id", Value: "bar"}}},
+			Exemplars: []*exemplarspb.Exemplar{
+				{Value: 11, Ts: 1, Labels: labelpb.ZLabelSet{Labels: []labelpb.ZLabel{{Name: "traceID", Value: "abc"}}}},
+				{Value: 22.1212, Ts: 2, Labels: labelpb.ZLabelSet{Labels: []labelpb.ZLabel{{Name: "traceID", Value: "def"}}}},
+				{Value: 33.1313, Ts: 3, Labels: labelpb.ZLabelSet{Labels: []labelpb.ZLabel{{Name: "traceID", Value: "ghi"}}}},
+			},
+		},
+	}
+)
+
+func testMulitTSDBExemplars(t *testing.T, m *MultiTSDB) {
+	g := &errgroup.Group{}
+	respFoo := make(chan []exemplarspb.ExemplarData)
+	respBar := make(chan []exemplarspb.ExemplarData)
+	for i := 0; i < 100; i++ {
+		s := m.TSDBExemplars()
+		testutil.Assert(t, len(s) == 2)
+
+		g.Go(func() error {
+			srv := newExemplarsServer(context.Background())
+			if err := s["foo"].Exemplars(&exemplarspb.ExemplarsRequest{
+				Query: `{a="1"}`,
+				Start: 0,
+				End:   10,
+			}, srv); err != nil {
+				return err
+			}
+			respFoo <- srv.Data
+			return nil
+		})
+		g.Go(func() error {
+			srv := newExemplarsServer(context.Background())
+			if err := s["bar"].Exemplars(&exemplarspb.ExemplarsRequest{
+				Query: `{a="1"}`,
+				Start: 0,
+				End:   10,
+			}, srv); err != nil {
+				return err
+			}
+			respBar <- srv.Data
+			return nil
+		})
+	}
+	var err error
+	go func() {
+		err = g.Wait()
+		close(respFoo)
+		close(respBar)
+	}()
+OuterE:
+	for {
+		select {
+		case r, ok := <-respFoo:
+			if !ok {
+				break OuterE
+			}
+			checkExemplarsResponse(t, expectedFooRespExemplars, r)
+		case r, ok := <-respBar:
+			if !ok {
+				break OuterE
+			}
+			checkExemplarsResponse(t, expectedBarRespExemplars, r)
+		}
+	}
+	testutil.Ok(t, err)
+}
+
+// exemplarsServer is test gRPC exemplarsAPI exemplars server.
+type exemplarsServer struct {
+	// This field just exist to pseudo-implement the unused methods of the interface.
+	exemplarspb.Exemplars_ExemplarsServer
+
+	ctx context.Context
+
+	Data     []exemplarspb.ExemplarData
+	Warnings []string
+
+	Size int64
+}
+
+func newExemplarsServer(ctx context.Context) *exemplarsServer {
+	return &exemplarsServer{ctx: ctx}
+}
+
+func (e *exemplarsServer) Send(r *exemplarspb.ExemplarsResponse) error {
+	e.Size += int64(r.Size())
+
+	if r.GetWarning() != "" {
+		e.Warnings = append(e.Warnings, r.GetWarning())
+		return nil
+	}
+
+	if r.GetData() != nil {
+		e.Data = append(e.Data, *r.GetData())
+		return nil
+	}
+
+	// Unsupported field, skip.
+	return nil
+}
+
+func (s *exemplarsServer) Context() context.Context {
+	return s.ctx
+}
+
+func checkExemplarsResponse(t *testing.T, expected []exemplarspb.ExemplarData, data []exemplarspb.ExemplarData) {
+	testutil.Equals(t, len(expected), len(data))
+	for i, _ := range data {
+		testutil.Equals(t, expected[i].SeriesLabels, data[i].SeriesLabels)
+		testutil.Equals(t, len(expected[i].Exemplars), len(data[i].Exemplars))
+		for j, _ := range data[i].Exemplars {
+			testutil.Equals(t, *expected[i].Exemplars[j], *data[i].Exemplars[j])
+		}
+	}
 }
 
 func BenchmarkMultiTSDB(b *testing.B) {

--- a/pkg/receive/writer.go
+++ b/pkg/receive/writer.go
@@ -114,10 +114,14 @@ func (r *Writer) Write(ctx context.Context, tenantID string, wreq *prompb.WriteR
 					level.Debug(logger).Log("msg", "Out of order exemplar")
 				case storage.ErrDuplicateExemplar:
 					numExemplarsDuplicate++
-					level.Debug(logger).Log("msg", "Out of order exemplar")
+					level.Debug(logger).Log("msg", "Duplicate exemplar")
 				case storage.ErrExemplarLabelLength:
 					numExemplarsLabelLength++
-					level.Debug(logger).Log("msg", "Label length for exemplar exceeds max limit")
+					level.Debug(logger).Log("msg", "Label length for exemplar exceeds max limit", "limit", exemplar.ExemplarMaxLabelSetLength)
+				default:
+					if err != nil {
+						level.Debug(logger).Log("msg", "Error ingesting exemplar", "err", err)
+					}
 				}
 			}
 		}

--- a/pkg/receive/writer.go
+++ b/pkg/receive/writer.go
@@ -141,15 +141,15 @@ func (r *Writer) Write(ctx context.Context, tenantID string, wreq *prompb.WriteR
 	}
 	if numExemplarsOutOfOrder > 0 {
 		level.Warn(r.logger).Log("msg", "Error on ingesting out-of-order exemplars", "numDropped", numExemplarsOutOfOrder)
-		errs.Add(errors.Wrapf(storage.ErrOutOfOrderExemplar, "add %d samples", numExemplarsOutOfOrder))
+		errs.Add(errors.Wrapf(storage.ErrOutOfOrderExemplar, "add %d exemplars", numExemplarsOutOfOrder))
 	}
 	if numExemplarsDuplicate > 0 {
 		level.Warn(r.logger).Log("msg", "Error on ingesting duplicate exemplars", "numDropped", numExemplarsDuplicate)
-		errs.Add(errors.Wrapf(storage.ErrDuplicateExemplar, "add %d samples", numExemplarsDuplicate))
+		errs.Add(errors.Wrapf(storage.ErrDuplicateExemplar, "add %d exemplars", numExemplarsDuplicate))
 	}
 	if numExemplarsLabelLength > 0 {
 		level.Warn(r.logger).Log("msg", "Error on ingesting exemplars with label length exceeding maximum limit", "numDropped", numExemplarsLabelLength)
-		errs.Add(errors.Wrapf(storage.ErrExemplarLabelLength, "add %d samples", numExemplarsLabelLength))
+		errs.Add(errors.Wrapf(storage.ErrExemplarLabelLength, "add %d exemplars", numExemplarsLabelLength))
 	}
 
 	if err := app.Commit(); err != nil {

--- a/pkg/receive/writer_test.go
+++ b/pkg/receive/writer_test.go
@@ -1,0 +1,174 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package receive
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-kit/kit/log"
+	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/prometheus/pkg/exemplar"
+	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/tsdb"
+
+	"github.com/thanos-io/thanos/pkg/block/metadata"
+	"github.com/thanos-io/thanos/pkg/runutil"
+	"github.com/thanos-io/thanos/pkg/store/labelpb"
+	"github.com/thanos-io/thanos/pkg/store/storepb/prompb"
+	"github.com/thanos-io/thanos/pkg/testutil"
+)
+
+func TestWriter(t *testing.T) {
+	lbls := []labelpb.ZLabel{{Name: "__name__", Value: "test"}}
+	tests := map[string]struct {
+		reqs             []*prompb.WriteRequest
+		expectedErr      error
+		expectedIngested []prompb.TimeSeries
+		maxExemplars     int
+	}{
+		"should succeed on valid series with exemplars": {
+			reqs: []*prompb.WriteRequest{{
+				Timeseries: []prompb.TimeSeries{
+					{
+						Labels: lbls,
+						// Ingesting an exemplar requires a sample to create the series first.
+						Samples: []prompb.Sample{{Value: 1, Timestamp: 10}},
+						Exemplars: []prompb.Exemplar{
+							{
+								Labels:    []labelpb.ZLabel{{Name: "traceID", Value: "123"}},
+								Value:     111,
+								Timestamp: 11,
+							},
+							{
+								Labels:    []labelpb.ZLabel{{Name: "traceID", Value: "234"}},
+								Value:     112,
+								Timestamp: 12,
+							},
+						},
+					},
+				},
+			}},
+			expectedErr:  nil,
+			maxExemplars: 2,
+		},
+		"should error out on valid series with out of order exemplars": {
+			reqs: []*prompb.WriteRequest{
+				{
+					Timeseries: []prompb.TimeSeries{
+						{
+							Labels: lbls,
+							// Ingesting an exemplar requires a sample to create the series first.
+							Samples: []prompb.Sample{{Value: 1, Timestamp: 10}},
+							Exemplars: []prompb.Exemplar{
+								{
+									Labels:    []labelpb.ZLabel{{Name: "traceID", Value: "123"}},
+									Value:     111,
+									Timestamp: 11,
+								},
+							},
+						},
+					},
+				},
+				{
+					Timeseries: []prompb.TimeSeries{
+						{
+							Labels: lbls,
+							Exemplars: []prompb.Exemplar{
+								{
+									Labels:    []labelpb.ZLabel{{Name: "traceID", Value: "1234"}},
+									Value:     111,
+									Timestamp: 10,
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedErr:  errors.Wrapf(storage.ErrOutOfOrderExemplar, "add 1 exemplars"),
+			maxExemplars: 2,
+		},
+		"should error out when exemplar label length exceeds the limit": {
+			reqs: []*prompb.WriteRequest{
+				{
+					Timeseries: []prompb.TimeSeries{
+						{
+							Labels: lbls,
+							// Ingesting an exemplar requires a sample to create the series first.
+							Samples: []prompb.Sample{{Value: 1, Timestamp: 10}},
+							Exemplars: []prompb.Exemplar{
+								{
+									Labels:    []labelpb.ZLabel{{Name: strings.Repeat("a", exemplar.ExemplarMaxLabelSetLength), Value: "1"}},
+									Value:     111,
+									Timestamp: 11,
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedErr:  errors.Wrapf(storage.ErrExemplarLabelLength, "add 1 exemplars"),
+			maxExemplars: 2,
+		},
+	}
+
+	for testName, testData := range tests {
+		t.Run(testName, func(t *testing.T) {
+			dir, err := ioutil.TempDir("", "test")
+			testutil.Ok(t, err)
+			defer func() { testutil.Ok(t, os.RemoveAll(dir)) }()
+
+			logger := log.NewNopLogger()
+
+			m := NewMultiTSDB(dir, logger, prometheus.NewRegistry(), &tsdb.Options{
+				MinBlockDuration:  (2 * time.Hour).Milliseconds(),
+				MaxBlockDuration:  (2 * time.Hour).Milliseconds(),
+				RetentionDuration: (6 * time.Hour).Milliseconds(),
+				NoLockfile:        true,
+				MaxExemplars:      testData.maxExemplars,
+			},
+				labels.FromStrings("replica", "01"),
+				"tenant_id",
+				nil,
+				false,
+				metadata.NoneFunc,
+			)
+			defer func() { testutil.Ok(t, m.Close()) }()
+
+			testutil.Ok(t, m.Flush())
+			testutil.Ok(t, m.Open())
+
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+
+			app, err := m.TenantAppendable(DefaultTenant)
+			testutil.Ok(t, err)
+
+			testutil.Ok(t, runutil.Retry(1*time.Second, ctx.Done(), func() error {
+				_, err = app.Appender(context.Background())
+				return err
+			}))
+
+			w := NewWriter(logger, m)
+
+			for idx, req := range testData.reqs {
+				err = w.Write(context.Background(), DefaultTenant, req)
+
+				// We expect no error on any request except the last one
+				// which may error (and in that case we assert on it).
+				if testData.expectedErr == nil || idx < len(testData.reqs)-1 {
+					testutil.Ok(t, err)
+				} else {
+					testutil.Equals(t, testData.expectedErr.Error(), err.Error())
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes
- Enable exemplar ingestion in Receive
- Add exemplars API implementation for TSDB and MultiTSDB
- Expose exemplars gRPC API from Receive

Fixes #4235 

## Verification
- Local testing, modified some existing tests for ingestion. Need to add E2E tests.
