### PR TITLE
*: Fix docker-build target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -182,13 +182,12 @@ docker-multi-stage:
 	@echo ">> building docker image 'thanos' with Dockerfile.multi-stage"
 	@docker build -f Dockerfile.multi-stage -t "thanos" --build-arg BASE_DOCKER_SHA=$(BASE_DOCKER_SHA) .
 
-GET_SHA = $(shell echo '$1'_SHA | tr '[:lower:]' '[:upper:]')
 # docker-build builds docker images with multiple architectures.
 .PHONY: docker-build $(BUILD_DOCKER_ARCHS)
 docker-build: $(BUILD_DOCKER_ARCHS)
 $(BUILD_DOCKER_ARCHS): docker-build-%:
 	@docker build -t "thanos-linux-$*" \
-  --build-arg BASE_DOCKER_SHA=$($(call GET_SHA,$*)) \
+  --build-arg BASE_DOCKER_SHA=$($(shell echo '$*')) \
   --build-arg ARCH="$*" \
   -f Dockerfile.multi-arch .
 

--- a/Makefile
+++ b/Makefile
@@ -187,7 +187,7 @@ docker-multi-stage:
 docker-build: $(BUILD_DOCKER_ARCHS)
 $(BUILD_DOCKER_ARCHS): docker-build-%:
 	@docker build -t "thanos-linux-$*" \
-  --build-arg BASE_DOCKER_SHA=$($(shell echo '$*')) \
+  --build-arg BASE_DOCKER_SHA="$($*)" \
   --build-arg ARCH="$*" \
   -f Dockerfile.multi-arch .
 


### PR DESCRIPTION
Signed-off-by: Matej Gera <matejgera@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [X] Change is not relevant to the end user.

## Changes

Fixed the `docker-build` target, which currently fails always with:
```
Sending build context to Docker daemon  295.7MB
Step 1/7 : ARG BASE_DOCKER_SHA="97a9aacc097e5dbdec33b0d671adea0785e76d26ff2b979ee28570baf6a9155d"
Step 2/7 : FROM quay.io/prometheus/busybox@sha256:${BASE_DOCKER_SHA}
invalid reference format
make: *** [Makefile:190: docker-build-amd64] Error 1
```

Presumably caused as a side-effect of https://github.com/thanos-io/thanos/pull/4965. This PR fixes the target to correctly obtain the relevant SHA.

This currently causes `publish_main` job to fail as well, meaning no images are being published.

## Verification

Run `docker-build` locally and was able to get pass the problematic step.

<!-- How you tested it? How do you know it works? -->
