### PR TITLE
adds duration_ms in int64 to the logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#4482](https://github.com/thanos-io/thanos/pull/4482) COS: Add http_config for cos object store client.
 - [#4487](https://github.com/thanos-io/thanos/pull/4487) Query: Add memcached auto discovery support.
 - [#4444](https://github.com/thanos-io/thanos/pull/4444) UI: Add search block UI.
+- [#4509](https://github.com/thanos-io/thanos/pull/4509) Logging: Adds duration_ms in int64 to the logs.
 
 ### Fixed
 

--- a/cmd/thanos/downsample.go
+++ b/cmd/thanos/downsample.go
@@ -317,7 +317,7 @@ func processDownsampling(ctx context.Context, logger log.Logger, bkt objstore.Bu
 	if err != nil {
 		return errors.Wrapf(err, "download block %s", m.ULID)
 	}
-	level.Info(logger).Log("msg", "downloaded block", "id", m.ULID, "duration", time.Since(begin))
+	level.Info(logger).Log("msg", "downloaded block", "id", m.ULID, "duration", time.Since(begin), "duration_ms", time.Since(begin).Milliseconds())
 
 	if err := block.VerifyIndex(logger, filepath.Join(bdir, block.IndexFilename), m.MinTime, m.MaxTime); err != nil {
 		return errors.Wrap(err, "input block index not valid")
@@ -345,7 +345,7 @@ func processDownsampling(ctx context.Context, logger log.Logger, bkt objstore.Bu
 	resdir := filepath.Join(dir, id.String())
 
 	level.Info(logger).Log("msg", "downsampled block",
-		"from", m.ULID, "to", id, "duration", time.Since(begin))
+		"from", m.ULID, "to", id, "duration", time.Since(begin), "duration_ms", time.Since(begin).Milliseconds())
 
 	if err := block.VerifyIndex(logger, filepath.Join(resdir, block.IndexFilename), m.MinTime, m.MaxTime); err != nil {
 		return errors.Wrap(err, "output block index not valid")
@@ -358,7 +358,7 @@ func processDownsampling(ctx context.Context, logger log.Logger, bkt objstore.Bu
 		return errors.Wrapf(err, "upload downsampled block %s", id)
 	}
 
-	level.Info(logger).Log("msg", "uploaded block", "id", id, "duration", time.Since(begin))
+	level.Info(logger).Log("msg", "uploaded block", "id", id, "duration", time.Since(begin), "duration_ms", time.Since(begin).Milliseconds())
 
 	// It is not harmful if these fails.
 	if err := os.RemoveAll(bdir); err != nil {

--- a/pkg/block/fetcher.go
+++ b/pkg/block/fetcher.go
@@ -473,7 +473,7 @@ func (f *BaseFetcher) fetch(ctx context.Context, metrics *FetcherMetrics, filter
 		return metas, resp.partial, errors.Wrap(resp.metaErrs.Err(), "incomplete view")
 	}
 
-	level.Info(f.logger).Log("msg", "successfully synchronized block metadata", "duration", time.Since(start).String(), "cached", len(f.cached), "returned", len(metas), "partial", len(resp.partial))
+	level.Info(f.logger).Log("msg", "successfully synchronized block metadata", "duration", time.Since(start).String(), "duration_ms", time.Since(start).Milliseconds(), "cached", len(f.cached), "returned", len(metas), "partial", len(resp.partial))
 	return metas, resp.partial, nil
 }
 

--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -759,7 +759,7 @@ func (cg *Group) compact(ctx context.Context, dir string, planner Planner, comp 
 		}
 		toCompactDirs = append(toCompactDirs, bdir)
 	}
-	level.Info(cg.logger).Log("msg", "downloaded and verified blocks; compacting blocks", "plan", fmt.Sprintf("%v", toCompactDirs), "duration", time.Since(begin))
+	level.Info(cg.logger).Log("msg", "downloaded and verified blocks; compacting blocks", "plan", fmt.Sprintf("%v", toCompactDirs), "duration", time.Since(begin), "duration_ms", time.Since(begin).Milliseconds())
 
 	begin = time.Now()
 	compID, err = comp.Compact(dir, toCompactDirs, nil)
@@ -784,7 +784,7 @@ func (cg *Group) compact(ctx context.Context, dir string, planner Planner, comp 
 		cg.verticalCompactions.Inc()
 	}
 	level.Info(cg.logger).Log("msg", "compacted blocks", "new", compID,
-		"blocks", fmt.Sprintf("%v", toCompactDirs), "duration", time.Since(begin), "overlapping_blocks", overlappingBlocks)
+		"blocks", fmt.Sprintf("%v", toCompactDirs), "duration", time.Since(begin), "duration_ms", time.Since(begin).Milliseconds(), "overlapping_blocks", overlappingBlocks)
 
 	bdir := filepath.Join(dir, compID.String())
 	index := filepath.Join(bdir, block.IndexFilename)
@@ -821,7 +821,7 @@ func (cg *Group) compact(ctx context.Context, dir string, planner Planner, comp 
 	if err := block.Upload(ctx, cg.logger, cg.bkt, bdir, cg.hashFunc); err != nil {
 		return false, ulid.ULID{}, retry(errors.Wrapf(err, "upload of %s failed", compID))
 	}
-	level.Info(cg.logger).Log("msg", "uploaded block", "result_block", compID, "duration", time.Since(begin))
+	level.Info(cg.logger).Log("msg", "uploaded block", "result_block", compID, "duration", time.Since(begin), "duration_ms", time.Since(begin).Milliseconds())
 
 	// Mark for deletion the blocks we just compacted from the group and bucket so they do not get included
 	// into the next planning cycle.


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Motivation

Currently the logged lines contain a `duration` field that is encoded as a string with varying units. When ingesting these structured logs into a logging system (eg. elasticsearch), the field is parsed as a string which doesn't allow for range queries.

Example from v0.19.0:
```json
{
      "ts": "2021-08-02T11:38:26.928570654Z",
      "cached": 23731,
      "duration": "2.09562852s",
      "tier": "sv",
      "stage": "main",
      "returned": 1567,
      "type": "monitoring",
      "component": "block.BaseFetcher",
      "msg": "successfully synchronized block metadata",
      "caller": "fetcher.go:476",
      "level": "info",
      "partial": 0
}
```
Adding a dedicated `duration_ms` integer field solves this problem.

Example:
```json
{
      "duration": "2.09562852s",
      "duration_ms": "2095",
}
```
In order to avoid schema conflicts and introducing a breaking change, we're adding a new field rather than changing the existing one.

## Changes

<!-- Enumerate changes you made -->
Adds an integer `duration_ms` to the logged lines with the `duration` field.

## Verification

<!-- How you tested it? How do you know it works? -->

@igorwwwwwwwwwwwwwwwwwwww thanks for co-authoring this PR.