### PR TITLE
e2e: Add memcached as cache in store-gateway test

### DIFF
--- a/test/e2e/compact_test.go
+++ b/test/e2e/compact_test.go
@@ -35,7 +35,6 @@ import (
 	"github.com/thanos-io/thanos/pkg/objstore/s3"
 	"github.com/thanos-io/thanos/pkg/promclient"
 	"github.com/thanos-io/thanos/pkg/runutil"
-	storecache "github.com/thanos-io/thanos/pkg/store/cache"
 	"github.com/thanos-io/thanos/pkg/testutil"
 	"github.com/thanos-io/thanos/pkg/testutil/e2eutil"
 	"github.com/thanos-io/thanos/test/e2e/e2ethanos"
@@ -452,7 +451,7 @@ func testCompactWithStoreGateway(t *testing.T, penaltyDedup bool) {
 			Insecure:  true,
 		},
 	}
-	str, err := e2ethanos.NewStoreGW(e, "1", svcConfig, storecache.CachingWithBackendConfig{})
+	str, err := e2ethanos.NewStoreGW(e, "1", svcConfig, nil)
 	testutil.Ok(t, err)
 	testutil.Ok(t, e2e.StartAndWaitReady(str))
 	testutil.Ok(t, str.WaitSumMetrics(e2e.Equals(float64(len(rawBlockIDs)+7)), "thanos_blocks_meta_synced"))

--- a/test/e2e/compact_test.go
+++ b/test/e2e/compact_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/thanos-io/thanos/pkg/objstore/s3"
 	"github.com/thanos-io/thanos/pkg/promclient"
 	"github.com/thanos-io/thanos/pkg/runutil"
+	storecache "github.com/thanos-io/thanos/pkg/store/cache"
 	"github.com/thanos-io/thanos/pkg/testutil"
 	"github.com/thanos-io/thanos/pkg/testutil/e2eutil"
 	"github.com/thanos-io/thanos/test/e2e/e2ethanos"
@@ -451,7 +452,7 @@ func testCompactWithStoreGateway(t *testing.T, penaltyDedup bool) {
 			Insecure:  true,
 		},
 	}
-	str, err := e2ethanos.NewStoreGW(e, "1", svcConfig)
+	str, err := e2ethanos.NewStoreGW(e, "1", svcConfig, storecache.CachingWithBackendConfig{})
 	testutil.Ok(t, err)
 	testutil.Ok(t, e2e.StartAndWaitReady(str))
 	testutil.Ok(t, str.WaitSumMetrics(e2e.Equals(float64(len(rawBlockIDs)+7)), "thanos_blocks_meta_synced"))

--- a/test/e2e/e2ethanos/services.go
+++ b/test/e2e/e2ethanos/services.go
@@ -588,7 +588,7 @@ receivers:
 	return s, nil
 }
 
-func NewStoreGW(e e2e.Environment, name string, bucketConfig client.BucketConfig, cacheConfig storecache.CachingWithBackendConfig, relabelConfig ...relabel.Config) (*e2e.InstrumentedRunnable, error) {
+func NewStoreGW(e e2e.Environment, name string, bucketConfig client.BucketConfig, cacheConfig *storecache.CachingWithBackendConfig, relabelConfig ...relabel.Config) (*e2e.InstrumentedRunnable, error) {
 	dir := filepath.Join(e.SharedDir(), "data", "store", name)
 	container := filepath.Join(ContainerSharedDir, "data", "store", name)
 	if err := os.MkdirAll(dir, 0750); err != nil {
@@ -604,32 +604,39 @@ func NewStoreGW(e e2e.Environment, name string, bucketConfig client.BucketConfig
 	if err != nil {
 		return nil, errors.Wrapf(err, "generate store relabel file: %v", relabelConfig)
 	}
+	cacheConfigBytes := []byte{}
+	if cacheConfig != nil {
+		cacheConfigBytes, err = yaml.Marshal(*cacheConfig)
+		if err != nil {
+			return nil, errors.Wrapf(err, "generate cache config file: %v", *cacheConfig)
+		}
+	}
 
-	cacheConfigBytes, err := yaml.Marshal(cacheConfig)
-	if err != nil {
-		return nil, errors.Wrapf(err, "generate cache config file: %v", cacheConfig)
+	args := e2e.BuildArgs(map[string]string{
+		"--debug.name":        fmt.Sprintf("store-gw-%v", name),
+		"--grpc-address":      ":9091",
+		"--grpc-grace-period": "0s",
+		"--http-address":      ":8080",
+		"--log.level":         infoLogLevel,
+		"--data-dir":          container,
+		"--objstore.config":   string(bktConfigBytes),
+		// Accelerated sync time for quicker test (3m by default).
+		"--sync-block-duration":               "3s",
+		"--block-sync-concurrency":            "1",
+		"--store.grpc.series-max-concurrency": "1",
+		"--selector.relabel-config":           string(relabelConfigBytes),
+		"--consistency-delay":                 "30m",
+	})
+
+	if len(cacheConfigBytes) != 0 {
+		args = append(args, "--store.caching-bucket.config", string(cacheConfigBytes))
 	}
 
 	store := NewService(
 		e,
 		fmt.Sprintf("store-gw-%v", name),
 		DefaultImage(),
-		e2e.NewCommand("store", e2e.BuildArgs(map[string]string{
-			"--debug.name":        fmt.Sprintf("store-gw-%v", name),
-			"--grpc-address":      ":9091",
-			"--grpc-grace-period": "0s",
-			"--http-address":      ":8080",
-			"--log.level":         infoLogLevel,
-			"--data-dir":          container,
-			"--objstore.config":   string(bktConfigBytes),
-			// Accelerated sync time for quicker test (3m by default).
-			"--sync-block-duration":               "3s",
-			"--block-sync-concurrency":            "1",
-			"--store.grpc.series-max-concurrency": "1",
-			"--selector.relabel-config":           string(relabelConfigBytes),
-			"--consistency-delay":                 "30m",
-			"--store.caching-bucket.config":       string(cacheConfigBytes),
-		})...),
+		e2e.NewCommand("store", args...),
 		e2e.NewHTTPReadinessProbe("http", "/-/ready", 200, 200),
 		8080,
 		9091,

--- a/test/e2e/store_gateway_test.go
+++ b/test/e2e/store_gateway_test.go
@@ -77,7 +77,7 @@ func TestStoreGateway(t *testing.T) {
 				Insecure:  true,
 			},
 		},
-		memcachedConfig,
+		&memcachedConfig,
 		relabel.Config{
 			Action:       relabel.Drop,
 			Regex:        relabel.MustNewRegexp("value2"),

--- a/test/e2e/store_gateway_test.go
+++ b/test/e2e/store_gateway_test.go
@@ -274,3 +274,131 @@ func TestStoreGateway(t *testing.T) {
 
 	// TODO(khyati) Let's add some case for compaction-meta.json once the PR will be merged: https://github.com/thanos-io/thanos/pull/2136.
 }
+
+func TestStoreGatewayMemcachedCache(t *testing.T) {
+	t.Parallel()
+
+	e, err := e2e.NewDockerEnvironment("e2e_test_store_gateway_memcached_cache")
+	testutil.Ok(t, err)
+	t.Cleanup(e2ethanos.CleanScenario(t, e))
+
+	const bucket = "store_gateway_memcached_cache_test"
+	m := e2ethanos.NewMinio(e, "thanos-minio", bucket)
+	testutil.Ok(t, e2e.StartAndWaitReady(m))
+
+	memcached := e2ethanos.NewMemcached(e, "1")
+	testutil.Ok(t, e2e.StartAndWaitReady(memcached))
+
+	memcachedConfig := storecache.CachingWithBackendConfig{
+		Type: storecache.MemcachedBucketCacheProvider,
+		BackendConfig: cacheutil.MemcachedClientConfig{
+			Addresses:                 []string{memcached.InternalEndpoint("memcached")},
+			MaxIdleConnections:        100,
+			MaxAsyncConcurrency:       20,
+			MaxGetMultiConcurrency:    100,
+			MaxGetMultiBatchSize:      0,
+			Timeout:                   time.Minute,
+			MaxAsyncBufferSize:        10000,
+			DNSProviderUpdateInterval: 10 * time.Second,
+		},
+		ChunkSubrangeSize: 16000,
+	}
+
+	s1, err := e2ethanos.NewStoreGW(
+		e,
+		"1",
+		client.BucketConfig{
+			Type: client.S3,
+			Config: s3.Config{
+				Bucket:    bucket,
+				AccessKey: e2edb.MinioAccessKey,
+				SecretKey: e2edb.MinioSecretKey,
+				Endpoint:  m.InternalEndpoint("http"),
+				Insecure:  true,
+			},
+		},
+		&memcachedConfig,
+	)
+	testutil.Ok(t, err)
+	testutil.Ok(t, e2e.StartAndWaitReady(s1))
+
+	// We need Prometheus to monitor the metrics exposed by Thanos Store.
+	prom, sidecar, err := e2ethanos.NewPrometheusWithSidecar(e, "1", defaultPromConfig("test", 0, "", "", s1.InternalEndpoint("http")), e2ethanos.DefaultPrometheusImage())
+	testutil.Ok(t, err)
+	testutil.Ok(t, e2e.StartAndWaitReady(prom, sidecar))
+
+	q, err := e2ethanos.NewQuerierBuilder(e, "1", s1.InternalEndpoint("grpc"), sidecar.InternalEndpoint("grpc")).Build()
+	testutil.Ok(t, err)
+	testutil.Ok(t, e2e.StartAndWaitReady(q))
+
+	dir := filepath.Join(e.SharedDir(), "tmp")
+	testutil.Ok(t, os.MkdirAll(dir, os.ModePerm))
+
+	series := []labels.Labels{labels.FromStrings("a", "1", "b", "2")}
+	extLset := labels.FromStrings("ext1", "value1", "replica", "1")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	t.Cleanup(cancel)
+
+	now := time.Now()
+	id, err := e2eutil.CreateBlockWithBlockDelay(ctx, dir, series, 10, timestamp.FromTime(now), timestamp.FromTime(now.Add(2*time.Hour)), 30*time.Minute, extLset, 0, metadata.NoneFunc)
+	testutil.Ok(t, err)
+
+	l := log.NewLogfmtLogger(os.Stdout)
+	bkt, err := s3.NewBucketWithConfig(l, s3.Config{
+		Bucket:    bucket,
+		AccessKey: e2edb.MinioAccessKey,
+		SecretKey: e2edb.MinioSecretKey,
+		Endpoint:  m.Endpoint("http"), // We need separate client config, when connecting to minio from outside.
+		Insecure:  true,
+	}, "test-feed")
+	testutil.Ok(t, err)
+
+	testutil.Ok(t, objstore.UploadDir(ctx, l, bkt, path.Join(dir, id.String()), id.String()))
+
+	// Wait for store to sync blocks.
+	// thanos_blocks_meta_synced: 1x loadedMeta 0x labelExcludedMeta 0x TooFreshMeta.
+	testutil.Ok(t, s1.WaitSumMetrics(e2e.Equals(1), "thanos_blocks_meta_synced"))
+	testutil.Ok(t, s1.WaitSumMetrics(e2e.Equals(0), "thanos_blocks_meta_sync_failures_total"))
+
+	testutil.Ok(t, s1.WaitSumMetrics(e2e.Equals(1), "thanos_bucket_store_blocks_loaded"))
+	testutil.Ok(t, s1.WaitSumMetrics(e2e.Equals(0), "thanos_bucket_store_block_drops_total"))
+	testutil.Ok(t, s1.WaitSumMetrics(e2e.Equals(0), "thanos_bucket_store_block_load_failures_total"))
+
+	t.Run("query with cache miss", func(t *testing.T) {
+		queryAndAssertSeries(t, ctx, q.Endpoint("http"), "{a=\"1\"}",
+			promclient.QueryOptions{
+				Deduplicate: false,
+			},
+			[]model.Metric{
+				{
+					"a":       "1",
+					"b":       "2",
+					"ext1":    "value1",
+					"replica": "1",
+				},
+			},
+		)
+
+		testutil.Ok(t, s1.WaitSumMetrics(e2e.Equals(0), "thanos_store_bucket_cache_operation_hits_total"))
+	})
+
+	t.Run("query with cache hit", func(t *testing.T) {
+		queryAndAssertSeries(t, ctx, q.Endpoint("http"), "{a=\"1\"}",
+			promclient.QueryOptions{
+				Deduplicate: false,
+			},
+			[]model.Metric{
+				{
+					"a":       "1",
+					"b":       "2",
+					"ext1":    "value1",
+					"replica": "1",
+				},
+			},
+		)
+
+		testutil.Ok(t, s1.WaitSumMetrics(e2e.Greater(0), "thanos_store_bucket_cache_operation_hits_total"))
+	})
+
+}

--- a/test/e2e/store_gateway_test.go
+++ b/test/e2e/store_gateway_test.go
@@ -33,7 +33,7 @@ import (
 	"github.com/thanos-io/thanos/test/e2e/e2ethanos"
 )
 
-// TODO(bwplotka): Extend this test to have multiple stores and memcached.
+// TODO(bwplotka): Extend this test to have multiple stores.
 // TODO(bwplotka): Extend this test for downsampling.
 func TestStoreGateway(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes
- Extended newStoreGW services to accept caching bucket config.
- Added Memcached in Store Gateway e2e test.
- Added a separate test for Store Gateway with Memcached.
<!-- Enumerate changes you made -->

## Verification
The tests passed after the changes.
<!-- How you tested it? How do you know it works? -->
