### PR TITLE
docs: ignore cloud.baidu.com from mdox validation

### DIFF
--- a/.mdox.validate.yaml
+++ b/.mdox.validate.yaml
@@ -17,3 +17,6 @@ validators:
   # 301 errors even when curl-ed.
   - regex: 'envoyproxy\.io'
     type: 'ignore'
+  # couldn't reach even when curl-ed.
+  - regex: 'cloud\.baidu\.com'
+    type: 'ignore'


### PR DESCRIPTION
Most of the time `cloud.baidu.com` is unreachable from CI servers. Lets
ignore it to avoid flakiness during CI validations.

Signed-off-by: Arunprasad Rajkumar <arajkuma@redhat.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
