### PR TITLE
Cache: support redis cache backend

### DIFF
--- a/docs/components/query-frontend.md
+++ b/docs/components/query-frontend.md
@@ -95,6 +95,34 @@ config:
   expiration: 24h
 ```
 
+#### Redis
+
+The default redis config is:
+
+```yaml mdox-exec="go run scripts/cfggen/main.go --name=queryfrontend.RedisResponseCacheConfig"
+type: REDIS
+config:
+  addr: ""
+  username: ""
+  password: ""
+  dial_timeout: 5s
+  read_timeout: 3s
+  write_timeout: 3s
+  pool_size: 100
+  min_idle_conns: 10
+  idle_timeout: 5m0s
+  max_conn_age: 0s
+  max_get_multi_concurrency: 100
+  get_multi_batch_size: 100
+  max_set_multi_concurrency: 100
+  set_multi_batch_size: 100
+  expiration: 24h0m0s
+```
+
+`expiration` specifies redis cache valid time. If set to 0s, so using a default of 24 hours expiration time.
+
+Other cache configuration parameters, you can refer to [redis-index-cache](store.md#redis-index-cache).
+
 ### Slow Query Log
 
 Query Frontend supports `--query-frontend.log-queries-longer-than` flag to log queries running longer than some duration.

--- a/docs/components/query-frontend.md
+++ b/docs/components/query-frontend.md
@@ -105,6 +105,7 @@ config:
   addr: ""
   username: ""
   password: ""
+  db: 0
   dial_timeout: 5s
   read_timeout: 3s
   write_timeout: 3s

--- a/docs/components/store.md
+++ b/docs/components/store.md
@@ -304,11 +304,54 @@ While the remaining settings are **optional**:
 - `dns_provider_update_interval`: the DNS discovery update interval.
 - `auto_discovery`: whether to use the auto-discovery mechanism for memcached.
 
+### Redis index cache
+
+The `memcached` index cache allows to use [Redis](https://redis.io) as cache backend. This cache type is configured using `--index-cache.config-file` to reference the configuration file or `--index-cache.config` to put yaml config directly:
+
+```yaml mdox-exec="go run scripts/cfggen/main.go --name=cacheutil.RedisClientConfig"
+type: REDIS
+config:
+  addr: ""
+  username: ""
+  password: ""
+  dial_timeout: 5s
+  read_timeout: 3s
+  write_timeout: 3s
+  pool_size: 100
+  min_idle_conns: 10
+  idle_timeout: 5m0s
+  max_conn_age: 0s
+  max_get_multi_concurrency: 100
+  get_multi_batch_size: 100
+  max_set_multi_concurrency: 100
+  set_multi_batch_size: 100
+```
+
+The **required** settings are:
+
+- `addr`: redis server address.
+
+While the remaining settings are **optional**:
+
+- `username`: the username to connect redis, only redis 6.0 and grater need this field.
+- `password`: the password to connect redis.
+- `dial_timeout`: the redis dial timeout.
+- `read_timeout`: the redis read timeout.
+- `write_timeout`: the redis write timeout.
+- `pool_size`: maximum number of socket connections.
+- `min_idle_conns`: specifies the minimum number of idle connections which is useful when establishing new connection is slow.
+- `idle_timeout`: amount of time after which client closes idle connections. Should be less than server's timeout.
+- `max_conn_age`: connection age at which client retires (closes) the connection.
+- `max_get_multi_concurrency`: specifies the maximum number of concurrent GetMulti() operations.
+- `get_multi_batch_size`: specifies the maximum size per batch for mget.
+- `max_set_multi_concurrency`: specifies the maximum number of concurrent SetMulti() operations.
+- `set_multi_batch_size`: specifies the maximum size per batch for pipeline set.
+
 ## Caching Bucket
 
 Thanos Store Gateway supports a "caching bucket" with [chunks](../design.md#chunk) and metadata caching to speed up loading of [chunks](../design.md#chunk) from TSDB blocks. To configure caching, one needs to use `--store.caching-bucket.config=<yaml content>` or `--store.caching-bucket.config-file=<file.yaml>`.
 
-Both memcached and in-memory cache "backend"s are supported:
+memcached/in-memory/redis cache "backend"s are supported:
 
 ```yaml
 type: MEMCACHED # Case-insensitive
@@ -333,7 +376,8 @@ metafile_content_ttl: 24h
 metafile_max_size: 1MiB
 ```
 
-`config` field for memcached supports all the same configuration as memcached for [index cache](#memcached-index-cache). `addresses` in the config field is a **required** setting
+- `config` field for memcached supports all the same configuration as memcached for [index cache](#memcached-index-cache). `addresses` in the config field is a **required** setting
+- `config` field for redis supports all the same configuration as redis for [index cache](#redis-index-cache).
 
 Additional options to configure various aspects of [chunks](../design.md#chunk) cache are available:
 

--- a/docs/components/store.md
+++ b/docs/components/store.md
@@ -306,7 +306,7 @@ While the remaining settings are **optional**:
 
 ### Redis index cache
 
-The `memcached` index cache allows to use [Redis](https://redis.io) as cache backend. This cache type is configured using `--index-cache.config-file` to reference the configuration file or `--index-cache.config` to put yaml config directly:
+The `redis` index cache allows to use [Redis](https://redis.io) as cache backend. This cache type is configured using `--index-cache.config-file` to reference the configuration file or `--index-cache.config` to put yaml config directly:
 
 ```yaml mdox-exec="go run scripts/cfggen/main.go --name=cacheutil.RedisClientConfig"
 type: REDIS

--- a/docs/components/store.md
+++ b/docs/components/store.md
@@ -314,6 +314,7 @@ config:
   addr: ""
   username: ""
   password: ""
+  db: 0
   dial_timeout: 5s
   read_timeout: 3s
   write_timeout: 3s
@@ -335,6 +336,7 @@ While the remaining settings are **optional**:
 
 - `username`: the username to connect redis, only redis 6.0 and grater need this field.
 - `password`: the password to connect redis.
+- `db`: the database to be selected after connecting to the server.
 - `dial_timeout`: the redis dial timeout.
 - `read_timeout`: the redis read timeout.
 - `write_timeout`: the redis write timeout.

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,8 @@ require (
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da
 	github.com/golang/snappy v0.0.4
 	github.com/googleapis/gax-go v2.0.2+incompatible
-	github.com/grafana/dskit v0.0.0-20210908150159-fcf48cb19aa4
+	github.com/grafana/dskit v0.0.0-20211021180445-3bd016e9d7f1
+	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware/providers/kit/v2 v2.0.0-20201002093600-73cf2ae9d891
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.0.0-rc.2.0.20201207153454-9f6bf00c00a7
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/Azure/go-autorest/autorest/azure/auth v0.5.8
 	github.com/NYTimes/gziphandler v1.1.1
 	github.com/alecthomas/units v0.0.0-20210927113745-59d0afb8317a
+	github.com/alicebob/miniredis/v2 v2.14.3
 	github.com/aliyun/aliyun-oss-go-sdk v2.0.4+incompatible
 	github.com/baidubce/bce-sdk-go v0.9.81
 	github.com/blang/semver/v4 v4.0.0
@@ -29,11 +30,13 @@ require (
 	github.com/fsnotify/fsnotify v1.5.1
 	github.com/go-kit/log v0.2.0
 	github.com/go-openapi/strfmt v0.21.0
+	github.com/go-redis/redis/v8 v8.11.4
 	github.com/gogo/protobuf v1.3.2
 	github.com/gogo/status v1.1.0
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da
 	github.com/golang/snappy v0.0.4
 	github.com/googleapis/gax-go v2.0.2+incompatible
+	github.com/grafana/dskit v0.0.0-20210908150159-fcf48cb19aa4
 	github.com/grpc-ecosystem/go-grpc-middleware/providers/kit/v2 v2.0.0-20201002093600-73cf2ae9d891
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.0.0-rc.2.0.20201207153454-9f6bf00c00a7
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -946,8 +946,9 @@ github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:Fecb
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-middleware v1.1.0/go.mod h1:f5nM7jw/oeRSadq3xCzHAvxcr8HZnzsqU6ILg/0NiiE=
-github.com/grpc-ecosystem/go-grpc-middleware v1.2.2 h1:FlFbCRLd5Jr4iYXZufAvgWN6Ao0JrI5chLINnUXDDr0=
 github.com/grpc-ecosystem/go-grpc-middleware v1.2.2/go.mod h1:EaizFBKfUKtMIF5iaDEhniwNedqGo9FuLFzppDr3uwI=
+github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 h1:+9834+KizmvFV7pXQGSXQTsaWhq2GjuNUt0aUU0YBYw=
+github.com/grpc-ecosystem/go-grpc-middleware v1.3.0/go.mod h1:z0ButlSOZa5vEBq9m2m2hlwIgKw+rp3sdCBRoJY+30Y=
 github.com/grpc-ecosystem/go-grpc-middleware/providers/kit/v2 v2.0.0-20201002093600-73cf2ae9d891 h1:RhOqTAECcPnehv3hKlYy1fAnpQ7rnZu58l3mpq6gT1k=
 github.com/grpc-ecosystem/go-grpc-middleware/providers/kit/v2 v2.0.0-20201002093600-73cf2ae9d891/go.mod h1:516cTXxZzi4NBUBbKcwmO4Eqbb6GHAEd3o4N+GYyCBY=
 github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.0.0-20200501113911-9a95f0fdbfea/go.mod h1:GugMBs30ZSAkckqXEAIEGyYdDH6EgqowG8ppA3Zt+AY=

--- a/pkg/cache/memcached.go
+++ b/pkg/cache/memcached.go
@@ -18,7 +18,7 @@ import (
 // MemcachedCache is a memcached-based cache.
 type MemcachedCache struct {
 	logger    log.Logger
-	memcached cacheutil.MemcachedClient
+	memcached cacheutil.RemoteCacheClient
 	name      string
 
 	// Metrics.
@@ -27,7 +27,7 @@ type MemcachedCache struct {
 }
 
 // NewMemcachedCache makes a new MemcachedCache.
-func NewMemcachedCache(name string, logger log.Logger, memcached cacheutil.MemcachedClient, reg prometheus.Registerer) *MemcachedCache {
+func NewMemcachedCache(name string, logger log.Logger, memcached cacheutil.RemoteCacheClient, reg prometheus.Registerer) *MemcachedCache {
 	c := &MemcachedCache{
 		logger:    logger,
 		memcached: memcached,

--- a/pkg/cache/redis.go
+++ b/pkg/cache/redis.go
@@ -1,0 +1,69 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package cache
+
+import (
+	"context"
+	"time"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/thanos-io/thanos/pkg/cacheutil"
+)
+
+// RedisCache is a redis cache.
+type RedisCache struct {
+	logger      log.Logger
+	redisClient *cacheutil.RedisClient
+	name        string
+
+	// Metrics.
+	requests prometheus.Counter
+	hits     prometheus.Counter
+}
+
+// NewRedisCache makes a new RedisCache.
+func NewRedisCache(name string, logger log.Logger, redisClient *cacheutil.RedisClient, reg prometheus.Registerer) *RedisCache {
+	c := &RedisCache{
+		logger:      logger,
+		redisClient: redisClient,
+		name:        name,
+	}
+
+	c.requests = promauto.With(reg).NewCounter(prometheus.CounterOpts{
+		Name:        "thanos_cache_redis_requests_total",
+		Help:        "Total number of items requests to redis.",
+		ConstLabels: prometheus.Labels{"name": name},
+	})
+
+	c.hits = promauto.With(reg).NewCounter(prometheus.CounterOpts{
+		Name:        "thanos_cache_redis_hits_total",
+		Help:        "Total number of items requests to the cache that were a hit.",
+		ConstLabels: prometheus.Labels{"name": name},
+	})
+
+	level.Info(logger).Log("msg", "created redis cache")
+
+	return c
+}
+
+// Store data identified by keys.
+func (c *RedisCache) Store(ctx context.Context, data map[string][]byte, ttl time.Duration) {
+	c.redisClient.SetMulti(ctx, data, ttl)
+}
+
+// Fetch fetches multiple keys and returns a map containing cache hits, along with a list of missing keys.
+// In case of error, it logs and return an empty cache hits map.
+func (c *RedisCache) Fetch(ctx context.Context, keys []string) map[string][]byte {
+	c.requests.Add(float64(len(keys)))
+	results := c.redisClient.GetMulti(ctx, keys)
+	c.hits.Add(float64(len(results)))
+	return results
+}
+
+func (c *RedisCache) Name() string {
+	return c.name
+}

--- a/pkg/cache/redis.go
+++ b/pkg/cache/redis.go
@@ -7,8 +7,8 @@ import (
 	"context"
 	"time"
 
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/log/level"
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/thanos-io/thanos/pkg/cacheutil"

--- a/pkg/cache/redis_test.go
+++ b/pkg/cache/redis_test.go
@@ -1,0 +1,120 @@
+package cache
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/go-kit/kit/log"
+	"github.com/prometheus/client_golang/prometheus"
+	prom_testutil "github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/thanos-io/thanos/pkg/cacheutil"
+	"github.com/thanos-io/thanos/pkg/testutil"
+)
+
+func TestRedisCache(t *testing.T) {
+	// Init some data to conveniently define test cases later one.
+	key1 := "key1"
+	key2 := "key2"
+	key3 := "key3"
+	value1 := []byte{1}
+	value2 := []byte{2}
+	value3 := []byte{3}
+
+	type args struct {
+		data      map[string][]byte
+		fetchKeys []string
+	}
+	type want struct {
+		hits map[string][]byte
+	}
+	tests := []struct {
+		name string
+		args args
+		want want
+	}{
+		{
+			name: "all hit",
+			args: args{
+				data: map[string][]byte{
+					key1: value1,
+					key2: value2,
+					key3: value3,
+				},
+				fetchKeys: []string{key1, key2, key3},
+			},
+			want: want{
+				hits: map[string][]byte{
+					key1: value1,
+					key2: value2,
+					key3: value3,
+				},
+			},
+		},
+		{
+			name: "partial hit",
+			args: args{
+				data: map[string][]byte{
+					key1: value1,
+					key2: value2,
+				},
+				fetchKeys: []string{key1, key2, key3},
+			},
+			want: want{
+				hits: map[string][]byte{
+					key1: value1,
+					key2: value2,
+				},
+			},
+		},
+		{
+			name: "not hit",
+			args: args{
+				data:      map[string][]byte{},
+				fetchKeys: []string{key1, key2, key3},
+			},
+			want: want{
+				hits: map[string][]byte{},
+			},
+		},
+	}
+	s, err := miniredis.Run()
+	if err != nil {
+		testutil.Ok(t, err)
+	}
+	defer s.Close()
+	logger := log.NewLogfmtLogger(os.Stderr)
+	reg := prometheus.NewRegistry()
+	cfg := cacheutil.RedisClientConfig{
+		Addr:         s.Addr(),
+		DialTimeout:  time.Second,
+		ReadTimeout:  time.Second,
+		WriteTimeout: time.Second,
+		MinIdleConns: 10,
+		MaxConnAge:   time.Minute * 10,
+		IdleTimeout:  time.Minute * 5,
+	}
+	c, err := cacheutil.NewRedisClientWithConfig(logger, t.Name(), cfg, reg)
+	if err != nil {
+		testutil.Ok(t, err)
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			defer s.FlushAll()
+			c := NewRedisCache(tt.name, logger, c, reg)
+			// Store the cache expected before running the test.
+			ctx := context.Background()
+			c.Store(ctx, tt.args.data, time.Hour)
+
+			// Fetch postings from cached and assert on it.
+			hits := c.Fetch(ctx, tt.args.fetchKeys)
+			testutil.Equals(t, tt.want.hits, hits)
+
+			// Assert on metrics.
+			testutil.Equals(t, float64(len(tt.args.fetchKeys)), prom_testutil.ToFloat64(c.requests))
+			testutil.Equals(t, float64(len(tt.want.hits)), prom_testutil.ToFloat64(c.hits))
+		})
+	}
+}

--- a/pkg/cache/redis_test.go
+++ b/pkg/cache/redis_test.go
@@ -90,17 +90,8 @@ func TestRedisCache(t *testing.T) {
 	defer s.Close()
 	logger := log.NewLogfmtLogger(os.Stderr)
 	reg := prometheus.NewRegistry()
-	cfg := cacheutil.RedisClientConfig{
-		Addr:                   s.Addr(),
-		DialTimeout:            time.Second,
-		ReadTimeout:            time.Second,
-		WriteTimeout:           time.Second,
-		MinIdleConns:           10,
-		MaxConnAge:             time.Minute * 10,
-		IdleTimeout:            time.Minute * 5,
-		MaxGetMultiConcurrency: 2,
-		GetMultiBatchSize:      2,
-	}
+	cfg := cacheutil.DefaultRedisClientConfig
+	cfg.Addr = s.Addr()
 	c, err := cacheutil.NewRedisClientWithConfig(logger, t.Name(), cfg, reg)
 	if err != nil {
 		testutil.Ok(t, err)

--- a/pkg/cache/redis_test.go
+++ b/pkg/cache/redis_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/alicebob/miniredis/v2"
-	"github.com/go-kit/kit/log"
+	"github.com/go-kit/log"
 	"github.com/prometheus/client_golang/prometheus"
 	prom_testutil "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/thanos-io/thanos/pkg/cacheutil"

--- a/pkg/cacheutil/memcached_client.go
+++ b/pkg/cacheutil/memcached_client.go
@@ -29,6 +29,7 @@ import (
 
 const (
 	opSet                 = "set"
+	opSetMulti            = "setmulti"
 	opGetMulti            = "getmulti"
 	reasonMaxItemSize     = "max-item-size"
 	reasonAsyncBufferFull = "async-buffer-full"
@@ -58,9 +59,14 @@ var (
 	}
 )
 
-// MemcachedClient is a high level client to interact with memcached.
-type MemcachedClient interface {
-	// GetMulti fetches multiple keys at once from memcached. In case of error,
+var (
+	_ RemoteCacheClient = (*memcachedClient)(nil)
+	_ RemoteCacheClient = (*RedisClient)(nil)
+)
+
+// RemoteCacheClient is a high level client to interact with remote cache.
+type RemoteCacheClient interface {
+	// GetMulti fetches multiple keys at once from remoteCache. In case of error,
 	// an empty map is returned and the error tracked/logged.
 	GetMulti(ctx context.Context, keys []string) map[string][]byte
 
@@ -73,13 +79,16 @@ type MemcachedClient interface {
 	Stop()
 }
 
+// MemcachedClient for compatible.
+type MemcachedClient = RemoteCacheClient
+
 // memcachedClientBackend is an interface used to mock the underlying client in tests.
 type memcachedClientBackend interface {
 	GetMulti(keys []string) (map[string]*memcache.Item, error)
 	Set(item *memcache.Item) error
 }
 
-// MemcachedClientConfig is the config accepted by MemcachedClient.
+// MemcachedClientConfig is the config accepted by RemoteCacheClient.
 type MemcachedClientConfig struct {
 	// Addresses specifies the list of memcached addresses. The addresses get
 	// resolved with the DNS provider.
@@ -196,7 +205,7 @@ type memcachedGetMultiResult struct {
 	err   error
 }
 
-// NewMemcachedClient makes a new MemcachedClient.
+// NewMemcachedClient makes a new RemoteCacheClient.
 func NewMemcachedClient(logger log.Logger, name string, conf []byte, reg prometheus.Registerer) (*memcachedClient, error) {
 	config, err := parseMemcachedClientConfig(conf)
 	if err != nil {
@@ -206,7 +215,7 @@ func NewMemcachedClient(logger log.Logger, name string, conf []byte, reg prometh
 	return NewMemcachedClientWithConfig(logger, name, config, reg)
 }
 
-// NewMemcachedClientWithConfig makes a new MemcachedClient.
+// NewMemcachedClientWithConfig makes a new RemoteCacheClient.
 func NewMemcachedClientWithConfig(logger log.Logger, name string, config MemcachedClientConfig, reg prometheus.Registerer) (*memcachedClient, error) {
 	if err := config.validate(); err != nil {
 		return nil, err

--- a/pkg/cacheutil/redis_client.go
+++ b/pkg/cacheutil/redis_client.go
@@ -1,0 +1,205 @@
+package cacheutil
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/go-redis/redis/v8"
+	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"gopkg.in/yaml.v3"
+)
+
+var (
+	defaultRedisClientConfig = RedisClientConfig{}
+)
+
+// RedisClientConfig is the config accepted by RedisClient.
+type RedisClientConfig struct {
+	// Addr specifies the addresses of redis server.
+	Addr string `yaml:"addr"`
+
+	// Use the specified Username to authenticate the current connection
+	// with one of the connections defined in the ACL list when connecting
+	// to a Redis 6.0 instance, or greater, that is using the Redis ACL system.
+	Username string `yaml:"username"`
+	// Optional password. Must match the password specified in the
+	// requirepass server configuration option (if connecting to a Redis 5.0 instance, or lower),
+	// or the User Password when connecting to a Redis 6.0 instance, or greater,
+	// that is using the Redis ACL system.
+	Password string `yaml:"password"`
+
+	// DialTimeout specifies the client dial timeout.
+	// Default is 5 seconds.
+	DialTimeout time.Duration `yaml:"dial_timeout"`
+
+	// ReadTimeout specifies the client read timeout.
+	// Default is 3 seconds.
+	ReadTimeout time.Duration `yaml:"read_timeout"`
+
+	// WriteTimeout specifies the client write timeout.
+	// Default is ReadTimeout.
+	WriteTimeout time.Duration `yaml:"write_timeout"`
+
+	// Maximum number of socket connections.
+	// Default is 10 connections per every available CPU as reported by runtime.GOMAXPROCS.
+	PoolSize int `yaml:"pool_size"`
+
+	// MinIdleConns specifies the minimum number of idle connections which is useful when establishing
+	// new connection is slow.
+	MinIdleConns int `yaml:"min_idle_conns"`
+
+	// Amount of time after which client closes idle connections.
+	// Should be less than server's timeout.
+	// Default is 5 minutes. -1 disables idle timeout check.
+	IdleTimeout time.Duration `yaml:"idle_timeout"`
+
+	// Connection age at which client retires (closes) the connection.
+	// Default is to not close aged connections.
+	MaxConnAge time.Duration `yaml:"max_conn_age"`
+}
+
+func (c *RedisClientConfig) validate() error {
+	if c.Addr == "" {
+		return errors.New("no redis addr provided")
+	}
+	return nil
+}
+
+// RedisClient is a wrap of redis.Client.
+type RedisClient struct {
+	*redis.Client
+	logger           log.Logger
+	durationSet      prometheus.Observer
+	durationSetMulti prometheus.Observer
+	durationGetMulti prometheus.Observer
+}
+
+// NewRedisClient makes a new RedisClient.
+func NewRedisClient(logger log.Logger, name string, conf []byte, reg prometheus.Registerer) (*RedisClient, error) {
+	config, err := parseRedisClientConfig(conf)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewRedisClientWithConfig(logger, name, config, reg)
+}
+
+// NewRedisClientWithConfig makes a new RedisClient.
+func NewRedisClientWithConfig(logger log.Logger, name string, config RedisClientConfig,
+	reg prometheus.Registerer) (*RedisClient, error) {
+
+	if err := config.validate(); err != nil {
+		return nil, err
+	}
+	redisClient := redis.NewClient(&redis.Options{
+		Addr:         config.Addr,
+		Username:     config.Username,
+		Password:     config.Password,
+		DialTimeout:  config.DialTimeout,
+		ReadTimeout:  config.ReadTimeout,
+		WriteTimeout: config.WriteTimeout,
+		MinIdleConns: config.MinIdleConns,
+		MaxConnAge:   config.MaxConnAge,
+		IdleTimeout:  config.IdleTimeout,
+	})
+
+	if reg != nil {
+		reg = prometheus.WrapRegistererWith(prometheus.Labels{"name": name}, reg)
+	}
+
+	c := &RedisClient{
+		Client: redisClient,
+		logger: logger,
+	}
+	duration := promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "thanos_redis_operation_duration_seconds",
+		Help:    "Duration of operations against memcached.",
+		Buckets: []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.2, 0.5, 1, 3, 6, 10},
+	}, []string{"operation"})
+	c.durationSet = duration.WithLabelValues(opSet)
+	c.durationSetMulti = duration.WithLabelValues(opSetMulti)
+	c.durationGetMulti = duration.WithLabelValues(opGetMulti)
+	return c, nil
+}
+
+// SetAsync implement RemoteCacheClient.
+func (c *RedisClient) SetAsync(ctx context.Context, key string, value []byte, ttl time.Duration) error {
+	start := time.Now()
+	if _, err := c.Set(ctx, key, value, ttl).Result(); err != nil {
+		level.Warn(c.logger).Log("msg", "failed to set item into redis", "err", err, "key", key,
+			"value_size", len(value))
+		return nil
+	}
+	c.durationSet.Observe(time.Since(start).Seconds())
+	return nil
+}
+
+// SetMulti set multiple keys and value.
+func (c *RedisClient) SetMulti(ctx context.Context, data map[string][]byte, ttl time.Duration) {
+	start := time.Now()
+	_, err := c.Pipelined(ctx, func(p redis.Pipeliner) error {
+		for key, val := range data {
+			p.SetEX(ctx, key, val, ttl)
+		}
+		return nil
+	})
+	if err != nil {
+		level.Warn(c.logger).Log("msg", "failed to mset items into redis", "err", err, "items", len(data))
+		return
+	}
+	c.durationSetMulti.Observe(time.Since(start).Seconds())
+	return
+}
+
+// GetMulti implement RemoteCacheClient.
+func (c *RedisClient) GetMulti(ctx context.Context, keys []string) map[string][]byte {
+	start := time.Now()
+	resp, err := c.MGet(ctx, keys...).Result()
+	if err != nil {
+		level.Warn(c.logger).Log("msg", "failed to mget items from redis", "err", err, "items", len(resp))
+		return nil
+	}
+	var hits int
+	for i := 0; i < len(resp); i++ {
+		if resp[i] != nil {
+			hits++
+		}
+	}
+	results := make(map[string][]byte, hits)
+	for i := 0; i < len(resp); i++ {
+		v := resp[i]
+		switch vv := v.(type) {
+		case string:
+			results[keys[i]] = []byte(vv)
+		case []byte:
+			results[keys[i]] = vv
+		case nil: // miss
+		default:
+			level.Warn(c.logger).Log("msg",
+				fmt.Sprintf("unexpected redis mget result type:%T %v", v, v))
+		}
+	}
+	c.durationGetMulti.Observe(time.Since(start).Seconds())
+	return results
+}
+
+// Stop implement RemoteCacheClient.
+func (c *RedisClient) Stop() {
+	if err := c.Close(); err != nil {
+		level.Error(c.logger).Log("msg", "redis close err")
+	}
+}
+
+// parseRedisClientConfig unmarshals a buffer into a RedisClientConfig with default values.
+func parseRedisClientConfig(conf []byte) (RedisClientConfig, error) {
+	config := defaultRedisClientConfig
+	if err := yaml.Unmarshal(conf, &config); err != nil {
+		return RedisClientConfig{}, err
+	}
+	return config, nil
+}

--- a/pkg/cacheutil/redis_client.go
+++ b/pkg/cacheutil/redis_client.go
@@ -266,7 +266,7 @@ func (c *RedisClient) Stop() {
 	}
 }
 
-// stringToBytes converts string to byte slice. (copied from vendor/github.com/go-redis/redis/v8/internal/util/unsafe.go)
+// stringToBytes converts string to byte slice (copied from vendor/github.com/go-redis/redis/v8/internal/util/unsafe.go).
 func stringToBytes(s string) []byte {
 	return *(*[]byte)(unsafe.Pointer(
 		&struct {

--- a/pkg/queryfrontend/cache.go
+++ b/pkg/queryfrontend/cache.go
@@ -25,20 +25,21 @@ func newThanosCacheKeyGenerator(interval time.Duration) thanosCacheKeyGenerator 
 	}
 }
 
-// TODO(yeya24): Add other request params as request key.
 // GenerateCacheKey generates a cache key based on the Request and interval.
-func (t thanosCacheKeyGenerator) GenerateCacheKey(_ string, r queryrange.Request) string {
+// TODO(yeya24): Add other request params as request key.
+func (t thanosCacheKeyGenerator) GenerateCacheKey(userID string, r queryrange.Request) string {
 	currentInterval := r.GetStart() / t.interval.Milliseconds()
 	switch tr := r.(type) {
 	case *ThanosQueryRangeRequest:
 		i := 0
 		for ; i < len(t.resolutions) && t.resolutions[i] > tr.MaxSourceResolution; i++ {
 		}
-		return fmt.Sprintf("%s:%d:%d:%d", tr.Query, tr.Step, currentInterval, i)
+		// Cache key should has a uniq prefix, We use `fe` represent frontend.
+		return fmt.Sprintf("fe:%s:%s:%d:%d:%d", userID, tr.Query, tr.Step, currentInterval, i)
 	case *ThanosLabelsRequest:
-		return fmt.Sprintf("%s:%s:%d", tr.Label, tr.Matchers, currentInterval)
+		return fmt.Sprintf("fe:%s:%s:%s:%d", userID, tr.Label, tr.Matchers, currentInterval)
 	case *ThanosSeriesRequest:
-		return fmt.Sprintf("%s:%d", tr.Matchers, currentInterval)
+		return fmt.Sprintf("fe:%s:%s:%d", userID, tr.Matchers, currentInterval)
 	}
-	return fmt.Sprintf("%s:%d:%d", r.GetQuery(), r.GetStep(), currentInterval)
+	return fmt.Sprintf("fe:%s:%s:%d:%d", userID, r.GetQuery(), r.GetStep(), currentInterval)
 }

--- a/pkg/queryfrontend/cache_test.go
+++ b/pkg/queryfrontend/cache_test.go
@@ -27,7 +27,7 @@ func TestGenerateCacheKey(t *testing.T) {
 				Start: 0,
 				Step:  60 * seconds,
 			},
-			expected: "up:60000:0",
+			expected: "fe::up:60000:0",
 		},
 		{
 			name: "non downsampling resolution specified",
@@ -36,7 +36,7 @@ func TestGenerateCacheKey(t *testing.T) {
 				Start: 0,
 				Step:  60 * seconds,
 			},
-			expected: "up:60000:0:2",
+			expected: "fe::up:60000:0:2",
 		},
 		{
 			name: "10s step",
@@ -45,7 +45,7 @@ func TestGenerateCacheKey(t *testing.T) {
 				Start: 0,
 				Step:  10 * seconds,
 			},
-			expected: "up:10000:0:2",
+			expected: "fe::up:10000:0:2",
 		},
 		{
 			name: "1m downsampling resolution",
@@ -55,7 +55,7 @@ func TestGenerateCacheKey(t *testing.T) {
 				Step:                10 * seconds,
 				MaxSourceResolution: 60 * seconds,
 			},
-			expected: "up:10000:0:2",
+			expected: "fe::up:10000:0:2",
 		},
 		{
 			name: "5m downsampling resolution, different cache key",
@@ -65,7 +65,7 @@ func TestGenerateCacheKey(t *testing.T) {
 				Step:                10 * seconds,
 				MaxSourceResolution: 300 * seconds,
 			},
-			expected: "up:10000:0:1",
+			expected: "fe::up:10000:0:1",
 		},
 		{
 			name: "1h downsampling resolution, different cache key",
@@ -75,14 +75,14 @@ func TestGenerateCacheKey(t *testing.T) {
 				Step:                10 * seconds,
 				MaxSourceResolution: hour,
 			},
-			expected: "up:10000:0:0",
+			expected: "fe::up:10000:0:0",
 		},
 		{
 			name: "label names, no matcher",
 			req: &ThanosLabelsRequest{
 				Start: 0,
 			},
-			expected: ":[]:0",
+			expected: "fe:::[]:0",
 		},
 		{
 			name: "label names, single matcher",
@@ -90,7 +90,7 @@ func TestGenerateCacheKey(t *testing.T) {
 				Start:    0,
 				Matchers: [][]*labels.Matcher{{labels.MustNewMatcher(labels.MatchEqual, "foo", "bar")}},
 			},
-			expected: `:[[foo="bar"]]:0`,
+			expected: `fe:::[[foo="bar"]]:0`,
 		},
 		{
 			name: "label names, multiple matchers",
@@ -101,7 +101,7 @@ func TestGenerateCacheKey(t *testing.T) {
 					{labels.MustNewMatcher(labels.MatchEqual, "baz", "qux")},
 				},
 			},
-			expected: `:[[foo="bar"] [baz="qux"]]:0`,
+			expected: `fe:::[[foo="bar"] [baz="qux"]]:0`,
 		},
 		{
 			name: "label values, no matcher",
@@ -109,7 +109,7 @@ func TestGenerateCacheKey(t *testing.T) {
 				Start: 0,
 				Label: "up",
 			},
-			expected: "up:[]:0",
+			expected: "fe::up:[]:0",
 		},
 		{
 			name: "label values, single matcher",
@@ -118,7 +118,7 @@ func TestGenerateCacheKey(t *testing.T) {
 				Label:    "up",
 				Matchers: [][]*labels.Matcher{{labels.MustNewMatcher(labels.MatchEqual, "foo", "bar")}},
 			},
-			expected: `up:[[foo="bar"]]:0`,
+			expected: `fe::up:[[foo="bar"]]:0`,
 		},
 		{
 			name: "label values, multiple matchers",
@@ -130,7 +130,7 @@ func TestGenerateCacheKey(t *testing.T) {
 					{labels.MustNewMatcher(labels.MatchEqual, "baz", "qux")},
 				},
 			},
-			expected: `up:[[foo="bar"] [baz="qux"]]:0`,
+			expected: `fe::up:[[foo="bar"] [baz="qux"]]:0`,
 		},
 	} {
 		key := splitter.GenerateCacheKey("", tc.req)

--- a/pkg/queryfrontend/config.go
+++ b/pkg/queryfrontend/config.go
@@ -13,6 +13,7 @@ import (
 	cortexvalidation "github.com/cortexproject/cortex/pkg/util/validation"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+	"github.com/grafana/dskit/flagext"
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v2"
 
@@ -28,6 +29,7 @@ type ResponseCacheProvider string
 const (
 	INMEMORY  ResponseCacheProvider = "IN-MEMORY"
 	MEMCACHED ResponseCacheProvider = "MEMCACHED"
+	REDIS     ResponseCacheProvider = "REDIS"
 )
 
 var (
@@ -41,6 +43,15 @@ var (
 			MaxGetMultiBatchSize:      0,
 			MaxItemSize:               model.Bytes(1024 * 1024),
 			DNSProviderUpdateInterval: 10 * time.Second,
+		},
+		Expiration: 24 * time.Hour,
+	}
+	defaultRedisConfig = RedisResponseCacheConfig{
+		Redis: cacheutil.RedisClientConfig{
+			DialTimeout:  5 * time.Second,
+			ReadTimeout:  3 * time.Second,
+			WriteTimeout: 3 * time.Second,
+			IdleTimeout:  5 * time.Minute,
 		},
 		Expiration: 24 * time.Hour,
 	}
@@ -59,6 +70,13 @@ type InMemoryResponseCacheConfig struct {
 // MemcachedResponseCacheConfig holds the configs for the memcache cache provider.
 type MemcachedResponseCacheConfig struct {
 	Memcached cacheutil.MemcachedClientConfig `yaml:",inline"`
+	// Expiration sets a global expiration limit for all cached items.
+	Expiration time.Duration `yaml:"expiration"`
+}
+
+// RedisResponseCacheConfig holds the configs for the redis cache provider.
+type RedisResponseCacheConfig struct {
+	Redis cacheutil.RedisClientConfig `yaml:",inline"`
 	// Expiration sets a global expiration limit for all cached items.
 	Expiration time.Duration `yaml:"expiration"`
 }
@@ -133,6 +151,26 @@ func NewCacheConfig(logger log.Logger, confContentYaml []byte) (*cortexcache.Con
 			Background: cortexcache.BackgroundConfig{
 				WriteBackBuffer:     config.Memcached.MaxAsyncBufferSize,
 				WriteBackGoroutines: config.Memcached.MaxAsyncConcurrency,
+			},
+		}, nil
+	case string(REDIS):
+		config := defaultRedisConfig
+		if err := yaml.UnmarshalStrict(backendConfig, &config); err != nil {
+			return nil, err
+		}
+		if config.Expiration <= 0 {
+			level.Warn(logger).Log("msg", "redis cache valid time set to 0, so using a default of 24 hours expiration time")
+			config.Expiration = 24 * time.Hour
+		}
+		return &cortexcache.Config{
+			Redis: cortexcache.RedisConfig{
+				Endpoint:    config.Redis.Addr,
+				Timeout:     config.Redis.ReadTimeout, // There are some gap.
+				Expiration:  config.Expiration,
+				PoolSize:    config.Redis.PoolSize,
+				Password:    flagext.Secret{Value: config.Redis.Password},
+				IdleTimeout: config.Redis.IdleTimeout,
+				MaxConnAge:  config.Redis.MaxConnAge,
 			},
 		}, nil
 	default:

--- a/pkg/queryfrontend/config.go
+++ b/pkg/queryfrontend/config.go
@@ -161,12 +161,17 @@ func NewCacheConfig(logger log.Logger, confContentYaml []byte) (*cortexcache.Con
 		return &cortexcache.Config{
 			Redis: cortexcache.RedisConfig{
 				Endpoint:    config.Redis.Addr,
-				Timeout:     config.Redis.ReadTimeout, // There are some gap.
+				Timeout:     config.Redis.ReadTimeout,
 				Expiration:  config.Expiration,
+				DB:          config.Redis.DB,
 				PoolSize:    config.Redis.PoolSize,
 				Password:    flagext.Secret{Value: config.Redis.Password},
 				IdleTimeout: config.Redis.IdleTimeout,
 				MaxConnAge:  config.Redis.MaxConnAge,
+			},
+			Background: cortexcache.BackgroundConfig{
+				WriteBackBuffer:     config.Redis.MaxSetMultiConcurrency * config.Redis.SetMultiBatchSize,
+				WriteBackGoroutines: config.Redis.MaxSetMultiConcurrency,
 			},
 		}, nil
 	default:

--- a/pkg/queryfrontend/config.go
+++ b/pkg/queryfrontend/config.go
@@ -46,13 +46,9 @@ var (
 		},
 		Expiration: 24 * time.Hour,
 	}
-	defaultRedisConfig = RedisResponseCacheConfig{
-		Redis: cacheutil.RedisClientConfig{
-			DialTimeout:  5 * time.Second,
-			ReadTimeout:  3 * time.Second,
-			WriteTimeout: 3 * time.Second,
-			IdleTimeout:  5 * time.Minute,
-		},
+	// DefaultRedisConfig is default redis config for queryfrontend.
+	DefaultRedisConfig = RedisResponseCacheConfig{
+		Redis:      cacheutil.DefaultRedisClientConfig,
 		Expiration: 24 * time.Hour,
 	}
 )
@@ -154,7 +150,7 @@ func NewCacheConfig(logger log.Logger, confContentYaml []byte) (*cortexcache.Con
 			},
 		}, nil
 	case string(REDIS):
-		config := defaultRedisConfig
+		config := DefaultRedisConfig
 		if err := yaml.UnmarshalStrict(backendConfig, &config); err != nil {
 			return nil, err
 		}

--- a/pkg/store/cache/caching_bucket_factory.go
+++ b/pkg/store/cache/caching_bucket_factory.go
@@ -27,6 +27,7 @@ type BucketCacheProvider string
 const (
 	InMemoryBucketCacheProvider  BucketCacheProvider = "IN-MEMORY" // In-memory cache-provider for caching bucket.
 	MemcachedBucketCacheProvider BucketCacheProvider = "MEMCACHED" // Memcached cache-provider for caching bucket.
+	RedisBucketCacheProvider     BucketCacheProvider = "REDIS"     // Redis cache-provider for caching bucket.
 )
 
 // CachingWithBackendConfig is a configuration of caching bucket used by Store component.
@@ -86,7 +87,7 @@ func NewCachingBucketFromYaml(yamlContent []byte, bucket objstore.Bucket, logger
 
 	switch strings.ToUpper(string(config.Type)) {
 	case string(MemcachedBucketCacheProvider):
-		var memcached cacheutil.MemcachedClient
+		var memcached cacheutil.RemoteCacheClient
 		memcached, err := cacheutil.NewMemcachedClient(logger, "caching-bucket", backendConfig, reg)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to create memcached client")
@@ -97,6 +98,12 @@ func NewCachingBucketFromYaml(yamlContent []byte, bucket objstore.Bucket, logger
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to create inmemory cache")
 		}
+	case string(RedisBucketCacheProvider):
+		redisCache, err := cacheutil.NewRedisClient(logger, "caching-bucket", backendConfig, reg)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to create memcached client")
+		}
+		c = cache.NewRedisCache("caching-bucket", logger, redisCache, reg)
 	default:
 		return nil, errors.Errorf("unsupported cache type: %s", config.Type)
 	}

--- a/pkg/store/cache/factory.go
+++ b/pkg/store/cache/factory.go
@@ -21,6 +21,7 @@ type IndexCacheProvider string
 const (
 	INMEMORY  IndexCacheProvider = "IN-MEMORY"
 	MEMCACHED IndexCacheProvider = "MEMCACHED"
+	REDIS     IndexCacheProvider = "REDIS"
 )
 
 // IndexCacheConfig specifies the index cache config.
@@ -47,10 +48,15 @@ func NewIndexCache(logger log.Logger, confContentYaml []byte, reg prometheus.Reg
 	case string(INMEMORY):
 		cache, err = NewInMemoryIndexCache(logger, reg, backendConfig)
 	case string(MEMCACHED):
-		var memcached cacheutil.MemcachedClient
+		var memcached cacheutil.RemoteCacheClient
 		memcached, err = cacheutil.NewMemcachedClient(logger, "index-cache", backendConfig, reg)
 		if err == nil {
-			cache, err = NewMemcachedIndexCache(logger, memcached, reg)
+			cache, err = NewRemoteIndexCache(logger, memcached, reg)
+		}
+	case string(REDIS):
+		redisCache, err := cacheutil.NewRedisClient(logger, "index-cache", backendConfig, reg)
+		if err == nil {
+			cache, err = NewRemoteIndexCache(logger, redisCache, reg)
 		}
 	default:
 		return nil, errors.Errorf("index cache with type %s is not supported", cacheConfig.Type)

--- a/pkg/store/cache/factory.go
+++ b/pkg/store/cache/factory.go
@@ -54,7 +54,8 @@ func NewIndexCache(logger log.Logger, confContentYaml []byte, reg prometheus.Reg
 			cache, err = NewRemoteIndexCache(logger, memcached, reg)
 		}
 	case string(REDIS):
-		redisCache, err := cacheutil.NewRedisClient(logger, "index-cache", backendConfig, reg)
+		var redisCache cacheutil.RemoteCacheClient
+		redisCache, err = cacheutil.NewRedisClient(logger, "index-cache", backendConfig, reg)
 		if err == nil {
 			cache, err = NewRemoteIndexCache(logger, redisCache, reg)
 		}

--- a/pkg/store/cache/memcached.go
+++ b/pkg/store/cache/memcached.go
@@ -22,21 +22,21 @@ const (
 	memcachedDefaultTTL = 24 * time.Hour
 )
 
-// MemcachedIndexCache is a memcached-based index cache.
-type MemcachedIndexCache struct {
+// RemoteIndexCache is a memcached-based index cache.
+type RemoteIndexCache struct {
 	logger    log.Logger
-	memcached cacheutil.MemcachedClient
+	memcached cacheutil.RemoteCacheClient
 
 	// Metrics.
 	requests *prometheus.CounterVec
 	hits     *prometheus.CounterVec
 }
 
-// NewMemcachedIndexCache makes a new MemcachedIndexCache.
-func NewMemcachedIndexCache(logger log.Logger, memcached cacheutil.MemcachedClient, reg prometheus.Registerer) (*MemcachedIndexCache, error) {
-	c := &MemcachedIndexCache{
+// NewRemoteIndexCache makes a new RemoteIndexCache.
+func NewRemoteIndexCache(logger log.Logger, cacheClient cacheutil.RemoteCacheClient, reg prometheus.Registerer) (*RemoteIndexCache, error) {
+	c := &RemoteIndexCache{
 		logger:    logger,
-		memcached: memcached,
+		memcached: cacheClient,
 	}
 
 	c.requests = promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
@@ -53,7 +53,7 @@ func NewMemcachedIndexCache(logger log.Logger, memcached cacheutil.MemcachedClie
 	c.hits.WithLabelValues(cacheTypePostings)
 	c.hits.WithLabelValues(cacheTypeSeries)
 
-	level.Info(logger).Log("msg", "created memcached index cache")
+	level.Info(logger).Log("msg", "created cacheClient index cache")
 
 	return c, nil
 }
@@ -61,7 +61,7 @@ func NewMemcachedIndexCache(logger log.Logger, memcached cacheutil.MemcachedClie
 // StorePostings sets the postings identified by the ulid and label to the value v.
 // The function enqueues the request and returns immediately: the entry will be
 // asynchronously stored in the cache.
-func (c *MemcachedIndexCache) StorePostings(ctx context.Context, blockID ulid.ULID, l labels.Label, v []byte) {
+func (c *RemoteIndexCache) StorePostings(ctx context.Context, blockID ulid.ULID, l labels.Label, v []byte) {
 	key := cacheKey{blockID, cacheKeyPostings(l)}.string()
 
 	if err := c.memcached.SetAsync(ctx, key, v, memcachedDefaultTTL); err != nil {
@@ -72,7 +72,7 @@ func (c *MemcachedIndexCache) StorePostings(ctx context.Context, blockID ulid.UL
 // FetchMultiPostings fetches multiple postings - each identified by a label -
 // and returns a map containing cache hits, along with a list of missing keys.
 // In case of error, it logs and return an empty cache hits map.
-func (c *MemcachedIndexCache) FetchMultiPostings(ctx context.Context, blockID ulid.ULID, lbls []labels.Label) (hits map[labels.Label][]byte, misses []labels.Label) {
+func (c *RemoteIndexCache) FetchMultiPostings(ctx context.Context, blockID ulid.ULID, lbls []labels.Label) (hits map[labels.Label][]byte, misses []labels.Label) {
 	// Build the cache keys, while keeping a map between input label and the cache key
 	// so that we can easily reverse it back after the GetMulti().
 	keys := make([]string, 0, len(lbls))
@@ -121,7 +121,7 @@ func (c *MemcachedIndexCache) FetchMultiPostings(ctx context.Context, blockID ul
 // StoreSeries sets the series identified by the ulid and id to the value v.
 // The function enqueues the request and returns immediately: the entry will be
 // asynchronously stored in the cache.
-func (c *MemcachedIndexCache) StoreSeries(ctx context.Context, blockID ulid.ULID, id storage.SeriesRef, v []byte) {
+func (c *RemoteIndexCache) StoreSeries(ctx context.Context, blockID ulid.ULID, id storage.SeriesRef, v []byte) {
 	key := cacheKey{blockID, cacheKeySeries(id)}.string()
 
 	if err := c.memcached.SetAsync(ctx, key, v, memcachedDefaultTTL); err != nil {
@@ -132,7 +132,7 @@ func (c *MemcachedIndexCache) StoreSeries(ctx context.Context, blockID ulid.ULID
 // FetchMultiSeries fetches multiple series - each identified by ID - from the cache
 // and returns a map containing cache hits, along with a list of missing IDs.
 // In case of error, it logs and return an empty cache hits map.
-func (c *MemcachedIndexCache) FetchMultiSeries(ctx context.Context, blockID ulid.ULID, ids []storage.SeriesRef) (hits map[storage.SeriesRef][]byte, misses []storage.SeriesRef) {
+func (c *RemoteIndexCache) FetchMultiSeries(ctx context.Context, blockID ulid.ULID, ids []storage.SeriesRef) (hits map[storage.SeriesRef][]byte, misses []storage.SeriesRef) {
 	// Build the cache keys, while keeping a map between input id and the cache key
 	// so that we can easily reverse it back after the GetMulti().
 	keys := make([]string, 0, len(ids))
@@ -176,4 +176,9 @@ func (c *MemcachedIndexCache) FetchMultiSeries(ctx context.Context, blockID ulid
 
 	c.hits.WithLabelValues(cacheTypeSeries).Add(float64(len(hits)))
 	return hits, misses
+}
+
+// NewMemcachedIndexCache is alias NewRemoteIndexCache for compatible.
+func NewMemcachedIndexCache(logger log.Logger, memcached cacheutil.RemoteCacheClient, reg prometheus.Registerer) (*RemoteIndexCache, error) {
+	return NewRemoteIndexCache(logger, memcached, reg)
 }

--- a/pkg/store/cache/memcached_test.go
+++ b/pkg/store/cache/memcached_test.go
@@ -86,7 +86,7 @@ func TestMemcachedIndexCache_FetchMultiPostings(t *testing.T) {
 	for testName, testData := range tests {
 		t.Run(testName, func(t *testing.T) {
 			memcached := newMockedMemcachedClient(testData.mockedErr)
-			c, err := NewMemcachedIndexCache(log.NewNopLogger(), memcached, nil)
+			c, err := NewRemoteIndexCache(log.NewNopLogger(), memcached, nil)
 			testutil.Ok(t, err)
 
 			// Store the postings expected before running the test.
@@ -175,7 +175,7 @@ func TestMemcachedIndexCache_FetchMultiSeries(t *testing.T) {
 	for testName, testData := range tests {
 		t.Run(testName, func(t *testing.T) {
 			memcached := newMockedMemcachedClient(testData.mockedErr)
-			c, err := NewMemcachedIndexCache(log.NewNopLogger(), memcached, nil)
+			c, err := NewRemoteIndexCache(log.NewNopLogger(), memcached, nil)
 			testutil.Ok(t, err)
 
 			// Store the series expected before running the test.

--- a/scripts/cfggen/main.go
+++ b/scripts/cfggen/main.go
@@ -65,11 +65,13 @@ var (
 	indexCacheConfigs = map[storecache.IndexCacheProvider]interface{}{
 		storecache.INMEMORY:  storecache.InMemoryIndexCacheConfig{},
 		storecache.MEMCACHED: cacheutil.MemcachedClientConfig{},
+		storecache.REDIS:     cacheutil.DefaultRedisClientConfig,
 	}
 
 	queryfrontendCacheConfigs = map[queryfrontend.ResponseCacheProvider]interface{}{
 		queryfrontend.INMEMORY:  queryfrontend.InMemoryResponseCacheConfig{},
 		queryfrontend.MEMCACHED: queryfrontend.MemcachedResponseCacheConfig{},
+		queryfrontend.REDIS:     queryfrontend.DefaultRedisConfig,
 	}
 )
 


### PR DESCRIPTION
Hi, I am attempt to add redis cache support,  like cortex does.
First. i will make it a draft PR.

Signed-off-by: Jimmie Han <hanjinming@outlook.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.


## Changes

<!-- Enumerate changes you made -->
1. add redis support for bucket-cache/index-cache/query-frontend
## Verification

<!-- How you tested it? How do you know it works? -->
1. unit test.
2. continning test in production deployment.