### PR TITLE
tools bucket replicate: deletion marks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#4667](https://github.com/thanos-io/thanos/pull/4667) Add a pure aws-sdk auth for s3 storage.
 - [#5111](https://github.com/thanos-io/thanos/pull/5111) Add matcher support to Query Rules endpoint.
 - [#5117](https://github.com/thanos-io/thanos/pull/5117) Bucket replicate: Added flag `--ignore-marked-for-deletion` to avoid replication of blocks with the deletion mark.
+- [#5118](https://github.com/thanos-io/thanos/pull/5118) Bucket replicate: replicates also deletion marks.
 
 ### Fixed
 


### PR DESCRIPTION
If running replicate from an origin bucket with running compactor, old removed blocks get replicated but never marked as a deleted and once a new compacted block is synced this leads to overlapping blocks.

This PR adds synchronization of the deletion marks even in case the block is already synchronized (metadata JSON already there) because deletion mark is something that can change.

## Changes

 - `tools bucket replicate` now replicates event deletion marks

## Verification

 - Tests added
