### PR TITLE
block (UI and API): Add mark deletion and no compaction UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#4736](https://github.com/thanos-io/thanos/pull/4736) S3: Add capability to use custom AWS STS Endpoint.
 - [#4764](https://github.com/thanos-io/thanos/pull/4764) Compactor: add `block-viewer.global.sync-block-timeout` flag to set the timeout of synchronization block metas.
 - [#4801](https://github.com/thanos-io/thanos/pull/4801) Compactor: added Prometheus metrics for tracking the progress of compaction and downsampling.
+- [#4444](https://github.com/thanos-io/thanos/pull/4444) UI: add mark deletion and no compaction to the Block UI.
 
 ### Fixed
 

--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -257,7 +257,7 @@ func runCompact(
 			"/loaded",
 			component,
 		)
-		api = blocksAPI.NewBlocksAPI(logger, conf.webConf.disableCORS, conf.label, flagsMap)
+		api = blocksAPI.NewBlocksAPI(logger, conf.webConf.disableCORS, conf.label, flagsMap, bkt)
 		sy  *compact.Syncer
 	)
 	{

--- a/cmd/thanos/store.go
+++ b/cmd/thanos/store.go
@@ -415,7 +415,7 @@ func runStore(
 
 		// Configure Request Logging for HTTP calls.
 		logMiddleware := logging.NewHTTPServerMiddleware(logger, httpLogOpts...)
-		api := blocksAPI.NewBlocksAPI(logger, conf.webConfig.disableCORS, "", flagsMap)
+		api := blocksAPI.NewBlocksAPI(logger, conf.webConfig.disableCORS, "", flagsMap, bkt)
 		api.Register(r.WithPrefix("/api/v1"), tracer, logger, ins, logMiddleware)
 
 		metaFetcher.UpdateOnChange(func(blocks []metadata.Meta, err error) {

--- a/pkg/api/blocks/v1.go
+++ b/pkg/api/blocks/v1.go
@@ -4,7 +4,6 @@
 package v1
 
 import (
-	"context"
 	"net/http"
 	"time"
 
@@ -64,7 +63,7 @@ func (bapi *BlocksAPI) Register(r *route.Router, tracer opentracing.Tracer, logg
 	instr := api.GetInstr(tracer, logger, ins, logMiddleware, bapi.disableCORS)
 
 	r.Get("/blocks", instr("blocks", bapi.blocks))
-	r.Post("/blocks/mark", instr("blocks", bapi.markBlock))
+	r.Post("/blocks/mark", instr("blocks_mark", bapi.markBlock))
 }
 
 func (bapi *BlocksAPI) markBlock(r *http.Request) (interface{}, []error, *api.ApiError) {

--- a/pkg/api/blocks/v1.go
+++ b/pkg/api/blocks/v1.go
@@ -4,16 +4,23 @@
 package v1
 
 import (
+	"context"
 	"net/http"
 	"time"
 
 	"github.com/go-kit/kit/log"
+	"github.com/oklog/ulid"
 	"github.com/opentracing/opentracing-go"
+	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/common/route"
 	"github.com/thanos-io/thanos/pkg/api"
+	"github.com/thanos-io/thanos/pkg/block"
 	"github.com/thanos-io/thanos/pkg/block/metadata"
 	extpromhttp "github.com/thanos-io/thanos/pkg/extprom/http"
 	"github.com/thanos-io/thanos/pkg/logging"
+	"github.com/thanos-io/thanos/pkg/objstore"
 )
 
 // BlocksAPI is a very simple API used by Thanos Block Viewer.
@@ -23,6 +30,7 @@ type BlocksAPI struct {
 	globalBlocksInfo *BlocksInfo
 	loadedBlocksInfo *BlocksInfo
 	disableCORS      bool
+	bkt              objstore.Bucket
 }
 
 type BlocksInfo struct {
@@ -33,7 +41,7 @@ type BlocksInfo struct {
 }
 
 // NewBlocksAPI creates a simple API to be used by Thanos Block Viewer.
-func NewBlocksAPI(logger log.Logger, disableCORS bool, label string, flagsMap map[string]string) *BlocksAPI {
+func NewBlocksAPI(logger log.Logger, disableCORS bool, label string, flagsMap map[string]string, bkt objstore.Bucket) *BlocksAPI {
 	return &BlocksAPI{
 		baseAPI: api.NewBaseAPI(logger, disableCORS, flagsMap),
 		logger:  logger,
@@ -46,6 +54,7 @@ func NewBlocksAPI(logger log.Logger, disableCORS bool, label string, flagsMap ma
 			Label:  label,
 		},
 		disableCORS: disableCORS,
+		bkt: bkt,
 	}
 }
 
@@ -55,6 +64,42 @@ func (bapi *BlocksAPI) Register(r *route.Router, tracer opentracing.Tracer, logg
 	instr := api.GetInstr(tracer, logger, ins, logMiddleware, bapi.disableCORS)
 
 	r.Get("/blocks", instr("blocks", bapi.blocks))
+	r.Post("/blocks/mark", instr("blocks", bapi.markBlock))
+}
+
+func (bapi *BlocksAPI) markBlock(r *http.Request) (interface{}, []error, *api.ApiError) {
+	idParam := r.FormValue("id")
+	actionParam := r.FormValue("action")
+	detailParam := r.FormValue("detail")
+
+	if idParam == "" {
+		return nil, nil, &api.ApiError{Typ: api.ErrorBadData, Err: errors.New("ID cannot be empty")}
+	}
+
+	if actionParam == "" {
+		return nil, nil, &api.ApiError{Typ: api.ErrorBadData, Err: errors.New("Action cannot be empty")}
+	}
+
+	id, err := ulid.Parse(idParam)
+	if err != nil {
+		return nil, nil, &api.ApiError{Typ: api.ErrorBadData, Err: errors.Errorf("ULID %q is not valid: %v", idParam, err)}
+	}
+		
+	switch actionParam {
+		case "DELETION":
+			err := block.MarkForDeletion(r.Context(), bapi.logger, bapi.bkt, id, detailParam, promauto.With(nil).NewCounter(prometheus.CounterOpts{}))
+			if err != nil {
+				return nil, nil, &api.ApiError{Typ: api.ErrorBadData, Err: err}
+			}
+		case "NO COMPACTION":
+			err := block.MarkForNoCompact(r.Context(), bapi.logger, bapi.bkt, id, metadata.ManualNoCompactReason, detailParam, promauto.With(nil).NewCounter(prometheus.CounterOpts{}))
+			if err != nil {
+				return nil, nil, &api.ApiError{Typ: api.ErrorBadData, Err: err}
+			}
+		default:
+			return nil, nil, &api.ApiError{Typ: api.ErrorBadData, Err: errors.Errorf("not supported marker %v", actionParam)}
+	}
+	return nil, nil, nil
 }
 
 func (bapi *BlocksAPI) blocks(r *http.Request) (interface{}, []error, *api.ApiError) {

--- a/pkg/api/blocks/v1.go
+++ b/pkg/api/blocks/v1.go
@@ -48,7 +48,7 @@ const (
 )
 
 func parse(s string) ActionType {
-    switch s {
+	switch s {
 	case "DELETION":
 		return Deletion
 	case "NO COMPACTION":

--- a/pkg/api/blocks/v1.go
+++ b/pkg/api/blocks/v1.go
@@ -53,7 +53,7 @@ func NewBlocksAPI(logger log.Logger, disableCORS bool, label string, flagsMap ma
 			Label:  label,
 		},
 		disableCORS: disableCORS,
-		bkt: bkt,
+		bkt:         bkt,
 	}
 }
 
@@ -83,20 +83,20 @@ func (bapi *BlocksAPI) markBlock(r *http.Request) (interface{}, []error, *api.Ap
 	if err != nil {
 		return nil, nil, &api.ApiError{Typ: api.ErrorBadData, Err: errors.Errorf("ULID %q is not valid: %v", idParam, err)}
 	}
-		
+
 	switch actionParam {
-		case "DELETION":
-			err := block.MarkForDeletion(r.Context(), bapi.logger, bapi.bkt, id, detailParam, promauto.With(nil).NewCounter(prometheus.CounterOpts{}))
-			if err != nil {
-				return nil, nil, &api.ApiError{Typ: api.ErrorBadData, Err: err}
-			}
-		case "NO COMPACTION":
-			err := block.MarkForNoCompact(r.Context(), bapi.logger, bapi.bkt, id, metadata.ManualNoCompactReason, detailParam, promauto.With(nil).NewCounter(prometheus.CounterOpts{}))
-			if err != nil {
-				return nil, nil, &api.ApiError{Typ: api.ErrorBadData, Err: err}
-			}
-		default:
-			return nil, nil, &api.ApiError{Typ: api.ErrorBadData, Err: errors.Errorf("not supported marker %v", actionParam)}
+	case "DELETION":
+		err := block.MarkForDeletion(r.Context(), bapi.logger, bapi.bkt, id, detailParam, promauto.With(nil).NewCounter(prometheus.CounterOpts{}))
+		if err != nil {
+			return nil, nil, &api.ApiError{Typ: api.ErrorBadData, Err: err}
+		}
+	case "NO COMPACTION":
+		err := block.MarkForNoCompact(r.Context(), bapi.logger, bapi.bkt, id, metadata.ManualNoCompactReason, detailParam, promauto.With(nil).NewCounter(prometheus.CounterOpts{}))
+		if err != nil {
+			return nil, nil, &api.ApiError{Typ: api.ErrorBadData, Err: err}
+		}
+	default:
+		return nil, nil, &api.ApiError{Typ: api.ErrorBadData, Err: errors.Errorf("not supported marker %v", actionParam)}
 	}
 	return nil, nil, nil
 }

--- a/pkg/api/blocks/v1.go
+++ b/pkg/api/blocks/v1.go
@@ -51,7 +51,7 @@ func parse(s string) ActionType {
 	switch s {
 	case "DELETION":
 		return Deletion
-	case "NO COMPACTION":
+	case "NO_COMPACTION":
 		return NoCompaction
 	default:
 		return Unknown

--- a/pkg/api/blocks/v1_test.go
+++ b/pkg/api/blocks/v1_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
 package v1
 
 import (

--- a/pkg/api/blocks/v1_test.go
+++ b/pkg/api/blocks/v1_test.go
@@ -86,7 +86,7 @@ func testEndpoint(t *testing.T, test endpointTestCase, name string, responseComp
 	})
 }
 
-func TestCheckDeletion(t *testing.T) {
+func TestMarkBlockEndpoint(t *testing.T) {
 	ctx := context.Background()
 	tmpDir, err := ioutil.TempDir("", "test-read-mark")
 

--- a/pkg/api/blocks/v1_test.go
+++ b/pkg/api/blocks/v1_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/thanos-io/thanos/pkg/testutil"
 	"github.com/thanos-io/thanos/pkg/testutil/e2eutil"
 )
+
 func TestMain(m *testing.M) {
 	testutil.TolerantVerifyLeakMain(m)
 }
@@ -138,7 +139,7 @@ func TestMarkBlockEndpoint(t *testing.T) {
 		{
 			endpoint: api.markBlock,
 			query: url.Values{
-				"id": []string{ulid.MustNew(1, nil).String()},
+				"id":     []string{ulid.MustNew(1, nil).String()},
 				"action": []string{""},
 			},
 			errType: baseAPI.ErrorBadData,
@@ -147,7 +148,7 @@ func TestMarkBlockEndpoint(t *testing.T) {
 		{
 			endpoint: api.markBlock,
 			query: url.Values{
-				"id": []string{"invalid_id"},
+				"id":     []string{"invalid_id"},
 				"action": []string{"DELETION"},
 			},
 			errType: baseAPI.ErrorBadData,
@@ -156,7 +157,7 @@ func TestMarkBlockEndpoint(t *testing.T) {
 		{
 			endpoint: api.markBlock,
 			query: url.Values{
-				"id": []string{ulid.MustNew(2, nil).String()},
+				"id":     []string{ulid.MustNew(2, nil).String()},
 				"action": []string{"INVALID_ACTION"},
 			},
 			errType: baseAPI.ErrorBadData,
@@ -164,7 +165,7 @@ func TestMarkBlockEndpoint(t *testing.T) {
 		{
 			endpoint: api.markBlock,
 			query: url.Values{
-				"id": []string{b1.String()},
+				"id":     []string{b1.String()},
 				"action": []string{"DELETION"},
 			},
 			response: nil,

--- a/pkg/api/blocks/v1_test.go
+++ b/pkg/api/blocks/v1_test.go
@@ -1,0 +1,169 @@
+package v1
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"path"
+	"reflect"
+	"testing"
+	"time"
+	"strings"
+
+	"github.com/go-kit/kit/log"
+	"github.com/oklog/ulid"
+	"github.com/prometheus/common/route"
+	"github.com/prometheus/prometheus/pkg/labels"
+	baseAPI "github.com/thanos-io/thanos/pkg/api"
+	"github.com/thanos-io/thanos/pkg/block"
+	"github.com/thanos-io/thanos/pkg/block/metadata"
+	"github.com/thanos-io/thanos/pkg/objstore"
+	"github.com/thanos-io/thanos/pkg/testutil"
+	"github.com/thanos-io/thanos/pkg/testutil/e2eutil"
+)
+func TestMain(m *testing.M) {
+	testutil.TolerantVerifyLeakMain(m)
+}
+
+type endpointTestCase struct {
+	endpoint baseAPI.ApiFunc
+	params   map[string]string
+	query    url.Values
+	method   string
+	response interface{}
+	errType  baseAPI.ErrorType
+}
+type responeCompareFunction func(interface{}, interface{}) bool
+
+func testEndpoint(t *testing.T, test endpointTestCase, name string, responseCompareFunc responeCompareFunction) bool {
+	return t.Run(name, func(t *testing.T) {
+		// Build a context with the correct request params.
+		ctx := context.Background()
+		for p, v := range test.params {
+			ctx = route.WithParam(ctx, p, v)
+		}
+
+		reqURL := "http://example.com"
+		params := test.query.Encode()
+
+		var body io.Reader
+		if test.method == http.MethodPost {
+			body = strings.NewReader(params)
+		} else if test.method == "" {
+			test.method = "ANY"
+			reqURL += "?" + params
+		}
+
+		req, err := http.NewRequest(test.method, reqURL, body)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if body != nil {
+			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		}
+
+		resp, _, apiErr := test.endpoint(req.WithContext(ctx))
+		if apiErr != nil {
+			if test.errType == baseAPI.ErrorNone {
+				t.Fatalf("Unexpected error: %s", apiErr)
+			}
+			if test.errType != apiErr.Typ {
+				t.Fatalf("Expected error of type %q but got type %q", test.errType, apiErr.Typ)
+			}
+			return
+		}
+		if test.errType != baseAPI.ErrorNone {
+			t.Fatalf("Expected error of type %q but got none", test.errType)
+		}
+
+		if !responseCompareFunc(resp, test.response) {
+			t.Fatalf("Response does not match, expected:\n%+v\ngot:\n%+v", test.response, resp)
+		}
+	})
+}
+
+func TestCheckDeletion(t *testing.T) {
+	ctx := context.Background()
+	tmpDir, err := ioutil.TempDir("", "test-read-mark")
+
+	// create block
+	b1, err := e2eutil.CreateBlock(ctx, tmpDir, []labels.Labels{
+		{{Name: "a", Value: "1"}},
+		{{Name: "a", Value: "2"}},
+		{{Name: "a", Value: "3"}},
+		{{Name: "a", Value: "4"}},
+		{{Name: "b", Value: "1"}},
+	}, 100, 0, 1000, labels.Labels{{Name: "ext1", Value: "val1"}}, 124, metadata.NoneFunc)
+	testutil.Ok(t, err)
+
+	// upload block
+	bkt := objstore.WithNoopInstr(objstore.NewInMemBucket())
+	logger := log.NewNopLogger()
+	testutil.Ok(t, block.Upload(ctx, logger, bkt, path.Join(tmpDir, b1.String()), metadata.NoneFunc))
+
+	now := time.Now()
+	api := &BlocksAPI{
+		baseAPI: &baseAPI.BaseAPI{
+			Now: func() time.Time { return now },
+		},
+		logger: logger,
+		globalBlocksInfo: &BlocksInfo{
+			Blocks: []metadata.Meta{},
+			Label:  "foo",
+		},
+		loadedBlocksInfo: &BlocksInfo{
+			Blocks: []metadata.Meta{},
+			Label:  "foo",
+		},
+		disableCORS: true,
+		bkt:         bkt,
+	}
+
+	var tests = []endpointTestCase{
+		// Empty ID
+		{
+			endpoint: api.markBlock,
+			query: url.Values{
+				"id": []string{""},
+			},
+			errType: baseAPI.ErrorBadData,
+		},
+		// Empty action
+		{
+			endpoint: api.markBlock,
+			query: url.Values{
+				"id": []string{ulid.MustNew(1, nil).String()},
+				"action": []string{""},
+			},
+			errType: baseAPI.ErrorBadData,
+		},
+		// invalid ULID
+		{
+			endpoint: api.markBlock,
+			query: url.Values{
+				"id": []string{"invalid_id"},
+				"action": []string{"DELETION"},
+			},
+			errType: baseAPI.ErrorBadData,
+		},
+		// invalid action
+		{
+			endpoint: api.markBlock,
+			query: url.Values{
+				"id": []string{ulid.MustNew(2, nil).String()},
+				"action": []string{"INVALID_ACTION"},
+			},
+			errType: baseAPI.ErrorBadData,
+		},
+	}
+
+	for i, test := range tests {
+		if ok := testEndpoint(t, test, fmt.Sprintf("#%d %s", i, test.query.Encode()), reflect.DeepEqual); !ok {
+			return
+		}
+	}
+}

--- a/pkg/api/blocks/v1_test.go
+++ b/pkg/api/blocks/v1_test.go
@@ -7,11 +7,12 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"os"
 	"path"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
-	"strings"
 
 	"github.com/go-kit/kit/log"
 	"github.com/oklog/ulid"
@@ -89,6 +90,7 @@ func testEndpoint(t *testing.T, test endpointTestCase, name string, responseComp
 func TestMarkBlockEndpoint(t *testing.T) {
 	ctx := context.Background()
 	tmpDir, err := ioutil.TempDir("", "test-read-mark")
+	testutil.Ok(t, err)
 
 	// create block
 	b1, err := e2eutil.CreateBlock(ctx, tmpDir, []labels.Labels{
@@ -159,6 +161,14 @@ func TestMarkBlockEndpoint(t *testing.T) {
 			},
 			errType: baseAPI.ErrorBadData,
 		},
+		{
+			endpoint: api.markBlock,
+			query: url.Values{
+				"id": []string{b1.String()},
+				"action": []string{"DELETION"},
+			},
+			response: nil,
+		},
 	}
 
 	for i, test := range tests {
@@ -166,4 +176,8 @@ func TestMarkBlockEndpoint(t *testing.T) {
 			return
 		}
 	}
+
+	file := path.Join(tmpDir, b1.String())
+	_, err = os.Stat(file)
+	testutil.Ok(t, err)
 }

--- a/pkg/ui/react-app/src/thanos/pages/blocks/BlockDetails.tsx
+++ b/pkg/ui/react-app/src/thanos/pages/blocks/BlockDetails.tsx
@@ -16,7 +16,7 @@ export const BlockDetails: FC<BlockDetailsProps> = ({ block, selectBlock }) => {
 
   const submitMarkBlock = async (action: string, ulid: string, detail: string | null) => {
     try {
-      let body = detail
+      const body = detail
         ? new URLSearchParams({
             id: ulid,
             action,
@@ -35,8 +35,7 @@ export const BlockDetails: FC<BlockDetailsProps> = ({ block, selectBlock }) => {
       if (!response.ok) {
         throw new Error(response.statusText);
       }
-      setModalAction('');
-    } catch (error) {
+    } finally {
       setModalAction('');
     }
   };
@@ -114,14 +113,14 @@ export const BlockDetails: FC<BlockDetailsProps> = ({ block, selectBlock }) => {
           <div style={{ marginTop: '12px' }}>
             <Button
               onClick={() => {
-                setModalAction('NO COMPACTION');
+                setModalAction('NO_COMPACTION');
                 setDetailValue('');
               }}
             >
               Mark No Compaction
             </Button>
           </div>
-          <Modal isOpen={modalAction ? true : false}>
+          <Modal isOpen={!!modalAction}>
             <ModalBody>
               <ModalHeader toggle={() => setModalAction('')}>
                 Mark {modalAction === 'DELETION' ? 'Deletion' : 'No Compaction'} Detail (Optional)

--- a/pkg/ui/react-app/src/thanos/pages/blocks/BlockDetails.tsx
+++ b/pkg/ui/react-app/src/thanos/pages/blocks/BlockDetails.tsx
@@ -1,8 +1,8 @@
-import React, { FC } from 'react';
+import React, { FC, useState } from 'react';
 import { Block } from './block';
 import styles from './blocks.module.css';
 import moment from 'moment';
-import { Button } from 'reactstrap';
+import { Button, Modal, ModalBody, Form, Input, ModalHeader, ModalFooter } from 'reactstrap';
 import { download } from './helpers';
 
 export interface BlockDetailsProps {
@@ -11,6 +11,36 @@ export interface BlockDetailsProps {
 }
 
 export const BlockDetails: FC<BlockDetailsProps> = ({ block, selectBlock }) => {
+  const [modalAction, setModalAction] = useState<string>('');
+  const [detailValue, setDetailValue] = useState<string | null>(null);
+
+  const submitMarkBlock = async (action: string, ulid: string, detail: string | null) => {
+    try {
+      let body = detail
+        ? new URLSearchParams({
+            id: ulid,
+            action,
+            detail,
+          })
+        : new URLSearchParams({
+            id: ulid,
+            action,
+          });
+
+      const response = await fetch('/api/v1/blocks/mark', {
+        method: 'POST',
+        body,
+      });
+
+      if (!response.ok) {
+        throw new Error(response.statusText);
+      }
+      setModalAction('');
+    } catch (error) {
+      setModalAction('');
+    }
+  };
+
   return (
     <div className={`${styles.blockDetails} ${block && styles.open}`}>
       {block && (
@@ -71,6 +101,36 @@ export const BlockDetails: FC<BlockDetailsProps> = ({ block, selectBlock }) => {
               <Button>Download meta.json</Button>
             </a>
           </div>
+          <div style={{ marginTop: '12px' }}>
+            <Button onClick={() => setModalAction('DELETION')}>Mark Deletion</Button>
+          </div>
+          <div style={{ marginTop: '12px' }}>
+            <Button onClick={() => setModalAction('NO COMPACTION')}>Mark No Compaction</Button>
+          </div>
+          <Modal isOpen={modalAction ? true : false}>
+            <ModalBody>
+              <ModalHeader toggle={() => setModalAction('')}>
+                Mark {modalAction === 'DELETION' ? 'Deletion' : 'No Compaction'} Detail (Optional)
+              </ModalHeader>
+              <Form
+                onSubmit={(e) => {
+                  e.preventDefault();
+                  submitMarkBlock(modalAction, block.ulid, detailValue);
+                }}
+              >
+                <Input
+                  placeholder="Reason for marking block..."
+                  style={{ marginBottom: '16px', marginTop: '16px' }}
+                  onChange={(e) => setDetailValue(e.target.value)}
+                />
+                <ModalFooter>
+                  <Button color="primary" type="submit">
+                    Submit
+                  </Button>
+                </ModalFooter>
+              </Form>
+            </ModalBody>
+          </Modal>
         </>
       )}
     </div>

--- a/pkg/ui/react-app/src/thanos/pages/blocks/BlockDetails.tsx
+++ b/pkg/ui/react-app/src/thanos/pages/blocks/BlockDetails.tsx
@@ -102,10 +102,24 @@ export const BlockDetails: FC<BlockDetailsProps> = ({ block, selectBlock }) => {
             </a>
           </div>
           <div style={{ marginTop: '12px' }}>
-            <Button onClick={() => setModalAction('DELETION')}>Mark Deletion</Button>
+            <Button
+              onClick={() => {
+                setModalAction('DELETION');
+                setDetailValue('');
+              }}
+            >
+              Mark Deletion
+            </Button>
           </div>
           <div style={{ marginTop: '12px' }}>
-            <Button onClick={() => setModalAction('NO COMPACTION')}>Mark No Compaction</Button>
+            <Button
+              onClick={() => {
+                setModalAction('NO COMPACTION');
+                setDetailValue('');
+              }}
+            >
+              Mark No Compaction
+            </Button>
           </div>
           <Modal isOpen={modalAction ? true : false}>
             <ModalBody>


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->
This is part of LFX mentorship project (issue: #3112). We want to add mark deletion and no compaction button in block details UI.
<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes
- Add `/block/mark` endpoint for trigger marking block API
- Add button for mark deletion and no compaction in UI, with modal for asking the detail/reason

## Verification

Tested in local using `make quickstart`

Example of mark deletion:
![Example Deletion](https://user-images.githubusercontent.com/19685008/131659070-945b044f-76c4-46f4-a089-f4c6fc2bb1ac.gif)

Result of mark deletion:
![image](https://user-images.githubusercontent.com/19685008/131659225-815e843f-2f76-4f70-bc2e-919f30c0366c.png)


Example of mark no compaction:
![Example No Compaction](https://user-images.githubusercontent.com/19685008/131659109-0ba9001f-40ad-4d52-9f23-32c8261acbf6.gif)

Result of mark no compaction:
![image](https://user-images.githubusercontent.com/19685008/131659846-816dc50b-a930-4543-90fa-f4728ceabdf0.png)

cc: @squat @onprem 