### PR TITLE
Add custom certificate CA support for s3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#4942](https://github.com/thanos-io/thanos/pull/4942) Tracing: add `traceid_128bit` support for jaeger.
 - [#4917](https://github.com/thanos-io/thanos/pull/4917) Query: add initial query pushdown for a subset of aggregations. Can be enabled with `--enable-feature=query-pushdown` on Thanos Query.
 - [#4888](https://github.com/thanos-io/thanos/pull/4888) Cache: support redis cache backend.
+- [#4946](https://github.com/thanos-io/thanos/pull/4946) Store: Support tls_config configuration for the s3 minio client.
 
 ### Fixed
 

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -74,17 +74,17 @@ config:
     idle_conn_timeout: 1m30s
     response_header_timeout: 2m
     insecure_skip_verify: false
-    tls_config:
-      ca_file: /certs/ca.crt
-      cert_file: /certs/cert.crt
-      key_file: /certs/key.key
-      server_name: server
-      insecure_skip_verify: false
     tls_handshake_timeout: 10s
     expect_continue_timeout: 1s
     max_idle_conns: 100
     max_idle_conns_per_host: 100
     max_conns_per_host: 0
+    tls_config:
+      ca_file: ""
+      cert_file: ""
+      key_file: ""
+      server_name: ""
+      insecure_skip_verify: false
   trace:
     enable: false
   list_objects_version: ""

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -74,6 +74,12 @@ config:
     idle_conn_timeout: 1m30s
     response_header_timeout: 2m
     insecure_skip_verify: false
+    tls_config:
+      ca_file: /certs/ca.crt
+      cert_file: /certs/cert.crt
+      key_file: /certs/key.key
+      server_name: server
+      insecure_skip_verify: false
     tls_handshake_timeout: 10s
     expect_continue_timeout: 1s
     max_idle_conns: 100
@@ -104,6 +110,8 @@ Please refer to the documentation of [the Transport type](https://golang.org/pkg
 `part_size` is specified in bytes and refers to the minimum file size used for multipart uploads, as some custom S3 implementations may have different requirements. A value of `0` means to use a default 128 MiB size.
 
 Set `list_objects_version: "v1"` for S3 compatible APIs that don't support ListObjectsV2 (e.g. some versions of Ceph). Default value (`""`) is equivalent to `"v2"`.
+
+`http_config.tls_config` allows configuring TLS connections. Please refer to the document of [tls_config](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#tls_config) for detailed information on what each option does.
 
 For debug and testing purposes you can set
 

--- a/pkg/objstore/s3/s3.go
+++ b/pkg/objstore/s3/s3.go
@@ -6,7 +6,6 @@ package s3
 
 import (
 	"context"
-	"crypto/tls"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -25,6 +24,7 @@ import (
 	"github.com/minio/minio-go/v7/pkg/credentials"
 	"github.com/minio/minio-go/v7/pkg/encrypt"
 	"github.com/pkg/errors"
+	commoncfg "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/common/version"
 	"gopkg.in/yaml.v2"
@@ -117,13 +117,24 @@ type HTTPConfig struct {
 
 	// Allow upstream callers to inject a round tripper
 	Transport http.RoundTripper `yaml:"-"`
+
+	TLSConfig commoncfg.TLSConfig `yaml:"tls_config,omitempty"`
 }
 
 // DefaultTransport - this default transport is based on the Minio
 // DefaultTransport up until the following commit:
 // https://github.com/minio/minio-go/commit/008c7aa71fc17e11bf980c209a4f8c4d687fc884
 // The values have since diverged.
-func DefaultTransport(config Config) *http.Transport {
+func DefaultTransport(config Config) (*http.Transport, error) {
+	tlsConfig, err := commoncfg.NewTLSConfig(&config.HTTPConfig.TLSConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	if config.HTTPConfig.InsecureSkipVerify {
+		tlsConfig.InsecureSkipVerify = true
+	}
+
 	return &http.Transport{
 		Proxy: http.ProxyFromEnvironment,
 		DialContext: (&net.Dialer{
@@ -148,8 +159,8 @@ func DefaultTransport(config Config) *http.Transport {
 		//
 		// Refer: https://golang.org/src/net/http/transport.go?h=roundTrip#L1843.
 		DisableCompression: true,
-		TLSClientConfig:    &tls.Config{InsecureSkipVerify: config.HTTPConfig.InsecureSkipVerify},
-	}
+		TLSClientConfig:    tlsConfig,
+	}, nil
 }
 
 // Bucket implements the store.Bucket interface against s3-compatible APIs.
@@ -241,7 +252,11 @@ func NewBucketWithConfig(logger log.Logger, config Config, component string) (*B
 	if config.HTTPConfig.Transport != nil {
 		rt = config.HTTPConfig.Transport
 	} else {
-		rt = DefaultTransport(config)
+		var err error
+		rt, err = DefaultTransport(config)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	client, err := minio.New(config.Endpoint, &minio.Options{

--- a/pkg/objstore/s3/s3.go
+++ b/pkg/objstore/s3/s3.go
@@ -6,6 +6,8 @@ package s3
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -24,7 +26,6 @@ import (
 	"github.com/minio/minio-go/v7/pkg/credentials"
 	"github.com/minio/minio-go/v7/pkg/encrypt"
 	"github.com/pkg/errors"
-	commoncfg "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/common/version"
 	"gopkg.in/yaml.v2"
@@ -118,7 +119,83 @@ type HTTPConfig struct {
 	// Allow upstream callers to inject a round tripper
 	Transport http.RoundTripper `yaml:"-"`
 
-	TLSConfig commoncfg.TLSConfig `yaml:"tls_config,omitempty"`
+	TLSConfig TLSConfig `yaml:"tls_config"`
+}
+
+// NewTLSConfig creates a new tls.Config from the given TLSConfig.
+func NewTLSConfig(cfg *TLSConfig) (*tls.Config, error) {
+	tlsConfig := &tls.Config{InsecureSkipVerify: cfg.InsecureSkipVerify}
+
+	// If a CA cert is provided then let's read it in.
+	if len(cfg.CAFile) > 0 {
+		b, err := readCAFile(cfg.CAFile)
+		if err != nil {
+			return nil, err
+		}
+		if !updateRootCA(tlsConfig, b) {
+			return nil, fmt.Errorf("unable to use specified CA cert %s", cfg.CAFile)
+		}
+	}
+
+	if len(cfg.ServerName) > 0 {
+		tlsConfig.ServerName = cfg.ServerName
+	}
+	// If a client cert & key is provided then configure TLS config accordingly.
+	if len(cfg.CertFile) > 0 && len(cfg.KeyFile) == 0 {
+		return nil, fmt.Errorf("client cert file %q specified without client key file", cfg.CertFile)
+	} else if len(cfg.KeyFile) > 0 && len(cfg.CertFile) == 0 {
+		return nil, fmt.Errorf("client key file %q specified without client cert file", cfg.KeyFile)
+	} else if len(cfg.CertFile) > 0 && len(cfg.KeyFile) > 0 {
+		// Verify that client cert and key are valid.
+		if _, err := cfg.getClientCertificate(nil); err != nil {
+			return nil, err
+		}
+		tlsConfig.GetClientCertificate = cfg.getClientCertificate
+	}
+
+	return tlsConfig, nil
+}
+
+// readCAFile reads the CA cert file from disk.
+func readCAFile(f string) ([]byte, error) {
+	data, err := ioutil.ReadFile(f)
+	if err != nil {
+		return nil, fmt.Errorf("unable to load specified CA cert %s: %s", f, err)
+	}
+	return data, nil
+}
+
+// updateRootCA parses the given byte slice as a series of PEM encoded certificates and updates tls.Config.RootCAs.
+func updateRootCA(cfg *tls.Config, b []byte) bool {
+	caCertPool := x509.NewCertPool()
+	if !caCertPool.AppendCertsFromPEM(b) {
+		return false
+	}
+	cfg.RootCAs = caCertPool
+	return true
+}
+
+// getClientCertificate reads the pair of client cert and key from disk and returns a tls.Certificate.
+func (c *TLSConfig) getClientCertificate(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
+	cert, err := tls.LoadX509KeyPair(c.CertFile, c.KeyFile)
+	if err != nil {
+		return nil, fmt.Errorf("unable to use specified client cert (%s) & key (%s): %s", c.CertFile, c.KeyFile, err)
+	}
+	return &cert, nil
+}
+
+// TLSConfig configures the options for TLS connections.
+type TLSConfig struct {
+	// The CA cert to use for the targets.
+	CAFile string `yaml:"ca_file"`
+	// The client cert file for the targets.
+	CertFile string `yaml:"cert_file"`
+	// The client key file for the targets.
+	KeyFile string `yaml:"key_file"`
+	// Used to verify the hostname for the targets.
+	ServerName string `yaml:"server_name"`
+	// Disable target certificate validation.
+	InsecureSkipVerify bool `yaml:"insecure_skip_verify"`
 }
 
 // DefaultTransport - this default transport is based on the Minio
@@ -126,7 +203,7 @@ type HTTPConfig struct {
 // https://github.com/minio/minio-go/commit/008c7aa71fc17e11bf980c209a4f8c4d687fc884
 // The values have since diverged.
 func DefaultTransport(config Config) (*http.Transport, error) {
-	tlsConfig, err := commoncfg.NewTLSConfig(&config.HTTPConfig.TLSConfig)
+	tlsConfig, err := NewTLSConfig(&config.HTTPConfig.TLSConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/objstore/s3/s3_test.go
+++ b/pkg/objstore/s3/s3_test.go
@@ -177,29 +177,11 @@ http_config:
 	cfg, err := parseConfig(input)
 	testutil.Ok(t, err)
 
-	if cfg.HTTPConfig.TLSConfig.CAFile != "/certs/ca.crt" {
-		t.Errorf("parsing of ca_file failed: got %v, expected %v",
-			cfg.HTTPConfig.TLSConfig.CAFile, "/certs/ca.crt")
-	}
-
-	if cfg.HTTPConfig.TLSConfig.CertFile != "/certs/cert.crt" {
-		t.Errorf("parsing of cert_file failed: got %v, expected %v",
-			cfg.HTTPConfig.TLSConfig.CertFile, "/certs/cert.crt")
-	}
-
-	if cfg.HTTPConfig.TLSConfig.KeyFile != "/certs/key.key" {
-		t.Errorf("parsing of key_file failed: got %v, expected %v",
-			cfg.HTTPConfig.TLSConfig.KeyFile, "/certs/key.key")
-	}
-
-	if cfg.HTTPConfig.TLSConfig.ServerName != "server" {
-		t.Errorf("parsing of server_name failed: got %v, expected %v",
-			cfg.HTTPConfig.TLSConfig.ServerName, "server")
-	}
-
-	if cfg.HTTPConfig.TLSConfig.InsecureSkipVerify {
-		t.Errorf("parsing of insecure_skip_verify failed: got %v, expected %v", cfg.HTTPConfig.InsecureSkipVerify, false)
-	}
+	testutil.Equals(t, "/certs/ca.crt", cfg.HTTPConfig.TLSConfig.CAFile)
+	testutil.Equals(t, "/certs/cert.crt", cfg.HTTPConfig.TLSConfig.CertFile)
+	testutil.Equals(t, "/certs/key.key", cfg.HTTPConfig.TLSConfig.KeyFile)
+	testutil.Equals(t, "server", cfg.HTTPConfig.TLSConfig.ServerName)
+	testutil.Equals(t, false, cfg.HTTPConfig.TLSConfig.InsecureSkipVerify)
 }
 
 func TestParseConfig_CustomLegacyInsecureSkipVerify(t *testing.T) {
@@ -214,10 +196,7 @@ http_config:
 	testutil.Ok(t, err)
 	transport, err := DefaultTransport(cfg)
 	testutil.Ok(t, err)
-
-	if !transport.TLSClientConfig.InsecureSkipVerify {
-		t.Errorf("parsing of insecure_skip_verify failed: got %v, expected %v", transport.TLSClientConfig.InsecureSkipVerify, true)
-	}
+	testutil.Equals(t, true, transport.TLSClientConfig.InsecureSkipVerify)
 }
 
 func TestValidate_OK(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: clyang82 <chuyang@redhat.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

use prometheus common tls_config to connect with s3 object store so that we can pass the certificate in.

part of thanos-io/thanos#4820

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
