### PR TITLE
pkg/block: remove the extra node in childrenToULIDs

### DIFF
--- a/pkg/block/node.go
+++ b/pkg/block/node.go
@@ -32,9 +32,9 @@ func getNonRootIDs(root *Node) []ulid.ULID {
 	return ulids
 }
 
-func childrenToULIDs(a *Node) []ulid.ULID {
-	var ulids = []ulid.ULID{a.ULID}
-	for _, childNode := range a.Children {
+func childrenToULIDs(item *Node) []ulid.ULID {
+	var ulids = []ulid.ULID{}
+	for _, childNode := range item.Children {
 		ulids = append(ulids, childrenToULIDs(childNode)...)
 	}
 	return ulids


### PR DESCRIPTION
fix #4756 

`childrenToULIDs` is only called in `getNonRootIDs`, and a.ULID will be remove. so `a.ULID` should not be added to `ulids`