### PR TITLE
COS: Add http_config for cos object store client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 
 ### Added
 - [#4453](https://github.com/thanos-io/thanos/pull/4453) Tools: Add flag `--selector.relabel-config-file` / `--selector.relabel-config` / `--max-time` / `--min-time` to filter served blocks.
+- [#4482](https://github.com/thanos-io/thanos/pull/4482) COS: Add http_config for cos object store client.
 
 ### Fixed
 

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -389,6 +389,14 @@ config:
   app_id: ""
   secret_key: ""
   secret_id: ""
+  http_config:
+    idle_conn_timeout: 1m30s
+    response_header_timeout: 2m
+    tls_handshake_timeout: 10s
+    expect_continue_timeout: 1s
+    max_idle_conns: 100
+    max_idle_conns_per_host: 100
+    max_conns_per_host: 0
 ```
 
 Set the flags `--objstore.config-file` to reference to the configuration file.

--- a/pkg/objstore/cos/cos_test.go
+++ b/pkg/objstore/cos/cos_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
 package cos
 
 import (

--- a/pkg/objstore/cos/cos_test.go
+++ b/pkg/objstore/cos/cos_test.go
@@ -1,0 +1,61 @@
+package cos
+
+import (
+	"testing"
+	"time"
+
+	"github.com/prometheus/common/model"
+	"github.com/thanos-io/thanos/pkg/testutil"
+)
+
+func Test_parseConfig(t *testing.T) {
+	type args struct {
+		conf []byte
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    Config
+		wantErr bool
+	}{
+		{
+			name: "empty",
+			args: args{
+				conf: []byte(""),
+			},
+			want:    DefaultConfig,
+			wantErr: false,
+		},
+		{
+			name: "max_idle_conns",
+			args: args{
+				conf: []byte(`
+http_config:
+  max_idle_conns: 200
+`),
+			},
+			want: Config{
+				HTTPConfig: HTTPConfig{
+					IdleConnTimeout:       model.Duration(90 * time.Second),
+					ResponseHeaderTimeout: model.Duration(2 * time.Minute),
+					TLSHandshakeTimeout:   model.Duration(10 * time.Second),
+					ExpectContinueTimeout: model.Duration(1 * time.Second),
+					MaxIdleConns:          200,
+					MaxIdleConnsPerHost:   100,
+					MaxConnsPerHost:       0,
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseConfig(tt.args.conf)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseConfig() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			testutil.Equals(t, tt.want, got)
+		})
+	}
+}

--- a/scripts/cfggen/main.go
+++ b/scripts/cfggen/main.go
@@ -49,7 +49,7 @@ var (
 		client.GCS:        gcs.Config{},
 		client.S3:         s3.DefaultConfig,
 		client.SWIFT:      swift.DefaultConfig,
-		client.COS:        cos.Config{},
+		client.COS:        cos.DefaultConfig,
 		client.ALIYUNOSS:  oss.Config{},
 		client.FILESYSTEM: filesystem.Config{},
 	}


### PR DESCRIPTION
Fix #4479

The http.Transport is not auto-tuning and one size does not seem to fit all cases.
Add `HTTPConfig` Allow to tune most of the http.Transport parameters and `MaxIdleConnsPerHost` tune to 100.

Signed-off-by: hanjm <hanjinming@outlook.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->
add http_config for cos storage.
## Verification

<!-- How you tested it? How do you know it works? -->
unit test .
redeploy thanos tools bucket web, no TIME_WAIT connection.