### PR TITLE
Change Server TLS Min Version to 1.3

### DIFF
--- a/pkg/tls/options.go
+++ b/pkg/tls/options.go
@@ -35,7 +35,7 @@ func NewServerConfig(logger log.Logger, cert, key, clientCA string) (*tls.Config
 	}
 
 	tlsCfg := &tls.Config{
-		MinVersion: tls.VersionTLS12,
+		MinVersion: tls.VersionTLS13,
 	}
 
 	mngr := &serverTLSManager{


### PR DESCRIPTION
## Changes

Update TLS Min Version for Server - use TLS1.3 - better security support
