### PR TITLE
Receive: option to extract tenant from client certificate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ The binaries published with this release are built with Go1.17.8 to avoid [CVE-2
 
 ### Added
 
+- [#5153](https://github.com/thanos-io/thanos/pull/5153) Receive: option to extract tenant from client certificate
 - [#5110](https://github.com/thanos-io/thanos/pull/5110) Block: Do not upload DebugMeta files to obj store.
 - [#4963](https://github.com/thanos-io/thanos/pull/4963) Compactor, Store, Tools: Loading block metadata now only filters out duplicates within a source (or compaction group if replica labels are configured), and does so in parallel over sources.
 - [#5089](https://github.com/thanos-io/thanos/pull/5089) S3: Create an empty map in the case SSE-KMS is used and no KMSEncryptionContext is passed.

--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -191,7 +191,7 @@ func runReceive(
 		Registry:          reg,
 		Endpoint:          conf.endpoint,
 		TenantHeader:      conf.tenantHeader,
-		TenantAttribute:   conf.tenantAttribute,
+		TenantField:       conf.tenantField,
 		DefaultTenantID:   conf.defaultTenantID,
 		ReplicaHeader:     conf.replicaHeader,
 		ReplicationFactor: conf.replicationFactor,
@@ -709,7 +709,7 @@ type receiveConfig struct {
 	refreshInterval   *model.Duration
 	endpoint          string
 	tenantHeader      string
-	tenantAttribute   string
+	tenantField       string
 	tenantLabelName   string
 	defaultTenantID   string
 	replicaHeader     string
@@ -773,7 +773,7 @@ func (rc *receiveConfig) registerFlag(cmd extkingpin.FlagClause) {
 
 	cmd.Flag("receive.tenant-header", "HTTP header to determine tenant for write requests.").Default(receive.DefaultTenantHeader).StringVar(&rc.tenantHeader)
 
-	cmd.Flag("receive.tenant-certificate-attribute", "Use TLS client certificate's attribute to determine tenant for write requests. Must be one of organization, organizationalUnit or commonName.").Default("").StringVar(&rc.tenantAttribute)
+	cmd.Flag("receive.tenant-certificate-field", "Use TLS client's certificate field to determine tenant for write requests. Must be one of "+receive.CertificateFieldOrganization+", "+receive.CertificateFieldOrganizationalUnit+" or "+receive.CertificateFieldCommonName+". This setting will cause the receive.tenant-header flag value to be ignored.").Default("").EnumVar(&rc.tenantField, "", receive.CertificateFieldOrganization, receive.CertificateFieldOrganizationalUnit, receive.CertificateFieldCommonName)
 
 	cmd.Flag("receive.default-tenant-id", "Default tenant ID to use when none is provided via a header.").Default(receive.DefaultTenant).StringVar(&rc.defaultTenantID)
 

--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -191,6 +191,7 @@ func runReceive(
 		Registry:          reg,
 		Endpoint:          conf.endpoint,
 		TenantHeader:      conf.tenantHeader,
+		TenantAttribute:   conf.tenantAttribute,
 		DefaultTenantID:   conf.defaultTenantID,
 		ReplicaHeader:     conf.replicaHeader,
 		ReplicationFactor: conf.replicationFactor,
@@ -708,6 +709,7 @@ type receiveConfig struct {
 	refreshInterval   *model.Duration
 	endpoint          string
 	tenantHeader      string
+	tenantAttribute   string
 	tenantLabelName   string
 	defaultTenantID   string
 	replicaHeader     string
@@ -770,6 +772,8 @@ func (rc *receiveConfig) registerFlag(cmd extkingpin.FlagClause) {
 	cmd.Flag("receive.local-endpoint", "Endpoint of local receive node. Used to identify the local node in the hashring configuration.").StringVar(&rc.endpoint)
 
 	cmd.Flag("receive.tenant-header", "HTTP header to determine tenant for write requests.").Default(receive.DefaultTenantHeader).StringVar(&rc.tenantHeader)
+
+	cmd.Flag("receive.tenant-certificate-attribute", "Use TLS client certificate's attribute to determine tenant for write requests. Must be one of organization, organizationalUnit or commonName.").Default("").StringVar(&rc.tenantAttribute)
 
 	cmd.Flag("receive.default-tenant-id", "Default tenant ID to use when none is provided via a header.").Default(receive.DefaultTenant).StringVar(&rc.defaultTenantID)
 

--- a/docs/components/receive.md
+++ b/docs/components/receive.md
@@ -144,6 +144,12 @@ Flags:
       --receive.replication-factor=1
                                  How many times to replicate incoming write
                                  requests.
+      --receive.tenant-certificate-field=
+                                 Use TLS client's certificate field to determine
+                                 tenant for write requests. Must be one of
+                                 organization, organizationalUnit or commonName.
+                                 This setting will cause the
+                                 receive.tenant-header flag value to be ignored.
       --receive.tenant-header="THANOS-TENANT"
                                  HTTP header to determine tenant for write
                                  requests.

--- a/pkg/receive/handler.go
+++ b/pkg/receive/handler.go
@@ -848,25 +848,22 @@ func (h *Handler) getTenantFromCertificate(r *http.Request) (string, error) {
 	switch h.options.TenantField {
 
 	case CertificateFieldOrganization:
-		if len(cert.Subject.Organization) > 0 {
-			tenant = cert.Subject.Organization[0]
-		} else {
+		if len(cert.Subject.Organization) == 0 {
 			return "", errors.New("could not get organization field from client cert")
 		}
+		tenant = cert.Subject.Organization[0]
 
 	case CertificateFieldOrganizationalUnit:
-		if len(cert.Subject.OrganizationalUnit) > 0 {
-			tenant = cert.Subject.OrganizationalUnit[0]
-		} else {
+		if len(cert.Subject.OrganizationalUnit) == 0 {
 			return "", errors.New("could not get organizationalUnit field from client cert")
 		}
+		tenant = cert.Subject.OrganizationalUnit[0]
 
 	case CertificateFieldCommonName:
-		if cert.Subject.CommonName != "" {
-			tenant = cert.Subject.CommonName
-		} else {
+		if cert.Subject.CommonName == "" {
 			return "", errors.New("could not get commonName field from client cert")
 		}
+		tenant = cert.Subject.CommonName
 
 	default:
 		return "", errors.New("tls client cert field requested is not supported")

--- a/pkg/receive/handler.go
+++ b/pkg/receive/handler.go
@@ -829,7 +829,7 @@ func (p *peerGroup) get(ctx context.Context, addr string) (storepb.WriteableStor
 	return client, nil
 }
 
-// GetTenantFromCertificate extracts the tenant value from a client's presented certificate. The x509 field to use as
+// getTenantFromCertificate extracts the tenant value from a client's presented certificate. The x509 field to use as
 // value can be configured with Options.TenantField. An error is returned when the extraction has not succeeded.
 func (h *Handler) getTenantFromCertificate(r *http.Request) (string, error) {
 	var tenant string

--- a/pkg/receive/handler.go
+++ b/pkg/receive/handler.go
@@ -299,6 +299,7 @@ func (h *Handler) handleRequest(ctx context.Context, rep uint64, tenant string, 
 }
 
 func (h *Handler) receiveHTTP(w http.ResponseWriter, r *http.Request) {
+	var err error
 	span, ctx := tracing.StartSpan(r.Context(), "receive_http")
 	defer span.Finish()
 
@@ -326,7 +327,7 @@ func (h *Handler) receiveHTTP(w http.ResponseWriter, r *http.Request) {
 	} else {
 		compressed.Grow(512)
 	}
-	_, err := io.Copy(&compressed, r.Body)
+	_, err = io.Copy(&compressed, r.Body)
 	if err != nil {
 		http.Error(w, errors.Wrap(err, "read compressed request body").Error(), http.StatusInternalServerError)
 		return


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

This PR adds the option to extract the tenant label value from a supplied TLS client certificate. It takes priority over any header value sent. As such, it ensures that incoming remote_write requests are always put to the correct tenant. The attribute value from the cert can be one of organization, organizationalUnit or commonName. Running a private PKI for remote_write is highly recommended to control the values of the certificate. However, any client certificate will suffice as long as it is valid. If extracting the tentant from the certificate fails, the write request is denied with a 400 status code.
This feature is disabled by default.

## Verification

Running this change for some time now in a test environment without any issues.
