### PR TITLE
caching_bucket: Refactor caching keys

### DIFF
--- a/pkg/store/cache/caching_bucket_test.go
+++ b/pkg/store/cache/caching_bucket_test.go
@@ -673,3 +673,116 @@ func verifyObjectAttrs(t *testing.T, cb *CachingBucket, file string, expectedLen
 }
 
 func matchAll(string) bool { return true }
+
+func TestParseBucketCacheKey(t *testing.T) {
+	testcases := []struct {
+		key         string
+		expected    BucketCacheKey
+		expectedErr error
+	}{
+		{
+			key: "exists:name",
+			expected: BucketCacheKey{
+				Verb:  ExistsVerb,
+				Name:  "name",
+				Start: 0,
+				End:   0,
+			},
+			expectedErr: nil,
+		},
+		{
+			key: "content:name",
+			expected: BucketCacheKey{
+				Verb:  ContentVerb,
+				Name:  "name",
+				Start: 0,
+				End:   0,
+			},
+			expectedErr: nil,
+		},
+		{
+			key: "iter:name",
+			expected: BucketCacheKey{
+				Verb:  IterVerb,
+				Name:  "name",
+				Start: 0,
+				End:   0,
+			},
+			expectedErr: nil,
+		},
+		{
+			key: "attrs:name",
+			expected: BucketCacheKey{
+				Verb:  AttributesVerb,
+				Name:  "name",
+				Start: 0,
+				End:   0,
+			},
+			expectedErr: nil,
+		},
+		{
+			key: "subrange:name:10:20",
+			expected: BucketCacheKey{
+				Verb:  SubrangeVerb,
+				Name:  "name",
+				Start: 10,
+				End:   20,
+			},
+			expectedErr: nil,
+		},
+		// Any VerbType other than SubrangeVerb should not have a "start" and "end".
+		{
+			key:         "iter:name:10:20",
+			expected:    BucketCacheKey{},
+			expectedErr: ErrInvalidBucketCacheKeyFormat,
+		},
+		// Key must always have a name.
+		{
+			key:         "iter",
+			expected:    BucketCacheKey{},
+			expectedErr: ErrInvalidBucketCacheKeyFormat,
+		},
+		// Invalid VerbType should return an error.
+		{
+			key:         "random:name",
+			expected:    BucketCacheKey{},
+			expectedErr: ErrInvalidBucketCacheKeyVerb,
+		},
+		// Start must be an integer.
+		{
+			key:         "subrange:name:random:10",
+			expected:    BucketCacheKey{},
+			expectedErr: ErrParseKeyInt,
+		},
+		// End must be an integer.
+		{
+			key:         "subrange:name:10:random",
+			expected:    BucketCacheKey{},
+			expectedErr: ErrParseKeyInt,
+		},
+		// SubrangeVerb must have start and end.
+		{
+			key:         "subrange:name",
+			expected:    BucketCacheKey{},
+			expectedErr: ErrInvalidBucketCacheKeyFormat,
+		},
+		// SubrangeVerb must have start and end both.
+		{
+			key:         "subrange:name:10",
+			expected:    BucketCacheKey{},
+			expectedErr: ErrInvalidBucketCacheKeyFormat,
+		},
+		// Key must not be an empty string.
+		{
+			key:         "",
+			expected:    BucketCacheKey{},
+			expectedErr: ErrInvalidBucketCacheKeyFormat,
+		},
+	}
+
+	for _, tc := range testcases {
+		res, err := ParseBucketCacheKey(tc.key)
+		testutil.Equals(t, tc.expectedErr, err)
+		testutil.Equals(t, tc.expected, res)
+	}
+}


### PR DESCRIPTION
Signed-off-by: akanshat <akanshat1999@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes
- Replaced caching key functions with a struct that implements an interface with `generate()` and `parse()` methods.

<!-- Enumerate changes you made -->

## Verification
The tests passed.
<!-- How you tested it? How do you know it works? -->
