### PR TITLE
ui: unhide previously hidden pages

### DIFF
--- a/pkg/ui/react-app/src/thanos/Navbar.tsx
+++ b/pkg/ui/react-app/src/thanos/Navbar.tsx
@@ -34,9 +34,9 @@ const navConfig: { [component: string]: (NavConfig | NavDropDown)[] } = {
       children: [
         { name: 'Runtime & Build Information', uri: '/status' },
         { name: 'Command-Line Flags', uri: '/flags' },
-        // TODO(onprem): Uncomment after `--target` flag on Querier becomes
-        // non-hidden or we move to `--endpoint`.
-        // { name: 'Targets', uri: '/targets' },
+        { name: 'Alerts', uri: '/alerts' },
+        { name: 'Targets', uri: '/targets' },
+        { name: 'Rules', uri: '/rules' },
       ],
     },
   ],


### PR DESCRIPTION
With https://github.com/thanos-io/thanos/pull/4282 merged, it is time to
unhide these very useful pages from the navigation bar. :tada:

Signed-off-by: Giedrius Statkevičius <giedrius.statkevicius@vinted.com>


* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Verification

Checked those pages via the quickstart script after changes.
