### PR TITLE
store: optimized data retrieval from Prometheus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#4576](https://github.com/thanos-io/thanos/pull/4576) UI: add filter compaction level to the Block UI.
 - [#4731](https://github.com/thanos-io/thanos/pull/4731) Rule: add stateless mode to ruler according to https://thanos.io/tip/proposals-accepted/202005-scalable-rule-storage.md/. Continue https://github.com/thanos-io/thanos/pull/4250.
 - [#4612](https://github.com/thanos-io/thanos/pull/4612) Sidecar: add `--prometheus.http-client` and `--prometheus.http-client-file` flag for sidecar to connect Prometheus with basic auth or TLS.
+- [#4857](https://github.com/thanos-io/thanos/pull/4857) Sidecar: optimize data retrieval from Prometheus with range vectors; in the worst case this leads to about 10% query duration reduction, with a bigger range/step difference (and with more data) this can lead to up to 20x reduction of query duration.
 
 ### Fixed
 

--- a/pkg/store/prometheus.go
+++ b/pkg/store/prometheus.go
@@ -137,6 +137,10 @@ func (p *PrometheusStore) putBuffer(b *[]byte) {
 	p.buffers.Put(b)
 }
 
+type timerange struct {
+	mintime, maxtime int64
+}
+
 // Series returns all series for a requested time range and label matcher.
 func (p *PrometheusStore) Series(r *storepb.SeriesRequest, s storepb.Store_SeriesServer) error {
 	extLset := p.externalLabelsFn()
@@ -156,6 +160,17 @@ func (p *PrometheusStore) Series(r *storepb.SeriesRequest, s storepb.Store_Serie
 	availableMinTime, _ := p.timestamps()
 	if r.MinTime < availableMinTime {
 		r.MinTime = availableMinTime
+	}
+
+	timeranges := []timerange{}
+	// Range must be at least four times smaller than the step otherwise
+	// this optimization does not make sense. Deduced this from BenchmarkQueryRangeInterval.
+	if r.Range != 0 && r.Range*4 < r.Step {
+		for ts := r.MinTime; ts <= r.MaxTime; ts += r.Step {
+			timeranges = append(timeranges, timerange{ts, ts + r.Range})
+		}
+	} else {
+		timeranges = []timerange{{r.MinTime, r.MaxTime}}
 	}
 
 	if r.SkipChunks {
@@ -179,29 +194,33 @@ func (p *PrometheusStore) Series(r *storepb.SeriesRequest, s storepb.Store_Serie
 		return nil
 	}
 
-	q := &prompb.Query{StartTimestampMs: r.MinTime, EndTimestampMs: r.MaxTime}
-	for _, m := range matchers {
-		pm := &prompb.LabelMatcher{Name: m.Name, Value: m.Value}
+	queries := []*prompb.Query{}
+	for _, tr := range timeranges {
+		q := &prompb.Query{StartTimestampMs: tr.mintime, EndTimestampMs: tr.maxtime}
+		for _, m := range matchers {
+			pm := &prompb.LabelMatcher{Name: m.Name, Value: m.Value}
 
-		switch m.Type {
-		case labels.MatchEqual:
-			pm.Type = prompb.LabelMatcher_EQ
-		case labels.MatchNotEqual:
-			pm.Type = prompb.LabelMatcher_NEQ
-		case labels.MatchRegexp:
-			pm.Type = prompb.LabelMatcher_RE
-		case labels.MatchNotRegexp:
-			pm.Type = prompb.LabelMatcher_NRE
-		default:
-			return errors.New("unrecognized matcher type")
+			switch m.Type {
+			case labels.MatchEqual:
+				pm.Type = prompb.LabelMatcher_EQ
+			case labels.MatchNotEqual:
+				pm.Type = prompb.LabelMatcher_NEQ
+			case labels.MatchRegexp:
+				pm.Type = prompb.LabelMatcher_RE
+			case labels.MatchNotRegexp:
+				pm.Type = prompb.LabelMatcher_NRE
+			default:
+				return errors.New("unrecognized matcher type")
+			}
+			q.Matchers = append(q.Matchers, pm)
 		}
-		q.Matchers = append(q.Matchers, pm)
+		queries = append(queries, q)
 	}
 
 	queryPrometheusSpan, ctx := tracing.StartSpan(s.Context(), "query_prometheus")
-	queryPrometheusSpan.SetTag("query.request", q.String())
+	queryPrometheusSpan.SetTag("query.request", queries[0].String())
 
-	httpResp, err := p.startPromRemoteRead(ctx, q)
+	httpResp, err := p.startPromRemoteRead(ctx, queries)
 	if err != nil {
 		queryPrometheusSpan.Finish()
 		return errors.Wrap(err, "query Prometheus")
@@ -233,35 +252,39 @@ func (p *PrometheusStore) handleSampledPrometheusResponse(s storepb.Store_Series
 
 	span, _ := tracing.StartSpan(ctx, "transform_and_respond")
 	defer span.Finish()
-	span.SetTag("series_count", len(resp.Results[0].Timeseries))
+	seriesCount := 0
+	for _, r := range resp.Results {
+		for _, e := range r.Timeseries {
+			seriesCount++
+			lset := labelpb.ExtendSortedLabels(labelpb.ZLabelsToPromLabels(e.Labels), extLset)
+			if len(e.Samples) == 0 {
+				// As found in https://github.com/thanos-io/thanos/issues/381
+				// Prometheus can give us completely empty time series. Ignore these with log until we figure out that
+				// this is expected from Prometheus perspective.
+				level.Warn(p.logger).Log(
+					"msg",
+					"found timeseries without any chunk. See https://github.com/thanos-io/thanos/issues/381 for details",
+					"lset",
+					fmt.Sprintf("%v", lset),
+				)
+				continue
+			}
 
-	for _, e := range resp.Results[0].Timeseries {
-		lset := labelpb.ExtendSortedLabels(labelpb.ZLabelsToPromLabels(e.Labels), extLset)
-		if len(e.Samples) == 0 {
-			// As found in https://github.com/thanos-io/thanos/issues/381
-			// Prometheus can give us completely empty time series. Ignore these with log until we figure out that
-			// this is expected from Prometheus perspective.
-			level.Warn(p.logger).Log(
-				"msg",
-				"found timeseries without any chunk. See https://github.com/thanos-io/thanos/issues/381 for details",
-				"lset",
-				fmt.Sprintf("%v", lset),
-			)
-			continue
-		}
+			aggregatedChunks, err := p.chunkSamples(e, MaxSamplesPerChunk)
+			if err != nil {
+				return err
+			}
 
-		aggregatedChunks, err := p.chunkSamples(e, MaxSamplesPerChunk)
-		if err != nil {
-			return err
-		}
-
-		if err := s.Send(storepb.NewSeriesResponse(&storepb.Series{
-			Labels: labelpb.ZLabelsFromPromLabels(lset),
-			Chunks: aggregatedChunks,
-		})); err != nil {
-			return err
+			if err := s.Send(storepb.NewSeriesResponse(&storepb.Series{
+				Labels: labelpb.ZLabelsFromPromLabels(lset),
+				Chunks: aggregatedChunks,
+			})); err != nil {
+				return err
+			}
 		}
 	}
+	span.SetTag("series_count", seriesCount)
+
 	level.Debug(p.logger).Log("msg", "handled ReadRequest_SAMPLED request.", "series", len(resp.Results[0].Timeseries))
 	return nil
 }
@@ -338,7 +361,7 @@ func (p *PrometheusStore) handleStreamedPrometheusResponse(s storepb.Store_Serie
 	querySpan.SetTag("processed.chunks", seriesStats.Chunks)
 	querySpan.SetTag("processed.samples", seriesStats.Samples)
 	querySpan.SetTag("processed.bytes", bodySizer.BytesCount())
-	level.Debug(p.logger).Log("msg", "handled ReadRequest_STREAMED_XOR_CHUNKS request.", "frames", framesNum)
+	level.Debug(p.logger).Log("msg", "handled ReadRequest_STREAMED_XOR_CHUNKS request.", "frames", framesNum, "samples", seriesStats.Samples)
 	return nil
 }
 
@@ -421,9 +444,9 @@ func (p *PrometheusStore) chunkSamples(series *prompb.TimeSeries, maxSamplesPerC
 	return chks, nil
 }
 
-func (p *PrometheusStore) startPromRemoteRead(ctx context.Context, q *prompb.Query) (presp *http.Response, err error) {
+func (p *PrometheusStore) startPromRemoteRead(ctx context.Context, queries []*prompb.Query) (presp *http.Response, err error) {
 	reqb, err := proto.Marshal(&prompb.ReadRequest{
-		Queries:               []*prompb.Query{q},
+		Queries:               queries,
 		AcceptedResponseTypes: p.remoteReadAcceptableResponses,
 	})
 	if err != nil {

--- a/pkg/store/proxy.go
+++ b/pkg/store/proxy.go
@@ -225,6 +225,8 @@ func (s *ProxyStore) Series(r *storepb.SeriesRequest, srv storepb.Store_SeriesSe
 				MaxResolutionWindow:     r.MaxResolutionWindow,
 				SkipChunks:              r.SkipChunks,
 				PartialResponseDisabled: r.PartialResponseDisabled,
+				Step:                    r.Step,
+				Range:                   r.Range,
 			}
 			wg = &sync.WaitGroup{}
 		)


### PR DESCRIPTION
## Changes

Use the new Range/Interval query hints to only select data which is
really needed - instead of sending one big query with min/max time,
divide it into more, smaller queries, each requesting for a smaller
amount of time. Only do this where the step is at least four times
larger than the range to avoid sending a bunch of queries that together
request the same data. Via the benchmarks, I've been able to deduce that
the difference must be at least four times as large to make sense. Here is how the
benchmark numbers look like:

```
name                                                                  time/op
QueryRangeInterval/unoptimized_sidecar,_worst_case,_one_big_block-16  7.37ms ± 5%
QueryRangeInterval/unoptimized_sidecar,_small_blocks_with_2h_step-16  37.5ms ± 5%
QueryRangeInterval/optimized_sidecar,_worst_case,_one_big_block-16    6.62ms ±14%
QueryRangeInterval/optimized_sidecar,_small_blocks_with_2h_step-16    2.84ms ±15%

name                                                                  alloc/op
QueryRangeInterval/unoptimized_sidecar,_worst_case,_one_big_block-16  41.3kB ± 1%
QueryRangeInterval/unoptimized_sidecar,_small_blocks_with_2h_step-16  34.2kB ± 1%
QueryRangeInterval/optimized_sidecar,_worst_case,_one_big_block-16    41.1kB ± 1%
QueryRangeInterval/optimized_sidecar,_small_blocks_with_2h_step-16    33.0kB ± 0%

name                                                                  allocs/op
QueryRangeInterval/unoptimized_sidecar,_worst_case,_one_big_block-16     389 ± 0%
QueryRangeInterval/unoptimized_sidecar,_small_blocks_with_2h_step-16     265 ± 0%
QueryRangeInterval/optimized_sidecar,_worst_case,_one_big_block-16       389 ± 0%
QueryRangeInterval/optimized_sidecar,_small_blocks_with_2h_step-16       264 ± 0%
```

In the future, this optimization could be applied to other components that have a TSDB as well
such as Receive/Rule.

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

Signed-off-by: Giedrius Statkevičius <giedrius.statkevicius@vinted.com>

## Verification

Running manually with quickstart, tests pass.
