### PR TITLE
Tests: Fix flaky store gateway memcached test

### DIFF
--- a/test/e2e/store_gateway_test.go
+++ b/test/e2e/store_gateway_test.go
@@ -380,7 +380,7 @@ func TestStoreGatewayMemcachedCache(t *testing.T) {
 			},
 		)
 
-		testutil.Ok(t, s1.WaitSumMetrics(e2e.Equals(0), "thanos_store_bucket_cache_operation_hits_total"))
+		testutil.Ok(t, s1.WaitSumMetrics(e2e.Equals(0), "thanos_store_index_cache_hits_total"))
 	})
 
 	t.Run("query with cache hit", func(t *testing.T) {
@@ -398,7 +398,7 @@ func TestStoreGatewayMemcachedCache(t *testing.T) {
 			},
 		)
 
-		testutil.Ok(t, s1.WaitSumMetrics(e2e.Greater(0), "thanos_store_bucket_cache_operation_hits_total"))
+		testutil.Ok(t, s1.WaitSumMetrics(e2e.Greater(0), "thanos_store_index_cache_hits_total"))
 	})
 
 }


### PR DESCRIPTION
Signed-off-by: Matej Gera <matejgera@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

The recently introduced test for store gateway with memacached cache seems to be causing a lot of failures (see e.g. https://github.com/thanos-io/thanos/runs/3800344854).

I suspect the metric used for testing - `thanos_store_bucket_cache_operation_hits_total` - is not reflecting the actual operations (not sure why though?). Using `thanos_store_index_cache_hits_total` seems to make the test work as intended.

## Verification

Run tests locally + expecting CI pass
