### PR TITLE
go.mod: Fix invalid reference to github.com/efficientgo/tools/core

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/cortexproject/cortex v1.10.1-0.20211006150606-fb15b432e267
 	github.com/davecgh/go-spew v1.1.1
 	github.com/efficientgo/e2e v0.11.2-0.20211027134903-67d538984a47
-	github.com/efficientgo/tools/core v0.0.0-20210129205121-421d0828c9a6
+	github.com/efficientgo/tools/core v0.0.0-20210829154005-c7bad8450208
 	github.com/efficientgo/tools/extkingpin v0.0.0-20210609125236-d73259166f20
 	github.com/facette/natsort v0.0.0-20181210072756-2cd4dd1e2dcb
 	github.com/fatih/structtag v1.1.0


### PR DESCRIPTION
Signed-off-by: Matej Gera <matejgera@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [X] Change is not relevant to the end user.

## Changes

For some reason, the `go.mod` for `github.com/efficientgo/tools/core` points to an invalid git commit (it does not exist on any branch), which causes error:
```
thanos ❯ go get github.com/efficientgo/tools/core@421d0828c9a6                                                       
go get: github.com/efficientgo/tools/core@421d0828c9a6: invalid version: unknown revision 421d0828c9a6
```

Resolves #4806.

## Verification
Go get works for
