### PR TITLE
fix: incorrect html escape sequence used for '>' symbol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 
 ### Fixed
 
+- [#4476](https://github.com/thanos-io/thanos/pull/4476) UI: fix incorrect html escape sequence used for '>' symbol.
+
 ### Changed
 
 ## [v0.22.0](https://github.com/thanos-io/thanos/tree/release-0.22) - 2021.07.22

--- a/pkg/ui/react-app/src/pages/alerts/AlertContents.tsx
+++ b/pkg/ui/react-app/src/pages/alerts/AlertContents.tsx
@@ -85,7 +85,7 @@ const AlertsContent: FC<AlertsProps> = ({ groups = [], statsCount }) => {
         return hasFilterOn ? (
           <Fragment key={i}>
             <GroupInfo rules={group.rules}>
-              {group.file} &gt {group.name}
+              {group.file} &gt; {group.name}
             </GroupInfo>
             {group.rules.map((rule, j) => {
               return (


### PR DESCRIPTION
Signed-off-by: Arunprasad Rajkumar <arajkuma@redhat.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->
Added correct escape sequence \&gt; to represent > from html.

## Verification

Manual, refer the attached screen shots,

### Before

<img width="509" alt="Screenshot 2021-07-23 at 3 39 15 PM" src="https://user-images.githubusercontent.com/3874763/126767823-a62abbb1-eeef-4ba6-9240-31d006c366db.png">

### After
<img width="680" alt="Screenshot 2021-07-23 at 3 38 37 PM" src="https://user-images.githubusercontent.com/3874763/126767768-ba86ec73-be4e-40a7-9eb3-5b335540d9f8.png">
<!-- How you tested it? How do you know it works? -->
