### PR TITLE
rule: fix reload signal not working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 
 ### Fixed
 
+- [#4442](https://github.com/thanos-io/thanos/pull/4442) rule: fix reload signal not working
+
 ### Changed
 
 ## [v0.22.0 - in progress](https://github.com/thanos-io/thanos/tree/release-0.22)

--- a/cmd/thanos/rule.go
+++ b/cmd/thanos/rule.go
@@ -80,7 +80,6 @@ type ruleConfig struct {
 	ruleFiles      []string
 	objStoreConfig *extflag.PathOrContent
 	dataDir        string
-	reloadSignal   <-chan struct{}
 	lset           labels.Labels
 }
 
@@ -195,6 +194,7 @@ func registerRule(app *extkingpin.App) {
 			tracer,
 			comp,
 			*conf,
+			reload,
 			getFlagsMap(cmd.Flags()),
 			httpLogOpts,
 			grpcLogOpts,
@@ -257,6 +257,7 @@ func runRule(
 	tracer opentracing.Tracer,
 	comp component.Component,
 	conf ruleConfig,
+	reloadSignal <-chan struct{},
 	flagsMap map[string]string,
 	httpLogOpts []logging.Option,
 	grpcLogOpts []grpc_logging.Option,
@@ -483,7 +484,7 @@ func runRule(
 			}
 			for {
 				select {
-				case <-conf.reloadSignal:
+				case <-reloadSignal:
 					if err := reloadRules(logger, conf.ruleFiles, ruleMgr, conf.evalInterval, metrics); err != nil {
 						level.Error(logger).Log("msg", "reload rules by sighup failed", "err", err)
 					}

--- a/test/e2e/rule_test.go
+++ b/test/e2e/rule_test.go
@@ -99,9 +99,6 @@ groups:
 `
 )
 
-
-
-
 type rulesResp struct {
 	Status string
 	Data   *rulespb.RuleGroups

--- a/test/e2e/rule_test.go
+++ b/test/e2e/rule_test.go
@@ -139,10 +139,9 @@ func checkReloadSuccessful(t *testing.T, ctx context.Context, endpoint string, e
 	resp, err := http.DefaultClient.Do(req)
 	testutil.Ok(t, err)
 	testutil.Equals(t, 200, resp.StatusCode)
-	defer resp.Body.Close()
 
 	body, err := ioutil.ReadAll(resp.Body)
-	testutil.Ok(t, err)
+	testutil.Ok(t, resp.Body.Close())
 
 	var data = rulesResp{}
 

--- a/test/e2e/rule_test.go
+++ b/test/e2e/rule_test.go
@@ -140,7 +140,7 @@ func checkReloadSuccessful(t *testing.T, ctx context.Context, endpoint string, e
 	testutil.Ok(t, err)
 	testutil.Equals(t, 200, resp.StatusCode)
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, _ := ioutil.ReadAll(resp.Body)
 	testutil.Ok(t, resp.Body.Close())
 
 	var data = rulesResp{}


### PR DESCRIPTION
Signed-off-by: Juraj Michalek <juraj.michalek132@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes
Fixed a [bug](https://github.com/thanos-io/thanos/issues/4432) when sending sighup signal to thanos ruler didn't result in loading changes.
<!-- Enumerate changes you made -->

## Verification
1. Started thanos locally using `make quickstart`.
2. Modified recording rule in rules.yml created by the quickstart option
3. Sent sighup to thanos ruler
4. Looked at thanos ruler ui to check if changes were successfully loaded (they were)
5. Also added e2e test for it

<!-- How you tested it? How do you know it works? -->
