### PR TITLE
cache: fix quickstart script, improve checking

### DIFF
--- a/pkg/cache/groupcache.go
+++ b/pkg/cache/groupcache.go
@@ -88,6 +88,9 @@ func parseGroupcacheConfig(conf []byte) (GroupcacheConfig, error) {
 			return GroupcacheConfig{}, fmt.Errorf("peer %d must not have a trailing slash (%s)", i, peer)
 		}
 	}
+	if strings.HasSuffix(config.SelfURL, "/") {
+		return GroupcacheConfig{}, fmt.Errorf("self URL %s must not have a trailing slash", config.SelfURL)
+	}
 
 	return config, nil
 }

--- a/scripts/quickstart.sh
+++ b/scripts/quickstart.sh
@@ -169,9 +169,9 @@ if [ -n "${GCS_BUCKET}" -o -n "${S3_ENDPOINT}" ]; then
   cat >groupcache.yml <<-EOF
 		type: GROUPCACHE
 config:
-  self_url: http://localhost:10906/
+  self_url: http://localhost:10906
   peers:
-    - http://localhost:10906/
+    - http://localhost:10906
   groupcache_group: groupcache_test_group
 blocks_iter_ttl: 0s
 metafile_exists_ttl: 0s


### PR DESCRIPTION
Check that SelfURL also doesn't end with a slash since the galaxycache's
code checks whether the strings are equivalent when picking peers, and
peers cannot have slashes at the end so we need the same, exact format
of the URLs.

Fix quickstart script so that it wouldn't have slashes at the end.

Idea for the future: let's add smoke tests for `scripts/quickstart.sh`
to ensure smooth developer experience?

Signed-off-by: Giedrius Statkevičius <giedrius.statkevicius@vinted.com>
