### PR TITLE
Make progress metrics interval configurable

### DIFF
--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -693,7 +693,7 @@ func (cc *compactConfig) registerFlag(cmd extkingpin.FlagClause) {
 		Default("5m").DurationVar(&cc.blockViewerSyncBlockTimeout)
 	cmd.Flag("compact.cleanup-interval", "How often we should clean up partially uploaded blocks and blocks with deletion mark in the background when --wait has been enabled. Setting it to \"0s\" disables it - the cleaning will only happen at the end of an iteration.").
 		Default("5m").DurationVar(&cc.cleanupBlocksInterval)
-	cmd.Flag("compact.progress-interval", "How often we should calculate the compaction progress in the background when --wait has been enabled. Setting it to \"0s\" disables it. Now compaction, downsampling and retention progress are supported.").
+	cmd.Flag("compact.progress-interval", "Frequency of calculating the compaction progress in the background when --wait has been enabled. Setting it to \"0s\" disables it. Now compaction, downsampling and retention progress are supported.").
 		Default("5m").DurationVar(&cc.progressCalculateInterval)
 
 	cmd.Flag("compact.concurrency", "Number of goroutines to use when compacting groups.").

--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -459,57 +459,6 @@ func runCompact(
 		return cleanPartialMarked()
 	}
 
-	if conf.compactionProgressMetrics {
-		g.Add(func() error {
-			ps := compact.NewCompactionProgressCalculator(reg, tsdbPlanner)
-			rs := compact.NewRetentionProgressCalculator(reg, retentionByResolution)
-			var ds *compact.DownsampleProgressCalculator
-			if !conf.disableDownsampling {
-				ds = compact.NewDownsampleProgressCalculator(reg)
-			}
-
-			return runutil.Repeat(5*time.Minute, ctx.Done(), func() error {
-
-				if err := sy.SyncMetas(ctx); err != nil {
-					return errors.Wrapf(err, "could not sync metas")
-				}
-
-				metas := sy.Metas()
-				groups, err := grouper.Groups(metas)
-				if err != nil {
-					return errors.Wrapf(err, "could not group metadata for compaction")
-				}
-
-				if err = ps.ProgressCalculate(ctx, groups); err != nil {
-					return errors.Wrapf(err, "could not calculate compaction progress")
-				}
-
-				retGroups, err := grouper.Groups(metas)
-				if err != nil {
-					return errors.Wrapf(err, "could not group metadata for retention")
-				}
-
-				if err = rs.ProgressCalculate(ctx, retGroups); err != nil {
-					return errors.Wrapf(err, "could not calculate retention progress")
-				}
-
-				if !conf.disableDownsampling {
-					groups, err = grouper.Groups(metas)
-					if err != nil {
-						return errors.Wrapf(err, "could not group metadata into downsample groups")
-					}
-					if err := ds.ProgressCalculate(ctx, groups); err != nil {
-						return errors.Wrapf(err, "could not calculate downsampling progress")
-					}
-				}
-
-				return nil
-			})
-		}, func(err error) {
-			cancel()
-		})
-	}
-
 	g.Add(func() error {
 		defer runutil.CloseWithLogOnErr(logger, bkt, "bucket client")
 
@@ -588,6 +537,58 @@ func runCompact(
 			})
 		}
 
+		// Periodically calculate the progress of compaction, downsampling and retention.
+		if conf.progressCalculateInterval > 0 {
+			g.Add(func() error {
+				ps := compact.NewCompactionProgressCalculator(reg, tsdbPlanner)
+				rs := compact.NewRetentionProgressCalculator(reg, retentionByResolution)
+				var ds *compact.DownsampleProgressCalculator
+				if !conf.disableDownsampling {
+					ds = compact.NewDownsampleProgressCalculator(reg)
+				}
+
+				return runutil.Repeat(conf.progressCalculateInterval, ctx.Done(), func() error {
+
+					if err := sy.SyncMetas(ctx); err != nil {
+						return errors.Wrapf(err, "could not sync metas")
+					}
+
+					metas := sy.Metas()
+					groups, err := grouper.Groups(metas)
+					if err != nil {
+						return errors.Wrapf(err, "could not group metadata for compaction")
+					}
+
+					if err = ps.ProgressCalculate(ctx, groups); err != nil {
+						return errors.Wrapf(err, "could not calculate compaction progress")
+					}
+
+					retGroups, err := grouper.Groups(metas)
+					if err != nil {
+						return errors.Wrapf(err, "could not group metadata for retention")
+					}
+
+					if err = rs.ProgressCalculate(ctx, retGroups); err != nil {
+						return errors.Wrapf(err, "could not calculate retention progress")
+					}
+
+					if !conf.disableDownsampling {
+						groups, err = grouper.Groups(metas)
+						if err != nil {
+							return errors.Wrapf(err, "could not group metadata into downsample groups")
+						}
+						if err := ds.ProgressCalculate(ctx, groups); err != nil {
+							return errors.Wrapf(err, "could not calculate downsampling progress")
+						}
+					}
+
+					return nil
+				})
+			}, func(err error) {
+				cancel()
+			})
+		}
+
 		g.Add(func() error {
 			iterCtx, iterCancel := context.WithTimeout(ctx, conf.blockViewerSyncBlockTimeout)
 			_, _, _ = f.Fetch(iterCtx)
@@ -642,12 +643,10 @@ type compactConfig struct {
 	enableVerticalCompaction                       bool
 	dedupFunc                                      string
 	skipBlockWithOutOfOrderChunks                  bool
-	compactionProgressMetrics                      bool
+	progressCalculateInterval                      time.Duration
 }
 
 func (cc *compactConfig) registerFlag(cmd extkingpin.FlagClause) {
-	cmd.Flag("progress-metrics", "Enables the progress metrics, indicating the progress of compaction and downsampling").Default("true").BoolVar(&cc.compactionProgressMetrics)
-
 	cmd.Flag("debug.halt-on-error", "Halt the process if a critical compaction error is detected.").
 		Hidden().Default("true").BoolVar(&cc.haltOnError)
 	cmd.Flag("debug.accept-malformed-index",
@@ -694,6 +693,8 @@ func (cc *compactConfig) registerFlag(cmd extkingpin.FlagClause) {
 		Default("5m").DurationVar(&cc.blockViewerSyncBlockTimeout)
 	cmd.Flag("compact.cleanup-interval", "How often we should clean up partially uploaded blocks and blocks with deletion mark in the background when --wait has been enabled. Setting it to \"0s\" disables it - the cleaning will only happen at the end of an iteration.").
 		Default("5m").DurationVar(&cc.cleanupBlocksInterval)
+	cmd.Flag("compact.progress-interval", "How often we should calculate the compaction progress in the background when --wait has been enabled. Setting it to \"0s\" disables it. Now compaction, downsampling and retention progress are supported.").
+		Default("5m").DurationVar(&cc.progressCalculateInterval)
 
 	cmd.Flag("compact.concurrency", "Number of goroutines to use when compacting groups.").
 		Default("1").IntVar(&cc.compactionConcurrency)

--- a/docs/components/compact.md
+++ b/docs/components/compact.md
@@ -300,11 +300,11 @@ Flags:
       --compact.concurrency=1   Number of goroutines to use when compacting
                                 groups.
       --compact.progress-interval=5m  
-                                How often we should calculate the compaction
-                                progress in the background when --wait has been
-                                enabled. Setting it to "0s" disables it. Now
-                                compaction, downsampling and retention progress
-                                are supported.
+                                Frequency of calculating the compaction progress
+                                in the background when --wait has been enabled.
+                                Setting it to "0s" disables it. Now compaction,
+                                downsampling and retention progress are
+                                supported.
       --consistency-delay=30m   Minimum age of fresh (non-compacted) blocks
                                 before they are being processed. Malformed
                                 blocks older than the maximum of

--- a/docs/components/compact.md
+++ b/docs/components/compact.md
@@ -299,6 +299,12 @@ Flags:
                                 happen at the end of an iteration.
       --compact.concurrency=1   Number of goroutines to use when compacting
                                 groups.
+      --compact.progress-interval=5m  
+                                How often we should calculate the compaction
+                                progress in the background when --wait has been
+                                enabled. Setting it to "0s" disables it. Now
+                                compaction, downsampling and retention progress
+                                are supported.
       --consistency-delay=30m   Minimum age of fresh (non-compacted) blocks
                                 before they are being processed. Malformed
                                 blocks older than the maximum of
@@ -376,8 +382,6 @@ Flags:
                                 Path to YAML file that contains object store
                                 configuration. See format details:
                                 https://thanos.io/tip/thanos/storage.md/#configuration
-      --progress-metrics        Enables the progress metrics, indicating the
-                                progress of compaction and downsampling
       --retention.resolution-1h=0d  
                                 How long to retain samples of resolution 2 (1
                                 hour) in bucket. Setting this to 0d will retain


### PR DESCRIPTION
Signed-off-by: Ben Ye <ben.ye@bytedance.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

1. Only enable progress metrics if `wait` mode is enabled
2. Make the interval configurable instead of hardcoded 5m
3. Remove the original `progress-metrics` bool flag. Now to disable progress metrics, just set interval to 0.

## Verification

<!-- How you tested it? How do you know it works? -->
