### PR TITLE
query: Fixed deduplication inconsistency with vertically deduplicated data. Series without replica label is now assumed part of replication.

### DIFF
--- a/pkg/dedup/iter_test.go
+++ b/pkg/dedup/iter_test.go
@@ -125,59 +125,6 @@ func TestDedupSeriesSet(t *testing.T) {
 					lset:    labels.Labels{{Name: "a", Value: "1"}, {Name: "c", Value: "3"}},
 					samples: []sample{{10000, 1}, {20000, 2}},
 				}, {
-					lset:    labels.Labels{{Name: "a", Value: "1"}, {Name: "c", Value: "3"}, {Name: "d", Value: "4"}},
-					samples: []sample{{10000, 1}, {20000, 2}},
-				}, {
-					lset:    labels.Labels{{Name: "a", Value: "1"}, {Name: "c", Value: "3"}, {Name: "replica", Value: "replica-1"}},
-					samples: []sample{{10000, 1}, {20000, 2}},
-				}, {
-					lset:    labels.Labels{{Name: "a", Value: "1"}, {Name: "c", Value: "3"}, {Name: "replica", Value: "replica-2"}},
-					samples: []sample{{60000, 3}, {70000, 4}},
-				}, {
-					lset:    labels.Labels{{Name: "a", Value: "1"}, {Name: "c", Value: "3"}, {Name: "replica", Value: "replica-3"}},
-					samples: []sample{{200000, 5}, {210000, 6}},
-				}, {
-					lset:    labels.Labels{{Name: "a", Value: "1"}, {Name: "c", Value: "4"}, {Name: "replica", Value: "replica-1"}},
-					samples: []sample{{10000, 1}, {20000, 2}},
-				}, {
-					lset:    labels.Labels{{Name: "a", Value: "2"}, {Name: "c", Value: "3"}, {Name: "replica", Value: "replica-3"}},
-					samples: []sample{{10000, 1}, {20000, 2}},
-				}, {
-					lset:    labels.Labels{{Name: "a", Value: "2"}, {Name: "c", Value: "3"}, {Name: "replica", Value: "replica-3"}},
-					samples: []sample{{60000, 3}, {70000, 4}},
-				},
-			},
-			exp: []series{
-				{
-					lset:    labels.Labels{{Name: "a", Value: "1"}, {Name: "c", Value: "3"}},
-					samples: []sample{{10000, 1}, {20000, 2}, {60000, 3}, {70000, 4}, {200000, 5}, {210000, 6}},
-				},
-				{
-					lset:    labels.Labels{{Name: "a", Value: "1"}, {Name: "c", Value: "3"}, {Name: "d", Value: "4"}},
-					samples: []sample{{10000, 1}, {20000, 2}},
-				},
-				{
-					lset:    labels.Labels{{Name: "a", Value: "1"}, {Name: "c", Value: "3"}},
-					samples: []sample{{10000, 1}, {20000, 2}},
-				},
-				{
-					lset:    labels.Labels{{Name: "a", Value: "1"}, {Name: "c", Value: "4"}},
-					samples: []sample{{10000, 1}, {20000, 2}},
-				},
-				{
-					lset:    labels.Labels{{Name: "a", Value: "2"}, {Name: "c", Value: "3"}},
-					samples: []sample{{10000, 1}, {20000, 2}, {60000, 3}, {70000, 4}},
-				},
-			},
-			dedupLabels: map[string]struct{}{
-				"replica": {},
-			},
-		},
-		{
-			// Single dedup label with label without replica label value.
-			// Regression against https://github.com/thanos-io/thanos/discussions/4274
-			input: []series{
-				{
 					lset:    labels.Labels{{Name: "a", Value: "1"}, {Name: "c", Value: "3"}, {Name: "replica", Value: "replica-1"}},
 					samples: []sample{{10000, 1}, {20000, 2}},
 				}, {
@@ -188,9 +135,6 @@ func TestDedupSeriesSet(t *testing.T) {
 					samples: []sample{{200000, 5}, {210000, 6}},
 				}, {
 					lset:    labels.Labels{{Name: "a", Value: "1"}, {Name: "c", Value: "3"}, {Name: "d", Value: "4"}},
-					samples: []sample{{10000, 1}, {20000, 2}},
-				}, {
-					lset:    labels.Labels{{Name: "a", Value: "1"}, {Name: "c", Value: "3"}},
 					samples: []sample{{10000, 1}, {20000, 2}},
 				}, {
 					lset:    labels.Labels{{Name: "a", Value: "1"}, {Name: "c", Value: "4"}, {Name: "replica", Value: "replica-1"}},
@@ -210,10 +154,6 @@ func TestDedupSeriesSet(t *testing.T) {
 				},
 				{
 					lset:    labels.Labels{{Name: "a", Value: "1"}, {Name: "c", Value: "3"}, {Name: "d", Value: "4"}},
-					samples: []sample{{10000, 1}, {20000, 2}},
-				},
-				{
-					lset:    labels.Labels{{Name: "a", Value: "1"}, {Name: "c", Value: "3"}},
 					samples: []sample{{10000, 1}, {20000, 2}},
 				},
 				{
@@ -263,6 +203,9 @@ func TestDedupSeriesSet(t *testing.T) {
 			// Multi dedup label.
 			input: []series{
 				{
+					lset:    labels.Labels{{Name: "a", Value: "1"}, {Name: "c", Value: "3"}},
+					samples: []sample{{10000, 1}, {20000, 2}},
+				}, {
 					lset:    labels.Labels{{Name: "a", Value: "1"}, {Name: "c", Value: "3"}, {Name: "replica", Value: "replica-1"}, {Name: "replicaA", Value: "replica-1"}},
 					samples: []sample{{10000, 1}, {20000, 2}},
 				}, {
@@ -273,9 +216,6 @@ func TestDedupSeriesSet(t *testing.T) {
 					samples: []sample{{200000, 5}, {210000, 6}},
 				}, {
 					lset:    labels.Labels{{Name: "a", Value: "1"}, {Name: "c", Value: "3"}, {Name: "d", Value: "4"}},
-					samples: []sample{{10000, 1}, {20000, 2}},
-				}, {
-					lset:    labels.Labels{{Name: "a", Value: "1"}, {Name: "c", Value: "3"}},
 					samples: []sample{{10000, 1}, {20000, 2}},
 				}, {
 					lset:    labels.Labels{{Name: "a", Value: "1"}, {Name: "c", Value: "4"}, {Name: "replica", Value: "replica-1"}, {Name: "replicaA", Value: "replica-1"}},
@@ -295,10 +235,6 @@ func TestDedupSeriesSet(t *testing.T) {
 				},
 				{
 					lset:    labels.Labels{{Name: "a", Value: "1"}, {Name: "c", Value: "3"}, {Name: "d", Value: "4"}},
-					samples: []sample{{10000, 1}, {20000, 2}},
-				},
-				{
-					lset:    labels.Labels{{Name: "a", Value: "1"}, {Name: "c", Value: "3"}},
 					samples: []sample{{10000, 1}, {20000, 2}},
 				},
 				{
@@ -707,10 +643,10 @@ func TestSortReplicaLabel(t *testing.T) {
 			},
 			exp: []storepb.Series{
 				{Labels: []labelpb.ZLabel{{Name: "a", Value: "1"}, {Name: "c", Value: "3"}}},
-				{Labels: []labelpb.ZLabel{{Name: "a", Value: "1"}, {Name: "c", Value: "3"}, {Name: "c2", Value: "3"}}}, // Those series are problematic, because they are between replica series.
-				{Labels: []labelpb.ZLabel{{Name: "a", Value: "1"}, {Name: "c", Value: "3"}, {Name: "d", Value: "4"}, {Name: "x", Value: "replica-1"}}},
 				{Labels: []labelpb.ZLabel{{Name: "a", Value: "1"}, {Name: "c", Value: "3"}, {Name: "x", Value: "replica-1"}}},
 				{Labels: []labelpb.ZLabel{{Name: "a", Value: "1"}, {Name: "c", Value: "3"}, {Name: "x", Value: "replica-2"}}},
+				{Labels: []labelpb.ZLabel{{Name: "a", Value: "1"}, {Name: "c", Value: "3"}, {Name: "c2", Value: "3"}}},
+				{Labels: []labelpb.ZLabel{{Name: "a", Value: "1"}, {Name: "c", Value: "3"}, {Name: "d", Value: "4"}, {Name: "x", Value: "replica-1"}}},
 				{Labels: []labelpb.ZLabel{{Name: "a", Value: "1"}, {Name: "c", Value: "4"}, {Name: "x", Value: "replica-1"}}},
 			},
 			dedupLabels: map[string]struct{}{"x": {}},

--- a/pkg/query/querier_test.go
+++ b/pkg/query/querier_test.go
@@ -960,55 +960,6 @@ func TestQuerierWithDedupUnderstoodByPromQL_Rate(t *testing.T) {
 	})
 }
 
-func TestSortReplicaLabel(t *testing.T) {
-	tests := []struct {
-		input       []storepb.Series
-		exp         []storepb.Series
-		dedupLabels map[string]struct{}
-	}{
-		// 0 Single deduplication label.
-		{
-			input: []storepb.Series{
-				{Labels: []labelpb.ZLabel{{Name: "a", Value: "1"}, {Name: "b", Value: "replica-1"}, {Name: "c", Value: "3"}}},
-				{Labels: []labelpb.ZLabel{{Name: "a", Value: "1"}, {Name: "b", Value: "replica-1"}, {Name: "c", Value: "3"}, {Name: "d", Value: "4"}}},
-				{Labels: []labelpb.ZLabel{{Name: "a", Value: "1"}, {Name: "b", Value: "replica-1"}, {Name: "c", Value: "4"}}},
-				{Labels: []labelpb.ZLabel{{Name: "a", Value: "1"}, {Name: "b", Value: "replica-2"}, {Name: "c", Value: "3"}}},
-			},
-			exp: []storepb.Series{
-				{Labels: []labelpb.ZLabel{{Name: "a", Value: "1"}, {Name: "c", Value: "3"}, {Name: "b", Value: "replica-1"}}},
-				{Labels: []labelpb.ZLabel{{Name: "a", Value: "1"}, {Name: "c", Value: "3"}, {Name: "b", Value: "replica-2"}}},
-				{Labels: []labelpb.ZLabel{{Name: "a", Value: "1"}, {Name: "c", Value: "3"}, {Name: "d", Value: "4"}, {Name: "b", Value: "replica-1"}}},
-				{Labels: []labelpb.ZLabel{{Name: "a", Value: "1"}, {Name: "c", Value: "4"}, {Name: "b", Value: "replica-1"}}},
-			},
-			dedupLabels: map[string]struct{}{"b": {}},
-		},
-		// 1 Multi deduplication labels.
-		{
-			input: []storepb.Series{
-				{Labels: []labelpb.ZLabel{{Name: "a", Value: "1"}, {Name: "b", Value: "replica-1"}, {Name: "b1", Value: "replica-1"}, {Name: "c", Value: "3"}}},
-				{Labels: []labelpb.ZLabel{{Name: "a", Value: "1"}, {Name: "b", Value: "replica-1"}, {Name: "b1", Value: "replica-1"}, {Name: "c", Value: "3"}, {Name: "d", Value: "4"}}},
-				{Labels: []labelpb.ZLabel{{Name: "a", Value: "1"}, {Name: "b", Value: "replica-1"}, {Name: "b1", Value: "replica-1"}, {Name: "c", Value: "4"}}},
-				{Labels: []labelpb.ZLabel{{Name: "a", Value: "1"}, {Name: "b", Value: "replica-2"}, {Name: "b1", Value: "replica-2"}, {Name: "c", Value: "3"}}},
-				{Labels: []labelpb.ZLabel{{Name: "a", Value: "1"}, {Name: "b", Value: "replica-2"}, {Name: "c", Value: "3"}}},
-			},
-			exp: []storepb.Series{
-				{Labels: []labelpb.ZLabel{{Name: "a", Value: "1"}, {Name: "c", Value: "3"}, {Name: "b", Value: "replica-1"}, {Name: "b1", Value: "replica-1"}}},
-				{Labels: []labelpb.ZLabel{{Name: "a", Value: "1"}, {Name: "c", Value: "3"}, {Name: "b", Value: "replica-2"}}},
-				{Labels: []labelpb.ZLabel{{Name: "a", Value: "1"}, {Name: "c", Value: "3"}, {Name: "b", Value: "replica-2"}, {Name: "b1", Value: "replica-2"}}},
-				{Labels: []labelpb.ZLabel{{Name: "a", Value: "1"}, {Name: "c", Value: "3"}, {Name: "d", Value: "4"}, {Name: "b", Value: "replica-1"}, {Name: "b1", Value: "replica-1"}}},
-				{Labels: []labelpb.ZLabel{{Name: "a", Value: "1"}, {Name: "c", Value: "4"}, {Name: "b", Value: "replica-1"}, {Name: "b1", Value: "replica-1"}}},
-			},
-			dedupLabels: map[string]struct{}{"b": {}, "b1": {}},
-		},
-	}
-	for _, test := range tests {
-		t.Run("", func(t *testing.T) {
-			sortDedupLabels(test.input, test.dedupLabels)
-			testutil.Equals(t, test.exp, test.input)
-		})
-	}
-}
-
 const hackyStaleMarker = float64(-99999999)
 
 func expandSeries(t testing.TB, it chunkenc.Iterator) (res []sample) {

--- a/pkg/store/proxy_test.go
+++ b/pkg/store/proxy_test.go
@@ -481,7 +481,7 @@ func TestProxyStore_Series(t *testing.T) {
 
 			ctx := context.Background()
 			if len(tc.storeDebugMatchers) > 0 {
-				ctx = context.WithValue(ctx, StoreMatcherKey, tc.storeDebugMatchers)
+				ctx = context.WithValue(ctx, MatcherKey, tc.storeDebugMatchers)
 			}
 
 			s := newStoreSeriesServer(ctx)
@@ -1356,7 +1356,7 @@ func TestProxyStore_LabelNames(t *testing.T) {
 
 			ctx := context.Background()
 			if len(tc.storeDebugMatchers) > 0 {
-				ctx = context.WithValue(ctx, StoreMatcherKey, tc.storeDebugMatchers)
+				ctx = context.WithValue(ctx, MatcherKey, tc.storeDebugMatchers)
 			}
 			resp, err := q.LabelNames(ctx, tc.req)
 			if tc.expectedErr != nil {

--- a/pkg/testutil/testutil.go
+++ b/pkg/testutil/testutil.go
@@ -76,13 +76,20 @@ func Equals(tb testing.TB, exp, act interface{}, v ...interface{}) {
 	if len(v) > 0 {
 		msg = fmt.Sprintf(v[0].(string), v[1:]...)
 	}
-	tb.Fatal(sprintfWithLimit("\033[31m%s:%d:"+msg+"\n\n\texp: %#v\n\n\tgot: %#v%s\033[39m\n\n", filepath.Base(file), line, exp, act, diff(exp, act)))
+	tb.Fatal(sprintfWithLimit(
+		"\033[31m%s:%d:"+msg+"\n\n\texp: "+
+			sprintfWithLimit("%#v", exp)+
+			"\n\n\tgot: "+
+			sprintfWithLimit("%#v", act)+
+			sprintfWithLimit("%s", diff(exp, act))+
+			"\033[39m\n\n", filepath.Base(file), line),
+	)
 }
 
 func sprintfWithLimit(act string, v ...interface{}) string {
 	s := fmt.Sprintf(act, v...)
 	if len(s) > 10000 {
-		return s[:10000] + "...(output trimmed)"
+		return s[:1000] + "...(output trimmed)..." + s[len(s)-1000:]
 	}
 	return s
 }


### PR DESCRIPTION
Fix: https://github.com/thanos-io/thanos/discussions/4274

This PR changes how we treat series without replica (e.g after vertical deduplication). Right now we assume it's another replica allowing us to treat those uniformly for cases when PromQL see both non vertically deduped data and deduped ones.

+ benchmarks. Initial:

```
GOROOT=/home/bwplotka/.gvm/gos/go1.16.3 #gosetup
GOPATH=/home/bwplotka/Repos/thanosgopath #gosetup
/home/bwplotka/.gvm/gos/go1.16.3/bin/go test -c -o /tmp/___BenchmarkQuerySelect_in_github_com_thanos_io_thanos_pkg_query.test github.com/thanos-io/thanos/pkg/query #gosetup
/tmp/___BenchmarkQuerySelect_in_github_com_thanos_io_thanos_pkg_query.test -test.v -test.paniconexit0 -test.bench ^\QBenchmarkQuerySelect\E$ -test.run ^$ -test.benchmem -test.benchtime 2m
goos: linux
goarch: amd64
pkg: github.com/thanos-io/thanos/pkg/query
cpu: Intel(R) Core(TM) i7-9850H CPU @ 2.60GHz
BenchmarkQuerySelect
BenchmarkQuerySelect/1000000SeriesWith1Samples
Creating 500000 1-sample series with 1ms interval in /tmp/testorbench-queryselect823049899/0
Creating 500000 1-sample series with 1ms interval in /tmp/testorbench-queryselect823049899/1
BenchmarkQuerySelect/1000000SeriesWith1Samples/select
BenchmarkQuerySelect/1000000SeriesWith1Samples/select-12  	      63	1955984103 ns/op	803750001 B/op	12500068 allocs/op
BenchmarkQuerySelect/100000SeriesWith100Samples
Creating 50000 50-sample series with 1ms interval in /tmp/testorbench-queryselect953795598/0
Creating 50000 50-sample series with 1ms interval in /tmp/testorbench-queryselect953795598/1
BenchmarkQuerySelect/100000SeriesWith100Samples/select
BenchmarkQuerySelect/100000SeriesWith100Samples/select-12 	     789	 184461340 ns/op	81817277 B/op	 1250058 allocs/op
BenchmarkQuerySelect/1SeriesWith10000000Samples
Creating 1 5000000-sample series with 1ms interval in /tmp/testorbench-queryselect150567957/0
Creating 1 5000000-sample series with 1ms interval in /tmp/testorbench-queryselect150567957/1
BenchmarkQuerySelect/1SeriesWith10000000Samples/select
BenchmarkQuerySelect/1SeriesWith10000000Samples/select-12 	    6386	  21871206 ns/op	18687412 B/op	  166722 allocs/op
PASS
```



