### PR TITLE
Store: Fix (*model.TimeOrDurationValue).String() when value is negative

### DIFF
--- a/pkg/model/timeduration.go
+++ b/pkg/model/timeduration.go
@@ -51,6 +51,9 @@ func (tdv *TimeOrDurationValue) String() string {
 	case tdv.Time != nil:
 		return tdv.Time.String()
 	case tdv.Dur != nil:
+		if v := *tdv.Dur; v < 0 {
+			return "-" + (-v).String()
+		}
 		return tdv.Dur.String()
 	}
 

--- a/pkg/model/timeduration_test.go
+++ b/pkg/model/timeduration_test.go
@@ -14,26 +14,44 @@ import (
 )
 
 func TestTimeOrDurationValue(t *testing.T) {
-	cmd := kingpin.New("test", "test")
+	t.Run("positive", func(t *testing.T) {
+		cmd := kingpin.New("test", "test")
 
-	minTime := model.TimeOrDuration(cmd.Flag("min-time", "Start of time range limit to serve"))
+		minTime := model.TimeOrDuration(cmd.Flag("min-time", "Start of time range limit to serve"))
 
-	maxTime := model.TimeOrDuration(cmd.Flag("max-time", "End of time range limit to serve").
-		Default("9999-12-31T23:59:59Z"))
+		maxTime := model.TimeOrDuration(cmd.Flag("max-time", "End of time range limit to serve").
+			Default("9999-12-31T23:59:59Z"))
 
-	_, err := cmd.Parse([]string{"--min-time", "10s"})
-	if err != nil {
-		t.Fatal(err)
-	}
+		_, err := cmd.Parse([]string{"--min-time", "10s"})
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	testutil.Equals(t, "10s", minTime.String())
-	testutil.Equals(t, "9999-12-31 23:59:59 +0000 UTC", maxTime.String())
+		testutil.Equals(t, "10s", minTime.String())
+		testutil.Equals(t, "9999-12-31 23:59:59 +0000 UTC", maxTime.String())
 
-	prevTime := timestamp.FromTime(time.Now())
-	afterTime := timestamp.FromTime(time.Now().Add(15 * time.Second))
+		prevTime := timestamp.FromTime(time.Now())
+		afterTime := timestamp.FromTime(time.Now().Add(15 * time.Second))
 
-	testutil.Assert(t, minTime.PrometheusTimestamp() > prevTime, "minTime prometheus timestamp is less than time now.")
-	testutil.Assert(t, minTime.PrometheusTimestamp() < afterTime, "minTime prometheus timestamp is more than time now + 15s")
+		testutil.Assert(t, minTime.PrometheusTimestamp() > prevTime, "minTime prometheus timestamp is less than time now.")
+		testutil.Assert(t, minTime.PrometheusTimestamp() < afterTime, "minTime prometheus timestamp is more than time now + 15s")
 
-	testutil.Assert(t, maxTime.PrometheusTimestamp() == 253402300799000, "maxTime is not equal to 253402300799000")
+		testutil.Assert(t, maxTime.PrometheusTimestamp() == 253402300799000, "maxTime is not equal to 253402300799000")
+	})
+
+	t.Run("negative", func(t *testing.T) {
+		cmd := kingpin.New("test-negative", "test-negative")
+		var minTime model.TimeOrDurationValue
+		cmd.Flag("min-time", "Start of time range limit to serve").SetValue(&minTime)
+		_, err := cmd.Parse([]string{"--min-time=-10s"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		testutil.Equals(t, "-10s", minTime.String())
+
+		prevTime := timestamp.FromTime(time.Now().Add(-15 * time.Second))
+		afterTime := timestamp.FromTime(time.Now())
+		testutil.Assert(t, minTime.PrometheusTimestamp() > prevTime, "minTime prometheus timestamp is less than time now - 15s.")
+		testutil.Assert(t, minTime.PrometheusTimestamp() < afterTime, "minTime prometheus timestamp is more than time now.")
+	})
 }


### PR DESCRIPTION
Signed-off-by: Jimmiehan <hanjinming@outlook.com>

before this fix, set --min-time or --max-time negative value will be empty at page. beacuse prometheus/common model.Duration does not support negative. https://github.com/prometheus/common/blob/main/model/time.go#L236

![image](https://user-images.githubusercontent.com/7621241/134774673-835184d0-1a49-4d15-977d-638d59e15013.png)

fixed:
![image](https://user-images.githubusercontent.com/7621241/134774970-b58dd39f-f22e-470b-bb84-ce3bfa173e20.png)



<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->
`func (tdv *TimeOrDurationValue) String()` support negative.
## Verification

<!-- How you tested it? How do you know it works? -->
Unit test.