### PR TITLE
Automatic certificate rotation without restart

### DIFF
--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -58,7 +58,7 @@ func registerQuery(app *extkingpin.App) {
 	cmd := app.Command(comp.String(), "Query node exposing PromQL enabled Query API with data retrieved from multiple store nodes.")
 
 	httpBindAddr, httpGracePeriod, httpTLSConfig := extkingpin.RegisterHTTPFlags(cmd)
-	grpcBindAddr, grpcGracePeriod, grpcCert, grpcKey, grpcClientCA := extkingpin.RegisterGRPCFlags(cmd)
+	grpcBindAddr, grpcGracePeriod, grpcCert, grpcKey, grpcClientCA, grpcMaxConnAge := extkingpin.RegisterGRPCFlags(cmd)
 
 	secure := cmd.Flag("grpc-client-tls-secure", "Use TLS when talking to the gRPC server").Default("false").Bool()
 	skipVerify := cmd.Flag("grpc-client-tls-skip-verify", "Disable TLS certificate verification i.e self signed, signed by fake CA").Default("false").Bool()
@@ -220,6 +220,7 @@ func registerQuery(app *extkingpin.App) {
 			*grpcCert,
 			*grpcKey,
 			*grpcClientCA,
+			*grpcMaxConnAge,
 			*secure,
 			*skipVerify,
 			*cert,
@@ -281,6 +282,7 @@ func runQuery(
 	grpcCert string,
 	grpcKey string,
 	grpcClientCA string,
+	grpcMaxConnAge time.Duration,
 	secure bool,
 	skipVerify bool,
 	cert string,
@@ -626,6 +628,7 @@ func runQuery(
 			grpcserver.WithListen(grpcBindAddr),
 			grpcserver.WithGracePeriod(grpcGracePeriod),
 			grpcserver.WithTLSConfig(tlsCfg),
+			grpcserver.WithMaxConnAge(grpcMaxConnAge),
 		)
 
 		g.Add(func() error {

--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -328,6 +328,7 @@ func setupAndRunGRPCServer(g *run.Group,
 				grpcserver.WithListen(*conf.grpcBindAddr),
 				grpcserver.WithGracePeriod(time.Duration(*conf.grpcGracePeriod)),
 				grpcserver.WithTLSConfig(tlsCfg),
+				grpcserver.WithMaxConnAge(*conf.grpcMaxConnAge),
 			)
 			startGRPCListening <- struct{}{}
 		}
@@ -662,6 +663,7 @@ type receiveConfig struct {
 	grpcCert        *string
 	grpcKey         *string
 	grpcClientCA    *string
+	grpcMaxConnAge  *time.Duration
 
 	rwAddress          string
 	rwServerCert       string
@@ -708,7 +710,7 @@ type receiveConfig struct {
 
 func (rc *receiveConfig) registerFlag(cmd extkingpin.FlagClause) {
 	rc.httpBindAddr, rc.httpGracePeriod, rc.httpTLSConfig = extkingpin.RegisterHTTPFlags(cmd)
-	rc.grpcBindAddr, rc.grpcGracePeriod, rc.grpcCert, rc.grpcKey, rc.grpcClientCA = extkingpin.RegisterGRPCFlags(cmd)
+	rc.grpcBindAddr, rc.grpcGracePeriod, rc.grpcCert, rc.grpcKey, rc.grpcClientCA, rc.grpcMaxConnAge = extkingpin.RegisterGRPCFlags(cmd)
 
 	cmd.Flag("remote-write.address", "Address to listen on for remote write requests.").
 		Default("0.0.0.0:19291").StringVar(&rc.rwAddress)

--- a/docs/components/query.md
+++ b/docs/components/query.md
@@ -277,6 +277,10 @@ Flags:
                                  signed, signed by fake CA
       --grpc-grace-period=2m     Time to wait after an interrupt received for
                                  GRPC Server.
+      --grpc-server-max-connection-age=60m  
+                                 The grpc server max connection age. This
+                                 controls how often to re-read the tls
+                                 certificates and redo the TLS handshake
       --grpc-server-tls-cert=""  TLS Certificate for gRPC server, leave blank to
                                  disable TLS
       --grpc-server-tls-client-ca=""  

--- a/docs/components/receive.md
+++ b/docs/components/receive.md
@@ -82,6 +82,10 @@ Flags:
                                  from other components.
       --grpc-grace-period=2m     Time to wait after an interrupt received for
                                  GRPC Server.
+      --grpc-server-max-connection-age=60m  
+                                 The grpc server max connection age. This
+                                 controls how often to re-read the tls
+                                 certificates and redo the TLS handshake
       --grpc-server-tls-cert=""  TLS Certificate for gRPC server, leave blank to
                                  disable TLS
       --grpc-server-tls-client-ca=""  

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/facette/natsort v0.0.0-20181210072756-2cd4dd1e2dcb
 	github.com/fatih/structtag v1.1.0
 	github.com/felixge/fgprof v0.9.1
+	github.com/fortytw2/leaktest v1.3.0
 	github.com/fsnotify/fsnotify v1.4.9
 	github.com/go-kit/kit v0.10.0
 	github.com/go-openapi/strfmt v0.20.1

--- a/go.sum
+++ b/go.sum
@@ -361,6 +361,7 @@ github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSw
 github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible h1:TcekIExNqud5crz4xD2pavyTgWiPvpYe4Xau31I0PRk=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
+github.com/fortytw2/leaktest v1.3.0 h1:u8491cBMTQ8ft8aeV+adlcytMZylmA5nnwwkRZjI8vw=
 github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
 github.com/franela/goblin v0.0.0-20200105215937-c9ffbefa60db/go.mod h1:7dvUGVsVBjqR7JHJk0brhHOZYGmfBYOrK0ZhYMEtBr4=
 github.com/franela/goreq v0.0.0-20171204163338-bcd34c9993f8/go.mod h1:ZhphrRTfi2rbfLwlschooIH4+wKKDR4Pdxhh+TRoA20=

--- a/pkg/extkingpin/flags.go
+++ b/pkg/extkingpin/flags.go
@@ -6,6 +6,7 @@ package extkingpin
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	extflag "github.com/efficientgo/tools/extkingpin"
 	"github.com/prometheus/common/model"
@@ -26,6 +27,7 @@ func RegisterGRPCFlags(cmd FlagClause) (
 	grpcTLSSrvCert *string,
 	grpcTLSSrvKey *string,
 	grpcTLSSrvClientCA *string,
+	grpcMaxConnectionAge *time.Duration,
 ) {
 	grpcBindAddr = cmd.Flag("grpc-address", "Listen ip:port address for gRPC endpoints (StoreAPI). Make sure this address is routable from other components.").
 		Default("0.0.0.0:10901").String()
@@ -34,12 +36,14 @@ func RegisterGRPCFlags(cmd FlagClause) (
 	grpcTLSSrvCert = cmd.Flag("grpc-server-tls-cert", "TLS Certificate for gRPC server, leave blank to disable TLS").Default("").String()
 	grpcTLSSrvKey = cmd.Flag("grpc-server-tls-key", "TLS Key for the gRPC server, leave blank to disable TLS").Default("").String()
 	grpcTLSSrvClientCA = cmd.Flag("grpc-server-tls-client-ca", "TLS CA to verify clients against. If no client CA is specified, there is no client verification on server side. (tls.NoClientCert)").Default("").String()
+	grpcMaxConnectionAge = cmd.Flag("grpc-server-max-connection-age", "The grpc server max connection age. This controls how often to re-read the tls certificates and redo the TLS handshake ").Default("60m").Duration()
 
 	return grpcBindAddr,
 		grpcGracePeriod,
 		grpcTLSSrvCert,
 		grpcTLSSrvKey,
-		grpcTLSSrvClientCA
+		grpcTLSSrvClientCA,
+		grpcMaxConnectionAge
 }
 
 // RegisterCommonObjStoreFlags register flags commonly used to configure http servers with.

--- a/pkg/server/grpc/grpc.go
+++ b/pkg/server/grpc/grpc.go
@@ -25,6 +25,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
 	grpc_health "google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/reflection"
 	"google.golang.org/grpc/status"
 
@@ -90,6 +91,9 @@ func New(logger log.Logger, reg prometheus.Registerer, tracer opentracing.Tracer
 
 	if options.tlsConfig != nil {
 		options.grpcOpts = append(options.grpcOpts, grpc.Creds(credentials.NewTLS(options.tlsConfig)))
+	}
+	if options.maxConnAge > 0 {
+		options.grpcOpts = append(options.grpcOpts, grpc.KeepaliveParams(keepalive.ServerParameters{MaxConnectionAge: options.maxConnAge}))
 	}
 	s := grpc.NewServer(options.grpcOpts...)
 

--- a/pkg/server/grpc/option.go
+++ b/pkg/server/grpc/option.go
@@ -14,6 +14,7 @@ type options struct {
 	registerServerFuncs []registerServerFunc
 
 	gracePeriod time.Duration
+	maxConnAge  time.Duration
 	listen      string
 	network     string
 
@@ -78,5 +79,12 @@ func WithNetwork(s string) Option {
 func WithTLSConfig(cfg *tls.Config) Option {
 	return optionFunc(func(o *options) {
 		o.tlsConfig = cfg
+	})
+}
+
+// WithMaxConnAge sets the maximum connection age for gRPC server.
+func WithMaxConnAge(t time.Duration) Option {
+	return optionFunc(func(o *options) {
+		o.maxConnAge = t
 	})
 }

--- a/pkg/tls/options.go
+++ b/pkg/tls/options.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"sync"
 	"time"
 
 	"github.com/go-kit/kit/log"
@@ -67,12 +68,16 @@ type serverTLSManager struct {
 	srvCertPath string
 	srvKeyPath  string
 
+	mtx            sync.Mutex
 	srvCert        *tls.Certificate
 	srvCertModTime time.Time
 	srvKeyModTime  time.Time
 }
 
 func (m *serverTLSManager) getCertificate(clientHello *tls.ClientHelloInfo) (*tls.Certificate, error) {
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
+
 	statCert, err := os.Stat(m.srvCertPath)
 	if err != nil {
 		return nil, err
@@ -149,12 +154,16 @@ type clientTLSManager struct {
 	certPath string
 	keyPath  string
 
+	mtx         sync.Mutex
 	cert        *tls.Certificate
 	certModTime time.Time
 	keyModTime  time.Time
 }
 
 func (m *clientTLSManager) getClientCertificate(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
+
 	statCert, err := os.Stat(m.certPath)
 	if err != nil {
 		return nil, err

--- a/pkg/tls/options.go
+++ b/pkg/tls/options.go
@@ -7,7 +7,9 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"io/ioutil"
+	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
@@ -35,12 +37,12 @@ func NewServerConfig(logger log.Logger, cert, key, clientCA string) (*tls.Config
 		MinVersion: tls.VersionTLS12,
 	}
 
-	tlsCert, err := tls.LoadX509KeyPair(cert, key)
-	if err != nil {
-		return nil, errors.Wrap(err, "server credentials")
+	mngr := &serverTLSManager{
+		srvCertPath: cert,
+		srvKeyPath:  key,
 	}
 
-	tlsCfg.Certificates = []tls.Certificate{tlsCert}
+	tlsCfg.GetCertificate = mngr.getCertificate
 
 	if clientCA != "" {
 		caPEM, err := ioutil.ReadFile(filepath.Clean(clientCA))
@@ -59,6 +61,37 @@ func NewServerConfig(logger log.Logger, cert, key, clientCA string) (*tls.Config
 	}
 
 	return tlsCfg, nil
+}
+
+type serverTLSManager struct {
+	srvCertPath string
+	srvKeyPath  string
+
+	srvCert        *tls.Certificate
+	srvCertModTime time.Time
+	srvKeyModTime  time.Time
+}
+
+func (m *serverTLSManager) getCertificate(clientHello *tls.ClientHelloInfo) (*tls.Certificate, error) {
+	statCert, err := os.Stat(m.srvCertPath)
+	if err != nil {
+		return nil, err
+	}
+	statKey, err := os.Stat(m.srvKeyPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if m.srvCert == nil || !statCert.ModTime().Equal(m.srvCertModTime) || !statKey.ModTime().Equal(m.srvKeyModTime) {
+		cert, err := tls.LoadX509KeyPair(m.srvCertPath, m.srvKeyPath)
+		if err != nil {
+			return nil, errors.Wrap(err, "server credentials")
+		}
+		m.srvCertModTime = statCert.ModTime()
+		m.srvKeyModTime = statKey.ModTime()
+		m.srvCert = &cert
+	}
+	return m.srvCert, nil
 }
 
 // NewClientConfig provides new client TLS configuration.
@@ -101,12 +134,45 @@ func NewClientConfig(logger log.Logger, cert, key, caCert, serverName string, sk
 	}
 
 	if cert != "" {
-		cert, err := tls.LoadX509KeyPair(cert, key)
-		if err != nil {
-			return nil, errors.Wrap(err, "client credentials")
+		mngr := &clientTLSManager{
+			certPath: cert,
+			keyPath:  key,
 		}
-		tlsCfg.Certificates = []tls.Certificate{cert}
+		tlsCfg.GetClientCertificate = mngr.getClientCertificate
+
 		level.Info(logger).Log("msg", "TLS client authentication enabled")
 	}
 	return tlsCfg, nil
+}
+
+type clientTLSManager struct {
+	certPath string
+	keyPath  string
+
+	cert        *tls.Certificate
+	certModTime time.Time
+	keyModTime  time.Time
+}
+
+func (m *clientTLSManager) getClientCertificate(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
+	statCert, err := os.Stat(m.certPath)
+	if err != nil {
+		return nil, err
+	}
+	statKey, err := os.Stat(m.keyPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if m.cert == nil || !statCert.ModTime().Equal(m.certModTime) || !statKey.ModTime().Equal(m.keyModTime) {
+		cert, err := tls.LoadX509KeyPair(m.certPath, m.keyPath)
+		if err != nil {
+			return nil, errors.Wrap(err, "client credentials")
+		}
+		m.certModTime = statCert.ModTime()
+		m.keyModTime = statKey.ModTime()
+		m.cert = &cert
+	}
+
+	return m.cert, nil
 }

--- a/test/e2e/tls_test.go
+++ b/test/e2e/tls_test.go
@@ -53,8 +53,8 @@ func TestGRPCServerCertAutoRotate(t *testing.T) {
 	certSrv := filepath.Join(tmpDirSrv, "cert")
 	keySrv := filepath.Join(tmpDirSrv, "key")
 
-	genCerts(t, certSrv, keySrv, caClt, serverName)
-	genCerts(t, certClt, keyClt, caSrv, serverName)
+	genCerts(t, certSrv, keySrv, caClt)
+	genCerts(t, certClt, keyClt, caSrv)
 
 	configSrv, err := thTLS.NewServerConfig(logger, certSrv, keySrv, caSrv)
 	testutil.Ok(t, err)
@@ -90,8 +90,8 @@ func TestGRPCServerCertAutoRotate(t *testing.T) {
 	testutil.Equals(t, expMessage, resp.Message)
 
 	// Reload certs and check for a good state.
-	genCerts(t, certSrv, keySrv, caClt, serverName)
-	genCerts(t, certClt, keyClt, caSrv, serverName)
+	genCerts(t, certSrv, keySrv, caClt)
+	genCerts(t, certClt, keyClt, caSrv)
 	time.Sleep(50 * time.Millisecond) // Wait for the server MaxConnectionAge to expire.
 	resp, err = clt.UnaryEcho(context.Background(), &pb.EchoRequest{Message: expMessage})
 	testutil.Ok(t, err)
@@ -119,7 +119,7 @@ var cert = &x509.Certificate{
 // genCerts generates certificates and writes those to the provided paths.
 // When the CA file already exists it is not overwritten and
 // it is used to sign the certificates.
-func genCerts(t *testing.T, certPath, privkeyPath, caPath, serverName string) {
+func genCerts(t *testing.T, certPath, privkeyPath, caPath string) {
 	var (
 		err       error
 		caPrivKey *rsa.PrivateKey

--- a/test/e2e/tls_test.go
+++ b/test/e2e/tls_test.go
@@ -1,0 +1,184 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package e2e_test
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"io/ioutil"
+	"math/big"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/fortytw2/leaktest"
+	"github.com/go-kit/kit/log"
+	"github.com/thanos-io/thanos/pkg/testutil"
+	"github.com/thanos-io/thanos/pkg/testutil/e2eutil"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/keepalive"
+
+	thTLS "github.com/thanos-io/thanos/pkg/tls"
+	pb "google.golang.org/grpc/examples/features/proto/echo"
+)
+
+var serverName = "thanos"
+
+func TestGRPCServerCertAutoRotate(t *testing.T) {
+	defer leaktest.CheckTimeout(t, 10*time.Second)() // To see whether any goroutines leaked.
+
+	logger := log.NewLogfmtLogger(os.Stderr)
+	expMessage := "hello world"
+
+	tmpDirClt, err := ioutil.TempDir("", "test-tls-clt")
+	testutil.Ok(t, err)
+	defer func() { testutil.Ok(t, os.RemoveAll(tmpDirClt)) }()
+	caClt := filepath.Join(tmpDirClt, "ca")
+	certClt := filepath.Join(tmpDirClt, "cert")
+	keyClt := filepath.Join(tmpDirClt, "key")
+
+	tmpDirSrv, err := ioutil.TempDir("", "test-tls-srv")
+	testutil.Ok(t, err)
+	defer func() { testutil.Ok(t, os.RemoveAll(tmpDirSrv)) }()
+	caSrv := filepath.Join(tmpDirSrv, "ca")
+	certSrv := filepath.Join(tmpDirSrv, "cert")
+	keySrv := filepath.Join(tmpDirSrv, "key")
+
+	genCerts(t, certSrv, keySrv, caClt, serverName)
+	genCerts(t, certClt, keyClt, caSrv, serverName)
+
+	configSrv, err := thTLS.NewServerConfig(logger, certSrv, keySrv, caSrv)
+	testutil.Ok(t, err)
+
+	srv := grpc.NewServer(grpc.KeepaliveParams(keepalive.ServerParameters{MaxConnectionAge: 1 * time.Millisecond}), grpc.Creds(credentials.NewTLS(configSrv)))
+
+	pb.RegisterEchoServer(srv, &ecServer{})
+	p, err := e2eutil.FreePort()
+	testutil.Ok(t, err)
+	addr := fmt.Sprint("localhost:", p)
+	lis, err := net.Listen("tcp", addr)
+	testutil.Ok(t, err)
+
+	go func() {
+		testutil.Ok(t, srv.Serve(lis))
+	}()
+	defer func() { srv.Stop() }()
+	time.Sleep(50 * time.Millisecond) // Wait for the server to start.
+
+	// Setup the connection and the client.
+	configClt, err := thTLS.NewClientConfig(logger, certClt, keyClt, caClt, serverName, false)
+	testutil.Ok(t, err)
+	conn, err := grpc.Dial(addr, grpc.WithConnectParams(grpc.ConnectParams{MinConnectTimeout: 1 * time.Minute}), grpc.WithTransportCredentials(credentials.NewTLS(configClt)))
+	testutil.Ok(t, err)
+	defer func() {
+		testutil.Ok(t, conn.Close())
+	}()
+	clt := pb.NewEchoClient(conn)
+
+	// Check a good state.
+	resp, err := clt.UnaryEcho(context.Background(), &pb.EchoRequest{Message: expMessage})
+	testutil.Ok(t, err)
+	testutil.Equals(t, expMessage, resp.Message)
+
+	// Reload certs and check for a good state.
+	genCerts(t, certSrv, keySrv, caClt, serverName)
+	genCerts(t, certClt, keyClt, caSrv, serverName)
+	time.Sleep(50 * time.Millisecond) // Wait for the server MaxConnectionAge to expire.
+	resp, err = clt.UnaryEcho(context.Background(), &pb.EchoRequest{Message: expMessage})
+	testutil.Ok(t, err)
+	testutil.Equals(t, expMessage, resp.Message)
+}
+
+var caRoot = &x509.Certificate{
+	SerialNumber:          big.NewInt(2019),
+	NotAfter:              time.Now().AddDate(10, 0, 0),
+	IsCA:                  true,
+	ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+	KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+	BasicConstraintsValid: true,
+}
+
+var cert = &x509.Certificate{
+	SerialNumber: big.NewInt(1658),
+	DNSNames:     []string{serverName},
+	NotAfter:     time.Now().AddDate(10, 0, 0),
+	SubjectKeyId: []byte{1, 2, 3},
+	ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+	KeyUsage:     x509.KeyUsageDigitalSignature,
+}
+
+// genCerts generates certificates and writes those to the provided paths.
+// When the CA file already exists it is not overwritten and
+// it is used to sign the certificates.
+func genCerts(t *testing.T, certPath, privkeyPath, caPath, serverName string) {
+	var (
+		err       error
+		caPrivKey *rsa.PrivateKey
+		caSrvPriv = caPath + ".priv"
+	)
+
+	// When the CA private file exists don't overwrite it but
+	// use it to extract the private key to be used for signing the certificate.
+	if _, err := os.Stat(caSrvPriv); !os.IsNotExist(err) {
+		d, err := ioutil.ReadFile(caSrvPriv)
+		testutil.Ok(t, err)
+		caPrivKey, err = x509.ParsePKCS1PrivateKey(d)
+		testutil.Ok(t, err)
+	} else {
+		caPrivKey, err = rsa.GenerateKey(rand.Reader, 1024)
+		testutil.Ok(t, err)
+	}
+
+	certPrivKey, err := rsa.GenerateKey(rand.Reader, 1024)
+	testutil.Ok(t, err)
+
+	// Sign the cert with the CA private key.
+	certBytes, err := x509.CreateCertificate(rand.Reader, cert, caRoot, &certPrivKey.PublicKey, caPrivKey)
+	testutil.Ok(t, err)
+
+	if caPath != "" {
+		caBytes, err := x509.CreateCertificate(rand.Reader, caRoot, caRoot, &caPrivKey.PublicKey, caPrivKey)
+		testutil.Ok(t, err)
+		caPEM := pem.EncodeToMemory(&pem.Block{
+			Type:  "CERTIFICATE",
+			Bytes: caBytes,
+		})
+		testutil.Ok(t, ioutil.WriteFile(caPath, caPEM, 0644))
+		testutil.Ok(t, ioutil.WriteFile(caSrvPriv, x509.MarshalPKCS1PrivateKey(caPrivKey), 0644))
+	}
+
+	if certPath != "" {
+		certPEM := new(bytes.Buffer)
+		testutil.Ok(t, pem.Encode(certPEM, &pem.Block{
+			Type:  "CERTIFICATE",
+			Bytes: certBytes,
+		}))
+		testutil.Ok(t, ioutil.WriteFile(certPath, certPEM.Bytes(), 0644))
+	}
+
+	if privkeyPath != "" {
+		certPrivKeyPEM := new(bytes.Buffer)
+		testutil.Ok(t, pem.Encode(certPrivKeyPEM, &pem.Block{
+			Type:  "RSA PRIVATE KEY",
+			Bytes: x509.MarshalPKCS1PrivateKey(certPrivKey),
+		}))
+		testutil.Ok(t, ioutil.WriteFile(privkeyPath, certPrivKeyPEM.Bytes(), 0644))
+	}
+}
+
+type ecServer struct {
+	pb.UnimplementedEchoServer
+}
+
+func (s *ecServer) UnaryEcho(ctx context.Context, req *pb.EchoRequest) (*pb.EchoResponse, error) {
+	return &pb.EchoResponse{Message: req.Message}, nil
+}


### PR DESCRIPTION
This PR implements the second part of this [proposal](https://github.com/thanos-io/thanos/blob/main/docs/proposals-accepted/202106-automated-per-endpoint-mTLS.md), i.e. 

> Adding a new `--grpc-server-max-connection-age` CLI option which takes time as input and controls how often to re-do the tls handshake and re-read the certificates. This in reality is controlled by the keepalive’s MaxConnectionAge option (which will close the connection after every (e.g. 15m) inputted time duration) so when the connection is closed it requires a new tls handshake.
While reading the cert_file on each handshake we can improve the performance by keeping track of it’s modification time. We should re-load the certificates only if they are actually rotated and there is some change in their modification time otherwise returning the previously stored one. Also if the file is not modified recently then it could be found on the cache memory of the system running thanos and it would be faster to get the file details (i.e. modification time).

### Changes
Added new `--grpc-server-max-connection-age` flag which takes "time" as input and controls how often to re-read the tls certificates (BOTH client and server certs) and redo the TLS handshake.

### Verification

Added e2e tests.