### PR TITLE
Add series label for unhealthy index debug log

### DIFF
--- a/pkg/block/index.go
+++ b/pkg/block/index.go
@@ -328,7 +328,7 @@ func GatherIndexHealthStats(logger log.Logger, fn string, minTime, maxTime int64
 		if ooo > 0 {
 			stats.OutOfOrderSeries++
 			stats.OutOfOrderChunks += ooo
-			level.Debug(logger).Log("msg", "The out of order series are: ", "labels", lset)
+			level.Debug(logger).Log("msg", "found out of order series", "labels", lset)
 		}
 
 		seriesChunks.Add(int64(len(chks)))

--- a/pkg/block/index.go
+++ b/pkg/block/index.go
@@ -43,6 +43,8 @@ type HealthStats struct {
 	TotalSeries int64
 	// OutOfOrderSeries represents number of series that have out of order chunks.
 	OutOfOrderSeries int
+	// OutOfOrderSeries represents the labels of series that are out of order
+	OutOfOrderSeriesLabels labels.Labels
 
 	// OutOfOrderChunks represents number of chunks that are out of order (older time range is after younger one).
 	OutOfOrderChunks int
@@ -252,8 +254,10 @@ func GatherIndexHealthStats(logger log.Logger, fn string, minTime, maxTime int64
 		stats.TotalSeries++
 
 		if err := r.Series(id, &lset, &chks); err != nil {
+			stats.OutOfOrderSeriesLabels = lset
 			return stats, errors.Wrap(err, "read series")
 		}
+
 		if len(lset) == 0 {
 			return stats, errors.Errorf("empty label set detected for series %d", id)
 		}

--- a/pkg/block/index.go
+++ b/pkg/block/index.go
@@ -254,9 +254,7 @@ func GatherIndexHealthStats(logger log.Logger, fn string, minTime, maxTime int64
 		id := p.At()
 		stats.TotalSeries++
 
-		err := r.Series(id, &lset, &chks)
-		stats.OutOfOrderSeriesLabels = lset
-		if err != nil {
+		if err := r.Series(id, &lset, &chks); err != nil {
 			return stats, errors.Wrap(err, "read series")
 		}
 
@@ -334,6 +332,7 @@ func GatherIndexHealthStats(logger log.Logger, fn string, minTime, maxTime int64
 		if ooo > 0 {
 			stats.OutOfOrderSeries++
 			stats.OutOfOrderChunks += ooo
+			stats.OutOfOrderSeriesLabels = lset
 		}
 
 		seriesChunks.Add(int64(len(chks)))

--- a/pkg/block/index.go
+++ b/pkg/block/index.go
@@ -253,8 +253,9 @@ func GatherIndexHealthStats(logger log.Logger, fn string, minTime, maxTime int64
 		id := p.At()
 		stats.TotalSeries++
 
-		if err := r.Series(id, &lset, &chks); err != nil {
-			stats.OutOfOrderSeriesLabels = lset
+		err := r.Series(id, &lset, &chks)
+		stats.OutOfOrderSeriesLabels = lset
+		if err != nil {
 			return stats, errors.Wrap(err, "read series")
 		}
 

--- a/pkg/block/index.go
+++ b/pkg/block/index.go
@@ -44,7 +44,7 @@ type HealthStats struct {
 	// OutOfOrderSeries represents number of series that have out of order chunks.
 	OutOfOrderSeries int
 	// OutOfOrderSeries represents the labels of series that are out of order
-	OutOfOrderSeriesLabels labels.Labels
+	OutOfOrderSeriesLabels []labels.Labels
 
 	// OutOfOrderChunks represents number of chunks that are out of order (older time range is after younger one).
 	OutOfOrderChunks int
@@ -332,7 +332,7 @@ func GatherIndexHealthStats(logger log.Logger, fn string, minTime, maxTime int64
 		if ooo > 0 {
 			stats.OutOfOrderSeries++
 			stats.OutOfOrderChunks += ooo
-			stats.OutOfOrderSeriesLabels = lset
+			stats.OutOfOrderSeriesLabels = append(stats.OutOfOrderSeriesLabels, lset)
 		}
 
 		seriesChunks.Add(int64(len(chks)))

--- a/pkg/block/index.go
+++ b/pkg/block/index.go
@@ -115,13 +115,20 @@ func (i HealthStats) Issue347OutsideChunksErr() error {
 
 func (i HealthStats) OutOfOrderChunksErr() error {
 	if i.OutOfOrderChunks > 0 {
+		formatedSeriesLabels := ""
+		for _, value := range i.OutOfOrderSeriesLabels {
+			for _, label := range value {
+				formatedSeriesLabels += label.Name + ":" + label.Value + ","
+			}
+			formatedSeriesLabels += "\n"
+		}
 		return errors.New(fmt.Sprintf(
 			"%d/%d series have an average of %.3f out-of-order chunks: "+
-				"The out of order series are: %v. %.3f of these are exact duplicates (in terms of data and time range)",
+				"The out of order series are: %s.%.3f of these are exact duplicates (in terms of data and time range)",
 			i.OutOfOrderSeries,
 			i.TotalSeries,
 			float64(i.OutOfOrderChunks)/float64(i.OutOfOrderSeries),
-			i.OutOfOrderSeriesLabels,
+			formatedSeriesLabels,
 			float64(i.DuplicatedChunks)/float64(i.OutOfOrderChunks),
 		))
 	}

--- a/pkg/block/index.go
+++ b/pkg/block/index.go
@@ -328,13 +328,7 @@ func GatherIndexHealthStats(logger log.Logger, fn string, minTime, maxTime int64
 		if ooo > 0 {
 			stats.OutOfOrderSeries++
 			stats.OutOfOrderChunks += ooo
-			OutOfOrderSeriesLabels := ""
-			for _, label := range lset[:len(lset)-1] {
-				OutOfOrderSeriesLabels += label.Name + ":" + label.Value + ","
-			}
-			OutOfOrderSeriesLabels += lset[len(lset)-1].Name + ":" + lset[len(lset)-1].Value
-			debugMessage := fmt.Sprintf("The out of order series labels are %s", OutOfOrderSeriesLabels)
-			level.Debug(logger).Log("msg", debugMessage)
+			level.Debug(logger).Log("msg", "The out of order series are: ", "labels", lset)
 		}
 
 		seriesChunks.Add(int64(len(chks)))

--- a/pkg/block/index.go
+++ b/pkg/block/index.go
@@ -117,10 +117,11 @@ func (i HealthStats) OutOfOrderChunksErr() error {
 	if i.OutOfOrderChunks > 0 {
 		return errors.New(fmt.Sprintf(
 			"%d/%d series have an average of %.3f out-of-order chunks: "+
-				"%.3f of these are exact duplicates (in terms of data and time range)",
+				"The out of order series are: %v. %.3f of these are exact duplicates (in terms of data and time range)",
 			i.OutOfOrderSeries,
 			i.TotalSeries,
 			float64(i.OutOfOrderChunks)/float64(i.OutOfOrderSeries),
+			i.OutOfOrderSeriesLabels,
 			float64(i.DuplicatedChunks)/float64(i.OutOfOrderChunks),
 		))
 	}

--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -773,7 +773,7 @@ func (cg *Group) compact(ctx context.Context, dir string, planner Planner, comp 
 		}
 
 		if err := stats.CriticalErr(); err != nil {
-			return false, ulid.ULID{}, halt(errors.Wrapf(err, "block with not healthy index found %s; Compaction level %v; Labels: %v", bdir, meta.Compaction.Level, meta.Thanos.Labels))
+			return false, ulid.ULID{}, halt(errors.Wrapf(err, "block with not healthy index found %s; Compaction level %v; Labels: %v; Series labels: %v", bdir, meta.Compaction.Level, meta.Thanos.Labels, stats.OutOfOrderSeriesLabels))
 		}
 
 		if err := stats.OutOfOrderChunksErr(); err != nil {

--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -773,7 +773,7 @@ func (cg *Group) compact(ctx context.Context, dir string, planner Planner, comp 
 		}
 
 		if err := stats.CriticalErr(); err != nil {
-			return false, ulid.ULID{}, halt(errors.Wrapf(err, "block with not healthy index found %s; Compaction level %v; Labels: %v; Series labels: %v", bdir, meta.Compaction.Level, meta.Thanos.Labels, stats.OutOfOrderSeriesLabels))
+			return false, ulid.ULID{}, halt(errors.Wrapf(err, "block with not healthy index found %s; Compaction level %v; Labels: %v;", bdir, meta.Compaction.Level, meta.Thanos.Labels))
 		}
 
 		if err := stats.OutOfOrderChunksErr(); err != nil {

--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -773,7 +773,7 @@ func (cg *Group) compact(ctx context.Context, dir string, planner Planner, comp 
 		}
 
 		if err := stats.CriticalErr(); err != nil {
-			return false, ulid.ULID{}, halt(errors.Wrapf(err, "block with not healthy index found %s; Compaction level %v; Labels: %v;", bdir, meta.Compaction.Level, meta.Thanos.Labels))
+			return false, ulid.ULID{}, halt(errors.Wrapf(err, "block with not healthy index found %s; Compaction level %v; Labels: %v", bdir, meta.Compaction.Level, meta.Thanos.Labels))
 		}
 
 		if err := stats.OutOfOrderChunksErr(); err != nil {


### PR DESCRIPTION
Signed-off-by: metonymic-smokey <ahuja.aditi@gmail.com>

Fixes #4470 
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes
The debug log on compaction when an unhealthy index is found now mentions the series in the out of order index too. Earlier, only the proportion of such series was logged. 

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
