### PR TITLE
*: Attempt to fix multiarch builds by updating remote Docker engine version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
       - checkout
       - go/mod-download-cached
       - setup_remote_docker:
-          version: 18.06.0-ce
+          version: 20.10.11
       - run:
           name: Create Secret if PR is not forked
           # GCS integration tests are run only for author's PR that have write access, because these tests
@@ -74,7 +74,7 @@ jobs:
       - checkout
       - go/mod-download-cached
       - setup_remote_docker:
-          version: 18.06.0-ce
+          version: 20.10.11
       - attach_workspace:
           at: .
       # Register qemu to support multi-arch.
@@ -96,7 +96,7 @@ jobs:
       - checkout
       - go/mod-download-cached
       - setup_remote_docker:
-          version: 18.06.0-ce
+          version: 20.10.11
       - attach_workspace:
           at: .
       - run: make tarballs-release


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [X] Change is not relevant to the end user.

## Changes

This PR attempts to fix current issue on CI - #5077 - which causes the `publish_*` jobs not to pass on the CircleCI.

The first attempt is to update the remote Docker engine version (see: https://circleci.com/docs/2.0/building-docker-images/#docker-version)

Temporarily, the job has been allowed on all branches but pushing images has been commented out, we just need to make sure we pass the `docker-test` step

## Verification
Waiting on CI to pass

<!-- How you tested it? How do you know it works? -->
