### PR TITLE
Compactor: add block-viewer.global.sync-block-timeout for sync block metas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#4680](https://github.com/thanos-io/thanos/pull/4680) Query: add `exemplar.partial-response` flag to control partial response.
 - [#4679](https://github.com/thanos-io/thanos/pull/4679) Added `enable-feature` flag to enable negative offsets and @ modifier, similar to Prometheus.
 - [#4696](https://github.com/thanos-io/thanos/pull/4696) Query: add cache name to tracing spans.
+- [#4764](https://github.com/thanos-io/thanos/pull/4764) Compactor: add `block-viewer.global.sync-block-timeout` flag to set the timeout of synchronization block metas.
 
 ### Fixed
 

--- a/docs/components/compact.md
+++ b/docs/components/compact.md
@@ -284,6 +284,10 @@ Flags:
                                 Repeat interval for syncing the blocks between
                                 local and remote view for /global Block Viewer
                                 UI.
+      --block-viewer.global.sync-block-timeout=5m  
+                                Maximum time for syncing the blocks between
+                                local and remote view for /global Block Viewer
+                                UI.
       --bucket-web-label=BUCKET-WEB-LABEL  
                                 Prometheus label to use as timeline title in the
                                 bucket web UI


### PR DESCRIPTION
fix #4763

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

add flag `block-viewer.global.sync-block-timeout` to set the timeout of sync block metas.


Signed-off-by: ianwoolf btw515wolf2@gmail.com