### PR TITLE
[RECEIVE] Make out of bounds a non-recoverable error

### DIFF
--- a/pkg/receive/handler.go
+++ b/pkg/receive/handler.go
@@ -360,7 +360,7 @@ func (h *Handler) receiveHTTP(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusServiceUnavailable)
 	case errConflict:
 		http.Error(w, err.Error(), http.StatusConflict)
-	case storage.ErrOutOfBounds:
+	case errOutOfBounds:
 		http.Error(w, err.Error(), http.StatusBadRequest)
 	case errBadReplica:
 		http.Error(w, err.Error(), http.StatusBadRequest)

--- a/pkg/receive/handler_test.go
+++ b/pkg/receive/handler_test.go
@@ -331,7 +331,8 @@ func newTestHandlerHashring(appendables []*fakeAppendable, replicationFactor uin
 
 func TestReceiveQuorum(t *testing.T) {
 	appenderErrFn := func() error { return errors.New("failed to get appender") }
-	conflictErrFn := func() error { return storage.ErrOutOfBounds }
+	conflictErrFn := func() error { return storage.ErrOutOfOrderSample }
+	outOfBoundsErrFn := func() error { return storage.ErrOutOfBounds }
 	commitErrFn := func() error { return errors.New("failed to commit") }
 	wreq1 := &prompb.WriteRequest{
 		Timeseries: []prompb.TimeSeries{
@@ -396,6 +397,17 @@ func TestReceiveQuorum(t *testing.T) {
 			appendables: []*fakeAppendable{
 				{
 					appender: newFakeAppender(conflictErrFn, nil, nil),
+				},
+			},
+		},
+		{
+			name:              "size 1 outofbound",
+			status:            http.StatusBadRequest,
+			replicationFactor: 1,
+			wreq:              wreq1,
+			appendables: []*fakeAppendable{
+				{
+					appender: newFakeAppender(outOfBoundsErrFn, nil, nil),
 				},
 			},
 		},
@@ -667,7 +679,8 @@ func TestReceiveQuorum(t *testing.T) {
 
 func TestReceiveWithConsistencyDelay(t *testing.T) {
 	appenderErrFn := func() error { return errors.New("failed to get appender") }
-	conflictErrFn := func() error { return storage.ErrOutOfBounds }
+	conflictErrFn := func() error { return storage.ErrOutOfOrderSample }
+	outOfBoundsErrFn := func() error { return storage.ErrOutOfBounds }
 	commitErrFn := func() error { return errors.New("failed to commit") }
 	wreq1 := &prompb.WriteRequest{
 		Timeseries: []prompb.TimeSeries{
@@ -732,6 +745,17 @@ func TestReceiveWithConsistencyDelay(t *testing.T) {
 			appendables: []*fakeAppendable{
 				{
 					appender: newFakeAppender(conflictErrFn, nil, nil),
+				},
+			},
+		},
+		{
+			name:              "size 1 outofbound",
+			status:            http.StatusBadRequest,
+			replicationFactor: 1,
+			wreq:              wreq1,
+			appendables: []*fakeAppendable{
+				{
+					appender: newFakeAppender(outOfBoundsErrFn, nil, nil),
 				},
 			},
 		},

--- a/pkg/receive/writer.go
+++ b/pkg/receive/writer.go
@@ -85,10 +85,10 @@ func (r *Writer) Write(ctx context.Context, tenantID string, wreq *prompb.WriteR
 			switch err {
 			case storage.ErrOutOfOrderSample:
 				numOutOfOrder++
-				level.Debug(r.logger).Log("msg", "Out of order sample", "sample value", s.Value, "sample timestamp", s.Timestamp)
+				level.Debug(r.logger).Log("msg", "Out of order sample", "lset", lset, "sample value", s.Value, "sample timestamp", s.Timestamp)
 			case storage.ErrDuplicateSampleForTimestamp:
 				numDuplicates++
-				level.Debug(r.logger).Log("msg", "Duplicate sample for timestamp", "sample value", s.Value, "sample timestamp", s.Timestamp)
+				level.Debug(r.logger).Log("msg", "Duplicate sample for timestamp", "lset", lset, "sample value", s.Value, "sample timestamp", s.Timestamp)
 			case storage.ErrOutOfBounds:
 				numOutOfBounds++
 				level.Debug(r.logger).Log("msg", "Out of bounds metric", "lset", lset, "sample value", s.Value, "sample timestamp", s.Timestamp)

--- a/pkg/receive/writer.go
+++ b/pkg/receive/writer.go
@@ -85,13 +85,13 @@ func (r *Writer) Write(ctx context.Context, tenantID string, wreq *prompb.WriteR
 			switch err {
 			case storage.ErrOutOfOrderSample:
 				numOutOfOrder++
-				level.Debug(r.logger).Log("msg", "Out of order sample", "lset", lset, "sample", s)
+				level.Debug(r.logger).Log("msg", "Out of order sample", "sample value", s.Value, "sample timestamp", s.Timestamp)
 			case storage.ErrDuplicateSampleForTimestamp:
 				numDuplicates++
-				level.Debug(r.logger).Log("msg", "Duplicate sample for timestamp", "lset", lset, "sample", s)
+				level.Debug(r.logger).Log("msg", "Duplicate sample for timestamp", "sample value", s.Value, "sample timestamp", s.Timestamp)
 			case storage.ErrOutOfBounds:
 				numOutOfBounds++
-				level.Debug(r.logger).Log("msg", "Out of bounds metric", "lset", lset, "sample", s)
+				level.Debug(r.logger).Log("msg", "Out of bounds metric", "lset", lset, "sample value", s.Value, "sample timestamp", s.Timestamp)
 			}
 		}
 


### PR DESCRIPTION
Signed-off-by: Wiard van Rij <wvanrij@roku.com>

Relates to: https://github.com/thanos-io/thanos/issues/4831

Prometheus' remote write receiver treats `ErrOutOfOrder` as non-recoverable.
https://github.com/prometheus/prometheus/issues/5649#issuecomment-970730016_

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Out of bounds would result in a http 409, which causes Prometheus to retry, eventually causing an infinite loop which can only be solved by flushing the entire Prometheus data dir. 

This change removes OutOfBounds err from ConflictErr to it's own entity and it will allow Prometheus to deal with this as non-recoverable (i.e. dropping it, instead of retry).

Also made a small adjustment in the Debug.Log, as it could not print the sample, which causes a confusing debug message like: `sample="unsupported value type"` - Now it will print the sample value and timestamp.


## Verification

I mean, i'll be honest that it was a pain in the a. to test and debug this. What I have checked is that Prometheus now handles this as non-recoverable and nothing will build up anymore as pending. 

I have adjusted the test cases and added the OutOfBounds for it.
