### PR TITLE
Fix flaky test introduced by memcached autodiscovery

### DIFF
--- a/pkg/discovery/memcache/provider_test.go
+++ b/pkg/discovery/memcache/provider_test.go
@@ -29,6 +29,7 @@ func TestProviderUpdatesAddresses(t *testing.T) {
 
 	testutil.Ok(t, provider.Resolve(ctx, clusters))
 	addresses := provider.Addresses()
+	sort.Strings(addresses)
 	testutil.Equals(t, []string{"dns-1:11211", "dns-2:8080"}, addresses)
 
 	resolver.configs = map[string]*clusterConfig{


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

* Fix flaky test (https://github.com/thanos-io/thanos/issues/4523)

## Verification

<!-- How you tested it? How do you know it works? -->
