### PR TITLE
Add no lock option for stateless rule agent DB

### DIFF
--- a/cmd/thanos/rule.go
+++ b/cmd/thanos/rule.go
@@ -153,6 +153,7 @@ func registerRule(app *extkingpin.App) {
 
 		agentOpts := &agent.Options{
 			WALCompression: *walCompression,
+			NoLockfile:     *noLockFile,
 		}
 
 		// Parse and check query configuration.


### PR DESCRIPTION
Signed-off-by: Ben Ye <ben.ye@bytedance.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

Thanks to the version update in https://github.com/thanos-io/thanos/pull/4882, we can bring https://github.com/prometheus/prometheus/pull/9623 in to support the no lock option in the agent DB.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
