### PR TITLE
Fix store filter select menu color in dark mode

### DIFF
--- a/pkg/ui/react-app/src/hooks/useFetch.ts
+++ b/pkg/ui/react-app/src/hooks/useFetch.ts
@@ -25,7 +25,7 @@ export const useFetch = <T extends any>(url: string, options?: RequestInit): Fet
         setResponse(json);
         setIsLoading(false);
       } catch (error) {
-        setError(error);
+        setError(error as Error);
         setIsLoading(false);
       }
     };

--- a/pkg/ui/react-app/src/pages/graph/Panel.tsx
+++ b/pkg/ui/react-app/src/pages/graph/Panel.tsx
@@ -359,7 +359,15 @@ class Panel extends Component<PanelProps & PathPrefixProps, PanelState> {
                   getOptionLabel={(option: Store) => option.name}
                   getOptionValue={(option: Store) => option.name}
                   closeMenuOnSelect={false}
-                  styles={{ container: (provided, state) => ({ ...provided, marginBottom: 20, zIndex: 3, width: '100%' }) }}
+                  styles={{
+                    container: (provided, state) => ({
+                      ...provided,
+                      marginBottom: 20,
+                      zIndex: 3,
+                      width: '100%',
+                      color: '#000',
+                    }),
+                  }}
                   onChange={this.handleStoreMatchChange}
                 />
               </div>

--- a/pkg/ui/react-app/src/pages/targets/EndpointLink.tsx
+++ b/pkg/ui/react-app/src/pages/targets/EndpointLink.tsx
@@ -13,7 +13,7 @@ const EndpointLink: FC<EndpointLinkProps> = ({ endpoint, globalUrl }) => {
   } catch (e) {
     return (
       <UncontrolledAlert color="danger">
-        <strong>Error:</strong> {e.message}
+        <strong>Error:</strong> {(e as Error).message}
       </UncontrolledAlert>
     );
   }


### PR DESCRIPTION

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

This PR fixes the Store Filter select menu text color to be more legible in dark mode.

Before fix:

![Screenshot 2021-10-28 at 7 41 57 PM](https://user-images.githubusercontent.com/51132453/139285699-1a9c0b5d-d82a-4d2b-8849-767b66fb191f.png)

After fix:

![Screenshot 2021-10-28 at 7 53 13 PM](https://user-images.githubusercontent.com/51132453/139285966-0f11e483-5dc3-483d-959f-48a8ed79203e.png)

Note: Had to type annotate `catch` blocks due to errors when running `make assets`, but is unrelated to PR.
## Verification

Tested locally.