### PR TITLE
Remove flaky behavior in Thanos Query Frontend with a temporary fix

### DIFF
--- a/test/e2e/query_frontend_test.go
+++ b/test/e2e/query_frontend_test.go
@@ -387,12 +387,12 @@ func TestQueryFrontend(t *testing.T) {
 	})
 }
 
-// (Wiard) Query splitting behaviour is somewhat non-deterministric, due to the fact that we use a literal timestamp.FromTime(now.Add(-time.Hour).
+// (Wiard) Query splitting behavior is somewhat non-deterministric, due to the fact that we use a literal timestamp.FromTime(now.Add(-time.Hour).
 // If the start and end time falls between a new day (passed 23:59), it will see this as '24h' (default --query-range.split-interval).
 // My guess is that certain behavior has an underlying bug or that I'm a lost in the complexity.
 // It will need to double the testing values if the hour is "1" for thanos_frontend_split_queries_total and cortex_cache_*
 // However, only thanos_frontend_split_queries_total will need to double its value on hour 0. cortex_cache_*'s do not.
-// This test needs to be fixed properly and possibly requires more debugging, especially on the non-logical behaviour (or more documentation is required).
+// This test needs to be fixed properly and possibly requires more debugging, especially on the non-logical behavior (or more documentation is required).
 // https://github.com/thanos-io/thanos/issues/3570 - however, for now it won't fail tests if ran between hour 0 and 1.
 func doubleValueIfSplit(n float64, whenPartialOvernight bool) float64 {
 

--- a/test/e2e/query_frontend_test.go
+++ b/test/e2e/query_frontend_test.go
@@ -391,7 +391,7 @@ func TestQueryFrontend(t *testing.T) {
 // "The query splitting test case is flaky because we are using the current timestamp to send queries, which makes the splitting behavior non-deterministic"
 // (Wiard)
 // This should be resolved in a much better way, but for now it removes the flakyness.
-func DidItSplitValue(n float64, nightSwitch bool) float64 {
+func didItSplitValue(n float64, nightSwitch bool) float64 {
 
 	currentTime := time.Now()
 
@@ -497,13 +497,13 @@ func TestQueryFrontendMemcachedCache(t *testing.T) {
 
 	// https://github.com/thanos-io/thanos/issues/3570
 	// "The query splitting test case is flaky because we are using the current timestamp to send queries, which makes the splitting behavior non-deterministic"
-	testutil.Ok(t, queryFrontend.WaitSumMetrics(e2e.Equals(DidItSplitValue(1, true)), "cortex_cache_fetched_keys"))
+	testutil.Ok(t, queryFrontend.WaitSumMetrics(e2e.Equals(didItSplitValue(1, true)), "cortex_cache_fetched_keys"))
 
 	testutil.Ok(t, queryFrontend.WaitSumMetrics(e2e.Equals(0), "cortex_cache_hits"))
 
 	// https://github.com/thanos-io/thanos/issues/3570
 	// "The query splitting test case is flaky because we are using the current timestamp to send queries, which makes the splitting behavior non-deterministic"
-	testutil.Ok(t, queryFrontend.WaitSumMetrics(e2e.Equals(DidItSplitValue(1, false)), "thanos_frontend_split_queries_total"))
+	testutil.Ok(t, queryFrontend.WaitSumMetrics(e2e.Equals(didItSplitValue(1, false)), "thanos_frontend_split_queries_total"))
 
 	// Run the same range query again, the result can be retrieved from cache directly.
 	rangeQuery(
@@ -531,8 +531,8 @@ func TestQueryFrontendMemcachedCache(t *testing.T) {
 
 	// https://github.com/thanos-io/thanos/issues/3570
 	// "The query splitting test case is flaky because we are using the current timestamp to send queries, which makes the splitting behavior non-deterministic"
-	testutil.Ok(t, queryFrontend.WaitSumMetrics(e2e.Equals(DidItSplitValue(2, false)), "thanos_frontend_split_queries_total"))
+	testutil.Ok(t, queryFrontend.WaitSumMetrics(e2e.Equals(didItSplitValue(2, false)), "thanos_frontend_split_queries_total"))
 
-	testutil.Ok(t, queryFrontend.WaitSumMetrics(e2e.Equals(DidItSplitValue(2, true)), "cortex_cache_fetched_keys"))
-	testutil.Ok(t, queryFrontend.WaitSumMetrics(e2e.Equals(DidItSplitValue(1, true)), "cortex_cache_hits"))
+	testutil.Ok(t, queryFrontend.WaitSumMetrics(e2e.Equals(didItSplitValue(2, true)), "cortex_cache_fetched_keys"))
+	testutil.Ok(t, queryFrontend.WaitSumMetrics(e2e.Equals(didItSplitValue(1, true)), "cortex_cache_hits"))
 }


### PR DESCRIPTION
Signed-off-by: Wiard van Rij <wiard@outlook.com>

Relates to https://github.com/thanos-io/thanos/issues/3570

I was killing myself on why this was happening and it hit me as it became night. Since it was already a long standing issue and I had no clue on how to properly fix it: tada. Here we are.

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

Well, apparently (correct me if I'm wrong), queries are split by default of 24h. However if you do a query with a 'now' timestamp this 24h can already become 'true' if it passes the 00:00 (or 24:00, depending on how you look at it) mark. 

## Verification

Ran these tests locally and manually changing my time from 23:xx to 01:xx to 02:00 and it works on all cases. 