### PR TITLE
prober: Remove spam of changing probe status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 
 ### Fixed
 
+- [#5051](https://github.com/thanos-io/thanos/pull/5051) Prober: Remove spam of changing probe status.
 - [#4918](https://github.com/thanos-io/thanos/pull/4918) Tracing: Fixing force tracing with Jaeger.
 - [#4879](https://github.com/thanos-io/thanos/pull/4879) Bucket verify: Fixed bug causing wrong number of blocks to be checked.
 - [#4908](https://github.com/thanos-io/thanos/pull/4908) UI: Show 'minus' icon and add tooltip when store min / max time is not available.

--- a/pkg/prober/intrumentation.go
+++ b/pkg/prober/intrumentation.go
@@ -4,11 +4,12 @@
 package prober
 
 import (
+	"sync"
+
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-	"sync"
 
 	"github.com/thanos-io/thanos/pkg/component"
 )
@@ -52,7 +53,7 @@ func (p *InstrumentationProbe) Ready() {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	if p.statusString != ready {
-		level.Info(p.logger).Log("msg", "changing probe status", "status", "ready")
+		level.Info(p.logger).Log("msg", "changing probe status", "status", ready)
 		p.statusString = ready
 	}
 }


### PR DESCRIPTION
Issue: https://github.com/thanos-io/thanos/issues/5036

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Remove constant spam of "changing probe status" if status of the probe was set to the same value as before

## Verification

I ran `make quickstart` without my changes and saw that `"changing probe status"` messages are spammed even though probe status was set to the same value as before. Then I added my changes, ran `make quickstart` again and got certain that these kind of logs do not repeat if probe status does not change to different value than before.
