### PR TITLE
fix panic when warn is nil

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -211,7 +211,15 @@ func GetInstr(
 			if data, warnings, err := f(r); err != nil {
 				RespondError(w, err, data)
 			} else if data != nil {
-				Respond(w, data, warnings)
+				var _warnings []error
+				for i := range warnings {
+					if warnings[i] == nil {
+						level.Error(logger).Log("unexpected nil warning", "path", r.RequestURI, "warings", warnings)
+						continue
+					}
+					_warnings = append(_warnings, warnings[i])
+				}
+				respond(w, data, _warnings)
 			} else {
 				w.WriteHeader(http.StatusNoContent)
 			}
@@ -230,7 +238,7 @@ func GetInstr(
 	return instr
 }
 
-func Respond(w http.ResponseWriter, data interface{}, warnings []error) {
+func respond(w http.ResponseWriter, data interface{}, warnings []error) {
 	w.Header().Set("Content-Type", "application/json")
 	if len(warnings) > 0 {
 		w.Header().Set("Cache-Control", "no-store")

--- a/pkg/exemplars/exemplars.go
+++ b/pkg/exemplars/exemplars.go
@@ -6,6 +6,7 @@ package exemplars
 import (
 	"context"
 	"sort"
+	"sync"
 
 	"github.com/pkg/errors"
 	"github.com/prometheus/prometheus/storage"
@@ -32,6 +33,7 @@ type GRPCClient struct {
 
 type exemplarsServer struct {
 	// This field just exist to pseudo-implement the unused methods of the interface.
+	sync.RWMutex
 	exemplarspb.Exemplars_ExemplarsServer
 	ctx context.Context
 
@@ -40,6 +42,8 @@ type exemplarsServer struct {
 }
 
 func (srv *exemplarsServer) Send(res *exemplarspb.ExemplarsResponse) error {
+	srv.Lock()
+	defer srv.Unlock()
 	if res.GetWarning() != "" {
 		srv.warnings = append(srv.warnings, errors.New(res.GetWarning()))
 		return nil


### PR DESCRIPTION
Signed-off-by: ian woolf <btw515wolf2@gmail.com>

fix #4777 
<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.
