### PR TITLE
*: Update BusyBox image sha

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,9 +12,9 @@ arch = $(shell uname -m)
 # just visit https://quay.io/repository/prometheus/busybox?tag=latest&tab=tags.
 # TODO(bwplotka): https://github.com/thanos-io/thanos/issues/4949
 # Pinning is important but somehow quay kills the old images, so make sure to update regularly.
-# Update at 2021.12.14
-AMD64_SHA="c05b6700b0cab2e59ee0ff8d8d72eb0bb324f50732b87742e9a6024322ee83a1"
-ARM64_SHA="bcdd37d8cf48c8740b5ccb8fee5c5d36badaae112d34fd92be4723eb36c9cd5d"
+# Update at 2021.12.15
+AMD64_SHA="2548dd93c438f7cf8b68dc2ff140189d9bcdae7130d3941524becc31573ec9e3"
+ARM64_SHA="768a51a5f71827471e6e58f0d6200c2fa24f2cb5cde1ecbd67fe28f93d4ef464"
 
 ifeq ($(arch), x86_64)
     # amd64


### PR DESCRIPTION
Signed-off-by: Matej Gera <matejgera@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [X] Change is not relevant to the end user.

## Changes

It seems like recent changes to Prometheus BusyBox image have been reverted (https://github.com/prometheus/busybox/pull/47) and the SHA of the images changed again - E2E tests are currently not passing because of this. This PR updates the images' SHA again.

## Verification
 
Waiting on green CI :tumbler_glass: 
