### PR TITLE
logging: Allow request logging config to determine log level

### DIFF
--- a/pkg/logging/options.go
+++ b/pkg/logging/options.go
@@ -6,6 +6,7 @@ package logging
 import (
 	"fmt"
 	"math/rand"
+	"strings"
 	"time"
 
 	extflag "github.com/efficientgo/tools/extkingpin"
@@ -69,6 +70,12 @@ func WithFilter(f FilterLogging) Option {
 	}
 }
 
+func WithLevelledLogger(f LevelledLogging) Option {
+	return func(o *options) {
+		o.levelledLogger = f
+	}
+}
+
 // Interface for the additional methods.
 
 // Types for the Options.
@@ -104,6 +111,9 @@ type DurationToFields func(duration time.Duration) Fields
 // FilterLogging makes sure only the logs with level=lvl gets logged, or filtered.
 type FilterLogging func(logger log.Logger) log.Logger
 
+// LevelledLogging configures the logger to log at a specified level.
+type LevelledLogging func(logger log.Logger) log.Logger
+
 // DefaultFilterLogging allows logs from all levels to be logged in output.
 func DefaultFilterLogging(logger log.Logger) log.Logger {
 	return level.NewFilter(logger, level.AllowAll())
@@ -115,6 +125,7 @@ type options struct {
 	codeFunc          ErrorToCode
 	durationFieldFunc DurationToFields
 	filterLog         FilterLogging
+	levelledLogger    LevelledLogging
 }
 
 // DefaultCodeToLevel is the helper mapper that maps HTTP Response codes to log levels.
@@ -123,6 +134,21 @@ func DefaultCodeToLevel(logger log.Logger, code int) log.Logger {
 		return level.Debug(logger)
 	}
 	return level.Error(logger)
+}
+
+func DefaultLevelledLogger(logger log.Logger, lvl string) log.Logger {
+	switch strings.ToUpper(lvl) {
+	case "INFO":
+		return level.Info(logger)
+	case "DEBUG":
+		return level.Debug(logger)
+	case "WARN":
+		return level.Warn(logger)
+	case "ERROR":
+		return level.Error(logger)
+	default:
+		return level.Debug(logger)
+	}
 }
 
 // DefaultCodeToLevelGRPC is the helper mapper that maps gRPC Response codes to log levels.


### PR DESCRIPTION
Perhaps I am misunderstanding the original intentions, but the request logging configuration seems overly complicated.

I started working on documenting the config in https://github.com/thanos-io/thanos/pull/4934 and there are some comments there, but overall I find the config is unclear.

This PR changes the implementation slightly, since my take is that if I have gone to the trouble of configuring request logging, all I want to do is specify at what level I believe that should be output and have that determined by the ` --log.level`

This change allows the 'level' config in request logging 'options'
to determine the output level for those logs.

Prior to this, without setting --log.level flag on the component
to debug, no logs were emitted.

With this implementation, I think it would make sense to restrict the logging options to one of `debug`, `info`

If this approach seems reasonable to the maintainers we would need to tackle gRPC in similar fashion.

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
