### PR TITLE
pkg/block: childSources in addNodeBySources does not need to be assigne…

### DIFF
--- a/pkg/block/fetcher.go
+++ b/pkg/block/fetcher.go
@@ -660,9 +660,9 @@ func (f *DeduplicateFilter) DuplicateIDs() []ulid.ULID {
 
 func addNodeBySources(root, add *Node) bool {
 	var rootNode *Node
+	childSources := add.Compaction.Sources
 	for _, node := range root.Children {
 		parentSources := node.Compaction.Sources
-		childSources := add.Compaction.Sources
 
 		// Block exists with same sources, add as child.
 		if contains(parentSources, childSources) && contains(childSources, parentSources) {


### PR DESCRIPTION
`add` and `childSources` do not be changed, does no need to be assigned in each loop

Signed-off-by: ianwoolf btw515wolf2@gmail.com

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.