### PR TITLE
Adjust and rename `ThanosSidecarUnhealthy` to `ThanosSidecarNoConnectionToStartedPrometheus`; Remove `ThanosSidecarPrometheusDown` alert; Remove unused `thanos_sidecar_last_heartbeat_success_time_seconds` metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#4476](https://github.com/thanos-io/thanos/pull/4476) UI: fix incorrect html escape sequence used for '>' symbol.
 - [#4532](https://github.com/thanos-io/thanos/pull/4532) Mixin: Fixed "all jobs" selector in thanos mixin dashboards.
 - [#4607](https://github.com/thanos-io/thanos/pull/4607) Azure: Fix Azure MSI Rate Limit
+- [#4508](https://github.com/thanos-io/thanos/pull/4508) Adjust and rename `ThanosSidecarUnhealthy` to `ThanosSidecarNoConnectionToStartedPrometheus`; Remove `ThanosSidecarPrometheusDown`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 ### Added
 - [#4680](https://github.com/thanos-io/thanos/pull/4680) Query: add `exemplar.partial-response` flag to control partial response.
 
+### Fixed
+
+- [#4508](https://github.com/thanos-io/thanos/pull/4508) Adjust and rename `ThanosSidecarUnhealthy` to `ThanosSidecarNoConnectionToStartedPrometheus`; Remove `ThanosSidecarPrometheusDown` alert; Remove unused `thanos_sidecar_last_heartbeat_success_time_seconds` metrics.
+
 ## v0.23.0 - In Progress
 
 ### Added
@@ -36,7 +40,6 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#4476](https://github.com/thanos-io/thanos/pull/4476) UI: fix incorrect html escape sequence used for '>' symbol.
 - [#4532](https://github.com/thanos-io/thanos/pull/4532) Mixin: Fixed "all jobs" selector in thanos mixin dashboards.
 - [#4607](https://github.com/thanos-io/thanos/pull/4607) Azure: Fix Azure MSI Rate Limit
-- [#4508](https://github.com/thanos-io/thanos/pull/4508) Adjust and rename `ThanosSidecarUnhealthy` to `ThanosSidecarNoConnectionToStartedPrometheus`; Remove `ThanosSidecarPrometheusDown`.
 
 ### Changed
 

--- a/cmd/thanos/sidecar.go
+++ b/cmd/thanos/sidecar.go
@@ -138,10 +138,6 @@ func runSidecar(
 			Name: "thanos_sidecar_prometheus_up",
 			Help: "Boolean indicator whether the sidecar can reach its Prometheus peer.",
 		})
-		lastHeartbeat := promauto.With(reg).NewGauge(prometheus.GaugeOpts{
-			Name: "thanos_sidecar_last_heartbeat_success_time_seconds",
-			Help: "Timestamp of the last successful heartbeat in seconds.",
-		})
 
 		ctx, cancel := context.WithCancel(context.Background())
 		g.Add(func() error {
@@ -191,7 +187,6 @@ func runSidecar(
 				)
 				promUp.Set(1)
 				statusProber.Ready()
-				lastHeartbeat.SetToCurrentTime()
 				return nil
 			})
 			if err != nil {
@@ -213,7 +208,6 @@ func runSidecar(
 					promUp.Set(0)
 				} else {
 					promUp.Set(1)
-					lastHeartbeat.SetToCurrentTime()
 				}
 
 				return nil

--- a/examples/alerts/alerts.md
+++ b/examples/alerts/alerts.md
@@ -296,16 +296,6 @@ rules:
 ```yaml mdox-exec="cat examples/tmp/thanos-sidecar.yaml"
 name: thanos-sidecar
 rules:
-- alert: ThanosSidecarPrometheusDown
-  annotations:
-    description: Thanos Sidecar {{$labels.instance}} cannot connect to Prometheus.
-    runbook_url: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanossidecarprometheusdown
-    summary: Thanos Sidecar cannot connect to Prometheus
-  expr: |
-    thanos_sidecar_prometheus_up{job=~".*thanos-sidecar.*"} == 0
-  for: 5m
-  labels:
-    severity: critical
 - alert: ThanosSidecarBucketOperationsFailed
   annotations:
     description: Thanos Sidecar {{$labels.instance}} bucket operations are failing

--- a/examples/alerts/alerts.md
+++ b/examples/alerts/alerts.md
@@ -306,14 +306,18 @@ rules:
   for: 5m
   labels:
     severity: critical
-- alert: ThanosSidecarUnhealthy
+- alert: ThanosSidecarNoConnectionToStartedPrometheus
   annotations:
     description: Thanos Sidecar {{$labels.instance}} is unhealthy for more than {{$value}}
       seconds.
-    runbook_url: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanossidecarunhealthy
-    summary: Thanos Sidecar is unhealthy.
+    runbook_url: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanossidecarnoconnectiontostartedprometheus
+    summary: Thanos Sidecar cannot access Prometheus, even though Prometheus seems
+      healthy and has reloaded WAL.
   expr: |
-    time() - max by (job, instance) (thanos_sidecar_last_heartbeat_success_time_seconds{job=~".*thanos-sidecar.*"}) >= 240
+    time() - max by (pod, job, instance) (thanos_sidecar_last_heartbeat_success_time_seconds{job=~".*thanos-sidecar.*"}) >= 240
+    AND on (pod) (
+    min by (pod) (prometheus_tsdb_data_replay_duration_seconds) != 0
+    )
   for: 5m
   labels:
     severity: critical

--- a/examples/alerts/alerts.md
+++ b/examples/alerts/alerts.md
@@ -308,16 +308,14 @@ rules:
     severity: critical
 - alert: ThanosSidecarNoConnectionToStartedPrometheus
   annotations:
-    description: Thanos Sidecar {{$labels.instance}} is unhealthy for more than {{$value}}
-      seconds.
+    description: Thanos Sidecar {{$labels.instance}} is unhealthy.
     runbook_url: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanossidecarnoconnectiontostartedprometheus
     summary: Thanos Sidecar cannot access Prometheus, even though Prometheus seems
       healthy and has reloaded WAL.
   expr: |
-    time() - max by (pod, job, instance) (thanos_sidecar_last_heartbeat_success_time_seconds{job=~".*thanos-sidecar.*"}) >= 240
-    AND on (pod) (
-    min by (pod) (prometheus_tsdb_data_replay_duration_seconds) != 0
-    )
+    thanos_sidecar_prometheus_up{job=~".*thanos-sidecar.*"} == 0
+    AND on (namespace, pod)
+    prometheus_tsdb_data_replay_duration_seconds != 0
   for: 5m
   labels:
     severity: critical

--- a/examples/alerts/alerts.yaml
+++ b/examples/alerts/alerts.yaml
@@ -301,16 +301,6 @@ groups:
       severity: warning
 - name: thanos-sidecar
   rules:
-  - alert: ThanosSidecarPrometheusDown
-    annotations:
-      description: Thanos Sidecar {{$labels.instance}} cannot connect to Prometheus.
-      runbook_url: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanossidecarprometheusdown
-      summary: Thanos Sidecar cannot connect to Prometheus
-    expr: |
-      thanos_sidecar_prometheus_up{job=~".*thanos-sidecar.*"} == 0
-    for: 5m
-    labels:
-      severity: critical
   - alert: ThanosSidecarBucketOperationsFailed
     annotations:
       description: Thanos Sidecar {{$labels.instance}} bucket operations are failing
@@ -326,9 +316,13 @@ groups:
       description: Thanos Sidecar {{$labels.instance}} is unhealthy for more than
         {{$value}} seconds.
       runbook_url: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanossidecarunhealthy
-      summary: Thanos Sidecar is unhealthy.
+      summary: Thanos Sidecar cannot access Prometheus, even though Prometheus seems
+        healthy and has reloaded WAL.
     expr: |
-      time() - max by (job, instance) (thanos_sidecar_last_heartbeat_success_time_seconds{job=~".*thanos-sidecar.*"}) >= 240
+      time() - max by (pod, job, instance) (thanos_sidecar_last_heartbeat_success_time_seconds{job=~".*thanos-sidecar.*"}) >= 240
+      AND on (pod) (
+      min by (pod) (prometheus_tsdb_data_replay_duration_seconds) != 0
+      )
     for: 5m
     labels:
       severity: critical

--- a/examples/alerts/alerts.yaml
+++ b/examples/alerts/alerts.yaml
@@ -313,16 +313,14 @@ groups:
       severity: critical
   - alert: ThanosSidecarNoConnectionToStartedPrometheus
     annotations:
-      description: Thanos Sidecar {{$labels.instance}} is unhealthy for more than
-        {{$value}} seconds.
+      description: Thanos Sidecar {{$labels.instance}} is unhealthy.
       runbook_url: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanossidecarnoconnectiontostartedprometheus
       summary: Thanos Sidecar cannot access Prometheus, even though Prometheus seems
         healthy and has reloaded WAL.
     expr: |
-      time() - max by (pod, job, instance) (thanos_sidecar_last_heartbeat_success_time_seconds{job=~".*thanos-sidecar.*"}) >= 240
-      AND on (pod) (
-      min by (pod) (prometheus_tsdb_data_replay_duration_seconds) != 0
-      )
+      thanos_sidecar_prometheus_up{job=~".*thanos-sidecar.*"} == 0
+      AND on (namespace, pod)
+      prometheus_tsdb_data_replay_duration_seconds != 0
     for: 5m
     labels:
       severity: critical

--- a/examples/alerts/alerts.yaml
+++ b/examples/alerts/alerts.yaml
@@ -311,11 +311,11 @@ groups:
     for: 5m
     labels:
       severity: critical
-  - alert: ThanosSidecarUnhealthy
+  - alert: ThanosSidecarNoConnectionToStartedPrometheus
     annotations:
       description: Thanos Sidecar {{$labels.instance}} is unhealthy for more than
         {{$value}} seconds.
-      runbook_url: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanossidecarunhealthy
+      runbook_url: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanossidecarnoconnectiontostartedprometheus
       summary: Thanos Sidecar cannot access Prometheus, even though Prometheus seems
         healthy and has reloaded WAL.
     expr: |

--- a/examples/alerts/tests.yaml
+++ b/examples/alerts/tests.yaml
@@ -7,89 +7,14 @@ evaluation_interval: 1m
 tests:
 - interval: 1m
   input_series:
-  - series: 'thanos_sidecar_last_heartbeat_success_time_seconds{namespace="production", job="thanos-sidecar", instance="thanos-sidecar-0", pod="prometheus-0"}'
-    values: '5 10 43 17 10 0x5 0x10'
-  - series: 'thanos_sidecar_last_heartbeat_success_time_seconds{namespace="production", job="thanos-sidecar", instance="thanos-sidecar-1", pod="prometheus-1"}'
-    values: '4 9 42 15 10x5 0x10'
+  - series: 'thanos_sidecar_prometheus_up{namespace="production", job="thanos-sidecar", instance="thanos-sidecar-0", pod="prometheus-0"}'
+    values: '1x5 0x15'
+  - series: 'thanos_sidecar_prometheus_up{namespace="production", job="thanos-sidecar", instance="thanos-sidecar-1", pod="prometheus-1"}'
+    values: '1x4 0x15'
   - series: 'prometheus_tsdb_data_replay_duration_seconds{namespace="production", job="prometheus-k8s", instance="prometheus-k8s-0", pod="prometheus-0"}'
-    values: '5x5 0x5 5x15'
+    values: '4x5 0x5 5x15'
   - series: 'prometheus_tsdb_data_replay_duration_seconds{namespace="production", job="prometheus-k8s", instance="prometheus-k8s-1", pod="prometheus-1"}'
-    values: '10x20'
-  promql_expr_test:
-    - expr: time()
-      eval_time: 1m
-      exp_samples:
-        - labels: '{}'
-          value: 60
-    - expr: time()
-      eval_time: 2m
-      exp_samples:
-        - labels: '{}'
-          value: 120
-    - expr: max(thanos_sidecar_last_heartbeat_success_time_seconds{job="thanos-sidecar"}) by (job, instance)
-      eval_time: 0m
-      exp_samples:
-        - labels: '{job="thanos-sidecar", instance="thanos-sidecar-0"}'
-          value: 5
-        - labels: '{job="thanos-sidecar", instance="thanos-sidecar-1"}'
-          value: 4
-    - expr: max(thanos_sidecar_last_heartbeat_success_time_seconds{job="thanos-sidecar"}) by (job, instance)
-      eval_time: 2m
-      exp_samples:
-        - labels: '{job="thanos-sidecar", instance="thanos-sidecar-0"}'
-          value: 43
-        - labels: '{job="thanos-sidecar", instance="thanos-sidecar-1"}'
-          value: 42
-    - expr: max(thanos_sidecar_last_heartbeat_success_time_seconds{job="thanos-sidecar"}) by (job, instance)
-      eval_time: 10m
-      exp_samples:
-        - labels: '{job="thanos-sidecar", instance="thanos-sidecar-0"}'
-          value: 0
-        - labels: '{job="thanos-sidecar", instance="thanos-sidecar-1"}'
-          value: 0
-    - expr: max(thanos_sidecar_last_heartbeat_success_time_seconds{job="thanos-sidecar"}) by (job, instance)
-      eval_time: 10m
-      exp_samples:
-        - labels: '{job="thanos-sidecar", instance="thanos-sidecar-0"}'
-          value: 0
-        - labels: '{job="thanos-sidecar", instance="thanos-sidecar-1"}'
-          value: 0
-    - expr: time() - max(thanos_sidecar_last_heartbeat_success_time_seconds{job="thanos-sidecar"}) by (job, instance)
-      eval_time: 10m
-      exp_samples:
-        - labels: '{job="thanos-sidecar", instance="thanos-sidecar-0"}'
-          value: 600
-        - labels: '{job="thanos-sidecar", instance="thanos-sidecar-1"}'
-          value: 600
-    - expr: time() - max(thanos_sidecar_last_heartbeat_success_time_seconds{job="thanos-sidecar"}) by (job, instance)
-      eval_time: 11m
-      exp_samples:
-        - labels: '{job="thanos-sidecar", instance="thanos-sidecar-0"}'
-          value: 660
-        - labels: '{job="thanos-sidecar", instance="thanos-sidecar-1"}'
-          value: 660
-    - expr: time() - max(thanos_sidecar_last_heartbeat_success_time_seconds{job="thanos-sidecar"}) by (job, instance) >= 600
-      eval_time: 12m
-      exp_samples:
-        - labels: '{job="thanos-sidecar", instance="thanos-sidecar-0"}'
-          value: 720
-        - labels: '{job="thanos-sidecar", instance="thanos-sidecar-1"}'
-          value: 720
-    - expr: min(prometheus_tsdb_data_replay_duration_seconds{job="prometheus-k8s"}) by(job, instance)
-      eval_time: 0m
-      exp_samples:
-        - labels: '{job="prometheus-k8s", instance="prometheus-k8s-0"}'
-          value: 5
-        - labels: '{job="prometheus-k8s", instance="prometheus-k8s-1"}'
-          value: 10
-    - expr: min(prometheus_tsdb_data_replay_duration_seconds{job="prometheus-k8s"}) by(job, instance)
-      eval_time: 6m
-      exp_samples:
-        - labels: '{job="prometheus-k8s", instance="prometheus-k8s-0"}'
-          value: 0
-        - labels: '{job="prometheus-k8s", instance="prometheus-k8s-1"}'
-          value: 10
-
+    values: '10x14 0x6'
   alert_rule_test:
   - eval_time: 1m
     alertname: ThanosSidecarNoConnectionToStartedPrometheus
@@ -104,9 +29,10 @@ tests:
         severity: critical
         job: thanos-sidecar
         instance: thanos-sidecar-1
+        namespace: production
         pod: prometheus-1
       exp_annotations:
-        description: 'Thanos Sidecar thanos-sidecar-1 is unhealthy for more than 600 seconds.'
+        description: 'Thanos Sidecar thanos-sidecar-1 is unhealthy.'
         runbook_url: 'https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanossidecarnoconnectiontostartedprometheus'
         summary: 'Thanos Sidecar cannot access Prometheus, even though Prometheus seems healthy and has reloaded WAL.'
   - eval_time: 11m
@@ -116,9 +42,10 @@ tests:
         severity: critical
         job: thanos-sidecar
         instance: thanos-sidecar-1
+        namespace: production
         pod: prometheus-1
       exp_annotations:
-        description: 'Thanos Sidecar thanos-sidecar-1 is unhealthy for more than 660 seconds.'
+        description: 'Thanos Sidecar thanos-sidecar-1 is unhealthy.'
         runbook_url: 'https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanossidecarnoconnectiontostartedprometheus'
         summary: 'Thanos Sidecar cannot access Prometheus, even though Prometheus seems healthy and has reloaded WAL.'
   - eval_time: 12m
@@ -128,11 +55,26 @@ tests:
         severity: critical
         job: thanos-sidecar
         instance: thanos-sidecar-1
+        namespace: production
         pod: prometheus-1
       exp_annotations:
-        description: 'Thanos Sidecar thanos-sidecar-1 is unhealthy for more than 720 seconds.'
+        description: 'Thanos Sidecar thanos-sidecar-1 is unhealthy.'
         runbook_url: 'https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanossidecarnoconnectiontostartedprometheus'
         summary: 'Thanos Sidecar cannot access Prometheus, even though Prometheus seems healthy and has reloaded WAL.'
+  - eval_time: 20m
+    alertname: ThanosSidecarNoConnectionToStartedPrometheus
+    exp_alerts:
+    - exp_labels:
+        severity: critical
+        job: thanos-sidecar
+        instance: thanos-sidecar-0
+        namespace: production
+        pod: prometheus-0
+      exp_annotations:
+        description: 'Thanos Sidecar thanos-sidecar-0 is unhealthy.'
+        runbook_url: 'https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanossidecarnoconnectiontostartedprometheus'
+        summary: 'Thanos Sidecar cannot access Prometheus, even though Prometheus seems healthy and has reloaded WAL.'
+
 - interval: 1m
   input_series:
   - series: 'prometheus_rule_evaluations_total{namespace="production", job="thanos-ruler", instance="thanos-ruler-0"}'

--- a/examples/alerts/tests.yaml
+++ b/examples/alerts/tests.yaml
@@ -92,13 +92,13 @@ tests:
 
   alert_rule_test:
   - eval_time: 1m
-    alertname: ThanosSidecarUnhealthy
+    alertname: ThanosSidecarNoConnectionToStartedPrometheus
   - eval_time: 2m
-    alertname: ThanosSidecarUnhealthy
+    alertname: ThanosSidecarNoConnectionToStartedPrometheus
   - eval_time: 3m
-    alertname: ThanosSidecarUnhealthy
+    alertname: ThanosSidecarNoConnectionToStartedPrometheus
   - eval_time: 10m
-    alertname: ThanosSidecarUnhealthy
+    alertname: ThanosSidecarNoConnectionToStartedPrometheus
     exp_alerts:
     - exp_labels:
         severity: critical
@@ -107,10 +107,10 @@ tests:
         pod: prometheus-1
       exp_annotations:
         description: 'Thanos Sidecar thanos-sidecar-1 is unhealthy for more than 600 seconds.'
-        runbook_url: 'https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanossidecarunhealthy'
+        runbook_url: 'https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanossidecarnoconnectiontostartedprometheus'
         summary: 'Thanos Sidecar cannot access Prometheus, even though Prometheus seems healthy and has reloaded WAL.'
   - eval_time: 11m
-    alertname: ThanosSidecarUnhealthy
+    alertname: ThanosSidecarNoConnectionToStartedPrometheus
     exp_alerts:
     - exp_labels:
         severity: critical
@@ -119,10 +119,10 @@ tests:
         pod: prometheus-1
       exp_annotations:
         description: 'Thanos Sidecar thanos-sidecar-1 is unhealthy for more than 660 seconds.'
-        runbook_url: 'https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanossidecarunhealthy'
+        runbook_url: 'https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanossidecarnoconnectiontostartedprometheus'
         summary: 'Thanos Sidecar cannot access Prometheus, even though Prometheus seems healthy and has reloaded WAL.'
   - eval_time: 12m
-    alertname: ThanosSidecarUnhealthy
+    alertname: ThanosSidecarNoConnectionToStartedPrometheus
     exp_alerts:
     - exp_labels:
         severity: critical
@@ -131,7 +131,7 @@ tests:
         pod: prometheus-1
       exp_annotations:
         description: 'Thanos Sidecar thanos-sidecar-1 is unhealthy for more than 720 seconds.'
-        runbook_url: 'https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanossidecarunhealthy'
+        runbook_url: 'https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanossidecarnoconnectiontostartedprometheus'
         summary: 'Thanos Sidecar cannot access Prometheus, even though Prometheus seems healthy and has reloaded WAL.'
 - interval: 1m
   input_series:

--- a/examples/alerts/tests.yaml
+++ b/examples/alerts/tests.yaml
@@ -7,10 +7,14 @@ evaluation_interval: 1m
 tests:
 - interval: 1m
   input_series:
-  - series: 'thanos_sidecar_last_heartbeat_success_time_seconds{namespace="production", job="thanos-sidecar", instance="thanos-sidecar-0"}'
-    values: '5 10 43 17 11 0 0 0'
-  - series: 'thanos_sidecar_last_heartbeat_success_time_seconds{namespace="production", job="thanos-sidecar", instance="thanos-sidecar-1"}'
-    values: '4 9 42 15 10 0 0 0'
+  - series: 'thanos_sidecar_last_heartbeat_success_time_seconds{namespace="production", job="thanos-sidecar", instance="thanos-sidecar-0", pod="prometheus-0"}'
+    values: '5 10 43 17 10 0x5 0x10'
+  - series: 'thanos_sidecar_last_heartbeat_success_time_seconds{namespace="production", job="thanos-sidecar", instance="thanos-sidecar-1", pod="prometheus-1"}'
+    values: '4 9 42 15 10x5 0x10'
+  - series: 'prometheus_tsdb_data_replay_duration_seconds{namespace="production", job="prometheus-k8s", instance="prometheus-k8s-0", pod="prometheus-0"}'
+    values: '5x5 0x5 5x15'
+  - series: 'prometheus_tsdb_data_replay_duration_seconds{namespace="production", job="prometheus-k8s", instance="prometheus-k8s-1", pod="prometheus-1"}'
+    values: '10x20'
   promql_expr_test:
     - expr: time()
       eval_time: 1m
@@ -22,6 +26,13 @@ tests:
       exp_samples:
         - labels: '{}'
           value: 120
+    - expr: max(thanos_sidecar_last_heartbeat_success_time_seconds{job="thanos-sidecar"}) by (job, instance)
+      eval_time: 0m
+      exp_samples:
+        - labels: '{job="thanos-sidecar", instance="thanos-sidecar-0"}'
+          value: 5
+        - labels: '{job="thanos-sidecar", instance="thanos-sidecar-1"}'
+          value: 4
     - expr: max(thanos_sidecar_last_heartbeat_success_time_seconds{job="thanos-sidecar"}) by (job, instance)
       eval_time: 2m
       exp_samples:
@@ -37,7 +48,7 @@ tests:
         - labels: '{job="thanos-sidecar", instance="thanos-sidecar-1"}'
           value: 0
     - expr: max(thanos_sidecar_last_heartbeat_success_time_seconds{job="thanos-sidecar"}) by (job, instance)
-      eval_time: 11m
+      eval_time: 10m
       exp_samples:
         - labels: '{job="thanos-sidecar", instance="thanos-sidecar-0"}'
           value: 0
@@ -64,6 +75,21 @@ tests:
           value: 720
         - labels: '{job="thanos-sidecar", instance="thanos-sidecar-1"}'
           value: 720
+    - expr: min(prometheus_tsdb_data_replay_duration_seconds{job="prometheus-k8s"}) by(job, instance)
+      eval_time: 0m
+      exp_samples:
+        - labels: '{job="prometheus-k8s", instance="prometheus-k8s-0"}'
+          value: 5
+        - labels: '{job="prometheus-k8s", instance="prometheus-k8s-1"}'
+          value: 10
+    - expr: min(prometheus_tsdb_data_replay_duration_seconds{job="prometheus-k8s"}) by(job, instance)
+      eval_time: 6m
+      exp_samples:
+        - labels: '{job="prometheus-k8s", instance="prometheus-k8s-0"}'
+          value: 0
+        - labels: '{job="prometheus-k8s", instance="prometheus-k8s-1"}'
+          value: 10
+
   alert_rule_test:
   - eval_time: 1m
     alertname: ThanosSidecarUnhealthy
@@ -77,57 +103,36 @@ tests:
     - exp_labels:
         severity: critical
         job: thanos-sidecar
-        instance: thanos-sidecar-0
-      exp_annotations:
-        description: 'Thanos Sidecar thanos-sidecar-0 is unhealthy for more than 600 seconds.'
-        runbook_url: 'https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanossidecarunhealthy'
-        summary: 'Thanos Sidecar is unhealthy.'
-    - exp_labels:
-        severity: critical
-        job: thanos-sidecar
         instance: thanos-sidecar-1
+        pod: prometheus-1
       exp_annotations:
         description: 'Thanos Sidecar thanos-sidecar-1 is unhealthy for more than 600 seconds.'
         runbook_url: 'https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanossidecarunhealthy'
-        summary: 'Thanos Sidecar is unhealthy.'
+        summary: 'Thanos Sidecar cannot access Prometheus, even though Prometheus seems healthy and has reloaded WAL.'
   - eval_time: 11m
     alertname: ThanosSidecarUnhealthy
     exp_alerts:
     - exp_labels:
         severity: critical
         job: thanos-sidecar
-        instance: thanos-sidecar-0
-      exp_annotations:
-        description: 'Thanos Sidecar thanos-sidecar-0 is unhealthy for more than 660 seconds.'
-        runbook_url: 'https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanossidecarunhealthy'
-        summary: 'Thanos Sidecar is unhealthy.'
-    - exp_labels:
-        severity: critical
-        job: thanos-sidecar
         instance: thanos-sidecar-1
+        pod: prometheus-1
       exp_annotations:
         description: 'Thanos Sidecar thanos-sidecar-1 is unhealthy for more than 660 seconds.'
         runbook_url: 'https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanossidecarunhealthy'
-        summary: 'Thanos Sidecar is unhealthy.'
+        summary: 'Thanos Sidecar cannot access Prometheus, even though Prometheus seems healthy and has reloaded WAL.'
   - eval_time: 12m
     alertname: ThanosSidecarUnhealthy
     exp_alerts:
     - exp_labels:
         severity: critical
         job: thanos-sidecar
-        instance: thanos-sidecar-0
-      exp_annotations:
-        description: 'Thanos Sidecar thanos-sidecar-0 is unhealthy for more than 720 seconds.'
-        runbook_url: 'https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanossidecarunhealthy'
-        summary: 'Thanos Sidecar is unhealthy.'
-    - exp_labels:
-        severity: critical
-        job: thanos-sidecar
         instance: thanos-sidecar-1
+        pod: prometheus-1
       exp_annotations:
         description: 'Thanos Sidecar thanos-sidecar-1 is unhealthy for more than 720 seconds.'
         runbook_url: 'https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanossidecarunhealthy'
-        summary: 'Thanos Sidecar is unhealthy.'
+        summary: 'Thanos Sidecar cannot access Prometheus, even though Prometheus seems healthy and has reloaded WAL.'
 - interval: 1m
   input_series:
   - series: 'prometheus_rule_evaluations_total{namespace="production", job="thanos-ruler", instance="thanos-ruler-0"}'

--- a/mixin/README.md
+++ b/mixin/README.md
@@ -106,6 +106,7 @@ This project is intended to be used as a library. You can extend and customize d
   },
   sidecar+:: {
     selector: 'job=~".*thanos-sidecar.*"',
+    thanosPrometheusCommonDimensions: 'pod',
     title: '%(prefix)sSidecar' % $.dashboard.prefix,
   },
   // TODO(kakkoyun): Fix naming convention: bucketReplicate

--- a/mixin/README.md
+++ b/mixin/README.md
@@ -106,7 +106,7 @@ This project is intended to be used as a library. You can extend and customize d
   },
   sidecar+:: {
     selector: 'job=~".*thanos-sidecar.*"',
-    thanosPrometheusCommonDimensions: 'pod',
+    thanosPrometheusCommonDimensions: 'namespace, pod',
     title: '%(prefix)sSidecar' % $.dashboard.prefix,
   },
   // TODO(kakkoyun): Fix naming convention: bucketReplicate

--- a/mixin/alerts/sidecar.libsonnet
+++ b/mixin/alerts/sidecar.libsonnet
@@ -28,14 +28,13 @@
           {
             alert: 'ThanosSidecarNoConnectionToStartedPrometheus',
             annotations: {
-              description: 'Thanos Sidecar {{$labels.instance}}%s is unhealthy for more than {{$value}} seconds.' % location,
+              description: 'Thanos Sidecar {{$labels.instance}}%s is unhealthy.' % location,
               summary: 'Thanos Sidecar cannot access Prometheus, even though Prometheus seems healthy and has reloaded WAL.',
             },
             expr: |||
-              time() - max by (%(thanosPrometheusCommonDimensions)s, %(dimensions)s) (thanos_sidecar_last_heartbeat_success_time_seconds{%(selector)s}) >= 240
-              AND on (%(thanosPrometheusCommonDimensions)s) (
-              min by (%(thanosPrometheusCommonDimensions)s) (prometheus_tsdb_data_replay_duration_seconds) != 0
-              )
+              thanos_sidecar_prometheus_up{%(selector)s} == 0
+              AND on (%(thanosPrometheusCommonDimensions)s)
+              prometheus_tsdb_data_replay_duration_seconds != 0
             ||| % thanos.sidecar,
             'for': '5m',
             labels: {

--- a/mixin/alerts/sidecar.libsonnet
+++ b/mixin/alerts/sidecar.libsonnet
@@ -2,6 +2,7 @@
   local thanos = self,
   sidecar+:: {
     selector: error 'must provide selector for Thanos Sidecar alerts',
+    thanosPrometheusCommonDimensions: error 'must provide commonDimensions between Thanos and Prometheus metrics for Sidecar alerts',
     dimensions: std.join(', ', std.objectFields(thanos.targetGroups) + ['job', 'instance']),
   },
   prometheusAlerts+:: {
@@ -10,20 +11,6 @@
       {
         name: 'thanos-sidecar',
         rules: [
-          {
-            alert: 'ThanosSidecarPrometheusDown',
-            annotations: {
-              description: 'Thanos Sidecar {{$labels.instance}}%s cannot connect to Prometheus.' % location,
-              summary: 'Thanos Sidecar cannot connect to Prometheus',
-            },
-            expr: |||
-              thanos_sidecar_prometheus_up{%(selector)s} == 0
-            ||| % thanos.sidecar,
-            'for': '5m',
-            labels: {
-              severity: 'critical',
-            },
-          },
           {
             alert: 'ThanosSidecarBucketOperationsFailed',
             annotations: {
@@ -42,10 +29,13 @@
             alert: 'ThanosSidecarUnhealthy',
             annotations: {
               description: 'Thanos Sidecar {{$labels.instance}}%s is unhealthy for more than {{$value}} seconds.' % location,
-              summary: 'Thanos Sidecar is unhealthy.',
+              summary: 'Thanos Sidecar cannot access Prometheus, even though Prometheus seems healthy and has reloaded WAL.',
             },
             expr: |||
-              time() - max by (%(dimensions)s) (thanos_sidecar_last_heartbeat_success_time_seconds{%(selector)s}) >= 240
+              time() - max by (%(thanosPrometheusCommonDimensions)s, %(dimensions)s) (thanos_sidecar_last_heartbeat_success_time_seconds{%(selector)s}) >= 240
+              AND on (%(thanosPrometheusCommonDimensions)s) (
+              min by (%(thanosPrometheusCommonDimensions)s) (prometheus_tsdb_data_replay_duration_seconds) != 0
+              )
             ||| % thanos.sidecar,
             'for': '5m',
             labels: {

--- a/mixin/alerts/sidecar.libsonnet
+++ b/mixin/alerts/sidecar.libsonnet
@@ -26,7 +26,7 @@
             },
           },
           {
-            alert: 'ThanosSidecarUnhealthy',
+            alert: 'ThanosSidecarNoConnectionToStartedPrometheus',
             annotations: {
               description: 'Thanos Sidecar {{$labels.instance}}%s is unhealthy for more than {{$value}} seconds.' % location,
               summary: 'Thanos Sidecar cannot access Prometheus, even though Prometheus seems healthy and has reloaded WAL.',

--- a/mixin/config.libsonnet
+++ b/mixin/config.libsonnet
@@ -46,7 +46,7 @@
   },
   sidecar+:: {
     selector: 'job=~".*thanos-sidecar.*"',
-    thanosPrometheusCommonDimensions: 'pod',
+    thanosPrometheusCommonDimensions: 'namespace, pod',
     title: '%(prefix)sSidecar' % $.dashboard.prefix,
   },
   // TODO(kakkoyun): Fix naming convention: bucketReplicate

--- a/mixin/config.libsonnet
+++ b/mixin/config.libsonnet
@@ -46,6 +46,7 @@
   },
   sidecar+:: {
     selector: 'job=~".*thanos-sidecar.*"',
+    thanosPrometheusCommonDimensions: 'pod',
     title: '%(prefix)sSidecar' % $.dashboard.prefix,
   },
   // TODO(kakkoyun): Fix naming convention: bucketReplicate

--- a/mixin/runbook.md
+++ b/mixin/runbook.md
@@ -86,7 +86,7 @@
 |Name|Summary|Description|Severity|Runbook|
 |---|---|---|---|---|
 |ThanosSidecarBucketOperationsFailed|Thanos Sidecar bucket operations are failing|Thanos Sidecar {{$labels.instance}} bucket operations are failing|critical|[https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanossidecarbucketoperationsfailed](https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanossidecarbucketoperationsfailed)|
-|ThanosSidecarNoConnectionToStartedPrometheus|Thanos Sidecar cannot access Prometheus, even though Prometheus seems healthy and has reloaded WAL.|Thanos Sidecar {{$labels.instance}} is unhealthy for more than {{$value}} seconds.|critical|[https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanossidecarnoconnectiontostartedprometheus](https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanossidecarnoconnectiontostartedprometheus)|
+|ThanosSidecarNoConnectionToStartedPrometheus|Thanos Sidecar cannot access Prometheus, even though Prometheus seems healthy and has reloaded WAL.|Thanos Sidecar {{$labels.instance}} is unhealthy.|critical|[https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanossidecarnoconnectiontostartedprometheus](https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanossidecarnoconnectiontostartedprometheus)|
 
 ## thanos-store
 

--- a/mixin/runbook.md
+++ b/mixin/runbook.md
@@ -85,9 +85,8 @@
 
 |Name|Summary|Description|Severity|Runbook|
 |---|---|---|---|---|
-|ThanosSidecarPrometheusDown|Thanos Sidecar cannot connect to Prometheus|Thanos Sidecar {{$labels.instance}} cannot connect to Prometheus.|critical|[https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanossidecarprometheusdown](https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanossidecarprometheusdown)|
 |ThanosSidecarBucketOperationsFailed|Thanos Sidecar bucket operations are failing|Thanos Sidecar {{$labels.instance}} bucket operations are failing|critical|[https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanossidecarbucketoperationsfailed](https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanossidecarbucketoperationsfailed)|
-|ThanosSidecarUnhealthy|Thanos Sidecar is unhealthy.|Thanos Sidecar {{$labels.instance}} is unhealthy for more than {{$value}} seconds.|critical|[https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanossidecarunhealthy](https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanossidecarunhealthy)|
+|ThanosSidecarUnhealthy|Thanos Sidecar cannot access Prometheus, even though Prometheus seems healthy and has reloaded WAL.|Thanos Sidecar {{$labels.instance}} is unhealthy for more than {{$value}} seconds.|critical|[https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanossidecarunhealthy](https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanossidecarunhealthy)|
 
 ## thanos-store
 

--- a/mixin/runbook.md
+++ b/mixin/runbook.md
@@ -86,7 +86,7 @@
 |Name|Summary|Description|Severity|Runbook|
 |---|---|---|---|---|
 |ThanosSidecarBucketOperationsFailed|Thanos Sidecar bucket operations are failing|Thanos Sidecar {{$labels.instance}} bucket operations are failing|critical|[https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanossidecarbucketoperationsfailed](https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanossidecarbucketoperationsfailed)|
-|ThanosSidecarUnhealthy|Thanos Sidecar cannot access Prometheus, even though Prometheus seems healthy and has reloaded WAL.|Thanos Sidecar {{$labels.instance}} is unhealthy for more than {{$value}} seconds.|critical|[https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanossidecarunhealthy](https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanossidecarunhealthy)|
+|ThanosSidecarNoConnectionToStartedPrometheus|Thanos Sidecar cannot access Prometheus, even though Prometheus seems healthy and has reloaded WAL.|Thanos Sidecar {{$labels.instance}} is unhealthy for more than {{$value}} seconds.|critical|[https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanossidecarnoconnectiontostartedprometheus](https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanossidecarnoconnectiontostartedprometheus)|
 
 ## thanos-store
 

--- a/pkg/rules/rules_test.go
+++ b/pkg/rules/rules_test.go
@@ -82,7 +82,7 @@ func testRulesAgainstExamples(t *testing.T, dir string, server rulespb.RulesServ
 		{
 			Name:                    "thanos-sidecar",
 			File:                    filepath.Join(dir, "alerts.yaml"),
-			Rules:                   []*rulespb.Rule{someAlert, someAlert, someAlert},
+			Rules:                   []*rulespb.Rule{someAlert, someAlert},
 			Interval:                60,
 			PartialResponseStrategy: storepb.PartialResponseStrategy_ABORT,
 		},


### PR DESCRIPTION
Prior to this fix, `ThanosSidecarUnhealthy` would fire even when
Prometheus is busy with WAL replay. This would trigger a false positive alert.

This PR considers `prometheus_tsdb_data_replay_duration_seconds` metric from
Prometheus for `ThanosSidecarUnhealthy` alert. In order to correlate
Thanos and Prometheus metrics we need to specify common label(s) which
can be configured through `thanosPrometheusCommonDimensions` jsonnet
variable.

This PR also removes `ThanosSidecarPrometheusDown` as it would fire at the same as `ThanosSidecarUnhealthy`.

Rename `ThanosSidecarUnhealthy` to `ThanosSidecarNoConnectionToStartedPrometheus`.

Remove unused `thanos_sidecar_last_heartbeat_success_time_seconds` metric.

Fixes https://github.com/thanos-io/thanos/issues/3915.

Signed-off-by: Arunprasad Rajkumar <arajkuma@redhat.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
