### PR TITLE
store: get buf from chunk pool

### DIFF
--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -2491,7 +2491,7 @@ func (r *bucketChunkReader) loadChunks(ctx context.Context, res []seriesEntry, a
 	r.stats.chunksFetchedSizeSum += int(part.End - part.Start)
 
 	var (
-		buf        = make([]byte, EstimatedMaxChunkSize)
+		buf        []byte
 		readOffset = int(pIdxs[0].offset)
 
 		// Save a few allocations.
@@ -2500,6 +2500,14 @@ func (r *bucketChunkReader) loadChunks(ctx context.Context, res []seriesEntry, a
 		chunkLen int
 		n        int
 	)
+
+	bufPooled, err := r.block.chunkPool.Get(EstimatedMaxChunkSize)
+	if err == nil {
+		buf = *bufPooled
+	} else {
+		buf = make([]byte, EstimatedMaxChunkSize)
+	}
+	defer r.block.chunkPool.Put(&buf)
 
 	for i, pIdx := range pIdxs {
 		// Fast forward range reader to the next chunk start in case of sparse (for our purposes) byte range.


### PR DESCRIPTION
Get the `buf` from the chunkPool. With lots of concurrent `loadChunks`, the
`make()` has a cost. Benchmark diff:

```
name                            old time/op    new time/op    delta
BlockSeries/concurrency:_1-16     8.35ms ± 7%    7.80ms ± 6%  -6.59%  (p=0.000 n=76+75)
BlockSeries/concurrency:_2-16     4.36ms ± 5%    4.30ms ± 4%  -1.42%  (p=0.000 n=74+79)
BlockSeries/concurrency:_4-16     2.70ms ± 6%    2.63ms ± 5%  -2.48%  (p=0.000 n=80+77)
BlockSeries/concurrency:_8-16     2.21ms ± 5%    2.23ms ± 7%    ~     (p=0.055 n=78+78)
BlockSeries/concurrency:_16-16    2.24ms ± 8%    2.22ms ± 8%    ~     (p=0.265 n=76+78)
BlockSeries/concurrency:_32-16    3.42ms ± 9%    3.39ms ±11%    ~     (p=0.367 n=80+80)

name                            old alloc/op   new alloc/op   delta
BlockSeries/concurrency:_1-16     5.17MB ± 5%    4.95MB ± 7%  -4.16%  (p=0.000 n=76+78)
BlockSeries/concurrency:_2-16     5.27MB ± 8%    5.10MB ± 7%  -3.16%  (p=0.000 n=79+78)
BlockSeries/concurrency:_4-16     5.28MB ± 9%    4.92MB ± 8%  -6.88%  (p=0.000 n=79+79)
BlockSeries/concurrency:_8-16     5.39MB ± 8%    5.14MB ± 9%  -4.71%  (p=0.000 n=77+80)
BlockSeries/concurrency:_16-16    6.16MB ±12%    5.89MB ±12%  -4.39%  (p=0.000 n=78+78)
BlockSeries/concurrency:_32-16    9.03MB ±18%    8.88MB ±18%    ~     (p=0.137 n=80+80)

name                            old allocs/op  new allocs/op  delta
BlockSeries/concurrency:_1-16      31.7k ± 3%     31.1k ± 3%  -1.93%  (p=0.000 n=76+80)
BlockSeries/concurrency:_2-16      30.9k ± 3%     31.3k ± 4%  +1.58%  (p=0.000 n=75+80)
BlockSeries/concurrency:_4-16      31.9k ± 4%     31.5k ± 4%  -1.21%  (p=0.000 n=80+80)
BlockSeries/concurrency:_8-16      32.5k ± 4%     32.5k ± 4%    ~     (p=0.805 n=80+78)
BlockSeries/concurrency:_16-16     33.7k ± 8%     33.9k ± 7%    ~     (p=0.412 n=76+77)
BlockSeries/concurrency:_32-16     50.6k ±10%     50.7k ±11%    ~     (p=0.918 n=80+80)
```

Signed-off-by: Giedrius Statkevičius <giedrius.statkevicius@vinted.com>


* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.
