### PR TITLE
store: fix marshaling with sync.Pool

### DIFF
--- a/pkg/store/storepb/custom.go
+++ b/pkg/store/storepb/custom.go
@@ -500,7 +500,6 @@ func (m *SeriesResponse) Marshal() (dAtA []byte, err error) {
 	// Slow path with no sync.Pool.
 	if m.respPool == nil {
 		respBuf = make([]byte, size)
-		m.respBuf = nil
 
 		n, err := m.MarshalToSizedBuffer(respBuf)
 		if err != nil {
@@ -536,6 +535,7 @@ func (m *SeriesResponse) Marshal() (dAtA []byte, err error) {
 	m.respBuf = &respBuf
 
 	// Possibly trim it so that there wouldn't be left-over "garbage" in the slice.
+	// TODO: check if it is needed to always trim this.
 	marshalBuf := respBuf[:size]
 	n, err := m.MarshalToSizedBuffer(marshalBuf)
 	if err != nil {

--- a/pkg/store/storepb/custom_test.go
+++ b/pkg/store/storepb/custom_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"sort"
+	"sync"
 	"testing"
 
 	"github.com/pkg/errors"
@@ -524,4 +525,48 @@ func TestMatchersToString_Translate(t *testing.T) {
 		})
 
 	}
+}
+
+// Tests whether the Marshal() function properly checks the size
+// of a slice returned from a sync.Pool.
+// Reference: https://github.com/thanos-io/thanos/issues/4591.
+func TestMarshalChecksSize(t *testing.T) {
+	var s Series
+
+	rawData := []rawSeries{
+		{
+			lset: labels.Labels{labels.Label{Name: "a", Value: "c"}},
+			chunks: [][]sample{
+				{{t: 11, v: 11}, {t: 12, v: 12}, {t: 13, v: 13}, {t: 14, v: 14}},
+				{{t: 1, v: 1}, {t: 2, v: 2}, {t: 3, v: 3}, {t: 4, v: 4}},
+				{{t: 20, v: 20}, {t: 21, v: 21}, {t: 22, v: 22}, {t: 24, v: 24}},
+				{{t: 11, v: 11}, {t: 12, v: 12}, {t: 13, v: 13}, {t: 14, v: 14}},
+				{{t: 15, v: 15}, {t: 16, v: 16}, {t: 17, v: 17}, {t: 18, v: 18}},
+				{{t: 20, v: 20}, {t: 21, v: 21}, {t: 22, v: 23}, {t: 24, v: 24}},
+				{{t: 11, v: 11}, {t: 12, v: 12}, {t: 13, v: 13}, {t: 14, v: 14}},
+			},
+		},
+	}
+
+	listSS := newListSeriesSet(t, rawData)
+	lset, chks := listSS.At()
+
+	s.Chunks = chks
+	s.Labels = labelpb.ZLabelsFromPromLabels(lset)
+
+	resp := NewSeriesResponse(&s)
+
+	smallPool := sync.Pool{
+		New: func() interface{} {
+			b := make([]byte, 1)
+			return &b
+		},
+	}
+	resp.respPool = &smallPool
+
+	d, err := resp.Marshal()
+	testutil.Ok(t, err)
+	testutil.Assert(t, d != nil)
+
+	resp.Close()
 }

--- a/pkg/store/storepb/custom_test.go
+++ b/pkg/store/storepb/custom_test.go
@@ -529,7 +529,7 @@ func TestMatchersToString_Translate(t *testing.T) {
 
 // Tests whether the Marshal() function properly checks the size
 // of a slice returned from a sync.Pool.
-// Reference: https://github.com/thanos-io/thanos/issues/4591.
+// Regression test against https://github.com/thanos-io/thanos/issues/4591.
 func TestMarshalChecksSize(t *testing.T) {
 	var s Series
 


### PR DESCRIPTION
Do not forget to check the length of a slice returned by sync.Pool.
Annotate the whole function with comments to aid understanding of it.

Cover the case with a test that fails on `main`.

Fixes https://github.com/thanos-io/thanos/issues/4591.

cc @yeya24 as you've noticed this too

Signed-off-by: Giedrius Statkevičius <giedrius.statkevicius@vinted.com>
