### PR TITLE
reduce the length of scenario name

### DIFF
--- a/test/e2e/tools_bucket_web_test.go
+++ b/test/e2e/tools_bucket_web_test.go
@@ -112,7 +112,7 @@ func TestToolsBucketWebExternalPrefix(t *testing.T) {
 func TestToolsBucketWebExternalPrefixAndRoutePrefix(t *testing.T) {
 	t.Parallel()
 
-	s, err := e2e.NewScenario("e2e_test_tools_bucket_web_external_prefix_and_route_prefix")
+	s, err := e2e.NewScenario("e2e_test_tools_bucket_web_and_route_prefix")
 	testutil.Ok(t, err)
 	t.Cleanup(e2ethanos.CleanScenario(t, s))
 


### PR DESCRIPTION
Some linux systems support less than 64 characters for a host-name. the host name is more than 64 in this case `TestToolsBucketWebExternalPrefixAndRoutePrefix` so that the case cannot be passed:
```
06:22:50 toolsBucketWeb-1: level=error name=toolsBucketWeb-1 ts=2021-08-03T06:22:50.42873554Z caller=runutil.go:101 msg="function failed. Retrying in next tick" err="BaseFetcher: iter bucket: Get \"http://e2e_test_tools_bucket_web_external_prefix_and_route_prefix-minio-8080:8080/toolsBucketWeb_test/?location=\": dial tcp: lookup e2e_test_tools_bucket_web_external_prefix_and_route_prefix-minio-8080: no such host"

```

Signed-off-by: clyang82 <chuyang@redhat.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

reduce the length of scenario name

## Verification

<!-- How you tested it? How do you know it works? -->
