### PR TITLE
Improvement: add metrics to prom client

### DIFF
--- a/cmd/thanos/rule.go
+++ b/cmd/thanos/rule.go
@@ -303,8 +303,10 @@ func runRule(
 		dns.ResolverType(conf.query.dnsSDResolver),
 	)
 	var queryClients []*http_util.Client
+	queryClientMetrics := extpromhttp.NewClientMetrics(reg, "thanos_rule_query")
 	for _, cfg := range queryCfg {
-		c, err := http_util.NewHTTPClient(cfg.HTTPClientConfig, "query")
+		cfg.HTTPClientConfig.ClientMetrics = queryClientMetrics
+		c, err := http_util.NewHTTPClient(cfg.HTTPClientConfig,"query")
 		if err != nil {
 			return err
 		}
@@ -374,7 +376,9 @@ func runRule(
 		dns.ResolverType(conf.query.dnsSDResolver),
 	)
 	var alertmgrs []*alert.Alertmanager
+	amClientMetrics := extpromhttp.NewClientMetrics(reg, "thanos_rule_alertmanager")
 	for _, cfg := range alertingCfg.Alertmanagers {
+		cfg.HTTPClientConfig.ClientMetrics = amClientMetrics
 		c, err := http_util.NewHTTPClient(cfg.HTTPClientConfig, "alertmanager")
 		if err != nil {
 			return err

--- a/cmd/thanos/rule.go
+++ b/cmd/thanos/rule.go
@@ -306,7 +306,7 @@ func runRule(
 	queryClientMetrics := extpromhttp.NewClientMetrics(reg, "thanos_rule_query")
 	for _, cfg := range queryCfg {
 		cfg.HTTPClientConfig.ClientMetrics = queryClientMetrics
-		c, err := http_util.NewHTTPClient(cfg.HTTPClientConfig,"query")
+		c, err := http_util.NewHTTPClient(cfg.HTTPClientConfig, "query")
 		if err != nil {
 			return err
 		}

--- a/cmd/thanos/rule.go
+++ b/cmd/thanos/rule.go
@@ -303,7 +303,7 @@ func runRule(
 		dns.ResolverType(conf.query.dnsSDResolver),
 	)
 	var queryClients []*http_util.Client
-	queryClientMetrics := extpromhttp.NewClientMetrics(reg, "thanos_rule_query")
+	queryClientMetrics := extpromhttp.NewClientMetrics(extprom.WrapRegistererWith(prometheus.Labels{"client": "query"}, reg))
 	for _, cfg := range queryCfg {
 		cfg.HTTPClientConfig.ClientMetrics = queryClientMetrics
 		c, err := http_util.NewHTTPClient(cfg.HTTPClientConfig, "query")
@@ -376,7 +376,9 @@ func runRule(
 		dns.ResolverType(conf.query.dnsSDResolver),
 	)
 	var alertmgrs []*alert.Alertmanager
-	amClientMetrics := extpromhttp.NewClientMetrics(reg, "thanos_rule_alertmanager")
+	amClientMetrics := extpromhttp.NewClientMetrics(
+		extprom.WrapRegistererWith(prometheus.Labels{"client": "alertmanager"}, reg),
+	)
 	for _, cfg := range alertingCfg.Alertmanagers {
 		cfg.HTTPClientConfig.ClientMetrics = amClientMetrics
 		c, err := http_util.NewHTTPClient(cfg.HTTPClientConfig, "alertmanager")

--- a/pkg/extprom/http/instrument_client.go
+++ b/pkg/extprom/http/instrument_client.go
@@ -1,10 +1,14 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
 package http
 
 import (
+	"net/http"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"net/http"
 )
 
 // ClientMetrics holds a collection of metrics that can be used to instrument a http client.
@@ -44,7 +48,7 @@ func NewClientMetrics(reg prometheus.Registerer, namespace string) *ClientMetric
 			Subsystem: "http_client",
 			Name:      "dns_duration_seconds",
 			Help:      "Trace dns latency histogram.",
-			Buckets:   prometheus.DefBuckets,
+			Buckets:   []float64{0.025, .05, .1, .5, 1, 5, 10},
 		},
 		[]string{"event"},
 	)
@@ -55,7 +59,7 @@ func NewClientMetrics(reg prometheus.Registerer, namespace string) *ClientMetric
 			Subsystem: "http_client",
 			Name:      "tls_duration_seconds",
 			Help:      "Trace tls latency histogram.",
-			Buckets:   prometheus.DefBuckets,
+			Buckets:   []float64{0.025, .05, .1, .5, 1, 5, 10},
 		},
 		[]string{"event"},
 	)
@@ -66,7 +70,7 @@ func NewClientMetrics(reg prometheus.Registerer, namespace string) *ClientMetric
 			Subsystem: "http_client",
 			Name:      "request_duration_seconds",
 			Help:      "A histogram of request latencies.",
-			Buckets:   prometheus.DefBuckets,
+			Buckets:   []float64{0.025, .05, .1, .5, 1, 5, 10},
 		},
 		[]string{},
 	)

--- a/pkg/extprom/http/instrument_client.go
+++ b/pkg/extprom/http/instrument_client.go
@@ -1,0 +1,104 @@
+package http
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"net/http"
+)
+
+type ClientMetrics struct {
+	inFlightGauge            prometheus.Gauge
+	requestTotalCount        *prometheus.CounterVec
+	dnsLatencyHistogram      *prometheus.HistogramVec
+	tlsLatencyHistogram      *prometheus.HistogramVec
+	requestDurationHistogram *prometheus.HistogramVec
+}
+
+func NewClientMetrics(reg prometheus.Registerer, namespace string) *ClientMetrics {
+	var m ClientMetrics
+
+	m.inFlightGauge = promauto.With(reg).NewGauge(prometheus.GaugeOpts{
+		Namespace: namespace,
+		Subsystem: "http_client",
+		Name:      "in_flight_requests",
+		Help:      "A gauge of in-flight requests.",
+	})
+
+	m.requestTotalCount = promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+		Namespace: namespace,
+		Subsystem: "http_client",
+		Name:      "request_total",
+		Help:      "",
+	}, []string{"code", "method"})
+
+	m.dnsLatencyHistogram = promauto.With(reg).NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: namespace,
+			Subsystem: "http_client",
+			Name:      "dns_duration_seconds",
+			Help:      "Trace dns latency histogram.",
+			Buckets:   prometheus.DefBuckets,
+		},
+		[]string{"event"},
+	)
+
+	m.tlsLatencyHistogram = promauto.With(reg).NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: namespace,
+			Subsystem: "http_client",
+			Name:      "tls_duration_seconds",
+			Help:      "Trace tls latency histogram.",
+			Buckets:   prometheus.DefBuckets,
+		},
+		[]string{"event"},
+	)
+
+	m.requestDurationHistogram = promauto.With(reg).NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: namespace,
+			Subsystem: "http_client",
+			Name:      "request_duration_seconds",
+			Help:      "A histogram of request latencies.",
+			Buckets:   prometheus.DefBuckets,
+		},
+		[]string{},
+	)
+
+	return &m
+}
+
+func InstrumentedRoundTripper(tripper http.RoundTripper, m *ClientMetrics) http.RoundTripper {
+	if m == nil {
+		return tripper
+	}
+
+	trace := &promhttp.InstrumentTrace{
+		DNSStart: func(t float64) {
+			m.dnsLatencyHistogram.WithLabelValues("dns_start").Observe(t)
+		},
+		DNSDone: func(t float64) {
+			m.dnsLatencyHistogram.WithLabelValues("dns_done").Observe(t)
+		},
+		TLSHandshakeStart: func(t float64) {
+			m.tlsLatencyHistogram.WithLabelValues("tls_handshake_start").Observe(t)
+		},
+		TLSHandshakeDone: func(t float64) {
+			m.tlsLatencyHistogram.WithLabelValues("tls_handshake_done").Observe(t)
+		},
+	}
+
+	return promhttp.InstrumentRoundTripperInFlight(
+		m.inFlightGauge,
+		promhttp.InstrumentRoundTripperCounter(
+			m.requestTotalCount,
+			promhttp.InstrumentRoundTripperTrace(
+				trace,
+				promhttp.InstrumentRoundTripperDuration(
+					m.requestDurationHistogram,
+					tripper,
+				),
+			),
+		),
+	)
+}

--- a/pkg/extprom/http/instrument_client.go
+++ b/pkg/extprom/http/instrument_client.go
@@ -37,7 +37,7 @@ func NewClientMetrics(reg prometheus.Registerer) *ClientMetrics {
 	m.requestTotalCount = promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 		Subsystem: "http_client",
 		Name:      "request_total",
-		Help:      "",
+		Help:      "Total http client request by code and method.",
 	}, []string{"code", "method"})
 
 	m.dnsLatencyHistogram = promauto.With(reg).NewHistogramVec(
@@ -67,7 +67,7 @@ func NewClientMetrics(reg prometheus.Registerer) *ClientMetrics {
 			Help:      "A histogram of request latencies.",
 			Buckets:   []float64{0.025, .05, .1, .5, 1, 5, 10},
 		},
-		[]string{},
+		[]string{"code", "method"},
 	)
 
 	return &m

--- a/pkg/extprom/http/instrument_client.go
+++ b/pkg/extprom/http/instrument_client.go
@@ -25,18 +25,16 @@ type ClientMetrics struct {
 // It will also register the metrics with the included register.
 // This ClientMetrics should be re-used for diff clients with the same purpose.
 // e.g. 1 ClientMetrics should be used for all the clients that talk to Alertmanager.
-func NewClientMetrics(reg prometheus.Registerer, namespace string) *ClientMetrics {
+func NewClientMetrics(reg prometheus.Registerer) *ClientMetrics {
 	var m ClientMetrics
 
 	m.inFlightGauge = promauto.With(reg).NewGauge(prometheus.GaugeOpts{
-		Namespace: namespace,
 		Subsystem: "http_client",
 		Name:      "in_flight_requests",
 		Help:      "A gauge of in-flight requests.",
 	})
 
 	m.requestTotalCount = promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
-		Namespace: namespace,
 		Subsystem: "http_client",
 		Name:      "request_total",
 		Help:      "",
@@ -44,7 +42,6 @@ func NewClientMetrics(reg prometheus.Registerer, namespace string) *ClientMetric
 
 	m.dnsLatencyHistogram = promauto.With(reg).NewHistogramVec(
 		prometheus.HistogramOpts{
-			Namespace: namespace,
 			Subsystem: "http_client",
 			Name:      "dns_duration_seconds",
 			Help:      "Trace dns latency histogram.",
@@ -55,7 +52,6 @@ func NewClientMetrics(reg prometheus.Registerer, namespace string) *ClientMetric
 
 	m.tlsLatencyHistogram = promauto.With(reg).NewHistogramVec(
 		prometheus.HistogramOpts{
-			Namespace: namespace,
 			Subsystem: "http_client",
 			Name:      "tls_duration_seconds",
 			Help:      "Trace tls latency histogram.",
@@ -66,7 +62,6 @@ func NewClientMetrics(reg prometheus.Registerer, namespace string) *ClientMetric
 
 	m.requestDurationHistogram = promauto.With(reg).NewHistogramVec(
 		prometheus.HistogramOpts{
-			Namespace: namespace,
 			Subsystem: "http_client",
 			Name:      "request_duration_seconds",
 			Help:      "A histogram of request latencies.",

--- a/pkg/extprom/http/instrument_client.go
+++ b/pkg/extprom/http/instrument_client.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 )
 
+// ClientMetrics holds a collection of metrics that can be used to instrument a http client.
+// By setting this field in HTTPClientConfig, NewHTTPClient will create an instrumented client.
 type ClientMetrics struct {
 	inFlightGauge            prometheus.Gauge
 	requestTotalCount        *prometheus.CounterVec
@@ -15,6 +17,10 @@ type ClientMetrics struct {
 	requestDurationHistogram *prometheus.HistogramVec
 }
 
+// NewClientMetrics creates a new instance of ClientMetrics.
+// It will also register the metrics with the included register.
+// This ClientMetrics should be re-used for diff clients with the same purpose.
+// e.g. 1 ClientMetrics should be used for all the clients that talk to Alertmanager.
 func NewClientMetrics(reg prometheus.Registerer, namespace string) *ClientMetrics {
 	var m ClientMetrics
 
@@ -68,6 +74,8 @@ func NewClientMetrics(reg prometheus.Registerer, namespace string) *ClientMetric
 	return &m
 }
 
+// InstrumentedRoundTripper instruments the given roundtripper with metrics that are
+// registered in the provided ClientMetrics.
 func InstrumentedRoundTripper(tripper http.RoundTripper, m *ClientMetrics) http.RoundTripper {
 	if m == nil {
 		return tripper

--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -7,11 +7,12 @@ package http
 import (
 	"context"
 	"fmt"
-	extpromhttp "github.com/thanos-io/thanos/pkg/extprom/http"
 	"net/http"
 	"net/url"
 	"path"
 	"sync"
+
+	extpromhttp "github.com/thanos-io/thanos/pkg/extprom/http"
 
 	"github.com/go-kit/kit/log"
 	config_util "github.com/prometheus/common/config"

--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -36,7 +36,8 @@ type ClientConfig struct {
 	ProxyURL string `yaml:"proxy_url"`
 	// TLSConfig to use to connect to the targets.
 	TLSConfig TLSConfig `yaml:"tls_config"`
-
+	// ClientMetrics contains metrics that will be used to instrument
+	// the client that will be created with this config.
 	ClientMetrics *extpromhttp.ClientMetrics
 }
 

--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -39,7 +39,7 @@ type ClientConfig struct {
 	TLSConfig TLSConfig `yaml:"tls_config"`
 	// ClientMetrics contains metrics that will be used to instrument
 	// the client that will be created with this config.
-	ClientMetrics *extpromhttp.ClientMetrics
+	ClientMetrics *extpromhttp.ClientMetrics `yaml:"-"`
 }
 
 // TLSConfig configures TLS connections.


### PR DESCRIPTION
This pr add `pkg/extprom/http/instrument_client.go` with code to instrument an HTTP client.
The approach is to add metrics clients to the HTTP config.
Not sure if this is the right approach or if another clever design can be used, this was the most obvious and backward compatible way I could come up with.

fixes: https://github.com/thanos-io/thanos/issues/4545

Signed-off-by: Kevin Hellemun <17928966+OGKevin@users.noreply.github.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->

```
# HELP thanos_rule_query_http_client_in_flight_requests A gauge of in-flight requests.
# TYPE thanos_rule_query_http_client_in_flight_requests gauge
thanos_rule_query_http_client_in_flight_requests 0
# HELP thanos_rule_query_http_client_request_duration_seconds A histogram of request latencies.
# TYPE thanos_rule_query_http_client_request_duration_seconds histogram
thanos_rule_query_http_client_request_duration_seconds_bucket{le="0.005"} 0
thanos_rule_query_http_client_request_duration_seconds_bucket{le="0.01"} 1
thanos_rule_query_http_client_request_duration_seconds_bucket{le="0.025"} 2
thanos_rule_query_http_client_request_duration_seconds_bucket{le="0.05"} 2
thanos_rule_query_http_client_request_duration_seconds_bucket{le="0.1"} 2
thanos_rule_query_http_client_request_duration_seconds_bucket{le="0.25"} 2
thanos_rule_query_http_client_request_duration_seconds_bucket{le="0.5"} 2
thanos_rule_query_http_client_request_duration_seconds_bucket{le="1"} 2
thanos_rule_query_http_client_request_duration_seconds_bucket{le="2.5"} 2
thanos_rule_query_http_client_request_duration_seconds_bucket{le="5"} 2
thanos_rule_query_http_client_request_duration_seconds_bucket{le="10"} 2
thanos_rule_query_http_client_request_duration_seconds_bucket{le="+Inf"} 2
thanos_rule_query_http_client_request_duration_seconds_sum 0.018484452
thanos_rule_query_http_client_request_duration_seconds_count 2
# HELP thanos_rule_query_http_client_request_total 
# TYPE thanos_rule_query_http_client_request_total counter
thanos_rule_query_http_client_request_total{code="200",method="post"} 2
```
