### PR TITLE
Endpointset: Do not use info client to obtain metadata (for now)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 
 ## Unreleased
 
+### Fixed
+
+- [#4714](https://github.com/thanos-io/thanos/pull/4714) Endpointset: Do not use info client to obtain metadata.
+
 ## [v0.23.0](https://github.com/thanos-io/thanos/tree/release-0.23) - 2021.09.23
 
 ### Added

--- a/pkg/query/endpointset.go
+++ b/pkg/query/endpointset.go
@@ -77,14 +77,16 @@ func (es *grpcEndpointSpec) Addr() string {
 // Metadata method for gRPC endpoint tries to call InfoAPI exposed by Thanos components until context timeout. If we are unable to get metadata after
 // that time, we assume that the host is unhealthy and return error.
 func (es *grpcEndpointSpec) Metadata(ctx context.Context, client *endpointClients) (*endpointMetadata, error) {
-	if client.info != nil {
-		resp, err := client.info.Info(ctx, &infopb.InfoRequest{}, grpc.WaitForReady(true))
-		if err != nil {
-			return nil, errors.Wrapf(err, "fetching info from %s", es.addr)
-		}
+	// TODO(@matej-g): Info client should not be used due to https://github.com/thanos-io/thanos/issues/4699
+	// Uncomment this after it is implemented in https://github.com/thanos-io/thanos/pull/4282.
+	// if client.info != nil {
+	// 	resp, err := client.info.Info(ctx, &infopb.InfoRequest{}, grpc.WaitForReady(true))
+	// 	if err != nil {
+	// 		return nil, errors.Wrapf(err, "fetching info from %s", es.addr)
+	// 	}
 
-		return &endpointMetadata{resp}, nil
-	}
+	// 	return &endpointMetadata{resp}, nil
+	// }
 
 	// Call Info method of StoreAPI, this way querier will be able to discovery old components not exposing InfoAPI.
 	if client.store != nil {

--- a/pkg/query/endpointset.go
+++ b/pkg/query/endpointset.go
@@ -803,13 +803,15 @@ func (er *endpointRef) apisPresent() []string {
 	return apisPresent
 }
 
+// TODO(@matej-g): Info client should not be used due to https://github.com/thanos-io/thanos/issues/4699
+// Uncomment the nolint directive after https://github.com/thanos-io/thanos/pull/4282.
 type endpointClients struct {
 	store          storepb.StoreClient
 	rule           rulespb.RulesClient
 	metricMetadata metadatapb.MetadataClient
 	exemplar       exemplarspb.ExemplarsClient
 	target         targetspb.TargetsClient
-	info           infopb.InfoClient
+	info           infopb.InfoClient //nolint:structcheck,unused
 }
 
 type endpointMetadata struct {

--- a/pkg/query/endpointset.go
+++ b/pkg/query/endpointset.go
@@ -31,7 +31,8 @@ import (
 )
 
 const (
-	unhealthyEndpointMessage = "removing endpoint because it's unhealthy or does not exist"
+	unhealthyEndpointMessage  = "removing endpoint because it's unhealthy or does not exist"
+	noMetadataEndpointMessage = "cannot obtain metadata: neither info nor store client found"
 
 	// Default minimum and maximum time values used by Prometheus when they are not passed as query parameter.
 	MinTime = -9223309901257974
@@ -76,17 +77,25 @@ func (es *grpcEndpointSpec) Addr() string {
 // Metadata method for gRPC endpoint tries to call InfoAPI exposed by Thanos components until context timeout. If we are unable to get metadata after
 // that time, we assume that the host is unhealthy and return error.
 func (es *grpcEndpointSpec) Metadata(ctx context.Context, client *endpointClients) (*endpointMetadata, error) {
-	resp, err := client.info.Info(ctx, &infopb.InfoRequest{}, grpc.WaitForReady(true))
-	if err != nil {
-		// Call Info method of StoreAPI, this way querier will be able to discovery old components not exposing InfoAPI.
-		metadata, merr := es.getMetadataUsingStoreAPI(ctx, client.store)
-		if merr != nil {
-			return nil, errors.Wrapf(merr, "fallback fetching info from %s after err: %v", es.addr, err)
+	if client.info != nil {
+		resp, err := client.info.Info(ctx, &infopb.InfoRequest{}, grpc.WaitForReady(true))
+		if err != nil {
+			return nil, errors.Wrapf(err, "fetching info from %s", es.addr)
+		}
+
+		return &endpointMetadata{resp}, nil
+	}
+
+	// Call Info method of StoreAPI, this way querier will be able to discovery old components not exposing InfoAPI.
+	if client.store != nil {
+		metadata, err := es.getMetadataUsingStoreAPI(ctx, client.store)
+		if err != nil {
+			return nil, errors.Wrapf(err, "fallback fetching info from %s", es.addr)
 		}
 		return metadata, nil
 	}
 
-	return &endpointMetadata{resp}, nil
+	return nil, errors.New(noMetadataEndpointMessage)
 }
 
 func (es *grpcEndpointSpec) getMetadataUsingStoreAPI(ctx context.Context, client storepb.StoreClient) (*endpointMetadata, error) {
@@ -494,7 +503,9 @@ func (e *EndpointSet) getActiveEndpoints(ctx context.Context, endpoints map[stri
 					logger:      e.logger,
 					StoreClient: storepb.NewStoreClient(conn),
 					clients: &endpointClients{
-						info:  infopb.NewInfoClient(conn),
+						// TODO(@matej-g): Info client should not be used due to https://github.com/thanos-io/thanos/issues/4699
+						// Uncomment this after it is implemented in https://github.com/thanos-io/thanos/pull/4282.
+						// info:  infopb.NewInfoClient(conn),
 						store: storepb.NewStoreClient(conn),
 					},
 				}
@@ -667,6 +678,10 @@ func (er *endpointRef) Update(metadata *endpointMetadata) {
 func (er *endpointRef) ComponentType() component.Component {
 	er.mtx.RLock()
 	defer er.mtx.RUnlock()
+
+	if er.metadata == nil {
+		return component.UnknownStoreAPI
+	}
 
 	return component.FromString(er.metadata.ComponentType)
 }


### PR DESCRIPTION
Signed-off-by: Matej Gera <matejgera@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

In #4699 it was discovered that users might be receiving 'false' reports due to increase in number of `Unimplemented` error, caused by attempting to obtain metadata via gRPC service, which is not yet implemented.

The fix proposed here is to remove info client for now and instead always fall back to using store API to obtain metadata. After https://github.com/thanos-io/thanos/pull/4282 we should be able to switch back to using info client.

The PR also adjusts the tests accordingly and fixes some discrepancies (e.g. the mocked rule component was not exposing store API)

Resolves #4699

## Verification

Updated tests.
