### PR TITLE
add error log for BlocksCleaner

### DIFF
--- a/pkg/compact/blocks_cleaner.go
+++ b/pkg/compact/blocks_cleaner.go
@@ -47,6 +47,7 @@ func (s *BlocksCleaner) DeleteMarkedBlocks(ctx context.Context) error {
 		if time.Since(time.Unix(deletionMark.DeletionTime, 0)).Seconds() > s.deleteDelay.Seconds() {
 			if err := block.Delete(ctx, s.logger, s.bkt, deletionMark.ID); err != nil {
 				s.blockCleanupFailures.Inc()
+				level.Error(s.logger).Log("msg", "cleaning of blocks marked for deletion fail", "err", err)
 				return errors.Wrap(err, "delete block")
 			}
 			s.blocksCleaned.Inc()


### PR DESCRIPTION
Signed-off-by: ian woolf <btw515wolf2@gmail.com>

related to #4778 

Compactor doesn't print the error log when DeleteMarkedBlocks fails. So i add the error log to  `pkg/compact/blocks_cleaner.go`.

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

add log when DeletionMarkBlocks fail
