### PR TITLE
query: set default times for query_exemplars API

### DIFF
--- a/pkg/api/query/v1.go
+++ b/pkg/api/query/v1.go
@@ -28,7 +28,6 @@ import (
 	"strings"
 	"time"
 
-	cortexutil "github.com/cortexproject/cortex/pkg/util"
 	"github.com/go-kit/log"
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
@@ -821,18 +820,18 @@ func NewExemplarsHandler(client exemplars.UnaryClient, enablePartialResponse boo
 			err      error
 		)
 
-		start, err := cortexutil.ParseTime(r.FormValue("start"))
+		start, err := parseTimeParam(r, "start", infMinTime)
 		if err != nil {
 			return nil, nil, &api.ApiError{Typ: api.ErrorBadData, Err: err}
 		}
-		end, err := cortexutil.ParseTime(r.FormValue("end"))
+		end, err := parseTimeParam(r, "end", infMaxTime)
 		if err != nil {
 			return nil, nil, &api.ApiError{Typ: api.ErrorBadData, Err: err}
 		}
 
 		req := &exemplarspb.ExemplarsRequest{
-			Start:                   start,
-			End:                     end,
+			Start:                   timestamp.FromTime(start),
+			End:                     timestamp.FromTime(end),
 			Query:                   r.FormValue("query"),
 			PartialResponseStrategy: ps,
 		}


### PR DESCRIPTION
Signed-off-by: Paul Grave <paul@stomer.net>

## Changes

Fixes #5011 

I replaced calls to `cortexutil.ParseTime` with `parseTimeParam` in `NewExemplarsHandler` since the later allows default times to be set.
I removed the `cortexutil` since the above change made it redundant.

The impact is that this behaviour mirrors Prometheus’ behaviour and allows exemplars to be displayed in Grafana.

## Verification

I effected some functional tests. I ran my own container (paulgrave/thanos:0.24.1) on my cluster and validated that exemplars are now displayed in Grafana.
Executed `curl -v -d query=test http://localhost:10902/api/v1/query_exemplars` to validate that a) API doesn’t error b) returns a 200 instead of a 400.
Executed `curl -v -d query='my_requests_total{app="prom-py"}' -d start=1640770731.689 -d end=(date +%s)   http://localhost:10902/api/v1/query_exemplars | jq` to validate that exemplars are indeed returned like before.
Thanos is running as expected on my local cluster.

Unfortunately `make lint` and `make test` are broken on my M1 Mac.
