### PR TITLE
(WIP) Refactor http structs across objectstores

### DIFF
--- a/pkg/httpconfig/http.go
+++ b/pkg/httpconfig/http.go
@@ -62,6 +62,14 @@ type TLSConfig struct {
 	InsecureSkipVerify bool `yaml:"insecure_skip_verify"`
 }
 
+func (c *TLSConfig) GetClientCertificate(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
+	cert, err := tls.LoadX509KeyPair(c.CertFile, c.KeyFile)
+	if err != nil {
+		return nil, fmt.Errorf("unable to use specified client cert (%s) & key (%s): %s", c.CertFile, c.KeyFile, err)
+	}
+	return &cert, nil
+}
+
 // BasicAuth configures basic authentication for HTTP clients.
 type BasicAuth struct {
 	Username     string `yaml:"username"`
@@ -86,7 +94,7 @@ type TransportConfig struct {
 	TLSHandshakeTimeout   int64 `yaml:"tls_handshake_timeout"`
 }
 
-var defaultTransportConfig TransportConfig = TransportConfig{
+var DefaultTransportConfig TransportConfig = TransportConfig{
 	MaxIdleConns:          100,
 	MaxIdleConnsPerHost:   2,
 	ResponseHeaderTimeout: 0,
@@ -98,7 +106,7 @@ var defaultTransportConfig TransportConfig = TransportConfig{
 }
 
 func NewClientConfigFromYAML(cfg []byte) (*ClientConfig, error) {
-	conf := &ClientConfig{TransportConfig: defaultTransportConfig}
+	conf := &ClientConfig{TransportConfig: DefaultTransportConfig}
 	if err := yaml.Unmarshal(cfg, conf); err != nil {
 		return nil, err
 	}

--- a/pkg/objstore/azure/azure.go
+++ b/pkg/objstore/azure/azure.go
@@ -81,6 +81,11 @@ func (httpConf *HTTPConfig) UnmarshalYAML(value *yaml2.Node) error {
 	type transport httpconfig.TransportConfig
 	type tls httpconfig.TLSConfig
 
+	// Decoding at individual level to support old notation for HTTPConfig across object store. ie;
+	// http_config:
+	//     insecure_skip_verify: true  <- to support this old notation
+	//     tls_config:
+	//	       insecure_skip_verify: false <- and this new notation
 	if err := value.Decode((*conf)(httpConf)); err != nil {
 		return err
 	}

--- a/pkg/objstore/azure/azure_test.go
+++ b/pkg/objstore/azure/azure_test.go
@@ -185,14 +185,14 @@ func TestParseConfig_DefaultHTTPConfig(t *testing.T) {
 	cfg, err := parseConfig(validConfig)
 	testutil.Ok(t, err)
 
-	if time.Duration(cfg.HTTPConfig.TransportConfig.IdleConnTimeout) != time.Duration(90*time.Second) {
+	if time.Duration(cfg.HTTPConfig.TransportConfig.IdleConnTimeout) != 90*time.Second {
 		t.Errorf("parsing of idle_conn_timeout failed: got %v, expected %v",
 			time.Duration(cfg.HTTPConfig.TransportConfig.IdleConnTimeout), time.Duration(90*time.Second))
 	}
 
-	if time.Duration(cfg.HTTPConfig.TransportConfig.ResponseHeaderTimeout) != time.Duration(2*time.Minute) {
+	if time.Duration(cfg.HTTPConfig.TransportConfig.ResponseHeaderTimeout) != time.Duration(0*time.Second) {
 		t.Errorf("parsing of response_header_timeout failed: got %v, expected %v",
-			time.Duration(cfg.HTTPConfig.TransportConfig.IdleConnTimeout), time.Duration(2*time.Minute))
+			time.Duration(cfg.HTTPConfig.TransportConfig.ResponseHeaderTimeout), 0*time.Second)
 	}
 
 	if cfg.HTTPConfig.TLSConfig.InsecureSkipVerify {

--- a/pkg/objstore/azure/azure_test.go
+++ b/pkg/objstore/azure/azure_test.go
@@ -185,18 +185,18 @@ func TestParseConfig_DefaultHTTPConfig(t *testing.T) {
 	cfg, err := parseConfig(validConfig)
 	testutil.Ok(t, err)
 
-	if time.Duration(cfg.HTTPConfig.IdleConnTimeout) != time.Duration(90*time.Second) {
+	if time.Duration(cfg.HTTPConfig.TransportConfig.IdleConnTimeout) != time.Duration(90*time.Second) {
 		t.Errorf("parsing of idle_conn_timeout failed: got %v, expected %v",
-			time.Duration(cfg.HTTPConfig.IdleConnTimeout), time.Duration(90*time.Second))
+			time.Duration(cfg.HTTPConfig.TransportConfig.IdleConnTimeout), time.Duration(90*time.Second))
 	}
 
-	if time.Duration(cfg.HTTPConfig.ResponseHeaderTimeout) != time.Duration(2*time.Minute) {
+	if time.Duration(cfg.HTTPConfig.TransportConfig.ResponseHeaderTimeout) != time.Duration(2*time.Minute) {
 		t.Errorf("parsing of response_header_timeout failed: got %v, expected %v",
-			time.Duration(cfg.HTTPConfig.IdleConnTimeout), time.Duration(2*time.Minute))
+			time.Duration(cfg.HTTPConfig.TransportConfig.IdleConnTimeout), time.Duration(2*time.Minute))
 	}
 
-	if cfg.HTTPConfig.InsecureSkipVerify {
-		t.Errorf("parsing of insecure_skip_verify failed: got %v, expected %v", cfg.HTTPConfig.InsecureSkipVerify, false)
+	if cfg.HTTPConfig.TLSConfig.InsecureSkipVerify {
+		t.Errorf("parsing of insecure_skip_verify failed: got %v, expected %v", cfg.HTTPConfig.TLSConfig.InsecureSkipVerify, false)
 	}
 }
 
@@ -206,6 +206,7 @@ storage_account_key: "abc123"
 container: "MyContainer"
 endpoint: "blob.core.windows.net"
 http_config:
+  max_idle_conns: 1
   tls_config:
     ca_file: /certs/ca.crt
     cert_file: /certs/cert.crt
@@ -235,7 +236,5 @@ http_config:
   `)
 	cfg, err := parseConfig(input)
 	testutil.Ok(t, err)
-	transport, err := DefaultTransport(cfg)
-	testutil.Ok(t, err)
-	testutil.Equals(t, true, transport.TLSClientConfig.InsecureSkipVerify)
+	testutil.Equals(t, true, cfg.HTTPConfig.TLSConfig.InsecureSkipVerify)
 }

--- a/pkg/objstore/azure/helpers.go
+++ b/pkg/objstore/azure/helpers.go
@@ -6,7 +6,6 @@ package azure
 import (
 	"context"
 	"fmt"
-	"net"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -18,7 +17,8 @@ import (
 	"github.com/Azure/go-autorest/autorest/azure/auth"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
-	"github.com/thanos-io/thanos/pkg/objstore"
+	"github.com/prometheus/common/config"
+	"github.com/thanos-io/thanos/pkg/httpconfig"
 )
 
 // DirDelim is the delimiter used to model a directory structure in an object store bucket.
@@ -104,12 +104,12 @@ func getContainerURL(ctx context.Context, logger log.Logger, conf Config) (blob.
 		retryOptions.TryTimeout = time.Until(deadline)
 	}
 
-	dt, err := DefaultTransport(conf)
+	rt, err := httpconfig.NewRoundTripperFromConfig(config.DefaultHTTPClientConfig, conf.HTTPConfig.TransportConfig, "azure")
 	if err != nil {
 		return blob.ContainerURL{}, err
 	}
 	client := http.Client{
-		Transport: dt,
+		Transport: rt,
 	}
 
 	p := blob.NewPipeline(credentials, blob.PipelineOptions{
@@ -138,36 +138,6 @@ func getContainerURL(ctx context.Context, logger log.Logger, conf Config) (blob.
 	service := blob.NewServiceURL(*u, p)
 
 	return service.NewContainerURL(conf.ContainerName), nil
-}
-
-func DefaultTransport(config Config) (*http.Transport, error) {
-	tlsConfig, err := objstore.NewTLSConfig(&config.HTTPConfig.TLSConfig)
-	if err != nil {
-		return nil, err
-	}
-
-	if config.HTTPConfig.InsecureSkipVerify {
-		tlsConfig.InsecureSkipVerify = true
-	}
-	return &http.Transport{
-		Proxy: http.ProxyFromEnvironment,
-		DialContext: (&net.Dialer{
-			Timeout:   30 * time.Second,
-			KeepAlive: 30 * time.Second,
-			DualStack: true,
-		}).DialContext,
-
-		MaxIdleConns:          config.HTTPConfig.MaxIdleConns,
-		MaxIdleConnsPerHost:   config.HTTPConfig.MaxIdleConnsPerHost,
-		IdleConnTimeout:       time.Duration(config.HTTPConfig.IdleConnTimeout),
-		MaxConnsPerHost:       config.HTTPConfig.MaxConnsPerHost,
-		TLSHandshakeTimeout:   time.Duration(config.HTTPConfig.TLSHandshakeTimeout),
-		ExpectContinueTimeout: time.Duration(config.HTTPConfig.ExpectContinueTimeout),
-
-		ResponseHeaderTimeout: time.Duration(config.HTTPConfig.ResponseHeaderTimeout),
-		DisableCompression:    config.HTTPConfig.DisableCompression,
-		TLSClientConfig:       tlsConfig,
-	}, nil
 }
 
 func getContainer(ctx context.Context, logger log.Logger, conf Config) (blob.ContainerURL, error) {

--- a/pkg/objstore/cos/cos_test.go
+++ b/pkg/objstore/cos/cos_test.go
@@ -5,9 +5,8 @@ package cos
 
 import (
 	"testing"
-	"time"
 
-	"github.com/prometheus/common/model"
+	"github.com/thanos-io/thanos/pkg/httpconfig"
 	"github.com/thanos-io/thanos/pkg/testutil"
 )
 
@@ -39,13 +38,7 @@ http_config:
 			},
 			want: Config{
 				HTTPConfig: HTTPConfig{
-					IdleConnTimeout:       model.Duration(90 * time.Second),
-					ResponseHeaderTimeout: model.Duration(2 * time.Minute),
-					TLSHandshakeTimeout:   model.Duration(10 * time.Second),
-					ExpectContinueTimeout: model.Duration(1 * time.Second),
-					MaxIdleConns:          200,
-					MaxIdleConnsPerHost:   100,
-					MaxConnsPerHost:       0,
+					TransportConfig: httpconfig.DefaultTransportConfig,
 				},
 			},
 			wantErr: false,

--- a/pkg/objstore/s3/s3.go
+++ b/pkg/objstore/s3/s3.go
@@ -59,7 +59,6 @@ var DefaultConfig = Config{
 	PutUserMetadata: map[string]string{},
 	HTTPConfig: HTTPConfig{
 		TransportConfig: httpconfig.DefaultTransportConfig,
-		TLSConfig:       httpconfig.TLSConfig{},
 	},
 	PartSize: 1024 * 1024 * 64, // 64MB.
 }

--- a/pkg/objstore/s3/s3.go
+++ b/pkg/objstore/s3/s3.go
@@ -101,6 +101,7 @@ type TraceConfig struct {
 type HTTPConfig struct {
 	TransportConfig httpconfig.TransportConfig
 	TLSConfig       httpconfig.TLSConfig `yaml:"tls_config"`
+	Transport       http.RoundTripper    `yaml:"-"`
 }
 
 func (httpConf *HTTPConfig) UnmarshalYAML(value *yaml2.Node) error {
@@ -108,6 +109,11 @@ func (httpConf *HTTPConfig) UnmarshalYAML(value *yaml2.Node) error {
 	type transport httpconfig.TransportConfig
 	type tls httpconfig.TLSConfig
 
+	// Decoding at individual level to support old notation for HTTPConfig across object store. ie;
+	// http_config:
+	//     insecure_skip_verify: true  <- to support this old notation
+	//     tls_config:
+	//	       insecure_skip_verify: false <- and this new notation
 	if err := value.Decode((*conf)(httpConf)); err != nil {
 		return err
 	}

--- a/pkg/objstore/s3/s3_test.go
+++ b/pkg/objstore/s3/s3_test.go
@@ -123,18 +123,18 @@ insecure: false`)
 	cfg, err := parseConfig(input)
 	testutil.Ok(t, err)
 
-	if time.Duration(cfg.HTTPConfig.IdleConnTimeout) != time.Duration(90*time.Second) {
+	if time.Duration(cfg.HTTPConfig.TransportConfig.IdleConnTimeout) != time.Duration(90*time.Second) {
 		t.Errorf("parsing of idle_conn_timeout failed: got %v, expected %v",
-			time.Duration(cfg.HTTPConfig.IdleConnTimeout), time.Duration(90*time.Second))
+			time.Duration(cfg.HTTPConfig.TransportConfig.IdleConnTimeout), time.Duration(90*time.Second))
 	}
 
-	if time.Duration(cfg.HTTPConfig.ResponseHeaderTimeout) != time.Duration(2*time.Minute) {
+	if time.Duration(cfg.HTTPConfig.TransportConfig.ResponseHeaderTimeout) != time.Duration(2*time.Minute) {
 		t.Errorf("parsing of response_header_timeout failed: got %v, expected %v",
-			time.Duration(cfg.HTTPConfig.IdleConnTimeout), time.Duration(2*time.Minute))
+			time.Duration(cfg.HTTPConfig.TransportConfig.IdleConnTimeout), time.Duration(2*time.Minute))
 	}
 
-	if cfg.HTTPConfig.InsecureSkipVerify {
-		t.Errorf("parsing of insecure_skip_verify failed: got %v, expected %v", cfg.HTTPConfig.InsecureSkipVerify, false)
+	if cfg.HTTPConfig.TLSConfig.InsecureSkipVerify {
+		t.Errorf("parsing of insecure_skip_verify failed: got %v, expected %v", cfg.HTTPConfig.TLSConfig.InsecureSkipVerify, false)
 	}
 }
 
@@ -148,18 +148,18 @@ http_config:
 	cfg, err := parseConfig(input)
 	testutil.Ok(t, err)
 
-	if time.Duration(cfg.HTTPConfig.IdleConnTimeout) != time.Duration(50*time.Second) {
+	if time.Duration(cfg.HTTPConfig.TransportConfig.IdleConnTimeout) != time.Duration(50*time.Second) {
 		t.Errorf("parsing of idle_conn_timeout failed: got %v, expected %v",
-			time.Duration(cfg.HTTPConfig.IdleConnTimeout), time.Duration(50*time.Second))
+			time.Duration(cfg.HTTPConfig.TransportConfig.IdleConnTimeout), time.Duration(50*time.Second))
 	}
 
-	if time.Duration(cfg.HTTPConfig.ResponseHeaderTimeout) != time.Duration(1*time.Minute) {
+	if time.Duration(cfg.HTTPConfig.TransportConfig.ResponseHeaderTimeout) != time.Duration(1*time.Minute) {
 		t.Errorf("parsing of response_header_timeout failed: got %v, expected %v",
-			time.Duration(cfg.HTTPConfig.IdleConnTimeout), time.Duration(1*time.Minute))
+			time.Duration(cfg.HTTPConfig.TransportConfig.IdleConnTimeout), time.Duration(1*time.Minute))
 	}
 
-	if !cfg.HTTPConfig.InsecureSkipVerify {
-		t.Errorf("parsing of insecure_skip_verify failed: got %v, expected %v", cfg.HTTPConfig.InsecureSkipVerify, false)
+	if !cfg.HTTPConfig.TLSConfig.InsecureSkipVerify {
+		t.Errorf("parsing of insecure_skip_verify failed: got %v, expected %v", cfg.HTTPConfig.TLSConfig.InsecureSkipVerify, false)
 	}
 }
 
@@ -194,9 +194,7 @@ http_config:
   `)
 	cfg, err := parseConfig(input)
 	testutil.Ok(t, err)
-	transport, err := DefaultTransport(cfg)
-	testutil.Ok(t, err)
-	testutil.Equals(t, true, transport.TLSClientConfig.InsecureSkipVerify)
+	testutil.Equals(t, true, cfg.HTTPConfig.TLSConfig.InsecureSkipVerify)
 }
 
 func TestValidate_OK(t *testing.T) {

--- a/test/e2e/e2ethanos/services.go
+++ b/test/e2e/e2ethanos/services.go
@@ -31,7 +31,6 @@ import (
 
 	"github.com/thanos-io/thanos/pkg/alert"
 	"github.com/thanos-io/thanos/pkg/httpconfig"
-	"github.com/thanos-io/thanos/pkg/objstore"
 	"github.com/thanos-io/thanos/pkg/objstore/client"
 	"github.com/thanos-io/thanos/pkg/objstore/s3"
 	"github.com/thanos-io/thanos/pkg/queryfrontend"
@@ -1015,7 +1014,7 @@ func NewS3Config(bucket, endpoint, basePath string) s3.Config {
 		Endpoint:  endpoint,
 		Insecure:  false,
 		HTTPConfig: s3.HTTPConfig{
-			TLSConfig: objstore.TLSConfig{
+			TLSConfig: httpconfig.TLSConfig{
 				CAFile:   filepath.Join(basePath, "data", "certs", "CAs", "ca.crt"),
 				CertFile: filepath.Join(basePath, "data", "certs", "public.crt"),
 				KeyFile:  filepath.Join(basePath, "data", "certs", "private.key"),


### PR DESCRIPTION
Signed-off-by: Somesh Koli <somesh.koli@headout.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes
 - Refactors http config across objstores and uses one defined in `httpconfig` package.
 - Adds custom yaml unmarshaller to support old notation used in obj store http config.
 - Removed TLS config from `objstore` and uses one from `httpconfig`.
 - https://github.com/cortexproject/cortex/pull/4638
<!-- Enumerate changes you made -->

## Verification
Passes all the unit tests for obj parsing 
<!-- How you tested it? How do you know it works? -->
