### PR TITLE
Tracing: add `traceid_128bit` support for jaeger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#4897](https://github.com/thanos-io/thanos/pull/4897) Querier: Add validation for querier address flags.
 - [#4903](https://github.com/thanos-io/thanos/pull/4903) Compactor: Added tracing support for compaction.
 - [#4909](https://github.com/thanos-io/thanos/pull/4909) Compactor: Add flag --max-time / --min-time to filter blocks that are ready to be compacted.
+- [#4942](https://github.com/thanos-io/thanos/pull/4942) Tracing: add `traceid_128bit` support for jaeger.
 
 ### Fixed
 

--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -94,6 +94,7 @@ config:
   password: ""
   agent_host: ""
   agent_port: 0
+  traceid_128bit: false
 ```
 
 ### Stackdriver

--- a/pkg/tracing/jaeger/config_yaml.go
+++ b/pkg/tracing/jaeger/config_yaml.go
@@ -37,6 +37,7 @@ type Config struct {
 	Password               string        `yaml:"password"`
 	AgentHost              string        `yaml:"agent_host"`
 	AgentPort              int           `yaml:"agent_port"`
+	Gen128Bit              bool          `yaml:"traceid_128bit"`
 }
 
 // ParseConfigFromYaml uses config YAML to set the tracer's Configuration.
@@ -55,6 +56,10 @@ func ParseConfigFromYaml(cfg []byte) (*config.Configuration, error) {
 
 	if conf.RPCMetrics {
 		c.RPCMetrics = conf.RPCMetrics
+	}
+
+	if conf.Gen128Bit {
+		c.Gen128Bit = conf.Gen128Bit
 	}
 
 	if conf.Disabled {


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->
The OpenTelemetry jaegerreceiver always write 128bit traceID to backend https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.41.0/pkg/translator/jaeger/jaegerthrift_to_traces.go#L95 , with leading zero. 
like '00000000000000007aeab04b2badb0bd',  but jaeger query will parse it to 64bit traceid to search https://github.com/jaegertracing/jaeger/blob/main/model/ids.go#L51.
One of solution is make jaeger client use 1238bit traceID.
 
<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

1. add `traceid_128bit` field to tracing config, align to same field in  jaeger config .
## Verification

<!-- How you tested it? How do you know it works? -->
