### PR TITLE
Store: fix panic on stop application

### DIFF
--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -503,7 +503,6 @@ func runQuery(
 			}
 		}, func(error) {
 			cancelUpdate()
-			close(fileSDUpdates)
 		})
 	}
 	// Periodically update the addresses from static flags and file SD by resolving them using DNS SD if necessary.


### PR DESCRIPTION
Signed-off-by: Jimmiehan <hanjinming@outlook.com>

fix panic on stop application.  the  `(*Discovery).refresh` may send the channel after close channel. https://github.com/prometheus/prometheus/blob/v2.30.0/discovery/file/file.go#L343

logs 
```
ts=2021-09-19T08:24:41.135548308Z caller=log.go:168 level=debug msg="Stopping file discovery..." paths="[/etc/thanos-query/thanos-store-api-targets.yaml /etc/thanos-query/thanos-sidecar-targets.yaml]"
ts=2021-09-19T08:24:41.135746869Z caller=log.go:168 level=debug msg="File discovery stopped"
panic: send on closed channel

goroutine 307 [running]:
github.com/prometheus/prometheus/discovery/file.(*Discovery).refresh(0xc0000b2960, 0x2159ca8, 0xc0002d33c0, 0xc0001090e0)
        /Users/jimmiehan/go/pkg/mod/github.com/prometheus/prometheus@v1.8.2-0.20210720123808-b1ed4a0a663d/discovery/file/file.go:342 +0xa7d
github.com/prometheus/prometheus/discovery/file.(*Discovery).Run(0xc0000b2960, 0x2159ca8, 0xc0002d33c0, 0xc0001090e0)
        /Users/jimmiehan/go/pkg/mod/github.com/prometheus/prometheus@v1.8.2-0.20210720123808-b1ed4a0a663d/discovery/file/file.go:269 +0x415
main.runQuery.func5(0x1ec40b0, 0xc000057fc0)
        /Users/jimmiehan/github.com/hanjm/thanos/cmd/thanos/query.go:453 +0x45
github.com/oklog/run.(*Group).Run.func1(0xc000727200, 0xc00032af90, 0xc0001ecbf0)
        /Users/jimmiehan/go/pkg/mod/github.com/oklog/run@v1.1.0/group.go:38 +0x27
created by github.com/oklog/run.(*Group).Run
        /Users/jimmiehan/go/pkg/mod/github.com/oklog/run@v1.1.0/group.go:37 +0xbb
```
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
