### PR TITLE
store: bucket: reuse buffers for Series() responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 
 - [#4354](https://github.com/thanos-io/thanos/pull/4354) Receive: use the S2 library for decoding Snappy data; saves about 5-7% of CPU time in the Receive component when handling incoming remote write requests
 - [#4369](https://github.com/thanos-io/thanos/pull/4354) Build: do not upgrade apline version
+- [#4512](https://github.com/thanos-io/thanos/pull/4512) Store: reuse same buffer for Series() responses. On bigger queries this reduces Thanos Store memory usage by up to 25%.
 
 ## [v0.21.1](https://github.com/thanos-io/thanos/releases/tag/v0.21.1) - 2021.06.04
 

--- a/pkg/store/bucket_test.go
+++ b/pkg/store/bucket_test.go
@@ -1482,6 +1482,11 @@ func TestBucketSeries_OneBlock_InMemIndexCacheSegfault(t *testing.T) {
 		queryGate:            gate.NewNoop(),
 		chunksLimiterFactory: NewChunksLimiterFactory(0),
 		seriesLimiterFactory: NewSeriesLimiterFactory(0),
+		respBufferPool: &sync.Pool{
+			New: func() interface{} {
+				return &bytes.Buffer{}
+			},
+		},
 	}
 
 	t.Run("invoke series for one block. Fill the cache on the way.", func(t *testing.T) {

--- a/pkg/store/proxy_test.go
+++ b/pkg/store/proxy_test.go
@@ -1547,17 +1547,30 @@ type storeSeriesServer struct {
 	SeriesSet []storepb.Series
 	Warnings  []string
 	HintsSet  []*types.Any
-
-	Size int64
 }
 
 func newStoreSeriesServer(ctx context.Context) *storeSeriesServer {
 	return &storeSeriesServer{ctx: ctx}
 }
 
-func (s *storeSeriesServer) Send(r *storepb.SeriesResponse) error {
-	s.Size += int64(r.Size())
+func (s *storeSeriesServer) SendMsg(m interface{}) error {
+	r := m.(*storepb.SeriesResponseZeroMarshal)
 
+	_, err := r.Marshal()
+	if err != nil {
+		return err
+	}
+	return s.Send(r.Resp)
+}
+
+func (s *storeSeriesServer) Send(r *storepb.SeriesResponse) error {
+	/*
+	   Uncomment here for a fair comparison pre-SeriesResponseZeroMarshal.
+	   _, err := r.Marshal()
+	   if err != nil {
+	           return err
+	   }
+	*/
 	if r.GetWarning() != "" {
 		s.Warnings = append(s.Warnings, r.GetWarning())
 		return nil

--- a/pkg/store/storepb/custom.go
+++ b/pkg/store/storepb/custom.go
@@ -456,3 +456,24 @@ func CompareLabels(a, b []Label) int {
 func LabelsToPromLabelsUnsafe(lset []Label) labels.Labels {
 	return labelpb.ZLabelsToPromLabels(lset)
 }
+
+// SeriesResponseZeroMarshal is a struct that holds a series response
+// and who always marshals to the provided byte slice.
+type SeriesResponseZeroMarshal struct {
+	Resp *SeriesResponse
+	buf  []byte
+}
+
+// NewSeriesResponseZeroMarshal initializes a new zero-alloc marshaler.
+// initialBuf should be taken from a sync.Pool.
+func NewSeriesResponseZeroMarshal(s *SeriesResponse, initialBuf []byte) *SeriesResponseZeroMarshal {
+	return &SeriesResponseZeroMarshal{Resp: s, buf: initialBuf}
+}
+
+func (s *SeriesResponseZeroMarshal) Marshal() ([]byte, error) {
+	n, err := s.Resp.MarshalToSizedBuffer(s.buf)
+	if err != nil {
+		return nil, err
+	}
+	return s.buf[len(s.buf)-n:], nil
+}

--- a/pkg/store/storepb/testutil/series.go
+++ b/pkg/store/storepb/testutil/series.go
@@ -157,17 +157,30 @@ type SeriesServer struct {
 	SeriesSet []*storepb.Series
 	Warnings  []string
 	HintsSet  []*types.Any
-
-	Size int64
 }
 
 func NewSeriesServer(ctx context.Context) *SeriesServer {
 	return &SeriesServer{ctx: ctx}
 }
 
-func (s *SeriesServer) Send(r *storepb.SeriesResponse) error {
-	s.Size += int64(r.Size())
+func (s *SeriesServer) SendMsg(m interface{}) error {
+	r := m.(*storepb.SeriesResponseZeroMarshal)
 
+	_, err := r.Marshal()
+	if err != nil {
+		return err
+	}
+	return s.Send(r.Resp)
+}
+
+func (s *SeriesServer) Send(r *storepb.SeriesResponse) error {
+	/*
+	   Uncomment here for a fair comparison pre-SeriesResponseZeroMarshal.
+	   _, err := r.Marshal()
+	   if err != nil {
+	           return err
+	   }
+	*/
 	if r.GetWarning() != "" {
 		s.Warnings = append(s.Warnings, r.GetWarning())
 		return nil


### PR DESCRIPTION
Reuse the buffers for Series() responses instead of creating separate
buffers for each serialization. Benchmarks show the following numbers:

```
benchmark                                                                  old ns/op      new ns/op      delta
BenchmarkBucketSeries/1000000SeriesWith1Samples/1of1000000-16              99877102       88749937       -11.14%
BenchmarkBucketSeries/1000000SeriesWith1Samples/10of1000000-16             99204101       90633472       -8.64%
BenchmarkBucketSeries/1000000SeriesWith1Samples/1000000of1000000-16        1155098496     1147337285     -0.67%
BenchmarkBucketSeries/100000SeriesWith100Samples/1of10000000-16            6905145        6548419        -5.17%
BenchmarkBucketSeries/100000SeriesWith100Samples/100of10000000-16          6826941        6511485        -4.62%
BenchmarkBucketSeries/100000SeriesWith100Samples/10000000of10000000-16     124279560      117056437      -5.81%
BenchmarkBucketSeries/1SeriesWith10000000Samples/1of10000000-16            129306         125762         -2.74%
BenchmarkBucketSeries/1SeriesWith10000000Samples/100of10000000-16          127787         121835         -4.66%
BenchmarkBucketSeries/1SeriesWith10000000Samples/10000000of10000000-16     40783249       34989360       -14.21%

benchmark                                                                  old allocs     new allocs     delta
BenchmarkBucketSeries/1000000SeriesWith1Samples/1of1000000-16              9716           9686           -0.31%
BenchmarkBucketSeries/1000000SeriesWith1Samples/10of1000000-16             9793           9785           -0.08%
BenchmarkBucketSeries/1000000SeriesWith1Samples/1000000of1000000-16        11039980       11040286       +0.00%
BenchmarkBucketSeries/100000SeriesWith100Samples/1of10000000-16            1100           1100           +0.00%
BenchmarkBucketSeries/100000SeriesWith100Samples/100of10000000-16          1135           1138           +0.26%
BenchmarkBucketSeries/100000SeriesWith100Samples/10000000of10000000-16     1104813        1104738        -0.01%
BenchmarkBucketSeries/1SeriesWith10000000Samples/1of10000000-16            200            200            +0.00%
BenchmarkBucketSeries/1SeriesWith10000000Samples/100of10000000-16          200            200            +0.00%
BenchmarkBucketSeries/1SeriesWith10000000Samples/10000000of10000000-16     167478         167481         +0.00%

benchmark                                                                  old bytes      new bytes      delta
BenchmarkBucketSeries/1000000SeriesWith1Samples/1of1000000-16              62057274       62050735       -0.01%
BenchmarkBucketSeries/1000000SeriesWith1Samples/10of1000000-16             62051330       62047650       -0.01%
BenchmarkBucketSeries/1000000SeriesWith1Samples/1000000of1000000-16        1366494136     1286584232     -5.85%
BenchmarkBucketSeries/100000SeriesWith100Samples/1of10000000-16            4853300        4852006        -0.03%
BenchmarkBucketSeries/100000SeriesWith100Samples/100of10000000-16          4854534        4854798        +0.01%
BenchmarkBucketSeries/100000SeriesWith100Samples/10000000of10000000-16     158506115      126821624      -19.99%
BenchmarkBucketSeries/1SeriesWith10000000Samples/1of10000000-16            213481         212495         -0.46%
BenchmarkBucketSeries/1SeriesWith10000000Samples/100of10000000-16          213365         212681         -0.32%
BenchmarkBucketSeries/1SeriesWith10000000Samples/10000000of10000000-16     115299014      101064549      -12.35%
```

Performance could be improved even more by memoizing Size() calls
however that is not possible until SeriesResponse becomes an interface
because there are places in the generated code where the three struct
names are hardcoded.

Signed-off-by: Giedrius Statkevičius <giedrius.statkevicius@vinted.com>

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Made it so that in Series() we would marshal a response to a given buffer. The buffer comes from a `sync.Pool`.

## Verification

Unit/integration tests.