### PR TITLE
e2e: Fix flaky memcached test

### DIFF
--- a/test/e2e/compact_test.go
+++ b/test/e2e/compact_test.go
@@ -451,7 +451,7 @@ func testCompactWithStoreGateway(t *testing.T, penaltyDedup bool) {
 			Insecure:  true,
 		},
 	}
-	str, err := e2ethanos.NewStoreGW(e, "1", svcConfig, nil)
+	str, err := e2ethanos.NewStoreGW(e, "1", svcConfig, "")
 	testutil.Ok(t, err)
 	testutil.Ok(t, e2e.StartAndWaitReady(str))
 	testutil.Ok(t, str.WaitSumMetrics(e2e.Equals(float64(len(rawBlockIDs)+7)), "thanos_blocks_meta_synced"))


### PR DESCRIPTION
Signed-off-by: akanshat <akanshat1999@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes
- Passed raw config instead of a struct to avoid zero values.
- Because we only needed to verify the chunk caching operations, we added a label to `thanos_store_bucket_cache_operation_hits_total`.
<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
The tests passed without any flake this time.