### PR TITLE
ui: Add find overlap block UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 We use *breaking :warning:* to mark changes that are not backward compatible (relates only to v0.y.z releases.)
 
 ## Unreleased
+- [#4462](https://github.com/thanos-io/thanos/pull/4462) UI: Add find overlap block UI
 
 ### Added
 - [#4453](https://github.com/thanos-io/thanos/pull/4453) Tools: Add flag `--selector.relabel-config-file` / `--selector.relabel-config` / `--max-time` / `--min-time` to filter served blocks.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 We use *breaking :warning:* to mark changes that are not backward compatible (relates only to v0.y.z releases.)
 
 ## Unreleased
-- [#4462](https://github.com/thanos-io/thanos/pull/4462) UI: Add find overlap block UI
 
 ### Added
 - [#4453](https://github.com/thanos-io/thanos/pull/4453) Tools: Add flag `--selector.relabel-config-file` / `--selector.relabel-config` / `--max-time` / `--min-time` to filter served blocks.
@@ -17,6 +16,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#4487](https://github.com/thanos-io/thanos/pull/4487) Query: Add memcached auto discovery support.
 - [#4444](https://github.com/thanos-io/thanos/pull/4444) UI: Add search block UI.
 - [#4509](https://github.com/thanos-io/thanos/pull/4509) Logging: Adds duration_ms in int64 to the logs.
+- [#4462](https://github.com/thanos-io/thanos/pull/4462) UI: Add find overlap block UI
 
 ### Fixed
 

--- a/pkg/ui/react-app/src/thanos/pages/blocks/Blocks.tsx
+++ b/pkg/ui/react-app/src/thanos/pages/blocks/Blocks.tsx
@@ -9,9 +9,11 @@ import { Block } from './block';
 import { SourceView } from './SourceView';
 import { BlockDetails } from './BlockDetails';
 import { BlockSearchInput } from './BlockSearchInput';
-import { sortBlocks } from './helpers';
+import { sortBlocks, getOverlappingBlocks } from './helpers';
 import styles from './blocks.module.css';
 import TimeRange from './TimeRange';
+import Checkbox from '../../../components/Checkbox';
+
 export interface BlockListProps {
   blocks: Block[];
   err: string | null;
@@ -22,6 +24,8 @@ export interface BlockListProps {
 export const BlocksContent: FC<{ data: BlockListProps }> = ({ data }) => {
   const [selectedBlock, selectBlock] = useState<Block>();
   const [searchState, setSearchState] = useState<string>('');
+  const [findOverlapBlock, setFindOverlapBlock] = useState<boolean>(false);
+  const [overlapBlocks, setOverlapBlocks] = useState<Set<string>>(new Set());
 
   const { blocks, label, err } = data;
 
@@ -76,6 +80,20 @@ export const BlocksContent: FC<{ data: BlockListProps }> = ({ data }) => {
             onClick={() => setBlockSearchInput(searchState)}
             defaultValue={blockSearchParam}
           />
+          <Checkbox
+            id="find-overlap-block-checkbox"
+            onChange={({ target }) => {
+              setFindOverlapBlock(target.checked);
+              if (target.checked) {
+                setOverlapBlocks(getOverlappingBlocks(blockPools));
+              } else {
+                setOverlapBlocks(new Set());
+              }
+            }}
+            defaultChecked={findOverlapBlock}
+          >
+            Enable find overlap block
+          </Checkbox>
           <div className={styles.container}>
             <div className={styles.grid}>
               <div className={styles.sources}>
@@ -88,6 +106,8 @@ export const BlocksContent: FC<{ data: BlockListProps }> = ({ data }) => {
                     gridMinTime={viewMinTime}
                     gridMaxTime={viewMaxTime}
                     blockSearch={blockSearch}
+                    findOverlapBlock={findOverlapBlock}
+                    overlapBlocks={overlapBlocks}
                   />
                 ))}
               </div>

--- a/pkg/ui/react-app/src/thanos/pages/blocks/Blocks.tsx
+++ b/pkg/ui/react-app/src/thanos/pages/blocks/Blocks.tsx
@@ -1,7 +1,7 @@
 import React, { ChangeEvent, FC, useMemo, useState } from 'react';
 import { RouteComponentProps } from '@reach/router';
 import { UncontrolledAlert } from 'reactstrap';
-import { useQueryParams, withDefault, NumberParam, StringParam } from 'use-query-params';
+import { useQueryParams, withDefault, NumberParam, StringParam, BooleanParam } from 'use-query-params';
 import { withStatusIndicator } from '../../../components/withStatusIndicator';
 import { useFetch } from '../../../hooks/useFetch';
 import PathPrefixProps from '../../../types/PathPrefixProps';
@@ -24,11 +24,8 @@ export interface BlockListProps {
 export const BlocksContent: FC<{ data: BlockListProps }> = ({ data }) => {
   const [selectedBlock, selectBlock] = useState<Block>();
   const [searchState, setSearchState] = useState<string>('');
-  const [findOverlapBlock, setFindOverlapBlock] = useState<boolean>(false);
-
   const { blocks, label, err } = data;
 
-  const blockPools = useMemo(() => sortBlocks(blocks, label, findOverlapBlock), [blocks, label, findOverlapBlock]);
   const [gridMinTime, gridMaxTime] = useMemo(() => {
     if (!err && blocks.length > 0) {
       let gridMinTime = blocks[0].minTime;
@@ -46,13 +43,20 @@ export const BlocksContent: FC<{ data: BlockListProps }> = ({ data }) => {
     return [0, 0];
   }, [blocks, err]);
 
-  const [{ 'min-time': viewMinTime, 'max-time': viewMaxTime, ulid: blockSearchParam }, setQuery] = useQueryParams({
+  const [
+    { 'min-time': viewMinTime, 'max-time': viewMaxTime, ulid: blockSearchParam, 'find-overlapping': findOverlappingParam },
+    setQuery,
+  ] = useQueryParams({
     'min-time': withDefault(NumberParam, gridMinTime),
     'max-time': withDefault(NumberParam, gridMaxTime),
     ulid: withDefault(StringParam, ''),
+    'find-overlapping': withDefault(BooleanParam, false),
   });
 
+  const [findOverlappingBlocks, setFindOverlappingBlocks] = useState<boolean>(findOverlappingParam);
   const [blockSearch, setBlockSearch] = useState<string>(blockSearchParam);
+
+  const blockPools = useMemo(() => sortBlocks(blocks, label, findOverlappingBlocks), [blocks, label, findOverlappingBlocks]);
 
   const setViewTime = (times: number[]): void => {
     setQuery({
@@ -82,11 +86,14 @@ export const BlocksContent: FC<{ data: BlockListProps }> = ({ data }) => {
           <Checkbox
             id="find-overlap-block-checkbox"
             onChange={({ target }) => {
-              setFindOverlapBlock(target.checked);
+              setQuery({
+                'find-overlapping': target.checked,
+              });
+              setFindOverlappingBlocks(target.checked);
             }}
-            defaultChecked={findOverlapBlock}
+            defaultChecked={findOverlappingBlocks}
           >
-            Enable find overlap block
+            Enable find overlapping blocks
           </Checkbox>
           <div className={styles.container}>
             <div className={styles.grid}>

--- a/pkg/ui/react-app/src/thanos/pages/blocks/Blocks.tsx
+++ b/pkg/ui/react-app/src/thanos/pages/blocks/Blocks.tsx
@@ -93,7 +93,7 @@ export const BlocksContent: FC<{ data: BlockListProps }> = ({ data }) => {
             }}
             defaultChecked={findOverlappingBlocks}
           >
-            Enable find overlapping blocks
+            Enable finding overlapping blocks
           </Checkbox>
           <div className={styles.container}>
             <div className={styles.grid}>

--- a/pkg/ui/react-app/src/thanos/pages/blocks/Blocks.tsx
+++ b/pkg/ui/react-app/src/thanos/pages/blocks/Blocks.tsx
@@ -9,7 +9,7 @@ import { Block } from './block';
 import { SourceView } from './SourceView';
 import { BlockDetails } from './BlockDetails';
 import { BlockSearchInput } from './BlockSearchInput';
-import { sortBlocks, getOverlappingBlocks } from './helpers';
+import { sortBlocks } from './helpers';
 import styles from './blocks.module.css';
 import TimeRange from './TimeRange';
 import Checkbox from '../../../components/Checkbox';
@@ -25,11 +25,10 @@ export const BlocksContent: FC<{ data: BlockListProps }> = ({ data }) => {
   const [selectedBlock, selectBlock] = useState<Block>();
   const [searchState, setSearchState] = useState<string>('');
   const [findOverlapBlock, setFindOverlapBlock] = useState<boolean>(false);
-  const [overlapBlocks, setOverlapBlocks] = useState<Set<string>>(new Set());
 
   const { blocks, label, err } = data;
 
-  const blockPools = useMemo(() => sortBlocks(blocks, label), [blocks, label]);
+  const blockPools = useMemo(() => sortBlocks(blocks, label, findOverlapBlock), [blocks, label, findOverlapBlock]);
   const [gridMinTime, gridMaxTime] = useMemo(() => {
     if (!err && blocks.length > 0) {
       let gridMinTime = blocks[0].minTime;
@@ -84,11 +83,6 @@ export const BlocksContent: FC<{ data: BlockListProps }> = ({ data }) => {
             id="find-overlap-block-checkbox"
             onChange={({ target }) => {
               setFindOverlapBlock(target.checked);
-              if (target.checked) {
-                setOverlapBlocks(getOverlappingBlocks(blockPools));
-              } else {
-                setOverlapBlocks(new Set());
-              }
             }}
             defaultChecked={findOverlapBlock}
           >
@@ -105,9 +99,6 @@ export const BlocksContent: FC<{ data: BlockListProps }> = ({ data }) => {
                     selectBlock={selectBlock}
                     gridMinTime={viewMinTime}
                     gridMaxTime={viewMaxTime}
-                    blockSearch={blockSearch}
-                    findOverlapBlock={findOverlapBlock}
-                    overlapBlocks={overlapBlocks}
                   />
                 ))}
               </div>

--- a/pkg/ui/react-app/src/thanos/pages/blocks/Blocks.tsx
+++ b/pkg/ui/react-app/src/thanos/pages/blocks/Blocks.tsx
@@ -99,6 +99,7 @@ export const BlocksContent: FC<{ data: BlockListProps }> = ({ data }) => {
                     selectBlock={selectBlock}
                     gridMinTime={viewMinTime}
                     gridMaxTime={viewMaxTime}
+                    blockSearch={blockSearch}
                   />
                 ))}
               </div>

--- a/pkg/ui/react-app/src/thanos/pages/blocks/SourceView.test.tsx
+++ b/pkg/ui/react-app/src/thanos/pages/blocks/SourceView.test.tsx
@@ -16,6 +16,7 @@ describe('Blocks SourceView', () => {
     },
     gridMinTime: 1596096000000,
     gridMaxTime: 1595108031471,
+    blockSearch: '',
   };
 
   const sourceView = mount(<SourceView {...defaultProps} />);

--- a/pkg/ui/react-app/src/thanos/pages/blocks/SourceView.test.tsx
+++ b/pkg/ui/react-app/src/thanos/pages/blocks/SourceView.test.tsx
@@ -17,6 +17,8 @@ describe('Blocks SourceView', () => {
     gridMinTime: 1596096000000,
     gridMaxTime: 1595108031471,
     blockSearch: '',
+    findOverlapBlock: false,
+    overlapBlocks: new Set(),
   };
 
   const sourceView = mount(<SourceView {...defaultProps} />);

--- a/pkg/ui/react-app/src/thanos/pages/blocks/SourceView.test.tsx
+++ b/pkg/ui/react-app/src/thanos/pages/blocks/SourceView.test.tsx
@@ -4,7 +4,7 @@ import { SourceView, SourceViewProps, BlocksRow } from './SourceView';
 import { sampleAPIResponse } from './__testdata__/testdata';
 import { sortBlocks } from './helpers';
 
-const sorted = sortBlocks(sampleAPIResponse.data.blocks, sampleAPIResponse.data.label);
+const sorted = sortBlocks(sampleAPIResponse.data.blocks, sampleAPIResponse.data.label, false);
 const source = 'prometheus_one';
 
 describe('Blocks SourceView', () => {
@@ -16,9 +16,6 @@ describe('Blocks SourceView', () => {
     },
     gridMinTime: 1596096000000,
     gridMaxTime: 1595108031471,
-    blockSearch: '',
-    findOverlapBlock: false,
-    overlapBlocks: new Set(),
   };
 
   const sourceView = mount(<SourceView {...defaultProps} />);

--- a/pkg/ui/react-app/src/thanos/pages/blocks/SourceView.tsx
+++ b/pkg/ui/react-app/src/thanos/pages/blocks/SourceView.tsx
@@ -2,16 +2,20 @@ import React, { FC } from 'react';
 import { Block, BlocksPool } from './block';
 import { BlockSpan } from './BlockSpan';
 import styles from './blocks.module.css';
+import { getBlockByUlid } from './helpers';
 
 export const BlocksRow: FC<{
   blocks: Block[];
   gridMinTime: number;
   gridMaxTime: number;
   selectBlock: React.Dispatch<React.SetStateAction<Block | undefined>>;
-}> = ({ blocks, gridMinTime, gridMaxTime, selectBlock }) => {
+  blockSearch: string;
+}> = ({ blocks, gridMinTime, gridMaxTime, selectBlock, blockSearch }) => {
+  const blockSearchValue = getBlockByUlid(blocks, blockSearch);
+
   return (
     <div className={styles.row}>
-      {blocks.map<JSX.Element>((b) => (
+      {blockSearchValue.map<JSX.Element>((b) => (
         <BlockSpan selectBlock={selectBlock} block={b} gridMaxTime={gridMaxTime} gridMinTime={gridMinTime} key={b.ulid} />
       ))}
     </div>
@@ -24,9 +28,10 @@ export interface SourceViewProps {
   gridMinTime: number;
   gridMaxTime: number;
   selectBlock: React.Dispatch<React.SetStateAction<Block | undefined>>;
+  blockSearch: string;
 }
 
-export const SourceView: FC<SourceViewProps> = ({ data, title, gridMaxTime, gridMinTime, selectBlock }) => {
+export const SourceView: FC<SourceViewProps> = ({ data, title, gridMaxTime, gridMinTime, selectBlock, blockSearch }) => {
   return (
     <>
       <div className={styles.source}>
@@ -43,6 +48,7 @@ export const SourceView: FC<SourceViewProps> = ({ data, title, gridMaxTime, grid
                   key={`${k}-${i}`}
                   gridMaxTime={gridMaxTime}
                   gridMinTime={gridMinTime}
+                  blockSearch={blockSearch}
                 />
               ))}
             </React.Fragment>

--- a/pkg/ui/react-app/src/thanos/pages/blocks/SourceView.tsx
+++ b/pkg/ui/react-app/src/thanos/pages/blocks/SourceView.tsx
@@ -2,34 +2,19 @@ import React, { FC } from 'react';
 import { Block, BlocksPool } from './block';
 import { BlockSpan } from './BlockSpan';
 import styles from './blocks.module.css';
-import { getBlockByUlid } from './helpers';
 
 export const BlocksRow: FC<{
   blocks: Block[];
   gridMinTime: number;
   gridMaxTime: number;
   selectBlock: React.Dispatch<React.SetStateAction<Block | undefined>>;
-  blockSearch: string;
-  overlappingBlocksId: Set<string>;
-  findOverlapBlock: boolean;
-}> = ({ blocks, gridMinTime, gridMaxTime, selectBlock, blockSearch, overlappingBlocksId, findOverlapBlock }) => {
-  const blockSearchValue = getBlockByUlid(blocks, blockSearch);
-
+}> = ({ blocks, gridMinTime, gridMaxTime, selectBlock }) => {
   return (
     <div className={styles.row}>
-      {blockSearchValue.map<JSX.Element | null>((b) => {
-        if (overlappingBlocksId.has(b.ulid) || !findOverlapBlock) {
-          return (
-            <BlockSpan
-              selectBlock={selectBlock}
-              block={b}
-              gridMaxTime={gridMaxTime}
-              gridMinTime={gridMinTime}
-              key={b.ulid}
-            />
-          );
-        }
-        return null;
+      {blocks.map<JSX.Element>((b) => {
+        return (
+          <BlockSpan selectBlock={selectBlock} block={b} gridMaxTime={gridMaxTime} gridMinTime={gridMinTime} key={b.ulid} />
+        );
       })}
     </div>
   );
@@ -41,21 +26,9 @@ export interface SourceViewProps {
   gridMinTime: number;
   gridMaxTime: number;
   selectBlock: React.Dispatch<React.SetStateAction<Block | undefined>>;
-  blockSearch: string;
-  findOverlapBlock: boolean;
-  overlapBlocks: Set<string>;
 }
 
-export const SourceView: FC<SourceViewProps> = ({
-  data,
-  title,
-  gridMaxTime,
-  gridMinTime,
-  selectBlock,
-  blockSearch,
-  findOverlapBlock,
-  overlapBlocks,
-}) => {
+export const SourceView: FC<SourceViewProps> = ({ data, title, gridMaxTime, gridMinTime, selectBlock }) => {
   return (
     <>
       <div className={styles.source}>
@@ -72,9 +45,6 @@ export const SourceView: FC<SourceViewProps> = ({
                   key={`${k}-${i}`}
                   gridMaxTime={gridMaxTime}
                   gridMinTime={gridMinTime}
-                  blockSearch={blockSearch}
-                  findOverlapBlock={findOverlapBlock}
-                  overlappingBlocksId={overlapBlocks}
                 />
               ))}
             </React.Fragment>

--- a/pkg/ui/react-app/src/thanos/pages/blocks/SourceView.tsx
+++ b/pkg/ui/react-app/src/thanos/pages/blocks/SourceView.tsx
@@ -11,11 +11,9 @@ export const BlocksRow: FC<{
 }> = ({ blocks, gridMinTime, gridMaxTime, selectBlock }) => {
   return (
     <div className={styles.row}>
-      {blocks.map<JSX.Element>((b) => {
-        return (
-          <BlockSpan selectBlock={selectBlock} block={b} gridMaxTime={gridMaxTime} gridMinTime={gridMinTime} key={b.ulid} />
-        );
-      })}
+      {blocks.map<JSX.Element>((b) => (
+        <BlockSpan selectBlock={selectBlock} block={b} gridMaxTime={gridMaxTime} gridMinTime={gridMinTime} key={b.ulid} />
+      ))}
     </div>
   );
 };

--- a/pkg/ui/react-app/src/thanos/pages/blocks/SourceView.tsx
+++ b/pkg/ui/react-app/src/thanos/pages/blocks/SourceView.tsx
@@ -10,15 +10,26 @@ export const BlocksRow: FC<{
   gridMaxTime: number;
   selectBlock: React.Dispatch<React.SetStateAction<Block | undefined>>;
   blockSearch: string;
-}> = ({ blocks, gridMinTime, gridMaxTime, selectBlock, blockSearch }) => {
+  overlappingBlocksId: Set<string>;
+  findOverlapBlock: boolean;
+}> = ({ blocks, gridMinTime, gridMaxTime, selectBlock, blockSearch, overlappingBlocksId, findOverlapBlock }) => {
   const blockSearchValue = getBlockByUlid(blocks, blockSearch);
 
   return (
     <div className={styles.row}>
-      {blockSearchValue.map<JSX.Element>((b) => {
-        return (
-          <BlockSpan selectBlock={selectBlock} block={b} gridMaxTime={gridMaxTime} gridMinTime={gridMinTime} key={b.ulid} />
-        );
+      {blockSearchValue.map<JSX.Element | null>((b) => {
+        if (overlappingBlocksId.has(b.ulid) || !findOverlapBlock) {
+          return (
+            <BlockSpan
+              selectBlock={selectBlock}
+              block={b}
+              gridMaxTime={gridMaxTime}
+              gridMinTime={gridMinTime}
+              key={b.ulid}
+            />
+          );
+        }
+        return null;
       })}
     </div>
   );
@@ -31,9 +42,20 @@ export interface SourceViewProps {
   gridMaxTime: number;
   selectBlock: React.Dispatch<React.SetStateAction<Block | undefined>>;
   blockSearch: string;
+  findOverlapBlock: boolean;
+  overlapBlocks: Set<string>;
 }
 
-export const SourceView: FC<SourceViewProps> = ({ data, title, gridMaxTime, gridMinTime, selectBlock, blockSearch }) => {
+export const SourceView: FC<SourceViewProps> = ({
+  data,
+  title,
+  gridMaxTime,
+  gridMinTime,
+  selectBlock,
+  blockSearch,
+  findOverlapBlock,
+  overlapBlocks,
+}) => {
   return (
     <>
       <div className={styles.source}>
@@ -51,6 +73,8 @@ export const SourceView: FC<SourceViewProps> = ({ data, title, gridMaxTime, grid
                   gridMaxTime={gridMaxTime}
                   gridMinTime={gridMinTime}
                   blockSearch={blockSearch}
+                  findOverlapBlock={findOverlapBlock}
+                  overlappingBlocksId={overlapBlocks}
                 />
               ))}
             </React.Fragment>

--- a/pkg/ui/react-app/src/thanos/pages/blocks/helpers.ts
+++ b/pkg/ui/react-app/src/thanos/pages/blocks/helpers.ts
@@ -143,21 +143,5 @@ export const getOverlappingBlocks = (blockPools: { [source: string]: BlocksPool 
     }
   });
 
-  // for (let i = 0; i < blocks.length; i++) {
-  //   if (blocks[i].length <= 1) {
-  //     continue;
-  //   }
-  //   for (let j = 0; j < blocks[i].length - 1; j++) {
-  //     for (let k = 0; k < blocks[i][j].length; k++) {
-  //       for (let l = 0; l < blocks[i][j + 1].length; l++) {
-  //         if (isOverlapping(blocks[i][j][k], blocks[i][j + 1][l])) {
-  //           result.add(blocks[i][j][k].ulid);
-  //           result.add(blocks[i][j + 1][l].ulid);
-  //         }
-  //       }
-  //     }
-  //   }
-  // }
-
   return result;
 };

--- a/pkg/ui/react-app/src/thanos/pages/blocks/helpers.ts
+++ b/pkg/ui/react-app/src/thanos/pages/blocks/helpers.ts
@@ -10,8 +10,8 @@ const stringify = (map: LabelSet): string => {
 };
 
 export const isOverlapping = (a: Block, b: Block): boolean => {
-  if (a.minTime <= b.minTime) return b.minTime < a.maxTime;
-  else return a.minTime < b.maxTime;
+  if (a?.minTime <= b?.minTime) return b?.minTime < a?.maxTime;
+  else return a?.minTime < b?.maxTime;
 };
 
 const determineRow = (block: Block, rows: Block[][], startWithRow: number): number => {
@@ -119,4 +119,45 @@ export const getBlockByUlid = (blocks: Block[], ulid: string): Block[] => {
 
   const blockResult = blocks.filter((block, index) => resultIndex.includes(index));
   return blockResult;
+};
+
+export const getOverlappingBlocks = (blockPools: { [source: string]: BlocksPool }): Set<string> => {
+  let result: Set<string> = new Set();
+
+  Object.keys(blockPools).forEach((pk) => {
+    let blocks = Object.values(blockPools[pk]);
+    for (let i = 0; i < blocks.length; i++) {
+      if (blocks[i].length <= 1) {
+        continue;
+      }
+      for (let j = 0; j < blocks[i].length - 1; j++) {
+        for (let k = 0; k < blocks[i][j].length; k++) {
+          for (let l = 0; l < blocks[i][j + 1].length; l++) {
+            if (isOverlapping(blocks[i][j][k], blocks[i][j + 1][l])) {
+              result.add(blocks[i][j][k].ulid);
+              result.add(blocks[i][j + 1][l].ulid);
+            }
+          }
+        }
+      }
+    }
+  });
+
+  // for (let i = 0; i < blocks.length; i++) {
+  //   if (blocks[i].length <= 1) {
+  //     continue;
+  //   }
+  //   for (let j = 0; j < blocks[i].length - 1; j++) {
+  //     for (let k = 0; k < blocks[i][j].length; k++) {
+  //       for (let l = 0; l < blocks[i][j + 1].length; l++) {
+  //         if (isOverlapping(blocks[i][j][k], blocks[i][j + 1][l])) {
+  //           result.add(blocks[i][j][k].ulid);
+  //           result.add(blocks[i][j + 1][l].ulid);
+  //         }
+  //       }
+  //     }
+  //   }
+  // }
+
+  return result;
 };

--- a/pkg/ui/react-app/src/thanos/pages/blocks/helpers.ts
+++ b/pkg/ui/react-app/src/thanos/pages/blocks/helpers.ts
@@ -39,7 +39,7 @@ const splitOverlappingBlocks = (blocks: Block[]): Block[][] => {
   return rows;
 };
 
-const sortBlocksInRows = (blocks: Block[], findOverlapBlocks: boolean): BlocksPool => {
+const sortBlocksInRows = (blocks: Block[], findOverlappingBlocks: boolean): BlocksPool => {
   const poolWithOverlaps: { [key: string]: Block[] } = {};
 
   blocks
@@ -62,7 +62,7 @@ const sortBlocksInRows = (blocks: Block[], findOverlapBlocks: boolean): BlocksPo
   const pool: BlocksPool = {};
 
   Object.entries(poolWithOverlaps).forEach(([key, blks]) => {
-    if (findOverlapBlocks) {
+    if (findOverlappingBlocks) {
       let maxTime = 0;
       const filteredOverlap = blks.filter((value, index) => {
         const isOverlap = maxTime > value.minTime;
@@ -80,7 +80,11 @@ const sortBlocksInRows = (blocks: Block[], findOverlapBlocks: boolean): BlocksPo
   return pool;
 };
 
-export const sortBlocks = (blocks: Block[], label: string, findOverlapBlocks: boolean): { [source: string]: BlocksPool } => {
+export const sortBlocks = (
+  blocks: Block[],
+  label: string,
+  findOverlappingBlocks: boolean
+): { [source: string]: BlocksPool } => {
   const titles: { [key: string]: string } = {};
   const pool: { [key: string]: Block[] } = {};
 
@@ -107,7 +111,7 @@ export const sortBlocks = (blocks: Block[], label: string, findOverlapBlocks: bo
 
   const sortedPool: { [source: string]: BlocksPool } = {};
   Object.keys(pool).forEach((k) => {
-    sortedPool[k] = sortBlocksInRows(pool[k], findOverlapBlocks);
+    sortedPool[k] = sortBlocksInRows(pool[k], findOverlappingBlocks);
   });
   return sortedPool;
 };


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

This PR is part of LFX Mentorship project to improve Block Viewer UI (issue: #3112). We want to add feature so user can find overlapping blocks easily.

## Verification
When we haven't enable find overlapping block yet:
![image](https://user-images.githubusercontent.com/19685008/129063958-e898eb1d-aba3-4956-82cb-47bb9365d577.png)

Example `enable find overlapping block`:

![image](https://user-images.githubusercontent.com/19685008/129063893-6d847fad-0253-4b9e-9106-7c95dd91e5ac.png)

Tested on local using `make quickstart`


cc: @onprem @squat 