### PR TITLE
Fix Katacoda multi-tenant tutorial

### DIFF
--- a/tutorials/katacoda/thanos/7-multi-tenancy/step2.md
+++ b/tutorials/katacoda/thanos/7-multi-tenancy/step2.md
@@ -46,11 +46,10 @@ So why not we start something like this in front of our "Tomato" Querier?
 ```
 docker run -d --net=host --rm \
     --name prom-label-proxy \
-    quay.io/thanos/prom-label-proxy:v0.3.0-rc.0-ext1 \
+    quay.io/prometheuscommunity/prom-label-proxy:v0.3.0 \
     -label tenant \
     -upstream http://127.0.0.1:29090 \
     -insecure-listen-address 0.0.0.0:39090 \
-    -non-api-path-passthrough \
     -enable-label-apis && echo "Started prom-label-proxy"
 ```{{execute}}
 
@@ -97,8 +96,21 @@ At the end we should have setup as on following diagram:
 
 Let's check if our read isolation works:
 
-* [Query for Fruit Team through Caddy 39091 port](https://[[HOST_SUBDOMAIN]]-39091-[[KATACODA_HOST]].environments.katacoda.com/)
-* [Query for Veggie Team through Caddy 39092 port](https://[[HOST_SUBDOMAIN]]-39092-[[KATACODA_HOST]].environments.katacoda.com/)
+#### Team Fruit
+
+Firstly for `Team Fruit`, let's make a query for some data:
+```
+curl -g 'http://127.0.0.1:39091/api/v1/query?query=up'
+```{{execute}}
+Inspecting the output we should only see metrics with `"tenant":"team-fruit"`.
+
+#### Team Veggie
+
+Secondly for `Team Veggie`, let's make the same query to the other port:
+```
+curl -g 'http://127.0.0.1:39092/api/v1/query?query=up'
+```{{execute}}
+ Inspecting the output we should only see metrics with `"tenant":"team-veggie"`.
 
 Feel free to play around, you will see that we can only see Fruit or Veggie data depends where we go!
 


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

Fixes https://github.com/thanos-io/thanos/issues/4309:
* Updates `prom-label-proxy` image tag.
* Updates links to Querier UIs.
* Adds UI resources to `unsafe-passthrough-paths`.

## Verification

Verified tutorial works in my personal katacoda account [here](https://katacoda.com/ibillett/courses/thanos/7-multi-tenancy) per the documentation [here](https://github.com/ianbillett/thanos/blob/8191ed844ea60d621b7bc02d701fbae37a069b8f/tutorials/katacoda/README.md)
