### PR TITLE
store: close bkt properly

### DIFF
--- a/cmd/thanos/store.go
+++ b/cmd/thanos/store.go
@@ -278,17 +278,6 @@ func runStore(
 		return errors.Wrap(err, "get content of index cache configuration")
 	}
 
-	// Ensure we close up everything properly.
-	{
-		done := make(chan struct{})
-		g.Add(func() error {
-			<-done
-			return bkt.Close()
-		}, func(error) {
-			close(done)
-		})
-	}
-
 	// Create the index cache loading its config from config file, while keeping
 	// backward compatibility with the pre-config file era.
 	var indexCache storecache.IndexCache


### PR DESCRIPTION
Just a small fix: add bkt closing to the run group instead of closing it
at the of the function that only sets things up. In practice, this
didn't cause a bug because Close() is a noop. But as good Go
programmers, let's Close() the bucket properly at the end of Thanos
Store's lifetime.

