### PR TITLE
ui: remove white background in rules content table cell (#5024)

### DIFF
--- a/pkg/ui/react-app/src/pages/rules/RulesContent.tsx
+++ b/pkg/ui/react-app/src/pages/rules/RulesContent.tsx
@@ -110,7 +110,7 @@ export const RulesContent: FC<RouteComponentProps & RulesContentProps> = ({ resp
                           </div>
                         </td>
                       ) : (
-                        <td style={{ backgroundColor: '#F5F5F5' }}>
+                        <td>
                           <GraphExpressionLink title="record" expr={r.name} />
                           <GraphExpressionLink title="expr" expr={r.query} />
                         </td>


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

1. Remove white background from table cell in RulesContent table, so it's able for flexible color scheme (white/dark)

## Verification

1. I didn't test it, but I'm sure about it, it seems like any other table cells now
