### PR TITLE
Parallelize compactor block downloading and verification step

### DIFF
--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -727,10 +727,10 @@ func (cg *Group) compact(ctx context.Context, dir string, planner Planner, comp 
 	toCompactDirs := make([]string, len(toCompact))
 
 	var eg errgroup.Group
-	for i, meta := range toCompact {
+	for _, meta := range toCompact {
 		meta := meta
 		bdir := filepath.Join(dir, meta.ULID.String())
-		toCompactDirs[i] = bdir
+		toCompactDirs = append(toCompactDirs, bdir)
 		for _, s := range meta.Compaction.Sources {
 			if _, ok := uniqueSources[s]; ok {
 				return false, ulid.ULID{}, halt(errors.Errorf("overlapping sources detected for plan %v", toCompact))

--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -724,7 +724,7 @@ func (cg *Group) compact(ctx context.Context, dir string, planner Planner, comp 
 
 	// Once we have a plan we need to download the actual data.
 	begin := time.Now()
-	toCompactDirs := make([]string, len(toCompact))
+	toCompactDirs := make([]string, 0, len(toCompact))
 
 	var eg errgroup.Group
 	for _, meta := range toCompact {


### PR DESCRIPTION
Signed-off-by: ben.ye <ben.ye@bytedance.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

Now we are seeing a very slow blocks download and verification step (also due to our large indexes caused by some high cardinality labels).

For example, it takes 4h 23m to download and verify 7 raw blocks.

```
level=info ts=2021-07-10T01:17:45.841189934Z caller=compact.go:762 group="0@{  prometheus_replica=\"prometheus\"}" groupKey=0@17135574873524709607 msg="downloaded and verified blocks; compacting blocks" plan="[/var/thanos/compact/compact/0@17135574873524709607/01FA1KWD5B2DGR069Q96MWHP4M /var/thanos/compact/compact/0@17135574873524709607/01FA1TZEDY8EA5G5BGG0XSG9BG /var/thanos/compact/compact/0@17135574873524709607/01FA2261ZPD22S4E245XH1JZVD /var/thanos/compact/compact/0@17135574873524709607/01FA29V64MYFGG0QG1S9227ZEQ /var/thanos/compact/compact/0@17135574873524709607/01FA2V0GHS1FEVTFKQZ2ZVM79Y /var/thanos/compact/compact/0@17135574873524709607/01FA31XP4FKEE5AC6R6JNX9K98 /var/thanos/compact/compact/0@17135574873524709607/01FA38ZTYQMFR9GW36G717AERS]" duration=4h23m22.457449144s
```

## Changes

Use error group and make the block downloading and index verification concurrent. Ideally, this makes the download and verification step faster.

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
