### PR TITLE
bucket verify: fix to parse all blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#4769](https://github.com/thanos-io/thanos/pull/4769) Query-frontend+api: add "X-Request-ID" field and other fields to start call log.
 - [#4918](https://github.com/thanos-io/thanos/pull/4918) Tracing: Fixing force tracing with Jaeger.
 - [#4928](https://github.com/thanos-io/thanos/pull/4928) Azure: Only create an http client once, to conserve memory.
+- [#4879](https://github.com/thanos-io/thanos/pull/4879) Bucket verify: Fixed bug causing wrong number of blocks to be checked.
 
 ### Changed
 

--- a/pkg/verifier/index_issue.go
+++ b/pkg/verifier/index_issue.go
@@ -39,7 +39,7 @@ func (IndexKnownIssues) VerifyRepair(ctx Context, idMatcher func(ulid.ULID) bool
 
 	for id, meta := range metas {
 		if idMatcher != nil && !idMatcher(id) {
-			return nil
+			continue
 		}
 
 		tmpdir, err := ioutil.TempDir("", fmt.Sprintf("index-issue-block-%s-", id))
@@ -52,78 +52,92 @@ func (IndexKnownIssues) VerifyRepair(ctx Context, idMatcher func(ulid.ULID) bool
 			}
 		}()
 
-		if err = objstore.DownloadFile(ctx, ctx.Logger, ctx.Bkt, path.Join(id.String(), block.IndexFilename), filepath.Join(tmpdir, block.IndexFilename)); err != nil {
-			return errors.Wrapf(err, "download index file %s", path.Join(id.String(), block.IndexFilename))
-		}
-
-		stats, err := block.GatherIndexHealthStats(ctx.Logger, filepath.Join(tmpdir, block.IndexFilename), meta.MinTime, meta.MaxTime)
-		if err != nil {
-			return errors.Wrapf(err, "gather index issues %s", id)
-		}
-
-		level.Debug(ctx.Logger).Log("stats", fmt.Sprintf("%+v", stats), "id", id)
-		if err = stats.AnyErr(); err == nil {
-			return nil
+		stats, err := verifyIndex(ctx, id, tmpdir, meta)
+		if err == nil {
+			level.Debug(ctx.Logger).Log("msg", "no issue", "id", id)
+			continue
 		}
 
 		level.Warn(ctx.Logger).Log("msg", "detected issue", "id", id, "err", err)
 
 		if !repair {
 			// Only verify.
-			return nil
+			continue
 		}
 
-		if stats.OutOfOrderChunks > stats.DuplicatedChunks {
-			level.Warn(ctx.Logger).Log("msg", "detected overlaps are not entirely by duplicated chunks. We are able to repair only duplicates", "id", id)
-		}
-
-		if stats.OutsideChunks > (stats.CompleteOutsideChunks + stats.Issue347OutsideChunks) {
-			level.Warn(ctx.Logger).Log("msg", "detected outsiders are not all 'complete' outsiders or outsiders from https://github.com/prometheus/tsdb/issues/347. We can safely delete only these outsiders", "id", id)
-		}
-
-		if meta.Thanos.Downsample.Resolution > 0 {
-			return errors.New("cannot repair downsampled blocks")
-		}
-
-		level.Info(ctx.Logger).Log("msg", "downloading block for repair", "id", id)
-		if err = block.Download(ctx, ctx.Logger, ctx.Bkt, id, path.Join(tmpdir, id.String())); err != nil {
-			return errors.Wrapf(err, "download block %s", id)
-		}
-		level.Info(ctx.Logger).Log("msg", "downloaded block to be repaired", "id", id, "issue")
-
-		level.Info(ctx.Logger).Log("msg", "repairing block", "id", id, "issue")
-		resid, err := block.Repair(
-			ctx.Logger,
-			tmpdir,
-			id,
-			metadata.BucketRepairSource,
-			block.IgnoreCompleteOutsideChunk,
-			block.IgnoreDuplicateOutsideChunk,
-			block.IgnoreIssue347OutsideChunk,
-		)
-		if err != nil {
-			return errors.Wrapf(err, "repair failed for block %s", id)
-		}
-		level.Info(ctx.Logger).Log("msg", "verifying repaired block", "id", id, "newID", resid)
-
-		// Verify repaired block before uploading it.
-		if err := block.VerifyIndex(ctx.Logger, filepath.Join(tmpdir, resid.String(), block.IndexFilename), meta.MinTime, meta.MaxTime); err != nil {
-			return errors.Wrapf(err, "repaired block is invalid %s", resid)
-		}
-
-		level.Info(ctx.Logger).Log("msg", "uploading repaired block", "newID", resid)
-		if err = block.Upload(ctx, ctx.Logger, ctx.Bkt, filepath.Join(tmpdir, resid.String()), metadata.NoneFunc); err != nil {
-			return errors.Wrapf(err, "upload of %s failed", resid)
-		}
-
-		level.Info(ctx.Logger).Log("msg", "safe deleting broken block", "id", id, "issue")
-		if err := BackupAndDeleteDownloaded(ctx, filepath.Join(tmpdir, id.String()), id); err != nil {
-			return errors.Wrapf(err, "safe deleting old block %s failed", id)
+		if err = repairIndex(stats, ctx, id, meta, tmpdir); err != nil {
+			level.Error(ctx.Logger).Log("msg", "could not repair index", "err", err)
+			continue
 		}
 		level.Info(ctx.Logger).Log("msg", "all good, continuing", "id", id)
-		return nil
 	}
 
 	level.Info(ctx.Logger).Log("msg", "verified issue", "with-repair", repair)
 	return nil
+}
+
+func repairIndex(stats block.HealthStats, ctx Context, id ulid.ULID, meta *metadata.Meta, dir string) (err error) {
+	if stats.OutOfOrderChunks > stats.DuplicatedChunks {
+		level.Warn(ctx.Logger).Log("msg", "detected overlaps are not entirely by duplicated chunks. We are able to repair only duplicates", "id", id)
+	}
+
+	if stats.OutsideChunks > (stats.CompleteOutsideChunks + stats.Issue347OutsideChunks) {
+		level.Warn(ctx.Logger).Log("msg", "detected outsiders are not all 'complete' outsiders or outsiders from https://github.com/prometheus/tsdb/issues/347. We can safely delete only these outsiders", "id", id)
+	}
+
+	if meta.Thanos.Downsample.Resolution > 0 {
+		return errors.Wrap(err, "cannot repair downsampled blocks")
+	}
+
+	level.Info(ctx.Logger).Log("msg", "downloading block for repair", "id", id)
+	if err = block.Download(ctx, ctx.Logger, ctx.Bkt, id, path.Join(dir, id.String())); err != nil {
+		return errors.Wrapf(err, "download block %s", id)
+	}
+	level.Info(ctx.Logger).Log("msg", "downloaded block to be repaired", "id", id, "issue")
+
+	level.Info(ctx.Logger).Log("msg", "repairing block", "id", id, "issue")
+	resid, err := block.Repair(
+		ctx.Logger,
+		dir,
+		id,
+		metadata.BucketRepairSource,
+		block.IgnoreCompleteOutsideChunk,
+		block.IgnoreDuplicateOutsideChunk,
+		block.IgnoreIssue347OutsideChunk,
+	)
+	if err != nil {
+		return errors.Wrapf(err, "repair failed for block %s", id)
+	}
+	level.Info(ctx.Logger).Log("msg", "verifying repaired block", "id", id, "newID", resid)
+
+	if err := block.VerifyIndex(ctx.Logger, filepath.Join(dir, resid.String(), block.IndexFilename), meta.MinTime, meta.MaxTime); err != nil {
+		return errors.Wrapf(err, "repaired block is invalid %s", resid)
+	}
+
+	level.Info(ctx.Logger).Log("msg", "uploading repaired block", "newID", resid)
+	if err = block.Upload(ctx, ctx.Logger, ctx.Bkt, filepath.Join(dir, resid.String()), metadata.NoneFunc); err != nil {
+		return errors.Wrapf(err, "upload of %s failed", resid)
+	}
+
+	level.Info(ctx.Logger).Log("msg", "safe deleting broken block", "id", id, "issue")
+	if err := BackupAndDeleteDownloaded(ctx, filepath.Join(dir, id.String()), id); err != nil {
+		return errors.Wrapf(err, "safe deleting old block %s failed", id)
+	}
+
+	return nil
+}
+
+func verifyIndex(ctx Context, id ulid.ULID, dir string, meta *metadata.Meta) (stats block.HealthStats, err error) {
+	if err := objstore.DownloadFile(ctx, ctx.Logger, ctx.Bkt, path.Join(id.String(), block.IndexFilename), filepath.Join(dir, block.IndexFilename)); err != nil {
+		return stats, errors.Wrapf(err, "download index file %s", path.Join(id.String(), block.IndexFilename))
+	}
+
+	stats, err = block.GatherIndexHealthStats(ctx.Logger, filepath.Join(dir, block.IndexFilename), meta.MinTime, meta.MaxTime)
+	if err != nil {
+		return stats, errors.Wrapf(err, "gather index issues %s", id)
+	}
+
+	level.Debug(ctx.Logger).Log("stats", fmt.Sprintf("%+v", stats), "id", id)
+
+	return stats, stats.AnyErr()
 }


### PR DESCRIPTION
Only the first block is parsed. This commit fixes this issue to parse all blocks present in the bucket.
Fix issue #4878 .

Signed-off-by: Aymeric <aymeric.daurelle@cdiscount.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

* Split the function `VerifyRepair` in two dedicated functions `verify` and `repair`.
* Replace **return** statement by **continue** to go to the next iteration. This allow to parse all blocks from a bucket.
* Added a log in debug level to just say when a block has no issue :
```
level=debug ts=2021-11-19T11:50:37.47465883Z caller=index_issue.go:56 verifiers=index_known_issues verifier=index_known_issues msg="no issue" id=01FMVXMZABF699W6HC8HA2B0E3
```

## Verification

Tested locally. 

<details>
<p>

```
$ thanos tools bucket verify --objstore.config-file=/etc/default/thanos-storage-a01-dc1.yml -i index_known_issues  --log.level=debug                                                    
level=debug ts=2021-11-19T11:47:29.831109825Z caller=main.go:65 msg="maxprocs: Leaving GOMAXPROCS=[40]: CPU quota undefined"
level=info ts=2021-11-19T11:47:29.83165329Z caller=factory.go:49 msg="loading bucket configuration"
level=info ts=2021-11-19T11:47:29.83290754Z caller=verify.go:137 verifiers=index_known_issues msg="Starting verify task"
level=info ts=2021-11-19T11:47:29.83295293Z caller=index_issue.go:32 verifiers=index_known_issues verifier=index_known_issues msg="started verifying issue" with-repair=false
level=debug ts=2021-11-19T11:47:29.833026263Z caller=fetcher.go:323 component=block.BaseFetcher msg="fetching meta data" concurrency=32
level=info ts=2021-11-19T11:47:30.203705366Z caller=fetcher.go:481 component=block.BaseFetcher msg="successfully synchronized block metadata" duration=370.714829ms duration_ms=370 cached=126 returned=126 partial=0
level=debug ts=2021-11-19T11:47:41.106087905Z caller=index_issue.go:140 verifiers=index_known_issues verifier=index_known_issues stats="{TotalSeries:1987113 OutOfOrderSeries:0 OutOfOrderChunks:0 DuplicatedChunks:0 OutsideChunks:0 CompleteOutsideChunks:0 Issue347OutsideChunks:0 OutOfOrderLabels:0 SeriesMinLifeDuration:0s SeriesAvgLifeDuration:1h49m34.315s SeriesMaxLifeDuration:1h59m40.005s SeriesMinLifeDurationWithoutSingleSampleSeries:19.99s SeriesAvgLifeDurationWithoutSingleSampleSeries:1h50m56.676s SeriesMaxLifeDurationWithoutSingleSampleSeries:1h59m40.005s SeriesMinChunks:1 SeriesAvgChunks:1 SeriesMaxChunks:3 TotalChunks:3732159 ChunkMinDuration:0s ChunkAvgDuration:58m20.361s ChunkMaxDuration:1h59m40.005s ChunkMinSize:988 ChunkAvgSize:997 ChunkMaxSize:1009 SingleSampleSeries:24586 SingleSampleChunks:25008 LabelNamesCount:465 MetricLabelValuesCount:2525}" id=01FMRFSCZZ7192QRXWQCF78057
level=debug ts=2021-11-19T11:47:41.106168649Z caller=index_issue.go:56 verifiers=index_known_issues verifier=index_known_issues msg="no issue" id=01FMRFSCZZ7192QRXWQCF78057
level=debug ts=2021-11-19T11:47:51.188383145Z caller=index_issue.go:140 verifiers=index_known_issues verifier=index_known_issues stats="{TotalSeries:1998916 OutOfOrderSeries:0 OutOfOrderChunks:0 DuplicatedChunks:0 OutsideChunks:0 CompleteOutsideChunks:0 Issue347OutsideChunks:0 OutOfOrderLabels:0 SeriesMinLifeDuration:0s SeriesAvgLifeDuration:1h49m9.355s SeriesMaxLifeDuration:1h59m40.034s SeriesMinLifeDurationWithoutSingleSampleSeries:19.973s SeriesAvgLifeDurationWithoutSingleSampleSeries:1h50m34.317s SeriesMaxLifeDurationWithoutSingleSampleSeries:1h59m40.034s SeriesMinChunks:1 SeriesAvgChunks:1 SeriesMaxChunks:3 TotalChunks:3753340 ChunkMinDuration:0s ChunkAvgDuration:58m7.989s ChunkMaxDuration:1h59m40.034s ChunkMinSize:941 ChunkAvgSize:982 ChunkMaxSize:1010 SingleSampleSeries:25599 SingleSampleChunks:26049 LabelNamesCount:474 MetricLabelValuesCount:2563}" id=01FMSRZRK02ECGN1MDKVSQR7RP
level=debug ts=2021-11-19T11:47:51.188463996Z caller=index_issue.go:56 verifiers=index_known_issues verifier=index_known_issues msg="no issue" id=01FMSRZRK02ECGN1MDKVSQR7RP
level=debug ts=2021-11-19T11:50:15.84308204Z caller=index_issue.go:140 verifiers=index_known_issues verifier=index_known_issues stats="{TotalSeries:24464180 OutOfOrderSeries:0 OutOfOrderChunks:0 DuplicatedChunks:0 OutsideChunks:0 CompleteOutsideChunks:0 Issue347OutsideChunks:0 OutOfOrderLabels:0 SeriesMinLifeDuration:0s SeriesAvgLifeDuration:26h30m29.054s SeriesMaxLifeDuration:335h59m40s SeriesMinLifeDurationWithoutSingleSampleSeries:1.512s SeriesAvgLifeDurationWithoutSingleSampleSeries:103h7m20.052s SeriesMaxLifeDurationWithoutSingleSampleSeries:335h59m40s SeriesMinChunks:1 SeriesAvgChunks:1 SeriesMaxChunks:4 TotalChunks:28364272 ChunkMinDuration:0s ChunkAvgDuration:22h51m47.543s ChunkMaxDuration:335h59m40s ChunkMinSize:172 ChunkAvgSize:6197 ChunkMaxSize:3758101587 SingleSampleSeries:18175544 SingleSampleChunks:18175544 LabelNamesCount:475 MetricLabelValuesCount:2466}" id=01FEKXAXEN9H4Z2858JRA6V99Y
level=debug ts=2021-11-19T11:50:15.84314986Z caller=index_issue.go:56 verifiers=index_known_issues verifier=index_known_issues msg="no issue" id=01FEKXAXEN9H4Z2858JRA6V99Y
level=debug ts=2021-11-19T11:50:26.360474951Z caller=index_issue.go:140 verifiers=index_known_issues verifier=index_known_issues stats="{TotalSeries:2000070 OutOfOrderSeries:0 OutOfOrderChunks:0 DuplicatedChunks:0 OutsideChunks:0 CompleteOutsideChunks:0 Issue347OutsideChunks:0 OutOfOrderLabels:0 SeriesMinLifeDuration:0s SeriesAvgLifeDuration:1h49m5.436s SeriesMaxLifeDuration:1h59m40s SeriesMinLifeDurationWithoutSingleSampleSeries:19.97s SeriesAvgLifeDurationWithoutSingleSampleSeries:1h50m28.86s SeriesMaxLifeDurationWithoutSingleSampleSeries:1h59m40s SeriesMinChunks:1 SeriesAvgChunks:1 SeriesMaxChunks:2 TotalChunks:3755969 ChunkMinDuration:0s ChunkAvgDuration:58m5.473s ChunkMaxDuration:1h59m40s ChunkMinSize:9223372036854775807 ChunkAvgSize:0 ChunkMaxSize:-9223372036854775808 SingleSampleSeries:25171 SingleSampleChunks:25631 LabelNamesCount:474 MetricLabelValuesCount:2563}" id=01FMSRZQ2357K745RXT4E7KJBC
level=debug ts=2021-11-19T11:50:26.360557596Z caller=index_issue.go:56 verifiers=index_known_issues verifier=index_known_issues msg="no issue" id=01FMSRZQ2357K745RXT4E7KJBC
level=debug ts=2021-11-19T11:50:37.47459854Z caller=index_issue.go:140 verifiers=index_known_issues verifier=index_known_issues stats="{TotalSeries:2026059 OutOfOrderSeries:0 OutOfOrderChunks:0 DuplicatedChunks:0 OutsideChunks:0 CompleteOutsideChunks:0 Issue347OutsideChunks:0 OutOfOrderLabels:0 SeriesMinLifeDuration:0s SeriesAvgLifeDuration:1h47m55.585s SeriesMaxLifeDuration:1h59m40s SeriesMinLifeDurationWithoutSingleSampleSeries:19.965s SeriesAvgLifeDurationWithoutSingleSampleSeries:1h49m20.31s SeriesMaxLifeDurationWithoutSingleSampleSeries:1h59m40s SeriesMinChunks:1 SeriesAvgChunks:1 SeriesMaxChunks:2 TotalChunks:3777088 ChunkMinDuration:0s ChunkAvgDuration:57m53.553s ChunkMaxDuration:1h59m40s ChunkMinSize:9223372036854775807 ChunkAvgSize:0 ChunkMaxSize:-9223372036854775808 SingleSampleSeries:26166 SingleSampleChunks:26676 LabelNamesCount:475 MetricLabelValuesCount:2565}" id=01FMVXMZABF699W6HC8HA2B0E3
level=debug ts=2021-11-19T11:50:37.47465883Z caller=index_issue.go:56 verifiers=index_known_issues verifier=index_known_issues msg="no issue" id=01FMVXMZABF699W6HC8HA2B0E3
... etc...

```
</p>
</details>

<!-- How you tested it? How do you know it works? -->


