### PR TITLE
cache: add os.Exit if starting HTTP fails

### DIFF
--- a/pkg/cache/groupcache_test.go
+++ b/pkg/cache/groupcache_test.go
@@ -84,11 +84,13 @@ func TestMain(m *testing.M) {
 	go func() {
 		if err = httpServer.ListenAndServe(); err != nil {
 			fmt.Printf("failed to listen: %s\n", err.Error())
+			os.Exit(1)
 		}
 	}()
 	go func() {
 		if err = httpServerH2C.ListenAndServe(); err != nil {
 			fmt.Printf("failed to listen: %s\n", err.Error())
+			os.Exit(1)
 		}
 	}()
 


### PR DESCRIPTION
Add fixes according to the suggestions here
https://github.com/thanos-io/thanos/pull/5068#discussion_r787711237.

Signed-off-by: Giedrius Statkevičius <giedrius.statkevicius@vinted.com>
