### PR TITLE
Add RequestID for Deletion Requests

### DIFF
--- a/pkg/block/metadata/meta.go
+++ b/pkg/block/metadata/meta.go
@@ -114,6 +114,7 @@ func (m *Matchers) UnmarshalYAML(value *yaml.Node) (err error) {
 type DeletionRequest struct {
 	Matchers  Matchers             `json:"matchers" yaml:"matchers"`
 	Intervals tombstones.Intervals `json:"intervals,omitempty" yaml:"intervals,omitempty"`
+	RequestID string               `json:"request_id,omitempty" yaml:"request_id,omitempty"`
 }
 
 type File struct {


### PR DESCRIPTION
Signed-off-by: ilangofman <igofman99@gmail.com>

Hello, I mentioned this briefly in one of the community calls. Currently I am working on the adding the series deletion API in Cortex. To accomplish the task of permanently deleting the series, I would like to leverage the logic of the bucket rewrite work done inside of Thanos. To track which blocks have been rewritten, the proposed idea was to store the deletion request id inside of the `meta.json` file. Since the file is written from within Thanos, this PR will allow us to do this.  

If anyone is intrested, the proposal for the API in Cortex can be found [here](https://cortexmetrics.io/docs/proposals/block-storage-time-series-deletion/l).

Please let me know if there is any questions or concerns with this change.

Thanks

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->
- Add a new variable inside the deletion request struct to store the deletion request id (could be empty). 
## Verification

<!-- How you tested it? How do you know it works? -->
