### PR TITLE
 Fix typo in step2.md_2-lts_katacoda-tutorial

### DIFF
--- a/tutorials/katacoda/thanos/2-lts/step2.md
+++ b/tutorials/katacoda/thanos/2-lts/step2.md
@@ -40,7 +40,7 @@ Enter the credentials as mentioned below:
 **Access Key** = `minio`
 **Secret Key** = `melovethanos`
 
-## Sidear block backup
+## Sidecar block backup
 
 All Thanos components that use object storage uses the same `objstore.config` flag with the same "little" bucket config format.
 


### PR DESCRIPTION
Found a small typo in step2.md in 2-Lts katacoda tutorial.

