### PR TITLE
query: add `--endpoint-strict` flag to statically configure endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#4612](https://github.com/thanos-io/thanos/pull/4612) Sidecar: add `--prometheus.http-client` and `--prometheus.http-client-file` flag for sidecar to connect Prometheus with basic auth or TLS.
 - [#4847](https://github.com/thanos-io/thanos/pull/4847) Query: add `--alert.query-url` which is used in the user interface for rules/alerts pages. By default the HTTP listen address is used for this URL.
 - [#4856](https://github.com/thanos-io/thanos/pull/4856) Mixin: Add Query Frontend Grafana dashboard.
+- [#4874](https://github.com/thanos-io/thanos/pull/4874) Query: Add `--endpoint-strict` flag to statically configure Thanos API server endpoints. It is similar to `--store-strict` but supports passing any Thanos gRPC APIs: StoreAPI, MetadataAPI, RulesAPI, TargetsAPI and ExemplarsAPI.
 
 ### Fixed
 

--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -397,17 +397,17 @@ func runQuery(
 		}
 	}
 
-	dnsEndpointProvider := dns.NewProvider(
-		logger,
-		extprom.WrapRegistererWithPrefix("thanos_query_endpoints_", reg),
-		dns.ResolverType(dnsSDResolver),
-	)
-
 	for _, endpoint := range strictEndpoints {
 		if dns.IsDynamicNode(endpoint) {
 			return errors.Errorf("%s is a dynamically specified endpoint i.e. it uses SD and that is not permitted under strict mode. Use --endpoint for this", endpoint)
 		}
 	}
+
+	dnsEndpointProvider := dns.NewProvider(
+		logger,
+		extprom.WrapRegistererWithPrefix("thanos_query_endpoints_", reg),
+		dns.ResolverType(dnsSDResolver),
+	)
 
 	dnsRuleProvider := dns.NewProvider(
 		logger,

--- a/docs/components/query.md
+++ b/docs/components/query.md
@@ -263,6 +263,11 @@ Flags:
                                  prefixed with 'dns+' or 'dnssrv+' to detect
                                  Thanos API servers through respective DNS
                                  lookups.
+      --endpoint-strict=<staticendpoint> ...  
+                                 Addresses of only statically configured Thanos
+                                 API servers that are always used, even if the
+                                 health check fails. Useful if you have a
+                                 caching layer on top.
       --grpc-address="0.0.0.0:10901"  
                                  Listen ip:port address for gRPC endpoints
                                  (StoreAPI). Make sure this address is routable
@@ -382,10 +387,12 @@ Flags:
                                  'dns+' or 'dnssrv+' to detect store API servers
                                  through respective DNS lookups.
       --store-strict=<staticstore> ...  
-                                 Addresses of only statically configured store
-                                 API servers that are always used, even if the
-                                 health check fails. Useful if you have a
-                                 caching layer on top.
+                                 Deprecation Warning - This flag is deprecated
+                                 and replaced with `endpoint-strict`. Addresses
+                                 of only statically configured store API servers
+                                 that are always used, even if the health check
+                                 fails. Useful if you have a caching layer on
+                                 top.
       --store.response-timeout=0ms  
                                  If a Store doesn't send any data in this
                                  specified duration then a Store will be ignored


### PR DESCRIPTION
This PR completes 3rd task from [this](https://github.com/thanos-io/thanos/issues/2600#issuecomment-967241095) list.
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes
- Added `--endpoint-strict` flag (similar to `--store-strict`) which can be used to add statically configured endpoints.

<!-- Enumerate changes you made -->