### PR TITLE
UI: Fix error only appearing once for failing queries

### DIFF
--- a/pkg/ui/react-app/src/pages/graph/Panel.tsx
+++ b/pkg/ui/react-app/src/pages/graph/Panel.tsx
@@ -282,6 +282,10 @@ class Panel extends Component<PanelProps & PathPrefixProps, PanelState> {
     this.setOptions({ storeMatches: selectedStores || [] });
   };
 
+  handleToggleAlert = (): void => {
+    this.setState({ error: null });
+  };
+
   render() {
     const { pastQueries, metricNames, options, id, stores } = this.props;
     return (
@@ -317,7 +321,11 @@ class Panel extends Component<PanelProps & PathPrefixProps, PanelState> {
           </Col>
         </Row>
         <Row>
-          <Col>{this.state.error && <UncontrolledAlert color="danger">{this.state.error}</UncontrolledAlert>}</Col>
+          <Col>
+            <UncontrolledAlert isOpen={this.state.error || false} toggle={this.handleToggleAlert} color="danger">
+              {this.state.error}
+            </UncontrolledAlert>
+          </Col>
         </Row>
         <Row>
           <Col>


### PR DESCRIPTION
Signed-off-by: Nishidha Sri <nishidhasri@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Fixes #4301

Changed state change to null after discarding the error in src/pages/graph/Panel.tsx

<!-- Enumerate changes you made -->

## Verification

Tested it by manually firing a wrong query and then discarding it and firing the wrong query again. Did it several times.

<!-- How you tested it? How do you know it works? -->
