### PR TITLE
Upgrading prometheus/exporter-toolkit to add support for security-related HTTP headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#4801](https://github.com/thanos-io/thanos/pull/4801) Compactor: added Prometheus metrics for tracking the progress of compaction and downsampling.
 - [#4444](https://github.com/thanos-io/thanos/pull/4444) UI: add mark deletion and no compaction to the Block UI.
 - [#4576](https://github.com/thanos-io/thanos/pull/4576) UI: add filter compaction level to the Block UI.
+- [#4840](https://github.com/thanos-io/thanos/pull/4840) Updated prometheus/exporter-toolkit dependency to enable http security headers configuration.
 
 ### Fixed
 

--- a/docs/operating/https.md
+++ b/docs/operating/https.md
@@ -58,6 +58,30 @@ http_server_config:
   # Enable HTTP/2 support. Note that HTTP/2 is only supported with TLS.
   # This can not be changed on the fly.
   [ http2: <boolean> | default = true ]
+  # List of headers that can be added to HTTP responses.
+  [ headers:
+    # Set the Content-Security-Policy header to HTTP responses.
+    # Unset if blank.
+    [ Content-Security-Policy: <string> ]
+    # Set the X-Frame-Options header to HTTP responses.
+    # Unset if blank. Accepted values are deny and sameorigin.
+    # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options
+    [ X-Frame-Options: <string> ]
+    # Set the X-Content-Type-Options header to HTTP responses.
+    # Unset if blank. Accepted value is nosniff.
+    # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options
+    [ X-Content-Type-Options: <string> ]
+    # Set the X-XSS-Protection header to all responses.
+    # Unset if blank. Accepted value is nosniff.
+    # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection
+    [ X-XSS-Protection: <string> ]
+    # Set the Strict-Transport-Security header to HTTP responses.
+    # Unset if blank.
+    # Please make sure that you use this with care as this header might force
+    # browsers to load Prometheus and the other applications hosted on the same
+    # domain and subdomains over HTTPS.
+    # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security
+    [ Strict-Transport-Security: <string> ] ]
 
 # Usernames and hashed passwords that have full access to the web
 # server via basic authentication. If empty, no basic authentication is

--- a/go.mod
+++ b/go.mod
@@ -58,7 +58,7 @@ require (
 	github.com/prometheus/client_golang v1.11.0
 	github.com/prometheus/client_model v0.2.0
 	github.com/prometheus/common v0.30.0
-	github.com/prometheus/exporter-toolkit v0.6.1
+	github.com/prometheus/exporter-toolkit v0.7.0
 	github.com/prometheus/prometheus v1.8.2-0.20210914090109-37468d88dce8
 	github.com/tencentyun/cos-go-sdk-v5 v0.7.31
 	github.com/uber/jaeger-client-go v2.29.1+incompatible

--- a/go.sum
+++ b/go.sum
@@ -1481,8 +1481,9 @@ github.com/prometheus/common/sigv4 v0.1.0 h1:qoVebwtwwEhS85Czm2dSROY5fTo2PAPEVdD
 github.com/prometheus/common/sigv4 v0.1.0/go.mod h1:2Jkxxk9yYvCkE5G1sQT7GuEXm57JrvHu9k5YwTjsNtI=
 github.com/prometheus/exporter-toolkit v0.5.0/go.mod h1:OCkM4805mmisBhLmVFw858QYi3v0wKdY6/UxrT0pZVg=
 github.com/prometheus/exporter-toolkit v0.5.1/go.mod h1:OCkM4805mmisBhLmVFw858QYi3v0wKdY6/UxrT0pZVg=
-github.com/prometheus/exporter-toolkit v0.6.1 h1:Aqk75wQD92N9CqmTlZwjKwq6272nOGrWIbc8Z7+xQO0=
 github.com/prometheus/exporter-toolkit v0.6.1/go.mod h1:ZUBIj498ePooX9t/2xtDjeQYwvRpiPP2lh5u4iblj2g=
+github.com/prometheus/exporter-toolkit v0.7.0 h1:XtYeVeeC5daG4txbc9+mieKq+/AK4gtIBLl9Mulrjnk=
+github.com/prometheus/exporter-toolkit v0.7.0/go.mod h1:ZUBIj498ePooX9t/2xtDjeQYwvRpiPP2lh5u4iblj2g=
 github.com/prometheus/node_exporter v1.0.0-rc.0.0.20200428091818-01054558c289 h1:dTUS1vaLWq+Y6XKOTnrFpoVsQKLCbCp1OLj24TDi7oM=
 github.com/prometheus/node_exporter v1.0.0-rc.0.0.20200428091818-01054558c289/go.mod h1:FGbBv5OPKjch+jNUJmEQpMZytIdyW0NdBtWFcfSKusc=
 github.com/prometheus/procfs v0.0.0-20180125133057-cb4147076ac7/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=


### PR DESCRIPTION
Newest version of [prometheus/exporter-toolkit](https://github.com/prometheus/exporter-toolkit/pull/41) introduces new http server configuration for adding security related headers. 

This pull request aims to bring that feature into thanos by updating the dependency. 
<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

- Bumping `prometheus/exporter-toolkit` version from `v0.6.1` to `v0.7.0`
<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
