### PR TITLE
Fix race condition in filesystem bucket client Delete()

### DIFF
--- a/pkg/objstore/filesystem/filesystem.go
+++ b/pkg/objstore/filesystem/filesystem.go
@@ -199,7 +199,8 @@ func isDirEmpty(name string) (ok bool, err error) {
 	if os.IsNotExist(err) {
 		// The directory doesn't exist. We don't consider it an error and we treat it like empty.
 		return true, nil
-	} else if err != nil {
+	}
+	if err != nil {
 		return false, err
 	}
 	defer runutil.CloseWithErrCapture(&err, f, "dir open")

--- a/pkg/objstore/filesystem/filesystem.go
+++ b/pkg/objstore/filesystem/filesystem.go
@@ -11,12 +11,11 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/thanos-io/thanos/pkg/objstore"
+	"github.com/pkg/errors"
 	"gopkg.in/yaml.v2"
 
+	"github.com/thanos-io/thanos/pkg/objstore"
 	"github.com/thanos-io/thanos/pkg/runutil"
-
-	"github.com/pkg/errors"
 )
 
 // Config stores the configuration for storing and accessing blobs in filesystem.
@@ -197,12 +196,15 @@ func (b *Bucket) Upload(_ context.Context, name string, r io.Reader) (err error)
 
 func isDirEmpty(name string) (ok bool, err error) {
 	f, err := os.Open(filepath.Clean(name))
-	if err != nil {
+	if os.IsNotExist(err) {
+		// The directory doesn't exist. We don't consider it an error and we treat it like empty.
+		return true, nil
+	} else if err != nil {
 		return false, err
 	}
 	defer runutil.CloseWithErrCapture(&err, f, "dir open")
 
-	if _, err = f.Readdir(1); err == io.EOF {
+	if _, err = f.Readdir(1); err == io.EOF || os.IsNotExist(err) {
 		return true, nil
 	}
 	return false, err

--- a/pkg/objstore/filesystem/filesystem_test.go
+++ b/pkg/objstore/filesystem/filesystem_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
 package filesystem
 
 import (

--- a/pkg/objstore/filesystem/filesystem_test.go
+++ b/pkg/objstore/filesystem/filesystem_test.go
@@ -1,0 +1,43 @@
+package filesystem
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/thanos-io/thanos/pkg/testutil"
+)
+
+func TestDelete_EmptyDirDeletionRaceCondition(t *testing.T) {
+	const runs = 1000
+
+	ctx := context.Background()
+
+	for r := 0; r < runs; r++ {
+		b, err := NewBucket(t.TempDir())
+		testutil.Ok(t, err)
+
+		// Upload 2 objects in a subfolder.
+		testutil.Ok(t, b.Upload(ctx, "subfolder/first", strings.NewReader("first")))
+		testutil.Ok(t, b.Upload(ctx, "subfolder/second", strings.NewReader("second")))
+
+		// Prepare goroutines to concurrently delete the 2 objects (each one deletes a different object)
+		start := make(chan struct{})
+		group := sync.WaitGroup{}
+		group.Add(2)
+
+		for _, object := range []string{"first", "second"} {
+			go func(object string) {
+				defer group.Done()
+
+				<-start
+				testutil.Ok(t, b.Delete(ctx, "subfolder/"+object))
+			}(object)
+		}
+
+		// Go!
+		close(start)
+		group.Wait()
+	}
+}


### PR DESCRIPTION
* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

I found a race condition in the filesystem bucket client `Delete()`. The issue happen if 2 concurrent deletes occurs on different files in a subfolder containing only these 2 files. Both `Delete()` will try to delete the empty dir, but one of the two will fail with:

```
unexpected error: fdopendir /path/to/subfolder: no such file or directory
```

In this PR I propose to handle the `no such file or directory` in the `isDirEmpty()`. `isDirEmpty()` is used by Iter() and Delete(). In `Iter()` it's just used to skip empty dirs, so I think this change is fine there too.

## Verification

New unit test.
