### PR TITLE
Add capability to use custom AWS STS Endpoint

### DIFF
--- a/docs/storage.md
+++ b/docs/storage.md
@@ -88,6 +88,7 @@ config:
     kms_key_id: ""
     kms_encryption_context: {}
     encryption_key: ""
+  sts_endpoint: ""
 ```
 
 At a minimum, you will need to provide a value for the `bucket`, `endpoint`, `access_key`, and `secret_key` keys. The rest of the keys are optional.
@@ -225,6 +226,12 @@ We need access to CreateBucket and DeleteBucket and access to all buckets:
 With this policy you should be able to run set `THANOS_TEST_OBJSTORE_SKIP=GCS,AZURE,SWIFT,COS,ALIYUNOSS` and unset `S3_BUCKET` and run all tests using `make test`.
 
 Details about AWS policies: https://docs.aws.amazon.com/AmazonS3/latest/dev/using-with-s3-actions.html
+
+##### STS Endpoint
+
+If you want to use IAM credential retrieved from an instance profile, Thanos needs to authenticate through AWS STS. For this purposes you can specify your own STS Endpoint.
+
+By default Thanos will use endpoint: https://sts.amazonaws.com and AWS region coresponding endpoints.
 
 #### GCS
 

--- a/pkg/objstore/s3/s3.go
+++ b/pkg/objstore/s3/s3.go
@@ -86,6 +86,7 @@ type Config struct {
 	// NOTE we need to make sure this number does not produce more parts than 10 000.
 	PartSize  uint64    `yaml:"part_size"`
 	SSEConfig SSEConfig `yaml:"sse_config"`
+	STSEndpoint string	`yaml:"sts_endpoint"`
 }
 
 // SSEConfig deals with the configuration of SSE for Minio. The following options are valid:
@@ -228,6 +229,7 @@ func NewBucketWithConfig(logger log.Logger, config Config, component string) (*B
 				Client: &http.Client{
 					Transport: http.DefaultTransport,
 				},
+				Endpoint: config.STSEndpoint,
 			}),
 		}
 	}


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Added capability to use custom AWS STS Endpoint. It is helpfull when you cannot communicate out of AWS network to default endpoint https://sts.amazonaws.com/

If parameter `sts_endpoint` will not be set, minio used default https://sts.amazonaws.com/ or another regional mutation of this endpoint. Look [here](https://github.com/minio/minio-go/blob/89f47e72a59ecbbe7fd05f24e5539075bca8b796/pkg/credentials/iam_aws.go#L92)

## Verification

I cannot run test along our testing buckets, then I test only `make test-local` and `make test-e2e-local`. I will be happy when someone else try it on real bucket. 

## Review

It is my first public PR ever, then can I ask you (as maintainer of AWS/S3 client) to review this PR @bwplotka?
