### PR TITLE
cli: print usage before error when argument parsing causes an error

### DIFF
--- a/pkg/extkingpin/app.go
+++ b/pkg/extkingpin/app.go
@@ -104,8 +104,8 @@ func NewApp(app *kingpin.Application) *App {
 func (a *App) Parse() (cmd string, setup SetupFunc) {
 	cmd, err := a.app.Parse(os.Args[1:])
 	if err != nil {
-		fmt.Fprintln(os.Stderr, errors.Wrapf(err, "error parsing commandline arguments: %v", os.Args))
 		a.app.Usage(os.Args[1:])
+		fmt.Fprintln(os.Stderr, errors.Wrapf(err, "error parsing commandline arguments: %v", os.Args))
 		os.Exit(2)
 	}
 	return cmd, a.setups[cmd]


### PR DESCRIPTION
This intends to improve error reporting in k8s. Before this change
thanos would print the error, followed by the usage. The latter part
would fill up a container status message (in say `kubectl describe`)
with the usage, hiding the actual error.

Signed-off-by: Jan Fajerski <jfajersk@redhat.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
