### PR TITLE
Add tracing to exemplar APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ We use _breaking :warning:_ to mark changes that are not backward compatible (re
 
 ### Added
 
+- [#4299](https://github.com/thanos-io/thanos/pull/4299) Tracing: Add tracing to exemplar APIs.
 - [#4117](https://github.com/thanos-io/thanos/pull/4117) Mixin:  new alert ThanosReceiveTrafficBelowThreshold to flag if the ingestion average of the last hour dips below 50% of the ingestion average for the last 12 hours.
 - [#4107](https://github.com/thanos-io/thanos/pull/4107) Store: `LabelNames` and `LabelValues` now support label matchers.
 - [#3940](https://github.com/thanos-io/thanos/pull/3940) Sidecar: Added matchers support to `LabelValues`

--- a/pkg/api/query/v1.go
+++ b/pkg/api/query/v1.go
@@ -795,9 +795,9 @@ func NewExemplarsHandler(client exemplars.UnaryClient, enablePartialResponse boo
 		defer span.Finish()
 
 		var (
-			exemplarsData    []*exemplarspb.ExemplarData
-			exemplarWarnings storage.Warnings
-			exemplarError    error
+			data     []*exemplarspb.ExemplarData
+			warnings storage.Warnings
+			err      error
 		)
 
 		start, err := cortexutil.ParseTime(r.FormValue("start"))
@@ -817,13 +817,13 @@ func NewExemplarsHandler(client exemplars.UnaryClient, enablePartialResponse boo
 		}
 
 		tracing.DoInSpan(ctx, "retrieve_exemplars", func(ctx context.Context) {
-			exemplarsData, exemplarWarnings, exemplarError = client.Exemplars(ctx, req)
+			data, warnings, err = client.Exemplars(ctx, req)
 		})
 
-		if exemplarError != nil {
-			return nil, nil, &api.ApiError{Typ: api.ErrorInternal, Err: errors.Wrap(exemplarError, "retrieving exemplars")}
+		if err != nil {
+			return nil, nil, &api.ApiError{Typ: api.ErrorInternal, Err: errors.Wrap(err, "retrieving exemplars")}
 		}
-		return exemplarsData, exemplarWarnings, nil
+		return data, warnings, nil
 	}
 }
 

--- a/pkg/api/query/v1.go
+++ b/pkg/api/query/v1.go
@@ -791,6 +791,15 @@ func NewExemplarsHandler(client exemplars.UnaryClient, enablePartialResponse boo
 	}
 
 	return func(r *http.Request) (interface{}, []error, *api.ApiError) {
+		span, ctx := tracing.StartSpan(r.Context(), "exemplar_query_request")
+		defer span.Finish()
+
+		var (
+			exemplarsData    []*exemplarspb.ExemplarData
+			exemplarWarnings storage.Warnings
+			exemplarError    error
+		)
+
 		start, err := cortexutil.ParseTime(r.FormValue("start"))
 		if err != nil {
 			return nil, nil, &api.ApiError{Typ: api.ErrorBadData, Err: err}
@@ -806,11 +815,15 @@ func NewExemplarsHandler(client exemplars.UnaryClient, enablePartialResponse boo
 			Query:                   r.FormValue("query"),
 			PartialResponseStrategy: ps,
 		}
-		exemplarsData, warnings, err := client.Exemplars(r.Context(), req)
-		if err != nil {
-			return nil, nil, &api.ApiError{Typ: api.ErrorInternal, Err: errors.Wrap(err, "retrieving exemplars")}
+
+		tracing.DoInSpan(ctx, "retrieve_exemplars", func(ctx context.Context) {
+			exemplarsData, exemplarWarnings, exemplarError = client.Exemplars(r.Context(), req)
+		})
+
+		if exemplarError != nil {
+			return nil, nil, &api.ApiError{Typ: api.ErrorInternal, Err: errors.Wrap(exemplarError, "retrieving exemplars")}
 		}
-		return exemplarsData, warnings, nil
+		return exemplarsData, exemplarWarnings, nil
 	}
 }
 

--- a/pkg/api/query/v1.go
+++ b/pkg/api/query/v1.go
@@ -817,7 +817,7 @@ func NewExemplarsHandler(client exemplars.UnaryClient, enablePartialResponse boo
 		}
 
 		tracing.DoInSpan(ctx, "retrieve_exemplars", func(ctx context.Context) {
-			exemplarsData, exemplarWarnings, exemplarError = client.Exemplars(r.Context(), req)
+			exemplarsData, exemplarWarnings, exemplarError = client.Exemplars(ctx, req)
 		})
 
 		if exemplarError != nil {

--- a/pkg/exemplars/exemplars.go
+++ b/pkg/exemplars/exemplars.go
@@ -5,6 +5,7 @@ package exemplars
 
 import (
 	"context"
+	"github.com/thanos-io/thanos/pkg/tracing"
 	"sort"
 
 	"github.com/pkg/errors"
@@ -73,6 +74,9 @@ func NewGRPCClientWithDedup(es exemplarspb.ExemplarsServer, replicaLabels []stri
 }
 
 func (rr *GRPCClient) Exemplars(ctx context.Context, req *exemplarspb.ExemplarsRequest) ([]*exemplarspb.ExemplarData, storage.Warnings, error) {
+	span, ctx := tracing.StartSpan(ctx, "exemplar_grpc_request")
+	defer span.Finish()
+
 	resp := &exemplarsServer{ctx: ctx}
 
 	if err := rr.proxy.Exemplars(req, resp); err != nil {

--- a/pkg/exemplars/exemplars.go
+++ b/pkg/exemplars/exemplars.go
@@ -5,13 +5,13 @@ package exemplars
 
 import (
 	"context"
-	"github.com/thanos-io/thanos/pkg/tracing"
 	"sort"
 
 	"github.com/pkg/errors"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/thanos-io/thanos/pkg/exemplars/exemplarspb"
 	"github.com/thanos-io/thanos/pkg/store/labelpb"
+	"github.com/thanos-io/thanos/pkg/tracing"
 )
 
 var _ UnaryClient = &GRPCClient{}


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Follows https://github.com/thanos-io/thanos/pull/4238 & https://github.com/thanos-io/thanos/pull/4178 - adds tracing instrumentation to the exemplar endpoints.

Closes https://github.com/thanos-io/thanos/issues/4130

## Verification
Standard tests pass:
```
make build
make test-local
```

I have been trying and failing to figure out an additional unit test to verify this behaviour. 

It might be possible to setup a grpc server with a `basictracer-go` and register the exemplar APIs then verify spans are created when the API is called. Previous tracing PRs have not included this so might not be worth the effort :shrug: 
