### PR TITLE
Added PromQL compatibility automatic e2e test suite.

### DIFF
--- a/test/e2e/compatibility_test.go
+++ b/test/e2e/compatibility_test.go
@@ -71,7 +71,7 @@ scrape_configs:
 
 	t.Run("receive", func(t *testing.T) {
 		testutil.Ok(t, ioutil.WriteFile(filepath.Join(compliance.Dir(), "receive.yaml"),
-			[]byte(promLablsPromQLConfig(prom, queryReceive, []string{"prometheus", "receive", "tenant_id"})), os.ModePerm))
+			[]byte(promLabelsPromQLConfig(prom, queryReceive, []string{"prometheus", "receive", "tenant_id"})), os.ModePerm))
 
 		stdout, stderr, err := compliance.Exec(e2e.NewCommand("-config-file", filepath.Join(compliance.InternalDir(), "receive.yaml")))
 		testutil.Ok(t, err)
@@ -79,7 +79,7 @@ scrape_configs:
 	})
 	t.Run("sidecar", func(t *testing.T) {
 		testutil.Ok(t, ioutil.WriteFile(filepath.Join(compliance.Dir(), "sidecar.yaml"),
-			[]byte(promLablsPromQLConfig(prom, querySidecar, []string{"prometheus"})), os.ModePerm))
+			[]byte(promLabelsPromQLConfig(prom, querySidecar, []string{"prometheus"})), os.ModePerm))
 
 		stdout, stderr, err := compliance.Exec(e2e.NewCommand("-config-file", filepath.Join(compliance.InternalDir(), "sidecar.yaml")))
 		testutil.Ok(t, err)
@@ -87,7 +87,7 @@ scrape_configs:
 	})
 }
 
-func promLablsPromQLConfig(reference *e2edb.Prometheus, target e2e.Runnable, dropLabels []string) string {
+func promLabelsPromQLConfig(reference *e2edb.Prometheus, target e2e.Runnable, dropLabels []string) string {
 	return `reference_target_config:
   query_url: '` + reference.InternalEndpoint("http") + `'
 


### PR DESCRIPTION
👋🏽 Adding e2e test so it's easier to run PromQL compliance tests.

It's skipped by default because:

* It's scrape based - data set is build up by scraping Promlab servers
* You need to build your own promql-compliance-tester image locally (https://github.com/prometheus/compliance/pull/46).

If we/https://github.com/prometheus/compliance project will automate above (provide static dataset as we do in https://github.com/thanos-io/thanos/blob/b894fd6537c8b445aa9d907867e492bb26cebcd5/examples/interactive/interactive_test.go#L45) and push image on CI then we might consider running it on every commit.

Signed-off-by: Bartlomiej Plotka <bwplotka@gmail.com>
