### PR TITLE
Query: Put cache name on tracing spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 ### Added
 
 - [#4680](https://github.com/thanos-io/thanos/pull/4680) Query: add `exemplar.partial-response` flag to control partial response.
+- [#4696](https://github.com/thanos-io/thanos/pull/4696) Query: add cache name to tracing spans.
 
 ## v0.23.0 - In Progress
 

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -18,4 +18,6 @@ type Cache interface {
 	// Fetch multiple keys from cache. Returns map of input keys to data.
 	// If key isn't in the map, data for given key was not found.
 	Fetch(ctx context.Context, keys []string) map[string][]byte
+
+	Name() string
 }

--- a/pkg/cache/inmemory.go
+++ b/pkg/cache/inmemory.go
@@ -41,6 +41,7 @@ type InMemoryCache struct {
 	logger           log.Logger
 	maxSizeBytes     uint64
 	maxItemSizeBytes uint64
+	name             string
 
 	mtx         sync.Mutex
 	curSize     uint64
@@ -100,6 +101,7 @@ func NewInMemoryCacheWithConfig(name string, logger log.Logger, reg prometheus.R
 		logger:           logger,
 		maxSizeBytes:     uint64(config.MaxSize),
 		maxItemSizeBytes: uint64(config.MaxItemSize),
+		name:             name,
 	}
 
 	c.evicted = promauto.With(reg).NewCounter(prometheus.CounterOpts{
@@ -302,4 +304,8 @@ func (c *InMemoryCache) Fetch(ctx context.Context, keys []string) map[string][]b
 		}
 	}
 	return results
+}
+
+func (c *InMemoryCache) Name() string {
+	return c.name
 }

--- a/pkg/cache/memcached.go
+++ b/pkg/cache/memcached.go
@@ -19,6 +19,7 @@ import (
 type MemcachedCache struct {
 	logger    log.Logger
 	memcached cacheutil.MemcachedClient
+	name      string
 
 	// Metrics.
 	requests prometheus.Counter
@@ -30,6 +31,7 @@ func NewMemcachedCache(name string, logger log.Logger, memcached cacheutil.Memca
 	c := &MemcachedCache{
 		logger:    logger,
 		memcached: memcached,
+		name:      name,
 	}
 
 	c.requests = promauto.With(reg).NewCounter(prometheus.CounterOpts{
@@ -80,4 +82,8 @@ func (c *MemcachedCache) Fetch(ctx context.Context, keys []string) map[string][]
 	results := c.memcached.GetMulti(ctx, keys)
 	c.hits.Add(float64(len(results)))
 	return results
+}
+
+func (c *MemcachedCache) Name() string {
+	return c.name
 }

--- a/pkg/cache/tracing_cache.go
+++ b/pkg/cache/tracing_cache.go
@@ -27,6 +27,7 @@ func (t TracingCache) Store(ctx context.Context, data map[string][]byte, ttl tim
 
 func (t TracingCache) Fetch(ctx context.Context, keys []string) (result map[string][]byte) {
 	tracing.DoWithSpan(ctx, "cache_fetch", func(spanCtx context.Context, span opentracing.Span) {
+		span.SetTag("name", t.Name())
 		span.LogKV("requested keys", len(keys))
 
 		result = t.c.Fetch(spanCtx, keys)
@@ -38,4 +39,8 @@ func (t TracingCache) Fetch(ctx context.Context, keys []string) (result map[stri
 		span.LogKV("returned keys", len(result), "returned bytes", bytes)
 	})
 	return
+}
+
+func (t TracingCache) Name() string {
+	return t.c.Name()
 }

--- a/pkg/store/cache/caching_bucket_test.go
+++ b/pkg/store/cache/caching_bucket_test.go
@@ -295,6 +295,10 @@ func (m *mockCache) Fetch(_ context.Context, keys []string) map[string][]byte {
 	return found
 }
 
+func (m *mockCache) Name() string {
+	return "mockCache"
+}
+
 func (m *mockCache) flush() {
 	m.cache = map[string]cacheItem{}
 }


### PR DESCRIPTION
With multiple caches, this change lets you see clearly which spans relate to which cache.

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Added a name member to caches, add this as a tag when tracing.

## Verification

Left as an exercise.
