### PR TITLE
objectstore/cos: add `endpoint` field for config vpc internal endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#4888](https://github.com/thanos-io/thanos/pull/4888) Cache: support redis cache backend.
 - [#4946](https://github.com/thanos-io/thanos/pull/4946) Store: Support tls_config configuration for the s3 minio client.
 - [#4974](https://github.com/thanos-io/thanos/pull/4974) Store: Support tls_config configuration for connecting with Azure storage.
+- [#4999](https://github.com/thanos-io/thanos/pull/4999) COS: Support `endpoint` configuration for vpc internal endpoint.
 
 ### Fixed
 

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -405,6 +405,7 @@ To configure Tencent Account to use COS as storage store you need to set these p
 type: COS
 config:
   bucket: ""
+  endpoint: ""
   region: ""
   app_id: ""
   secret_key: ""
@@ -419,6 +420,12 @@ config:
     max_conns_per_host: 0
 ```
 
+The `secret_key` and `secret_id` field is required.
+The `http_config` field is optional for optimize HTTP transport settings.
+There are two ways to configure the required bucket information:
+  1. Provide the values of `bucket`, `region` and `app_id` keys.
+  2. Provide the values of `endpoint` key with url format when you want to specific vpc internal endpoint. Please refer to the document of [endpoint](https://intl.cloud.tencent.com/document/product/436/6224) for more detail.
+  
 Set the flags `--objstore.config-file` to reference to the configuration file.
 
 #### AliYun OSS

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -422,7 +422,7 @@ config:
 
 The `secret_key` and `secret_id` field is required. The `http_config` field is optional for optimize HTTP transport settings. There are two ways to configure the required bucket information:
 1. Provide the values of `bucket`, `region` and `app_id` keys.
-2. Provide the values of `endpoint` key with url format when you want to specific vpc internal endpoint. Please refer to the document of [endpoint](https://intl.cloud.tencent.com/document/product/436/6224) for more detail.
+2. Provide the values of `endpoint` key with url format when you want to specify vpc internal endpoint. Please refer to the document of [endpoint](https://intl.cloud.tencent.com/document/product/436/6224) for more detail.
 
 Set the flags `--objstore.config-file` to reference to the configuration file.
 

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -405,9 +405,9 @@ To configure Tencent Account to use COS as storage store you need to set these p
 type: COS
 config:
   bucket: ""
-  endpoint: ""
   region: ""
   app_id: ""
+  endpoint: ""
   secret_key: ""
   secret_id: ""
   http_config:
@@ -420,12 +420,10 @@ config:
     max_conns_per_host: 0
 ```
 
-The `secret_key` and `secret_id` field is required.
-The `http_config` field is optional for optimize HTTP transport settings.
-There are two ways to configure the required bucket information:
-  1. Provide the values of `bucket`, `region` and `app_id` keys.
-  2. Provide the values of `endpoint` key with url format when you want to specific vpc internal endpoint. Please refer to the document of [endpoint](https://intl.cloud.tencent.com/document/product/436/6224) for more detail.
-  
+The `secret_key` and `secret_id` field is required. The `http_config` field is optional for optimize HTTP transport settings. There are two ways to configure the required bucket information:
+1. Provide the values of `bucket`, `region` and `app_id` keys.
+2. Provide the values of `endpoint` key with url format when you want to specific vpc internal endpoint. Please refer to the document of [endpoint](https://intl.cloud.tencent.com/document/product/436/6224) for more detail.
+
 Set the flags `--objstore.config-file` to reference to the configuration file.
 
 #### AliYun OSS

--- a/pkg/objstore/cos/cos_test.go
+++ b/pkg/objstore/cos/cos_test.go
@@ -62,3 +62,76 @@ http_config:
 		})
 	}
 }
+
+func TestConfig_validate(t *testing.T) {
+	type fields struct {
+		Bucket     string
+		Region     string
+		AppId      string
+		Endpoint   string
+		SecretKey  string
+		SecretId   string
+		HTTPConfig HTTPConfig
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		wantErr bool
+	}{
+		{
+			name: "ok endpoint",
+			fields: fields{
+				Endpoint:  "http://bucket-123.cos.ap-beijing.myqcloud.com",
+				SecretId:  "sid",
+				SecretKey: "skey",
+			},
+			wantErr: false,
+		},
+		{
+			name: "ok bucket-appid-region",
+			fields: fields{
+				Bucket:    "bucket",
+				AppId:     "123",
+				Region:    "ap-beijing",
+				SecretId:  "sid",
+				SecretKey: "skey",
+			},
+			wantErr: false,
+		},
+		{
+			name: "missing skey",
+			fields: fields{
+				Bucket: "bucket",
+				AppId:  "123",
+				Region: "ap-beijing",
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing bucket",
+			fields: fields{
+				AppId:     "123",
+				Region:    "ap-beijing",
+				SecretId:  "sid",
+				SecretKey: "skey",
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conf := &Config{
+				Bucket:     tt.fields.Bucket,
+				Region:     tt.fields.Region,
+				AppId:      tt.fields.AppId,
+				Endpoint:   tt.fields.Endpoint,
+				SecretKey:  tt.fields.SecretKey,
+				SecretId:   tt.fields.SecretId,
+				HTTPConfig: tt.fields.HTTPConfig,
+			}
+			if err := conf.validate(); (err != nil) != tt.wantErr {
+				t.Errorf("validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: Jimmie Han <hanjinming@outlook.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

1.  Add `endpoint` field to COS object store config.
2. Add document and validate test.
## Verification

<!-- How you tested it? How do you know it works? -->
1. Unit test.
2. Real depoyment test.