### PR TITLE
query: fix to respect per-request timeout if specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 
 ### Fixed
 
+- [#3539](https://github.com/thanos-io/thanos/pull/3539) Query: Queries timeout based on lower value out of global Query timeout and per-request timeout specified as part of the query API.
 - [#4468](https://github.com/thanos-io/thanos/pull/4468) Rule: Fix temporary rule filename composition issue.
 - [#4476](https://github.com/thanos-io/thanos/pull/4476) UI: fix incorrect html escape sequence used for '>' symbol.
 - [#4532](https://github.com/thanos-io/thanos/pull/4532) Mixin: Fixed "all jobs" selector in thanos mixin dashboards.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,11 +24,11 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 
 ### Fixed
 
-- [#3539](https://github.com/thanos-io/thanos/pull/3539) Query: Queries timeout based on lower value out of global Query timeout and per-request timeout specified as part of the query API.
 - [#4468](https://github.com/thanos-io/thanos/pull/4468) Rule: Fix temporary rule filename composition issue.
 - [#4476](https://github.com/thanos-io/thanos/pull/4476) UI: fix incorrect html escape sequence used for '>' symbol.
 - [#4532](https://github.com/thanos-io/thanos/pull/4532) Mixin: Fixed "all jobs" selector in thanos mixin dashboards.
 - [#4607](https://github.com/thanos-io/thanos/pull/4607) Azure: Fix Azure MSI Rate Limit
+- [#4614](https://github.com/thanos-io/thanos/pull/3539) Query: Queries timeout based on lower value out of global Query timeout and per-request timeout specified as part of the query API.
 
 ### Changed
 - [#4519](https://github.com/thanos-io/thanos/pull/4519) Query: switch to miekgdns DNS resolver as the default one.

--- a/pkg/api/query/v1_test.go
+++ b/pkg/api/query/v1_test.go
@@ -1201,95 +1201,17 @@ func TestMetadataEndpoints(t *testing.T) {
 	}
 }
 
-// This test uses global Query timeout of 0s, per-request timeout of 10s.
-// This test verifies that lower value of {global Query timeout, per-request timeout} is used for executing queries.
-func TestQueryEndpointsForQueryTimeout(t *testing.T) {
-	lbls := []labels.Labels{
-		{
-			labels.Label{Name: "__name__", Value: "test_metric1"},
-			labels.Label{Name: "foo", Value: "bar"},
-		},
-		{
-			labels.Label{Name: "__name__", Value: "test_metric1"},
-			labels.Label{Name: "foo", Value: "boo"},
-		},
-		{
-			labels.Label{Name: "__name__", Value: "test_metric2"},
-			labels.Label{Name: "foo", Value: "boo"},
-		},
-		{
-			labels.Label{Name: "__name__", Value: "test_metric_replica1"},
-			labels.Label{Name: "foo", Value: "bar"},
-			labels.Label{Name: "replica", Value: "a"},
-		},
-		{
-			labels.Label{Name: "__name__", Value: "test_metric_replica1"},
-			labels.Label{Name: "foo", Value: "boo"},
-			labels.Label{Name: "replica", Value: "a"},
-		},
-		{
-			labels.Label{Name: "__name__", Value: "test_metric_replica1"},
-			labels.Label{Name: "foo", Value: "boo"},
-			labels.Label{Name: "replica", Value: "b"},
-		},
-		{
-			labels.Label{Name: "__name__", Value: "test_metric_replica1"},
-			labels.Label{Name: "foo", Value: "boo"},
-			labels.Label{Name: "replica1", Value: "a"},
-		},
-	}
+// This test verifies queries timeout with lower value of {global Query timeout, per-request timeout}.
+func TestQueryTimeout(t *testing.T) {
 
-	db, err := e2eutil.NewTSDB()
-	defer func() { testutil.Ok(t, db.Close()) }()
-	testutil.Ok(t, err)
+	// This test uses global Query timeout of 10s, per-request timeout of 0s.
+	globalQueryTest := queryTimeoutTest(t, time.Second*10, time.Second*0)
 
-	app := db.Appender(context.Background())
-	for _, lbl := range lbls {
-		for i := int64(0); i < 10; i++ {
-			_, err := app.Append(0, lbl, i*60000, float64(i))
-			testutil.Ok(t, err)
-		}
-	}
-	testutil.Ok(t, app.Commit())
+	// This test uses global Query timeout of 0s, per-request timeout of 10s.
+	requestQueryTest := queryTimeoutTest(t, time.Second*0, time.Second*10)
 
-	now := time.Now()
-	globalQueryTimeout := 0 * time.Second
-	perRequestTimeout := "10s"
-
-	qe := promql.NewEngine(promql.EngineOpts{
-		Logger:     nil,
-		Reg:        nil,
-		MaxSamples: 10000,
-		Timeout:    globalQueryTimeout,
-	})
-	api := &QueryAPI{
-		baseAPI: &baseAPI.BaseAPI{
-			Now: func() time.Time { return now },
-		},
-		queryableCreate: query.NewQueryableCreator(nil, nil, store.NewTSDBStore(nil, db, component.Query, nil), 2, globalQueryTimeout),
-		queryEngine: func(int64) *promql.Engine {
-			return qe
-		},
-		gate: gate.New(nil, 4),
-	}
-
-	var tests = []endpointTestCase{
-		{
-			endpoint: api.query,
-			query: url.Values{
-				"query":   []string{"2"},
-				"time":    []string{"123.4"},
-				"timeout": []string{perRequestTimeout},
-			},
-			errType: baseAPI.ErrorTimeout,
-		},
-	}
-
-	for i, test := range tests {
-		if ok := testEndpoint(t, test, fmt.Sprintf("#%d %s", i, test.query.Encode()), reflect.DeepEqual); !ok {
-			return
-		}
-	}
+	testEndpoint(t, globalQueryTest, globalQueryTest.query.Encode(), reflect.DeepEqual)
+	testEndpoint(t, requestQueryTest, requestQueryTest.query.Encode(), reflect.DeepEqual)
 }
 
 func TestParseTime(t *testing.T) {
@@ -1861,4 +1783,44 @@ func (s sample) T() int64 {
 
 func (s sample) V() float64 {
 	return s.v
+}
+
+func queryTimeoutTest(t *testing.T, globalTimeout, reqTimeout time.Duration) endpointTestCase {
+	db, err := e2eutil.NewTSDB()
+	defer func() { testutil.Ok(t, db.Close()) }()
+	testutil.Ok(t, err)
+
+	now := time.Now()
+	start := fmt.Sprintf("%d", now.Unix())
+	end := fmt.Sprintf("%d", now.Unix()+500)
+
+	qe := promql.NewEngine(promql.EngineOpts{
+		Logger:     nil,
+		Reg:        nil,
+		MaxSamples: 1000,
+		Timeout:    globalTimeout,
+	})
+	api := &QueryAPI{
+		baseAPI: &baseAPI.BaseAPI{
+			Now: func() time.Time { return now },
+		},
+		queryableCreate: query.NewQueryableCreator(nil, nil, store.NewTSDBStore(nil, db, component.Query, nil), 2, globalTimeout),
+		queryEngine: func(int64) *promql.Engine {
+			return qe
+		},
+		gate:           gate.New(nil, 4),
+		queryRangeHist: prometheus.NewHistogram(prometheus.HistogramOpts{}),
+	}
+
+	return endpointTestCase{
+		endpoint: api.queryRange,
+		query: url.Values{
+			"query":   []string{"up"},
+			"start":   []string{start},
+			"end":     []string{end},
+			"step":    []string{"1s"},
+			"timeout": []string{reqTimeout.String()},
+		},
+		errType: baseAPI.ErrorType(baseAPI.ErrorTimeout),
+	}
 }

--- a/pkg/api/query/v1_test.go
+++ b/pkg/api/query/v1_test.go
@@ -1286,7 +1286,7 @@ func TestQueryEndpointsForQueryTimeout(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		if ok := testEndpoint(t, test, fmt.Sprintf("#%d %s", i, test.query.Encode())); !ok {
+		if ok := testEndpoint(t, test, fmt.Sprintf("#%d %s", i, test.query.Encode()), reflect.DeepEqual); !ok {
 			return
 		}
 	}

--- a/pkg/query/querier.go
+++ b/pkg/query/querier.go
@@ -210,7 +210,7 @@ func (q *querier) Select(_ bool, hints *storage.SelectHints, ms ...*labels.Match
 	// We want to prevent this from happening for the async store API calls we make while preserving tracing context.
 	ctx := tracing.CopyTraceContext(context.Background(), q.ctx)
 	// The timeout value at q.ctx would contain least of {global Query timeout, per-request timeout}.
-	// For q.ctx, 'per-request timeout' is set pkg/api/query/v1.go (query(),query_range()) and later in call chain 'global Query timeout' is set at prometheus/promql/engine.go (exec()).
+	// For q.ctx, 'per-request timeout' is set by Thanos Query component and later replaced by 'global Query timeout' at downstream promql package of upstream Prometheus.
 	requestCancelTime, _ := q.ctx.Deadline()
 	requestTimeOut := time.Until(requestCancelTime)
 	ctx, cancel := context.WithTimeout(ctx, requestTimeOut)

--- a/pkg/query/querier.go
+++ b/pkg/query/querier.go
@@ -209,7 +209,11 @@ func (q *querier) Select(_ bool, hints *storage.SelectHints, ms ...*labels.Match
 	// The querier has a context but it gets canceled, as soon as query evaluation is completed, by the engine.
 	// We want to prevent this from happening for the async store API calls we make while preserving tracing context.
 	ctx := tracing.CopyTraceContext(context.Background(), q.ctx)
-	ctx, cancel := context.WithTimeout(ctx, q.selectTimeout)
+	// The timeout value at q.ctx would contain least of {global Query timeout, per-request timeout}.
+	// For q.ctx, 'per-request timeout' is set pkg/api/query/v1.go (query(),query_range()) and later in call chain 'global Query timeout' is set at prometheus/promql/engine.go (exec()).
+	requestCancelTime, _ := q.ctx.Deadline()
+	requestTimeOut := time.Until(requestCancelTime)
+	ctx, cancel := context.WithTimeout(ctx, requestTimeOut)
 	span, ctx := tracing.StartSpan(ctx, "querier_select", opentracing.Tags{
 		"minTime":  hints.Start,
 		"maxTime":  hints.End,


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->
fix for #3456

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->
Query component times out the queries under per-request-timeout if specified.
## Verification

<!-- How you tested it? How do you know it works? -->
- To simulate slow queries, added time.Sleep() at Series() implementation of [underlying Prometheus store](https://github.com/thanos-io/thanos/blob/a57bbfbe4dc4838093c499b5afa72ed305d4eaae/pkg/store/prometheus.go#L135)
- Observed the time-out behaviour in the cases of specifying / not specifying per-request timeout at the Query API calls. 
    - http://localhost:10904/api/v1/query?query=go_memstats_heap_inuse_bytes&step=10s&timeout=1s
     - http://localhost:10904/api/v1/query_range...
     - added a test to check if queries timeout as per per-request timeout if per-request timeout is specified.