### PR TITLE
querier: Select Optimization.

### DIFF
--- a/pkg/dedup/iter.go
+++ b/pkg/dedup/iter.go
@@ -12,21 +12,28 @@ import (
 )
 
 type dedupSeriesSet struct {
+	// TODO(bwplotka): Consider using ChunkSeriesSet to remove identical chunks out when deduplicating.
+	// Input series are assumed to be  sorted in replica-aware order.
 	set           storage.SeriesSet
 	replicaLabels map[string]struct{}
 	isCounter     bool
 
-	replicas []storage.Series
 	lset     labels.Labels
-	peek     storage.Series
-	ok       bool
+	replicas []storage.SampleIterable
+
+	strippedPeekLset labels.Labels
+	peek             storage.SampleIterable
+
+	ok bool
 }
 
 func NewSeriesSet(set storage.SeriesSet, replicaLabels map[string]struct{}, isCounter bool) storage.SeriesSet {
-	s := &dedupSeriesSet{set: set, replicaLabels: replicaLabels, isCounter: isCounter}
+	s := &dedupSeriesSet{set: newReplicaAwareSortSet(set, replicaLabels), replicaLabels: replicaLabels, isCounter: isCounter}
 	s.ok = s.set.Next()
 	if s.ok {
-		s.peek = s.set.At()
+		peek := s.set.At()
+		s.peek = peek
+		s.strippedPeekLset = stripReplicaLset(s.replicaLabels, peek.Labels())
 	}
 	return s
 }
@@ -35,33 +42,24 @@ func (s *dedupSeriesSet) Next() bool {
 	if !s.ok {
 		return false
 	}
-	// Set the label set we are currently gathering to the peek element
-	// without the replica label if it exists.
-	s.lset = s.peekLset()
+	// Set the replica label set we are currently gathering to the peek element
+	// without the replica label.
+	s.lset = s.strippedPeekLset
 	s.replicas = append(s.replicas[:0], s.peek)
 	return s.next()
 }
 
-// peekLset returns the label set of the current peek element stripped from the
-// replica label if it exists.
-func (s *dedupSeriesSet) peekLset() labels.Labels {
-	lset := s.peek.Labels()
-	if len(s.replicaLabels) == 0 {
-		return lset
-	}
-	// Check how many replica labels are present so that these are removed.
-	var totalToRemove int
-	for i := 0; i < len(s.replicaLabels); i++ {
-		if len(lset)-i == 0 {
-			break
-		}
-
-		if _, ok := s.replicaLabels[lset[len(lset)-i-1].Name]; ok {
-			totalToRemove++
+// stripReplicaLset returns the label set stripped from the replica label.
+// NOTE: It modifies the underlying array slice for efficiency reasons. Do not use passed strippedPeekLset.
+func stripReplicaLset(replicaLabels map[string]struct{}, lset labels.Labels) labels.Labels {
+	initialLen := len(lset)
+	// Statistically those are most likely at the end, so start lookup there.
+	for i := initialLen - 1; i >= 0 && len(lset)-initialLen < len(replicaLabels); i-- {
+		if _, ok := replicaLabels[lset[i].Name]; ok {
+			lset = append(lset[:i], lset[i+1:]...)
 		}
 	}
-	// Strip all present replica labels.
-	return lset[:len(lset)-totalToRemove]
+	return lset
 }
 
 func (s *dedupSeriesSet) next() bool {
@@ -71,12 +69,13 @@ func (s *dedupSeriesSet) next() bool {
 		// There's no next series, the current replicas are the last element.
 		return len(s.replicas) > 0
 	}
+	peek := s.set.At()
 	s.peek = s.set.At()
-	nextLset := s.peekLset()
+	s.strippedPeekLset = stripReplicaLset(s.replicaLabels, peek.Labels())
 
 	// If the label set modulo the replica label is equal to the current label set
 	// look for more replicas, otherwise a series is complete.
-	if !labels.Equal(s.lset, nextLset) {
+	if !labels.Equal(s.lset, s.strippedPeekLset) {
 		return true
 	}
 	s.replicas = append(s.replicas, s.peek)
@@ -85,10 +84,11 @@ func (s *dedupSeriesSet) next() bool {
 
 func (s *dedupSeriesSet) At() storage.Series {
 	if len(s.replicas) == 1 {
-		return seriesWithLabels{Series: s.replicas[0], lset: s.lset}
+		return series{SampleIterable: s.replicas[0], lset: s.lset}
 	}
+
 	// Clients may store the series, so we must make a copy of the slice before advancing.
-	repl := make([]storage.Series, len(s.replicas))
+	repl := make([]storage.SampleIterable, len(s.replicas))
 	copy(repl, s.replicas)
 	return newDedupSeries(s.lset, repl, s.isCounter)
 }
@@ -101,21 +101,21 @@ func (s *dedupSeriesSet) Warnings() storage.Warnings {
 	return s.set.Warnings()
 }
 
-type seriesWithLabels struct {
-	storage.Series
+type series struct {
+	storage.SampleIterable
 	lset labels.Labels
 }
 
-func (s seriesWithLabels) Labels() labels.Labels { return s.lset }
+func (s series) Labels() labels.Labels { return s.lset }
 
 type dedupSeries struct {
 	lset     labels.Labels
-	replicas []storage.Series
+	replicas []storage.SampleIterable
 
 	isCounter bool
 }
 
-func newDedupSeries(lset labels.Labels, replicas []storage.Series, isCounter bool) *dedupSeries {
+func newDedupSeries(lset labels.Labels, replicas []storage.SampleIterable, isCounter bool) *dedupSeries {
 	return &dedupSeries{lset: lset, isCounter: isCounter, replicas: replicas}
 }
 

--- a/pkg/dedup/replica.go
+++ b/pkg/dedup/replica.go
@@ -1,0 +1,59 @@
+package dedup
+
+import (
+	"sort"
+
+	"github.com/prometheus/prometheus/storage"
+	"github.com/thanos-io/thanos/pkg/store/storepb"
+)
+
+// replicaAwareSortSet is a set that re-sorts the input set series in order to deduplicate replicas.
+// TODO(bwplotka): Consider algorithm that uses the fact that input series are sorted, do not require full buffering.
+type replicaAwareSortSet struct {
+	set           storage.SeriesSet
+	replicaLabels map[string]struct{}
+
+	initialized bool
+	i           int
+	buff        []storage.Series
+}
+
+func newReplicaAwareSortSet(set storage.SeriesSet, replicaLabels map[string]struct{}) *replicaAwareSortSet {
+	return &replicaAwareSortSet{
+		set:           set,
+		replicaLabels: replicaLabels,
+		buff:          make([]storage.Series, 0, 1024),
+	}
+}
+func (r *replicaAwareSortSet) Next() bool {
+	if !r.initialized {
+		for r.set.Next() {
+			r.buff = append(r.buff, r.set.At())
+		}
+		r.initialized = true
+
+		cmpFunc := storepb.NewReplicaAwareLabelsCompareFunc(r.replicaLabels)
+		sort.Slice(r.buff, func(i, j int) bool {
+			return cmpFunc(r.buff[i].Labels(), r.buff[j].Labels()) < 0
+		})
+		r.i = -1
+	}
+
+	if r.set.Err() != nil || r.i >= len(r.buff)-1 {
+		return false
+	}
+	r.i++
+	return true
+}
+
+func (r *replicaAwareSortSet) At() storage.Series {
+	return r.buff[r.i]
+}
+
+func (r *replicaAwareSortSet) Err() error {
+	return r.set.Err()
+}
+
+func (r *replicaAwareSortSet) Warnings() storage.Warnings {
+	return r.Warnings()
+}

--- a/pkg/gate/gate.go
+++ b/pkg/gate/gate.go
@@ -28,6 +28,13 @@ var (
 	}
 )
 
+func NewNoop() Gate { return noop{} }
+
+type noop struct{}
+
+func (noop) Start(_ context.Context) error { return nil }
+func (noop) Done()                         {}
+
 // Gate controls the maximum number of concurrently running and waiting queries.
 //
 // Example of use:
@@ -94,13 +101,6 @@ func New(reg prometheus.Registerer, maxConcurrent int) Gate {
 		),
 	)
 }
-
-type noopGate struct{}
-
-func (noopGate) Start(context.Context) error { return nil }
-func (noopGate) Done()                       {}
-
-func NewNoop() Gate { return noopGate{} }
 
 type instrumentedDurationGate struct {
 	g        Gate

--- a/pkg/query/querier_test.go
+++ b/pkg/query/querier_test.go
@@ -960,55 +960,6 @@ func TestQuerierWithDedupUnderstoodByPromQL_Rate(t *testing.T) {
 	})
 }
 
-func TestSortReplicaLabel(t *testing.T) {
-	tests := []struct {
-		input       []storepb.Series
-		exp         []storepb.Series
-		dedupLabels map[string]struct{}
-	}{
-		// 0 Single deduplication label.
-		{
-			input: []storepb.Series{
-				{Labels: []labelpb.ZLabel{{Name: "a", Value: "1"}, {Name: "b", Value: "replica-1"}, {Name: "c", Value: "3"}}},
-				{Labels: []labelpb.ZLabel{{Name: "a", Value: "1"}, {Name: "b", Value: "replica-1"}, {Name: "c", Value: "3"}, {Name: "d", Value: "4"}}},
-				{Labels: []labelpb.ZLabel{{Name: "a", Value: "1"}, {Name: "b", Value: "replica-1"}, {Name: "c", Value: "4"}}},
-				{Labels: []labelpb.ZLabel{{Name: "a", Value: "1"}, {Name: "b", Value: "replica-2"}, {Name: "c", Value: "3"}}},
-			},
-			exp: []storepb.Series{
-				{Labels: []labelpb.ZLabel{{Name: "a", Value: "1"}, {Name: "c", Value: "3"}, {Name: "b", Value: "replica-1"}}},
-				{Labels: []labelpb.ZLabel{{Name: "a", Value: "1"}, {Name: "c", Value: "3"}, {Name: "b", Value: "replica-2"}}},
-				{Labels: []labelpb.ZLabel{{Name: "a", Value: "1"}, {Name: "c", Value: "3"}, {Name: "d", Value: "4"}, {Name: "b", Value: "replica-1"}}},
-				{Labels: []labelpb.ZLabel{{Name: "a", Value: "1"}, {Name: "c", Value: "4"}, {Name: "b", Value: "replica-1"}}},
-			},
-			dedupLabels: map[string]struct{}{"b": {}},
-		},
-		// 1 Multi deduplication labels.
-		{
-			input: []storepb.Series{
-				{Labels: []labelpb.ZLabel{{Name: "a", Value: "1"}, {Name: "b", Value: "replica-1"}, {Name: "b1", Value: "replica-1"}, {Name: "c", Value: "3"}}},
-				{Labels: []labelpb.ZLabel{{Name: "a", Value: "1"}, {Name: "b", Value: "replica-1"}, {Name: "b1", Value: "replica-1"}, {Name: "c", Value: "3"}, {Name: "d", Value: "4"}}},
-				{Labels: []labelpb.ZLabel{{Name: "a", Value: "1"}, {Name: "b", Value: "replica-1"}, {Name: "b1", Value: "replica-1"}, {Name: "c", Value: "4"}}},
-				{Labels: []labelpb.ZLabel{{Name: "a", Value: "1"}, {Name: "b", Value: "replica-2"}, {Name: "b1", Value: "replica-2"}, {Name: "c", Value: "3"}}},
-				{Labels: []labelpb.ZLabel{{Name: "a", Value: "1"}, {Name: "b", Value: "replica-2"}, {Name: "c", Value: "3"}}},
-			},
-			exp: []storepb.Series{
-				{Labels: []labelpb.ZLabel{{Name: "a", Value: "1"}, {Name: "c", Value: "3"}, {Name: "b", Value: "replica-1"}, {Name: "b1", Value: "replica-1"}}},
-				{Labels: []labelpb.ZLabel{{Name: "a", Value: "1"}, {Name: "c", Value: "3"}, {Name: "b", Value: "replica-2"}}},
-				{Labels: []labelpb.ZLabel{{Name: "a", Value: "1"}, {Name: "c", Value: "3"}, {Name: "b", Value: "replica-2"}, {Name: "b1", Value: "replica-2"}}},
-				{Labels: []labelpb.ZLabel{{Name: "a", Value: "1"}, {Name: "c", Value: "3"}, {Name: "d", Value: "4"}, {Name: "b", Value: "replica-1"}, {Name: "b1", Value: "replica-1"}}},
-				{Labels: []labelpb.ZLabel{{Name: "a", Value: "1"}, {Name: "c", Value: "4"}, {Name: "b", Value: "replica-1"}, {Name: "b1", Value: "replica-1"}}},
-			},
-			dedupLabels: map[string]struct{}{"b": {}, "b1": {}},
-		},
-	}
-	for _, test := range tests {
-		t.Run("", func(t *testing.T) {
-			sortDedupLabels(test.input, test.dedupLabels)
-			testutil.Equals(t, test.exp, test.input)
-		})
-	}
-}
-
 const hackyStaleMarker = float64(-99999999)
 
 func expandSeries(t testing.TB, it chunkenc.Iterator) (res []sample) {

--- a/pkg/query/query_bench_test.go
+++ b/pkg/query/query_bench_test.go
@@ -10,7 +10,9 @@ import (
 	"math/rand"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
+	"time"
 
 	"github.com/go-kit/kit/log"
 	"github.com/prometheus/prometheus/pkg/labels"
@@ -31,6 +33,7 @@ func TestQuerySelect(t *testing.T) {
 	})
 }
 
+// -test.benchtime 2m -test.benchmem -test.cpuprofile /home/bwplotka/Repos/_dev/thanos/2021/select/opt1-cpu.pprof
 func BenchmarkQuerySelect(b *testing.B) {
 	tb := testutil.NewTB(b)
 	storetestutil.RunSeriesInterestingCases(tb, 10e6, 10e5, func(t testutil.TB, samplesPerSeries, series int) {
@@ -78,19 +81,29 @@ func benchQuerySelect(t testutil.TB, totalSamples, totalSeries int, dedup bool) 
 
 			resps = append(resps, storepb.NewSeriesResponse(created[i]))
 		}
-
 	}
 
 	logger := log.NewNopLogger()
-	q := &querier{
-		ctx:           context.Background(),
-		logger:        logger,
-		proxy:         &mockedStoreServer{responses: resps},
-		replicaLabels: map[string]struct{}{"a_replica": {}},
-		deduplicate:   dedup,
-		selectGate:    gate.NewNoop(),
-	}
+	q := newQuerier(
+		context.Background(),
+		logger,
+		0, 0,
+		[]string{"a_replica"},
+		nil,
+		&mockedStoreServer{responses: resps},
+		true,
+		0,
+		false, false,
+		gate.NewNoop(),
+		1*time.Minute,
+	)
 	testSelect(t, q, expectedSeries)
+
+	if t.IsBenchmark() {
+		runtime.GC()
+		// TODO(bwplotka): Remove after testing.
+		testutil.Ok(t, testutil.WriteHeapProfile(fmt.Sprintf("../../../_dev/thanos/2021/select/opt1-sa%d-se%d.mem.pprof", totalSamples, totalSeries)))
+	}
 }
 
 type mockedStoreServer struct {
@@ -136,25 +149,26 @@ func testSelect(t testutil.TB, q *querier, expectedSeries []labels.Labels) {
 					}
 					testutil.Ok(t, iter.Err())
 				}
-
+				testutil.Ok(t, ss.Err())
 				testutil.Equals(t, len(expectedSeries), gotSeriesCount)
-			} else {
-				// Check more carefully.
-				var gotSeries []labels.Labels
-				for ss.Next() {
-					s := ss.At()
-					gotSeries = append(gotSeries, s.Labels())
+				continue
+			}
 
-					// This is when resource usage should actually start growing.
-					iter := s.Iterator()
-					for iter.Next() {
-						testT, testV = iter.At()
-					}
-					testutil.Ok(t, iter.Err())
+			// Check more carefully.
+			var gotSeries []labels.Labels
+			for ss.Next() {
+				s := ss.At()
+				gotSeries = append(gotSeries, s.Labels())
+
+				// This is when resource usage should actually start growing.
+				iter := s.Iterator()
+				for iter.Next() {
+					testT, testV = iter.At()
 				}
-				testutil.Equals(t, expectedSeries, gotSeries)
+				testutil.Ok(t, iter.Err())
 			}
 			testutil.Ok(t, ss.Err())
+			testutil.Equals(t, expectedSeries, gotSeries)
 		}
 	})
 }

--- a/pkg/receive/handler_test.go
+++ b/pkg/receive/handler_test.go
@@ -13,9 +13,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"path/filepath"
-	"runtime"
-	"runtime/pprof"
 	"strings"
 	"sync"
 	"testing"
@@ -1281,22 +1278,4 @@ func benchmarkHandlerMultiTSDBReceiveRemoteWrite(b testutil.TB) {
 			})
 		})
 	}
-
-	runtime.GC()
-	// Take snapshot at the end to reveal how much memory we keep in TSDB.
-	testutil.Ok(b, Heap("../../../_dev/thanos/2021/receive2"))
-
-}
-
-func Heap(dir string) (err error) {
-	if err := os.MkdirAll(dir, os.ModePerm); err != nil {
-		return err
-	}
-
-	f, err := os.Create(filepath.Join(dir, "errimpr1-go1.16.3.pprof"))
-	if err != nil {
-		return err
-	}
-	defer runutil.CloseWithErrCapture(&err, f, "close")
-	return pprof.WriteHeapProfile(f)
 }

--- a/pkg/store/bucket_test.go
+++ b/pkg/store/bucket_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/prometheus/prometheus/tsdb"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
 	"github.com/prometheus/prometheus/tsdb/encoding"
+	"github.com/thanos-io/thanos/pkg/gate"
 	"go.uber.org/atomic"
 
 	"github.com/thanos-io/thanos/pkg/block"

--- a/pkg/store/storepb/inprocess.go
+++ b/pkg/store/storepb/inprocess.go
@@ -11,14 +11,14 @@ import (
 )
 
 func ServerAsClient(srv StoreServer, clientReceiveBufferSize int) StoreClient {
-	return &serverAsClient{srv: srv, clientReceiveBufferSize: clientReceiveBufferSize}
+	return &serverAsClient{srv: srv, clientReceiveBufferSizeResponses: clientReceiveBufferSize}
 }
 
 // serverAsClient allows to use servers as clients.
 // NOTE: Passing CallOptions does not work - it would be needed to be implemented in grpc itself (before, after are private).
 type serverAsClient struct {
-	clientReceiveBufferSize int
-	srv                     StoreServer
+	clientReceiveBufferSizeResponses int
+	srv                              StoreServer
 }
 
 func (s serverAsClient) Info(ctx context.Context, in *InfoRequest, _ ...grpc.CallOption) (*InfoResponse, error) {
@@ -34,7 +34,7 @@ func (s serverAsClient) LabelValues(ctx context.Context, in *LabelValuesRequest,
 }
 
 func (s serverAsClient) Series(ctx context.Context, in *SeriesRequest, _ ...grpc.CallOption) (Store_SeriesClient, error) {
-	inSrv := &inProcessStream{recv: make(chan *SeriesResponse, s.clientReceiveBufferSize), err: make(chan error)}
+	inSrv := &inProcessStream{recv: make(chan *SeriesResponse, s.clientReceiveBufferSizeResponses), err: make(chan error)}
 	inSrv.ctx, inSrv.cancel = context.WithCancel(ctx)
 	go func() {
 		inSrv.err <- s.srv.Series(in, inSrv)

--- a/pkg/store/storepb/replica.go
+++ b/pkg/store/storepb/replica.go
@@ -1,0 +1,86 @@
+package storepb
+
+import (
+	"github.com/prometheus/prometheus/pkg/labels"
+)
+
+// LabelsCompare is a function that compares two label sets.
+// The result will be 0 if a==b, <0 if a < b, and >0 if a > b.
+type LabelsCompare func(a, b labels.Labels) int
+
+// NewReplicaAwareLabelsCompareFunc returns LabelsCompare function that compares the two label sets while ignoring
+// replica labels. If they are the same it compares with replica labels. The result will be 0 if a==b, <0 if a < b, and >0 if a > b.
+func NewReplicaAwareLabelsCompareFunc(replicaLabels map[string]struct{}) LabelsCompare {
+	return func(a, b labels.Labels) int {
+		withReplicaDecision := 0
+		ai, bi := 0, 0
+		for ai < len(a) && bi < len(b) {
+			cmp := cmpLabel(ai, bi, a, b)
+			_, arep := replicaLabels[a[ai].Name]
+			if arep {
+				if withReplicaDecision == 0 {
+					withReplicaDecision = cmp
+				}
+				ai++
+			}
+
+			_, brep := replicaLabels[b[bi].Name]
+			if brep {
+				if withReplicaDecision == 0 {
+					withReplicaDecision = cmp
+				}
+				bi++
+			}
+
+			if arep || brep {
+				continue
+			}
+			if cmp != 0 {
+				return cmp
+			}
+
+			ai++
+			bi++
+		}
+
+		for ; ai < len(a); ai++ {
+			// b finished earlier, so it's "smaller". Check if it does not have replica labels too.
+			_, arep := replicaLabels[a[ai].Name]
+			if !arep {
+				// b is still smaller.
+				return 1
+			}
+		}
+
+		for ; bi < len(b); bi++ {
+			// a finished earlier, so it's "smaller". Check if it does not have replica labels too.
+			_, brep := replicaLabels[b[bi].Name]
+			if !brep {
+				// a is still smaller.
+				return -1
+			}
+		}
+
+		if withReplicaDecision != 0 {
+			return withReplicaDecision
+		}
+
+		return len(a) - len(b)
+	}
+}
+
+func cmpLabel(ai, bi int, a, b labels.Labels) int {
+	if a[ai].Name != b[bi].Name {
+		if a[ai].Name < b[bi].Name {
+			return -1
+		}
+		return 1
+	}
+	if a[ai].Value != b[bi].Value {
+		if a[ai].Value < b[bi].Value {
+			return -1
+		}
+		return 1
+	}
+	return 0
+}

--- a/pkg/store/storepb/replica_test.go
+++ b/pkg/store/storepb/replica_test.go
@@ -1,0 +1,108 @@
+package storepb
+
+import (
+	"testing"
+
+	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/thanos-io/thanos/pkg/testutil"
+)
+
+func TestReplicaAwareLabelsCompare(t *testing.T) {
+	replicaLabels := map[string]struct{}{
+		"replica":  {},
+		"replica2": {},
+	}
+
+	a := labels.Labels{{Name: "aaa", Value: "111"}, {Name: "bbb", Value: "222"}, {Name: "replica", Value: "333"}, {Name: "xxx", Value: "444"}}
+
+	for _, tcase := range []struct {
+		a, b     labels.Labels
+		expected int
+	}{
+		{
+			a: a, b: labels.Labels{{Name: "aaa", Value: "110"}, {Name: "bbb", Value: "222"}, {Name: "replica", Value: "333"}, {Name: "xxx", Value: "444"}},
+			expected: 1,
+		},
+		{
+			a: a, b: labels.Labels{{Name: "aaa", Value: "111"}, {Name: "bbb", Value: "233"}, {Name: "replica", Value: "333"}, {Name: "xxx", Value: "444"}},
+			expected: -1,
+		},
+		{
+			a: a, b: labels.Labels{{Name: "aaa", Value: "111"}, {Name: "bar", Value: "222"}, {Name: "replica", Value: "333"}, {Name: "xxx", Value: "444"}},
+			expected: 1,
+		},
+		{
+			a: a, b: labels.Labels{{Name: "aaa", Value: "111"}, {Name: "bbc", Value: "222"}, {Name: "replica", Value: "333"}, {Name: "xxx", Value: "444"}},
+			expected: -1,
+		},
+		{
+			a: a, b: labels.Labels{{Name: "aaa", Value: "111"}},
+			expected: 1,
+		},
+		{
+			a: a, b: labels.Labels{{Name: "aaa", Value: "111"}, {Name: "bbb", Value: "222"}, {Name: "ccc", Value: "333"}, {Name: "replica", Value: "333"}, {Name: "xxx", Value: "444"}},
+			expected: 1,
+		},
+		{
+			a: a, b: labels.Labels{{Name: "aaa", Value: "111"}, {Name: "bbb", Value: "222"}, {Name: "ccc", Value: "333"}, {Name: "xxx", Value: "444"}},
+			expected: 1,
+		},
+		{
+			a: a, b: labels.Labels{{Name: "aaa", Value: "111"}, {Name: "bbb", Value: "222"}, {Name: "t", Value: "333"}, {Name: "xxx", Value: "444"}},
+			expected: 1,
+		},
+		{
+			a: a, b: labels.Labels{{Name: "aaa", Value: "111"}, {Name: "bbb", Value: "222"}, {Name: "replica", Value: "333"}, {Name: "xxx", Value: "444"}},
+			expected: 0,
+		},
+		{
+			a: a, b: labels.Labels{{Name: "aaa", Value: "111"}, {Name: "bbb", Value: "222"}, {Name: "replica", Value: "332"}, {Name: "xxx", Value: "444"}},
+			expected: 1,
+		},
+		{
+			a: a, b: labels.Labels{{Name: "aaa", Value: "111"}, {Name: "bbb", Value: "222"}, {Name: "replica", Value: "333"}, {Name: "replica2", Value: "333"}, {Name: "xxx", Value: "444"}},
+			expected: 1,
+		},
+		{
+			a: a, b: labels.Labels{{Name: "aaa", Value: "111"}, {Name: "bbb", Value: "222"}, {Name: "xxx", Value: "333"}},
+			expected: 1,
+		},
+		{
+			a: a, b: labels.Labels{{Name: "aaa", Value: "111"}, {Name: "bbb", Value: "222"}, {Name: "xxx", Value: "555"}},
+			expected: -1,
+		},
+		{
+			a: a, b: labels.Labels{{Name: "aaa", Value: "111"}, {Name: "bbb", Value: "222"}, {Name: "xxx", Value: "444"}},
+			expected: -1,
+		},
+		{
+			a: a, b: labels.Labels{{Name: "aaa", Value: "111"}, {Name: "bbb", Value: "222"}, {Name: "replica", Value: "333"}, {Name: "xxx", Value: "444"}, {Name: "replica2", Value: "333"}},
+			expected: -1,
+		},
+		{
+			a: a, b: labels.Labels{{Name: "aaa", Value: "111"}, {Name: "bbb", Value: "222"}, {Name: "xxx", Value: "444"}, {Name: "replica2", Value: "333"}},
+			expected: -1,
+		},
+		{
+			a:        labels.Labels{{Name: "a", Value: "1"}, {Name: "c", Value: "3"}, {Name: "d", Value: "4"}},
+			b:        labels.Labels{{Name: "a", Value: "1"}, {Name: "c", Value: "3"}, {Name: "replica", Value: "replica-1"}},
+			expected: 1,
+		},
+		{
+			a:        labels.Labels{{Name: "replica", Value: "replica-1"}},
+			b:        labels.Labels{{Name: "replica", Value: "replica-2"}},
+			expected: -1,
+		},
+		{
+			a:        labels.Labels{{Name: "replica", Value: "replica-1"}},
+			b:        labels.Labels{{Name: "replica", Value: "replica-1"}},
+			expected: 0,
+		},
+	} {
+		t.Run("", func(t *testing.T) {
+			testutil.Equals(t, tcase.expected, NewReplicaAwareLabelsCompareFunc(replicaLabels)(tcase.a, tcase.b))
+			// Opposite should be true too.
+			testutil.Equals(t, -1*tcase.expected, NewReplicaAwareLabelsCompareFunc(replicaLabels)(tcase.b, tcase.a))
+		})
+	}
+}

--- a/pkg/store/storepb/testutil/series.go
+++ b/pkg/store/storepb/testutil/series.go
@@ -195,18 +195,9 @@ func RunSeriesInterestingCases(t testutil.TB, maxSamples, maxSeries int, f func(
 		samplesPerSeries int
 		series           int
 	}{
-		{
-			samplesPerSeries: 1,
-			series:           maxSeries,
-		},
-		{
-			samplesPerSeries: maxSamples / (maxSeries / 10),
-			series:           maxSeries / 10,
-		},
-		{
-			samplesPerSeries: maxSamples,
-			series:           1,
-		},
+		{samplesPerSeries: 1, series: maxSeries},
+		{samplesPerSeries: maxSamples / (maxSeries / 10), series: maxSeries / 10},
+		{samplesPerSeries: maxSamples, series: 1},
 	} {
 		if ok := t.Run(fmt.Sprintf("%dSeriesWith%dSamples", tc.series, tc.samplesPerSeries), func(t testutil.TB) {
 			f(t, tc.samplesPerSeries, tc.series)

--- a/pkg/testutil/testutil.go
+++ b/pkg/testutil/testutil.go
@@ -76,13 +76,20 @@ func Equals(tb testing.TB, exp, act interface{}, v ...interface{}) {
 	if len(v) > 0 {
 		msg = fmt.Sprintf(v[0].(string), v[1:]...)
 	}
-	tb.Fatal(sprintfWithLimit("\033[31m%s:%d:"+msg+"\n\n\texp: %#v\n\n\tgot: %#v%s\033[39m\n\n", filepath.Base(file), line, exp, act, diff(exp, act)))
+	tb.Fatal(sprintfWithLimit(
+		"\033[31m%s:%d:"+msg+"\n\n\texp: "+
+			sprintfWithLimit("%#v", exp)+
+			"\n\n\tgot: "+
+			sprintfWithLimit("%#v", act)+
+			sprintfWithLimit("%s", diff(exp, act))+
+			"\033[39m\n\n", filepath.Base(file), line),
+	)
 }
 
 func sprintfWithLimit(act string, v ...interface{}) string {
 	s := fmt.Sprintf(act, v...)
 	if len(s) > 10000 {
-		return s[:10000] + "...(output trimmed)"
+		return s[:1000] + "...(output trimmed)..." + s[len(s)-1000:]
 	}
 	return s
 }


### PR DESCRIPTION
Fixes https://github.com/thanos-io/thanos/discussions/4274

* Moved to optimized storepb inprocess
* Moved dedup aware sorting to pre-dedup stage.
* Fixed sorting to ensure case with no replica label is always assumes as part of replica labels too.

Signed-off-by: Bartlomiej Plotka <bwplotka@gmail.com>

