### PR TITLE
objstore/azure: Only create an http client once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#4792](https://github.com/thanos-io/thanos/pull/4792) Store: Fix data race in BucketedBytes pool.
 - [#4769](https://github.com/thanos-io/thanos/pull/4769) Query-frontend+api: add "X-Request-ID" field and other fields to start call log.
 - [#4918](https://github.com/thanos-io/thanos/pull/4918) Tracing: Fixing force tracing with Jaeger.
+- [#4928](https://github.com/thanos-io/thanos/pull/4928) Azure: Only create an http client once, to conserve memory.
 
 ### Changed
 

--- a/pkg/objstore/azure/helpers.go
+++ b/pkg/objstore/azure/helpers.go
@@ -104,6 +104,10 @@ func getContainerURL(ctx context.Context, logger log.Logger, conf Config) (blob.
 		retryOptions.TryTimeout = time.Until(deadline)
 	}
 
+	client := http.Client{
+		Transport: DefaultTransport(conf),
+	}
+
 	p := blob.NewPipeline(credentials, blob.PipelineOptions{
 		Retry:     retryOptions,
 		Telemetry: blob.TelemetryOptions{Value: "Thanos"},
@@ -117,10 +121,6 @@ func getContainerURL(ctx context.Context, logger log.Logger, conf Config) (blob.
 		},
 		HTTPSender: pipeline.FactoryFunc(func(next pipeline.Policy, po *pipeline.PolicyOptions) pipeline.PolicyFunc {
 			return func(ctx context.Context, request pipeline.Request) (pipeline.Response, error) {
-				client := http.Client{
-					Transport: DefaultTransport(conf),
-				}
-
 				resp, err := client.Do(request.WithContext(ctx))
 
 				return pipeline.NewHTTPResponse(resp), err


### PR DESCRIPTION
`getContainerURL` was creating a new `http.Client` within `HTTPSender`.
This increased memory pressure on components making requests to Azure.

Move `http.Client` creation out of `HTTPSender`, only creating it once
per call to `getContainerURL`.

Signed-off-by: Andrew Seigner <andrew@sig.gy>

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

In objstore/azure, move `http.Client` creation out of `HTTPSender`, only creating it once
per call to `getContainerURL`.

## Verification

We observed a 2x~4x memory increase in our alertmanager, compactor, ruler during an upgrade from Cortex [v1.10.0](https://github.com/cortexproject/cortex/blob/v1.10.0/go.mod#L57) to [v1.11.0](https://github.com/cortexproject/cortex/blob/v1.11.0/go.mod#L85), and tracked it down to a change in `getContainerURL`.

Memory usage of alertmanager, compactor, ruler with Cortex [v1.10.0](https://github.com/cortexproject/cortex/blob/v1.10.0/go.mod#L57), [v1.11.0](https://github.com/cortexproject/cortex/blob/v1.11.0/go.mod#L85), and this PR:

<img width="1425" alt="thanos mem fix" src="https://user-images.githubusercontent.com/236915/145092487-2d832d36-699b-4a37-9e3a-e4cd502817b1.png">


