### PR TITLE
Use time.RFC3339 in bucket inspect command for consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#4879](https://github.com/thanos-io/thanos/pull/4879) Bucket verify: Fixed bug causing wrong number of blocks to be checked.
 - [#4908](https://github.com/thanos-io/thanos/pull/4908) UI: Show 'minus' icon and add tooltip when store min / max time is not available.
 - [#4883](https://github.com/thanos-io/thanos/pull/4883) Mixin: adhere to RFC 1123 compatible component naming.
+- [#5114](https://github.com/thanos-io/thanos/pull/5114) Tools `thanos bucket inspect` fix time formatting.
 
 ## [v0.24.0](https://github.com/thanos-io/thanos/tree/release-0.24) - 2021.12.22
 

--- a/cmd/thanos/tools_bucket.go
+++ b/cmd/thanos/tools_bucket.go
@@ -417,7 +417,7 @@ func registerBucketLs(app extkingpin.AppClause, objStoreConfig *extflag.PathOrCo
 				maxTime := time.Unix(m.MaxTime/1000, 0)
 
 				if _, err = fmt.Fprintf(os.Stdout, "%s -- %s - %s Diff: %s, Compaction: %d, Downsample: %d, Source: %s\n",
-					m.ULID, minTime.Format("2006-01-02 15:04"), maxTime.Format("2006-01-02 15:04"), maxTime.Sub(minTime),
+					m.ULID, minTime.Format(time.RFC3339), maxTime.Format(time.RFC3339), maxTime.Sub(minTime),
 					m.Compaction.Level, m.Thanos.Downsample.Resolution, m.Thanos.Source); err != nil {
 					return err
 				}
@@ -911,8 +911,8 @@ func printBlockData(blockMetas []*metadata.Meta, selectorLabels labels.Labels, s
 		var line []string
 		line = append(line,
 			blockMeta.ULID.String(),
-			time.Unix(blockMeta.MinTime/1000, 0).Format("02-01-2006 15:04:05"),
-			time.Unix(blockMeta.MaxTime/1000, 0).Format("02-01-2006 15:04:05"),
+			time.Unix(blockMeta.MinTime/1000, 0).Format(time.RFC3339),
+			time.Unix(blockMeta.MaxTime/1000, 0).Format(time.RFC3339),
 			timeRange.String(),
 			untilDown,
 			p.Sprintf("%d", blockMeta.Stats.NumSeries),
@@ -997,8 +997,8 @@ func (t Table) Less(i, j int) bool {
 
 func compare(s1, s2 string) bool {
 	// Values can be either Time, Duration, comma-delimited integers or strings.
-	s1Time, s1Err := time.Parse("02-01-2006 15:04:05", s1)
-	s2Time, s2Err := time.Parse("02-01-2006 15:04:05", s2)
+	s1Time, s1Err := time.Parse(time.RFC3339, s1)
+	s2Time, s2Err := time.Parse(time.RFC3339, s2)
 	if s1Err != nil || s2Err != nil {
 		s1Duration, s1Err := time.ParseDuration(s1)
 		s2Duration, s2Err := time.ParseDuration(s2)


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Most places in thanos use RFC3339 for formatting, but I noticed that `thanos tools bucket inspect` had the format hardcoded.

## Verification

Built the thanos binary and tried the inspect command to verify the output
