### PR TITLE
Implement objectSizer for minio object and timingReadCloser

### DIFF
--- a/pkg/objstore/objstore.go
+++ b/pkg/objstore/objstore.go
@@ -6,15 +6,15 @@ package objstore
 import (
 	"bytes"
 	"context"
-	"github.com/minio/minio-go/v7"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
 
-	"github.com/go-kit/log"
-	"github.com/go-kit/log/level"
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/minio/minio-go/v7"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"

--- a/pkg/objstore/objstore_test.go
+++ b/pkg/objstore/objstore_test.go
@@ -6,8 +6,12 @@ package objstore
 import (
 	"bytes"
 	"io"
+	"os"
+	"path"
+	"strings"
 	"testing"
 
+	"github.com/pkg/errors"
 	promtest "github.com/prometheus/client_golang/prometheus/testutil"
 
 	"github.com/thanos-io/thanos/pkg/testutil"
@@ -86,3 +90,73 @@ func TestTracingReader(t *testing.T) {
 	testutil.Ok(t, err)
 	testutil.Equals(t, int64(11), size)
 }
+
+func TestTryToGetSize(t *testing.T) {
+	tmpFile, err := os.OpenFile(path.Join(os.TempDir(), "test_try_get_size"), os.O_CREATE|os.O_RDWR, os.ModePerm)
+	testutil.Ok(t, err)
+	defer tmpFile.Close()
+	_, err = tmpFile.WriteString("abc")
+	testutil.Ok(t, err)
+
+	buf := make([]byte, 5)
+	bbuff := bytes.NewBuffer(buf)
+
+	sreader := strings.NewReader("hello world")
+
+	buf2 := make([]byte, 100)
+	breader := bytes.NewReader(buf2)
+
+	r := bytes.NewBuffer(make([]byte, 20))
+	trc := newTimingReadCloser(NopCloserWithSize(r), "test", nil, nil, nil)
+	for _, tcase := range []struct {
+		name    string
+		reader  io.Reader
+		expSize int64
+		expErr  error
+	}{
+		{
+			name:    "local file",
+			reader:  tmpFile,
+			expSize: 3,
+		},
+		{
+			name:    "bytes buffer",
+			reader:  bbuff,
+			expSize: 5,
+		},
+		{
+			name:    "bytes reader",
+			reader:  breader,
+			expSize: 100,
+		},
+		{
+			name:    "string reader",
+			reader:  sreader,
+			expSize: 11,
+		},
+		{
+			name:    "timing read closer",
+			reader:  trc,
+			expSize: 20,
+		},
+		{
+			name:   "other io.Reader implementation",
+			reader: &testReader{},
+			expErr: errors.Errorf("unsupported type of io.Reader: %T", &testReader{}),
+		},
+	} {
+		t.Run(tcase.name, func(t *testing.T) {
+			size, err := TryToGetSize(tcase.reader)
+			if tcase.expErr == nil {
+				testutil.Ok(t, err)
+				testutil.Equals(t, tcase.expSize, size)
+			} else {
+				testutil.Equals(t, tcase.expErr.Error(), err.Error())
+			}
+		})
+	}
+}
+
+type testReader struct{}
+
+func (r *testReader) Read([]byte) (n int, err error) { return 0, nil }


### PR DESCRIPTION
Signed-off-by: Ben Ye <ben.ye@bytedance.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

Running thanos bucket replicate to replicate data between two S3 buckets. I got:

```
level=warn ts=2021-09-21T07:25:43.073055Z caller=s3.go:447 component=replicate msg="could not guess file size for multipart upload; upload might be not optimized" name=01FFPW8PXW9TRWC0PGKFHCNFYM/chunks/000001 err="unsupported type of io.Reader: *objstore.timingReadCloser"
```

To fix this, I implemented ObjectSizer interface for `*objstore.timingReadCloser` support `*minio.Object` when checking file size.

## Changes

<!-- Enumerate changes you made -->


## Verification

<!-- How you tested it? How do you know it works? -->
