### PR TITLE
docs: Fix broken links on 'Getting Started' and in page footer

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -55,7 +55,7 @@ The `thanos` binary should now be in your `$PATH` and is the only thing required
 
 ## Contributing
 
-Contributions are very welcome! See our [CONTRIBUTING.md](../CONTRIBUTING.md) for more information.
+Contributions are very welcome! See our [CONTRIBUTING.md](https://github.com/thanos-io/thanos/tree/main/CONTRIBUTING.md) for more information.
 
 ## Community
 
@@ -66,7 +66,7 @@ Thanos is an open source project and we value and welcome new contributors and m
 
 ## Maintainers
 
-See [MAINTAINERS.md](../MAINTAINERS.md).
+See [MAINTAINERS.md](https://github.com/thanos-io/thanos/tree/main/MAINTAINERS.md).
 
 ## Community Thanos Kubernetes Applications
 
@@ -87,7 +87,7 @@ If you want to add yourself to this list, let us know!
 
 ## Operating
 
-See up to date [jsonnet mixins](https://github.com/thanos-io/thanos/tree/main/mixin/README.md) We also have example Grafana dashboards [here](../examples/dashboards/dashboards.md) and some [alerts](../examples/alerts/alerts.md) to get you started.
+See up to date [jsonnet mixins](https://github.com/thanos-io/thanos/tree/main/mixin/README.md) We also have example Grafana dashboards [here](https://github.com/thanos-io/thanos/tree/main/examples/dashboards/dashboards.md) and some [alerts](https://github.com/thanos-io/thanos/tree/main/examples/alerts/alerts.md) to get you started.
 
 ## Talks
 
@@ -152,4 +152,4 @@ However, in case you want to play and run Thanos components on a single node, we
 | Compact        | HTTP                    | 10912 |
 | Query Frontend | HTTP                    | 10913 |
 
-You can see example one-node setup [here](../scripts/quickstart.sh).
+You can see example one-node setup [here](https://github.com/thanos-io/thanos/tree/main/scripts/quickstart.sh).

--- a/scripts/website/contentpreprocess.sh
+++ b/scripts/website/contentpreprocess.sh
@@ -91,7 +91,7 @@ EOF
 # Add edit footer to all markdown files assumed as content.
 ALL_DOC_CONTENT_FILES=$(echo "${OUTPUT_CONTENT_DIR}/**/*.md")
 for file in ${ALL_DOC_CONTENT_FILES}; do
-  relFile=${file##${OUTPUT_CONTENT_DIR}/}
+  relFile=${file##${OUTPUT_CONTENT_DIR}/thanos/}
   echo "$(
     cat <<EOF
 


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [X] Change is not relevant to the end user.

## Changes

Fixes some links in `getting-started.md` which do not work on the thanos.io website, due to them being relative (works only when reading documentation on GitHub).

Also fixes broken links in page footer, inviting users to edit the docs on GitHub. This is achieved by adjusting the sub-string removal pattern in the `contentpreprocess.sh` script, to correct the path (right now it is resulting in `404` on all pages).

Resolves #4364 and #4353

## Verification

Build and deployed the web locally via `make web-serve` and confirmed the links are working.
