### PR TITLE
Combined same types of function params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,6 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#4239](https://github.com/thanos-io/thanos/pull/4239) Add penalty based deduplication mode for compactor.
 - [#4292](https://github.com/thanos-io/thanos/pull/4292) Receive: Enable exemplars ingestion and querying.
 - [#4392](https://github.com/thanos-io/thanos/pull/4392) Tools: Added `--delete-blocks` to bucket rewrite tool to mark the original blocks for deletion after rewriting is done.
-- [#4413](https://github.com/thanos-io/thanos/pull/4413) Combined same types of function params
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#4239](https://github.com/thanos-io/thanos/pull/4239) Add penalty based deduplication mode for compactor.
 - [#4292](https://github.com/thanos-io/thanos/pull/4292) Receive: Enable exemplars ingestion and querying.
 - [#4392](https://github.com/thanos-io/thanos/pull/4392) Tools: Added `--delete-blocks` to bucket rewrite tool to mark the original blocks for deletion after rewriting is done.
+- [#4413](https://github.com/thanos-io/thanos/pull/4413) Combined same types of function params
 
 ### Fixed
 

--- a/cmd/thanos/sidecar.go
+++ b/cmd/thanos/sidecar.go
@@ -391,7 +391,7 @@ func (s *promMetadata) UpdateLabels(ctx context.Context) error {
 	return nil
 }
 
-func (s *promMetadata) UpdateTimestamps(mint int64, maxt int64) {
+func (s *promMetadata) UpdateTimestamps(mint, maxt int64) {
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
 
@@ -410,7 +410,7 @@ func (s *promMetadata) Labels() labels.Labels {
 	return s.labels
 }
 
-func (s *promMetadata) Timestamps() (mint int64, maxt int64) {
+func (s *promMetadata) Timestamps() (mint, maxt int64) {
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
 

--- a/pkg/alert/alert.go
+++ b/pkg/alert/alert.go
@@ -102,7 +102,7 @@ type Queue struct {
 	dropped prometheus.Counter
 }
 
-func relabelLabels(lset labels.Labels, excludeLset []string) (toAdd labels.Labels, toExclude labels.Labels) {
+func relabelLabels(lset labels.Labels, excludeLset []string) (toAdd, toExclude labels.Labels) {
 	for _, ln := range excludeLset {
 		toExclude = append(toExclude, labels.Label{Name: ln})
 	}

--- a/pkg/alert/alert_test.go
+++ b/pkg/alert/alert_test.go
@@ -90,7 +90,7 @@ func TestQueue_Push_Relabelled_Alerts(t *testing.T) {
 	)
 }
 
-func assertSameHosts(t *testing.T, expected []*url.URL, found []*url.URL) {
+func assertSameHosts(t *testing.T, expected, found []*url.URL) {
 	testutil.Equals(t, len(expected), len(found))
 
 	host := map[string]struct{}{}

--- a/pkg/api/query/v1_test.go
+++ b/pkg/api/query/v1_test.go
@@ -76,7 +76,7 @@ type endpointTestCase struct {
 type responeCompareFunction func(interface{}, interface{}) bool
 
 // Checks if both responses have Stats present or not.
-func lookupStats(a interface{}, b interface{}) bool {
+func lookupStats(a, b interface{}) bool {
 	ra := a.(*queryData)
 	rb := b.(*queryData)
 	return (ra.Stats == nil && rb.Stats == nil) || (ra.Stats != nil && rb.Stats != nil)

--- a/pkg/block/fetcher.go
+++ b/pkg/block/fetcher.go
@@ -646,7 +646,7 @@ func (f *DeduplicateFilter) DuplicateIDs() []ulid.ULID {
 	return f.duplicateIDs
 }
 
-func addNodeBySources(root *Node, add *Node) bool {
+func addNodeBySources(root, add *Node) bool {
 	var rootNode *Node
 	for _, node := range root.Children {
 		parentSources := node.Compaction.Sources
@@ -674,7 +674,7 @@ func addNodeBySources(root *Node, add *Node) bool {
 	return addNodeBySources(rootNode, add)
 }
 
-func contains(s1 []ulid.ULID, s2 []ulid.ULID) bool {
+func contains(s1, s2 []ulid.ULID) bool {
 	for _, a := range s2 {
 		found := false
 		for _, e := range s1 {

--- a/pkg/block/indexheader/binary_reader.go
+++ b/pkg/block/indexheader/binary_reader.go
@@ -653,7 +653,7 @@ func (r *BinaryReader) IndexVersion() (int, error) {
 }
 
 // TODO(bwplotka): Get advantage of multi value offset fetch.
-func (r *BinaryReader) PostingsOffset(name string, value string) (index.Range, error) {
+func (r *BinaryReader) PostingsOffset(name, value string) (index.Range, error) {
 	rngs, err := r.postingsOffset(name, value)
 	if err != nil {
 		return index.Range{}, err

--- a/pkg/block/indexheader/header_test.go
+++ b/pkg/block/indexheader/header_test.go
@@ -458,7 +458,7 @@ func getSymbolTable(b index.ByteSlice) (map[uint32]string, error) {
 // readSymbols reads the symbol table fully into memory and allocates proper strings for them.
 // Strings backed by the mmap'd memory would cause memory faults if applications keep using them
 // after the reader is closed.
-func readSymbols(bs index.ByteSlice, version int, off int) ([]string, map[uint32]string, error) {
+func readSymbols(bs index.ByteSlice, version, off int) ([]string, map[uint32]string, error) {
 	if off == 0 {
 		return nil, nil, nil
 	}

--- a/pkg/block/indexheader/lazy_binary_reader.go
+++ b/pkg/block/indexheader/lazy_binary_reader.go
@@ -156,7 +156,7 @@ func (r *LazyBinaryReader) IndexVersion() (int, error) {
 }
 
 // PostingsOffset implements Reader.
-func (r *LazyBinaryReader) PostingsOffset(name string, value string) (index.Range, error) {
+func (r *LazyBinaryReader) PostingsOffset(name, value string) (index.Range, error) {
 	r.readerMx.RLock()
 	defer r.readerMx.RUnlock()
 

--- a/pkg/compact/blocks_cleaner.go
+++ b/pkg/compact/blocks_cleaner.go
@@ -26,7 +26,7 @@ type BlocksCleaner struct {
 }
 
 // NewBlocksCleaner creates a new BlocksCleaner.
-func NewBlocksCleaner(logger log.Logger, bkt objstore.Bucket, ignoreDeletionMarkFilter *block.IgnoreDeletionMarkFilter, deleteDelay time.Duration, blocksCleaned prometheus.Counter, blockCleanupFailures prometheus.Counter) *BlocksCleaner {
+func NewBlocksCleaner(logger log.Logger, bkt objstore.Bucket, ignoreDeletionMarkFilter *block.IgnoreDeletionMarkFilter, deleteDelay time.Duration, blocksCleaned, blockCleanupFailures prometheus.Counter) *BlocksCleaner {
 	return &BlocksCleaner{
 		logger:                   logger,
 		ignoreDeletionMarkFilter: ignoreDeletionMarkFilter,

--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -71,7 +71,7 @@ type syncerMetrics struct {
 	blocksMarkedForDeletion   prometheus.Counter
 }
 
-func newSyncerMetrics(reg prometheus.Registerer, blocksMarkedForDeletion prometheus.Counter, garbageCollectedBlocks prometheus.Counter) *syncerMetrics {
+func newSyncerMetrics(reg prometheus.Registerer, blocksMarkedForDeletion, garbageCollectedBlocks prometheus.Counter) *syncerMetrics {
 	var m syncerMetrics
 
 	m.garbageCollectedBlocks = garbageCollectedBlocks
@@ -96,7 +96,7 @@ func newSyncerMetrics(reg prometheus.Registerer, blocksMarkedForDeletion prometh
 
 // NewMetaSyncer returns a new Syncer for the given Bucket and directory.
 // Blocks must be at least as old as the sync delay for being considered.
-func NewMetaSyncer(logger log.Logger, reg prometheus.Registerer, bkt objstore.Bucket, fetcher block.MetadataFetcher, duplicateBlocksFilter *block.DeduplicateFilter, ignoreDeletionMarkFilter *block.IgnoreDeletionMarkFilter, blocksMarkedForDeletion prometheus.Counter, garbageCollectedBlocks prometheus.Counter, blockSyncConcurrency int) (*Syncer, error) {
+func NewMetaSyncer(logger log.Logger, reg prometheus.Registerer, bkt objstore.Bucket, fetcher block.MetadataFetcher, duplicateBlocksFilter *block.DeduplicateFilter, ignoreDeletionMarkFilter *block.IgnoreDeletionMarkFilter, blocksMarkedForDeletion, garbageCollectedBlocks prometheus.Counter, blockSyncConcurrency int) (*Syncer, error) {
 	if logger == nil {
 		logger = log.NewNopLogger()
 	}

--- a/pkg/compactv2/changelog.go
+++ b/pkg/compactv2/changelog.go
@@ -30,6 +30,6 @@ func (l *changeLog) DeleteSeries(del labels.Labels, intervals tombstones.Interva
 	_, _ = fmt.Fprintf(l.w, "Deleted %v %v\n", del.String(), intervals)
 }
 
-func (l *changeLog) ModifySeries(old labels.Labels, new labels.Labels) {
+func (l *changeLog) ModifySeries(old, new labels.Labels) {
 	_, _ = fmt.Fprintf(l.w, "Relabelled %v %v\n", old.String(), new.String())
 }

--- a/pkg/discovery/dns/provider.go
+++ b/pkg/discovery/dns/provider.go
@@ -99,7 +99,7 @@ func IsDynamicNode(addr string) bool {
 
 // GetQTypeName splits the provided addr into two parts: the QType (if any)
 // and the name.
-func GetQTypeName(addr string) (qtype string, name string) {
+func GetQTypeName(addr string) (qtype, name string) {
 	qtypeAndName := strings.SplitN(addr, "+", 2)
 	if len(qtypeAndName) != 2 {
 		return "", addr

--- a/pkg/extkingpin/app.go
+++ b/pkg/extkingpin/app.go
@@ -111,7 +111,7 @@ func (a *App) Parse() (cmd string, setup SetupFunc) {
 	return cmd, a.setups[cmd]
 }
 
-func (a *App) Command(cmd string, help string) AppClause {
+func (a *App) Command(cmd, help string) AppClause {
 	c := a.app.Command(cmd, help)
 	return &appClause{
 		c:          c,
@@ -129,7 +129,7 @@ type appClause struct {
 	prefix string
 }
 
-func (a *appClause) Command(cmd string, help string) AppClause {
+func (a *appClause) Command(cmd, help string) AppClause {
 	c := a.c.Command(cmd, help)
 	return &appClause{
 		c:          c,

--- a/pkg/logging/grpc.go
+++ b/pkg/logging/grpc.go
@@ -79,7 +79,7 @@ func fillGlobalOptionConfig(reqLogConfig *RequestConfig, isgRPC bool) (string, b
 }
 
 // getGRPCLoggingOption returns the logging ENUM based on logStart and logEnd values.
-func getGRPCLoggingOption(logStart bool, logEnd bool) (grpc_logging.Decision, error) {
+func getGRPCLoggingOption(logStart, logEnd bool) (grpc_logging.Decision, error) {
 	if !logStart && !logEnd {
 		return grpc_logging.NoLogCall, nil
 	}

--- a/pkg/logging/http.go
+++ b/pkg/logging/http.go
@@ -89,7 +89,7 @@ func NewHTTPServerMiddleware(logger log.Logger, opts ...Option) *HTTPServerMiddl
 }
 
 // getHTTPLoggingOption returns the logging ENUM based on logStart and logEnd values.
-func getHTTPLoggingOption(logStart bool, logEnd bool) (Decision, error) {
+func getHTTPLoggingOption(logStart, logEnd bool) (Decision, error) {
 	if !logStart && !logEnd {
 		return NoLogCall, nil
 	}

--- a/pkg/query/internal/test-storeset-pre-v0.8.0/storeset.go
+++ b/pkg/query/internal/test-storeset-pre-v0.8.0/storeset.go
@@ -72,7 +72,7 @@ func (s *grpcStoreSpec) Addr() string {
 
 // Metadata method for gRPC store API tries to reach host Info method until context timeout. If we are unable to get metadata after
 // that time, we assume that the host is unhealthy and return error.
-func (s *grpcStoreSpec) Metadata(ctx context.Context, client storepb.StoreClient) (labelSets []labels.Labels, mint int64, maxt int64, err error) {
+func (s *grpcStoreSpec) Metadata(ctx context.Context, client storepb.StoreClient) (labelSets []labels.Labels, mint, maxt int64, err error) {
 	resp, err := client.Info(ctx, &storepb.InfoRequest{}, grpc.WaitForReady(true))
 	if err != nil {
 		return nil, 0, 0, errors.Wrapf(err, "fetching store info from %s", s.addr)
@@ -181,7 +181,7 @@ type storeRef struct {
 	logger log.Logger
 }
 
-func (s *storeRef) Update(labelSets []labels.Labels, minTime int64, maxTime int64) {
+func (s *storeRef) Update(labelSets []labels.Labels, minTime, maxTime int64) {
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
 

--- a/pkg/query/querier_test.go
+++ b/pkg/query/querier_test.go
@@ -743,7 +743,7 @@ type mockedQueryable struct {
 
 // Querier creates a querier with the provided min and max time.
 // The promQL engine sets mint and it is calculated based on the default lookback delta.
-func (q *mockedQueryable) Querier(_ context.Context, mint int64, maxt int64) (storage.Querier, error) {
+func (q *mockedQueryable) Querier(_ context.Context, mint, maxt int64) (storage.Querier, error) {
 	if q.Creator == nil {
 		return q.querier, nil
 	}

--- a/pkg/query/storeset.go
+++ b/pkg/query/storeset.go
@@ -117,7 +117,7 @@ func (s *grpcStoreSpec) Addr() string {
 
 // Metadata method for gRPC store API tries to reach host Info method until context timeout. If we are unable to get metadata after
 // that time, we assume that the host is unhealthy and return error.
-func (s *grpcStoreSpec) Metadata(ctx context.Context, client storepb.StoreClient) (labelSets []labels.Labels, mint int64, maxt int64, Type component.StoreAPI, err error) {
+func (s *grpcStoreSpec) Metadata(ctx context.Context, client storepb.StoreClient) (labelSets []labels.Labels, mint, maxt int64, Type component.StoreAPI, err error) {
 	resp, err := client.Info(ctx, &storepb.InfoRequest{}, grpc.WaitForReady(true))
 	if err != nil {
 		return nil, 0, 0, nil, errors.Wrapf(err, "fetching store info from %s", s.addr)
@@ -298,7 +298,7 @@ type storeRef struct {
 	logger log.Logger
 }
 
-func (s *storeRef) Update(labelSets []labels.Labels, minTime int64, maxTime int64, storeType component.StoreAPI, rule rulespb.RulesClient, target targetspb.TargetsClient, metadata metadatapb.MetadataClient, exemplar exemplarspb.ExemplarsClient) {
+func (s *storeRef) Update(labelSets []labels.Labels, minTime, maxTime int64, storeType component.StoreAPI, rule rulespb.RulesClient, target targetspb.TargetsClient, metadata metadatapb.MetadataClient, exemplar exemplarspb.ExemplarsClient) {
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
 
@@ -365,7 +365,7 @@ func (s *storeRef) LabelSets() []labels.Labels {
 	return labelSet
 }
 
-func (s *storeRef) TimeRange() (mint int64, maxt int64) {
+func (s *storeRef) TimeRange() (mint, maxt int64) {
 	s.mtx.RLock()
 	defer s.mtx.RUnlock()
 

--- a/pkg/query/test.go
+++ b/pkg/query/test.go
@@ -646,7 +646,7 @@ func (i inProcessClient) LabelSets() []labels.Labels {
 	return []labels.Labels{i.extLset}
 }
 
-func (i inProcessClient) TimeRange() (mint int64, maxt int64) {
+func (i inProcessClient) TimeRange() (mint, maxt int64) {
 	r, err := i.Info(context.TODO(), &storepb.InfoRequest{})
 	testutil.Ok(i.t, err)
 	return r.MinTime, r.MaxTime

--- a/pkg/queryfrontend/request.go
+++ b/pkg/queryfrontend/request.go
@@ -52,7 +52,7 @@ func (r *ThanosQueryRangeRequest) GetCachingOptions() queryrange.CachingOptions 
 }
 
 // WithStartEnd clone the current request with different start and end timestamp.
-func (r *ThanosQueryRangeRequest) WithStartEnd(start int64, end int64) queryrange.Request {
+func (r *ThanosQueryRangeRequest) WithStartEnd(start, end int64) queryrange.Request {
 	q := *r
 	q.Start = start
 	q.End = end
@@ -124,7 +124,7 @@ func (r *ThanosLabelsRequest) GetQuery() string { return "" }
 func (r *ThanosLabelsRequest) GetCachingOptions() queryrange.CachingOptions { return r.CachingOptions }
 
 // WithStartEnd clone the current request with different start and end timestamp.
-func (r *ThanosLabelsRequest) WithStartEnd(start int64, end int64) queryrange.Request {
+func (r *ThanosLabelsRequest) WithStartEnd(start, end int64) queryrange.Request {
 	q := *r
 	q.Start = start
 	q.End = end
@@ -194,7 +194,7 @@ func (r *ThanosSeriesRequest) GetQuery() string { return "" }
 func (r *ThanosSeriesRequest) GetCachingOptions() queryrange.CachingOptions { return r.CachingOptions }
 
 // WithStartEnd clone the current request with different start and end timestamp.
-func (r *ThanosSeriesRequest) WithStartEnd(start int64, end int64) queryrange.Request {
+func (r *ThanosSeriesRequest) WithStartEnd(start, end int64) queryrange.Request {
 	q := *r
 	q.Start = start
 	q.End = end

--- a/pkg/receive/multitsdb_test.go
+++ b/pkg/receive/multitsdb_test.go
@@ -398,7 +398,7 @@ func (s *exemplarsServer) Context() context.Context {
 	return s.ctx
 }
 
-func checkExemplarsResponse(t *testing.T, expected []exemplarspb.ExemplarData, data []exemplarspb.ExemplarData) {
+func checkExemplarsResponse(t *testing.T, expected, data []exemplarspb.ExemplarData) {
 	testutil.Equals(t, len(expected), len(data))
 	for i := range data {
 		testutil.Equals(t, expected[i].SeriesLabels, data[i].SeriesLabels)

--- a/pkg/store/bucket_test.go
+++ b/pkg/store/bucket_test.go
@@ -876,7 +876,7 @@ func testSharding(t *testing.T, reuseDisk string, bkt objstore.Bucket, all ...ul
 	}
 }
 
-func expectedTouchedBlockOps(all []ulid.ULID, expected []ulid.ULID, cached []ulid.ULID) []string {
+func expectedTouchedBlockOps(all, expected, cached []ulid.ULID) []string {
 	var ops []string
 	for _, id := range all {
 		blockCached := false
@@ -1818,7 +1818,7 @@ func TestBigEndianPostingsCount(t *testing.T) {
 	testutil.Equals(t, count, c)
 }
 
-func createBlockWithOneSeriesWithStep(t testutil.TB, dir string, lbls labels.Labels, blockIndex int, totalSamples int, random *rand.Rand, step int64) ulid.ULID {
+func createBlockWithOneSeriesWithStep(t testutil.TB, dir string, lbls labels.Labels, blockIndex, totalSamples int, random *rand.Rand, step int64) ulid.ULID {
 	headOpts := tsdb.DefaultHeadOptions()
 	headOpts.ChunkDirRoot = dir
 	headOpts.ChunkRange = int64(totalSamples) * step

--- a/pkg/store/cache/caching_bucket.go
+++ b/pkg/store/cache/caching_bucket.go
@@ -285,7 +285,7 @@ func (cb *CachingBucket) Attributes(ctx context.Context, name string) (objstore.
 	return cb.cachedAttributes(ctx, name, cfgName, cfg.cache, cfg.ttl)
 }
 
-func (cb *CachingBucket) cachedAttributes(ctx context.Context, name string, cfgName string, cache cache.Cache, ttl time.Duration) (objstore.ObjectAttributes, error) {
+func (cb *CachingBucket) cachedAttributes(ctx context.Context, name, cfgName string, cache cache.Cache, ttl time.Duration) (objstore.ObjectAttributes, error) {
 	key := cachingKeyAttributes(name)
 
 	cb.operationRequests.WithLabelValues(objstore.OpAttributes, cfgName).Inc()
@@ -486,7 +486,7 @@ func cachingKeyAttributes(name string) string {
 	return fmt.Sprintf("attrs:%s", name)
 }
 
-func cachingKeyObjectSubrange(name string, start int64, end int64) string {
+func cachingKeyObjectSubrange(name string, start, end int64) string {
 	return fmt.Sprintf("subrange:%s:%d:%d", name, start, end)
 }
 

--- a/pkg/store/cache/caching_bucket_test.go
+++ b/pkg/store/cache/caching_bucket_test.go
@@ -237,7 +237,7 @@ func TestChunksCaching(t *testing.T) {
 	}
 }
 
-func verifyGetRange(t *testing.T, cachingBucket *CachingBucket, name string, offset, length int64, expectedLength int64) {
+func verifyGetRange(t *testing.T, cachingBucket *CachingBucket, name string, offset, length, expectedLength int64) {
 	r, err := cachingBucket.GetRange(context.Background(), name, offset, length)
 	testutil.Ok(t, err)
 
@@ -485,7 +485,7 @@ func TestExistsCachingDisabled(t *testing.T) {
 	verifyExists(t, cb, testFilename, false, false, cfgName)
 }
 
-func verifyExists(t *testing.T, cb *CachingBucket, file string, exists bool, fromCache bool, cfgName string) {
+func verifyExists(t *testing.T, cb *CachingBucket, file string, exists, fromCache bool, cfgName string) {
 	t.Helper()
 	hitsBefore := int(promtest.ToFloat64(cb.operationHits.WithLabelValues(objstore.OpExists, cfgName)))
 	ok, err := cb.Exists(context.Background(), file)

--- a/pkg/store/labelpb/label.go
+++ b/pkg/store/labelpb/label.go
@@ -254,7 +254,7 @@ func (m *ZLabel) Compare(other ZLabel) int {
 //
 // In case of existing labels already present in given label set, it will be overwritten by external one.
 // NOTE: Labels and extend has to be sorted.
-func ExtendSortedLabels(lset labels.Labels, extend labels.Labels) labels.Labels {
+func ExtendSortedLabels(lset, extend labels.Labels) labels.Labels {
 	ret := make(labels.Labels, 0, len(lset)+len(extend))
 
 	// Inject external labels in place.

--- a/pkg/testutil/e2eutil/prometheus.go
+++ b/pkg/testutil/e2eutil/prometheus.go
@@ -128,7 +128,7 @@ func NewPrometheusOnPath(prefix string) (*Prometheus, error) {
 	return newPrometheus("", prefix)
 }
 
-func newPrometheus(binPath string, prefix string) (*Prometheus, error) {
+func newPrometheus(binPath, prefix string) (*Prometheus, error) {
 	if binPath == "" {
 		binPath = PrometheusBinary()
 	}
@@ -297,7 +297,7 @@ func (p *Prometheus) Appender() storage.Appender {
 
 // CreateEmptyBlock produces empty block like it was the case before fix: https://github.com/prometheus/tsdb/pull/374.
 // (Prometheus pre v2.7.0).
-func CreateEmptyBlock(dir string, mint int64, maxt int64, extLset labels.Labels, resolution int64) (ulid.ULID, error) {
+func CreateEmptyBlock(dir string, mint, maxt int64, extLset labels.Labels, resolution int64) (ulid.ULID, error) {
 	entropy := rand.New(rand.NewSource(time.Now().UnixNano()))
 	uid := ulid.MustNew(ulid.Now(), entropy)
 

--- a/pkg/testutil/testutil.go
+++ b/pkg/testutil/testutil.go
@@ -100,7 +100,7 @@ func typeAndKind(v interface{}) (reflect.Type, reflect.Kind) {
 
 // diff returns a diff of both values as long as both are of the same type and
 // are a struct, map, slice, array or string. Otherwise it returns an empty string.
-func diff(expected interface{}, actual interface{}) string {
+func diff(expected, actual interface{}) string {
 	if expected == nil || actual == nil {
 		return ""
 	}
@@ -143,7 +143,7 @@ func diff(expected interface{}, actual interface{}) string {
 }
 
 // GatherAndCompare compares the metrics of a Gatherers pair.
-func GatherAndCompare(t *testing.T, g1 prometheus.Gatherer, g2 prometheus.Gatherer, filter string) {
+func GatherAndCompare(t *testing.T, g1, g2 prometheus.Gatherer, filter string) {
 	g1m, err := g1.Gather()
 	Ok(t, err)
 	g2m, err := g2.Gather()

--- a/pkg/tracing/stackdriver/tracer.go
+++ b/pkg/tracing/stackdriver/tracer.go
@@ -55,11 +55,11 @@ func (t *tracer) StartSpan(operationName string, opts ...opentracing.StartSpanOp
 	return span
 }
 
-func (t *tracer) Extract(format interface{}, carrier interface{}) (opentracing.SpanContext, error) {
+func (t *tracer) Extract(format, carrier interface{}) (opentracing.SpanContext, error) {
 	return t.wrapped.Extract(format, carrier)
 }
 
-func (t *tracer) Inject(sm opentracing.SpanContext, format interface{}, carrier interface{}) error {
+func (t *tracer) Inject(sm opentracing.SpanContext, format, carrier interface{}) error {
 	return t.wrapped.Inject(sm, format, carrier)
 }
 

--- a/pkg/ui/ui.go
+++ b/pkg/ui/ui.go
@@ -126,7 +126,7 @@ func (bu *BaseUI) getTemplate(name string) (string, error) {
 	return string(baseTmpl) + string(menuTmpl) + string(pageTmpl), nil
 }
 
-func (bu *BaseUI) executeTemplate(w http.ResponseWriter, name string, prefix string, data interface{}) {
+func (bu *BaseUI) executeTemplate(w http.ResponseWriter, name, prefix string, data interface{}) {
 	text, err := bu.getTemplate(name)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/pkg/verifier/duplicated_compaction.go
+++ b/pkg/verifier/duplicated_compaction.go
@@ -131,7 +131,7 @@ func duplicatedBlocks(blocks []tsdb.BlockMeta) (res [][]tsdb.BlockMeta) {
 	return res
 }
 
-func sameULIDSlices(a []ulid.ULID, b []ulid.ULID) bool {
+func sameULIDSlices(a, b []ulid.ULID) bool {
 	if len(a) != len(b) {
 		return false
 	}

--- a/pkg/verifier/verify.go
+++ b/pkg/verifier/verify.go
@@ -111,7 +111,7 @@ idLoop:
 }
 
 // New returns verifier's manager.
-func NewManager(reg prometheus.Registerer, logger log.Logger, bkt objstore.Bucket, backupBkt objstore.Bucket, fetcher block.MetadataFetcher, deleteDelay time.Duration, vs Registry) *Manager {
+func NewManager(reg prometheus.Registerer, logger log.Logger, bkt, backupBkt objstore.Bucket, fetcher block.MetadataFetcher, deleteDelay time.Duration, vs Registry) *Manager {
 	return &Manager{
 		Context: Context{
 			Logger:      logger,

--- a/test/e2e/e2ethanos/services.go
+++ b/test/e2e/e2ethanos/services.go
@@ -60,7 +60,7 @@ func DefaultImage() string {
 	return "thanos"
 }
 
-func NewPrometheus(sharedDir string, name string, config string, promImage string, enableFeatures ...string) (*e2e.HTTPService, string, error) {
+func NewPrometheus(sharedDir, name, config, promImage string, enableFeatures ...string) (*e2e.HTTPService, string, error) {
 	dir := filepath.Join(sharedDir, "data", "prometheus", name)
 	container := filepath.Join(e2e.ContainerSharedDir, "data", "prometheus", name)
 	if err := os.MkdirAll(dir, 0750); err != nil {
@@ -95,7 +95,7 @@ func NewPrometheus(sharedDir string, name string, config string, promImage strin
 	return prom, container, nil
 }
 
-func NewPrometheusWithSidecar(sharedDir string, netName string, name string, config, promImage string, enableFeatures ...string) (*e2e.HTTPService, *Service, error) {
+func NewPrometheusWithSidecar(sharedDir, netName, name, config, promImage string, enableFeatures ...string) (*e2e.HTTPService, *Service, error) {
 	prom, dataDir, err := NewPrometheus(sharedDir, name, config, promImage, enableFeatures...)
 	if err != nil {
 		return nil, nil, err
@@ -275,7 +275,7 @@ func (q *QuerierBuilder) Build() (*Service, error) {
 func RemoteWriteEndpoint(addr string) string { return fmt.Sprintf("http://%s/api/v1/receive", addr) }
 
 // NewRoutingAndIngestingReceiver creates a Thanos Receive instances that is configured both for ingesting samples and routing samples to other receivers.
-func NewRoutingAndIngestingReceiver(sharedDir string, networkName string, name string, replicationFactor int, hashring ...receive.HashringConfig) (*Service, error) {
+func NewRoutingAndIngestingReceiver(sharedDir, networkName, name string, replicationFactor int, hashring ...receive.HashringConfig) (*Service, error) {
 
 	localEndpoint := NewService(fmt.Sprintf("receive-%v", name), "", e2e.NewCommand("", ""), nil, 8080, 9091, 8081).GRPCNetworkEndpointFor(networkName)
 	if len(hashring) == 0 {
@@ -322,7 +322,7 @@ func NewRoutingAndIngestingReceiver(sharedDir string, networkName string, name s
 }
 
 // NewRoutingReceiver creates a Thanos Receive instance that is only configured to route to other receive instances. It has no local storage.
-func NewRoutingReceiver(sharedDir string, name string, replicationFactor int, hashring ...receive.HashringConfig) (*Service, error) {
+func NewRoutingReceiver(sharedDir, name string, replicationFactor int, hashring ...receive.HashringConfig) (*Service, error) {
 
 	if len(hashring) == 0 {
 		return nil, errors.New("hashring should not be empty for receive-distributor mode")
@@ -367,7 +367,7 @@ func NewRoutingReceiver(sharedDir string, name string, replicationFactor int, ha
 }
 
 // NewIngestingReceiver creates a Thanos Receive instance that is only configured to ingest, not route to other receivers.
-func NewIngestingReceiver(sharedDir string, name string) (*Service, error) {
+func NewIngestingReceiver(sharedDir, name string) (*Service, error) {
 	dir := filepath.Join(sharedDir, "data", "receive", name)
 	dataDir := filepath.Join(dir, "data")
 	container := filepath.Join(e2e.ContainerSharedDir, "data", "receive", name)
@@ -399,7 +399,7 @@ func NewIngestingReceiver(sharedDir string, name string) (*Service, error) {
 	return receiver, nil
 }
 
-func NewRoutingAndIngestingReceiverWithConfigWatcher(sharedDir string, networkName string, name string, replicationFactor int, hashring ...receive.HashringConfig) (*Service, error) {
+func NewRoutingAndIngestingReceiverWithConfigWatcher(sharedDir, networkName, name string, replicationFactor int, hashring ...receive.HashringConfig) (*Service, error) {
 	localEndpoint := NewService(fmt.Sprintf("receive-%v", name), "", e2e.NewCommand("", ""), nil, 8080, 9091, 8081).GRPCNetworkEndpointFor(networkName)
 	if len(hashring) == 0 {
 		hashring = []receive.HashringConfig{{Endpoints: []string{localEndpoint}}}
@@ -449,7 +449,7 @@ func NewRoutingAndIngestingReceiverWithConfigWatcher(sharedDir string, networkNa
 	return receiver, nil
 }
 
-func NewRuler(sharedDir string, name string, ruleSubDir string, amCfg []alert.AlertmanagerConfig, queryCfg []query.Config) (*Service, error) {
+func NewRuler(sharedDir, name, ruleSubDir string, amCfg []alert.AlertmanagerConfig, queryCfg []query.Config) (*Service, error) {
 	dir := filepath.Join(sharedDir, "data", "rule", name)
 	container := filepath.Join(e2e.ContainerSharedDir, "data", "rule", name)
 	if err := os.MkdirAll(dir, 0750); err != nil {
@@ -497,7 +497,7 @@ func NewRuler(sharedDir string, name string, ruleSubDir string, amCfg []alert.Al
 	return ruler, nil
 }
 
-func NewAlertmanager(sharedDir string, name string) (*e2e.HTTPService, error) {
+func NewAlertmanager(sharedDir, name string) (*e2e.HTTPService, error) {
 	dir := filepath.Join(sharedDir, "data", "am", name)
 	container := filepath.Join(e2e.ContainerSharedDir, "data", "am", name)
 	if err := os.MkdirAll(dir, 0750); err != nil {
@@ -536,7 +536,7 @@ receivers:
 	return s, nil
 }
 
-func NewStoreGW(sharedDir string, name string, bucketConfig client.BucketConfig, relabelConfig ...relabel.Config) (*Service, error) {
+func NewStoreGW(sharedDir, name string, bucketConfig client.BucketConfig, relabelConfig ...relabel.Config) (*Service, error) {
 	dir := filepath.Join(sharedDir, "data", "store", name)
 	container := filepath.Join(e2e.ContainerSharedDir, "data", "store", name)
 	if err := os.MkdirAll(dir, 0750); err != nil {
@@ -581,7 +581,7 @@ func NewStoreGW(sharedDir string, name string, bucketConfig client.BucketConfig,
 	return store, nil
 }
 
-func NewCompactor(sharedDir string, name string, bucketConfig client.BucketConfig, relabelConfig []relabel.Config, extArgs ...string) (*e2e.HTTPService, error) {
+func NewCompactor(sharedDir, name string, bucketConfig client.BucketConfig, relabelConfig []relabel.Config, extArgs ...string) (*e2e.HTTPService, error) {
 	dir := filepath.Join(sharedDir, "data", "compact", name)
 	container := filepath.Join(e2e.ContainerSharedDir, "data", "compact", name)
 
@@ -621,7 +621,7 @@ func NewCompactor(sharedDir string, name string, bucketConfig client.BucketConfi
 	return compactor, nil
 }
 
-func NewQueryFrontend(name string, downstreamURL string, cacheConfig queryfrontend.CacheProviderConfig) (*e2e.HTTPService, error) {
+func NewQueryFrontend(name, downstreamURL string, cacheConfig queryfrontend.CacheProviderConfig) (*e2e.HTTPService, error) {
 	cacheConfigBytes, err := yaml.Marshal(cacheConfig)
 	if err != nil {
 		return nil, errors.Wrapf(err, "marshal response cache config file: %v", cacheConfig)

--- a/test/e2e/query_test.go
+++ b/test/e2e/query_test.go
@@ -379,7 +379,7 @@ func mustURLParse(t *testing.T, addr string) *url.URL {
 	return u
 }
 
-func instantQuery(t *testing.T, ctx context.Context, addr string, q string, opts promclient.QueryOptions, expectedSeriesLen int) model.Vector {
+func instantQuery(t *testing.T, ctx context.Context, addr, q string, opts promclient.QueryOptions, expectedSeriesLen int) model.Vector {
 	t.Helper()
 
 	fmt.Println("queryAndAssert: Waiting for", expectedSeriesLen, "results for query", q)
@@ -407,7 +407,7 @@ func instantQuery(t *testing.T, ctx context.Context, addr string, q string, opts
 	return result
 }
 
-func queryAndAssertSeries(t *testing.T, ctx context.Context, addr string, q string, opts promclient.QueryOptions, expected []model.Metric) {
+func queryAndAssertSeries(t *testing.T, ctx context.Context, addr, q string, opts promclient.QueryOptions, expected []model.Metric) {
 	t.Helper()
 
 	result := instantQuery(t, ctx, addr, q, opts, len(expected))
@@ -416,7 +416,7 @@ func queryAndAssertSeries(t *testing.T, ctx context.Context, addr string, q stri
 	}
 }
 
-func queryAndAssert(t *testing.T, ctx context.Context, addr string, q string, opts promclient.QueryOptions, expected model.Vector) {
+func queryAndAssert(t *testing.T, ctx context.Context, addr, q string, opts promclient.QueryOptions, expected model.Vector) {
 	t.Helper()
 
 	sortResults(expected)
@@ -464,7 +464,7 @@ func labelValues(t *testing.T, ctx context.Context, addr, label string, matchers
 	}))
 }
 
-func series(t *testing.T, ctx context.Context, addr string, matchers []*labels.Matcher, start int64, end int64, check func(res []map[string]string) bool) {
+func series(t *testing.T, ctx context.Context, addr string, matchers []*labels.Matcher, start, end int64, check func(res []map[string]string) bool) {
 	t.Helper()
 
 	logger := log.NewLogfmtLogger(os.Stdout)
@@ -483,7 +483,7 @@ func series(t *testing.T, ctx context.Context, addr string, matchers []*labels.M
 }
 
 //nolint:unparam
-func rangeQuery(t *testing.T, ctx context.Context, addr string, q string, start, end, step int64, opts promclient.QueryOptions, check func(res model.Matrix) bool) {
+func rangeQuery(t *testing.T, ctx context.Context, addr, q string, start, end, step int64, opts promclient.QueryOptions, check func(res model.Matrix) bool) {
 	t.Helper()
 
 	logger := log.NewLogfmtLogger(os.Stdout)
@@ -506,7 +506,7 @@ func rangeQuery(t *testing.T, ctx context.Context, addr string, q string, start,
 	}))
 }
 
-func queryExemplars(t *testing.T, ctx context.Context, addr string, q string, start, end int64, check func(data []*exemplarspb.ExemplarData) bool) {
+func queryExemplars(t *testing.T, ctx context.Context, addr, q string, start, end int64, check func(data []*exemplarspb.ExemplarData) bool) {
 	t.Helper()
 
 	logger := log.NewLogfmtLogger(os.Stdout)

--- a/test/e2e/rules_api_test.go
+++ b/test/e2e/rules_api_test.go
@@ -145,7 +145,7 @@ func TestRulesAPI_Fanout(t *testing.T) {
 	})
 }
 
-func ruleAndAssert(t *testing.T, ctx context.Context, addr string, typ string, want []*rulespb.RuleGroup) {
+func ruleAndAssert(t *testing.T, ctx context.Context, addr, typ string, want []*rulespb.RuleGroup) {
 	t.Helper()
 
 	fmt.Println("ruleAndAssert: Waiting for results for rules type", typ)

--- a/test/e2e/targets_api_test.go
+++ b/test/e2e/targets_api_test.go
@@ -99,7 +99,7 @@ func TestTargetsAPI_Fanout(t *testing.T) {
 }
 
 //nolint:unused
-func targetAndAssert(t *testing.T, ctx context.Context, addr string, state string, want *targetspb.TargetDiscovery) {
+func targetAndAssert(t *testing.T, ctx context.Context, addr, state string, want *targetspb.TargetDiscovery) {
 	t.Helper()
 
 	fmt.Println("targetAndAssert: Waiting for results for targets state", state)


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

- [ ] I added CHANGELOG entry for this change.
- [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

If parameters of the same type lie consecutively, mention their type once at the end of the last parameter.

Unlike other languages, like C, where all parameters must be specified with types explicitly, it is not required to do so in Go. Combining the types is usually recommended for the sake of brevity.

## Verification

<!-- How you tested it? How do you know it works? -->
