### PR TITLE
Compactor: Adding minimum retention flag validation for downsampling retention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#4946](https://github.com/thanos-io/thanos/pull/4946) Store: Support tls_config configuration for the s3 minio client.
 - [#4974](https://github.com/thanos-io/thanos/pull/4974) Store: Support tls_config configuration for connecting with Azure storage.
 - [#4999](https://github.com/thanos-io/thanos/pull/4999) COS: Support `endpoint` configuration for vpc internal endpoint.
+- [#5059](https://github.com/thanos-io/thanos/pull/5059) Compactor: Adding minimum retention flag validation for downsampling retention.
 
 ### Fixed
 - [#4918](https://github.com/thanos-io/thanos/pull/4918) Tracing: Fixing force tracing with Jaeger.

--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -389,15 +389,15 @@ func runCompact(
 
 	if retentionByResolution[compact.ResolutionLevelRaw].Seconds() != 0 {
 		// If downsampling is enabled, error if raw retention is not sufficient for downsampling to occur (upper bound 10 days for 1h resolution)
-		if !conf.disableDownsampling && retentionByResolution[compact.ResolutionLevelRaw].Seconds() < downsample.ResLevel2DownsampleRange {
-			return errors.New("raw resolution must be higher than the minimum block size after which 1h resolution downsampling will occur (10 days)")
+		if !conf.disableDownsampling && retentionByResolution[compact.ResolutionLevelRaw].Seconds() < downsample.ResLevel1DownsampleRange {
+			return errors.New("raw resolution must be higher than the minimum block size after which 1h resolution downsampling will occur (40 hours)")
 		}
 		level.Info(logger).Log("msg", "retention policy of raw samples is enabled", "duration", retentionByResolution[compact.ResolutionLevelRaw])
 	}
 	if retentionByResolution[compact.ResolutionLevel5m].Seconds() != 0 {
 		// If retention is lower than minimum downsample range, then no downsampling at this resolution will be persisted
-		if !conf.disableDownsampling && retentionByResolution[compact.ResolutionLevel5m].Seconds() < downsample.ResLevel1DownsampleRange {
-			return errors.New("5m resolution retention must be higher than the minimum block size after which 5m resolution downsampling will occur (40 hours)")
+		if !conf.disableDownsampling && retentionByResolution[compact.ResolutionLevel5m].Seconds() < downsample.ResLevel2DownsampleRange {
+			return errors.New("5m resolution retention must be higher than the minimum block size after which 5m resolution downsampling will occur (10 days)")
 		}
 		level.Info(logger).Log("msg", "retention policy of 5 min aggregated samples is enabled", "duration", retentionByResolution[compact.ResolutionLevel5m])
 	}

--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -388,12 +388,24 @@ func runCompact(
 	}
 
 	if retentionByResolution[compact.ResolutionLevelRaw].Seconds() != 0 {
+		// If downsampling is enabled, error if raw retention is not sufficient for downsampling to occur (upper bound 10 days for 1h resolution)
+		if !conf.disableDownsampling && retentionByResolution[compact.ResolutionLevelRaw].Seconds() < downsample.ResLevel2DownsampleRange {
+			return errors.New("raw resolution must be higher than the minimum block size after which 1h resolution downsampling will occur (10 days)")
+		}
 		level.Info(logger).Log("msg", "retention policy of raw samples is enabled", "duration", retentionByResolution[compact.ResolutionLevelRaw])
 	}
 	if retentionByResolution[compact.ResolutionLevel5m].Seconds() != 0 {
+		// If retention is lower than minimum downsample range, then no downsampling at this resolution will be persisted
+		if !conf.disableDownsampling && retentionByResolution[compact.ResolutionLevel5m].Seconds() < downsample.ResLevel1DownsampleRange {
+			return errors.New("5m resolution retention must be higher than the minimum block size after which 5m resolution downsampling will occur (40 hours)")
+		}
 		level.Info(logger).Log("msg", "retention policy of 5 min aggregated samples is enabled", "duration", retentionByResolution[compact.ResolutionLevel5m])
 	}
 	if retentionByResolution[compact.ResolutionLevel1h].Seconds() != 0 {
+		// If retention is lower than minimum downsample range, then no downsampling at this resolution will be persisted
+		if !conf.disableDownsampling && retentionByResolution[compact.ResolutionLevel1h].Seconds() < downsample.ResLevel2DownsampleRange {
+			return errors.New("1h resolution retention must be higher than the minimum block size after which 1h resolution downsampling will occur (10 days)")
+		}
 		level.Info(logger).Log("msg", "retention policy of 1 hour aggregated samples is enabled", "duration", retentionByResolution[compact.ResolutionLevel1h])
 	}
 

--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -390,14 +390,14 @@ func runCompact(
 	if retentionByResolution[compact.ResolutionLevelRaw].Seconds() != 0 {
 		// If downsampling is enabled, error if raw retention is not sufficient for downsampling to occur (upper bound 10 days for 1h resolution)
 		if !conf.disableDownsampling && retentionByResolution[compact.ResolutionLevelRaw].Seconds() < downsample.ResLevel1DownsampleRange {
-			return errors.New("raw resolution must be higher than the minimum block size after which 1h resolution downsampling will occur (40 hours)")
+			return errors.New("raw resolution must be higher than the minimum block size after which 5m resolution downsampling will occur (40 hours)")
 		}
 		level.Info(logger).Log("msg", "retention policy of raw samples is enabled", "duration", retentionByResolution[compact.ResolutionLevelRaw])
 	}
 	if retentionByResolution[compact.ResolutionLevel5m].Seconds() != 0 {
 		// If retention is lower than minimum downsample range, then no downsampling at this resolution will be persisted
 		if !conf.disableDownsampling && retentionByResolution[compact.ResolutionLevel5m].Seconds() < downsample.ResLevel2DownsampleRange {
-			return errors.New("5m resolution retention must be higher than the minimum block size after which 5m resolution downsampling will occur (10 days)")
+			return errors.New("5m resolution retention must be higher than the minimum block size after which 1h resolution downsampling will occur (10 days)")
 		}
 		level.Info(logger).Log("msg", "retention policy of 5 min aggregated samples is enabled", "duration", retentionByResolution[compact.ResolutionLevel5m])
 	}

--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -402,10 +402,6 @@ func runCompact(
 		level.Info(logger).Log("msg", "retention policy of 5 min aggregated samples is enabled", "duration", retentionByResolution[compact.ResolutionLevel5m])
 	}
 	if retentionByResolution[compact.ResolutionLevel1h].Seconds() != 0 {
-		// If retention is lower than minimum downsample range, then no downsampling at this resolution will be persisted
-		if !conf.disableDownsampling && retentionByResolution[compact.ResolutionLevel1h].Seconds() < downsample.ResLevel2DownsampleRange {
-			return errors.New("1h resolution retention must be higher than the minimum block size after which 1h resolution downsampling will occur (10 days)")
-		}
 		level.Info(logger).Log("msg", "retention policy of 1 hour aggregated samples is enabled", "duration", retentionByResolution[compact.ResolutionLevel1h])
 	}
 

--- a/cmd/thanos/downsample.go
+++ b/cmd/thanos/downsample.go
@@ -283,7 +283,7 @@ metaSendLoop:
 			// Only downsample blocks once we are sure to get roughly 2 chunks out of it.
 			// NOTE(fabxc): this must match with at which block size the compactor creates downsampled
 			// blocks. Otherwise we may never downsample some data.
-			if m.MaxTime-m.MinTime < downsample.DownsampleRange0 {
+			if m.MaxTime-m.MinTime < downsample.ResLevel1DownsampleRange {
 				continue
 			}
 
@@ -301,7 +301,7 @@ metaSendLoop:
 			// Only downsample blocks once we are sure to get roughly 2 chunks out of it.
 			// NOTE(fabxc): this must match with at which block size the compactor creates downsampled
 			// blocks. Otherwise we may never downsample some data.
-			if m.MaxTime-m.MinTime < downsample.DownsampleRange1 {
+			if m.MaxTime-m.MinTime < downsample.ResLevel2DownsampleRange {
 				continue
 			}
 		}

--- a/cmd/thanos/main_test.go
+++ b/cmd/thanos/main_test.go
@@ -121,7 +121,7 @@ func TestRegression4960_Deadlock(t *testing.T) {
 			ctx,
 			dir,
 			[]labels.Labels{{{Name: "a", Value: "1"}}},
-			1, 0, downsample.DownsampleRange0+1, // Pass the minimum DownsampleRange0 check.
+			1, 0, downsample.ResLevel1DownsampleRange+1, // Pass the minimum ResLevel1DownsampleRange check.
 			labels.Labels{{Name: "e1", Value: "1"}},
 			downsample.ResLevel0, metadata.NoneFunc)
 		testutil.Ok(t, err)
@@ -132,7 +132,7 @@ func TestRegression4960_Deadlock(t *testing.T) {
 			ctx,
 			dir,
 			[]labels.Labels{{{Name: "a", Value: "2"}}},
-			1, 0, downsample.DownsampleRange0+1, // Pass the minimum DownsampleRange0 check.
+			1, 0, downsample.ResLevel1DownsampleRange+1, // Pass the minimum ResLevel1DownsampleRange check.
 			labels.Labels{{Name: "e1", Value: "2"}},
 			downsample.ResLevel0, metadata.NoneFunc)
 		testutil.Ok(t, err)
@@ -143,7 +143,7 @@ func TestRegression4960_Deadlock(t *testing.T) {
 			ctx,
 			dir,
 			[]labels.Labels{{{Name: "a", Value: "2"}}},
-			1, 0, downsample.DownsampleRange0+1, // Pass the minimum DownsampleRange0 check.
+			1, 0, downsample.ResLevel1DownsampleRange+1, // Pass the minimum ResLevel1DownsampleRange check.
 			labels.Labels{{Name: "e1", Value: "2"}},
 			downsample.ResLevel0, metadata.NoneFunc)
 		testutil.Ok(t, err)
@@ -183,7 +183,7 @@ func TestCleanupDownsampleCacheFolder(t *testing.T) {
 			ctx,
 			dir,
 			[]labels.Labels{{{Name: "a", Value: "1"}}},
-			1, 0, downsample.DownsampleRange0+1, // Pass the minimum DownsampleRange0 check.
+			1, 0, downsample.ResLevel1DownsampleRange+1, // Pass the minimum ResLevel1DownsampleRange check.
 			labels.Labels{{Name: "e1", Value: "1"}},
 			downsample.ResLevel0, metadata.NoneFunc)
 		testutil.Ok(t, err)

--- a/docs/components/compact.md
+++ b/docs/components/compact.md
@@ -2,10 +2,9 @@
 
 The `thanos compact` command applies the compaction procedure of the Prometheus 2.0 storage engine to block data stored in object storage. It is generally not semantically concurrency safe and must be deployed as a singleton against a bucket.
 
-Compactor is also responsible for downsampling of data:
-
-* Creating 5m downsampling for blocks larger than **40 hours** (2d, 2w)
-* Creating 1h downsampling for blocks larger than **10 days** (2w)
+Compactor is also responsible for downsampling of data. There is a time delay before downsampling at a given resolution is possible. This is necessary because downsampled chunks will have fewer samples in them, and as chunks are fixed size, data spanning more time will be required to fill them. 
+* Creating 5m downsampling for blocks older than **40 hours** (2d)
+* Creating 1h downsampling for blocks older than **10 days** (2w)
 
 Example:
 
@@ -160,6 +159,12 @@ Resolution is a distance between data points on your graphs. E.g.
 * `raw` - the same as scrape interval at the moment of data ingestion
 * `5 minutes` - data point is every 5 minutes
 * `1 hour` - data point is every 1h
+
+Compactor downsampling is done in two passes:
+1) All raw resolution metrics that are older than **40 hours** are downsampled at a 5m resolution
+2) All 5m resolution metrics older than **10 days** are downsampled at a 1h resolution
+
+> **NOTE:** If retention at each resolution is lower than minimum age for the successive downsampling pass, data will be deleted before downsampling can be completed. As a rule of thumb retention for each downsampling level should be the same, and should be greater than the maximum date range (10 days for 5m to 1h downsampling).
 
 Keep in mind, that the initial goal of downsampling is not saving disk or object storage space. In fact, downsampling doesn't save you **any** space but instead, it adds 2 more blocks for each raw block which are only slightly smaller or relatively similar size to raw block. This is done by internal downsampling implementation which to be mathematically correct holds various aggregations. This means that downsampling can increase the size of your storage a bit (~3x), if you choose to store all resolutions (recommended and by default).
 

--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -123,9 +123,9 @@ func UntilNextDownsampling(m *metadata.Meta) (time.Duration, error) {
 	case downsample.ResLevel2:
 		return time.Duration(0), errors.New("no downsampling")
 	case downsample.ResLevel1:
-		return time.Duration(downsample.DownsampleRange1*time.Millisecond) - timeRange, nil
+		return time.Duration(downsample.ResLevel2DownsampleRange*time.Millisecond) - timeRange, nil
 	case downsample.ResLevel0:
-		return time.Duration(downsample.DownsampleRange0*time.Millisecond) - timeRange, nil
+		return time.Duration(downsample.ResLevel1DownsampleRange*time.Millisecond) - timeRange, nil
 	default:
 		panic(errors.Errorf("invalid resolution %v", m.Thanos.Downsample.Resolution))
 	}
@@ -637,7 +637,7 @@ func (ds *DownsampleProgressCalculator) ProgressCalculate(ctx context.Context, g
 					continue
 				}
 
-				if m.MaxTime-m.MinTime < downsample.DownsampleRange0 {
+				if m.MaxTime-m.MinTime < downsample.ResLevel1DownsampleRange {
 					continue
 				}
 				groupBlocks[group.key]++
@@ -653,7 +653,7 @@ func (ds *DownsampleProgressCalculator) ProgressCalculate(ctx context.Context, g
 					continue
 				}
 
-				if m.MaxTime-m.MinTime < downsample.DownsampleRange1 {
+				if m.MaxTime-m.MinTime < downsample.ResLevel2DownsampleRange {
 					continue
 				}
 				groupBlocks[group.key]++

--- a/pkg/compact/compact_test.go
+++ b/pkg/compact/compact_test.go
@@ -509,10 +509,10 @@ func TestDownsampleProgressCalculate(t *testing.T) {
 			// This test case has blocks from multiple groups and resolution levels. Only the blocks in the second group should be downsampled since the others either have time differences not in the range for their resolution, or a resolution which should not be downsampled.
 			testName: "multi_group_test",
 			input: []*metadata.Meta{
-				createBlockMeta(6, 1, downsample.DownsampleRange0, map[string]string{"a": "1"}, downsample.ResLevel0, []uint64{7, 8}),
-				createBlockMeta(7, 0, downsample.DownsampleRange1, map[string]string{"b": "2"}, downsample.ResLevel1, []uint64{8, 9}),
-				createBlockMeta(9, 0, downsample.DownsampleRange1, map[string]string{"b": "2"}, downsample.ResLevel1, []uint64{8, 11}),
-				createBlockMeta(8, 0, downsample.DownsampleRange1, map[string]string{"a": "1", "b": "2"}, downsample.ResLevel2, []uint64{9, 10}),
+				createBlockMeta(6, 1, downsample.ResLevel1DownsampleRange, map[string]string{"a": "1"}, downsample.ResLevel0, []uint64{7, 8}),
+				createBlockMeta(7, 0, downsample.ResLevel2DownsampleRange, map[string]string{"b": "2"}, downsample.ResLevel1, []uint64{8, 9}),
+				createBlockMeta(9, 0, downsample.ResLevel2DownsampleRange, map[string]string{"b": "2"}, downsample.ResLevel1, []uint64{8, 11}),
+				createBlockMeta(8, 0, downsample.ResLevel2DownsampleRange, map[string]string{"a": "1", "b": "2"}, downsample.ResLevel2, []uint64{9, 10}),
 			},
 			expected: map[string]float64{
 				keys[0]: 0.0,
@@ -524,7 +524,7 @@ func TestDownsampleProgressCalculate(t *testing.T) {
 			// This block should be downsampled.
 			testName: "res_level0_test",
 			input: []*metadata.Meta{
-				createBlockMeta(9, 0, downsample.DownsampleRange0, map[string]string{"a": "1"}, downsample.ResLevel0, []uint64{10, 11}),
+				createBlockMeta(9, 0, downsample.ResLevel1DownsampleRange, map[string]string{"a": "1"}, downsample.ResLevel0, []uint64{10, 11}),
 			},
 			expected: map[string]float64{
 				keys[0]: 1.0,
@@ -534,7 +534,7 @@ func TestDownsampleProgressCalculate(t *testing.T) {
 			// This block should be downsampled.
 			testName: "res_level1_test",
 			input: []*metadata.Meta{
-				createBlockMeta(9, 0, downsample.DownsampleRange1, map[string]string{"b": "2"}, downsample.ResLevel1, []uint64{10, 11}),
+				createBlockMeta(9, 0, downsample.ResLevel2DownsampleRange, map[string]string{"b": "2"}, downsample.ResLevel1, []uint64{10, 11}),
 			},
 			expected: map[string]float64{
 				keys[1]: 1.0,
@@ -545,7 +545,7 @@ func TestDownsampleProgressCalculate(t *testing.T) {
 			// Blocks with this resolution should not be downsampled.
 			testName: "res_level2_test",
 			input: []*metadata.Meta{
-				createBlockMeta(10, 0, downsample.DownsampleRange1, map[string]string{"a": "1", "b": "2"}, downsample.ResLevel2, []uint64{11, 12}),
+				createBlockMeta(10, 0, downsample.ResLevel2DownsampleRange, map[string]string{"a": "1", "b": "2"}, downsample.ResLevel2, []uint64{11, 12}),
 			},
 			expected: map[string]float64{
 				keys[2]: 0.0,
@@ -555,7 +555,7 @@ func TestDownsampleProgressCalculate(t *testing.T) {
 			// This block should be downsampled.
 			testName: "res_level0_test_incorrect",
 			input: []*metadata.Meta{
-				createBlockMeta(9, 1, downsample.DownsampleRange0, map[string]string{"a": "1"}, downsample.ResLevel0, []uint64{10, 11}),
+				createBlockMeta(9, 1, downsample.ResLevel1DownsampleRange, map[string]string{"a": "1"}, downsample.ResLevel0, []uint64{10, 11}),
 			},
 			expected: map[string]float64{
 				keys[0]: 0.0,
@@ -566,7 +566,7 @@ func TestDownsampleProgressCalculate(t *testing.T) {
 			// This block should be downsampled.
 			testName: "res_level1_test",
 			input: []*metadata.Meta{
-				createBlockMeta(9, 1, downsample.DownsampleRange1, map[string]string{"b": "2"}, downsample.ResLevel1, []uint64{10, 11}),
+				createBlockMeta(9, 1, downsample.ResLevel2DownsampleRange, map[string]string{"b": "2"}, downsample.ResLevel1, []uint64{10, 11}),
 			},
 			expected: map[string]float64{
 				keys[1]: 0.0,

--- a/pkg/compact/downsample/downsample.go
+++ b/pkg/compact/downsample/downsample.go
@@ -35,8 +35,8 @@ const (
 
 // Downsampling ranges i.e. minimum block size after which we start to downsample blocks (in seconds).
 const (
-	DownsampleRange0 = 40 * 60 * 60 * 1000      // 40 hours.
-	DownsampleRange1 = 10 * 24 * 60 * 60 * 1000 // 10 days.
+	ResLevel1DownsampleRange = 40 * 60 * 60 * 1000      // 40 hours.
+	ResLevel2DownsampleRange = 10 * 24 * 60 * 60 * 1000 // 10 days.
 )
 
 // Downsample downsamples the given block. It writes a new block into dir and returns its ID.

--- a/test/e2e/e2ethanos/services.go
+++ b/test/e2e/e2ethanos/services.go
@@ -735,6 +735,7 @@ func NewCompactor(e e2e.Environment, name string, bucketConfig client.BucketConf
 				"--selector.relabel-config": string(relabelConfigBytes),
 				"--wait":                    "",
 			}), extArgs...)...),
+			Readiness:        e2e.NewHTTPReadinessProbe("http", "/-/ready", 200, 200),
 			User:             strconv.Itoa(os.Getuid()),
 			WaitReadyBackoff: &defaultBackoffConfig,
 		},

--- a/test/e2e/e2ethanos/services.go
+++ b/test/e2e/e2ethanos/services.go
@@ -735,7 +735,6 @@ func NewCompactor(e e2e.Environment, name string, bucketConfig client.BucketConf
 				"--selector.relabel-config": string(relabelConfigBytes),
 				"--wait":                    "",
 			}), extArgs...)...),
-			Readiness:        e2e.NewHTTPReadinessProbe("http", "/-/ready", 200, 200),
 			User:             strconv.Itoa(os.Getuid()),
 			WaitReadyBackoff: &defaultBackoffConfig,
 		},


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes
* [x] Added 40h minimum raw resolution retention if downsampling enabled and `--retention.resolution-raw` > 0 
* [x] Added 10d minimum 5m resolution retention if downsampling enabled and `--retention.resolution-5m` > 0
* [x] Added 10d minimum 1h resolution retention if downsampling enabled and `--retention.resolution-1h` > 0
* [x] Added clarifying docs around why downsampling time delay  

## Verification
* Ran locally with e2e compactor tests with flags enabled below set retention to test flag validation 

Changes based on: https://github.com/thanos-io/thanos/issues/813 

tl;dr: For downsampling to happen, blocks must be pass a certain age for the preceding resolution. This was always the case in [Compactor](https://github.com/thanos-io/thanos/blob/c31cb08f1b0cf9ad7f23a57210812499a8fa0764/cmd/thanos/downsample.go#L265-L318) but not transparently to users. As such, it's very easy to set up retention in such a way that disrupts downsampling or leads to accidental data loss. 