### PR TITLE
.*: Apply webrouteprefix on debug and metric endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 
 ### Fixed
 
+- [#4471](https://github.com/thanos-io/thanos/pull/4471) **breaking:** if `--web.route-prefix` or `--web.external-prefix` is set: Serve `/debug/*`, `/-/ready`, `/-/healthy`, and `/metrics` routes under the prefix from `--web.route-prefix`. Previously, these endpoints were served from the root URL.
+
 ### Added
 
 - [#5220](https://github.com/thanos-io/thanos/pull/5220) Query Frontend: Add `--query-frontend.forward-header` flag, forward headers to downstream querier.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 
 ### Fixed
 
-- [#4471](https://github.com/thanos-io/thanos/pull/4471) **breaking:** if `--web.route-prefix` or `--web.external-prefix` is set: Serve `/debug/*`, `/-/ready`, `/-/healthy`, and `/metrics` routes under the prefix from `--web.route-prefix`. Previously, these endpoints were served from the root URL.
+- [#4471](https://github.com/thanos-io/thanos/pull/4471) Compact, Query, Rule, Store: *breaking :warning:* If `--web.route-prefix` or `--web.external-prefix` is set, serve `/debug/*`, `/-/ready`, `/-/healthy`, and `/metrics` routes under the prefix from `--web.route-prefix`. Previously, these endpoints were served from the root URL even when the rest of the app was served from a subpath.
 
 ### Added
 

--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -180,7 +180,7 @@ func runCompact(
 		prober.NewInstrumentation(component, logger, extprom.WrapRegistererWithPrefix("thanos_", reg)),
 	)
 
-	srv := httpserver.New(logger, reg, component, httpProbe,
+	srv := httpserver.New(logger, reg, component, conf.webConf.routePrefix, httpProbe,
 		httpserver.WithListen(conf.http.bindAddress),
 		httpserver.WithGracePeriod(time.Duration(conf.http.gracePeriod)),
 		httpserver.WithTLSConfig(conf.http.tlsConfig),

--- a/cmd/thanos/downsample.go
+++ b/cmd/thanos/downsample.go
@@ -145,7 +145,7 @@ func RunDownsample(
 		})
 	}
 
-	srv := httpserver.New(logger, reg, comp, httpProbe,
+	srv := httpserver.New(logger, reg, comp, "/", httpProbe,
 		httpserver.WithListen(httpBindAddr),
 		httpserver.WithGracePeriod(httpGracePeriod),
 		httpserver.WithTLSConfig(httpTLSConfig),

--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -633,7 +633,7 @@ func runQuery(
 
 		api.Register(router.WithPrefix("/api/v1"), tracer, logger, ins, logMiddleware)
 
-		srv := httpserver.New(logger, reg, comp, httpProbe,
+		srv := httpserver.New(logger, reg, comp, webRoutePrefix, httpProbe,
 			httpserver.WithListen(httpBindAddr),
 			httpserver.WithGracePeriod(httpGracePeriod),
 			httpserver.WithTLSConfig(httpTLSConfig),

--- a/cmd/thanos/query_frontend.go
+++ b/cmd/thanos/query_frontend.go
@@ -268,7 +268,7 @@ func runQueryFrontend(
 
 	// Start metrics HTTP server.
 	{
-		srv := httpserver.New(logger, reg, comp, httpProbe,
+		srv := httpserver.New(logger, reg, comp, "/", httpProbe,
 			httpserver.WithListen(cfg.http.bindAddress),
 			httpserver.WithGracePeriod(time.Duration(cfg.http.gracePeriod)),
 			httpserver.WithTLSConfig(cfg.http.tlsConfig),

--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -240,7 +240,7 @@ func runReceive(
 
 	level.Debug(logger).Log("msg", "setting up http server")
 	{
-		srv := httpserver.New(logger, reg, comp, httpProbe,
+		srv := httpserver.New(logger, reg, comp, "/", httpProbe,
 			httpserver.WithListen(*conf.httpBindAddr),
 			httpserver.WithGracePeriod(time.Duration(*conf.httpGracePeriod)),
 			httpserver.WithTLSConfig(*conf.httpTLSConfig),

--- a/cmd/thanos/rule.go
+++ b/cmd/thanos/rule.go
@@ -664,7 +664,7 @@ func runRule(
 		api := v1.NewRuleAPI(logger, reg, thanosrules.NewGRPCClient(ruleMgr), ruleMgr, conf.web.disableCORS, flagsMap)
 		api.Register(router.WithPrefix("/api/v1"), tracer, logger, ins, logMiddleware)
 
-		srv := httpserver.New(logger, reg, comp, httpProbe,
+		srv := httpserver.New(logger, reg, comp, conf.web.routePrefix, httpProbe,
 			httpserver.WithListen(conf.http.bindAddress),
 			httpserver.WithGracePeriod(time.Duration(conf.http.gracePeriod)),
 			httpserver.WithTLSConfig(conf.http.tlsConfig),

--- a/cmd/thanos/sidecar.go
+++ b/cmd/thanos/sidecar.go
@@ -132,7 +132,7 @@ func runSidecar(
 		prober.NewInstrumentation(comp, logger, extprom.WrapRegistererWithPrefix("thanos_", reg)),
 	)
 
-	srv := httpserver.New(logger, reg, comp, httpProbe,
+	srv := httpserver.New(logger, reg, comp, "/", httpProbe,
 		httpserver.WithListen(conf.http.bindAddress),
 		httpserver.WithGracePeriod(time.Duration(conf.http.gracePeriod)),
 		httpserver.WithTLSConfig(conf.http.tlsConfig),

--- a/cmd/thanos/store.go
+++ b/cmd/thanos/store.go
@@ -225,7 +225,7 @@ func runStore(
 		prober.NewInstrumentation(conf.component, logger, extprom.WrapRegistererWithPrefix("thanos_", reg)),
 	)
 
-	srv := httpserver.New(logger, reg, conf.component, httpProbe,
+	srv := httpserver.New(logger, reg, conf.component, conf.webConfig.routePrefix, httpProbe,
 		httpserver.WithListen(conf.httpConfig.bindAddress),
 		httpserver.WithGracePeriod(time.Duration(conf.httpConfig.gracePeriod)),
 		httpserver.WithTLSConfig(conf.httpConfig.tlsConfig),

--- a/cmd/thanos/store.go
+++ b/cmd/thanos/store.go
@@ -80,6 +80,7 @@ type storeConfig struct {
 func (sc *storeConfig) registerFlag(cmd extkingpin.FlagClause) {
 	sc.httpConfig = *sc.httpConfig.registerFlag(cmd)
 	sc.grpcConfig = *sc.grpcConfig.registerFlag(cmd)
+	sc.webConfig = *sc.webConfig.registerFlag(cmd)
 
 	cmd.Flag("data-dir", "Local data directory used for caching purposes (index-header, in-mem cache items and meta.jsons). If removed, no data will be lost, just store will have to rebuild the cache. NOTE: Putting raw blocks here will not cause the store to read them. For such use cases use Prometheus + sidecar.").
 		Default("./data").StringVar(&sc.dataDir)
@@ -156,15 +157,6 @@ func (sc *storeConfig) registerFlag(cmd extkingpin.FlagClause) {
 
 	cmd.Flag("store.index-header-lazy-reader-idle-timeout", "If index-header lazy reader is enabled and this idle timeout setting is > 0, memory map-ed index-headers will be automatically released after 'idle timeout' inactivity.").
 		Hidden().Default("5m").DurationVar(&sc.lazyIndexReaderIdleTimeout)
-
-	cmd.Flag("web.external-prefix", "Static prefix for all HTML links and redirect URLs in the bucket web UI interface. Actual endpoints are still served on / or the web.route-prefix. This allows thanos bucket web UI to be served behind a reverse proxy that strips a URL sub-path.").
-		Default("").StringVar(&sc.webConfig.externalPrefix)
-
-	cmd.Flag("web.prefix-header", "Name of HTTP request header used for dynamic prefixing of UI links and redirects. This option is ignored if web.external-prefix argument is set. Security risk: enable this option only if a reverse proxy in front of thanos is resetting the header. The --web.prefix-header=X-Forwarded-Prefix option can be useful, for example, if Thanos UI is served via Traefik reverse proxy with PathPrefixStrip option enabled, which sends the stripped prefix value in X-Forwarded-Prefix header. This allows thanos UI to be served on a sub-path.").
-		Default("").StringVar(&sc.webConfig.prefixHeaderName)
-
-	cmd.Flag("web.disable-cors", "Whether to disable CORS headers to be set by Thanos. By default Thanos sets CORS headers to be allowed by all.").
-		Default("false").BoolVar(&sc.webConfig.disableCORS)
 
 	sc.reqLogConfig = extkingpin.RegisterRequestLoggingFlags(cmd)
 }

--- a/cmd/thanos/tools_bucket.go
+++ b/cmd/thanos/tools_bucket.go
@@ -552,7 +552,7 @@ func registerBucketWeb(app extkingpin.AppClause, objStoreConfig *extflag.PathOrC
 			prober.NewInstrumentation(comp, logger, extprom.WrapRegistererWithPrefix("thanos_", reg)),
 		)
 
-		srv := httpserver.New(logger, reg, comp, httpProbe,
+		srv := httpserver.New(logger, reg, comp, "/", httpProbe,
 			httpserver.WithListen(*httpBindAddr),
 			httpserver.WithGracePeriod(time.Duration(*httpGracePeriod)),
 			httpserver.WithTLSConfig(*httpTLSConfig),

--- a/docs/components/store.md
+++ b/docs/components/store.md
@@ -211,6 +211,10 @@ Flags:
                                  stripped prefix value in X-Forwarded-Prefix
                                  header. This allows thanos UI to be served on a
                                  sub-path.
+      --web.route-prefix=""      Prefix for API and UI endpoints. This allows
+                                 thanos UI to be served on a sub-path. This
+                                 option is analogous to --web.route-prefix of
+                                 Prometheus.
 
 ```
 

--- a/pkg/cache/groupcache_test.go
+++ b/pkg/cache/groupcache_test.go
@@ -48,10 +48,10 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 
-	httpServer := httpserver.New(log.NewNopLogger(), nil, component.Bucket, &prober.HTTPProbe{},
+	httpServer := httpserver.New(log.NewNopLogger(), nil, component.Bucket, "/", &prober.HTTPProbe{},
 		httpserver.WithListen("0.0.0.0:12345"))
 	httpServer.Handle("/", router)
-	httpServerH2C := httpserver.New(log.NewNopLogger(), nil, component.Bucket, &prober.HTTPProbe{},
+	httpServerH2C := httpserver.New(log.NewNopLogger(), nil, component.Bucket, "/", &prober.HTTPProbe{},
 		httpserver.WithListen("0.0.0.0:12346"), httpserver.WithEnableH2C(true))
 	httpServerH2C.Handle("/", router)
 

--- a/pkg/replicate/replicator.go
+++ b/pkg/replicate/replicator.go
@@ -98,7 +98,8 @@ func RunReplicate(
 		prober.NewInstrumentation(component.Replicate, logger, extprom.WrapRegistererWithPrefix("thanos_", reg)),
 	)
 
-	s := http.New(logger, reg, component.Replicate, httpProbe,
+	s := http.New(logger, reg, component.Replicate, "/",
+		httpProbe,
 		http.WithListen(httpBindAddr),
 		http.WithGracePeriod(httpGracePeriod),
 		http.WithTLSConfig(httpTLSConfig),

--- a/pkg/server/http/http.go
+++ b/pkg/server/http/http.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/pprof"
+	"path"
 
 	"github.com/felixge/fgprof"
 	"github.com/go-kit/log"
@@ -35,7 +36,7 @@ type Server struct {
 }
 
 // New creates a new Server.
-func New(logger log.Logger, reg *prometheus.Registry, comp component.Component, prober *prober.HTTPProbe, opts ...Option) *Server {
+func New(logger log.Logger, reg *prometheus.Registry, comp component.Component, webRoutePrefix string, prober *prober.HTTPProbe, opts ...Option) *Server {
 	options := options{}
 	for _, o := range opts {
 		o.apply(&options)
@@ -46,9 +47,9 @@ func New(logger log.Logger, reg *prometheus.Registry, comp component.Component, 
 		mux = options.mux
 	}
 
-	registerMetrics(mux, reg)
-	registerProbes(mux, prober, logger)
-	registerProfiler(mux)
+	registerMetrics(mux, reg, webRoutePrefix)
+	registerProbes(mux, prober, logger, webRoutePrefix)
+	registerProfiler(mux, webRoutePrefix)
 
 	var h http.Handler
 	if options.enableH2C {
@@ -108,26 +109,26 @@ func (s *Server) Handle(pattern string, handler http.Handler) {
 	s.mux.Handle(pattern, handler)
 }
 
-func registerProfiler(mux *http.ServeMux) {
-	mux.HandleFunc("/debug/pprof/", pprof.Index)
-	mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
-	mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
-	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
-	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
-	mux.Handle("/debug/fgprof", fgprof.Handler())
+func registerProfiler(mux *http.ServeMux, webRoutePrefix string) {
+	mux.HandleFunc(path.Join(webRoutePrefix, "/debug/pprof/"), pprof.Index)
+	mux.HandleFunc(path.Join(webRoutePrefix, "/debug/pprof/cmdline"), pprof.Cmdline)
+	mux.HandleFunc(path.Join(webRoutePrefix, "/debug/pprof/profile"), pprof.Profile)
+	mux.HandleFunc(path.Join(webRoutePrefix, "/debug/pprof/symbol"), pprof.Symbol)
+	mux.HandleFunc(path.Join(webRoutePrefix, "/debug/pprof/trace"), pprof.Trace)
+	mux.Handle(path.Join(webRoutePrefix, "/debug/fgprof"), fgprof.Handler())
 }
 
-func registerMetrics(mux *http.ServeMux, g prometheus.Gatherer) {
+func registerMetrics(mux *http.ServeMux, g prometheus.Gatherer, webRoutePrefix string) {
 	if g != nil {
-		mux.Handle("/metrics", promhttp.HandlerFor(g, promhttp.HandlerOpts{
+		mux.Handle(path.Join(webRoutePrefix, "/metrics"), promhttp.HandlerFor(g, promhttp.HandlerOpts{
 			EnableOpenMetrics: true,
 		}))
 	}
 }
 
-func registerProbes(mux *http.ServeMux, p *prober.HTTPProbe, logger log.Logger) {
+func registerProbes(mux *http.ServeMux, p *prober.HTTPProbe, logger log.Logger, webRoutePrefix string) {
 	if p != nil {
-		mux.Handle("/-/healthy", p.HealthyHandler(logger))
-		mux.Handle("/-/ready", p.ReadyHandler(logger))
+		mux.Handle(path.Join(webRoutePrefix, "/-/healthy"), p.HealthyHandler(logger))
+		mux.Handle(path.Join(webRoutePrefix, "/-/ready"), p.ReadyHandler(logger))
 	}
 }

--- a/test/e2e/compact_test.go
+++ b/test/e2e/compact_test.go
@@ -871,7 +871,7 @@ func TestCompactRoutePrefix(t *testing.T) {
 	e, err := e2e.NewDockerEnvironment(name)
 	testutil.Ok(t, err)
 	t.Cleanup(e2ethanos.CleanScenario(t, e))
-	routePrefix := "test"
+	routePrefix := t.Name()
 
 	dir := filepath.Join(e.SharedDir(), "tmp")
 	testutil.Ok(t, os.MkdirAll(dir, os.ModePerm))
@@ -886,7 +886,7 @@ func TestCompactRoutePrefix(t *testing.T) {
 		Config: e2ethanos.NewS3Config(bucket, m.InternalEndpoint("https"), e2ethanos.ContainerSharedDir),
 	}
 
-	c, err := e2ethanos.NewCompactor(e, "expect-to-halt", svcConfig, nil, "--web.external-prefix=test", "--web.route-prefix=test")
+	c, err := e2ethanos.NewCompactor(e, "expect-to-halt", svcConfig, nil, "--web.external-prefix="+routePrefix, "--web.route-prefix="+routePrefix)
 	testutil.Ok(t, err)
 
 	// Not using e2e.StartAndWaitReady(c) because the health check will fail since its path is not prefixed.

--- a/test/e2e/e2ethanos/services.go
+++ b/test/e2e/e2ethanos/services.go
@@ -14,6 +14,7 @@ import (
 	"math/big"
 	"net"
 	"os"
+	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -274,11 +275,16 @@ func (q *QuerierBuilder) Initiate(service e2e.InstrumentedRunnableBuilder, store
 		return nil, err
 	}
 
+	// Query defaults to using --web.external-prefix when --web.route-prefix is not set.
+	if q.routePrefix == "" {
+		q.routePrefix = q.externalPrefix
+	}
+
 	querier := initiateService(
 		service,
 		q.image,
 		e2e.NewCommand("query", args...),
-		e2e.NewHTTPReadinessProbe("http", "/-/ready", 200, 200),
+		e2e.NewHTTPReadinessProbe("http", path.Join("/", q.routePrefix, "/-/ready"), 200, 200),
 	)
 
 	return querier, nil
@@ -290,12 +296,17 @@ func (q *QuerierBuilder) Build() (e2e.InstrumentedRunnable, error) {
 		return nil, err
 	}
 
+	// Query defaults to using --web.external-prefix when --web.route-prefix is not set.
+	if q.routePrefix == "" {
+		q.routePrefix = q.externalPrefix
+	}
+
 	querier := NewService(
 		q.environment,
 		fmt.Sprintf("querier-%v", q.name),
 		q.image,
 		e2e.NewCommand("query", args...),
-		e2e.NewHTTPReadinessProbe("http", "/-/ready", 200, 200),
+		e2e.NewHTTPReadinessProbe("http", path.Join("/", q.routePrefix, "/-/ready"), 200, 200),
 		8080,
 		9091,
 	)

--- a/test/e2e/rule_test.go
+++ b/test/e2e/rule_test.go
@@ -574,7 +574,7 @@ func TestRuleRoutePrefix(t *testing.T) {
 	testutil.Ok(t, err)
 	t.Cleanup(e2ethanos.CleanScenario(t, e))
 
-	routePrefix := "test"
+	routePrefix := t.Name()
 
 	r, err := e2ethanos.NewTSDBRuler(e, "1", "/tmp", routePrefix, []alert.AlertmanagerConfig{}, []httpconfig.Config{
 		{

--- a/test/e2e/rules_api_test.go
+++ b/test/e2e/rules_api_test.go
@@ -78,9 +78,9 @@ func TestRulesAPI_Fanout(t *testing.T) {
 	}
 
 	// Recreate rulers with the corresponding query config.
-	r1, err := e2ethanos.NewTSDBRuler(e, "rule1", thanosRulesSubDir, nil, queryCfg)
+	r1, err := e2ethanos.NewTSDBRuler(e, "rule1", thanosRulesSubDir, "", nil, queryCfg)
 	testutil.Ok(t, err)
-	r2, err := e2ethanos.NewTSDBRuler(e, "rule2", thanosRulesSubDir, nil, queryCfg)
+	r2, err := e2ethanos.NewTSDBRuler(e, "rule2", thanosRulesSubDir, "", nil, queryCfg)
 	testutil.Ok(t, err)
 	testutil.Ok(t, e2e.StartAndWaitReady(r1, r2))
 

--- a/test/e2e/store_gateway_test.go
+++ b/test/e2e/store_gateway_test.go
@@ -542,7 +542,7 @@ func TestStoreGatewayRoutePrefix(t *testing.T) {
 	testutil.Ok(t, err)
 	t.Cleanup(e2ethanos.CleanScenario(t, e))
 
-	routePrefix := "test"
+	routePrefix := t.Name()
 
 	const bucket = "store_gateway_test"
 	m, err := e2ethanos.NewMinio(e, "thanos-minio", bucket)
@@ -557,7 +557,7 @@ func TestStoreGatewayRoutePrefix(t *testing.T) {
 			Config: e2ethanos.NewS3Config(bucket, m.InternalEndpoint("https"), e2ethanos.ContainerSharedDir),
 		},
 		"",
-		[]string{"--web.route-prefix=test", "--web.external-prefix=test"},
+		[]string{"--web.route-prefix=" + t.Name(), "--web.external-prefix=" + t.Name()},
 	)
 	testutil.Ok(t, err)
 	testutil.Ok(t, s.Start())

--- a/test/e2e/tools_bucket_web_test.go
+++ b/test/e2e/tools_bucket_web_test.go
@@ -111,7 +111,7 @@ func TestToolsBucketWebExternalPrefixAndRoutePrefix(t *testing.T) {
 	t.Cleanup(e2ethanos.CleanScenario(t, e))
 
 	externalPrefix := "testThanos"
-	routePrefix := "test"
+	routePrefix := t.Name()
 	const bucket = "toolsBucketWeb_test"
 	m, err := e2ethanos.NewMinio(e, "thanos", bucket)
 	testutil.Ok(t, err)


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

Fixes https://github.com/thanos-io/thanos/issues/2727

## Changes

This is a continuation of the work started by @ranjithkumar007 in https://github.com/thanos-io/thanos/pull/2524.

I've completed the rebase, fixed prefix handling in Thanos Store, added prefix handling logic to Thanos Compact (the flags were there but ignored, previously), and added additional testing around prefix behaviors in e2e tests.

Related issues:

- https://github.com/thanos-io/thanos/issues/2486
- https://github.com/thanos-io/thanos/issues/1700
    - Note: @bwplotka [advocated for](https://github.com/thanos-io/thanos/issues/1700#issuecomment-548482922) keeping the prefix off of these endpoints in this issue, but I agree with @FUSAKLA's [opinion](https://github.com/thanos-io/thanos/issues/1700#issuecomment-552018897) that it's making a decision for the user.
    - I think it's simpler to serve the whole app as specified via the command line flags, and users may block endpoints that they do not want others to access (same as if they don't prefix the routes).
    - Prometheus prefixes all endpoints (including /metrics and /debug/*), so this PR makes Thanos consistent with that.
- https://github.com/thanos-io/thanos/issues/3260

Essentially, it prefixes the debug and metrics endpoints with the value of `--web.route-prefix` if available.

For those like me who have Thanos components behind a reverse proxy (e.g. `https://example.com/thanos/query`) then this will *break* their access to some endpoints (e.g. `/metrics`, `/-/ready` and `/-/healthy`) if they hard coded around it like we did (see below).

Bad:
```
   # This will break
    location = /thanos/query/metrics {
       proxy_pass http://127.0.0.1:10902/metrics;
    }
```

Good:
```
   # This will work
    location /thanos/query/ {
        proxy_pass http://127.0.0.1:10902/thanos/query/;
    }
```

## Verification

<!-- How you tested it? How do you know it works? -->
Verified with local tests and deployment of a build to our own servers to verify that the endpoints are served as expected both with and without `--web.external-prefix` (and thereby `--web.route-prefix`) being set.

Additionally, added more e2e tests to verify this works as expected on the components that support setting a prefix.