### PR TITLE
ui: Add search block UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#4453](https://github.com/thanos-io/thanos/pull/4453) Tools: Add flag `--selector.relabel-config-file` / `--selector.relabel-config` / `--max-time` / `--min-time` to filter served blocks.
 - [#4482](https://github.com/thanos-io/thanos/pull/4482) COS: Add http_config for cos object store client.
 - [#4487](https://github.com/thanos-io/thanos/pull/4487) Query: Add memcached auto discovery support.
+- [#4444](https://github.com/thanos-io/thanos/pull/4444) UI: Add search block UI.
 
 ### Fixed
 

--- a/pkg/ui/react-app/src/thanos/pages/blocks/BlockInput.tsx
+++ b/pkg/ui/react-app/src/thanos/pages/blocks/BlockInput.tsx
@@ -1,0 +1,30 @@
+import React, { FC, ChangeEvent } from 'react';
+import { Button, InputGroup, InputGroupAddon, InputGroupText, Input } from 'reactstrap';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faSearch } from '@fortawesome/free-solid-svg-icons';
+import styles from './blocks.module.css';
+
+interface BlockInputProps {
+  onChange: ({ target }: ChangeEvent<HTMLInputElement>) => void;
+  onClick: () => void;
+}
+
+export const BlockInput: FC<BlockInputProps> = ({ onChange, onClick }) => {
+  return (
+    <>
+      <InputGroup className={styles.blockInput}>
+        <InputGroupAddon addonType="prepend">
+          <InputGroupText>
+            <FontAwesomeIcon icon={faSearch} />
+          </InputGroupText>
+        </InputGroupAddon>
+        <Input placeholder="Search block by ulid" onChange={onChange} />
+        <InputGroupAddon addonType="append">
+          <Button className="execute-btn" color="primary" onClick={onClick}>
+            Search
+          </Button>
+        </InputGroupAddon>
+      </InputGroup>
+    </>
+  );
+};

--- a/pkg/ui/react-app/src/thanos/pages/blocks/BlockSearchInput.tsx
+++ b/pkg/ui/react-app/src/thanos/pages/blocks/BlockSearchInput.tsx
@@ -1,30 +1,31 @@
 import React, { FC, ChangeEvent } from 'react';
-import { Button, InputGroup, InputGroupAddon, InputGroupText, Input } from 'reactstrap';
+import { Button, InputGroup, InputGroupAddon, InputGroupText, Input, Form } from 'reactstrap';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faSearch } from '@fortawesome/free-solid-svg-icons';
 import styles from './blocks.module.css';
 
-interface BlockInputProps {
+interface BlockSearchInputProps {
   onChange: ({ target }: ChangeEvent<HTMLInputElement>) => void;
   onClick: () => void;
+  defaultValue: string;
 }
 
-export const BlockInput: FC<BlockInputProps> = ({ onChange, onClick }) => {
+export const BlockSearchInput: FC<BlockSearchInputProps> = ({ onChange, onClick, defaultValue }) => {
   return (
-    <>
+    <Form onSubmit={(e) => e.preventDefault()}>
       <InputGroup className={styles.blockInput}>
         <InputGroupAddon addonType="prepend">
           <InputGroupText>
             <FontAwesomeIcon icon={faSearch} />
           </InputGroupText>
         </InputGroupAddon>
-        <Input placeholder="Search block by ulid" onChange={onChange} />
+        <Input placeholder="Search block by ulid" onChange={onChange} defaultValue={defaultValue} />
         <InputGroupAddon addonType="append">
-          <Button className="execute-btn" color="primary" onClick={onClick}>
+          <Button className="execute-btn" color="primary" onClick={onClick} type="submit">
             Search
           </Button>
         </InputGroupAddon>
       </InputGroup>
-    </>
+    </Form>
   );
 };

--- a/pkg/ui/react-app/src/thanos/pages/blocks/Blocks.tsx
+++ b/pkg/ui/react-app/src/thanos/pages/blocks/Blocks.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useMemo, useState } from 'react';
+import React, { ChangeEvent, FC, useMemo, useState } from 'react';
 import { RouteComponentProps } from '@reach/router';
 import { UncontrolledAlert } from 'reactstrap';
 import { useQueryParams, withDefault, NumberParam } from 'use-query-params';
@@ -8,10 +8,10 @@ import PathPrefixProps from '../../../types/PathPrefixProps';
 import { Block } from './block';
 import { SourceView } from './SourceView';
 import { BlockDetails } from './BlockDetails';
+import { BlockInput } from './BlockInput';
 import { sortBlocks } from './helpers';
 import styles from './blocks.module.css';
 import TimeRange from './TimeRange';
-
 export interface BlockListProps {
   blocks: Block[];
   err: string | null;
@@ -21,6 +21,8 @@ export interface BlockListProps {
 
 export const BlocksContent: FC<{ data: BlockListProps }> = ({ data }) => {
   const [selectedBlock, selectBlock] = useState<Block>();
+  const [searchState, setSearchState] = useState<string>('');
+  const [blockSearch, setBlockSearch] = useState<string>('');
 
   const { blocks, label, err } = data;
 
@@ -58,6 +60,10 @@ export const BlocksContent: FC<{ data: BlockListProps }> = ({ data }) => {
 
   return (
     <>
+      <BlockInput
+        onChange={({ target }: ChangeEvent<HTMLInputElement>): void => setSearchState(target.value)}
+        onClick={() => setBlockSearch(searchState)}
+      />
       {blocks.length > 0 ? (
         <div className={styles.container}>
           <div className={styles.grid}>
@@ -70,6 +76,7 @@ export const BlocksContent: FC<{ data: BlockListProps }> = ({ data }) => {
                   selectBlock={selectBlock}
                   gridMinTime={viewMinTime}
                   gridMaxTime={viewMaxTime}
+                  blockSearch={blockSearch}
                 />
               ))}
             </div>

--- a/pkg/ui/react-app/src/thanos/pages/blocks/Blocks.tsx
+++ b/pkg/ui/react-app/src/thanos/pages/blocks/Blocks.tsx
@@ -1,14 +1,14 @@
 import React, { ChangeEvent, FC, useMemo, useState } from 'react';
 import { RouteComponentProps } from '@reach/router';
 import { UncontrolledAlert } from 'reactstrap';
-import { useQueryParams, withDefault, NumberParam } from 'use-query-params';
+import { useQueryParams, withDefault, NumberParam, StringParam } from 'use-query-params';
 import { withStatusIndicator } from '../../../components/withStatusIndicator';
 import { useFetch } from '../../../hooks/useFetch';
 import PathPrefixProps from '../../../types/PathPrefixProps';
 import { Block } from './block';
 import { SourceView } from './SourceView';
 import { BlockDetails } from './BlockDetails';
-import { BlockInput } from './BlockInput';
+import { BlockSearchInput } from './BlockSearchInput';
 import { sortBlocks } from './helpers';
 import styles from './blocks.module.css';
 import TimeRange from './TimeRange';
@@ -22,7 +22,6 @@ export interface BlockListProps {
 export const BlocksContent: FC<{ data: BlockListProps }> = ({ data }) => {
   const [selectedBlock, selectBlock] = useState<Block>();
   const [searchState, setSearchState] = useState<string>('');
-  const [blockSearch, setBlockSearch] = useState<string>('');
 
   const { blocks, label, err } = data;
 
@@ -44,10 +43,13 @@ export const BlocksContent: FC<{ data: BlockListProps }> = ({ data }) => {
     return [0, 0];
   }, [blocks, err]);
 
-  const [{ 'min-time': viewMinTime, 'max-time': viewMaxTime }, setQuery] = useQueryParams({
+  const [{ 'min-time': viewMinTime, 'max-time': viewMaxTime, ulid: blockSearchParam }, setQuery] = useQueryParams({
     'min-time': withDefault(NumberParam, gridMinTime),
     'max-time': withDefault(NumberParam, gridMaxTime),
+    ulid: withDefault(StringParam, ''),
   });
+
+  const [blockSearch, setBlockSearch] = useState<string>(blockSearchParam);
 
   const setViewTime = (times: number[]): void => {
     setQuery({
@@ -56,40 +58,50 @@ export const BlocksContent: FC<{ data: BlockListProps }> = ({ data }) => {
     });
   };
 
+  const setBlockSearchInput = (searchState: string): void => {
+    setQuery({
+      ulid: searchState,
+    });
+    setBlockSearch(searchState);
+  };
+
   if (err) return <UncontrolledAlert color="danger">{err.toString()}</UncontrolledAlert>;
 
   return (
     <>
-      <BlockInput
-        onChange={({ target }: ChangeEvent<HTMLInputElement>): void => setSearchState(target.value)}
-        onClick={() => setBlockSearch(searchState)}
-      />
       {blocks.length > 0 ? (
-        <div className={styles.container}>
-          <div className={styles.grid}>
-            <div className={styles.sources}>
-              {Object.keys(blockPools).map((pk) => (
-                <SourceView
-                  key={pk}
-                  data={blockPools[pk]}
-                  title={pk}
-                  selectBlock={selectBlock}
-                  gridMinTime={viewMinTime}
-                  gridMaxTime={viewMaxTime}
-                  blockSearch={blockSearch}
-                />
-              ))}
+        <>
+          <BlockSearchInput
+            onChange={({ target }: ChangeEvent<HTMLInputElement>): void => setSearchState(target.value)}
+            onClick={() => setBlockSearchInput(searchState)}
+            defaultValue={blockSearchParam}
+          />
+          <div className={styles.container}>
+            <div className={styles.grid}>
+              <div className={styles.sources}>
+                {Object.keys(blockPools).map((pk) => (
+                  <SourceView
+                    key={pk}
+                    data={blockPools[pk]}
+                    title={pk}
+                    selectBlock={selectBlock}
+                    gridMinTime={viewMinTime}
+                    gridMaxTime={viewMaxTime}
+                    blockSearch={blockSearch}
+                  />
+                ))}
+              </div>
+              <TimeRange
+                gridMinTime={gridMinTime}
+                gridMaxTime={gridMaxTime}
+                viewMinTime={viewMinTime}
+                viewMaxTime={viewMaxTime}
+                onChange={setViewTime}
+              />
             </div>
-            <TimeRange
-              gridMinTime={gridMinTime}
-              gridMaxTime={gridMaxTime}
-              viewMinTime={viewMinTime}
-              viewMaxTime={viewMaxTime}
-              onChange={setViewTime}
-            />
+            <BlockDetails selectBlock={selectBlock} block={selectedBlock} />
           </div>
-          <BlockDetails selectBlock={selectBlock} block={selectedBlock} />
-        </div>
+        </>
       ) : (
         <UncontrolledAlert color="warning">No blocks found.</UncontrolledAlert>
       )}

--- a/pkg/ui/react-app/src/thanos/pages/blocks/SourceView.test.tsx
+++ b/pkg/ui/react-app/src/thanos/pages/blocks/SourceView.test.tsx
@@ -16,6 +16,7 @@ describe('Blocks SourceView', () => {
     },
     gridMinTime: 1596096000000,
     gridMaxTime: 1595108031471,
+    blockSearch: '',
   };
 
   const sourceView = mount(<SourceView {...defaultProps} />);

--- a/pkg/ui/react-app/src/thanos/pages/blocks/SourceView.tsx
+++ b/pkg/ui/react-app/src/thanos/pages/blocks/SourceView.tsx
@@ -2,18 +2,32 @@ import React, { FC } from 'react';
 import { Block, BlocksPool } from './block';
 import { BlockSpan } from './BlockSpan';
 import styles from './blocks.module.css';
+import { getBlockByUlid } from './helpers';
 
 export const BlocksRow: FC<{
   blocks: Block[];
   gridMinTime: number;
   gridMaxTime: number;
   selectBlock: React.Dispatch<React.SetStateAction<Block | undefined>>;
-}> = ({ blocks, gridMinTime, gridMaxTime, selectBlock }) => {
+  blockSearch: string;
+}> = ({ blocks, gridMinTime, gridMaxTime, selectBlock, blockSearch }) => {
+  const blockSearchValue = getBlockByUlid(blocks, blockSearch);
+
   return (
     <div className={styles.row}>
-      {blocks.map<JSX.Element>((b) => (
-        <BlockSpan selectBlock={selectBlock} block={b} gridMaxTime={gridMaxTime} gridMinTime={gridMinTime} key={b.ulid} />
-      ))}
+      {blocks.map<JSX.Element | undefined>((b) => {
+        if (b.ulid === blockSearchValue || blockSearch === '') {
+          return (
+            <BlockSpan
+              selectBlock={selectBlock}
+              block={b}
+              gridMaxTime={gridMaxTime}
+              gridMinTime={gridMinTime}
+              key={b.ulid}
+            />
+          );
+        }
+      })}
     </div>
   );
 };
@@ -24,9 +38,10 @@ export interface SourceViewProps {
   gridMinTime: number;
   gridMaxTime: number;
   selectBlock: React.Dispatch<React.SetStateAction<Block | undefined>>;
+  blockSearch: string;
 }
 
-export const SourceView: FC<SourceViewProps> = ({ data, title, gridMaxTime, gridMinTime, selectBlock }) => {
+export const SourceView: FC<SourceViewProps> = ({ data, title, gridMaxTime, gridMinTime, selectBlock, blockSearch }) => {
   return (
     <>
       <div className={styles.source}>
@@ -43,6 +58,7 @@ export const SourceView: FC<SourceViewProps> = ({ data, title, gridMaxTime, grid
                   key={`${k}-${i}`}
                   gridMaxTime={gridMaxTime}
                   gridMinTime={gridMinTime}
+                  blockSearch={blockSearch}
                 />
               ))}
             </React.Fragment>

--- a/pkg/ui/react-app/src/thanos/pages/blocks/SourceView.tsx
+++ b/pkg/ui/react-app/src/thanos/pages/blocks/SourceView.tsx
@@ -15,18 +15,10 @@ export const BlocksRow: FC<{
 
   return (
     <div className={styles.row}>
-      {blocks.map<JSX.Element | undefined>((b) => {
-        if (b.ulid === blockSearchValue || blockSearch === '') {
-          return (
-            <BlockSpan
-              selectBlock={selectBlock}
-              block={b}
-              gridMaxTime={gridMaxTime}
-              gridMinTime={gridMinTime}
-              key={b.ulid}
-            />
-          );
-        }
+      {blockSearchValue.map<JSX.Element>((b) => {
+        return (
+          <BlockSpan selectBlock={selectBlock} block={b} gridMaxTime={gridMaxTime} gridMinTime={gridMinTime} key={b.ulid} />
+        );
       })}
     </div>
   );

--- a/pkg/ui/react-app/src/thanos/pages/blocks/blocks.module.css
+++ b/pkg/ui/react-app/src/thanos/pages/blocks/blocks.module.css
@@ -190,3 +190,7 @@
 .level-6 {
   background: var(--level-6);
 }
+
+.blockInput {
+  margin-bottom: 12px;
+}

--- a/pkg/ui/react-app/src/thanos/pages/blocks/helpers.ts
+++ b/pkg/ui/react-app/src/thanos/pages/blocks/helpers.ts
@@ -1,4 +1,5 @@
 import { LabelSet, Block, BlocksPool } from './block';
+import { Fuzzy, FuzzyResult } from '@nexucis/fuzzy';
 
 const stringify = (map: LabelSet): string => {
   let t = '';
@@ -102,4 +103,18 @@ export const download = (blob: Block): string => {
   const url = window.URL.createObjectURL(new Blob([JSON.stringify(blob, null, 2)], { type: 'application/json' }));
 
   return url;
+};
+
+export const getBlockByUlid = (blocks: Block[], ulid: string): string => {
+  const ulidArray = blocks.map((block) => block.ulid);
+  const fuz = new Fuzzy({ caseSensitive: true });
+
+  const result: FuzzyResult[] = fuz.filter(ulid, ulidArray);
+
+  if (result.length > 0) {
+    let index = result[0].index;
+    return blocks[index].ulid;
+  }
+
+  return '';
 };

--- a/pkg/ui/react-app/src/thanos/pages/blocks/helpers.ts
+++ b/pkg/ui/react-app/src/thanos/pages/blocks/helpers.ts
@@ -105,16 +105,18 @@ export const download = (blob: Block): string => {
   return url;
 };
 
-export const getBlockByUlid = (blocks: Block[], ulid: string): string => {
+export const getBlockByUlid = (blocks: Block[], ulid: string): Block[] => {
+  if (ulid === '') {
+    return blocks;
+  }
+
   const ulidArray = blocks.map((block) => block.ulid);
   const fuz = new Fuzzy({ caseSensitive: true });
 
   const result: FuzzyResult[] = fuz.filter(ulid, ulidArray);
 
-  if (result.length > 0) {
-    let index = result[0].index;
-    return blocks[index].ulid;
-  }
+  const resultIndex = result.map((value) => value.index);
 
-  return '';
+  const blockResult = blocks.filter((block, index) => resultIndex.includes(index));
+  return blockResult;
 };


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

This PR is part of LFX Mentorship project (issue: #3112). We want to add Search Block by ID.

## Verification
When we haven't search anything yet:

![image](https://user-images.githubusercontent.com/19685008/125622951-80a090fa-717e-40f4-9220-1244b33b0c46.png)

Example search block by ID:

![image](https://user-images.githubusercontent.com/19685008/125622720-88c294dc-4a19-4211-b42a-60ff08e9f32e.png)

Tested on local using `make quickstart`
