### PR TITLE
query-frontend+api: add X-Request-ID field and other context field  to start call log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#4754](https://github.com/thanos-io/thanos/pull/4754) Query: Fix possible panic on stores endpoint.
 - [#4753](https://github.com/thanos-io/thanos/pull/4753) Store: validate block sync concurrency parameter
 - [#4792](https://github.com/thanos-io/thanos/pull/4792) Store: Fix data race in BucketedBytes pool.
+- [#4769](https://github.com/thanos-io/thanos/pull/4769) Query-frontend+api: add "X-Request-ID" field and other fields to start call log.
 
 ## [v0.23.1](https://github.com/thanos-io/thanos/tree/release-0.23) - 2021.10.1
 

--- a/cmd/thanos/query_frontend.go
+++ b/cmd/thanos/query_frontend.go
@@ -284,9 +284,10 @@ func runQueryFrontend(
 					logger,
 					ins.NewHandler(
 						name,
-						logMiddleware.HTTPMiddleware(
-							name,
-							gziphandler.GzipHandler(middleware.RequestID(f)),
+						gziphandler.GzipHandler(
+							middleware.RequestID(
+								logMiddleware.HTTPMiddleware(name, f),
+							),
 						),
 					),
 					// Cortex frontend middlewares require orgID.

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -219,9 +219,9 @@ func GetInstr(
 
 		return tracing.HTTPMiddleware(tracer, name, logger,
 			ins.NewHandler(name,
-				logMiddleware.HTTPMiddleware(name,
-					gziphandler.GzipHandler(
-						middleware.RequestID(hf),
+				gziphandler.GzipHandler(
+					middleware.RequestID(
+						logMiddleware.HTTPMiddleware(name, hf),
 					),
 				),
 			),

--- a/pkg/logging/http.go
+++ b/pkg/logging/http.go
@@ -22,9 +22,9 @@ type HTTPServerMiddleware struct {
 	logger log.Logger
 }
 
-func (m *HTTPServerMiddleware) preCall(start time.Time) {
+func (m *HTTPServerMiddleware) preCall(name string, start time.Time, r *http.Request) {
 	logger := m.opts.filterLog(m.logger)
-	level.Debug(logger).Log("http.start_time", start.String(), "msg", "started call")
+	level.Debug(logger).Log("http.start_time", start.String(), "http.method", fmt.Sprintf("%s %s", r.Method, r.URL), "http.request_id", r.Header.Get("X-Request-ID"), "thanos.method_name", name, "msg", "started call")
 }
 
 func (m *HTTPServerMiddleware) postCall(name string, start time.Time, wrapped *httputil.ResponseWriterWithStatus, r *http.Request) {
@@ -68,7 +68,7 @@ func (m *HTTPServerMiddleware) HTTPMiddleware(name string, next http.Handler) ht
 			next.ServeHTTP(w, r)
 
 		case LogStartAndFinishCall:
-			m.preCall(start)
+			m.preCall(name, start, r)
 			next.ServeHTTP(wrapped, r)
 			m.postCall(name, start, wrapped, r)
 


### PR DESCRIPTION
Add more context to link start call with finished call.

Signed-off-by: Aymeric <aymeric.daurelle@cdiscount.com>
Fix issue #4768 .

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

- Move **logMiddleware.HTTPMiddleware** after **middleware.RequestID** 
- Update **preCall** function of **logMiddleware.HTTPMiddleware** to "http.method", "http.request_id" and "thanos.method_name" fields.

## Verification

<!-- How you tested it? How do you know it works? -->
Tested functionally on local.
