### PR TITLE
Querier: Added tenant identifier in querier http request metrics

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -204,7 +204,10 @@ func GetInstr(
 	disableCORS bool,
 ) InstrFunc {
 	instr := func(name string, f ApiFunc) http.HandlerFunc {
+
+		var tenantIdentifier string
 		hf := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			tenantIdentifier = r.Header.Get("tenantIdentifier")
 			if !disableCORS {
 				SetCORS(w)
 			}
@@ -223,7 +226,7 @@ func GetInstr(
 					gziphandler.GzipHandler(
 						middleware.RequestID(hf),
 					),
-				),
+				), tenantIdentifier,
 			),
 		)
 	}


### PR DESCRIPTION
Signed-off-by: Abhishek357 <abhisheksinghchauhan357@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->
Fixes #3572 

A promql query is executed using different endpoints of v1 API. To instrument these endpoints Thanos exposes 4 metrics (i.e.  http_request_duration_seconds, http_request_size_bytes, http_requests_total, http_response_size_bytes). This PR focuses on adding tenant identifier(tenant which is making the promql query) as a label to these metrics. These tenant identifiers are extracted from the header of requests.


<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
