### PR TITLE
store: Avoid 404 errors on deletion-mark.json

### DIFF
--- a/pkg/block/metadata/markers.go
+++ b/pkg/block/metadata/markers.go
@@ -91,6 +91,13 @@ func (n *NoCompactMark) markerFilename() string { return NoCompactMarkFilename }
 // ReadMarker reads the given mark file from <dir>/<marker filename>.json in bucket.
 func ReadMarker(ctx context.Context, logger log.Logger, bkt objstore.InstrumentedBucketReader, dir string, marker Marker) error {
 	markerFile := path.Join(dir, marker.markerFilename())
+	ok, err := bkt.Exists(ctx, markerFile)
+	if err != nil {
+		return errors.Wrapf(err, "file exists: %s", metaFile)
+	}
+	if (!ok) {
+		return ErrorMarkerNotFound
+	}
 	r, err := bkt.ReaderWithExpectedErrs(bkt.IsObjNotFoundErr).Get(ctx, markerFile)
 	if err != nil {
 		if bkt.IsObjNotFoundErr(err) {


### PR DESCRIPTION

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

Check deletion-mark.json meta file exists before to retrieve it in order to avoid http 404 issues.

## Verification

<!-- How you tested it? How do you know it works? -->
