### PR TITLE
Add talk and blog post of use cases at LastPass to the Getting Started section

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -88,6 +88,7 @@ See up to date [jsonnet mixins](https://github.com/thanos-io/thanos/tree/main/mi
 
 ## Talks
 
+* 10.2021: [Adopting Thanos gradually across all of LastPass infrastructures](https://www.youtube.com/watch?v=Ddq8m04594A)
 * 12.2020: [Absorbing Thanos Infinite Powers for Multi-Cluster Telemetry](https://www.youtube.com/watch?v=6Nx2BFyr7qQ)
 * 12.2020: [Turn It Up to a Million: Ingesting Millions of Metrics with Thanos Receive](https://www.youtube.com/watch?v=5MJqdJq41Ms)
 * 02.2018: [Very first Prometheus Meetup Slides](https://www.slideshare.net/BartomiejPotka/thanos-global-durable-prometheus-monitoring)
@@ -99,6 +100,10 @@ See up to date [jsonnet mixins](https://github.com/thanos-io/thanos/tree/main/mi
 * 2019: [Prometheus in Practice: HA with Thanos](https://www.slideshare.net/ThomasRiley45/prometheus-in-practice-high-availability-with-thanos-devopsdays-edinburgh-2019)
 
 ## Blog posts
+
+* 2021:
+
+  * [Adopting Thanos at LastPass](https://krisztianfekete.org/adopting-thanos-at-lastpass/)
 
 * 2020:
 


### PR DESCRIPTION
Signed-off-by: fktkrt <fktkrt@gmail.com>

## Changes

I added links to a blog post and a conference talk of how LastPass is using Thanos. We discussed this with @wiardvanrij on CNCF Slack's  #thanos channel.

## Verification

It's just a docs change.
