### PR TITLE
Support triggering update sha workflow manually

### DIFF
--- a/.github/workflows/container-version.yaml
+++ b/.github/workflows/container-version.yaml
@@ -1,4 +1,5 @@
 on:
+  workflow_dispatch: {}
   schedule:
     - cron: '37 13 * * *'
 name: busybox-update workflow

--- a/.github/workflows/container-version.yaml
+++ b/.github/workflows/container-version.yaml
@@ -1,5 +1,5 @@
 on:
-  workflow_dispatch: {}
+  workflow_dispatch:
   schedule:
     - cron: '37 13 * * *'
 name: busybox-update workflow


### PR DESCRIPTION
Signed-off-by: Ben Ye <ben.ye@bytedance.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Now the workflow is triggered by a cron job every day. But if the busybox image is updated after running the cron job that day, then the CI will be broken until the next day.

To support better control on this, I added support to trigger it manually. See doc https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch.

## Verification

<!-- How you tested it? How do you know it works? -->

I am not sure if the current syntax is correct or not so would be great to have more eyes for review.
