### PR TITLE
Query: Fix (*Stream).receive infinite loop when target response Unimplemented error (#4676)

### DIFF
--- a/pkg/exemplars/proxy.go
+++ b/pkg/exemplars/proxy.go
@@ -191,8 +191,8 @@ func (stream *exemplarsStream) receive(ctx context.Context) error {
 			if err := stream.server.Send(exemplarspb.NewWarningExemplarsResponse(err)); err != nil {
 				return errors.Wrapf(err, "sending exemplars error to server %v", stream.server)
 			}
-
-			continue
+			// Not an error if response strategy is warning.
+			return nil
 		}
 
 		if w := exemplar.GetWarning(); w != "" {

--- a/pkg/metadata/proxy.go
+++ b/pkg/metadata/proxy.go
@@ -135,7 +135,8 @@ func (stream *metricMetadataStream) receive(ctx context.Context) error {
 				return errors.Wrapf(err, "sending metadata error to server %v", stream.server)
 			}
 
-			continue
+			// Not an error if response strategy is warning.
+			return nil
 		}
 
 		if w := resp.GetWarning(); w != "" {

--- a/pkg/targets/proxy.go
+++ b/pkg/targets/proxy.go
@@ -119,8 +119,8 @@ func (stream *targetsStream) receive(ctx context.Context) error {
 			if err := stream.server.Send(targetspb.NewWarningTargetsResponse(err)); err != nil {
 				return errors.Wrapf(err, "sending targets error to server %v", stream.server)
 			}
-
-			continue
+			// Not an error if response strategy is warning.
+			return nil
 		}
 
 		if w := target.GetWarning(); w != "" {


### PR DESCRIPTION
Fix #4676.
This PR base on #4680.

grpc doc say https://github.com/grpc/grpc-go/blob/v1.40.0/stream.go#L123
```
	// RecvMsg blocks until it receives a message into m or the stream is
	// done. It returns io.EOF when the stream completes successfully. On
	// any other error, the stream is aborted and the error contains the RPC
	// status.
```

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->
if gRPC bid-stream response error, `return`.

## Verification

<!-- How you tested it? How do you know it works? -->
test in #4676