### PR TITLE
Making the querier ready after first iteration of service discovery

### DIFF
--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -690,7 +690,15 @@ func runQuery(
 			grpcserver.WithMaxConnAge(grpcMaxConnAge),
 		)
 
+		firstServiceDiscovery := true
+
 		g.Add(func() error {
+			if firstServiceDiscovery {
+				ctx, cancel := context.WithCancel(context.Background())
+				endpoints.Update(ctx)
+				cancel()
+				firstServiceDiscovery = false
+			}
 			statusProber.Ready()
 			return s.ListenAndServe()
 		}, func(error) {


### PR DESCRIPTION
Signed-off-by: soumya <somu12.ss@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.
### Closes
Issue #5026

## Changes

- Running a single iteration of service discovery before making the querier ready

<!-- Enumerate changes you made -->

## Verification
Tested locally
<!-- How you tested it? How do you know it works? -->

### Screenshots
I am attaching a screenshot of my command line logs -
![Screenshot from 2022-02-25 01-39-09](https://user-images.githubusercontent.com/61948033/155599706-e44c1427-4c12-432b-b99e-341fa3ad7e3a.png)


