### PR TITLE
remove search keymap from new expression editor

### DIFF
--- a/pkg/ui/react-app/src/pages/graph/CMExpressionInput.tsx
+++ b/pkg/ui/react-app/src/pages/graph/CMExpressionInput.tsx
@@ -7,7 +7,7 @@ import { history, historyKeymap } from '@codemirror/history';
 import { defaultKeymap, insertNewlineAndIndent } from '@codemirror/commands';
 import { bracketMatching } from '@codemirror/matchbrackets';
 import { closeBrackets, closeBracketsKeymap } from '@codemirror/closebrackets';
-import { searchKeymap, highlightSelectionMatches } from '@codemirror/search';
+import { highlightSelectionMatches } from '@codemirror/search';
 import { commentKeymap } from '@codemirror/comment';
 import { lintKeymap } from '@codemirror/lint';
 import { PromQLExtension, CompleteStrategy } from 'codemirror-promql';
@@ -135,7 +135,6 @@ const CMExpressionInput: FC<PathPrefixProps & CMExpressionInputProps> = ({
           keymap.of([
             ...closeBracketsKeymap,
             ...defaultKeymap,
-            ...searchKeymap,
             ...historyKeymap,
             ...commentKeymap,
             ...completionKeymap,


### PR DESCRIPTION
This PR is removing the inner search tool that you have when you press CTRL-F when having the focus in the PromQL 

![image](https://user-images.githubusercontent.com/4548045/128996912-a24e800f-80ef-45ee-88a0-d9a2ab8809ef.png)

Which is not really helpful in the usage of writing PromQL query.

It also to be synchronized with Prometheus: https://github.com/prometheus/prometheus/pull/9184