### PR TITLE
match support for labels api in query frontend

### DIFF
--- a/pkg/queryfrontend/cache.go
+++ b/pkg/queryfrontend/cache.go
@@ -36,7 +36,7 @@ func (t thanosCacheKeyGenerator) GenerateCacheKey(_ string, r queryrange.Request
 		}
 		return fmt.Sprintf("%s:%d:%d:%d", tr.Query, tr.Step, currentInterval, i)
 	case *ThanosLabelsRequest:
-		return fmt.Sprintf("%s:%d", tr.Label, currentInterval)
+		return fmt.Sprintf("%s:%s:%d", tr.Label, tr.Matchers, currentInterval)
 	case *ThanosSeriesRequest:
 		return fmt.Sprintf("%s:%d", tr.Matchers, currentInterval)
 	}

--- a/pkg/queryfrontend/labels_codec.go
+++ b/pkg/queryfrontend/labels_codec.go
@@ -139,6 +139,9 @@ func (c labelsCodec) EncodeRequest(ctx context.Context, r queryrange.Request) (*
 			"end":                        []string{encodeTime(thanosReq.End)},
 			queryv1.PartialResponseParam: []string{strconv.FormatBool(thanosReq.PartialResponse)},
 		}
+		if len(thanosReq.Matchers) > 0 {
+			params[queryv1.MatcherParam] = matchersToStringSlice(thanosReq.Matchers)
+		}
 		if len(thanosReq.StoreMatchers) > 0 {
 			params[queryv1.StoreMatcherParam] = matchersToStringSlice(thanosReq.StoreMatchers)
 		}
@@ -274,6 +277,11 @@ func (c labelsCodec) parseLabelsRequest(r *http.Request, op string) (queryrange.
 		err    error
 	)
 	result.Start, result.End, err = parseMetadataTimeRange(r, c.defaultMetadataTimeRange)
+	if err != nil {
+		return nil, err
+	}
+
+	result.Matchers, err = parseMatchersParam(r.Form, queryv1.MatcherParam)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/queryfrontend/labels_codec_test.go
+++ b/pkg/queryfrontend/labels_codec_test.go
@@ -91,19 +91,20 @@ func TestLabelsCodec_DecodeRequest(t *testing.T) {
 		},
 		{
 			name:            "label_names partial_response default to true",
-			url:             "/api/v1/labels?start=123&end=456",
+			url:             `/api/v1/labels?start=123&end=456&match[]={foo="bar"}`,
 			partialResponse: true,
 			expectedRequest: &ThanosLabelsRequest{
 				Path:            "/api/v1/labels",
 				Start:           123000,
 				End:             456000,
 				PartialResponse: true,
+				Matchers:        [][]*labels.Matcher{{labels.MustNewMatcher(labels.MatchEqual, "foo", "bar")}},
 				StoreMatchers:   [][]*labels.Matcher{},
 			},
 		},
 		{
 			name:            "label_values partial_response default to true",
-			url:             "/api/v1/label/__name__/values?start=123&end=456",
+			url:             `/api/v1/label/__name__/values?start=123&end=456&match[]={foo="bar"}`,
 			partialResponse: true,
 			expectedRequest: &ThanosLabelsRequest{
 				Path:            "/api/v1/label/__name__/values",
@@ -111,6 +112,7 @@ func TestLabelsCodec_DecodeRequest(t *testing.T) {
 				End:             456000,
 				PartialResponse: true,
 				Label:           "__name__",
+				Matchers:        [][]*labels.Matcher{{labels.MustNewMatcher(labels.MatchEqual, "foo", "bar")}},
 				StoreMatchers:   [][]*labels.Matcher{},
 			},
 		},
@@ -130,13 +132,14 @@ func TestLabelsCodec_DecodeRequest(t *testing.T) {
 		},
 		{
 			name:            "partial_response default to false, but set to true in query",
-			url:             "/api/v1/labels?start=123&end=456&partial_response=true",
+			url:             `/api/v1/labels?start=123&end=456&partial_response=true&match[]={foo="bar"}`,
 			partialResponse: false,
 			expectedRequest: &ThanosLabelsRequest{
 				Path:            "/api/v1/labels",
 				Start:           123000,
 				End:             456000,
 				PartialResponse: true,
+				Matchers:        [][]*labels.Matcher{{labels.MustNewMatcher(labels.MatchEqual, "foo", "bar")}},
 				StoreMatchers:   [][]*labels.Matcher{},
 			},
 		},
@@ -145,9 +148,10 @@ func TestLabelsCodec_DecodeRequest(t *testing.T) {
 			url:             `/api/v1/labels?start=123&end=456&storeMatch[]={__address__="localhost:10901", cluster="test"}`,
 			partialResponse: false,
 			expectedRequest: &ThanosLabelsRequest{
-				Path:  "/api/v1/labels",
-				Start: 123000,
-				End:   456000,
+				Path:     "/api/v1/labels",
+				Start:    123000,
+				End:      456000,
+				Matchers: [][]*labels.Matcher{},
 				StoreMatchers: [][]*labels.Matcher{
 					{
 						labels.MustNewMatcher(labels.MatchEqual, "__address__", "localhost:10901"),

--- a/pkg/queryfrontend/request.go
+++ b/pkg/queryfrontend/request.go
@@ -4,7 +4,6 @@
 package queryfrontend
 
 import (
-	"github.com/thanos-io/thanos/vendor/github.com/opentracing/opentracing-go"
 	"time"
 
 	"github.com/cortexproject/cortex/pkg/querier/queryrange"

--- a/pkg/queryfrontend/request.go
+++ b/pkg/queryfrontend/request.go
@@ -103,6 +103,7 @@ type ThanosLabelsRequest struct {
 	End             int64
 	Label           string
 	Path            string
+	Matchers        [][]*labels.Matcher
 	StoreMatchers   [][]*labels.Matcher
 	PartialResponse bool
 	CachingOptions  queryrange.CachingOptions
@@ -143,6 +144,8 @@ func (r *ThanosLabelsRequest) LogToSpan(sp opentracing.Span) {
 		otlog.String("start", timestamp.Time(r.GetStart()).String()),
 		otlog.String("end", timestamp.Time(r.GetEnd()).String()),
 		otlog.Bool("partial_response", r.PartialResponse),
+		otlog.String("label", r.Label),
+		otlog.Object("matchers", r.Matchers),
 		otlog.Object("storeMatchers", r.StoreMatchers),
 	}
 	if r.Label != "" {

--- a/pkg/queryfrontend/request.go
+++ b/pkg/queryfrontend/request.go
@@ -4,6 +4,7 @@
 package queryfrontend
 
 import (
+	"github.com/thanos-io/thanos/vendor/github.com/opentracing/opentracing-go"
 	"time"
 
 	"github.com/cortexproject/cortex/pkg/querier/queryrange"
@@ -144,7 +145,6 @@ func (r *ThanosLabelsRequest) LogToSpan(sp opentracing.Span) {
 		otlog.String("start", timestamp.Time(r.GetStart()).String()),
 		otlog.String("end", timestamp.Time(r.GetEnd()).String()),
 		otlog.Bool("partial_response", r.PartialResponse),
-		otlog.String("label", r.Label),
 		otlog.Object("matchers", r.Matchers),
 		otlog.Object("storeMatchers", r.StoreMatchers),
 	}


### PR DESCRIPTION
Signed-off-by: Sandeep Raveesh <crsandy@gmail.com>

Fixes https://github.com/thanos-io/thanos/issues/4580

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

This PR adds the support for match[] parameter for labels api in query frontend

## Verification

I added the required tests to verify this.
