### PR TITLE
Increase indexheader_lazy_load_duration_seconds buckets

### DIFF
--- a/pkg/block/indexheader/lazy_binary_reader.go
+++ b/pkg/block/indexheader/lazy_binary_reader.go
@@ -59,7 +59,7 @@ func NewLazyBinaryReaderMetrics(reg prometheus.Registerer) *LazyBinaryReaderMetr
 		loadDuration: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
 			Name:    "indexheader_lazy_load_duration_seconds",
 			Help:    "Duration of the index-header lazy loading in seconds.",
-			Buckets: []float64{0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1, 2, 5},
+			Buckets: []float64{0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1, 2, 5, 15, 30, 60, 120, 300},
 		}),
 	}
 }


### PR DESCRIPTION
* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

In Cortex we've noticed that the 99th percentile computed on`indexheader_lazy_load_duration_seconds` is always capped to 5s even if the average can be way higher. Reason is that the largest histogram bucket is 5s but lazy loading can take way longer than that (mostly depending on index size and the disk speed).

In this PR I proposes to add more buckets to the metric, to have a better estimation of 99th percentile on high durations.

> Change is not relevant to the end user.

Is it? Do you track such changes in CHANGELOG?

## Verification

N/A
