### PR TITLE
docs(query): fix link to PartialResponseStrategy

### DIFF
--- a/docs/components/query.md
+++ b/docs/components/query.md
@@ -115,7 +115,7 @@ Let's walk through all of those extensions:
 
 ### Partial Response
 
-QueryAPI and StoreAPI has additional behaviour controlled via query parameter called [PartialResponseStrategy](../../pkg/store/storepb/rpc.pb.go).
+QueryAPI and StoreAPI has additional behaviour controlled via query parameter called [PartialResponseStrategy](https://github.com/thanos-io/thanos/blob/main/pkg/store/storepb/rpc.pb.go).
 
 This parameter controls tradeoff between accuracy and availability.
 
@@ -252,7 +252,7 @@ Query node exposing PromQL enabled Query API with data retrieved from multiple
 store nodes.
 
 Flags:
-      --alert.query-url=ALERT.QUERY-URL  
+      --alert.query-url=ALERT.QUERY-URL
                                  The external Thanos Query URL that would be set
                                  in all alerts 'Source' field.
       --enable-feature= ...      Comma separated experimental feature names to
@@ -263,16 +263,16 @@ Flags:
                                  prefixed with 'dns+' or 'dnssrv+' to detect
                                  Thanos API servers through respective DNS
                                  lookups.
-      --endpoint-strict=<staticendpoint> ...  
+      --endpoint-strict=<staticendpoint> ...
                                  Addresses of only statically configured Thanos
                                  API servers that are always used, even if the
                                  health check fails. Useful if you have a
                                  caching layer on top.
-      --grpc-address="0.0.0.0:10901"  
+      --grpc-address="0.0.0.0:10901"
                                  Listen ip:port address for gRPC endpoints
                                  (StoreAPI). Make sure this address is routable
                                  from other components.
-      --grpc-client-server-name=""  
+      --grpc-client-server-name=""
                                  Server name to verify the hostname on the
                                  returned gRPC certificates. See
                                  https://tools.ietf.org/html/rfc4366#section-3.1
@@ -282,18 +282,18 @@ Flags:
                                  to the server
       --grpc-client-tls-key=""   TLS Key for the client's certificate
       --grpc-client-tls-secure   Use TLS when talking to the gRPC server
-      --grpc-client-tls-skip-verify  
+      --grpc-client-tls-skip-verify
                                  Disable TLS certificate verification i.e self
                                  signed, signed by fake CA
       --grpc-grace-period=2m     Time to wait after an interrupt received for
                                  GRPC Server.
-      --grpc-server-max-connection-age=60m  
+      --grpc-server-max-connection-age=60m
                                  The grpc server max connection age. This
                                  controls how often to re-read the tls
                                  certificates and redo the TLS handshake
       --grpc-server-tls-cert=""  TLS Certificate for gRPC server, leave blank to
                                  disable TLS
-      --grpc-server-tls-client-ca=""  
+      --grpc-server-tls-client-ca=""
                                  TLS CA to verify clients against. If no client
                                  CA is specified, there is no client
                                  verification on server side. (tls.NoClientCert)
@@ -301,7 +301,7 @@ Flags:
                                  disable TLS
   -h, --help                     Show context-sensitive help (also try
                                  --help-long and --help-man).
-      --http-address="0.0.0.0:10902"  
+      --http-address="0.0.0.0:10902"
                                  Listen host:port for HTTP endpoints.
       --http-grace-period=2m     Time to wait after an interrupt received for
                                  HTTP Server.
@@ -323,7 +323,7 @@ Flags:
       --query.auto-downsampling  Enable automatic adjustment (step / 5) to what
                                  source of data should be used in store gateways
                                  if no max_source_resolution param is specified.
-      --query.default-evaluation-interval=1m  
+      --query.default-evaluation-interval=1m
                                  Set default evaluation interval for sub
                                  queries.
       --query.default-step=1s    Set default step for range queries. Default
@@ -333,7 +333,7 @@ Flags:
                                  max(rangeSeconds / 250, defaultStep)). This
                                  will not work from Grafana, but Grafana has
                                  __step variable which can be used.
-      --query.lookback-delta=QUERY.LOOKBACK-DELTA  
+      --query.lookback-delta=QUERY.LOOKBACK-DELTA
                                  The maximum lookback duration for retrieving
                                  metrics during expression evaluations. PromQL
                                  always evaluates the query for the certain
@@ -348,10 +348,10 @@ Flags:
                                  it will use the promql default of 5m.
       --query.max-concurrent=20  Maximum number of queries processed
                                  concurrently by query node.
-      --query.max-concurrent-select=4  
+      --query.max-concurrent-select=4
                                  Maximum number of select requests made
                                  concurrently per a query.
-      --query.metadata.default-time-range=0s  
+      --query.metadata.default-time-range=0s
                                  The default metadata time range duration for
                                  retrieving labels through Labels and Series API
                                  when the range parameters are not specified.
@@ -360,24 +360,24 @@ Flags:
       --query.partial-response   Enable partial response for queries if no
                                  partial_response param is specified.
                                  --no-query.partial-response for disabling.
-      --query.replica-label=QUERY.REPLICA-LABEL ...  
+      --query.replica-label=QUERY.REPLICA-LABEL ...
                                  Labels to treat as a replica indicator along
                                  which data is deduplicated. Still you will be
                                  able to query without deduplication using
                                  'dedup=false' parameter. Data includes time
                                  series, recording rules, and alerting rules.
       --query.timeout=2m         Maximum time to process query by query node.
-      --request.logging-config=<content>  
+      --request.logging-config=<content>
                                  Alternative to 'request.logging-config-file'
                                  flag (mutually exclusive). Content of YAML file
                                  with request logging configuration. See format
                                  details:
                                  https://gist.github.com/yashrsharma44/02f5765c5710dd09ce5d14e854f22825
-      --request.logging-config-file=<file-path>  
+      --request.logging-config-file=<file-path>
                                  Path to YAML file with request logging
                                  configuration. See format details:
                                  https://gist.github.com/yashrsharma44/02f5765c5710dd09ce5d14e854f22825
-      --selector-label=<name>="<value>" ...  
+      --selector-label=<name>="<value>" ...
                                  Query selector labels that will be exposed in
                                  info endpoint (repeated).
       --store=<store> ...        Deprecation Warning - This flag is deprecated
@@ -386,35 +386,35 @@ Flags:
                                  (repeatable). The scheme may be prefixed with
                                  'dns+' or 'dnssrv+' to detect store API servers
                                  through respective DNS lookups.
-      --store-strict=<staticstore> ...  
+      --store-strict=<staticstore> ...
                                  Deprecation Warning - This flag is deprecated
                                  and replaced with `endpoint-strict`. Addresses
                                  of only statically configured store API servers
                                  that are always used, even if the health check
                                  fails. Useful if you have a caching layer on
                                  top.
-      --store.response-timeout=0ms  
+      --store.response-timeout=0ms
                                  If a Store doesn't send any data in this
                                  specified duration then a Store will be ignored
                                  and partial data will be returned if it's
                                  enabled. 0 disables timeout.
-      --store.sd-dns-interval=30s  
+      --store.sd-dns-interval=30s
                                  Interval between DNS resolutions.
-      --store.sd-files=<path> ...  
+      --store.sd-files=<path> ...
                                  Path to files that contain addresses of store
                                  API servers. The path can be a glob pattern
                                  (repeatable).
       --store.sd-interval=5m     Refresh interval to re-read file SD files. It
                                  is used as a resync fallback.
-      --store.unhealthy-timeout=5m  
+      --store.unhealthy-timeout=5m
                                  Timeout before an unhealthy store is cleaned
                                  from the store UI page.
-      --tracing.config=<content>  
+      --tracing.config=<content>
                                  Alternative to 'tracing.config-file' flag
                                  (mutually exclusive). Content of YAML file with
                                  tracing configuration. See format details:
                                  https://thanos.io/tip/thanos/tracing.md/#configuration
-      --tracing.config-file=<file-path>  
+      --tracing.config-file=<file-path>
                                  Path to YAML file with tracing configuration.
                                  See format details:
                                  https://thanos.io/tip/thanos/tracing.md/#configuration


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

Using relative link can work when viewing the document inside of the Git
repository, but when viewing on
https://thanos.io/tip/components/query.md/ it returns a 404.

## Verification

<!-- How you tested it? How do you know it works? -->
