### PR TITLE
Query frontend: Add benchmarks for labels codec and query range codec

### DIFF
--- a/pkg/queryfrontend/labels_codec_test.go
+++ b/pkg/queryfrontend/labels_codec_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"testing"
@@ -520,4 +521,210 @@ func TestLabelsCodec_MergeResponse(t *testing.T) {
 			}
 		})
 	}
+}
+
+func BenchmarkLabelsCodecEncodeAndDecodeRequest(b *testing.B) {
+	codec := NewThanosLabelsCodec(false, time.Hour*2)
+	ctx := context.TODO()
+
+	b.Run("SeriesRequest", func(b *testing.B) {
+		req := &ThanosSeriesRequest{
+			Start: 123000,
+			End:   456000,
+			Path:  "/api/v1/series",
+			Dedup: true,
+		}
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for n := 0; n < b.N; n++ {
+			reqEnc, err := codec.EncodeRequest(ctx, req)
+			testutil.Ok(b, err)
+			_, err = codec.DecodeRequest(ctx, reqEnc)
+			testutil.Ok(b, err)
+		}
+	})
+
+	b.Run("LabelsRequest", func(b *testing.B) {
+		req := &ThanosLabelsRequest{
+			Path:            "/api/v1/labels",
+			Start:           123000,
+			End:             456000,
+			PartialResponse: true,
+			Matchers:        [][]*labels.Matcher{{labels.MustNewMatcher(labels.MatchEqual, "foo", "bar")}},
+			StoreMatchers:   [][]*labels.Matcher{},
+		}
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for n := 0; n < b.N; n++ {
+			reqEnc, err := codec.EncodeRequest(ctx, req)
+			testutil.Ok(b, err)
+			_, err = codec.DecodeRequest(ctx, reqEnc)
+			testutil.Ok(b, err)
+		}
+	})
+}
+
+func BenchmarkLabelsCodecDecodeResponse(b *testing.B) {
+	codec := NewThanosLabelsCodec(false, time.Hour*2)
+	ctx := context.TODO()
+
+	b.Run("SeriesResponse", func(b *testing.B) {
+		seriesData, err := json.Marshal(&ThanosSeriesResponse{
+			Status: "success",
+			Data:   []labelpb.ZLabelSet{{Labels: []labelpb.ZLabel{{Name: "foo", Value: "bar"}}}},
+		})
+		testutil.Ok(b, err)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for n := 0; n < b.N; n++ {
+			_, err := codec.DecodeResponse(
+				ctx,
+				makeResponse(seriesData, false),
+				&ThanosSeriesRequest{})
+			testutil.Ok(b, err)
+		}
+	})
+
+	b.Run("SeriesResponseWithHeaders", func(b *testing.B) {
+		seriesDataWithHeaders, err := json.Marshal(&ThanosSeriesResponse{
+			Status:  "success",
+			Data:    []labelpb.ZLabelSet{{Labels: []labelpb.ZLabel{{Name: "foo", Value: "bar"}}}},
+			Headers: []*ResponseHeader{{Name: cacheControlHeader, Values: []string{noStoreValue}}},
+		})
+		testutil.Ok(b, err)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for n := 0; n < b.N; n++ {
+			_, err := codec.DecodeResponse(
+				ctx,
+				makeResponse(seriesDataWithHeaders, true),
+				&ThanosSeriesRequest{})
+			testutil.Ok(b, err)
+		}
+	})
+
+	b.Run("LabelsResponse", func(b *testing.B) {
+		labelsData, err := json.Marshal(&ThanosLabelsResponse{
+			Status: "success",
+			Data:   []string{"__name__"},
+		})
+		testutil.Ok(b, err)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for n := 0; n < b.N; n++ {
+			_, err := codec.DecodeResponse(
+				ctx,
+				makeResponse(labelsData, false),
+				&ThanosLabelsRequest{})
+			testutil.Ok(b, err)
+		}
+	})
+
+	b.Run("LabelsResponseWithHeaders", func(b *testing.B) {
+		labelsDataWithHeaders, err := json.Marshal(&ThanosLabelsResponse{
+			Status:  "success",
+			Data:    []string{"__name__"},
+			Headers: []*ResponseHeader{{Name: cacheControlHeader, Values: []string{noStoreValue}}},
+		})
+		testutil.Ok(b, err)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for n := 0; n < b.N; n++ {
+			_, err := codec.DecodeResponse(
+				ctx,
+				makeResponse(labelsDataWithHeaders, true),
+				&ThanosLabelsRequest{})
+			testutil.Ok(b, err)
+		}
+	})
+}
+
+func BenchmarkLabelsCodecMergeResponses_1(b *testing.B) {
+	benchmarkMergeResponses(b, 1)
+}
+
+func BenchmarkLabelsCodecMergeResponses_10(b *testing.B) {
+	benchmarkMergeResponses(b, 10)
+}
+
+func BenchmarkLabelsCodecMergeResponses_100(b *testing.B) {
+	benchmarkMergeResponses(b, 100)
+}
+
+func BenchmarkLabelsCodecMergeResponses_1000(b *testing.B) {
+	benchmarkMergeResponses(b, 1000)
+}
+
+func benchmarkMergeResponses(b *testing.B, size int) {
+	codec := NewThanosLabelsCodec(false, time.Hour*2)
+	queryResLabel, queryResSeries := makeQueryRangeResponses(size)
+
+	b.Run("SeriesResponses", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			_, _ = codec.MergeResponse(queryResSeries...)
+		}
+	})
+
+	b.Run("LabelsResponses", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			_, _ = codec.MergeResponse(queryResLabel...)
+		}
+	})
+
+}
+
+func makeQueryRangeResponses(size int) ([]queryrange.Response, []queryrange.Response) {
+	labelResp := make([]queryrange.Response, 0, size)
+	seriesResp := make([]queryrange.Response, 0, size)
+
+	// Generate with some duplicated values.
+	for i := 0; i < size; i++ {
+		labelResp = append(labelResp, &ThanosLabelsResponse{
+			Status: "success",
+			Data:   []string{fmt.Sprintf("data-%d", i), fmt.Sprintf("data-%d", i+1)},
+		})
+
+		seriesResp = append(seriesResp, &ThanosSeriesResponse{
+			Status: "success",
+			Data:   []labelpb.ZLabelSet{{Labels: []labelpb.ZLabel{{Name: fmt.Sprintf("foo-%d", i), Value: fmt.Sprintf("bar-%d", i)}}}},
+		},
+			&ThanosSeriesResponse{
+				Status: "success",
+				Data:   []labelpb.ZLabelSet{{Labels: []labelpb.ZLabel{{Name: fmt.Sprintf("foo-%d", i+1), Value: fmt.Sprintf("bar-%d", i+1)}}}},
+			})
+	}
+
+	return labelResp, seriesResp
+}
+
+func makeResponse(data []byte, withHeader bool) *http.Response {
+	r := &http.Response{
+		StatusCode: 200, Body: ioutil.NopCloser(bytes.NewBuffer(data)),
+	}
+
+	if withHeader {
+		r.Header = map[string][]string{
+			cacheControlHeader: {noStoreValue},
+		}
+	}
+
+	return r
 }

--- a/pkg/queryfrontend/labels_codec_test.go
+++ b/pkg/queryfrontend/labels_codec_test.go
@@ -693,7 +693,7 @@ func benchmarkMergeResponses(b *testing.B, size int) {
 
 func makeQueryRangeResponses(size int) ([]queryrange.Response, []queryrange.Response) {
 	labelResp := make([]queryrange.Response, 0, size)
-	seriesResp := make([]queryrange.Response, 0, size)
+	seriesResp := make([]queryrange.Response, 0, size*2)
 
 	// Generate with some duplicated values.
 	for i := 0; i < size; i++ {
@@ -702,14 +702,17 @@ func makeQueryRangeResponses(size int) ([]queryrange.Response, []queryrange.Resp
 			Data:   []string{fmt.Sprintf("data-%d", i), fmt.Sprintf("data-%d", i+1)},
 		})
 
-		seriesResp = append(seriesResp, &ThanosSeriesResponse{
-			Status: "success",
-			Data:   []labelpb.ZLabelSet{{Labels: []labelpb.ZLabel{{Name: fmt.Sprintf("foo-%d", i), Value: fmt.Sprintf("bar-%d", i)}}}},
-		},
+		seriesResp = append(
+			seriesResp,
+			&ThanosSeriesResponse{
+				Status: "success",
+				Data:   []labelpb.ZLabelSet{{Labels: []labelpb.ZLabel{{Name: fmt.Sprintf("foo-%d", i), Value: fmt.Sprintf("bar-%d", i)}}}},
+			},
 			&ThanosSeriesResponse{
 				Status: "success",
 				Data:   []labelpb.ZLabelSet{{Labels: []labelpb.ZLabel{{Name: fmt.Sprintf("foo-%d", i+1), Value: fmt.Sprintf("bar-%d", i+1)}}}},
-			})
+			},
+		)
 	}
 
 	return labelResp, seriesResp

--- a/pkg/queryfrontend/queryrange_codec_test.go
+++ b/pkg/queryfrontend/queryrange_codec_test.go
@@ -282,3 +282,26 @@ func TestQueryRangeCodec_EncodeRequest(t *testing.T) {
 		})
 	}
 }
+
+func BenchmarkQueryRangeCodecEncodeAndDecodeRequest(b *testing.B) {
+	codec := NewThanosQueryRangeCodec(true)
+	ctx := context.TODO()
+
+	req := &ThanosQueryRangeRequest{
+		Start:               123000,
+		End:                 456000,
+		Step:                1000,
+		MaxSourceResolution: int64(compact.ResolutionLevel1h),
+		Dedup:               true,
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for n := 0; n < b.N; n++ {
+		reqEnc, err := codec.EncodeRequest(ctx, req)
+		testutil.Ok(b, err)
+		_, err = codec.DecodeRequest(ctx, reqEnc)
+		testutil.Ok(b, err)
+	}
+}


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [X] Change is not relevant to the end user.

## Changes

As a part of working on query frontend performance related task (https://github.com/thanos-io/thanos/issues/4571), I'm adding benchmarks to query frontend packages for codecs.

Results:
``` bash
queryfrontend ❯ go test -bench=.                                                                     query-frontend-benchmarks
goos: linux
goarch: amd64
pkg: github.com/thanos-io/thanos/pkg/queryfrontend
cpu: Intel(R) Core(TM) i7-9850H CPU @ 2.60GHz
BenchmarkLabelsCodecEncodeAndDecodeRequest/SeriesRequest-12               217172              5070 ns/op            3496 B/op         44 allocs/op
BenchmarkLabelsCodecEncodeAndDecodeRequest/LabelsRequest-12               165806              7023 ns/op            3937 B/op         57 allocs/op
BenchmarkLabelsCodecDecodeResponse/SeriesResponse-12                      335694              3269 ns/op            2056 B/op         34 allocs/op
BenchmarkLabelsCodecDecodeResponse/SeriesResponseWithHeaders-12           279236              3689 ns/op            2528 B/op         39 allocs/op
BenchmarkLabelsCodecDecodeResponse/LabelsResponse-12                      569709              2272 ns/op            1328 B/op         20 allocs/op
BenchmarkLabelsCodecDecodeResponse/LabelsResponseWithHeaders-12           468223              2578 ns/op            1800 B/op         25 allocs/op
BenchmarkLabelsCodecMergeResponses_1/SeriesResponses-12                  1980333               635.0 ns/op           368 B/op         10 allocs/op
BenchmarkLabelsCodecMergeResponses_1/LabelsResponses-12                 460894840                2.546 ns/op           0 B/op          0 allocs/op
BenchmarkLabelsCodecMergeResponses_10/SeriesResponses-12                  216445              5103 ns/op            2929 B/op         68 allocs/op
BenchmarkLabelsCodecMergeResponses_10/LabelsResponses-12                  659503              1676 ns/op             593 B/op          4 allocs/op
BenchmarkLabelsCodecMergeResponses_100/SeriesResponses-12                  18146             63734 ns/op           31966 B/op        618 allocs/op
BenchmarkLabelsCodecMergeResponses_100/LabelsResponses-12                  51276             22847 ns/op            7151 B/op         11 allocs/op
BenchmarkLabelsCodecMergeResponses_1000/SeriesResponses-12                  1598            699492 ns/op          342276 B/op       6046 allocs/op
BenchmarkLabelsCodecMergeResponses_1000/LabelsResponses-12                  3666            298388 ns/op          101812 B/op         36 allocs/op
BenchmarkQueryRangeCodecEncodeAndDecodeRequest-12                         169071              6655 ns/op            4000 B/op         58 allocs/op
PASS
ok      github.com/thanos-io/thanos/pkg/queryfrontend   19.568s
```

## Verification
Benchmarks ran
