### PR TITLE
Fixed Night Mode in BlocksUI

### DIFF
--- a/pkg/ui/react-app/src/thanos/pages/blocks/blocks.module.css
+++ b/pkg/ui/react-app/src/thanos/pages/blocks/blocks.module.css
@@ -2,6 +2,8 @@
   display: flex;
   --top: 72px;
   min-height: calc(100vh - var(--top));
+  position: relative;
+  z-index: 1;
 }
 
 .grid {

--- a/pkg/ui/react-app/src/themes/_bootstrap_dark.scss
+++ b/pkg/ui/react-app/src/themes/_bootstrap_dark.scss
@@ -37,6 +37,10 @@ body.bootstrap-dark {
   background-color: $body-bg; // 2
 }
 
+body.bootstrap-dark button{
+  color: $body-color;
+}
+
 .bootstrap-dark {
   @import 'node_modules/bootstrap/scss/root';
   @import 'node_modules/bootstrap/scss/type';


### PR DESCRIPTION
Signed-off-by: Blacklion14 <rkush214@gmail.com>

## Changes

I changed ThIs [css](https://github.com/thanos-io/thanos/blob/main/pkg/ui/react-app/src/thanos/pages/blocks/blocks.module.css) file and added a z-index so that the blocks which were behind the container of bootstrap-dark have came to front

Also i changed this bootstrap-dark.css file a bit in order to make close Button in blocks details div to be visible clearly in dark mode. This change may not create any ambiguity because in general we will always willing to have a white contrast text colour inside a button in dark-mode . And this will change colour of only text inside button not the background colour. 
If some one wants to change colour to some other white contrast they can directly change it from here.

## Verification

I ran the UI and it is running clearly without any errors or bugs.
