### PR TITLE
Adds more contact options when creating a new issue on Github

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false # Show or hide the Create a blank issue choice when users select New issue.
+contact_links:
+  - name: "Questions via Thanos Community Support via the CNCF slack - #thanos"
+    url: https://cloud-native.slack.com/archives/CK5RSSC10.
+    about: "Join us for questions, answers or Thanos related chat. Please do create issues on Github for better collaboration. If you don't have an account, sign up at https://slack.cncf.io/"
+  - name: "Question via Thanos Discussions (similar to Stack Overflow)"
+    url: https://github.com/thanos-io/thanos/discussions
+    about: "Please ask and answer questions here for async response."


### PR DESCRIPTION
Signed-off-by: Wiard van Rij <wiard@outlook.com>

Inspired and copy/pasta'd from jaegertracing :) 

It will look like this (but with our own text)

![image](https://user-images.githubusercontent.com/5786097/123264474-5e10bd80-d4fa-11eb-846d-12595abd3090.png)

As discussed via slack: https://cloud-native.slack.com/archives/CL25937SP/p1622453498082200 