### PR TITLE
Add --delete-blocks flag to bucket rewrite tool to mark original blocks for deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#4327](https://github.com/thanos-io/thanos/pull/4327) Add environment variable substitution to all YAML configuration flags.
 - [#4239](https://github.com/thanos-io/thanos/pull/4239) Add penalty based deduplication mode for compactor.
 - [#4292](https://github.com/thanos-io/thanos/pull/4292) Receive: Enable exemplars ingestion and querying.
+- [#4392](https://github.com/thanos-io/thanos/pull/4392) Tools: Added `--delete-blocks` to bucket rewrite tool to mark the original blocks for deletion after rewriting is done.
 
 ### Fixed
 

--- a/cmd/thanos/tools_bucket.go
+++ b/cmd/thanos/tools_bucket.go
@@ -825,7 +825,7 @@ func registerBucketRewrite(app extkingpin.AppClause, objStoreConfig *extflag.Pat
 	toRelabel := extflag.RegisterPathOrContent(cmd, "rewrite.to-relabel-config", "YAML file that contains relabel configs that will be applied to blocks", extflag.WithEnvSubstitution())
 	provideChangeLog := cmd.Flag("rewrite.add-change-log", "If specified, all modifications are written to new block directory. Disable if latency is to high.").Default("true").Bool()
 	promBlocks := cmd.Flag("prom-blocks", "If specified, we assume the blocks to be uploaded are only used with Prometheus so we don't check external labels in this case.").Default("false").Bool()
-	deleteBlocks := cmd.Flag("delete-blocks", "whether to delete the original blocks after rewriting blocks successfully. Available in non dry-run mode only.").Default("false").Bool()
+	deleteBlocks := cmd.Flag("delete-blocks", "Whether to delete the original blocks after rewriting blocks successfully. Available in non dry-run mode only.").Default("false").Bool()
 	cmd.Setup(func(g *run.Group, logger log.Logger, reg *prometheus.Registry, _ opentracing.Tracer, _ <-chan struct{}, _ bool) error {
 		confContentYaml, err := objStoreConfig.Content()
 		if err != nil {

--- a/cmd/thanos/tools_bucket.go
+++ b/cmd/thanos/tools_bucket.go
@@ -888,6 +888,7 @@ func registerBucketRewrite(app extkingpin.AppClause, objStoreConfig *extflag.Pat
 		g.Add(func() error {
 			chunkPool := chunkenc.NewPool()
 			changeLog := compactv2.NewChangeLog(ioutil.Discard)
+			stubCounter := promauto.With(nil).NewCounter(prometheus.CounterOpts{})
 			for _, id := range ids {
 				// Delete series from block & modify.
 				level.Info(logger).Log("msg", "downloading block", "source", id)
@@ -974,7 +975,7 @@ func registerBucketRewrite(app extkingpin.AppClause, objStoreConfig *extflag.Pat
 				level.Info(logger).Log("msg", "uploaded", "source", id, "new", newID)
 
 				if !*dryRun && *deleteBlocks {
-					if err := block.MarkForDeletion(ctx, logger, bkt, id, "block rewritten", promauto.With(nil).NewCounter(prometheus.CounterOpts{})); err != nil {
+					if err := block.MarkForDeletion(ctx, logger, bkt, id, "block rewritten", stubCounter); err != nil {
 						level.Error(logger).Log("msg", "failed to mark block for deletion", "id", id.String(), "err", err)
 					}
 				}

--- a/cmd/thanos/tools_bucket.go
+++ b/cmd/thanos/tools_bucket.go
@@ -825,6 +825,7 @@ func registerBucketRewrite(app extkingpin.AppClause, objStoreConfig *extflag.Pat
 	toRelabel := extflag.RegisterPathOrContent(cmd, "rewrite.to-relabel-config", "YAML file that contains relabel configs that will be applied to blocks", extflag.WithEnvSubstitution())
 	provideChangeLog := cmd.Flag("rewrite.add-change-log", "If specified, all modifications are written to new block directory. Disable if latency is to high.").Default("true").Bool()
 	promBlocks := cmd.Flag("prom-blocks", "If specified, we assume the blocks to be uploaded are only used with Prometheus so we don't check external labels in this case.").Default("false").Bool()
+	deleteBlocks := cmd.Flag("delete-blocks", "whether to delete the original blocks after rewriting blocks successfully. Available in non dry-run mode only.").Default("false").Bool()
 	cmd.Setup(func(g *run.Group, logger log.Logger, reg *prometheus.Registry, _ opentracing.Tracer, _ <-chan struct{}, _ bool) error {
 		confContentYaml, err := objStoreConfig.Content()
 		if err != nil {
@@ -971,6 +972,12 @@ func registerBucketRewrite(app extkingpin.AppClause, objStoreConfig *extflag.Pat
 					}
 				}
 				level.Info(logger).Log("msg", "uploaded", "source", id, "new", newID)
+
+				if !*dryRun && *deleteBlocks {
+					if err := block.MarkForDeletion(ctx, logger, bkt, id, "block rewritten", promauto.With(nil).NewCounter(prometheus.CounterOpts{})); err != nil {
+						level.Error(logger).Log("msg", "failed to mark block for deletion", "id", id.String(), "err", err)
+					}
+				}
 			}
 			level.Info(logger).Log("msg", "rewrite done", "IDs", strings.Join(*blockIDs, ","))
 			return nil

--- a/docs/components/tools.md
+++ b/docs/components/tools.md
@@ -718,6 +718,9 @@ block for deletion to avoid overlaps. WARNING: This procedure is *IRREVERSIBLE*
 after certain time (delete delay), so do backup your blocks first.
 
 Flags:
+      --delete-blocks           Whether to delete the original blocks after
+                                rewriting blocks successfully. Available in non
+                                dry-run mode only.
       --dry-run                 Prints the series changes instead of doing them.
                                 Defaults to true, for user to double check. (:
                                 Pass --no-dry-run to skip this.


### PR DESCRIPTION

Signed-off-by: yeya24 <yb532204897@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Fixes #4287 
<!-- Enumerate changes you made -->

Add a new `delete-blocks` flag.

## Verification

<!-- How you tested it? How do you know it works? -->
