### PR TITLE
COS: Change to official COS object store SDK.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -45,7 +45,6 @@ require (
 	github.com/lovoo/gcloud-opentracing v0.3.0
 	github.com/miekg/dns v1.1.42
 	github.com/minio/minio-go/v7 v7.0.10
-	github.com/mozillazg/go-cos v0.13.0
 	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f
 	github.com/ncw/swift v1.0.52
 	github.com/oklog/run v1.1.0
@@ -61,6 +60,7 @@ require (
 	github.com/prometheus/common v0.29.0
 	github.com/prometheus/exporter-toolkit v0.6.0
 	github.com/prometheus/prometheus v1.8.2-0.20210720123808-b1ed4a0a663d
+	github.com/tencentyun/cos-go-sdk-v5 v0.7.31
 	github.com/uber/jaeger-client-go v2.29.1+incompatible
 	github.com/uber/jaeger-lib v2.4.1+incompatible
 	github.com/weaveworks/common v0.0.0-20210722103813-e649eff5ab4a

--- a/go.sum
+++ b/go.sum
@@ -161,6 +161,7 @@ github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbt
 github.com/PuerkitoBio/urlesc v0.0.0-20160726150825-5bd2802263f2/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 h1:d+Bc7a5rLufV/sSk/8dngufqelfh6jnri85riMAaF/M=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
+github.com/QcloudApi/qcloud_sign_golang v0.0.0-20141224014652-e4130a326409/go.mod h1:1pk82RBxDY/JZnPQrtqHlUFfCctgdorsd9M06fMynOM=
 github.com/SAP/go-hdb v0.14.1/go.mod h1:7fdQLVC2lER3urZLjZCm0AuMQfApof92n3aylBPEkMo=
 github.com/Shopify/logrus-bugsnag v0.0.0-20171204204709-577dee27f20d/go.mod h1:HI8ITrYtUY+O+ZhtlqUnD8+KwNPOyugEhfP9fdUIaEQ=
 github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWXgklEdEo=
@@ -1229,7 +1230,6 @@ github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe/go.mod h1:wL8QJ
 github.com/morikuni/aec v0.0.0-20170113033406-39771216ff4c/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
 github.com/morikuni/aec v1.0.0 h1:nP9CBfwrvYnBRgY6qfDQkygYDmYwOilePFkwzv4dU8A=
 github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
-github.com/mozillazg/go-cos v0.13.0 h1:RylOpEESdWMLb13bl0ADhko12uMN3JmHqqwFu4OYGBY=
 github.com/mozillazg/go-cos v0.13.0/go.mod h1:Zp6DvvXn0RUOXGJ2chmWt2bLEqRAnJnS3DnAZsJsoaE=
 github.com/mozillazg/go-httpheader v0.2.1 h1:geV7TrjbL8KXSyvghnFm+NyTux/hxwueTSrwhe88TQQ=
 github.com/mozillazg/go-httpheader v0.2.1/go.mod h1:jJ8xECTlalr6ValeXYdOF8fFUISeBAdw6E61aqQma60=
@@ -1569,6 +1569,10 @@ github.com/syndtr/gocapability v0.0.0-20170704070218-db04d3cc01c8/go.mod h1:hkRG
 github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/tchap/go-patricia v2.2.6+incompatible/go.mod h1:bmLyhP68RS6kStMGxByiQ23RP/odRBOTVjwp2cDyi6I=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.194/go.mod h1:7sCQWVkxcsR38nffDW057DRGk8mUjK1Ing/EFOK8s8Y=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/kms v1.0.194/go.mod h1:yrBKWhChnDqNz1xuXdSbWXG56XawEq0G5j1lg4VwBD4=
+github.com/tencentyun/cos-go-sdk-v5 v0.7.31 h1:NujkkOKMJ3IFs1+trCwXOKRCIPQ8qI5Lxul9JkhTg6M=
+github.com/tencentyun/cos-go-sdk-v5 v0.7.31/go.mod h1:4E4+bQ2gBVJcgEC9Cufwylio4mXOct2iu05WjgEBx1o=
 github.com/thanos-io/thanos v0.8.1-0.20200109203923-552ffa4c1a0d/go.mod h1:usT/TxtJQ7DzinTt+G9kinDQmRS5sxwu0unVKZ9vdcw=
 github.com/thanos-io/thanos v0.13.1-0.20200731083140-69b87607decf/go.mod h1:G8caR6G7pSDreRDvFm9wFuyjEBztmr8Ag3kBYpa/fEc=
 github.com/thanos-io/thanos v0.13.1-0.20200807203500-9b578afb4763/go.mod h1:KyW0a93tsh7v4hXAwo2CVAIRYuZT1Kkf4e04gisQjAg=


### PR DESCRIPTION
Change to official COS object store SDK.
Fix objstore e2e test invalid test bucket name.
Fix setRange when off>0.

Signed-off-by: hanjm <hanjinming@outlook.com>

Hi all, 
The COS objstore support is implement via `github.com/mozillazg/go-cos` at 2019 year,
the `mozillazg/go-cos` is unfficial and not actively update now, it's latest tag version date is 2019-09-18.
the official sdk `github.com/tencentyun/cos-go-sdk-v5` which based on `mozillazg/go-cos` is keeping actively update, the latest tag date is `2021-09-07`.

It should be change to official SDK to get more support. I fix testing bucket name bug and setRange bug, then it has passed the e2e objectore test. 

thanks to @jojohappy and mozillazg/go-cos author. 
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->
1. Change to official COS object store SDK. 
2. Fix objstore e2e test invalid test bucket name.
3. Fix setRange when off>0.

## Verification

<!-- How you tested it? How do you know it works? -->
run objstore e2e test: 
```
export COS_APP_ID=*** COS_SECRET_ID=*** COS_SECRET_KEY=*** COS_REGION=ap-guangzhou  
```
```
$ THANOS_TEST_OBJSTORE_SKIP=AZURE,ALIYUNOSS,BOS,GCS,S3,SWIFT go test ./pkg/block/... ./pkg/compact/... ./pkg/compactv2/... ./pkg/objstore/... ./pkg/shipper/... ./pkg/store/...                       

ok      github.com/thanos-io/thanos/pkg/block   28.246s
ok      github.com/thanos-io/thanos/pkg/block/indexheader       (cached)
ok      github.com/thanos-io/thanos/pkg/block/metadata  (cached)
ok      github.com/thanos-io/thanos/pkg/compact 57.286s
ok      github.com/thanos-io/thanos/pkg/compact/downsample      (cached)
ok      github.com/thanos-io/thanos/pkg/compactv2       (cached)
ok      github.com/thanos-io/thanos/pkg/objstore        (cached)
ok      github.com/thanos-io/thanos/pkg/objstore/azure  (cached)
?       github.com/thanos-io/thanos/pkg/objstore/bos    [no test files]
?       github.com/thanos-io/thanos/pkg/objstore/client [no test files]
ok      github.com/thanos-io/thanos/pkg/objstore/clientutil     (cached)
ok      github.com/thanos-io/thanos/pkg/objstore/cos    0.550s
?       github.com/thanos-io/thanos/pkg/objstore/filesystem     [no test files]
ok      github.com/thanos-io/thanos/pkg/objstore/gcs    (cached)
ok      github.com/thanos-io/thanos/pkg/objstore/objtesting     159.416s
?       github.com/thanos-io/thanos/pkg/objstore/oss    [no test files]
ok      github.com/thanos-io/thanos/pkg/objstore/s3     2.745s
ok      github.com/thanos-io/thanos/pkg/objstore/swift  (cached)
ok      github.com/thanos-io/thanos/pkg/shipper 38.908s
ok      github.com/thanos-io/thanos/pkg/store   197.293s
ok      github.com/thanos-io/thanos/pkg/store/cache     (cached)
?       github.com/thanos-io/thanos/pkg/store/hintspb   [no test files]
ok      github.com/thanos-io/thanos/pkg/store/labelpb   (cached)
ok      github.com/thanos-io/thanos/pkg/store/storepb   (cached)
?       github.com/thanos-io/thanos/pkg/store/storepb/prompb    [no test files]
?       github.com/thanos-io/thanos/pkg/store/storepb/testutil  [no test files]

```