### PR TITLE
shipper: better error message when thanos.shipper.json invalid

### DIFF
--- a/pkg/shipper/shipper.go
+++ b/pkg/shipper/shipper.go
@@ -470,14 +470,15 @@ func WriteMetaFile(logger log.Logger, dir string, meta *Meta) error {
 
 // ReadMetaFile reads the given meta from <dir>/thanos.shipper.json.
 func ReadMetaFile(dir string) (*Meta, error) {
-	b, err := ioutil.ReadFile(filepath.Join(dir, filepath.Clean(MetaFilename)))
+	fpath := filepath.Join(dir, filepath.Clean(MetaFilename))
+	b, err := os.ReadFile(fpath)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrapf(err, "failed to read %s", fpath)
 	}
-	var m Meta
 
+	var m Meta
 	if err := json.Unmarshal(b, &m); err != nil {
-		return nil, err
+		return nil, errors.Wrapf(err, "failed to parse %s as JSON: %q", fpath, string(b))
 	}
 	if m.Version != MetaVersion1 {
 		return nil, errors.Errorf("unexpected meta file version %d", m.Version)


### PR DESCRIPTION
* [na] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

* Improve diagnostics in error from shipper.ReadMetaFile when thanos.shipper.json is invalid JSON, to help in troubleshooting
* Replace usages of ioutil in shipper tests, as it's deprecated
* Add three testcases for shipper.ReadMetaFile

## Verification

I added a testcase corresponding to my change.