### PR TITLE
rule: Added ability to specify multiple remote write targets.

### DIFF
--- a/test/e2e/e2ethanos/services.go
+++ b/test/e2e/e2ethanos/services.go
@@ -551,11 +551,11 @@ func NewTSDBRuler(e e2e.Environment, name, ruleSubDir string, amCfg []alert.Aler
 	return newRuler(e, name, ruleSubDir, amCfg, queryCfg, nil)
 }
 
-func NewStatelessRuler(e e2e.Environment, name, ruleSubDir string, amCfg []alert.AlertmanagerConfig, queryCfg []httpconfig.Config, remoteWriteCfg *config.RemoteWriteConfig) (*e2e.InstrumentedRunnable, error) {
+func NewStatelessRuler(e e2e.Environment, name, ruleSubDir string, amCfg []alert.AlertmanagerConfig, queryCfg []httpconfig.Config, remoteWriteCfg []*config.RemoteWriteConfig) (*e2e.InstrumentedRunnable, error) {
 	return newRuler(e, name, ruleSubDir, amCfg, queryCfg, remoteWriteCfg)
 }
 
-func newRuler(e e2e.Environment, name, ruleSubDir string, amCfg []alert.AlertmanagerConfig, queryCfg []httpconfig.Config, remoteWriteCfg *config.RemoteWriteConfig) (*e2e.InstrumentedRunnable, error) {
+func newRuler(e e2e.Environment, name, ruleSubDir string, amCfg []alert.AlertmanagerConfig, queryCfg []httpconfig.Config, remoteWriteCfg []*config.RemoteWriteConfig) (*e2e.InstrumentedRunnable, error) {
 	dir := filepath.Join(e.SharedDir(), "data", "rule", name)
 	container := filepath.Join(ContainerSharedDir, "data", "rule", name)
 
@@ -592,7 +592,9 @@ func newRuler(e e2e.Environment, name, ruleSubDir string, amCfg []alert.Alertman
 		"--resend-delay":                  "5s",
 	}
 	if remoteWriteCfg != nil {
-		rwCfgBytes, err := yaml.Marshal(remoteWriteCfg)
+		rwCfgBytes, err := yaml.Marshal(struct {
+			RemoteWriteConfigs []*config.RemoteWriteConfig `yaml:"remote_write,omitempty"`
+		}{remoteWriteCfg})
 		if err != nil {
 			return nil, errors.Wrapf(err, "generate remote write config: %v", remoteWriteCfg)
 		}

--- a/test/e2e/rule_test.go
+++ b/test/e2e/rule_test.go
@@ -492,7 +492,12 @@ func TestRule_CanRemoteWriteData(t *testing.T) {
 	testutil.Ok(t, e2e.StartAndWaitReady(receiver))
 	rwURL := mustURLParse(t, e2ethanos.RemoteWriteEndpoint(receiver.InternalEndpoint("remote-write")))
 
-	q, err := e2ethanos.NewQuerierBuilder(e, "1", receiver.InternalEndpoint("grpc")).Build()
+	receiver2, err := e2ethanos.NewIngestingReceiver(e, "2")
+	testutil.Ok(t, err)
+	testutil.Ok(t, e2e.StartAndWaitReady(receiver2))
+	rwURL2 := mustURLParse(t, e2ethanos.RemoteWriteEndpoint(receiver2.InternalEndpoint("remote-write")))
+
+	q, err := e2ethanos.NewQuerierBuilder(e, "1", receiver.InternalEndpoint("grpc"), receiver2.InternalEndpoint("grpc")).Build()
 	testutil.Ok(t, err)
 	testutil.Ok(t, e2e.StartAndWaitReady(q))
 	r, err := e2ethanos.NewStatelessRuler(e, "1", rulesSubDir, []alert.AlertmanagerConfig{
@@ -515,9 +520,9 @@ func TestRule_CanRemoteWriteData(t *testing.T) {
 				Scheme: "http",
 			},
 		},
-	}, &config.RemoteWriteConfig{
-		URL:  &common_cfg.URL{URL: rwURL},
-		Name: "thanos-receiver",
+	}, []*config.RemoteWriteConfig{
+		{URL: &common_cfg.URL{URL: rwURL}, Name: "thanos-receiver"},
+		{URL: &common_cfg.URL{URL: rwURL2}, Name: "thanos-receiver2"},
 	})
 	testutil.Ok(t, err)
 	testutil.Ok(t, e2e.StartAndWaitReady(r))
@@ -534,6 +539,12 @@ func TestRule_CanRemoteWriteData(t *testing.T) {
 				"__name__":  "test_absent_metric",
 				"job":       "thanos-receive",
 				"receive":   "1",
+				"tenant_id": "default-tenant",
+			},
+			{
+				"__name__":  "test_absent_metric",
+				"job":       "thanos-receive",
+				"receive":   "2",
 				"tenant_id": "default-tenant",
 			},
 		})


### PR DESCRIPTION
This is mainly for non surprising remote write YAML format, but also for ability
to add more targets, similar to agent supported model.

Signed-off-by: Bartlomiej Plotka <bwplotka@gmail.com>
