### PR TITLE
Add step for merging release branch back to main.

### DIFF
--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -125,14 +125,14 @@ The whole release from release candidate `rc.0` to actual release should have ex
 
 12. After releasing a major version, please cut a release for `kube-thanos` as well. https://github.com/thanos-io/kube-thanos/releases Make sure all the flag changes are reflected in the manifests. Otherwise, the process is the same, except we don't have `rc` for the `kube-thanos`. We do this to make sure we have compatible manifests for each major versions.
 
-13. Merge `release-<major>.<minor>` branch back to main. This is important for Go modules tooling to make release tags reachable from main branch. 
+13. Merge `release-<major>.<minor>` branch back to main. This is important for Go modules tooling to make release tags reachable from main branch.
 
     - Create `merge-release-<major>.<minor>-to-main` branch **from `release-<major>.<minor>` branch** locally
     - Merge upstream `main` branch into your `merge-release-<major>.<minor>-to-main` and resolve conflicts
     - Send PR for merging your `merge-release-<major>.<minor>-to-main` branch into `main`
     - Once approved, merge the PR by using "Merge" commit.
-       - This can either be done by temporarily enabling "Allow merge commits" option in "Settings > Options".
-       - Alternatively, this can be done locally by merging `merge-release-<major>.<minor>-to-main` branch into `main`, and pushing resulting `main` to upstream repository. This doesn't break `main` branch protection, since PR has been approved already, and it also doesn't require removing the protection.
+      - This can either be done by temporarily enabling "Allow merge commits" option in "Settings > Options".
+      - Alternatively, this can be done locally by merging `merge-release-<major>.<minor>-to-main` branch into `main`, and pushing resulting `main` to upstream repository. This doesn't break `main` branch protection, since PR has been approved already, and it also doesn't require removing the protection.
 
 ## Pre-releases (release candidates)
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -125,6 +125,14 @@ The whole release from release candidate `rc.0` to actual release should have ex
 
 12. After releasing a major version, please cut a release for `kube-thanos` as well. https://github.com/thanos-io/kube-thanos/releases Make sure all the flag changes are reflected in the manifests. Otherwise, the process is the same, except we don't have `rc` for the `kube-thanos`. We do this to make sure we have compatible manifests for each major versions.
 
+13. Merge `release-<major>.<minor>` branch back to main. This is important for Go modules tooling to make release tags reachable from main branch. 
+   - Create `merge-release-<major>.<minor>-to-main` branch **from `release-<major>.<minor>` branch** locally
+   - Merge upstream `main` branch into your `merge-release-<major>.<minor>-to-main` and resolve conflicts
+   - Send PR for merging your `merge-release-<major>.<minor>-to-main` branch into `main`
+   - Once approved, merge the PR by using "Merge" commit.
+      - This can either be done by temporarily enabling "Allow merge commits" option in "Settings > Options".
+      - Alternatively, this can be done locally by merging `merge-release-<major>.<minor>-to-main` branch into `main`, and pushing resulting `main` to upstream repository. This doesn't break `main` branch protection, since PR has been approved already, and it also doesn't require removing the protection.
+
 ## Pre-releases (release candidates)
 
 The following changes to the above procedures apply:

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -126,12 +126,13 @@ The whole release from release candidate `rc.0` to actual release should have ex
 12. After releasing a major version, please cut a release for `kube-thanos` as well. https://github.com/thanos-io/kube-thanos/releases Make sure all the flag changes are reflected in the manifests. Otherwise, the process is the same, except we don't have `rc` for the `kube-thanos`. We do this to make sure we have compatible manifests for each major versions.
 
 13. Merge `release-<major>.<minor>` branch back to main. This is important for Go modules tooling to make release tags reachable from main branch. 
-   - Create `merge-release-<major>.<minor>-to-main` branch **from `release-<major>.<minor>` branch** locally
-   - Merge upstream `main` branch into your `merge-release-<major>.<minor>-to-main` and resolve conflicts
-   - Send PR for merging your `merge-release-<major>.<minor>-to-main` branch into `main`
-   - Once approved, merge the PR by using "Merge" commit.
-      - This can either be done by temporarily enabling "Allow merge commits" option in "Settings > Options".
-      - Alternatively, this can be done locally by merging `merge-release-<major>.<minor>-to-main` branch into `main`, and pushing resulting `main` to upstream repository. This doesn't break `main` branch protection, since PR has been approved already, and it also doesn't require removing the protection.
+
+    - Create `merge-release-<major>.<minor>-to-main` branch **from `release-<major>.<minor>` branch** locally
+    - Merge upstream `main` branch into your `merge-release-<major>.<minor>-to-main` and resolve conflicts
+    - Send PR for merging your `merge-release-<major>.<minor>-to-main` branch into `main`
+    - Once approved, merge the PR by using "Merge" commit.
+       - This can either be done by temporarily enabling "Allow merge commits" option in "Settings > Options".
+       - Alternatively, this can be done locally by merging `merge-release-<major>.<minor>-to-main` branch into `main`, and pushing resulting `main` to upstream repository. This doesn't break `main` branch protection, since PR has been approved already, and it also doesn't require removing the protection.
 
 ## Pre-releases (release candidates)
 


### PR DESCRIPTION
This PR updates release procedure to include merging of release branch to `main` (after each release). This makes the latest version tags reachable from `main`, which is important for Go modules to not get confused about which version to use when trying to use branch names. This is only important for projects (eg. Cortex) that depend on Thanos. 

For example:
```
$ go get github.com/thanos-io/thanos@main
go get: github.com/thanos-io/thanos@main (v0.19.1-0.20211012092857-7dee6fa15682) requires github.com/thanos-io/thanos@v0.22.0, not github.com/thanos-io/thanos@main (v0.19.1-0.20211012092857-7dee6fa15682)
```

This happens because latest reachable tag from `main` branch is `v0.19.0` and not `v0.23.1`.


