### PR TITLE
Query: fix streamSeriesSet defer in for loop

### DIFF
--- a/pkg/store/proxy.go
+++ b/pkg/store/proxy.go
@@ -418,6 +418,8 @@ func startStreamSeriesSet(
 				}
 			}
 		}()
+		// The `defer` only executed when function return, we do `defer cancel` in for loop,
+		// so make the loop body as a function, release timers created by context as early.
 		handleRecvResponse := func() (next bool) {
 			frameTimeoutCtx, cancel := frameCtx(s.responseTimeout)
 			defer cancel()


### PR DESCRIPTION
Defer in for loop will lead too many timer in heap.

here is the pprof log:
```
[*]* ./go tool pprof  *:19192/debug/pprof/heap
Fetching profile over HTTP from http://*:19192/debug/pprof/heap
Saved profile in *pprof.thanos.alloc_objects.alloc_space.inuse_objects.inuse_space.011.pb.gz
File: thanos
Type: inuse_space
Time: Nov 3, 2021 at 2:41pm (CST)
Entering interactive mode (type "help" for commands, "o" for options)
(pprof) top10
Showing nodes accounting for 153.80MB, 84.79% of 181.38MB total
Dropped 76 nodes (cum <= 0.91MB)
Showing top 10 nodes out of 111
      flat  flat%   sum%        cum   cum%
   50.52MB 27.85% 27.85%    54.52MB 30.06%  github.com/thanos-io/thanos/pkg/store/storepb.(*Series).Unmarshal
   36.01MB 19.86% 47.71%    36.01MB 19.86%  google.golang.org/grpc.(*parser).recvMsg
   17.72MB  9.77% 57.48%    17.72MB  9.77%  time.goFunc
   11.38MB  6.28% 63.75%    11.38MB  6.28%  time.startTimer
    8.51MB  4.69% 68.45%     8.51MB  4.69%  google.golang.org/grpc/internal/transport.newBufWriter
    6.83MB  3.77% 72.21%    23.48MB 12.95%  github.com/prometheus/prometheus/promql.(*evaluator).rangeEval
    6.50MB  3.58% 75.79%     6.50MB  3.58%  github.com/thanos-io/thanos/pkg/query.newChunkSeries (inline)
    6.01MB  3.31% 79.11%     6.01MB  3.31%  bytes.makeSlice
    5.16MB  2.84% 81.95%     5.16MB  2.84%  bufio.NewReaderSize
    5.16MB  2.84% 84.79%     5.16MB  2.84%  github.com/thanos-io/thanos/pkg/query.(*seriesServer).Send
(pprof) traces time.startTimer
File: thanos
Type: inuse_space
Time: Nov 3, 2021 at 2:41pm (CST)
-----------+-------------------------------------------------------
     bytes:  2.84MB
   11.38MB   time.startTimer
             time.AfterFunc
             context.WithDeadline
             context.WithTimeout
             github.com/thanos-io/thanos/pkg/store.frameCtx
             github.com/thanos-io/thanos/pkg/store.startStreamSeriesSet.func1
-----------+-------------------------------------------------------
     bytes:  2.27MB
         0   time.startTimer
             time.AfterFunc
             context.WithDeadline
             context.WithTimeout
             github.com/thanos-io/thanos/pkg/store.frameCtx
             github.com/thanos-io/thanos/pkg/store.startStreamSeriesSet.func1

```

Signed-off-by: Jimmiehan <hanjinming@outlook.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->
Make it as function. so the timer will be released in every loop.
## Verification

<!-- How you tested it? How do you know it works? -->
1. Unit test.
2. Deploy and pprof again, the `time.startTimer` has disappeared. 