### PR TITLE
store: add retry block for bucket initial sync

### DIFF
--- a/cmd/thanos/store.go
+++ b/cmd/thanos/store.go
@@ -361,11 +361,15 @@ func runStore(
 			defer runutil.CloseWithLogOnErr(logger, bkt, "bucket client")
 
 			level.Info(logger).Log("msg", "initializing bucket store")
+			// note(someshkoli): flag required to input interval duration ?
+			runutil.RetryWithLog(logger, time.Second*2, ctx.Done(), func() error {
+				if err := bs.InitialSync(ctx); err != nil {
+					return errors.Wrap(err, "bucket store initial sync")
+				}
+				return nil
+			})
 			begin := time.Now()
-			if err := bs.InitialSync(ctx); err != nil {
-				close(bucketStoreReady)
-				return errors.Wrap(err, "bucket store initial sync")
-			}
+
 			level.Info(logger).Log("msg", "bucket store ready", "init_duration", time.Since(begin).String())
 			close(bucketStoreReady)
 


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [X] Change is not relevant to the end user.

## Changes
Pushes bucket initial sync into a retry block to avoid server shutdown due to objstore unavailability. 
Closes #4489 
<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
