### PR TITLE
scripts: Install grpcurl@latest when querying a store API

### DIFF
--- a/scripts/insecure_grpcurl_series.sh
+++ b/scripts/insecure_grpcurl_series.sh
@@ -38,7 +38,7 @@ if [ -z "${REQUESTED_MAX_TIME}" ]; then
   exit 1
 fi
 
-go install github.com/fullstorydev/grpcurl/cmd/grpcurl
+go install github.com/fullstorydev/grpcurl/cmd/grpcurl@v1.8.2
 
 SERIES_REQUEST='{
   "min_time": '${REQUESTED_MIN_TIME}',


### PR DESCRIPTION
Running `scripts/insecure_grpcurl_series.sh` yields the following error:
```
no required module provides package github.com/fullstorydev/grpcurl/cmd/grpcurl; to add it:
	go get github.com/fullstorydev/grpcurl/cmd/grpcurl
```

This PR resolves it by adding the `@latest` prefix to the go install argument

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->
* Modify `scripts/insecure_grpcurl_series.sh` to install `github.com/fullstorydev/grpcurl/cmd/grpcurl@latest` instead of `github.com/fullstorydev/grpcurl/cmd/grpcurl`
## Verification

<!-- How you tested it? How do you know it works? -->
I ran `scripts/insecure_grpcurl_series.sh` locally.