### PR TITLE
ruler: fixes issue 4302, adds display of alert duration time in Alerts UI

### DIFF
--- a/pkg/ui/react-app/src/pages/alerts/CollapsibleAlertPanel.tsx
+++ b/pkg/ui/react-app/src/pages/alerts/CollapsibleAlertPanel.tsx
@@ -35,14 +35,31 @@ const CollapsibleAlertPanel: FC<CollapsibleAlertPanelProps> = ({ rule, showAnnot
             <div>
               expr: <a href={createExternalExpressionLink(rule.query)}>{rule.query}</a>
             </div>
-            <div>
-              <div>labels:</div>
-              <div className="ml-5">severity: {rule.labels.severity}</div>
-            </div>
-            <div>
-              <div>annotations:</div>
-              <div className="ml-5">summary: {rule.annotations.summary}</div>
-            </div>
+            {rule.duration > 0 && (
+              <div>
+                <div>for: {formatDuration(rule.duration * 1000)}</div>
+              </div>
+            )}
+            {rule.labels && Object.keys(rule.labels).length > 0 && (
+              <div>
+                <div>labels:</div>
+                {Object.entries(rule.labels).map(([key, value]) => (
+                  <div className="ml-4" key={key}>
+                    {key}: {value}
+                  </div>
+                ))}
+              </div>
+            )}
+            {rule.annotations && Object.keys(rule.annotations).length > 0 && (
+              <div>
+                <div>annotations:</div>
+                {Object.entries(rule.annotations).map(([key, value]) => (
+                  <div className="ml-4" key={key}>
+                    {key}: {value}
+                  </div>
+                ))}
+              </div>
+            )}
           </code>
         </pre>
         {rule.alerts.length > 0 && (

--- a/pkg/ui/react-app/src/utils/utils.test.ts
+++ b/pkg/ui/react-app/src/utils/utils.test.ts
@@ -1,19 +1,19 @@
 import moment from 'moment';
 
 import {
-  escapeHTML,
-  metricToSeriesName,
-  formatTime,
-  parseTime,
-  formatDuration,
-  parseDuration,
-  humanizeDuration,
-  formatRelative,
-  now,
-  toQueryString,
-  encodePanelOptionsToQueryString,
-  parseOption,
   decodePanelOptionsFromQueryString,
+  encodePanelOptionsToQueryString,
+  escapeHTML,
+  formatDuration,
+  formatTime,
+  formatRelative,
+  humanizeDuration,
+  metricToSeriesName,
+  now,
+  parseDuration,
+  parseOption,
+  parseTime,
+  toQueryString,
 } from '.';
 import { PanelType } from '../pages/graph/Panel';
 


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user. (reasoning: cosmetic)

## Changes

<!-- Enumerate changes you made -->
Closes #4303.

- adds display of alert duration time in Alerts UI
- new function formatDuration() as used in Prometheus project
- also displays all labels and all annotations, not just severity and summary

## Verification

<!-- How you tested it? How do you know it works? -->
Tested locally with `make Quickstart` and `yarn start` for the React UI portion. Screenshot added below.

<img width="996" alt="Screen Shot 2021-06-12 at 12 46 32 PM" src="https://user-images.githubusercontent.com/4127665/121785052-2b230d00-cb7d-11eb-8aa8-1256b79622a3.png">


Original:
<img width="521" alt="Screen Shot 2021-06-12 at 1 02 41 PM" src="https://user-images.githubusercontent.com/4127665/121785279-8acde800-cb7e-11eb-8881-7c6652ef7c6f.png">

yarn test, since added new func and tests:
```
  PASS  src/pages/graph/DataTable.test.tsx
 PASS  src/utils/utils.test.ts
 PASS  src/App.test.tsx
 PASS  src/pages/targets/ScrapePoolPanel.test.tsx
 PASS  src/thanos/pages/blocks/Blocks.test.tsx
 PASS  src/pages/targets/ScrapePoolList.test.tsx
 PASS  src/pages/graph/TimeInput.test.tsx
 PASS  src/pages/graph/ExpressionInput.test.tsx
 PASS  src/thanos/pages/stores/StorePoolPanel.test.tsx
 PASS  src/pages/graph/GraphControls.test.tsx
 PASS  src/thanos/pages/blocks/BlockDetails.test.tsx
 PASS  src/pages/graph/Panel.test.tsx
 PASS  src/thanos/pages/stores/Stores.test.tsx
 PASS  src/pages/graph/Graph.test.tsx
 PASS  src/pages/graph/PanelList.test.tsx
 PASS  src/pages/graph/CMExpressionInput.test.tsx
 PASS  src/pages/tsdbStatus/TSDBStatus.test.tsx
 PASS  src/thanos/pages/blocks/helpers.test.tsx
 PASS  src/pages/targets/Targets.test.tsx
 PASS  src/pages/targets/Filter.test.tsx
 PASS  src/pages/flags/Flags.test.tsx
 PASS  src/pages/graph/GraphHelpers.test.ts
 PASS  src/pages/status/Status.test.tsx
 PASS  src/Navbar.test.tsx
 PASS  src/hooks/useLocalStorage.test.tsx
 PASS  src/pages/graph/SeriesName.test.tsx
 PASS  src/pages/graph/GraphTabContent.test.tsx
 PASS  src/components/Checkbox.test.tsx
 PASS  src/pages/targets/EndpointLink.test.tsx
 PASS  src/pages/targets/TargetLabels.test.tsx
 PASS  src/thanos/pages/blocks/SourceView.test.tsx
 PASS  src/components/ToggleMoreLess.test.tsx
 PASS  src/thanos/pages/stores/StoreLabels.test.tsx
 PASS  src/pages/targets/target.test.ts
 PASS  src/pages/graph/QueryStatsView.test.tsx

Test Suites: 35 passed, 35 total
Tests:       268 passed, 268 total
Snapshots:   4 passed, 4 total
Time:        11.354s, estimated 15s
```
