### PR TITLE
COS: Fix tools replicate

### DIFF
--- a/pkg/objstore/cos/cos.go
+++ b/pkg/objstore/cos/cos.go
@@ -333,8 +333,19 @@ func (b *Bucket) getRange(ctx context.Context, name string, off, length int64) (
 		runutil.ExhaustCloseWithLogOnErr(b.logger, resp.Body, "cos get range obj close")
 		return nil, err
 	}
+	// Add size info into reader for pass it to Upload function.
+	r := objectSizerReadCloser{ReadCloser: resp.Body, size: resp.ContentLength}
+	return r, nil
+}
 
-	return resp.Body, nil
+type objectSizerReadCloser struct {
+	io.ReadCloser
+	size int64
+}
+
+// ObjectSize implement objstore.ObjectSizer.
+func (o objectSizerReadCloser) ObjectSize() (int64, error) {
+	return o.size, nil
 }
 
 // Get returns a reader for the given object name.

--- a/pkg/objstore/cos/cos.go
+++ b/pkg/objstore/cos/cos.go
@@ -333,7 +333,7 @@ func (b *Bucket) getRange(ctx context.Context, name string, off, length int64) (
 		runutil.ExhaustCloseWithLogOnErr(b.logger, resp.Body, "cos get range obj close")
 		return nil, err
 	}
-	// Add size info into reader for pass it to Upload function.
+	// Add size info into reader to pass it to Upload function.
 	r := objectSizerReadCloser{ReadCloser: resp.Body, size: resp.ContentLength}
 	return r, nil
 }


### PR DESCRIPTION
Fix issue reported by @wu3396 (https://github.com/thanos-io/thanos/pull/5139#issuecomment-1040001559 ), pr #5139 introduce multi-part upload, it uses TryToGetSize to get the size of `reader`, but it will error when the reader is wrapped by TimingReadCloser. this pr continue to fix it.

1. Fix `TryToGetSize` error when the reader wrappered by `TimingReadCloser`, It will also fix `cos/s3/bos/swift`  get size error when use `objstore.TryToGetSize(r)`. 
2. Add size info into reader returned by `(*bucket).Get` for pass it to `(*bucket).Upload` function.

Signed-off-by: Jimmie Han <hanjinming@outlook.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->
1. Implement ObjectSizer interface for timingReadCloser.
2. Add unit test.
## Verification

<!-- How you tested it? How do you know it works? -->
1. unit test.
2. use `thanos tool replicate` to reproduce the issue and verify.