### PR TITLE
Fix: Filter block rows in bucket UI according to searched block ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 
 ### Fixed
 
+- [#5102](https://github.com/thanos-io/thanos/pull/5102) Fix: Filter block rows in bucket UI according to searched block ID
 - [#5051](https://github.com/thanos-io/thanos/pull/5051) Prober: Remove spam of changing probe status.
 - [#4918](https://github.com/thanos-io/thanos/pull/4918) Tracing: Fixing force tracing with Jaeger.
 - [#4879](https://github.com/thanos-io/thanos/pull/4879) Bucket verify: Fixed bug causing wrong number of blocks to be checked.

--- a/pkg/ui/react-app/src/thanos/pages/blocks/Blocks.tsx
+++ b/pkg/ui/react-app/src/thanos/pages/blocks/Blocks.tsx
@@ -10,7 +10,7 @@ import { SourceView } from './SourceView';
 import { BlockDetails } from './BlockDetails';
 import { BlockSearchInput } from './BlockSearchInput';
 import { BlockFilterCompaction } from './BlockFilterCompaction';
-import { sortBlocks } from './helpers';
+import { sortBlocks, getBlockByUlid, getFilteredBlockPools } from './helpers';
 import styles from './blocks.module.css';
 import TimeRange from './TimeRange';
 import Checkbox from '../../../components/Checkbox';
@@ -71,6 +71,8 @@ export const BlocksContent: FC<{ data: BlockListProps }> = ({ data }) => {
   const [blockSearch, setBlockSearch] = useState<string>(blockSearchParam);
 
   const blockPools = useMemo(() => sortBlocks(blocks, label, findOverlappingBlocks), [blocks, label, findOverlappingBlocks]);
+  const filteredBlocks = useMemo(() => getBlockByUlid(blocks, blockSearch), [blocks, blockSearch]);
+  const filteredBlockPools = useMemo(() => getFilteredBlockPools(blockPools, filteredBlocks), [filteredBlocks, blockPools]);
 
   const setViewTime = (times: number[]): void => {
     setQuery({
@@ -89,7 +91,7 @@ export const BlocksContent: FC<{ data: BlockListProps }> = ({ data }) => {
   const onChangeCompactionCheckbox = (target: EventTarget & HTMLInputElement) => {
     setFilterCompaction(target.checked);
     if (target.checked) {
-      let compactionLevel: number = parseInt(compactionLevelInput);
+      const compactionLevel: number = parseInt(compactionLevelInput);
       setQuery({
         'filter-compaction': target.checked,
         'compaction-level': compactionLevel,
@@ -151,18 +153,24 @@ export const BlocksContent: FC<{ data: BlockListProps }> = ({ data }) => {
           <div className={styles.container}>
             <div className={styles.grid}>
               <div className={styles.sources}>
-                {Object.keys(blockPools).map((pk) => (
-                  <SourceView
-                    key={pk}
-                    data={blockPools[pk]}
-                    title={pk}
-                    selectBlock={selectBlock}
-                    gridMinTime={viewMinTime}
-                    gridMaxTime={viewMaxTime}
-                    blockSearch={blockSearch}
-                    compactionLevel={compactionLevel}
-                  />
-                ))}
+                {Object.keys(filteredBlockPools).length > 0 ? (
+                  Object.keys(filteredBlockPools).map((pk) => (
+                    <SourceView
+                      key={pk}
+                      data={filteredBlockPools[pk]}
+                      title={pk}
+                      selectBlock={selectBlock}
+                      gridMinTime={viewMinTime}
+                      gridMaxTime={viewMaxTime}
+                      blockSearch={blockSearch}
+                      compactionLevel={compactionLevel}
+                    />
+                  ))
+                ) : (
+                  <div>
+                    <h3>No Blocks Found!</h3>
+                  </div>
+                )}
               </div>
               <TimeRange
                 gridMinTime={gridMinTime}

--- a/pkg/ui/react-app/src/thanos/pages/blocks/helpers.test.tsx
+++ b/pkg/ui/react-app/src/thanos/pages/blocks/helpers.test.tsx
@@ -1,4 +1,4 @@
-import { sortBlocks, isOverlapping } from './helpers';
+import { sortBlocks, isOverlapping, getFilteredBlockPools } from './helpers';
 
 // Number of blocks in data: 8.
 const overlapCaseData = {
@@ -200,7 +200,382 @@ const overlapCaseData = {
   label: 'monitor',
 };
 
+// Total number of blocks = 8
+const blockPools = {
+  '1': {
+    '1-0': [
+      [
+        {
+          ulid: '01FV7ZG6MBEM5X5H08RXV27AJK',
+          minTime: 1644166200000,
+          maxTime: 1644166500000,
+          stats: {
+            numSamples: 168320,
+            numSeries: 2809,
+            numChunks: 2809,
+          },
+          compaction: {
+            level: 1,
+            sources: ['01FV7ZG6MBEM5X5H08RXV27AJK'],
+          },
+          version: 1,
+          thanos: {
+            labels: {
+              prometheus: 'prom-1',
+            },
+            downsample: {
+              resolution: 0,
+            },
+            source: 'sidecar',
+            segment_files: ['000001'],
+            files: [
+              {
+                rel_path: 'chunks/000001',
+                size_bytes: 145198,
+              },
+              {
+                rel_path: 'index',
+                size_bytes: 252717,
+              },
+              {
+                rel_path: 'meta.json',
+              },
+            ],
+          },
+        },
+        {
+          ulid: '01FV7ZSBKB4NN14FXD6WZ17EZP',
+          minTime: 1644166500000,
+          maxTime: 1644166800000,
+          stats: {
+            numSamples: 168320,
+            numSeries: 2809,
+            numChunks: 2809,
+          },
+          compaction: {
+            level: 1,
+            sources: ['01FV7ZSBKB4NN14FXD6WZ17EZP'],
+          },
+          version: 1,
+          thanos: {
+            labels: {
+              prometheus: 'prom-1',
+            },
+            downsample: {
+              resolution: 0,
+            },
+            source: 'sidecar',
+            segment_files: ['000001'],
+            files: [
+              {
+                rel_path: 'chunks/000001',
+                size_bytes: 142780,
+              },
+              {
+                rel_path: 'index',
+                size_bytes: 252717,
+              },
+              {
+                rel_path: 'meta.json',
+              },
+            ],
+          },
+        },
+      ],
+    ],
+  },
+  '2': {
+    '1-0': [
+      [
+        {
+          ulid: '01FV7B65Z2KR15ZKC3E9HCCNXH',
+          minTime: 1644144900000,
+          maxTime: 1644145200000,
+          stats: {
+            numSamples: 171320,
+            numSeries: 2859,
+            numChunks: 2859,
+          },
+          compaction: {
+            level: 1,
+            sources: ['01FV7B65Z2KR15ZKC3E9HCCNXH'],
+          },
+          version: 1,
+          thanos: {
+            labels: {
+              prometheus: 'prom-2',
+            },
+            downsample: {
+              resolution: 0,
+            },
+            source: 'sidecar',
+            segment_files: ['000001'],
+            files: [
+              {
+                rel_path: 'chunks/000001',
+                size_bytes: 152262,
+              },
+              {
+                rel_path: 'index',
+                size_bytes: 257544,
+              },
+              {
+                rel_path: 'meta.json',
+              },
+            ],
+          },
+        },
+        {
+          ulid: '01FV7BFAY2ZFJ0PK3872CPZHY8',
+          minTime: 1644145200000,
+          maxTime: 1644145500000,
+          stats: {
+            numSamples: 171320,
+            numSeries: 2859,
+            numChunks: 2859,
+          },
+          compaction: {
+            level: 1,
+            sources: ['01FV7BFAY2ZFJ0PK3872CPZHY8'],
+          },
+          version: 1,
+          thanos: {
+            labels: {
+              prometheus: 'prom-2',
+            },
+            downsample: {
+              resolution: 0,
+            },
+            source: 'sidecar',
+            segment_files: ['000001'],
+            files: [
+              {
+                rel_path: 'chunks/000001',
+                size_bytes: 164725,
+              },
+              {
+                rel_path: 'index',
+                size_bytes: 257544,
+              },
+              {
+                rel_path: 'meta.json',
+              },
+            ],
+          },
+        },
+      ],
+    ],
+  },
+  '3': {
+    '1-0': [
+      [
+        {
+          ulid: '01FT8X9MJF5G7PFRNGZBYT8SCS',
+          minTime: 1643123700000,
+          maxTime: 1643124000000,
+          stats: {
+            numSamples: 171320,
+            numSeries: 2859,
+            numChunks: 2859,
+          },
+          compaction: {
+            level: 1,
+            sources: ['01FT8X9MJF5G7PFRNGZBYT8SCS'],
+          },
+          version: 1,
+          thanos: {
+            labels: {
+              prometheus: 'prom-2 random:2',
+            },
+            downsample: {
+              resolution: 0,
+            },
+            source: 'sidecar',
+            segment_files: ['000001'],
+            files: [
+              {
+                rel_path: 'chunks/000001',
+                size_bytes: 143670,
+              },
+              {
+                rel_path: 'index',
+                size_bytes: 257574,
+              },
+              {
+                rel_path: 'meta.json',
+              },
+            ],
+          },
+        },
+        {
+          ulid: '01FT8XJSHDYNVJ0SWP2SGMC2DR',
+          minTime: 1643124000000,
+          maxTime: 1643124300000,
+          stats: {
+            numSamples: 171320,
+            numSeries: 2859,
+            numChunks: 2859,
+          },
+          compaction: {
+            level: 1,
+            sources: ['01FT8XJSHDYNVJ0SWP2SGMC2DR'],
+          },
+          version: 1,
+          thanos: {
+            labels: {
+              prometheus: 'prom-2 random:2',
+            },
+            downsample: {
+              resolution: 0,
+            },
+            source: 'sidecar',
+            segment_files: ['000001'],
+            files: [
+              {
+                rel_path: 'chunks/000001',
+                size_bytes: 148750,
+              },
+              {
+                rel_path: 'index',
+                size_bytes: 257574,
+              },
+              {
+                rel_path: 'meta.json',
+              },
+            ],
+          },
+        },
+      ],
+    ],
+  },
+  '4': {
+    '1-0': [
+      [
+        {
+          ulid: '01FT8XJRPTQ9VP1K1Y3M3RHK4R',
+          minTime: 1643124000000,
+          maxTime: 1643124300000,
+          stats: {
+            numSamples: 171320,
+            numSeries: 2859,
+            numChunks: 2859,
+          },
+          compaction: {
+            level: 1,
+            sources: ['01FT8XJRPTQ9VP1K1Y3M3RHK4R'],
+          },
+          version: 1,
+          thanos: {
+            labels: {
+              prometheus: 'prom-1 random:1',
+            },
+            downsample: {
+              resolution: 0,
+            },
+            source: 'sidecar',
+            segment_files: ['000001'],
+            files: [
+              {
+                rel_path: 'chunks/000001',
+                size_bytes: 210856,
+              },
+              {
+                rel_path: 'index',
+                size_bytes: 257590,
+              },
+              {
+                rel_path: 'meta.json',
+              },
+            ],
+          },
+        },
+        {
+          ulid: '01FT8XVXNNJCT16QQTFYDKRG7W',
+          minTime: 1643124300000,
+          maxTime: 1643124600000,
+          stats: {
+            numSamples: 171320,
+            numSeries: 2859,
+            numChunks: 2859,
+          },
+          compaction: {
+            level: 1,
+            sources: ['01FT8XVXNNJCT16QQTFYDKRG7W'],
+          },
+          version: 1,
+          thanos: {
+            labels: {
+              prometheus: 'prom-1 random:1',
+            },
+            downsample: {
+              resolution: 0,
+            },
+            source: 'sidecar',
+            segment_files: ['000001'],
+            files: [
+              {
+                rel_path: 'chunks/000001',
+                size_bytes: 224409,
+              },
+              {
+                rel_path: 'index',
+                size_bytes: 257590,
+              },
+              {
+                rel_path: 'meta.json',
+              },
+            ],
+          },
+        },
+      ],
+    ],
+  },
+};
+
+// Total filtered blocks = 1
+const filteredBlocks = [
+  {
+    ulid: '01FV7B65Z2KR15ZKC3E9HCCNXH',
+    minTime: 1644144900000,
+    maxTime: 1644145200000,
+    stats: {
+      numSamples: 171320,
+      numSeries: 2859,
+      numChunks: 2859,
+    },
+    compaction: {
+      level: 1,
+      sources: ['01FV7B65Z2KR15ZKC3E9HCCNXH'],
+    },
+    version: 1,
+    thanos: {
+      labels: {
+        prometheus: 'prom-2',
+      },
+      downsample: {
+        resolution: 0,
+      },
+      source: 'sidecar',
+      segment_files: ['000001'],
+      files: [
+        {
+          rel_path: 'chunks/000001',
+          size_bytes: 152262,
+        },
+        {
+          rel_path: 'index',
+          size_bytes: 257544,
+        },
+        {
+          rel_path: 'meta.json',
+        },
+      ],
+    },
+  },
+];
+
 const sorted = sortBlocks(overlapCaseData.blocks, overlapCaseData.label);
+const filteredBlockPools = getFilteredBlockPools(blockPools, filteredBlocks);
 const source = 'prometheus_one';
 
 describe('overlapping blocks', () => {
@@ -254,5 +629,30 @@ describe('isOverlapping helper', () => {
 
   it('should return false if second block starts where first ends (a.maxTime == b.minTime)', () => {
     expect(isOverlapping({ ...b, minTime: 10, maxTime: 20 }, { ...b, minTime: 20, maxTime: 30 })).toBe(false);
+  });
+});
+
+describe('Block Pools', () => {
+  it('should have exactly 4 objects', () => {
+    expect(Object.keys(blockPools)).toHaveLength(4);
+  });
+});
+
+describe('Filtered block pools', () => {
+  const objectKeyArray = Object.keys(filteredBlockPools);
+  const filteredBlockPoolArray =
+    filteredBlockPools[objectKeyArray[0]][Object.keys(filteredBlockPools[objectKeyArray[0]])[0]][0];
+
+  it('should have exactly one object', () => {
+    expect(objectKeyArray).toHaveLength(1);
+  });
+  it('should have key equals 2', () => {
+    expect(objectKeyArray[0]).toEqual('2');
+  });
+  it('should contain contain blocks having same labels', () => {
+    expect(filteredBlockPoolArray[0].thanos.labels).toEqual(filteredBlockPoolArray[1].thanos.labels);
+  });
+  it('should contain the first block having exactly the same labels as in filteredBlocks', () => {
+    expect(filteredBlockPoolArray[0].thanos.labels).toEqual(filteredBlocks[0].thanos.labels);
   });
 });

--- a/pkg/ui/react-app/src/thanos/pages/blocks/helpers.ts
+++ b/pkg/ui/react-app/src/thanos/pages/blocks/helpers.ts
@@ -146,3 +146,21 @@ export const getBlocksByCompactionLevel = (blocks: Block[], compactionLevel: num
   const blockResult = blocks.filter((block) => block.compaction.level === compactionLevel);
   return blockResult;
 };
+
+export const getFilteredBlockPools = (
+  blockPools: { [source: string]: BlocksPool },
+  filteredBlocks: Block[]
+): { [source: string]: BlocksPool } => {
+  const newblockPools: { [source: string]: BlocksPool } = {};
+  Object.keys(blockPools).map((key: string) => {
+    const poolArrayIndex = blockPools[key];
+    const poolArray = poolArrayIndex[Object.keys(poolArrayIndex)[0]];
+    for (let i = 0; i < filteredBlocks.length; i++) {
+      if (JSON.stringify(filteredBlocks[i].thanos.labels) === JSON.stringify(poolArray[0][0].thanos.labels)) {
+        Object.assign(newblockPools, { [key]: blockPools[key] });
+        break;
+      }
+    }
+  });
+  return newblockPools;
+};


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->
Issue: #5044 

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

- Added a function to filter block rows with respect to searched ULID
- Shows only the row which contains the searched block ID
- Added an edge case to show "No blocks found" if no block matches with the searched block

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->

- Tested locally with 4 different block labels.
### UI preview

Attached a short video file that demonstrates my implementation.

https://user-images.githubusercontent.com/61948033/151028795-566c7bd9-8662-4a88-b861-a5f59d202ac1.mp4


