### PR TITLE
receive: use s2 when decompressing snappy data, reduce CPU usage for incoming remote write requests by ~5-7%

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 
 ### Changed
 
-- 
+- [#4354](https://github.com/thanos-io/thanos/pull/4354) Receive: use the S2 library for decoding Snappy data; saves about 5-7% of CPU time in the Receive component when handling incoming remote write requests
 
 ## [v0.21.1](https://github.com/thanos-io/thanos/releases/tag/v0.21.1) - 2021.06.04
 

--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 	github.com/hashicorp/golang-lru v0.5.4
 	github.com/jpillora/backoff v1.0.0
+	github.com/klauspost/compress v1.13.1
 	github.com/leanovate/gopter v0.2.4
 	github.com/lightstep/lightstep-tracer-go v0.18.1
 	github.com/lovoo/gcloud-opentracing v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -819,6 +819,8 @@ github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.4.0/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
 github.com/klauspost/compress v1.9.5/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
+github.com/klauspost/compress v1.13.1 h1:wXr2uRxZTJXHLly6qhJabee5JqIhTRoLBhDOA74hDEQ=
+github.com/klauspost/compress v1.13.1/go.mod h1:8dP1Hq4DHOhN9w426knH3Rhby4rFm6D8eO+e+Dq5Gzg=
 github.com/klauspost/cpuid v0.0.0-20170728055534-ae7887de9fa5/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
 github.com/klauspost/cpuid v1.2.3/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
 github.com/klauspost/cpuid v1.3.1 h1:5JNjFYYQrZeKRJ0734q51WCEEn2huer72Dc7K+R/b6s=

--- a/pkg/receive/handler.go
+++ b/pkg/receive/handler.go
@@ -20,8 +20,8 @@ import (
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/gogo/protobuf/proto"
-	"github.com/golang/snappy"
 	"github.com/jpillora/backoff"
+	"github.com/klauspost/compress/s2"
 	"github.com/mwitkow/go-conntrack"
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
@@ -295,7 +295,7 @@ func (h *Handler) receiveHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	reqBuf, err := snappy.Decode(nil, compressed.Bytes())
+	reqBuf, err := s2.Decode(nil, compressed.Bytes())
 	if err != nil {
 		level.Error(h.logger).Log("msg", "snappy decode error", "err", err)
 		http.Error(w, errors.Wrap(err, "snappy decode error").Error(), http.StatusBadRequest)


### PR DESCRIPTION
Use https://github.com/klauspost/compress/tree/master/s2#s2-compression
for decompressing Snappy data. I think if this pays off then we could
also try using this in Prometheus for encoding?

Benchmarks show these numbers:
```
benchmark                                                                                       old ns/op     new ns/op     delta
BenchmarkHandlerReceiveHTTP/typical_labels_under_1KB,_500_of_them/OK-16                         1139713       1071864       -5.95%
BenchmarkHandlerReceiveHTTP/typical_labels_under_1KB,_500_of_them/conflict_errors-16            1294286       1207937       -6.67%
BenchmarkHandlerReceiveHTTP/typical_labels_under_1KB,_5000_of_them/OK-16                        11613568      10849901      -6.58%
BenchmarkHandlerReceiveHTTP/typical_labels_under_1KB,_5000_of_them/conflict_errors-16           13100752      12478380      -4.75%
BenchmarkHandlerReceiveHTTP/extremely_large_label_value_10MB,_10_of_them/OK-16                  96128949      89515761      -6.88%
BenchmarkHandlerReceiveHTTP/extremely_large_label_value_10MB,_10_of_them/conflict_errors-16     96769948      90741611      -6.23%

benchmark                                                                                       old allocs     new allocs     delta
BenchmarkHandlerReceiveHTTP/typical_labels_under_1KB,_500_of_them/OK-16                         4578           4578           +0.00%
BenchmarkHandlerReceiveHTTP/typical_labels_under_1KB,_500_of_them/conflict_errors-16            7618           7617           -0.01%
BenchmarkHandlerReceiveHTTP/typical_labels_under_1KB,_5000_of_them/OK-16                        45325          45324          -0.00%
BenchmarkHandlerReceiveHTTP/typical_labels_under_1KB,_5000_of_them/conflict_errors-16           75133          75133          +0.00%
BenchmarkHandlerReceiveHTTP/extremely_large_label_value_10MB,_10_of_them/OK-16                  81             82             +1.23%
BenchmarkHandlerReceiveHTTP/extremely_large_label_value_10MB,_10_of_them/conflict_errors-16     203            202            -0.49%

benchmark                                                                                       old bytes     new bytes     delta
BenchmarkHandlerReceiveHTTP/typical_labels_under_1KB,_500_of_them/OK-16                         1254474       1254280       -0.02%
BenchmarkHandlerReceiveHTTP/typical_labels_under_1KB,_500_of_them/conflict_errors-16            1427791       1427618       -0.01%
BenchmarkHandlerReceiveHTTP/typical_labels_under_1KB,_5000_of_them/OK-16                        13826832      13806752      -0.15%
BenchmarkHandlerReceiveHTTP/typical_labels_under_1KB,_5000_of_them/conflict_errors-16           15412336      15412232      -0.00%
BenchmarkHandlerReceiveHTTP/extremely_large_label_value_10MB,_10_of_them/OK-16                  120041647     120018331     -0.02%
BenchmarkHandlerReceiveHTTP/extremely_large_label_value_10MB,_10_of_them/conflict_errors-16     119704515     119701011     -0.00%
```


Signed-off-by: Giedrius Statkevičius <giedrius.statkevicius@vinted.com>


* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

