### PR TITLE
Added DefaultTransport function to package exthttp

### DIFF
--- a/pkg/exthttp/transport.go
+++ b/pkg/exthttp/transport.go
@@ -4,13 +4,48 @@
 package exthttp
 
 import (
+	"crypto/tls"
 	"net"
 	"net/http"
 	"time"
+
+	"github.com/prometheus/common/model"
 )
+
+var DefaultConfig = HTTPConfig{
+	IdleConnTimeout:       model.Duration(90 * time.Second),
+	ResponseHeaderTimeout: model.Duration(2 * time.Minute),
+	TLSHandshakeTimeout:   model.Duration(10 * time.Second),
+	ExpectContinueTimeout: model.Duration(1 * time.Second),
+	MaxIdleConns:          100,
+	MaxIdleConnsPerHost:   100,
+	MaxConnsPerHost:       0,
+}
+
+// HTTPConfig stores the http.Transport configuration
+type HTTPConfig struct {
+	IdleConnTimeout       model.Duration `yaml:"idle_conn_timeout"`
+	ResponseHeaderTimeout model.Duration `yaml:"response_header_timeout"`
+	InsecureSkipVerify    bool           `yaml:"insecure_skip_verify"`
+
+	TLSHandshakeTimeout   model.Duration `yaml:"tls_handshake_timeout"`
+	ExpectContinueTimeout model.Duration `yaml:"expect_continue_timeout"`
+	MaxIdleConns          int            `yaml:"max_idle_conns"`
+	MaxIdleConnsPerHost   int            `yaml:"max_idle_conns_per_host"`
+	MaxConnsPerHost       int            `yaml:"max_conns_per_host"`
+	DisableCompression    bool           `yaml:"disable_compression"`
+	// Allow upstream callers to inject a round tripper
+	Transport http.RoundTripper `yaml:"-"`
+}
 
 // NewTransport creates a new http.Transport with default settings.
 func NewTransport() *http.Transport {
+	transport := DefaultTransport(DefaultConfig)
+	return transport
+}
+
+// Default Transport function that creates a http.Transport with specified settings.
+func DefaultTransport(config HTTPConfig) *http.Transport {
 	return &http.Transport{
 		Proxy: http.ProxyFromEnvironment,
 		DialContext: (&net.Dialer{
@@ -18,10 +53,15 @@ func NewTransport() *http.Transport {
 			KeepAlive: 30 * time.Second,
 			DualStack: true,
 		}).DialContext,
-		ForceAttemptHTTP2:     true,
-		MaxIdleConns:          100,
-		IdleConnTimeout:       90 * time.Second,
-		TLSHandshakeTimeout:   10 * time.Second,
-		ExpectContinueTimeout: 1 * time.Second,
+
+		MaxIdleConns:          config.MaxIdleConns,
+		MaxIdleConnsPerHost:   config.MaxIdleConnsPerHost,
+		IdleConnTimeout:       time.Duration(config.IdleConnTimeout),
+		MaxConnsPerHost:       config.MaxConnsPerHost,
+		TLSHandshakeTimeout:   time.Duration(config.TLSHandshakeTimeout),
+		ExpectContinueTimeout: time.Duration(config.ExpectContinueTimeout),
+		ResponseHeaderTimeout: time.Duration(config.ResponseHeaderTimeout),
+		DisableCompression:    config.DisableCompression,
+		TLSClientConfig:       &tls.Config{InsecureSkipVerify: config.InsecureSkipVerify},
 	}
 }

--- a/pkg/objstore/azure/azure.go
+++ b/pkg/objstore/azure/azure.go
@@ -18,6 +18,7 @@ import (
 	"github.com/go-kit/kit/log/level"
 	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
+	"github.com/thanos-io/thanos/pkg/exthttp"
 	"github.com/thanos-io/thanos/pkg/objstore"
 	yaml "gopkg.in/yaml.v2"
 )
@@ -37,7 +38,7 @@ var DefaultConfig = Config{
 	ReaderConfig: ReaderConfig{
 		MaxRetryRequests: 0,
 	},
-	HTTPConfig: HTTPConfig{
+	HTTPConfig: exthttp.HTTPConfig{
 		IdleConnTimeout:       model.Duration(90 * time.Second),
 		ResponseHeaderTimeout: model.Duration(2 * time.Minute),
 		TLSHandshakeTimeout:   model.Duration(10 * time.Second),
@@ -51,15 +52,15 @@ var DefaultConfig = Config{
 
 // Config Azure storage configuration.
 type Config struct {
-	StorageAccountName string         `yaml:"storage_account"`
-	StorageAccountKey  string         `yaml:"storage_account_key"`
-	ContainerName      string         `yaml:"container"`
-	Endpoint           string         `yaml:"endpoint"`
-	MaxRetries         int            `yaml:"max_retries"`
-	MSIResource        string         `yaml:"msi_resource"`
-	PipelineConfig     PipelineConfig `yaml:"pipeline_config"`
-	ReaderConfig       ReaderConfig   `yaml:"reader_config"`
-	HTTPConfig         HTTPConfig     `yaml:"http_config"`
+	StorageAccountName string             `yaml:"storage_account"`
+	StorageAccountKey  string             `yaml:"storage_account_key"`
+	ContainerName      string             `yaml:"container"`
+	Endpoint           string             `yaml:"endpoint"`
+	MaxRetries         int                `yaml:"max_retries"`
+	MSIResource        string             `yaml:"msi_resource"`
+	PipelineConfig     PipelineConfig     `yaml:"pipeline_config"`
+	ReaderConfig       ReaderConfig       `yaml:"reader_config"`
+	HTTPConfig         exthttp.HTTPConfig `yaml:"http_config"`
 }
 
 type ReaderConfig struct {
@@ -71,19 +72,6 @@ type PipelineConfig struct {
 	TryTimeout    model.Duration `yaml:"try_timeout"`
 	RetryDelay    model.Duration `yaml:"retry_delay"`
 	MaxRetryDelay model.Duration `yaml:"max_retry_delay"`
-}
-
-type HTTPConfig struct {
-	IdleConnTimeout       model.Duration `yaml:"idle_conn_timeout"`
-	ResponseHeaderTimeout model.Duration `yaml:"response_header_timeout"`
-	InsecureSkipVerify    bool           `yaml:"insecure_skip_verify"`
-
-	TLSHandshakeTimeout   model.Duration `yaml:"tls_handshake_timeout"`
-	ExpectContinueTimeout model.Duration `yaml:"expect_continue_timeout"`
-	MaxIdleConns          int            `yaml:"max_idle_conns"`
-	MaxIdleConnsPerHost   int            `yaml:"max_idle_conns_per_host"`
-	MaxConnsPerHost       int            `yaml:"max_conns_per_host"`
-	DisableCompression    bool           `yaml:"disable_compression"`
 }
 
 // Bucket implements the store.Bucket interface against Azure APIs.

--- a/pkg/objstore/cos/cos_test.go
+++ b/pkg/objstore/cos/cos_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/prometheus/common/model"
+	"github.com/thanos-io/thanos/pkg/exthttp"
 	"github.com/thanos-io/thanos/pkg/testutil"
 )
 
@@ -38,7 +39,7 @@ http_config:
 `),
 			},
 			want: Config{
-				HTTPConfig: HTTPConfig{
+				HTTPConfig: exthttp.HTTPConfig{
 					IdleConnTimeout:       model.Duration(90 * time.Second),
 					ResponseHeaderTimeout: model.Duration(2 * time.Minute),
 					TLSHandshakeTimeout:   model.Duration(10 * time.Second),


### PR DESCRIPTION
Added a DefaultTransport function to the exthttp package (#4624)

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

Added a **DefaultTransport()** function that takes in a HTTPConfig object as an argument and creates a http.Trasnport with these config values.