### PR TITLE
rule: fix skips rule files based on their names. (#4232)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 ### Fixed
 
 - [#4442](https://github.com/thanos-io/thanos/pull/4442) rule: fix reload signal not working
+- [#4232](https://github.com/thanos-io/thanos/issues/4232) rule: fix skips rule files based on their names.
 
 ### Changed
 

--- a/pkg/rules/manager.go
+++ b/pkg/rules/manager.go
@@ -356,7 +356,7 @@ func (m *Manager) Update(evalInterval time.Duration, files []string) error {
 
 			// Use full file name appending to work dir, so we can differentiate between different dirs and same filenames(!).
 			// This will be also used as key for file group name.
-			newFn := filepath.Join(m.workDir, s.String(), strings.TrimLeft(fn, m.workDir))
+			newFn := filepath.Join(m.workDir, s.String(), filepath.Base(fn))
 			if err := os.MkdirAll(filepath.Dir(newFn), os.ModePerm); err != nil {
 				errs.Add(errors.Wrapf(err, "create %s", filepath.Dir(newFn)))
 				continue


### PR DESCRIPTION
Signed-off-by: DaiWei <daiwei233@outlook.com>

Closes: [#4232](https://github.com/thanos-io/thanos/issues/4232)

* [x] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

> https://github.com/thanos-io/thanos/blob/f4a5904b0c3be7565298cf257ad43ac1942021cc/pkg/rules/manager.go#L358

Ruler will skips rule files based on their names, explained in [#4232](https://github.com/thanos-io/thanos/issues/4232)

At past:

```go
newFn := filepath.Join(m.workDir, s.String(), strings.TrimLeft(fn, m.workDir))
```

Now:

```go
newFn := filepath.Join(m.workDir, s.String(), filepath.Base(fn))
```



At path,  I have two rule file:

```
{ruler_dir}/test.yml
{ruler_dir}/test1.yml
```

 We will got the same fn `yml`, It's going to overwrite the previous one.



## Verification

