### PR TITLE
Switch to use Miekg by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 
 - [#4468](https://github.com/thanos-io/thanos/pull/4468) Rule: Fix temporary rule filename composition issue.
 - [#4476](https://github.com/thanos-io/thanos/pull/4476) UI: fix incorrect html escape sequence used for '>' symbol.
+- [#4519](https://github.com/thanos-io/thanos/pull/4519) Store: fix cannot unmarshal DNS message errors.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,9 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 
 - [#4468](https://github.com/thanos-io/thanos/pull/4468) Rule: Fix temporary rule filename composition issue.
 - [#4476](https://github.com/thanos-io/thanos/pull/4476) UI: fix incorrect html escape sequence used for '>' symbol.
-- [#4519](https://github.com/thanos-io/thanos/pull/4519) Store: fix cannot unmarshal DNS message errors.
 
 ### Changed
+- [#4519](https://github.com/thanos-io/thanos/pull/4519) Query: switch to miekgdns DNS resolver as the default one.
 
 ## [v0.22.0](https://github.com/thanos-io/thanos/tree/release-0.22) - 2021.07.22
 

--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -127,7 +127,7 @@ func registerQuery(app *extkingpin.App) {
 		Default("30s"))
 
 	dnsSDResolver := cmd.Flag("store.sd-dns-resolver", fmt.Sprintf("Resolver to use. Possible options: [%s, %s]", dns.GolangResolverType, dns.MiekgdnsResolverType)).
-		Default(string(dns.GolangResolverType)).Hidden().String()
+		Default(string(dns.MiekgdnsResolverType)).Hidden().String()
 
 	unhealthyStoreTimeout := extkingpin.ModelDuration(cmd.Flag("store.unhealthy-timeout", "Timeout before an unhealthy store is cleaned from the store UI page.").Default("5m"))
 

--- a/pkg/cacheutil/memcached_client.go
+++ b/pkg/cacheutil/memcached_client.go
@@ -247,7 +247,7 @@ func newMemcachedClient(
 		addressProvider = dns.NewProvider(
 			logger,
 			extprom.WrapRegistererWithPrefix("thanos_memcached_", reg),
-			dns.GolangResolverType,
+			dns.MiekgdnsResolverType,
 		)
 	}
 


### PR DESCRIPTION
Signed-off-by: clyang82 <chuyang@redhat.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

ref: https://github.com/thanos-io/thanos/issues/4204
I saw the same issue exists in version 0.22 in OCP 4.8. 
If I understand correctly, `Miekg resolver was working fine for everyone, but Go native not`. so have this PR to use Miekg as default resolver.

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
