### PR TITLE
Fix make test installing prometheus 2.4.3 error

### DIFF
--- a/.bingo/prometheus.mod
+++ b/.bingo/prometheus.mod
@@ -9,6 +9,7 @@ replace (
 	github.com/cockroachdb/cmux => github.com/cockroachdb/cmux v0.0.0-20170110192607-30d10be49292
 	github.com/cockroachdb/cockroach => github.com/cockroachdb/cockroach v0.0.0-20170608034007-84bc9597164f
 	github.com/googleapis/gnostic => github.com/googleapis/gnostic v0.2.3-0.20180520015035-48a0ecefe2e4
+	github.com/gophercloud/gophercloud => github.com/gophercloud/gophercloud v0.18.0
 	github.com/miekg/dns => github.com/miekg/dns v1.0.4
 	github.com/prometheus/client_golang => github.com/prometheus/client_golang v0.9.0-pre1.0.20180607123607-faf4ec335fe0
 	github.com/prometheus/common => github.com/prometheus/common v0.0.0-20180518154759-7600349dcfe1


### PR DESCRIPTION
Signed-off-by: hanjm <hanjinming@outlook.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

Thanos project CI make test  error, i found the root cause is the `github.com/gophercloud/gophercloud` release a new [incompatible version two days ago] (https://github.com/gophercloud/gophercloud/releases/tag/v0.19.0).  
```
# github.com/prometheus/prometheus/discovery/openstack
../../../../go/pkg/mod/github.com/prometheus/prometheus@v2.4.3+incompatible/discovery/openstack/hypervisor.go:119:38: not enough arguments in call to hypervisors.List
        have (*gophercloud.ServiceClient)
        want (*gophercloud.ServiceClient, hypervisors.ListOptsBuilder)
make: *** [/Users/jimmiehan/go/bin/prometheus-v2.4.3+incompatible] Error 2
```
need replace it in go.mod .

## Verification

<!-- How you tested it? How do you know it works? -->
run make test.