### PR TITLE
docs: update relabeling for Thanos Ruler

### DIFF
--- a/docs/components/rule.md
+++ b/docs/components/rule.md
@@ -197,14 +197,14 @@ On HTTP address Ruler exposes its UI that shows mainly Alerts and Rules page (si
 
 ## Ruler HA
 
-Ruler aims to use a similar approach to the one that Prometheus has. You can configure external labels, as well as simple relabelling.
+Ruler aims to use a similar approach to the one that Prometheus has. You can configure external labels, as well as relabelling.
 
 In case of Ruler in HA you need to make sure you have the following labelling setup:
 
 * Labels that identify the HA group ruler and replica label with different value for each ruler instance, e.g: `cluster="eu1", replica="A"` and `cluster=eu1, replica="B"` by using `--label` flag.
 * Labels that need to be dropped just before sending to alermanager in order for alertmanager to deduplicate alerts e.g `--alert.label-drop="replica"`.
 
-Full relabelling is planned to be done in future and is tracked here: https://github.com/thanos-io/thanos/issues/660
+Advanced relabelling configuration is possible with the `--alert.relabel-config` and `--alert.relabel-config-file` flags. The configuration format is identical to the [`alert_relabel_configs`](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#alert_relabel_configs) field of Prometheus. Note that Thanos Ruler drops the labels listed in `--alert.label-drop` before alert relabelling.
 
 ## Flags
 


### PR DESCRIPTION

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [X] Change is not relevant to the end user.

## Changes

Advanced relabeling is possible since commit 745f0f3d. This change
updates the documentation to reflect the reality.

## Verification

No functional change.
