### PR TITLE
loadMeta: Reduce the number of queries with object stores

### DIFF
--- a/pkg/block/fetcher.go
+++ b/pkg/block/fetcher.go
@@ -227,6 +227,9 @@ func (f *BaseFetcher) loadMeta(ctx context.Context, id ulid.ULID) (*metadata.Met
 		metaFile       = path.Join(id.String(), MetaFilename)
 		cachedBlockDir = filepath.Join(f.cacheDir, id.String())
 	)
+	if m, seen := f.cached[id]; seen {
+		return m, nil
+	}
 
 	// TODO(bwplotka): If that causes problems (obj store rate limits), add longer ttl to cached items.
 	// For 1y and 100 block sources this generates ~1.5-3k HEAD RPM. AWS handles 330k RPM per prefix.

--- a/pkg/block/fetcher.go
+++ b/pkg/block/fetcher.go
@@ -227,6 +227,7 @@ func (f *BaseFetcher) loadMeta(ctx context.Context, id ulid.ULID) (*metadata.Met
 		metaFile       = path.Join(id.String(), MetaFilename)
 		cachedBlockDir = filepath.Join(f.cacheDir, id.String())
 	)
+	// Reduced query object storage
 	if m, seen := f.cached[id]; seen {
 		return m, nil
 	}


### PR DESCRIPTION
Signed-off-by: chenjianwei666888@gmail.com

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

loadMeta with cache,Reduce the number of queries with object stores

## Verification

<!-- How you tested it? How do you know it works? -->
