### PR TITLE
Multiple `append` combined into a single call

### DIFF
--- a/pkg/store/proxy_test.go
+++ b/pkg/store/proxy_test.go
@@ -1075,31 +1075,7 @@ func TestProxyStore_Series_RegressionFillResponseChannel(t *testing.T) {
 
 	var cls []Client
 	for i := 0; i < 10; i++ {
-		cls = append(cls, &testClient{
-			StoreClient: &mockedStoreAPI{
-				RespError: errors.New("test error"),
-			},
-			minTime: 1,
-			maxTime: 300,
-		})
-		cls = append(cls, &testClient{
-			StoreClient: &mockedStoreAPI{
-				RespSeries: []*storepb.SeriesResponse{
-					storepb.NewWarnSeriesResponse(errors.New("warning")),
-					storepb.NewWarnSeriesResponse(errors.New("warning")),
-					storepb.NewWarnSeriesResponse(errors.New("warning")),
-					storepb.NewWarnSeriesResponse(errors.New("warning")),
-					storepb.NewWarnSeriesResponse(errors.New("warning")),
-					storepb.NewWarnSeriesResponse(errors.New("warning")),
-					storepb.NewWarnSeriesResponse(errors.New("warning")),
-					storepb.NewWarnSeriesResponse(errors.New("warning")),
-					storepb.NewWarnSeriesResponse(errors.New("warning")),
-					storepb.NewWarnSeriesResponse(errors.New("warning")),
-				},
-			},
-			minTime: 1,
-			maxTime: 300,
-		})
+		cls = append(cls, &testClient{StoreClient: &mockedStoreAPI{RespError: errors.New("test error")}, minTime: 1, maxTime: 300}, &testClient{StoreClient: &mockedStoreAPI{RespSeries: []*storepb.SeriesResponse{storepb.NewWarnSeriesResponse(errors.New("warning")), storepb.NewWarnSeriesResponse(errors.New("warning")), storepb.NewWarnSeriesResponse(errors.New("warning")), storepb.NewWarnSeriesResponse(errors.New("warning")), storepb.NewWarnSeriesResponse(errors.New("warning")), storepb.NewWarnSeriesResponse(errors.New("warning")), storepb.NewWarnSeriesResponse(errors.New("warning")), storepb.NewWarnSeriesResponse(errors.New("warning")), storepb.NewWarnSeriesResponse(errors.New("warning")), storepb.NewWarnSeriesResponse(errors.New("warning"))}}, minTime: 1, maxTime: 300})
 
 	}
 


### PR DESCRIPTION
## Description

Appending calls in a single call of `append` allocates memory just once to accommodate all the elements to be appended. Whereas multiple calls to `append` introduce many overheads, most notably being the possibility of more calls for memory allocation because the total number of elements to be appended over multiple calls of `append` is unknown beforehand, resulting in inaccurate preallocation.
