### PR TITLE
query: pass queryURL along to the UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#4576](https://github.com/thanos-io/thanos/pull/4576) UI: add filter compaction level to the Block UI.
 - [#4731](https://github.com/thanos-io/thanos/pull/4731) Rule: add stateless mode to ruler according to https://thanos.io/tip/proposals-accepted/202005-scalable-rule-storage.md/. Continue https://github.com/thanos-io/thanos/pull/4250.
 - [#4612](https://github.com/thanos-io/thanos/pull/4612) Sidecar: add `--prometheus.http-client` and `--prometheus.http-client-file` flag for sidecar to connect Prometheus with basic auth or TLS.
+- [#4847](https://github.com/thanos-io/thanos/pull/4847) Query: add `--alert.query-url` which is used in the user interface for rules/alerts pages. By default the HTTP listen address is used for this URL.
 
 ### Fixed
 

--- a/docs/components/query.md
+++ b/docs/components/query.md
@@ -252,6 +252,9 @@ Query node exposing PromQL enabled Query API with data retrieved from multiple
 store nodes.
 
 Flags:
+      --alert.query-url=ALERT.QUERY-URL  
+                                 The external Thanos Query URL that would be set
+                                 in all alerts 'Source' field.
       --enable-feature= ...      Comma separated experimental feature names to
                                  enable.The current list of features is
                                  promql-negative-offset and promql-at-modifier.

--- a/pkg/ui/query.go
+++ b/pkg/ui/query.go
@@ -32,9 +32,10 @@ type Query struct {
 	now     func() model.Time
 }
 
-func NewQueryUI(logger log.Logger, endpointSet *query.EndpointSet, externalPrefix, prefixHeader string) *Query {
+func NewQueryUI(logger log.Logger, endpointSet *query.EndpointSet, externalPrefix, prefixHeader, alertQueryURL string) *Query {
 	tmplVariables := map[string]string{
 		"Component": component.Query.String(),
+		"queryURL":  alertQueryURL,
 	}
 	runtimeInfo := api.GetRuntimeInfoFunc(logger)
 


### PR DESCRIPTION
## Changes

Pass `queryURL` to the UI to have proper URLs in the React UI. Without
this, all URLs are set to `http://localhost:10902` i.e. the default
value set in `config.ts`.

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Verification

Started Thanos via the quickstart script and checked that http://localhost:10904/rules, for example, has proper, clickable URLs.
