### PR TITLE
Store: Make queryStats log with human-readable format.

### DIFF
--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -20,6 +20,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/alecthomas/units"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/gogo/protobuf/types"
@@ -1091,16 +1092,16 @@ func (s *BucketStore) Series(req *storepb.SeriesRequest, srv storepb.Store_Serie
 	defer func() {
 		s.metrics.seriesDataTouched.WithLabelValues("postings").Observe(float64(stats.postingsTouched))
 		s.metrics.seriesDataFetched.WithLabelValues("postings").Observe(float64(stats.postingsFetched))
-		s.metrics.seriesDataSizeTouched.WithLabelValues("postings").Observe(float64(stats.postingsTouchedSizeSum))
-		s.metrics.seriesDataSizeFetched.WithLabelValues("postings").Observe(float64(stats.postingsFetchedSizeSum))
+		s.metrics.seriesDataSizeTouched.WithLabelValues("postings").Observe(float64(stats.PostingsTouchedSizeSum))
+		s.metrics.seriesDataSizeFetched.WithLabelValues("postings").Observe(float64(stats.PostingsFetchedSizeSum))
 		s.metrics.seriesDataTouched.WithLabelValues("series").Observe(float64(stats.seriesTouched))
 		s.metrics.seriesDataFetched.WithLabelValues("series").Observe(float64(stats.seriesFetched))
-		s.metrics.seriesDataSizeTouched.WithLabelValues("series").Observe(float64(stats.seriesTouchedSizeSum))
-		s.metrics.seriesDataSizeFetched.WithLabelValues("series").Observe(float64(stats.seriesFetchedSizeSum))
+		s.metrics.seriesDataSizeTouched.WithLabelValues("series").Observe(float64(stats.SeriesTouchedSizeSum))
+		s.metrics.seriesDataSizeFetched.WithLabelValues("series").Observe(float64(stats.SeriesFetchedSizeSum))
 		s.metrics.seriesDataTouched.WithLabelValues("chunks").Observe(float64(stats.chunksTouched))
 		s.metrics.seriesDataFetched.WithLabelValues("chunks").Observe(float64(stats.chunksFetched))
-		s.metrics.seriesDataSizeTouched.WithLabelValues("chunks").Observe(float64(stats.chunksTouchedSizeSum))
-		s.metrics.seriesDataSizeFetched.WithLabelValues("chunks").Observe(float64(stats.chunksFetchedSizeSum))
+		s.metrics.seriesDataSizeTouched.WithLabelValues("chunks").Observe(float64(stats.ChunksTouchedSizeSum))
+		s.metrics.seriesDataSizeFetched.WithLabelValues("chunks").Observe(float64(stats.ChunksFetchedSizeSum))
 		s.metrics.resultSeriesCount.Observe(float64(stats.mergedSeriesCount))
 		s.metrics.cachedPostingsCompressions.WithLabelValues(labelEncode).Add(float64(stats.cachedPostingsCompressions))
 		s.metrics.cachedPostingsCompressions.WithLabelValues(labelDecode).Add(float64(stats.cachedPostingsDecompressions))
@@ -1108,8 +1109,8 @@ func (s *BucketStore) Series(req *storepb.SeriesRequest, srv storepb.Store_Serie
 		s.metrics.cachedPostingsCompressionErrors.WithLabelValues(labelDecode).Add(float64(stats.cachedPostingsDecompressionErrors))
 		s.metrics.cachedPostingsCompressionTimeSeconds.WithLabelValues(labelEncode).Add(stats.CachedPostingsCompressionTimeSum.Seconds())
 		s.metrics.cachedPostingsCompressionTimeSeconds.WithLabelValues(labelDecode).Add(stats.CachedPostingsDecompressionTimeSum.Seconds())
-		s.metrics.cachedPostingsOriginalSizeBytes.Add(float64(stats.cachedPostingsOriginalSizeSum))
-		s.metrics.cachedPostingsCompressedSizeBytes.Add(float64(stats.cachedPostingsCompressedSizeSum))
+		s.metrics.cachedPostingsOriginalSizeBytes.Add(float64(stats.CachedPostingsOriginalSizeSum))
+		s.metrics.cachedPostingsCompressedSizeBytes.Add(float64(stats.CachedPostingsCompressedSizeSum))
 
 		level.Debug(s.logger).Log("msg", "stats query processed",
 			"request", req,
@@ -1990,7 +1991,7 @@ func (r *bucketIndexReader) fetchPostings(ctx context.Context, keys []labels.Lab
 		// Get postings for the given key from cache first.
 		if b, ok := fromCache[key]; ok {
 			r.stats.postingsTouched++
-			r.stats.postingsTouchedSizeSum += len(b)
+			r.stats.PostingsTouchedSizeSum += units.Base2Bytes(len(b))
 
 			// Even if this instance is not using compression, there may be compressed
 			// entries in the cache written by other stores.
@@ -2066,7 +2067,7 @@ func (r *bucketIndexReader) fetchPostings(ctx context.Context, keys []labels.Lab
 			r.stats.postingsFetchCount++
 			r.stats.postingsFetched += j - i
 			r.stats.PostingsFetchDurationSum += fetchTime
-			r.stats.postingsFetchedSizeSum += int(length)
+			r.stats.PostingsFetchedSizeSum += units.Base2Bytes(int(length))
 			r.mtx.Unlock()
 
 			for _, p := range ptrs[i:j] {
@@ -2106,11 +2107,11 @@ func (r *bucketIndexReader) fetchPostings(ctx context.Context, keys []labels.Lab
 
 				// If we just fetched it we still have to update the stats for touched postings.
 				r.stats.postingsTouched++
-				r.stats.postingsTouchedSizeSum += len(pBytes)
+				r.stats.PostingsTouchedSizeSum += units.Base2Bytes(len(pBytes))
 				r.stats.cachedPostingsCompressions += compressions
 				r.stats.cachedPostingsCompressionErrors += compressionErrors
-				r.stats.cachedPostingsOriginalSizeSum += len(pBytes)
-				r.stats.cachedPostingsCompressedSizeSum += compressedSize
+				r.stats.CachedPostingsOriginalSizeSum += units.Base2Bytes(len(pBytes))
+				r.stats.CachedPostingsCompressedSizeSum += units.Base2Bytes(compressedSize)
 				r.stats.CachedPostingsCompressionTimeSum += compressionTime
 				r.mtx.Unlock()
 			}
@@ -2228,7 +2229,7 @@ func (r *bucketIndexReader) loadSeries(ctx context.Context, ids []storage.Series
 	r.stats.seriesFetchCount++
 	r.stats.seriesFetched += len(ids)
 	r.stats.SeriesFetchDurationSum += time.Since(begin)
-	r.stats.seriesFetchedSizeSum += int(end - start)
+	r.stats.SeriesFetchedSizeSum += units.Base2Bytes(int(end - start))
 	r.mtx.Unlock()
 
 	for i, id := range ids {
@@ -2332,7 +2333,7 @@ func (r *bucketIndexReader) LoadSeriesForTime(ref storage.SeriesRef, lset *[]sym
 	}
 
 	r.stats.seriesTouched++
-	r.stats.seriesTouchedSizeSum += len(b)
+	r.stats.SeriesTouchedSizeSum += units.Base2Bytes(len(b))
 	return decodeSeriesForTime(b, lset, chks, skipChunks, mint, maxt)
 }
 
@@ -2516,7 +2517,7 @@ func (r *bucketChunkReader) loadChunks(ctx context.Context, res []seriesEntry, a
 	r.stats.chunksFetchCount++
 	r.stats.chunksFetched += len(pIdxs)
 	r.stats.ChunksFetchDurationSum += time.Since(fetchBegin)
-	r.stats.chunksFetchedSizeSum += int(part.End - part.Start)
+	r.stats.ChunksFetchedSizeSum += units.Base2Bytes(int(part.End - part.Start))
 
 	var (
 		buf        []byte
@@ -2577,7 +2578,7 @@ func (r *bucketChunkReader) loadChunks(ctx context.Context, res []seriesEntry, a
 				return errors.Wrap(err, "populate chunk")
 			}
 			r.stats.chunksTouched++
-			r.stats.chunksTouchedSizeSum += int(chunkDataLen)
+			r.stats.ChunksTouchedSizeSum += units.Base2Bytes(int(chunkDataLen))
 			continue
 		}
 
@@ -2602,14 +2603,14 @@ func (r *bucketChunkReader) loadChunks(ctx context.Context, res []seriesEntry, a
 
 		r.stats.chunksFetchCount++
 		r.stats.ChunksFetchDurationSum += time.Since(fetchBegin)
-		r.stats.chunksFetchedSizeSum += len(*nb)
+		r.stats.ChunksFetchedSizeSum += units.Base2Bytes(len(*nb))
 		err = populateChunk(&(res[pIdx.seriesEntry].chks[pIdx.chunk]), rawChunk((*nb)[n:]), aggrs, r.save)
 		if err != nil {
 			r.block.chunkPool.Put(nb)
 			return errors.Wrap(err, "populate chunk")
 		}
 		r.stats.chunksTouched++
-		r.stats.chunksTouchedSizeSum += int(chunkDataLen)
+		r.stats.ChunksTouchedSizeSum += units.Base2Bytes(int(chunkDataLen))
 
 		r.block.chunkPool.Put(nb)
 	}
@@ -2663,33 +2664,33 @@ type queryStats struct {
 	blocksQueried int
 
 	postingsTouched          int
-	postingsTouchedSizeSum   int
+	PostingsTouchedSizeSum   units.Base2Bytes
 	postingsToFetch          int
 	postingsFetched          int
-	postingsFetchedSizeSum   int
+	PostingsFetchedSizeSum   units.Base2Bytes
 	postingsFetchCount       int
 	PostingsFetchDurationSum time.Duration
 
 	cachedPostingsCompressions         int
 	cachedPostingsCompressionErrors    int
-	cachedPostingsOriginalSizeSum      int
-	cachedPostingsCompressedSizeSum    int
+	CachedPostingsOriginalSizeSum      units.Base2Bytes
+	CachedPostingsCompressedSizeSum    units.Base2Bytes
 	CachedPostingsCompressionTimeSum   time.Duration
 	cachedPostingsDecompressions       int
 	cachedPostingsDecompressionErrors  int
 	CachedPostingsDecompressionTimeSum time.Duration
 
 	seriesTouched          int
-	seriesTouchedSizeSum   int
+	SeriesTouchedSizeSum   units.Base2Bytes
 	seriesFetched          int
-	seriesFetchedSizeSum   int
+	SeriesFetchedSizeSum   units.Base2Bytes
 	seriesFetchCount       int
 	SeriesFetchDurationSum time.Duration
 
 	chunksTouched          int
-	chunksTouchedSizeSum   int
+	ChunksTouchedSizeSum   units.Base2Bytes
 	chunksFetched          int
-	chunksFetchedSizeSum   int
+	ChunksFetchedSizeSum   units.Base2Bytes
 	chunksFetchCount       int
 	ChunksFetchDurationSum time.Duration
 
@@ -2703,32 +2704,32 @@ func (s queryStats) merge(o *queryStats) *queryStats {
 	s.blocksQueried += o.blocksQueried
 
 	s.postingsTouched += o.postingsTouched
-	s.postingsTouchedSizeSum += o.postingsTouchedSizeSum
+	s.PostingsTouchedSizeSum += o.PostingsTouchedSizeSum
 	s.postingsFetched += o.postingsFetched
-	s.postingsFetchedSizeSum += o.postingsFetchedSizeSum
+	s.PostingsFetchedSizeSum += o.PostingsFetchedSizeSum
 	s.postingsFetchCount += o.postingsFetchCount
 	s.PostingsFetchDurationSum += o.PostingsFetchDurationSum
 
 	s.cachedPostingsCompressions += o.cachedPostingsCompressions
 	s.cachedPostingsCompressionErrors += o.cachedPostingsCompressionErrors
-	s.cachedPostingsOriginalSizeSum += o.cachedPostingsOriginalSizeSum
-	s.cachedPostingsCompressedSizeSum += o.cachedPostingsCompressedSizeSum
+	s.CachedPostingsOriginalSizeSum += o.CachedPostingsOriginalSizeSum
+	s.CachedPostingsCompressedSizeSum += o.CachedPostingsCompressedSizeSum
 	s.CachedPostingsCompressionTimeSum += o.CachedPostingsCompressionTimeSum
 	s.cachedPostingsDecompressions += o.cachedPostingsDecompressions
 	s.cachedPostingsDecompressionErrors += o.cachedPostingsDecompressionErrors
 	s.CachedPostingsDecompressionTimeSum += o.CachedPostingsDecompressionTimeSum
 
 	s.seriesTouched += o.seriesTouched
-	s.seriesTouchedSizeSum += o.seriesTouchedSizeSum
+	s.SeriesTouchedSizeSum += o.SeriesTouchedSizeSum
 	s.seriesFetched += o.seriesFetched
-	s.seriesFetchedSizeSum += o.seriesFetchedSizeSum
+	s.SeriesFetchedSizeSum += o.SeriesFetchedSizeSum
 	s.seriesFetchCount += o.seriesFetchCount
 	s.SeriesFetchDurationSum += o.SeriesFetchDurationSum
 
 	s.chunksTouched += o.chunksTouched
-	s.chunksTouchedSizeSum += o.chunksTouchedSizeSum
+	s.ChunksTouchedSizeSum += o.ChunksTouchedSizeSum
 	s.chunksFetched += o.chunksFetched
-	s.chunksFetchedSizeSum += o.chunksFetchedSizeSum
+	s.ChunksFetchedSizeSum += o.ChunksFetchedSizeSum
 	s.chunksFetchCount += o.chunksFetchCount
 	s.ChunksFetchDurationSum += o.ChunksFetchDurationSum
 

--- a/pkg/store/bucket_test.go
+++ b/pkg/store/bucket_test.go
@@ -1387,7 +1387,7 @@ func TestBucketSeries_OneBlock_InMemIndexCacheSegfault(t *testing.T) {
 	testutil.Ok(t, err)
 	defer func() { testutil.Ok(t, bkt.Close()) }()
 
-	logger := log.NewNopLogger()
+	logger := log.NewLogfmtLogger(os.Stderr)
 	thanosMeta := metadata.Thanos{
 		Labels:     labels.Labels{{Name: "ext1", Value: "1"}}.Map(),
 		Downsample: metadata.ThanosDownsample{Resolution: 0},


### PR DESCRIPTION
The queryStats log is very useful to debug query in thanos-store.
But currently the duration field is unexported so that `fmt.Printf("%+v", stats)` print a number for time.Duration.

Before: <details>
<p>
level=debug msg="stats query processed" stats="&{blocksQueried:1 postingsTouched:102 postingsTouchedSizeSum:1122 postingsToFetch:0 postingsFetched:1 postingsFetchedSizeSum:404 postingsFetchCount:1 postingsFetchDurationSum:162905 cachedPostingsCompressions:1 cachedPostingsCompressionErrors:0 cachedPostingsOriginalSizeSum:404 cachedPostingsCompressedSizeSum:18 cachedPostingsCompressionTimeSum:29569 cachedPostingsDecompressions:101 cachedPostingsDecompressionErrors:0 cachedPostingsDecompressionTimeSum:65901 seriesTouched:100 seriesTouchedSizeSum:1229 seriesFetched:54 seriesFetchedSizeSum:67120 seriesFetchCount:1 seriesFetchDurationSum:247635 chunksTouched:100 chunksTouchedSizeSum:1236 chunksFetched:100 chunksFetchedSizeSum:17817 chunksFetchCount:1 chunksFetchDurationSum:135030 getAllDuration:1744138 mergedSeriesCount:100 mergedChunksCount:100 mergeDuration:106200}" err=null
</p>
</details>

After: <details>Logs
<p>
level=debug msg="stats query processed" request="max_time:99 matchers:<name:\"foo\" value:\"bar\" > matchers:<name:\"b\" value:\"1\" > matchers:<type:NEQ name:\"i\" > " stats="&{blocksQueried:2 postingsTouched:203 postingsTouchedSizeSum:2812 postingsToFetch:0 postingsFetched:203 postingsFetchedSizeSum:4478 postingsFetchCount:2 PostingsFetchDurationSum:576.127µs cachedPostingsCompressions:203 cachedPostingsCompressionErrors:0 cachedPostingsOriginalSizeSum:2812 cachedPostingsCompressedSizeSum:1454 CachedPostingsCompressionTimeSum:358.132µs cachedPostingsDecompressions:0 cachedPostingsDecompressionErrors:0 CachedPostingsDecompressionTimeSum:0s seriesTouched:100 seriesTouchedSizeSum:1229 seriesFetched:100 seriesFetchedSizeSum:68592 seriesFetchCount:1 SeriesFetchDurationSum:353.677µs chunksTouched:100 chunksTouchedSizeSum:1236 chunksFetched:100 chunksFetchedSizeSum:17817 chunksFetchCount:1 ChunksFetchDurationSum:221.653µs GetAllDuration:4.764037ms mergedSeriesCount:100 mergedChunksCount:100 MergeDuration:127.72µs}" err=null
</p>
</details>

Signed-off-by: Jimmie Han <hanjinming@outlook.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->
1. Exporte time.Duration type field.
2. add request field to log.
3. change the xxsizeSum field type to units.Base2bytes

## Verification

<!-- How you tested it? How do you know it works? -->
Unit test