### PR TITLE
fix tools bucket replicate: fix ignoring of deleted blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#4667](https://github.com/thanos-io/thanos/pull/4667) Add a pure aws-sdk auth for s3 storage.
 - [#5111](https://github.com/thanos-io/thanos/pull/5111) Add matcher support to Query Rules endpoint.
 - [#5117](https://github.com/thanos-io/thanos/pull/5117) Bucket replicate: Added flag `--ignore-marked-for-deletion` to avoid replication of blocks with the deletion mark.
-- [#5148](https://github.com/thanos-io/thanos/pull/5148) Receive: Add tenant tag for tracing spans.  
+- [#5148](https://github.com/thanos-io/thanos/pull/5148) Receive: Add tenant tag for tracing spans.
 
 ## Changed
 - [#5144](https://github.com/thanos-io/thanos/pull/5144) UI: Improve graph color
@@ -220,11 +220,11 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 
 ### Changed
 
--
+- 
 
 ### Removed
 
--
+- 
 
 ## [v0.20.0](https://github.com/thanos-io/thanos/releases/tag/v0.20.0) - 2021.04.28
 

--- a/pkg/replicate/replicator.go
+++ b/pkg/replicate/replicator.go
@@ -251,7 +251,7 @@ func newMetaFetcher(
 	if ignoreMarkedForDeletion {
 		filters = append(filters, thanosblock.NewIgnoreDeletionMarkFilter(logger, fromBkt, 0, concurrency))
 	}
-	fetcher, err := thanosblock.NewMetaFetcher(
+	return thanosblock.NewMetaFetcher(
 		logger,
 		concurrency,
 		fromBkt,
@@ -259,8 +259,4 @@ func newMetaFetcher(
 		reg,
 		filters,
 	)
-	if err != nil {
-		return nil, err
-	}
-	return fetcher, nil
 }

--- a/pkg/replicate/replicator.go
+++ b/pkg/replicate/replicator.go
@@ -10,8 +10,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/thanos-io/thanos/pkg/objstore"
-
 	extflag "github.com/efficientgo/tools/extkingpin"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
@@ -29,6 +27,7 @@ import (
 	"github.com/thanos-io/thanos/pkg/component"
 	"github.com/thanos-io/thanos/pkg/extprom"
 	thanosmodel "github.com/thanos-io/thanos/pkg/model"
+	"github.com/thanos-io/thanos/pkg/objstore"
 	"github.com/thanos-io/thanos/pkg/objstore/client"
 	"github.com/thanos-io/thanos/pkg/prober"
 	"github.com/thanos-io/thanos/pkg/runutil"
@@ -237,7 +236,15 @@ func RunReplicate(
 	return nil
 }
 
-func newMetaFetcher(logger log.Logger, fromBkt objstore.InstrumentedBucket, reg prometheus.Registerer, minTime, maxTime thanosmodel.TimeOrDurationValue, concurrency int, ignoreMarkedForDeletion bool) (*thanosblock.MetaFetcher, error) {
+func newMetaFetcher(
+	logger log.Logger,
+	fromBkt objstore.InstrumentedBucket,
+	reg prometheus.Registerer,
+	minTime,
+	maxTime thanosmodel.TimeOrDurationValue,
+	concurrency int,
+	ignoreMarkedForDeletion bool,
+) (*thanosblock.MetaFetcher, error) {
 	filters := []thanosblock.MetadataFilter{
 		thanosblock.NewTimePartitionMetaFilter(minTime, maxTime),
 	}

--- a/pkg/replicate/replicator.go
+++ b/pkg/replicate/replicator.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/thanos-io/thanos/pkg/objstore"
+
 	extflag "github.com/efficientgo/tools/extkingpin"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
@@ -167,15 +169,7 @@ func RunReplicate(
 	}, []string{"result"})
 	replicationRunDuration.WithLabelValues(labelSuccess)
 	replicationRunDuration.WithLabelValues(labelError)
-
-	fetcher, err := thanosblock.NewMetaFetcher(
-		logger,
-		32,
-		fromBkt,
-		"",
-		reg,
-		[]thanosblock.MetadataFilter{thanosblock.NewTimePartitionMetaFilter(*minTime, *maxTime)},
-	)
+	fetcher, err := newMetaFetcher(logger, fromBkt, reg, *minTime, *maxTime, 32, ignoreMarkedForDeletion)
 	if err != nil {
 		return errors.Wrapf(err, "create meta fetcher with bucket %v", fromBkt)
 	}
@@ -186,7 +180,6 @@ func RunReplicate(
 		resolutions,
 		compactions,
 		blockIDs,
-		ignoreMarkedForDeletion,
 	).Filter
 	metrics := newReplicationMetrics(reg)
 	ctx, cancel := context.WithCancel(context.Background())
@@ -242,4 +235,25 @@ func RunReplicate(
 	level.Info(logger).Log("msg", "starting replication")
 
 	return nil
+}
+
+func newMetaFetcher(logger log.Logger, fromBkt objstore.InstrumentedBucket, reg prometheus.Registerer, minTime, maxTime thanosmodel.TimeOrDurationValue, concurrency int, ignoreMarkedForDeletion bool) (*thanosblock.MetaFetcher, error) {
+	filters := []thanosblock.MetadataFilter{
+		thanosblock.NewTimePartitionMetaFilter(minTime, maxTime),
+	}
+	if ignoreMarkedForDeletion {
+		filters = append(filters, thanosblock.NewIgnoreDeletionMarkFilter(logger, fromBkt, 0, concurrency))
+	}
+	fetcher, err := thanosblock.NewMetaFetcher(
+		logger,
+		concurrency,
+		fromBkt,
+		"",
+		reg,
+		filters,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return fetcher, nil
 }

--- a/pkg/replicate/scheme_test.go
+++ b/pkg/replicate/scheme_test.go
@@ -14,8 +14,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/thanos-io/thanos/pkg/model"
-
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/oklog/ulid"
@@ -24,6 +22,7 @@ import (
 
 	"github.com/thanos-io/thanos/pkg/block/metadata"
 	"github.com/thanos-io/thanos/pkg/compact"
+	"github.com/thanos-io/thanos/pkg/model"
 	"github.com/thanos-io/thanos/pkg/objstore"
 	"github.com/thanos-io/thanos/pkg/testutil"
 )


### PR DESCRIPTION
Even though ignoring of deleted blocks by the `tools bucket replicate`  added in https://github.com/thanos-io/thanos/pull/5117 works

It does not use the code base for filtering already prepared and that brings one additional drawback and that is it fails on reading block metadata if in process of deletion (which was also the case we were hitting)

The former implementation first read all meta files (which fails for the block that is being deleted) and only after checks for the deletion mark. The deletion mark has to be checked first, as the filtered meta fetcher does.

Sorry about that

Please, @GiedriusS and @wiardvanrij would you take a look one more time? :pray: 