### PR TITLE
Fix bucket tools to dry run with multiple block ID's

### DIFF
--- a/cmd/thanos/tools_bucket.go
+++ b/cmd/thanos/tools_bucket.go
@@ -1133,8 +1133,8 @@ func registerBucketRewrite(app extkingpin.AppClause, objStoreConfig *extflag.Pat
 				}
 
 				if tbc.dryRun {
-					level.Info(logger).Log("msg", "dry run finished. Changes should be printed to stderr")
-					return nil
+					level.Info(logger).Log("msg", "dry run finished. Changes should be printed to stderr", "Block ID", id)
+					continue
 				}
 
 				level.Info(logger).Log("msg", "wrote new block after modifications; flushing", "source", id, "new", newID)


### PR DESCRIPTION
Signed-off-by: 4molybdenum2 <tathagatapaul7@gmail.com>

Fixed Bucket Tools such that it supports Dry Run with multiple block ID's (#4713)

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

- Changed the code such that when dry run mode is enabled for multiple id's the function doesn't return nil after first iteration of the loop and instead continues to the next iteration.
- Updated logger to log the block ID for each such block in dry run.
