### PR TITLE
resolver: Improve logs when A record does not resolve from SRV record set

### DIFF
--- a/pkg/discovery/dns/resolver.go
+++ b/pkg/discovery/dns/resolver.go
@@ -118,7 +118,7 @@ func (s *dnsSD) Resolve(ctx context.Context, name string, qtype QType) ([]string
 					return nil, errors.Wrapf(err, "lookup IP addresses %q", host)
 				}
 				if len(resIPs) == 0 {
-					level.Error(s.logger).Log("msg", "failed to lookup IP addresses", "host", host, "err", err)
+					level.Error(s.logger).Log("msg", "failed to lookup IP addresses", "srv", host, "a", rec.Target, "err", err)
 				}
 			}
 			for _, resIP := range resIPs {


### PR DESCRIPTION
* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

- I've improved the log when an A record of part of a SRV record fails to resolve to include which A record did not resolve.

## Verification

- None, this feels fairly low risk.

## Other

I'm hoping this is fairly uncontroversial, but happy to take advice on naming. I didn't think this was worth raising an issue about, but we've had problems where A records didn't resolve as part of a SRV record and only outputting the SRV record in the log.