### PR TITLE
Query: Fix exemplarsServer data race (#4777)

### DIFF
--- a/pkg/exemplars/proxy_test.go
+++ b/pkg/exemplars/proxy_test.go
@@ -292,8 +292,7 @@ func TestProxy(t *testing.T) {
 	}
 }
 
-// TestProxyDataRace find the concurrent data race bug.
-// go test -race -run TestProxyDataRace -v
+// TestProxyDataRace find the concurrent data race bug ( go test -race -run TestProxyDataRace -v ).
 func TestProxyDataRace(t *testing.T) {
 	logger := log.NewLogfmtLogger(os.Stderr)
 	p := NewProxy(logger, func() []*exemplarspb.ExemplarStore {


### PR DESCRIPTION
Fix #4777.
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

1. write a unit test, go test -race to reproduce it .
2. add `sync.Mutex` to `*exemplarsServer`.
## Verification

<!-- How you tested it? How do you know it works? -->
1. `go test -race`
2. deploy it at Production, monitor log.