### PR TITLE
block replication concurrently

### DIFF
--- a/pkg/replicate/scheme.go
+++ b/pkg/replicate/scheme.go
@@ -11,6 +11,7 @@ import (
 	"io/ioutil"
 	"path"
 	"sort"
+	"sync"
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
@@ -203,9 +204,35 @@ func (rs *replicationScheme) execute(ctx context.Context) error {
 		return availableBlocks[i].BlockMeta.MinTime < availableBlocks[j].BlockMeta.MinTime
 	})
 
+	// Replicate concurrently
+	var wg sync.WaitGroup
+	errChan := make(chan error)
+	finishChan := make(chan struct{})
+
 	for _, b := range availableBlocks {
-		if err := rs.ensureBlockIsReplicated(ctx, b.BlockMeta.ULID); err != nil {
-			return errors.Wrapf(err, "ensure block %v is replicated", b.BlockMeta.ULID.String())
+		wg.Add(1)
+		go func(b *metadata.Meta) {
+			defer wg.Done()
+			if err := rs.ensureBlockIsReplicated(ctx, b.BlockMeta.ULID); err != nil {
+				errChan <- errors.Wrapf(err, "ensure block %v is replicated", b.BlockMeta.ULID.String())
+			}
+			return
+		}(b)
+
+	}
+
+	go func() {
+		wg.Wait()
+		close(finishChan)
+	}()
+
+Loop:
+	for {
+		select {
+		case err := <-errChan:
+			return err
+		case <-finishChan:
+			break Loop
 		}
 	}
 


### PR DESCRIPTION
Signed-off-by: Hangzhi <1454678938@qq.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->
This PR fixes issue #4278
* [ ] I added CHANGELOG entry for this change.
* [X] Change is not relevant to the end user.

## Changes

Make block replication run concurrently with goroutine. 

## Verification

<!-- How you tested it? How do you know it works? -->
