### PR TITLE
Do not upload meta files to obj store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 
 ### Added
 
+- [#5110](https://github.com/thanos-io/thanos/pull/5110) Block: Do not upload DebugMeta files to obj store.
 - [#4963](https://github.com/thanos-io/thanos/pull/4963) Compactor, Store, Tools: Loading block metadata now only filters out duplicates within a source (or compaction group if replica labels are configured), and does so in parallel over sources.
 - [#5089](https://github.com/thanos-io/thanos/pull/5089) S3: Create an empty map in the case SSE-KMS is used and no KMSEncryptionContext is passed.
 - [#4970](https://github.com/thanos-io/thanos/pull/4970) Added a new flag `exclude-delete` to `tools bucket ls`, which excludes blocks marked for deletion.

--- a/pkg/block/block.go
+++ b/pkg/block/block.go
@@ -9,7 +9,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path"
@@ -144,11 +143,6 @@ func upload(ctx context.Context, logger log.Logger, bkt objstore.Bucket, bdir st
 
 	if err := meta.Write(&metaEncoded); err != nil {
 		return errors.Wrap(err, "encode meta file")
-	}
-
-	// TODO(yeya24): Remove this step.
-	if err := bkt.Upload(ctx, path.Join(DebugMetas, fmt.Sprintf("%s.json", id)), strings.NewReader(metaEncoded.String())); err != nil {
-		return cleanUp(logger, bkt, id, errors.Wrap(err, "upload debug meta file"))
 	}
 
 	if err := objstore.UploadDir(ctx, logger, bkt, path.Join(bdir, ChunksDirname), path.Join(id.String(), ChunksDirname)); err != nil {

--- a/pkg/block/block_test.go
+++ b/pkg/block/block_test.go
@@ -141,7 +141,7 @@ func TestUpload(t *testing.T) {
 	{
 		// Full block.
 		testutil.Ok(t, Upload(ctx, log.NewNopLogger(), bkt, path.Join(tmpDir, "test", b1.String()), metadata.NoneFunc))
-		testutil.Equals(t, 4, len(bkt.Objects()))
+		testutil.Equals(t, 3, len(bkt.Objects()))
 		testutil.Equals(t, 3751, len(bkt.Objects()[path.Join(b1.String(), ChunksDirname, "000001")]))
 		testutil.Equals(t, 401, len(bkt.Objects()[path.Join(b1.String(), IndexFilename)]))
 		testutil.Equals(t, 546, len(bkt.Objects()[path.Join(b1.String(), MetaFilename)]))
@@ -191,7 +191,7 @@ func TestUpload(t *testing.T) {
 	{
 		// Test Upload is idempotent.
 		testutil.Ok(t, Upload(ctx, log.NewNopLogger(), bkt, path.Join(tmpDir, "test", b1.String()), metadata.NoneFunc))
-		testutil.Equals(t, 4, len(bkt.Objects()))
+		testutil.Equals(t, 3, len(bkt.Objects()))
 		testutil.Equals(t, 3751, len(bkt.Objects()[path.Join(b1.String(), ChunksDirname, "000001")]))
 		testutil.Equals(t, 401, len(bkt.Objects()[path.Join(b1.String(), IndexFilename)]))
 		testutil.Equals(t, 546, len(bkt.Objects()[path.Join(b1.String(), MetaFilename)]))
@@ -209,7 +209,7 @@ func TestUpload(t *testing.T) {
 		err = Upload(ctx, log.NewNopLogger(), bkt, path.Join(tmpDir, b2.String()), metadata.NoneFunc)
 		testutil.NotOk(t, err)
 		testutil.Equals(t, "empty external labels are not allowed for Thanos block.", err.Error())
-		testutil.Equals(t, 4, len(bkt.Objects()))
+		testutil.Equals(t, 3, len(bkt.Objects()))
 	}
 	{
 		// No external labels with UploadPromBlocks.
@@ -223,7 +223,7 @@ func TestUpload(t *testing.T) {
 		testutil.Ok(t, err)
 		err = UploadPromBlock(ctx, log.NewNopLogger(), bkt, path.Join(tmpDir, b2.String()), metadata.NoneFunc)
 		testutil.Ok(t, err)
-		testutil.Equals(t, 8, len(bkt.Objects()))
+		testutil.Equals(t, 6, len(bkt.Objects()))
 		testutil.Equals(t, 3736, len(bkt.Objects()[path.Join(b2.String(), ChunksDirname, "000001")]))
 		testutil.Equals(t, 401, len(bkt.Objects()[path.Join(b2.String(), IndexFilename)]))
 		testutil.Equals(t, 525, len(bkt.Objects()[path.Join(b2.String(), MetaFilename)]))
@@ -249,15 +249,14 @@ func TestDelete(t *testing.T) {
 		}, 100, 0, 1000, labels.Labels{{Name: "ext1", Value: "val1"}}, 124, metadata.NoneFunc)
 		testutil.Ok(t, err)
 		testutil.Ok(t, Upload(ctx, log.NewNopLogger(), bkt, path.Join(tmpDir, b1.String()), metadata.NoneFunc))
-		testutil.Equals(t, 4, len(bkt.Objects()))
+		testutil.Equals(t, 3, len(bkt.Objects()))
 
 		markedForDeletion := promauto.With(prometheus.NewRegistry()).NewCounter(prometheus.CounterOpts{Name: "test"})
 		testutil.Ok(t, MarkForDeletion(ctx, log.NewNopLogger(), bkt, b1, "", markedForDeletion))
 
 		// Full delete.
 		testutil.Ok(t, Delete(ctx, log.NewNopLogger(), bkt, b1))
-		// Still debug meta entry is expected.
-		testutil.Equals(t, 1, len(bkt.Objects()))
+		testutil.Equals(t, 0, len(bkt.Objects()))
 	}
 	{
 		b2, err := e2eutil.CreateBlock(ctx, tmpDir, []labels.Labels{
@@ -269,13 +268,12 @@ func TestDelete(t *testing.T) {
 		}, 100, 0, 1000, labels.Labels{{Name: "ext1", Value: "val1"}}, 124, metadata.NoneFunc)
 		testutil.Ok(t, err)
 		testutil.Ok(t, Upload(ctx, log.NewNopLogger(), bkt, path.Join(tmpDir, b2.String()), metadata.NoneFunc))
-		testutil.Equals(t, 5, len(bkt.Objects()))
+		testutil.Equals(t, 3, len(bkt.Objects()))
 
 		// Remove meta.json and check if delete can delete it.
 		testutil.Ok(t, bkt.Delete(ctx, path.Join(b2.String(), MetaFilename)))
 		testutil.Ok(t, Delete(ctx, log.NewNopLogger(), bkt, b2))
-		// Still 2 debug meta entries are expected.
-		testutil.Equals(t, 2, len(bkt.Objects()))
+		testutil.Equals(t, 0, len(bkt.Objects()))
 	}
 }
 
@@ -415,7 +413,7 @@ func TestHashDownload(t *testing.T) {
 	testutil.Ok(t, err)
 
 	testutil.Ok(t, Upload(ctx, log.NewNopLogger(), instrumentedBkt, path.Join(tmpDir, b1.String()), metadata.SHA256Func))
-	testutil.Equals(t, 4, len(bkt.Objects()))
+	testutil.Equals(t, 3, len(bkt.Objects()))
 
 	m, err := DownloadMeta(ctx, log.NewNopLogger(), bkt, b1)
 	testutil.Ok(t, err)
@@ -447,7 +445,7 @@ func TestHashDownload(t *testing.T) {
         thanos_objstore_bucket_operations_total{bucket="test",operation="get"} 2
         thanos_objstore_bucket_operations_total{bucket="test",operation="get_range"} 0
         thanos_objstore_bucket_operations_total{bucket="test",operation="iter"} 2
-        thanos_objstore_bucket_operations_total{bucket="test",operation="upload"} 4
+        thanos_objstore_bucket_operations_total{bucket="test",operation="upload"} 3
 		`), `thanos_objstore_bucket_operations_total`))
 	}
 
@@ -465,7 +463,7 @@ func TestHashDownload(t *testing.T) {
         thanos_objstore_bucket_operations_total{bucket="test",operation="get"} 4
         thanos_objstore_bucket_operations_total{bucket="test",operation="get_range"} 0
         thanos_objstore_bucket_operations_total{bucket="test",operation="iter"} 4
-        thanos_objstore_bucket_operations_total{bucket="test",operation="upload"} 4
+        thanos_objstore_bucket_operations_total{bucket="test",operation="upload"} 3
 		`), `thanos_objstore_bucket_operations_total`))
 	}
 
@@ -485,7 +483,7 @@ func TestHashDownload(t *testing.T) {
 			thanos_objstore_bucket_operations_total{bucket="test",operation="get"} 7
 			thanos_objstore_bucket_operations_total{bucket="test",operation="get_range"} 0
 			thanos_objstore_bucket_operations_total{bucket="test",operation="iter"} 6
-			thanos_objstore_bucket_operations_total{bucket="test",operation="upload"} 4
+			thanos_objstore_bucket_operations_total{bucket="test",operation="upload"} 3
 			`), `thanos_objstore_bucket_operations_total`))
 	}
 }
@@ -516,8 +514,8 @@ func TestUploadCleanup(t *testing.T) {
 		testutil.Assert(t, errors.Is(uploadErr, errUploadFailed))
 
 		// If upload of index fails, block is deleted.
-		testutil.Equals(t, 1, len(bkt.Objects())) // Only debug meta file is present.
-		testutil.Assert(t, len(bkt.Objects()[path.Join(DebugMetas, fmt.Sprintf("%s.json", b1.String()))]) > 0)
+		testutil.Equals(t, 0, len(bkt.Objects()))
+		testutil.Assert(t, len(bkt.Objects()[path.Join(DebugMetas, fmt.Sprintf("%s.json", b1.String()))]) == 0)
 	}
 
 	{
@@ -527,11 +525,11 @@ func TestUploadCleanup(t *testing.T) {
 		testutil.Assert(t, errors.Is(uploadErr, errUploadFailed))
 
 		// If upload of meta.json fails, nothing is cleaned up.
-		testutil.Equals(t, 4, len(bkt.Objects()))
+		testutil.Equals(t, 3, len(bkt.Objects()))
 		testutil.Assert(t, len(bkt.Objects()[path.Join(b1.String(), ChunksDirname, "000001")]) > 0)
 		testutil.Assert(t, len(bkt.Objects()[path.Join(b1.String(), IndexFilename)]) > 0)
 		testutil.Assert(t, len(bkt.Objects()[path.Join(b1.String(), MetaFilename)]) > 0)
-		testutil.Assert(t, len(bkt.Objects()[path.Join(DebugMetas, fmt.Sprintf("%s.json", b1.String()))]) > 0)
+		testutil.Assert(t, len(bkt.Objects()[path.Join(DebugMetas, fmt.Sprintf("%s.json", b1.String()))]) == 0)
 	}
 }
 

--- a/pkg/shipper/shipper_e2e_test.go
+++ b/pkg/shipper/shipper_e2e_test.go
@@ -134,7 +134,7 @@ func TestShipper_SyncBlocks_e2e(t *testing.T) {
 				thanos_objstore_bucket_operations_total{bucket="test",operation="get"} 0
 				thanos_objstore_bucket_operations_total{bucket="test",operation="get_range"} 0
 				thanos_objstore_bucket_operations_total{bucket="test",operation="iter"} 0
-				thanos_objstore_bucket_operations_total{bucket="test",operation="upload"} 25
+				thanos_objstore_bucket_operations_total{bucket="test",operation="upload"} 20
 				`), `thanos_objstore_bucket_operations_total`))
 				testutil.Equals(t, 0, b)
 			}


### PR DESCRIPTION
Signed-off-by: Romain Dauby <romain.dauby@gmail.com>

Fix #3839 

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

* do not upload DebugMeta files to bucket (obj store)

## Verification

Unit test, e2e tests passed locally and also in my fork with Github actions.
