### PR TITLE
Allow to customize attributes cache for CachingBucket.GetRange() operation

### DIFF
--- a/pkg/store/cache/caching_bucket.go
+++ b/pkg/store/cache/caching_bucket.go
@@ -320,7 +320,7 @@ func (cb *CachingBucket) cachedGetRange(ctx context.Context, name string, offset
 	cb.operationRequests.WithLabelValues(objstore.OpGetRange, cfgName).Inc()
 	cb.requestedGetRangeBytes.WithLabelValues(cfgName).Add(float64(length))
 
-	attrs, err := cb.cachedAttributes(ctx, name, cfgName, cfg.cache, cfg.attributesTTL)
+	attrs, err := cb.cachedAttributes(ctx, name, cfgName, cfg.attributes.cache, cfg.attributes.ttl)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get object attributes: %s", name)
 	}

--- a/pkg/store/cache/caching_bucket_factory.go
+++ b/pkg/store/cache/caching_bucket_factory.go
@@ -106,7 +106,7 @@ func NewCachingBucketFromYaml(yamlContent []byte, bucket objstore.Bucket, logger
 	cfg := NewCachingBucketConfig()
 
 	// Configure cache.
-	cfg.CacheGetRange("chunks", c, isTSDBChunkFile, config.ChunkSubrangeSize, config.ChunkObjectAttrsTTL, config.ChunkSubrangeTTL, config.MaxChunksGetRangeRequests)
+	cfg.CacheGetRange("chunks", c, isTSDBChunkFile, config.ChunkSubrangeSize, c, config.ChunkObjectAttrsTTL, config.ChunkSubrangeTTL, config.MaxChunksGetRangeRequests)
 	cfg.CacheExists("meta.jsons", c, isMetaFile, config.MetafileExistsTTL, config.MetafileDoesntExistTTL)
 	cfg.CacheGet("meta.jsons", c, isMetaFile, int(config.MetafileMaxSize), config.MetafileContentTTL, config.MetafileExistsTTL, config.MetafileDoesntExistTTL)
 

--- a/pkg/store/cache/caching_bucket_test.go
+++ b/pkg/store/cache/caching_bucket_test.go
@@ -224,7 +224,7 @@ func TestChunksCaching(t *testing.T) {
 			}
 
 			cfg := NewCachingBucketConfig()
-			cfg.CacheGetRange("chunks", cache, isTSDBChunkFile, subrangeSize, time.Hour, time.Hour, tc.maxGetRangeRequests)
+			cfg.CacheGetRange("chunks", cache, isTSDBChunkFile, subrangeSize, cache, time.Hour, time.Hour, tc.maxGetRangeRequests)
 
 			cachingBucket, err := NewCachingBucket(inmem, cfg, nil, nil)
 			testutil.Ok(t, err)
@@ -337,8 +337,9 @@ func TestMergeRanges(t *testing.T) {
 func TestInvalidOffsetAndLength(t *testing.T) {
 	b := &testBucket{objstore.NewInMemBucket()}
 
+	cache := newMockCache()
 	cfg := NewCachingBucketConfig()
-	cfg.CacheGetRange("chunks", newMockCache(), func(string) bool { return true }, 10000, time.Hour, time.Hour, 3)
+	cfg.CacheGetRange("chunks", cache, func(string) bool { return true }, 10000, cache, time.Hour, time.Hour, 3)
 
 	c, err := NewCachingBucket(b, cfg, nil, nil)
 	testutil.Ok(t, err)


### PR DESCRIPTION
* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

`CachingBucket.GetRange()` currently caches attributes in the same cache backend where the subobjects are cached. We have an use cases for which we would like to set a different caching backend for attributes. In this PR I'm proposing to allow it.

Draft: if PR is fine, then I will do changes in Cortex first in order to get the PR correctly compile (right now I've committed a change to `vendor/` too).

## Verification

Existing tests.
