### PR TITLE
Tests: Query Frontend - Fix incorrect check in E2E tests

### DIFF
--- a/test/e2e/query_frontend_test.go
+++ b/test/e2e/query_frontend_test.go
@@ -109,7 +109,7 @@ func TestQueryFrontend(t *testing.T) {
 			14,
 			promclient.QueryOptions{},
 			func(res model.Matrix) error {
-				if len(res) > 0 {
+				if len(res) == 0 {
 					return errors.Errorf("expected some results, got nothing")
 				}
 				return nil
@@ -151,7 +151,7 @@ func TestQueryFrontend(t *testing.T) {
 			14,
 			promclient.QueryOptions{},
 			func(res model.Matrix) error {
-				if len(res) > 0 {
+				if len(res) == 0 {
 					return errors.Errorf("expected some results, got nothing")
 				}
 				return nil
@@ -196,7 +196,7 @@ func TestQueryFrontend(t *testing.T) {
 			14,
 			promclient.QueryOptions{},
 			func(res model.Matrix) error {
-				if len(res) > 0 {
+				if len(res) == 0 {
 					return errors.Errorf("expected some results, got nothing")
 				}
 				return nil
@@ -459,7 +459,7 @@ func TestQueryFrontendMemcachedCache(t *testing.T) {
 		14,
 		promclient.QueryOptions{},
 		func(res model.Matrix) error {
-			if len(res) > 0 {
+			if len(res) == 0 {
 				return errors.Errorf("expected some results, got nothing")
 			}
 			return nil
@@ -489,7 +489,7 @@ func TestQueryFrontendMemcachedCache(t *testing.T) {
 		14,
 		promclient.QueryOptions{},
 		func(res model.Matrix) error {
-			if len(res) > 0 {
+			if len(res) == 0 {
 				return errors.Errorf("expected some results, got nothing")
 			}
 			return nil


### PR DESCRIPTION
Signed-off-by: Matej Gera <matejgera@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [X] Change is not relevant to the end user.

## Changes

Small fix for what seems to be an incorrect condition - in the check func, we should be returning error if there are no results, not when there are results available. This seems to currently always make the E2E test fail.

## Verification

Run tests locally - :heavy_check_mark: 
