### PR TITLE
store: batch postings requests to cache

### DIFF
--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -1030,7 +1030,7 @@ func (s *BucketStore) Series(req *storepb.SeriesRequest, srv storepb.Store_Serie
 		}
 	}
 
-	matchingBlocks := []matchingBlock{}
+	matchingBlocks := []*matchingBlock{}
 
 	s.mtx.RLock()
 
@@ -1047,7 +1047,7 @@ func (s *BucketStore) Series(req *storepb.SeriesRequest, srv storepb.Store_Serie
 			debugFoundBlockSetOverview(s.logger, req.MinTime, req.MaxTime, req.MaxResolutionWindow, bs.labels, blocks)
 		}
 
-		matchingBlocks = append(matchingBlocks, matchingBlock{
+		matchingBlocks = append(matchingBlocks, &matchingBlock{
 			matchers: blockMatchers,
 			blocks:   blocks,
 		})
@@ -1058,7 +1058,7 @@ func (s *BucketStore) Series(req *storepb.SeriesRequest, srv storepb.Store_Serie
 	c.CorkAt(corkAt)
 
 	for _, matchingBlock := range matchingBlocks {
-		blockMatchers := matchingBlock.matchers
+		matchingBlock := matchingBlock
 
 		for _, b := range matchingBlock.blocks {
 			b := b
@@ -1094,7 +1094,7 @@ func (s *BucketStore) Series(req *storepb.SeriesRequest, srv storepb.Store_Serie
 					b.extLset,
 					indexr,
 					chunkr,
-					blockMatchers,
+					matchingBlock.matchers,
 					chunksLimiter,
 					seriesLimiter,
 					req.SkipChunks,

--- a/pkg/store/bucket_e2e_test.go
+++ b/pkg/store/bucket_e2e_test.go
@@ -74,8 +74,8 @@ func (c *swappableCache) StorePostings(ctx context.Context, blockID ulid.ULID, l
 	c.ptr.StorePostings(ctx, blockID, l, v)
 }
 
-func (c *swappableCache) FetchMultiPostings(ctx context.Context, blockID ulid.ULID, keys []labels.Label) (map[labels.Label][]byte, []labels.Label) {
-	return c.ptr.FetchMultiPostings(ctx, blockID, keys)
+func (c *swappableCache) FetchMultiPostings(ctx context.Context, toFetch map[ulid.ULID][]labels.Label) (map[ulid.ULID]map[labels.Label][]byte, map[ulid.ULID][]labels.Label) {
+	return c.ptr.FetchMultiPostings(ctx, toFetch)
 }
 
 func (c *swappableCache) StoreSeries(ctx context.Context, blockID ulid.ULID, id storage.SeriesRef, v []byte) {

--- a/pkg/store/cache/cache.go
+++ b/pkg/store/cache/cache.go
@@ -32,7 +32,7 @@ type IndexCache interface {
 
 	// FetchMultiPostings fetches multiple postings - each identified by a label -
 	// and returns a map containing cache hits, along with a list of missing keys.
-	FetchMultiPostings(ctx context.Context, blockID ulid.ULID, keys []labels.Label) (hits map[labels.Label][]byte, misses []labels.Label)
+	FetchMultiPostings(ctx context.Context, toFetch map[ulid.ULID][]labels.Label) (hits map[ulid.ULID]map[labels.Label][]byte, misses map[ulid.ULID][]labels.Label)
 
 	// StoreSeries stores a single series.
 	StoreSeries(ctx context.Context, blockID ulid.ULID, id storage.SeriesRef, v []byte)

--- a/pkg/store/cache/cork.go
+++ b/pkg/store/cache/cork.go
@@ -1,0 +1,210 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package storecache
+
+import (
+	"context"
+	"sync"
+
+	"go.uber.org/atomic"
+
+	"github.com/oklog/ulid"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/storage"
+)
+
+// ValueOnce is similar to Once, except it returns the retrieved hits and misses each time.
+type valueOnce struct {
+	m            sync.Mutex
+	done         atomic.Uint32
+	hits, misses interface{}
+}
+
+// Do runs the specified function only once, but all callers gets the same
+// result from that single execution.
+func (o *valueOnce) Do(f func() (interface{}, interface{})) (interface{}, interface{}) {
+	if o.done.Load() == 1 {
+		return o.hits, o.misses
+	}
+
+	o.m.Lock()
+	defer o.m.Unlock()
+	if o.done.Load() == 0 {
+		defer o.done.Store(1)
+		o.hits, o.misses = f()
+	}
+	return o.hits, o.misses
+}
+
+// corkedIndexCache waits for a bit until at least the given
+// number of workers have executed a Fetch operation, only then
+// it executes the query once and fans out the results.
+// This greatly improves performance because with some
+// cache providers even a simple Get() operation might result in a new
+// TCP connection being established, and requests for only one key seriously
+// hamper the performance because the roundtrip takes a much longer time in comparison
+// with how long it takes to retrieve the cache item.
+// WARNING: Only use it where the number of callers is guaranteed.
+// The corking word comes from corking TCP sockets:
+// https://baus.net/on-tcp_cork/.
+type corkedIndexCache struct {
+	originalIndexCache IndexCache
+
+	cork                uint
+	postingsWG          *sync.WaitGroup
+	postingsGet         *valueOnce
+	postingsToBeFetched map[ulid.ULID][]labels.Label
+	postingsLock        sync.Mutex
+	postingsCounter     int
+}
+
+// CorkedIndexCache is like a IndexCache but it is corked.
+// If the user is not calling FetchPostings() then it must call
+// DonePostings() at the end.
+type CorkedIndexCache interface {
+	IndexCache
+
+	// CorkAt ensures that at least the given number of calls will happen before
+	// the actual fetch.
+	CorkAt(uint)
+
+	// DonePostings reduces the counter by one of how many calls we are waiting for.
+	// It is necessary to call it at least the number at which the index cache
+	// was corked.
+	DonePostings()
+}
+
+// CorkedDoneTracker is for tracking whether DonePostings() has been called.
+// It calls DonePostings() if no fetching has happened.
+type CorkedDoneTracker struct {
+	indexCache CorkedIndexCache
+
+	fetchedPostings bool
+}
+
+func NewCorkedTracker(ic CorkedIndexCache) *CorkedDoneTracker {
+	return &CorkedDoneTracker{indexCache: ic}
+}
+
+func (c *CorkedDoneTracker) Close() {
+	if !c.fetchedPostings {
+		c.indexCache.DonePostings()
+	}
+}
+
+func (c *CorkedDoneTracker) StorePostings(ctx context.Context, blockID ulid.ULID, l labels.Label, v []byte) {
+	c.indexCache.StorePostings(ctx, blockID, l, v)
+}
+
+func (c *CorkedDoneTracker) FetchMultiPostings(ctx context.Context, toFetch map[ulid.ULID][]labels.Label) (hits map[ulid.ULID]map[labels.Label][]byte, misses map[ulid.ULID][]labels.Label) {
+	c.fetchedPostings = true
+	return c.indexCache.FetchMultiPostings(ctx, toFetch)
+}
+
+func (c *CorkedDoneTracker) StoreSeries(ctx context.Context, blockID ulid.ULID, id storage.SeriesRef, v []byte) {
+	c.indexCache.StoreSeries(ctx, blockID, id, v)
+}
+
+func (c *CorkedDoneTracker) FetchMultiSeries(ctx context.Context, blockID ulid.ULID, ids []storage.SeriesRef) (hits map[storage.SeriesRef][]byte, misses []storage.SeriesRef) {
+	return c.indexCache.FetchMultiSeries(ctx, blockID, ids)
+}
+
+func (c *CorkedDoneTracker) DonePostings() {
+	c.indexCache.DonePostings()
+}
+
+func (c *CorkedDoneTracker) CorkAt(n uint) {
+	c.indexCache.CorkAt(n)
+}
+
+func (c *corkedIndexCache) reducePostingsCounter() {
+	c.postingsCounter--
+	if c.postingsCounter == 0 {
+		c.postingsWG = &sync.WaitGroup{}
+		c.postingsWG.Add(int(c.cork))
+		c.postingsToBeFetched = map[ulid.ULID][]labels.Label{}
+		c.postingsGet = new(valueOnce)
+		c.postingsCounter = int(c.cork)
+	}
+}
+
+func (c *corkedIndexCache) DonePostings() {
+	if c.cork <= 1 {
+		return
+	}
+
+	c.postingsLock.Lock()
+	currentWG := c.postingsWG
+	c.reducePostingsCounter()
+	c.postingsLock.Unlock()
+
+	currentWG.Done()
+}
+
+func NewCorkedIndexCache(original IndexCache) CorkedIndexCache {
+	return &corkedIndexCache{originalIndexCache: original,
+		postingsGet:         new(valueOnce),
+		postingsToBeFetched: map[ulid.ULID][]labels.Label{},
+		postingsLock:        sync.Mutex{},
+		postingsWG:          &sync.WaitGroup{},
+	}
+}
+
+func (c *corkedIndexCache) CorkAt(n uint) {
+	c.cork = n
+	c.postingsWG.Add(int(n))
+	c.postingsCounter = int(n)
+}
+
+// StorePostings stores postings for a single series.
+func (c *corkedIndexCache) StorePostings(ctx context.Context, blockID ulid.ULID, l labels.Label, v []byte) {
+	c.originalIndexCache.StorePostings(ctx, blockID, l, v)
+}
+
+// FetchMultiPostings fetches multiple postings - each identified by a label -
+// and returns a map containing cache hits, along with a list of missing keys.
+func (c *corkedIndexCache) FetchMultiPostings(ctx context.Context, toFetch map[ulid.ULID][]labels.Label) (map[ulid.ULID]map[labels.Label][]byte, map[ulid.ULID][]labels.Label) {
+	// Call directly if we are the only one.
+	if c.cork <= 1 {
+		return c.originalIndexCache.FetchMultiPostings(ctx, toFetch)
+	}
+
+	c.postingsLock.Lock()
+	// Add new keys.
+	for blID, keys := range toFetch {
+		c.postingsToBeFetched[blID] = append(c.postingsToBeFetched[blID], keys...)
+	}
+
+	currentWG := c.postingsWG
+	currentValueOnce := c.postingsGet
+	currentToBeFetched := c.postingsToBeFetched
+
+	// If everyone has arrived at this point then refresh the whole data.
+	c.reducePostingsCounter()
+	c.postingsLock.Unlock()
+
+	// Block until everyone has arrived.
+	currentWG.Done()
+	currentWG.Wait()
+
+	// Do the work with the old data (pre-refresh).
+	hits, misses := currentValueOnce.Do(func() (interface{}, interface{}) {
+		hits, misses := c.originalIndexCache.FetchMultiPostings(ctx, currentToBeFetched)
+
+		return hits, misses
+	})
+
+	return hits.(map[ulid.ULID]map[labels.Label][]byte), misses.(map[ulid.ULID][]labels.Label)
+}
+
+// StoreSeries stores a single series.
+func (c *corkedIndexCache) StoreSeries(ctx context.Context, blockID ulid.ULID, id storage.SeriesRef, v []byte) {
+	c.originalIndexCache.StoreSeries(ctx, blockID, id, v)
+}
+
+// FetchMultiSeries fetches multiple series - each identified by ID - from the cache
+// and returns a map containing cache hits, along with a list of missing IDs.
+func (c *corkedIndexCache) FetchMultiSeries(ctx context.Context, blockID ulid.ULID, ids []storage.SeriesRef) (hits map[storage.SeriesRef][]byte, misses []storage.SeriesRef) {
+	return c.originalIndexCache.FetchMultiSeries(ctx, blockID, ids)
+}

--- a/pkg/store/cache/cork_test.go
+++ b/pkg/store/cache/cork_test.go
@@ -1,0 +1,91 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package storecache
+
+import (
+	"context"
+	"testing"
+
+	"github.com/oklog/ulid"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/storage"
+	"github.com/thanos-io/thanos/pkg/testutil"
+	"golang.org/x/sync/errgroup"
+)
+
+type indexCacheCorkMock struct {
+	calls int
+}
+
+func (i *indexCacheCorkMock) StorePostings(ctx context.Context, blockID ulid.ULID, l labels.Label, v []byte) {
+}
+
+func (i *indexCacheCorkMock) FetchMultiPostings(ctx context.Context, toFetch map[ulid.ULID][]labels.Label) (hits map[ulid.ULID]map[labels.Label][]byte, misses map[ulid.ULID][]labels.Label) {
+	i.calls++
+	return nil, nil
+}
+
+func (i *indexCacheCorkMock) StoreSeries(ctx context.Context, blockID ulid.ULID, id storage.SeriesRef, v []byte) {
+
+}
+
+func (i *indexCacheCorkMock) FetchMultiSeries(ctx context.Context, blockID ulid.ULID, ids []storage.SeriesRef) (hits map[storage.SeriesRef][]byte, misses []storage.SeriesRef) {
+	return nil, nil
+}
+
+func TestCorkedIndexCache(t *testing.T) {
+	indexCache := &indexCacheCorkMock{}
+
+	c := NewCorkedIndexCache(indexCache)
+	const workers = 3
+	c.CorkAt(workers)
+
+	eg := &errgroup.Group{}
+
+	for i := 0; i < workers; i++ {
+		eg.Go(func() error {
+			c.FetchMultiPostings(context.Background(), map[ulid.ULID][]labels.Label{ulid.MustNew(0, nil): {}})
+			return nil
+		})
+	}
+	testutil.Ok(t, eg.Wait())
+
+	testutil.Equals(t, 1, indexCache.calls)
+
+	// Try again to see if it works.
+	for i := 0; i < workers; i++ {
+		eg.Go(func() error {
+			c.FetchMultiPostings(context.Background(), map[ulid.ULID][]labels.Label{ulid.MustNew(0, nil): {}})
+			return nil
+		})
+	}
+	testutil.Ok(t, eg.Wait())
+	testutil.Equals(t, 2, indexCache.calls)
+
+	// Call DonePostings one time too much to see whether the counter works well.
+	for i := 0; i < workers+1; i++ {
+		c.DonePostings()
+	}
+
+	// Now we should only need two more calls for an actual call to happen.
+	for i := 0; i < workers-1; i++ {
+		eg.Go(func() error {
+			c.FetchMultiPostings(context.Background(), map[ulid.ULID][]labels.Label{ulid.MustNew(0, nil): {}})
+			return nil
+		})
+	}
+
+	testutil.Ok(t, eg.Wait())
+	testutil.Equals(t, 3, indexCache.calls)
+
+	// Let's see if it works with just one caller.
+	c.CorkAt(1)
+	c.FetchMultiPostings(context.Background(), map[ulid.ULID][]labels.Label{ulid.MustNew(0, nil): {}})
+	testutil.Equals(t, 4, indexCache.calls)
+
+	// Edge case.
+	c.CorkAt(0)
+	c.FetchMultiPostings(context.Background(), map[ulid.ULID][]labels.Label{ulid.MustNew(0, nil): {}})
+	testutil.Equals(t, 5, indexCache.calls)
+}


### PR DESCRIPTION
Batch postings requests to the cache to improve the efficiency and so that we could
leverage the already existing batching mechanism in the memcached-client layer.

So, instead of a bunch of requests to get one or two keys, there are fewer roundtrips but
with longer GET commands.

If the approach looks good then I could add this to the series requests as well?

In my tests, this greatly reduces the number of `i/o timeout` errors.

Signed-off-by: Giedrius Statkevičius <giedrius.statkevicius@vinted.com>


* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Changed the IndexCache interface that it would be possible to retrieve multiple `labels.Label` from specified `ulid.ULID`s. Added a `CorkedIndexCache` interface which builds on top - it actually performs the postings fetch only after the counter becomes zero. `DonePostings()` has been added so that the possible `FetchPostings` callers could signal to `CorkedIndexCache` that they won't call `FetchPostings`. It's not harmful to call it more, even if FetchPostings was called.

## Verification

Improved testing suite + existing tests that execute this path. Adhoc tests in pre-production.
