### PR TITLE
fix: add null check to exemplar data

### DIFF
--- a/pkg/exemplars/exemplars.go
+++ b/pkg/exemplars/exemplars.go
@@ -89,6 +89,10 @@ func (rr *GRPCClient) Exemplars(ctx context.Context, req *exemplarspb.ExemplarsR
 		return nil, nil, errors.Wrap(err, "proxy Exemplars")
 	}
 
+	if resp.data == nil {
+		return make([]*exemplarspb.ExemplarData, 0), resp.warnings, nil
+	}
+
 	resp.data = dedupExemplarsResponse(resp.data, rr.replicaLabels)
 	return resp.data, resp.warnings, nil
 }


### PR DESCRIPTION
Fixes: #5189

## Changes

Added a nil check for exemplar data

Did not add unit tests, since this is a rather simple method that already has no test