### PR TITLE
E2E Tests: Bump `efficientgo/e2e` version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/chromedp/chromedp v0.5.3
 	github.com/cortexproject/cortex v1.10.1-0.20211124141505-4e9fc3a2b5ab
 	github.com/davecgh/go-spew v1.1.1
-	github.com/efficientgo/e2e v0.11.2-0.20211027134903-67d538984a47
+	github.com/efficientgo/e2e v0.11.2-0.20220224081107-b67f7b039363
 	github.com/efficientgo/tools/core v0.0.0-20210829154005-c7bad8450208
 	github.com/efficientgo/tools/extkingpin v0.0.0-20210609125236-d73259166f20
 	github.com/facette/natsort v0.0.0-20181210072756-2cd4dd1e2dcb

--- a/go.sum
+++ b/go.sum
@@ -549,8 +549,8 @@ github.com/eclipse/paho.mqtt.golang v1.2.0/go.mod h1:H9keYFcgq3Qr5OUJm/JZI/i6U7j
 github.com/edsrzf/mmap-go v0.0.0-20170320065105-0bce6a688712/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
 github.com/edsrzf/mmap-go v1.0.0 h1:CEBF7HpRnUCSJgGUb5h1Gm7e3VkmVDrR8lvWVLtrOFw=
 github.com/edsrzf/mmap-go v1.0.0/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
-github.com/efficientgo/e2e v0.11.2-0.20211027134903-67d538984a47 h1:k0qDUhOU0KJqKztQYJL1qMBR9nCOntuIRWYwA56Z634=
-github.com/efficientgo/e2e v0.11.2-0.20211027134903-67d538984a47/go.mod h1:vDnF4AAEZmO0mvyFIATeDJPFaSRM7ywaOnKd61zaSoE=
+github.com/efficientgo/e2e v0.11.2-0.20220224081107-b67f7b039363 h1:wlimY9L7RuHjNugLWsYH1wFTpkonEc3rktYSLx8aXu0=
+github.com/efficientgo/e2e v0.11.2-0.20220224081107-b67f7b039363/go.mod h1:vDnF4AAEZmO0mvyFIATeDJPFaSRM7ywaOnKd61zaSoE=
 github.com/efficientgo/tools/core v0.0.0-20210731122119-5d4a0645ce9a h1:Az9zRvQubUIHE+tHAm0gG7Dwge08V8Q/9uNSIFjFm+A=
 github.com/efficientgo/tools/core v0.0.0-20210731122119-5d4a0645ce9a/go.mod h1:OmVcnJopJL8d3X3sSXTiypGoUSgFq1aDGmlrdi9dn/M=
 github.com/efficientgo/tools/extkingpin v0.0.0-20210609125236-d73259166f20 h1:kM/ALyvAnTrwSB+nlKqoKaDnZbInp1YImZvW+gtHwc8=

--- a/test/e2e/e2ethanos/service.go
+++ b/test/e2e/e2ethanos/service.go
@@ -24,7 +24,7 @@ func NewService(
 	readiness *e2e.HTTPReadinessProbe,
 	http, grpc int,
 	otherPorts ...Port,
-) *e2e.InstrumentedRunnable {
+) e2e.InstrumentedRunnable {
 	return newUninitiatedService(e, name, http, grpc, otherPorts...).Init(
 		e2e.StartOptions{
 			Image:            image,
@@ -41,7 +41,7 @@ func newUninitiatedService(
 	name string,
 	http, grpc int,
 	otherPorts ...Port,
-) *e2e.FutureInstrumentedRunnable {
+) e2e.InstrumentedRunnableBuilder {
 	metricsPorts := "http"
 	ports := map[string]int{
 		"http": http,
@@ -56,15 +56,15 @@ func newUninitiatedService(
 		}
 	}
 
-	return e2e.NewInstrumentedRunnable(e, name, ports, metricsPorts)
+	return e2e.NewInstrumentedRunnable(e, name).WithPorts(ports, metricsPorts)
 }
 
 func initiateService(
-	service *e2e.FutureInstrumentedRunnable,
+	service e2e.InstrumentedRunnableBuilder,
 	image string,
 	command e2e.Command,
 	readiness *e2e.HTTPReadinessProbe,
-) *e2e.InstrumentedRunnable {
+) e2e.InstrumentedRunnable {
 	return service.Init(
 		e2e.StartOptions{
 			Image:            image,

--- a/test/e2e/e2ethanos/services.go
+++ b/test/e2e/e2ethanos/services.go
@@ -81,7 +81,7 @@ func defaultPromHttpConfig() string {
 `
 }
 
-func NewPrometheus(e e2e.Environment, name, promConfig, webConfig, promImage string, enableFeatures ...string) (*e2e.InstrumentedRunnable, string, error) {
+func NewPrometheus(e e2e.Environment, name, promConfig, webConfig, promImage string, enableFeatures ...string) (e2e.InstrumentedRunnable, string, error) {
 	dir := filepath.Join(e.SharedDir(), "data", "prometheus", name)
 	container := filepath.Join(ContainerSharedDir, "data", "prometheus", name)
 	if err := os.MkdirAll(dir, 0750); err != nil {
@@ -119,8 +119,10 @@ func NewPrometheus(e e2e.Environment, name, promConfig, webConfig, promImage str
 	prom := e2e.NewInstrumentedRunnable(
 		e,
 		fmt.Sprintf("prometheus-%s", name),
+	).WithPorts(
 		map[string]int{"http": 9090},
-		"http").Init(
+		"http",
+	).Init(
 		e2e.StartOptions{
 			Image:            promImage,
 			Command:          e2e.NewCommandWithoutEntrypoint("prometheus", args...),
@@ -133,11 +135,11 @@ func NewPrometheus(e e2e.Environment, name, promConfig, webConfig, promImage str
 	return prom, container, nil
 }
 
-func NewPrometheusWithSidecar(e e2e.Environment, name, promConfig, webConfig, promImage, minTime string, enableFeatures ...string) (*e2e.InstrumentedRunnable, *e2e.InstrumentedRunnable, error) {
+func NewPrometheusWithSidecar(e e2e.Environment, name, promConfig, webConfig, promImage, minTime string, enableFeatures ...string) (e2e.InstrumentedRunnable, e2e.InstrumentedRunnable, error) {
 	return NewPrometheusWithSidecarCustomImage(e, name, promConfig, webConfig, promImage, minTime, DefaultImage(), enableFeatures...)
 }
 
-func NewPrometheusWithSidecarCustomImage(e e2e.Environment, name, promConfig, webConfig, promImage, minTime string, sidecarImage string, enableFeatures ...string) (*e2e.InstrumentedRunnable, *e2e.InstrumentedRunnable, error) {
+func NewPrometheusWithSidecarCustomImage(e e2e.Environment, name, promConfig, webConfig, promImage, minTime string, sidecarImage string, enableFeatures ...string) (e2e.InstrumentedRunnable, e2e.InstrumentedRunnable, error) {
 	prom, dataDir, err := NewPrometheus(e, name, promConfig, webConfig, promImage, enableFeatures...)
 	if err != nil {
 		return nil, nil, err
@@ -150,7 +152,7 @@ func NewPrometheusWithSidecarCustomImage(e e2e.Environment, name, promConfig, we
 		"--http-address":      ":8080",
 		"--prometheus.url":    "http://" + prom.InternalEndpoint("http"),
 		"--tsdb.path":         dataDir,
-		"--log.level":         infoLogLevel,
+		"--log.level":         "debug",
 	}
 	if len(webConfig) > 0 {
 		args["--prometheus.http-client"] = defaultPromHttpConfig()
@@ -256,7 +258,7 @@ func (q *QuerierBuilder) WithTracingConfig(tracingConfig string) *QuerierBuilder
 	return q
 }
 
-func (q *QuerierBuilder) BuildUninitiated() *e2e.FutureInstrumentedRunnable {
+func (q *QuerierBuilder) BuildUninitiated() e2e.InstrumentedRunnableBuilder {
 	return newUninitiatedService(
 		q.environment,
 		fmt.Sprintf("querier-%v", q.name),
@@ -265,7 +267,7 @@ func (q *QuerierBuilder) BuildUninitiated() *e2e.FutureInstrumentedRunnable {
 	)
 }
 
-func (q *QuerierBuilder) Initiate(service *e2e.FutureInstrumentedRunnable, storeAddresses ...string) (*e2e.InstrumentedRunnable, error) {
+func (q *QuerierBuilder) Initiate(service e2e.InstrumentedRunnableBuilder, storeAddresses ...string) (e2e.InstrumentedRunnable, error) {
 	q.storeAddresses = storeAddresses
 	args, err := q.collectArgs()
 	if err != nil {
@@ -282,7 +284,7 @@ func (q *QuerierBuilder) Initiate(service *e2e.FutureInstrumentedRunnable, store
 	return querier, nil
 }
 
-func (q *QuerierBuilder) Build() (*e2e.InstrumentedRunnable, error) {
+func (q *QuerierBuilder) Build() (e2e.InstrumentedRunnable, error) {
 	args, err := q.collectArgs()
 	if err != nil {
 		return nil, err
@@ -386,24 +388,24 @@ func RemoteWriteEndpoint(addr string) string { return fmt.Sprintf("http://%s/api
 
 // NewUninitiatedReceiver returns a future receiver that can be initiated. It is useful
 // for obtaining a receiver address for hashring before the receiver is started.
-func NewUninitiatedReceiver(e e2e.Environment, name string) *e2e.FutureInstrumentedRunnable {
+func NewUninitiatedReceiver(e e2e.Environment, name string) e2e.InstrumentedRunnableBuilder {
 	return newUninitiatedService(e, fmt.Sprintf("receive-%v", name), 8080, 9091, Port{Name: "remote-write", PortNum: 8081})
 }
 
 // NewRoutingAndIngestingReceiverFromService creates a Thanos Receive instances from an unitiated service.
 // It is configured both for ingesting samples and routing samples to other receivers.
-func NewRoutingAndIngestingReceiverFromService(service *e2e.FutureInstrumentedRunnable, sharedDir string, replicationFactor int, hashring ...receive.HashringConfig) (*e2e.InstrumentedRunnable, error) {
+func NewRoutingAndIngestingReceiverFromService(service e2e.InstrumentedRunnableBuilder, sharedDir string, replicationFactor int, hashring ...receive.HashringConfig) (e2e.InstrumentedRunnable, error) {
 	var localEndpoint string
 	if len(hashring) == 0 {
 		localEndpoint = "0.0.0.0:9091"
 		hashring = []receive.HashringConfig{{Endpoints: []string{localEndpoint}}}
 	} else {
-		localEndpoint = service.InternalEndpoint("grpc")
+		localEndpoint = service.Future().InternalEndpoint("grpc")
 	}
 
-	dir := filepath.Join(sharedDir, "data", "receive", service.Name())
+	dir := filepath.Join(sharedDir, "data", "receive", service.Future().Name())
 	dataDir := filepath.Join(dir, "data")
-	container := filepath.Join(ContainerSharedDir, "data", "receive", service.Name())
+	container := filepath.Join(ContainerSharedDir, "data", "receive", service.Future().Name())
 	if err := os.MkdirAll(dataDir, 0750); err != nil {
 		return nil, errors.Wrap(err, "create receive dir")
 	}
@@ -417,12 +419,12 @@ func NewRoutingAndIngestingReceiverFromService(service *e2e.FutureInstrumentedRu
 		DefaultImage(),
 		// TODO(bwplotka): BuildArgs should be interface.
 		e2e.NewCommand("receive", e2e.BuildArgs(map[string]string{
-			"--debug.name":                 service.Name(),
+			"--debug.name":                 service.Future().Name(),
 			"--grpc-address":               ":9091",
 			"--grpc-grace-period":          "0s",
 			"--http-address":               ":8080",
 			"--remote-write.address":       ":8081",
-			"--label":                      fmt.Sprintf(`receive="%s"`, service.Name()),
+			"--label":                      fmt.Sprintf(`receive="%s"`, service.Future().Name()),
 			"--tsdb.path":                  filepath.Join(container, "data"),
 			"--log.level":                  infoLogLevel,
 			"--receive.replication-factor": strconv.Itoa(replicationFactor),
@@ -435,18 +437,18 @@ func NewRoutingAndIngestingReceiverFromService(service *e2e.FutureInstrumentedRu
 	return receiver, nil
 }
 
-func NewRoutingAndIngestingReceiverWithConfigWatcher(service *e2e.FutureInstrumentedRunnable, sharedDir string, replicationFactor int, hashring ...receive.HashringConfig) (*e2e.InstrumentedRunnable, error) {
+func NewRoutingAndIngestingReceiverWithConfigWatcher(service e2e.InstrumentedRunnableBuilder, sharedDir string, replicationFactor int, hashring ...receive.HashringConfig) (e2e.InstrumentedRunnable, error) {
 	var localEndpoint string
 	if len(hashring) == 0 {
 		localEndpoint = "0.0.0.0:9091"
 		hashring = []receive.HashringConfig{{Endpoints: []string{localEndpoint}}}
 	} else {
-		localEndpoint = service.InternalEndpoint("grpc")
+		localEndpoint = service.Future().InternalEndpoint("grpc")
 	}
 
-	dir := filepath.Join(sharedDir, "data", "receive", service.Name())
+	dir := filepath.Join(sharedDir, "data", "receive", service.Future().Name())
 	dataDir := filepath.Join(dir, "data")
-	container := filepath.Join(ContainerSharedDir, "data", "receive", service.Name())
+	container := filepath.Join(ContainerSharedDir, "data", "receive", service.Future().Name())
 	if err := os.MkdirAll(dataDir, 0750); err != nil {
 		return nil, errors.Wrap(err, "create receive dir")
 	}
@@ -464,12 +466,12 @@ func NewRoutingAndIngestingReceiverWithConfigWatcher(service *e2e.FutureInstrume
 		DefaultImage(),
 		// TODO(bwplotka): BuildArgs should be interface.
 		e2e.NewCommand("receive", e2e.BuildArgs(map[string]string{
-			"--debug.name":                              service.Name(),
+			"--debug.name":                              service.Future().Name(),
 			"--grpc-address":                            ":9091",
 			"--grpc-grace-period":                       "0s",
 			"--http-address":                            ":8080",
 			"--remote-write.address":                    ":8081",
-			"--label":                                   fmt.Sprintf(`receive="%s"`, service.Name()),
+			"--label":                                   fmt.Sprintf(`receive="%s"`, service.Future().Name()),
 			"--tsdb.path":                               filepath.Join(container, "data"),
 			"--log.level":                               infoLogLevel,
 			"--receive.replication-factor":              strconv.Itoa(replicationFactor),
@@ -484,7 +486,7 @@ func NewRoutingAndIngestingReceiverWithConfigWatcher(service *e2e.FutureInstrume
 }
 
 // NewRoutingReceiver creates a Thanos Receive instance that is only configured to route to other receive instances. It has no local storage.
-func NewRoutingReceiver(e e2e.Environment, name string, replicationFactor int, hashring ...receive.HashringConfig) (*e2e.InstrumentedRunnable, error) {
+func NewRoutingReceiver(e e2e.Environment, name string, replicationFactor int, hashring ...receive.HashringConfig) (e2e.InstrumentedRunnable, error) {
 
 	if len(hashring) == 0 {
 		return nil, errors.New("hashring should not be empty for receive-distributor mode")
@@ -528,7 +530,7 @@ func NewRoutingReceiver(e e2e.Environment, name string, replicationFactor int, h
 }
 
 // NewIngestingReceiver creates a Thanos Receive instance that is only configured to ingest, not route to other receivers.
-func NewIngestingReceiver(e e2e.Environment, name string) (*e2e.InstrumentedRunnable, error) {
+func NewIngestingReceiver(e e2e.Environment, name string) (e2e.InstrumentedRunnable, error) {
 	dir := filepath.Join(e.SharedDir(), "data", "receive", name)
 	dataDir := filepath.Join(dir, "data")
 	container := filepath.Join(ContainerSharedDir, "data", "receive", name)
@@ -558,15 +560,15 @@ func NewIngestingReceiver(e e2e.Environment, name string) (*e2e.InstrumentedRunn
 	return receiver, nil
 }
 
-func NewTSDBRuler(e e2e.Environment, name, ruleSubDir string, amCfg []alert.AlertmanagerConfig, queryCfg []httpconfig.Config) (*e2e.InstrumentedRunnable, error) {
+func NewTSDBRuler(e e2e.Environment, name, ruleSubDir string, amCfg []alert.AlertmanagerConfig, queryCfg []httpconfig.Config) (e2e.InstrumentedRunnable, error) {
 	return newRuler(e, name, ruleSubDir, amCfg, queryCfg, nil)
 }
 
-func NewStatelessRuler(e e2e.Environment, name, ruleSubDir string, amCfg []alert.AlertmanagerConfig, queryCfg []httpconfig.Config, remoteWriteCfg []*config.RemoteWriteConfig) (*e2e.InstrumentedRunnable, error) {
+func NewStatelessRuler(e e2e.Environment, name, ruleSubDir string, amCfg []alert.AlertmanagerConfig, queryCfg []httpconfig.Config, remoteWriteCfg []*config.RemoteWriteConfig) (e2e.InstrumentedRunnable, error) {
 	return newRuler(e, name, ruleSubDir, amCfg, queryCfg, remoteWriteCfg)
 }
 
-func newRuler(e e2e.Environment, name, ruleSubDir string, amCfg []alert.AlertmanagerConfig, queryCfg []httpconfig.Config, remoteWriteCfg []*config.RemoteWriteConfig) (*e2e.InstrumentedRunnable, error) {
+func newRuler(e e2e.Environment, name, ruleSubDir string, amCfg []alert.AlertmanagerConfig, queryCfg []httpconfig.Config, remoteWriteCfg []*config.RemoteWriteConfig) (e2e.InstrumentedRunnable, error) {
 	dir := filepath.Join(e.SharedDir(), "data", "rule", name)
 	container := filepath.Join(ContainerSharedDir, "data", "rule", name)
 
@@ -624,7 +626,7 @@ func newRuler(e e2e.Environment, name, ruleSubDir string, amCfg []alert.Alertman
 	return ruler, nil
 }
 
-func NewAlertmanager(e e2e.Environment, name string) (*e2e.InstrumentedRunnable, error) {
+func NewAlertmanager(e e2e.Environment, name string) (e2e.InstrumentedRunnable, error) {
 	dir := filepath.Join(e.SharedDir(), "data", "am", name)
 	container := filepath.Join(ContainerSharedDir, "data", "am", name)
 	if err := os.MkdirAll(dir, 0750); err != nil {
@@ -644,7 +646,11 @@ receivers:
 	}
 
 	s := e2e.NewInstrumentedRunnable(
-		e, fmt.Sprintf("alertmanager-%v", name), map[string]int{"http": 8080}, "http").Init(
+		e, fmt.Sprintf("alertmanager-%v", name),
+	).WithPorts(
+		map[string]int{"http": 8080},
+		"http",
+	).Init(
 		e2e.StartOptions{
 			Image: DefaultAlertmanagerImage(),
 			Command: e2e.NewCommandWithoutEntrypoint("/bin/alertmanager", e2e.BuildArgs(map[string]string{
@@ -664,7 +670,7 @@ receivers:
 	return s, nil
 }
 
-func NewStoreGW(e e2e.Environment, name string, bucketConfig client.BucketConfig, cacheConfig string, extArgs []string, relabelConfig ...relabel.Config) (*e2e.InstrumentedRunnable, error) {
+func NewStoreGW(e e2e.Environment, name string, bucketConfig client.BucketConfig, cacheConfig string, extArgs []string, relabelConfig ...relabel.Config) (e2e.InstrumentedRunnable, error) {
 	dir := filepath.Join(e.SharedDir(), "data", "store", name)
 	container := filepath.Join(ContainerSharedDir, "data", "store", name)
 	if err := os.MkdirAll(dir, 0750); err != nil {
@@ -714,7 +720,7 @@ func NewStoreGW(e e2e.Environment, name string, bucketConfig client.BucketConfig
 	return store, nil
 }
 
-func NewCompactor(e e2e.Environment, name string, bucketConfig client.BucketConfig, relabelConfig []relabel.Config, extArgs ...string) (*e2e.InstrumentedRunnable, error) {
+func NewCompactor(e e2e.Environment, name string, bucketConfig client.BucketConfig, relabelConfig []relabel.Config, extArgs ...string) (e2e.InstrumentedRunnable, error) {
 	dir := filepath.Join(e.SharedDir(), "data", "compact", name)
 	container := filepath.Join(ContainerSharedDir, "data", "compact", name)
 
@@ -733,18 +739,22 @@ func NewCompactor(e e2e.Environment, name string, bucketConfig client.BucketConf
 	}
 
 	compactor := e2e.NewInstrumentedRunnable(
-		e, fmt.Sprintf("compact-%s", name), map[string]int{"http": 8080}, "http").Init(
+		e, fmt.Sprintf("compact-%s", name),
+	).WithPorts(
+		map[string]int{"http": 8080}, "http",
+	).Init(
 		e2e.StartOptions{
 			Image: DefaultImage(),
 			Command: e2e.NewCommand("compact", append(e2e.BuildArgs(map[string]string{
-				"--debug.name":              fmt.Sprintf("compact-%s", name),
-				"--log.level":               infoLogLevel,
-				"--data-dir":                container,
-				"--objstore.config":         string(bktConfigBytes),
-				"--http-address":            ":8080",
-				"--block-sync-concurrency":  "20",
-				"--selector.relabel-config": string(relabelConfigBytes),
-				"--wait":                    "",
+				"--debug.name":               fmt.Sprintf("compact-%s", name),
+				"--log.level":                infoLogLevel,
+				"--data-dir":                 container,
+				"--objstore.config":          string(bktConfigBytes),
+				"--http-address":             ":8080",
+				"--block-sync-concurrency":   "50",
+				"--compact.cleanup-interval": "15s",
+				"--selector.relabel-config":  string(relabelConfigBytes),
+				"--wait":                     "",
 			}), extArgs...)...),
 			Readiness:        e2e.NewHTTPReadinessProbe("http", "/-/ready", 200, 200),
 			User:             strconv.Itoa(os.Getuid()),
@@ -755,7 +765,7 @@ func NewCompactor(e e2e.Environment, name string, bucketConfig client.BucketConf
 	return compactor, nil
 }
 
-func NewQueryFrontend(e e2e.Environment, name, downstreamURL string, cacheConfig queryfrontend.CacheProviderConfig) (*e2e.InstrumentedRunnable, error) {
+func NewQueryFrontend(e e2e.Environment, name, downstreamURL string, cacheConfig queryfrontend.CacheProviderConfig) (e2e.InstrumentedRunnable, error) {
 	cacheConfigBytes, err := yaml.Marshal(cacheConfig)
 	if err != nil {
 		return nil, errors.Wrapf(err, "marshal response cache config file: %v", cacheConfig)
@@ -770,7 +780,8 @@ func NewQueryFrontend(e e2e.Environment, name, downstreamURL string, cacheConfig
 	})
 
 	queryFrontend := e2e.NewInstrumentedRunnable(
-		e, fmt.Sprintf("query-frontend-%s", name), map[string]int{"http": 8080}, "http").Init(
+		e, fmt.Sprintf("query-frontend-%s", name),
+	).WithPorts(map[string]int{"http": 8080}, "http").Init(
 		e2e.StartOptions{
 			Image:            DefaultImage(),
 			Command:          e2e.NewCommand("query-frontend", args...),
@@ -783,7 +794,7 @@ func NewQueryFrontend(e e2e.Environment, name, downstreamURL string, cacheConfig
 	return queryFrontend, nil
 }
 
-func NewReverseProxy(e e2e.Environment, name, tenantID, target string) (*e2e.InstrumentedRunnable, error) {
+func NewReverseProxy(e e2e.Environment, name, tenantID, target string) (e2e.InstrumentedRunnable, error) {
 	conf := fmt.Sprintf(`
 events {
 	worker_connections  1024;
@@ -811,7 +822,7 @@ http {
 		return nil, errors.Wrap(err, "creating nginx config file failed")
 	}
 
-	nginx := e2e.NewInstrumentedRunnable(e, fmt.Sprintf("nginx-%s", name), map[string]int{"http": 80}, "http").Init(
+	nginx := e2e.NewInstrumentedRunnable(e, fmt.Sprintf("nginx-%s", name)).WithPorts(map[string]int{"http": 80}, "http").Init(
 		e2e.StartOptions{
 			Image:            "docker.io/nginx:1.21.1-alpine",
 			Volumes:          []string{filepath.Join(dir, "/nginx.conf") + ":/etc/nginx/nginx.conf:ro"},
@@ -825,7 +836,7 @@ http {
 // NewMinio returns minio server, used as a local replacement for S3.
 // TODO(@matej-g): This is a temporary workaround for https://github.com/efficientgo/e2e/issues/11;
 // after this is addresses fixed all calls should be replaced with e2edb.NewMinio.
-func NewMinio(env e2e.Environment, name, bktName string) (*e2e.InstrumentedRunnable, error) {
+func NewMinio(env e2e.Environment, name, bktName string) (e2e.InstrumentedRunnable, error) {
 	image := "minio/minio:RELEASE.2019-12-30T05-45-39Z"
 	minioKESGithubContent := "https://raw.githubusercontent.com/minio/kes/master"
 	commands := []string{
@@ -848,15 +859,15 @@ func NewMinio(env e2e.Environment, name, bktName string) (*e2e.InstrumentedRunna
 	return e2e.NewInstrumentedRunnable(
 		env,
 		name,
+	).WithPorts(
 		map[string]int{"https": 8090},
-		"https").Init(
+		"https",
+	).Init(
 		e2e.StartOptions{
 			Image: image,
 			// Create the required bucket before starting minio.
-			Command: e2e.NewCommandWithoutEntrypoint("sh", "-c", fmt.Sprintf(strings.Join(commands, " && "), minioKESGithubContent, minioKESGithubContent, bktName, 8090)),
-			//TODO(@clyang82): This is a temporary workaround for https://github.com/efficientgo/e2e/issues/9
-			//Readiness: e2e.NewHTTPReadinessProbe("http", "/minio/health/ready", 200, 200),
-			Readiness: e2e.NewCmdReadinessProbe(e2e.NewCommand("sh", "-c", "sleep 1 && curl -k https://127.0.0.1:8090/minio/health/ready")),
+			Command:   e2e.NewCommandWithoutEntrypoint("sh", "-c", fmt.Sprintf(strings.Join(commands, " && "), minioKESGithubContent, minioKESGithubContent, bktName, 8090)),
+			Readiness: e2e.NewHTTPSReadinessProbe("https", "/minio/health/ready", 200, 200),
 			EnvVars: map[string]string{
 				"MINIO_ACCESS_KEY": e2edb.MinioAccessKey,
 				"MINIO_SECRET_KEY": e2edb.MinioSecretKey,
@@ -872,8 +883,8 @@ func NewMinio(env e2e.Environment, name, bktName string) (*e2e.InstrumentedRunna
 	), nil
 }
 
-func NewMemcached(e e2e.Environment, name string) *e2e.InstrumentedRunnable {
-	memcached := e2e.NewInstrumentedRunnable(e, fmt.Sprintf("memcached-%s", name), map[string]int{"memcached": 11211}, "memcached").Init(
+func NewMemcached(e e2e.Environment, name string) e2e.InstrumentedRunnable {
+	memcached := e2e.NewInstrumentedRunnable(e, fmt.Sprintf("memcached-%s", name)).WithPorts(map[string]int{"memcached": 11211}, "memcached").Init(
 		e2e.StartOptions{
 			Image:            "docker.io/memcached:1.6.3-alpine",
 			Command:          e2e.NewCommand("memcached", []string{"-m 1024", "-I 1m", "-c 1024", "-v"}...),
@@ -894,7 +905,7 @@ func NewToolsBucketWeb(
 	minTime string,
 	maxTime string,
 	relabelConfig string,
-) (*e2e.InstrumentedRunnable, error) {
+) (e2e.InstrumentedRunnable, error) {
 	bktConfigBytes, err := yaml.Marshal(bucketConfig)
 	if err != nil {
 		return nil, errors.Wrapf(err, "generate tools bucket web config file: %v", bucketConfig)

--- a/test/e2e/exemplars_api_test.go
+++ b/test/e2e/exemplars_api_test.go
@@ -26,8 +26,8 @@ const (
 func TestExemplarsAPI_Fanout(t *testing.T) {
 	t.Parallel()
 	var (
-		prom1, prom2       *e2e.InstrumentedRunnable
-		sidecar1, sidecar2 *e2e.InstrumentedRunnable
+		prom1, prom2       e2e.InstrumentedRunnable
+		sidecar1, sidecar2 e2e.InstrumentedRunnable
 		err                error
 		e                  *e2e.DockerEnvironment
 	)
@@ -42,7 +42,7 @@ func TestExemplarsAPI_Fanout(t *testing.T) {
 	prom1, sidecar1, err = e2ethanos.NewPrometheusWithSidecar(
 		e,
 		"prom1",
-		defaultPromConfig("ha", 0, "", "", "localhost:9090", qUnitiated.InternalEndpoint("http")),
+		defaultPromConfig("ha", 0, "", "", "localhost:9090", qUnitiated.Future().InternalEndpoint("http")),
 		"",
 		e2ethanos.DefaultPrometheusImage(),
 		"",
@@ -52,7 +52,7 @@ func TestExemplarsAPI_Fanout(t *testing.T) {
 	prom2, sidecar2, err = e2ethanos.NewPrometheusWithSidecar(
 		e,
 		"prom2",
-		defaultPromConfig("ha", 1, "", "", "localhost:9090", qUnitiated.InternalEndpoint("http")),
+		defaultPromConfig("ha", 1, "", "", "localhost:9090", qUnitiated.Future().InternalEndpoint("http")),
 		"",
 		e2ethanos.DefaultPrometheusImage(),
 		"",
@@ -64,7 +64,7 @@ func TestExemplarsAPI_Fanout(t *testing.T) {
 config:
   sampler_type: const
   sampler_param: 1
-  service_name: %s`, qUnitiated.Name())
+  service_name: %s`, qUnitiated.Future().Name())
 
 	stores := []string{sidecar1.InternalEndpoint("grpc"), sidecar2.InternalEndpoint("grpc")}
 

--- a/test/e2e/query_test.go
+++ b/test/e2e/query_test.go
@@ -165,7 +165,7 @@ func TestQuery(t *testing.T) {
 
 	prom1, sidecar1, err := e2ethanos.NewPrometheusWithSidecar(e, "alone", defaultPromConfig("prom-alone", 0, "", ""), "", e2ethanos.DefaultPrometheusImage(), "")
 	testutil.Ok(t, err)
-	prom2, sidecar2, err := e2ethanos.NewPrometheusWithSidecar(e, "remote-and-sidecar", defaultPromConfig("prom-both-remote-write-and-sidecar", 1234, e2ethanos.RemoteWriteEndpoint(receiver.InternalEndpoint("remote-write")), ""), "", e2ethanos.DefaultPrometheusImage(), "")
+	prom2, sidecar2, err := e2ethanos.NewPrometheusWithSidecar(e, "remote-and-sidecar", defaultPromConfig("prom-both-remote-write-and-sidecar", 1234, e2ethanos.RemoteWriteEndpoint(receiver.Future().InternalEndpoint("remote-write")), ""), "", e2ethanos.DefaultPrometheusImage(), "")
 	testutil.Ok(t, err)
 	prom3, sidecar3, err := e2ethanos.NewPrometheusWithSidecar(e, "ha1", defaultPromConfig("prom-ha", 0, "", filepath.Join(e2ethanos.ContainerSharedDir, "", "*.yaml")), "", e2ethanos.DefaultPrometheusImage(), "")
 	testutil.Ok(t, err)
@@ -174,7 +174,7 @@ func TestQuery(t *testing.T) {
 	testutil.Ok(t, e2e.StartAndWaitReady(prom1, sidecar1, prom2, sidecar2, prom3, sidecar3, prom4, sidecar4))
 
 	// Querier. Both fileSD and directly by flags.
-	q, err := e2ethanos.NewQuerierBuilder(e, "1", sidecar1.InternalEndpoint("grpc"), sidecar2.InternalEndpoint("grpc"), receiver.InternalEndpoint("grpc")).
+	q, err := e2ethanos.NewQuerierBuilder(e, "1", sidecar1.InternalEndpoint("grpc"), sidecar2.InternalEndpoint("grpc"), receiver.Future().InternalEndpoint("grpc")).
 		WithFileSDStoreAddresses(sidecar3.InternalEndpoint("grpc"), sidecar4.InternalEndpoint("grpc")).Build()
 	testutil.Ok(t, err)
 	testutil.Ok(t, e2e.StartAndWaitReady(q))
@@ -319,11 +319,11 @@ func TestQueryLabelNames(t *testing.T) {
 
 	prom1, sidecar1, err := e2ethanos.NewPrometheusWithSidecar(e, "alone", defaultPromConfig("prom-alone", 0, "", ""), "", e2ethanos.DefaultPrometheusImage(), "")
 	testutil.Ok(t, err)
-	prom2, sidecar2, err := e2ethanos.NewPrometheusWithSidecar(e, "remote-and-sidecar", defaultPromConfig("prom-both-remote-write-and-sidecar", 1234, e2ethanos.RemoteWriteEndpoint(receiver.InternalEndpoint("remote-write")), ""), "", e2ethanos.DefaultPrometheusImage(), "")
+	prom2, sidecar2, err := e2ethanos.NewPrometheusWithSidecar(e, "remote-and-sidecar", defaultPromConfig("prom-both-remote-write-and-sidecar", 1234, e2ethanos.RemoteWriteEndpoint(receiver.Future().InternalEndpoint("remote-write")), ""), "", e2ethanos.DefaultPrometheusImage(), "")
 	testutil.Ok(t, err)
 	testutil.Ok(t, e2e.StartAndWaitReady(prom1, sidecar1, prom2, sidecar2))
 
-	q, err := e2ethanos.NewQuerierBuilder(e, "1", sidecar1.InternalEndpoint("grpc"), sidecar2.InternalEndpoint("grpc"), receiver.InternalEndpoint("grpc")).Build()
+	q, err := e2ethanos.NewQuerierBuilder(e, "1", sidecar1.InternalEndpoint("grpc"), sidecar2.InternalEndpoint("grpc"), receiver.Future().InternalEndpoint("grpc")).Build()
 	testutil.Ok(t, err)
 	testutil.Ok(t, e2e.StartAndWaitReady(q))
 
@@ -371,11 +371,11 @@ func TestQueryLabelValues(t *testing.T) {
 
 	prom1, sidecar1, err := e2ethanos.NewPrometheusWithSidecar(e, "alone", defaultPromConfig("prom-alone", 0, "", ""), "", e2ethanos.DefaultPrometheusImage(), "")
 	testutil.Ok(t, err)
-	prom2, sidecar2, err := e2ethanos.NewPrometheusWithSidecar(e, "remote-and-sidecar", defaultPromConfig("prom-both-remote-write-and-sidecar", 1234, e2ethanos.RemoteWriteEndpoint(receiver.InternalEndpoint("remote-write")), ""), "", e2ethanos.DefaultPrometheusImage(), "")
+	prom2, sidecar2, err := e2ethanos.NewPrometheusWithSidecar(e, "remote-and-sidecar", defaultPromConfig("prom-both-remote-write-and-sidecar", 1234, e2ethanos.RemoteWriteEndpoint(receiver.Future().InternalEndpoint("remote-write")), ""), "", e2ethanos.DefaultPrometheusImage(), "")
 	testutil.Ok(t, err)
 	testutil.Ok(t, e2e.StartAndWaitReady(prom1, sidecar1, prom2, sidecar2))
 
-	q, err := e2ethanos.NewQuerierBuilder(e, "1", sidecar1.InternalEndpoint("grpc"), sidecar2.InternalEndpoint("grpc"), receiver.InternalEndpoint("grpc")).Build()
+	q, err := e2ethanos.NewQuerierBuilder(e, "1", sidecar1.InternalEndpoint("grpc"), sidecar2.InternalEndpoint("grpc"), receiver.Future().InternalEndpoint("grpc")).Build()
 	testutil.Ok(t, err)
 	testutil.Ok(t, e2e.StartAndWaitReady(q))
 
@@ -470,7 +470,7 @@ func TestQueryCompatibilityWithPreInfoAPI(t *testing.T) {
 			p1, s1, err := e2ethanos.NewPrometheusWithSidecarCustomImage(
 				e,
 				"p1",
-				defaultPromConfig("p1", 0, "", filepath.Join(e2ethanos.ContainerSharedDir, promRulesSubDir, "*.yaml"), "localhost:9090", qUninit.InternalEndpoint("http")),
+				defaultPromConfig("p1", 0, "", filepath.Join(e2ethanos.ContainerSharedDir, promRulesSubDir, "*.yaml"), "localhost:9090", qUninit.Future().InternalEndpoint("http")),
 				"",
 				e2ethanos.DefaultPrometheusImage(),
 				"",
@@ -490,7 +490,7 @@ func TestQueryCompatibilityWithPreInfoAPI(t *testing.T) {
 config:
   sampler_type: const
   sampler_param: 1
-  service_name: %s`, qUninit.Name())). // Use fake tracing config to trigger exemplar.
+  service_name: %s`, qUninit.Future().Name())). // Use fake tracing config to trigger exemplar.
 				WithImage(tcase.queryImage).
 				Initiate(qUninit, s1.InternalEndpoint("grpc"))
 			testutil.Ok(t, err)
@@ -1088,7 +1088,7 @@ func queryExemplars(t *testing.T, ctx context.Context, addr, q string, start, en
 	}))
 }
 
-func synthesizeSamples(ctx context.Context, prometheus *e2e.InstrumentedRunnable, testSamples []fakeMetricSample) error {
+func synthesizeSamples(ctx context.Context, prometheus e2e.InstrumentedRunnable, testSamples []fakeMetricSample) error {
 	samples := make([]model.Sample, len(testSamples))
 	for i, s := range testSamples {
 		samples[i] = newSample(s)

--- a/test/e2e/receive_test.go
+++ b/test/e2e/receive_test.go
@@ -346,9 +346,9 @@ func TestReceive(t *testing.T) {
 
 		h := receive.HashringConfig{
 			Endpoints: []string{
-				r1.InternalEndpoint("grpc"),
-				r2.InternalEndpoint("grpc"),
-				r3.InternalEndpoint("grpc"),
+				r1.Future().InternalEndpoint("grpc"),
+				r2.Future().InternalEndpoint("grpc"),
+				r3.Future().InternalEndpoint("grpc"),
 			},
 		}
 
@@ -361,15 +361,15 @@ func TestReceive(t *testing.T) {
 		testutil.Ok(t, err)
 		testutil.Ok(t, e2e.StartAndWaitReady(r1Runnable, r2Runnable, r3Runnable))
 
-		prom1, _, err := e2ethanos.NewPrometheus(e, "1", defaultPromConfig("prom1", 0, e2ethanos.RemoteWriteEndpoint(r1.InternalEndpoint("remote-write")), ""), "", e2ethanos.DefaultPrometheusImage())
+		prom1, _, err := e2ethanos.NewPrometheus(e, "1", defaultPromConfig("prom1", 0, e2ethanos.RemoteWriteEndpoint(r1.Future().InternalEndpoint("remote-write")), ""), "", e2ethanos.DefaultPrometheusImage())
 		testutil.Ok(t, err)
-		prom2, _, err := e2ethanos.NewPrometheus(e, "2", defaultPromConfig("prom2", 0, e2ethanos.RemoteWriteEndpoint(r2.InternalEndpoint("remote-write")), ""), "", e2ethanos.DefaultPrometheusImage())
+		prom2, _, err := e2ethanos.NewPrometheus(e, "2", defaultPromConfig("prom2", 0, e2ethanos.RemoteWriteEndpoint(r2.Future().InternalEndpoint("remote-write")), ""), "", e2ethanos.DefaultPrometheusImage())
 		testutil.Ok(t, err)
-		prom3, _, err := e2ethanos.NewPrometheus(e, "3", defaultPromConfig("prom3", 0, e2ethanos.RemoteWriteEndpoint(r3.InternalEndpoint("remote-write")), ""), "", e2ethanos.DefaultPrometheusImage())
+		prom3, _, err := e2ethanos.NewPrometheus(e, "3", defaultPromConfig("prom3", 0, e2ethanos.RemoteWriteEndpoint(r3.Future().InternalEndpoint("remote-write")), ""), "", e2ethanos.DefaultPrometheusImage())
 		testutil.Ok(t, err)
 		testutil.Ok(t, e2e.StartAndWaitReady(prom1, prom2, prom3))
 
-		q, err := e2ethanos.NewQuerierBuilder(e, "1", r1.InternalEndpoint("grpc"), r2.InternalEndpoint("grpc"), r3.InternalEndpoint("grpc")).Build()
+		q, err := e2ethanos.NewQuerierBuilder(e, "1", r1.Future().InternalEndpoint("grpc"), r2.Future().InternalEndpoint("grpc"), r3.Future().InternalEndpoint("grpc")).Build()
 		testutil.Ok(t, err)
 		testutil.Ok(t, e2e.StartAndWaitReady(q))
 
@@ -418,9 +418,9 @@ func TestReceive(t *testing.T) {
 
 		h := receive.HashringConfig{
 			Endpoints: []string{
-				r1.InternalEndpoint("grpc"),
-				r2.InternalEndpoint("grpc"),
-				r3.InternalEndpoint("grpc"),
+				r1.Future().InternalEndpoint("grpc"),
+				r2.Future().InternalEndpoint("grpc"),
+				r3.Future().InternalEndpoint("grpc"),
 			},
 		}
 
@@ -434,15 +434,15 @@ func TestReceive(t *testing.T) {
 		testutil.Ok(t, err)
 		testutil.Ok(t, e2e.StartAndWaitReady(r1Runnable, r2Runnable, r3Runnable))
 
-		prom1, _, err := e2ethanos.NewPrometheus(e, "1", defaultPromConfig("prom1", 0, e2ethanos.RemoteWriteEndpoint(r1.InternalEndpoint("remote-write")), ""), "", e2ethanos.DefaultPrometheusImage())
+		prom1, _, err := e2ethanos.NewPrometheus(e, "1", defaultPromConfig("prom1", 0, e2ethanos.RemoteWriteEndpoint(r1.Future().InternalEndpoint("remote-write")), ""), "", e2ethanos.DefaultPrometheusImage())
 		testutil.Ok(t, err)
-		prom2, _, err := e2ethanos.NewPrometheus(e, "2", defaultPromConfig("prom2", 0, e2ethanos.RemoteWriteEndpoint(r2.InternalEndpoint("remote-write")), ""), "", e2ethanos.DefaultPrometheusImage())
+		prom2, _, err := e2ethanos.NewPrometheus(e, "2", defaultPromConfig("prom2", 0, e2ethanos.RemoteWriteEndpoint(r2.Future().InternalEndpoint("remote-write")), ""), "", e2ethanos.DefaultPrometheusImage())
 		testutil.Ok(t, err)
-		prom3, _, err := e2ethanos.NewPrometheus(e, "3", defaultPromConfig("prom3", 0, e2ethanos.RemoteWriteEndpoint(r3.InternalEndpoint("remote-write")), ""), "", e2ethanos.DefaultPrometheusImage())
+		prom3, _, err := e2ethanos.NewPrometheus(e, "3", defaultPromConfig("prom3", 0, e2ethanos.RemoteWriteEndpoint(r3.Future().InternalEndpoint("remote-write")), ""), "", e2ethanos.DefaultPrometheusImage())
 		testutil.Ok(t, err)
 		testutil.Ok(t, e2e.StartAndWaitReady(prom1, prom2, prom3))
 
-		q, err := e2ethanos.NewQuerierBuilder(e, "1", r1.InternalEndpoint("grpc"), r2.InternalEndpoint("grpc"), r3.InternalEndpoint("grpc")).Build()
+		q, err := e2ethanos.NewQuerierBuilder(e, "1", r1.Future().InternalEndpoint("grpc"), r2.Future().InternalEndpoint("grpc"), r3.Future().InternalEndpoint("grpc")).Build()
 		testutil.Ok(t, err)
 		testutil.Ok(t, e2e.StartAndWaitReady(q))
 
@@ -496,9 +496,9 @@ func TestReceive(t *testing.T) {
 
 		h := receive.HashringConfig{
 			Endpoints: []string{
-				r1.InternalEndpoint("grpc"),
-				r2.InternalEndpoint("grpc"),
-				r3.InternalEndpoint("grpc"),
+				r1.Future().InternalEndpoint("grpc"),
+				r2.Future().InternalEndpoint("grpc"),
+				r3.Future().InternalEndpoint("grpc"),
 			},
 		}
 
@@ -511,11 +511,11 @@ func TestReceive(t *testing.T) {
 		testutil.Ok(t, err)
 		testutil.Ok(t, e2e.StartAndWaitReady(r1Runnable, r2Runnable, r3Runnable))
 
-		prom1, _, err := e2ethanos.NewPrometheus(e, "1", defaultPromConfig("prom1", 0, e2ethanos.RemoteWriteEndpoint(r1.InternalEndpoint("remote-write")), ""), "", e2ethanos.DefaultPrometheusImage())
+		prom1, _, err := e2ethanos.NewPrometheus(e, "1", defaultPromConfig("prom1", 0, e2ethanos.RemoteWriteEndpoint(r1.Future().InternalEndpoint("remote-write")), ""), "", e2ethanos.DefaultPrometheusImage())
 		testutil.Ok(t, err)
 		testutil.Ok(t, e2e.StartAndWaitReady(prom1))
 
-		q, err := e2ethanos.NewQuerierBuilder(e, "1", r1.InternalEndpoint("grpc"), r2.InternalEndpoint("grpc"), r3.InternalEndpoint("grpc")).Build()
+		q, err := e2ethanos.NewQuerierBuilder(e, "1", r1.Future().InternalEndpoint("grpc"), r2.Future().InternalEndpoint("grpc"), r3.Future().InternalEndpoint("grpc")).Build()
 		testutil.Ok(t, err)
 		testutil.Ok(t, e2e.StartAndWaitReady(q))
 
@@ -568,9 +568,9 @@ func TestReceive(t *testing.T) {
 
 		h := receive.HashringConfig{
 			Endpoints: []string{
-				r1.InternalEndpoint("grpc"),
-				r2.InternalEndpoint("grpc"),
-				r3.InternalEndpoint("grpc"),
+				r1.Future().InternalEndpoint("grpc"),
+				r2.Future().InternalEndpoint("grpc"),
+				r3.Future().InternalEndpoint("grpc"),
 			},
 		}
 
@@ -581,11 +581,11 @@ func TestReceive(t *testing.T) {
 		testutil.Ok(t, err)
 		testutil.Ok(t, e2e.StartAndWaitReady(r1Runnable, r2Runnable))
 
-		prom1, _, err := e2ethanos.NewPrometheus(e, "1", defaultPromConfig("prom1", 0, e2ethanos.RemoteWriteEndpoint(r1.InternalEndpoint("remote-write")), ""), "", e2ethanos.DefaultPrometheusImage())
+		prom1, _, err := e2ethanos.NewPrometheus(e, "1", defaultPromConfig("prom1", 0, e2ethanos.RemoteWriteEndpoint(r1.Future().InternalEndpoint("remote-write")), ""), "", e2ethanos.DefaultPrometheusImage())
 		testutil.Ok(t, err)
 		testutil.Ok(t, e2e.StartAndWaitReady(prom1))
 
-		q, err := e2ethanos.NewQuerierBuilder(e, "1", r1.InternalEndpoint("grpc"), r2.InternalEndpoint("grpc")).Build()
+		q, err := e2ethanos.NewQuerierBuilder(e, "1", r1.Future().InternalEndpoint("grpc"), r2.Future().InternalEndpoint("grpc")).Build()
 		testutil.Ok(t, err)
 		testutil.Ok(t, e2e.StartAndWaitReady(q))
 
@@ -625,7 +625,7 @@ func TestReceive(t *testing.T) {
 
 		h := receive.HashringConfig{
 			Endpoints: []string{
-				r1.InternalEndpoint("grpc"),
+				r1.Future().InternalEndpoint("grpc"),
 			},
 		}
 
@@ -634,9 +634,9 @@ func TestReceive(t *testing.T) {
 		testutil.Ok(t, err)
 		testutil.Ok(t, e2e.StartAndWaitReady(r1Runnable))
 
-		rp1, err := e2ethanos.NewReverseProxy(e, "1", "tenant-1", "http://"+r1.InternalEndpoint("remote-write"))
+		rp1, err := e2ethanos.NewReverseProxy(e, "1", "tenant-1", "http://"+r1.Future().InternalEndpoint("remote-write"))
 		testutil.Ok(t, err)
-		rp2, err := e2ethanos.NewReverseProxy(e, "2", "tenant-2", "http://"+r1.InternalEndpoint("remote-write"))
+		rp2, err := e2ethanos.NewReverseProxy(e, "2", "tenant-2", "http://"+r1.Future().InternalEndpoint("remote-write"))
 		testutil.Ok(t, err)
 		testutil.Ok(t, e2e.StartAndWaitReady(rp1, rp2))
 
@@ -646,7 +646,7 @@ func TestReceive(t *testing.T) {
 		testutil.Ok(t, err)
 		testutil.Ok(t, e2e.StartAndWaitReady(prom1, prom2))
 
-		q, err := e2ethanos.NewQuerierBuilder(e, "1", r1.InternalEndpoint("grpc")).Build()
+		q, err := e2ethanos.NewQuerierBuilder(e, "1", r1.Future().InternalEndpoint("grpc")).Build()
 		testutil.Ok(t, err)
 		testutil.Ok(t, e2e.StartAndWaitReady(q))
 		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)

--- a/test/e2e/rule_test.go
+++ b/test/e2e/rule_test.go
@@ -152,7 +152,7 @@ func reloadRulesHTTP(t *testing.T, ctx context.Context, endpoint string) {
 	testutil.Equals(t, 200, resp.StatusCode)
 }
 
-func reloadRulesSignal(t *testing.T, r *e2e.InstrumentedRunnable) {
+func reloadRulesSignal(t *testing.T, r e2e.InstrumentedRunnable) {
 	c := e2e.NewCommand("kill", "-1", "1")
 	_, _, err := r.Exec(c)
 	testutil.Ok(t, err)

--- a/test/e2e/rules_api_test.go
+++ b/test/e2e/rules_api_test.go
@@ -71,7 +71,7 @@ func TestRulesAPI_Fanout(t *testing.T) {
 	queryCfg := []httpconfig.Config{
 		{
 			EndpointsConfig: httpconfig.EndpointsConfig{
-				StaticAddresses: []string{qUninit.InternalEndpoint("http")},
+				StaticAddresses: []string{qUninit.Future().InternalEndpoint("http")},
 				Scheme:          "http",
 			},
 		},

--- a/test/e2e/store_gateway_test.go
+++ b/test/e2e/store_gateway_test.go
@@ -476,7 +476,7 @@ metafile_content_ttl: 0s`
 
 	// Wait for store to sync blocks.
 	// thanos_blocks_meta_synced: 1x loadedMeta 0x labelExcludedMeta 0x TooFreshMeta.
-	for _, st := range []*e2e.InstrumentedRunnable{store1, store2, store3} {
+	for _, st := range []e2e.InstrumentedRunnable{store1, store2, store3} {
 		t.Run(st.Name(), func(t *testing.T) {
 			testutil.Ok(t, st.WaitSumMetrics(e2e.Equals(1), "thanos_blocks_meta_synced"))
 			testutil.Ok(t, st.WaitSumMetrics(e2e.Equals(0), "thanos_blocks_meta_sync_failures_total"))
@@ -502,7 +502,7 @@ metafile_content_ttl: 0s`
 			},
 		)
 
-		for _, st := range []*e2e.InstrumentedRunnable{store1, store2, store3} {
+		for _, st := range []e2e.InstrumentedRunnable{store1, store2, store3} {
 			testutil.Ok(t, st.WaitSumMetricsWithOptions(e2e.Greater(0), []string{`thanos_cache_groupcache_loads_total`}))
 			testutil.Ok(t, st.WaitSumMetricsWithOptions(e2e.Greater(0), []string{`thanos_store_bucket_cache_operation_hits_total`}, e2e.WithLabelMatchers(matchers.MustNewMatcher(matchers.MatchEqual, "config", "chunks"))))
 		}


### PR DESCRIPTION
Signed-off-by: Matej Gera <matejgera@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [X] Change is not relevant to the end user.

## Changes

Bumping the `efficientgo/e2e` to the latest `main` - this includes some refactoring changes (no effect on test functionality) and using the new HTTPS readiness probe for `minio`.

## Verification

Running E2E tests
