### PR TITLE
sidecar: not ready when Prometheus is unavailable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 
 ### Changed
 
+- [#4939](https://github.com/thanos-io/thanos/pull/4939) Sidecar: set Sidecar to NOT READY when it cannot establish a connection with Prometheus
 - [#4864](https://github.com/thanos-io/thanos/pull/4864) UI: Remove the old PromQL editor
 
 ## [v0.23.1](https://github.com/thanos-io/thanos/tree/release-0.23) - 2021.10.1

--- a/cmd/thanos/sidecar.go
+++ b/cmd/thanos/sidecar.go
@@ -223,8 +223,10 @@ func runSidecar(
 				if err := m.UpdateLabels(iterCtx); err != nil {
 					level.Warn(logger).Log("msg", "heartbeat failed", "err", err)
 					promUp.Set(0)
+					statusProber.NotReady(err)
 				} else {
 					promUp.Set(1)
+					statusProber.Ready()
 				}
 
 				return nil


### PR DESCRIPTION
## Changes

Set Sidecar to not be ready when Prometheus is unavailable. This avoids
problems when Prometheus is replaying WAL and Sidecar is "up" but then
Query hangs while waiting for a response from Prometheus/Sidecar. Also,
it gets shown as UP in the Stores page with no ext. labels during this
time that is confusing.


* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Verification

Improved e2e tests which pass.
