### PR TITLE
Store: Fix data race in advertised label set in bucket store

### DIFF
--- a/pkg/info/info.go
+++ b/pkg/info/info.go
@@ -35,6 +35,13 @@ func NewInfoServer(
 ) *InfoServer {
 	srv := &InfoServer{
 		component: component,
+		// By default, do not return info for any API.
+		getLabelSet:           func() []labelpb.ZLabelSet { return nil },
+		getStoreInfo:          func() *infopb.StoreInfo { return nil },
+		getExemplarsInfo:      func() *infopb.ExemplarsInfo { return nil },
+		getRulesInfo:          func() *infopb.RulesInfo { return nil },
+		getTargetsInfo:        func() *infopb.TargetsInfo { return nil },
+		getMetricMetadataInfo: func() *infopb.MetricMetadataInfo { return nil },
 	}
 
 	for _, o := range options {
@@ -146,31 +153,7 @@ func RegisterInfoServer(infoSrv infopb.InfoServer) func(*grpc.Server) {
 
 // Info returns the information about label set and available APIs exposed by the component.
 func (srv *InfoServer) Info(ctx context.Context, req *infopb.InfoRequest) (*infopb.InfoResponse, error) {
-	if srv.getLabelSet == nil {
-		srv.getLabelSet = func() []labelpb.ZLabelSet { return nil }
-	}
-
-	if srv.getStoreInfo == nil {
-		srv.getStoreInfo = func() *infopb.StoreInfo { return nil }
-	}
-
-	if srv.getExemplarsInfo == nil {
-		srv.getExemplarsInfo = func() *infopb.ExemplarsInfo { return nil }
-	}
-
-	if srv.getRulesInfo == nil {
-		srv.getRulesInfo = func() *infopb.RulesInfo { return nil }
-	}
-
-	if srv.getTargetsInfo == nil {
-		srv.getTargetsInfo = func() *infopb.TargetsInfo { return nil }
-	}
-
-	if srv.getMetricMetadataInfo == nil {
-		srv.getMetricMetadataInfo = func() *infopb.MetricMetadataInfo { return nil }
-	}
-
-	resp := &infopb.InfoResponse{
+	return &infopb.InfoResponse{
 		LabelSets:      srv.getLabelSet(),
 		ComponentType:  srv.component,
 		Store:          srv.getStoreInfo(),
@@ -178,7 +161,5 @@ func (srv *InfoServer) Info(ctx context.Context, req *infopb.InfoRequest) (*info
 		Rules:          srv.getRulesInfo(),
 		Targets:        srv.getTargetsInfo(),
 		MetricMetadata: srv.getMetricMetadataInfo(),
-	}
-
-	return resp, nil
+	}, nil
 }

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -705,7 +705,6 @@ func (s *BucketStore) Info(context.Context, *storepb.InfoRequest) (*storepb.Info
 		LabelSets: s.LabelSet(),
 	}
 
-
 	return res, nil
 }
 

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -684,7 +684,9 @@ func (s *BucketStore) TimeRange() (mint, maxt int64) {
 }
 
 func (s *BucketStore) LabelSet() []labelpb.ZLabelSet {
+	s.mtx.RLock()
 	labelSets := s.advLabelSets
+	s.mtx.RUnlock()
 
 	if s.enableCompatibilityLabel && len(labelSets) > 0 {
 		labelSets = append(labelSets, labelpb.ZLabelSet{Labels: []labelpb.ZLabel{{Name: CompatibilityTypeLabelName, Value: "store"}}})
@@ -700,11 +702,10 @@ func (s *BucketStore) Info(context.Context, *storepb.InfoRequest) (*storepb.Info
 		StoreType: component.Store.ToProto(),
 		MinTime:   mint,
 		MaxTime:   maxt,
+		LabelSets: s.LabelSet(),
 	}
 
-	s.mtx.RLock()
-	res.LabelSets = s.LabelSet()
-	s.mtx.RUnlock()
+
 	return res, nil
 }
 

--- a/test/e2e/query_test.go
+++ b/test/e2e/query_test.go
@@ -120,7 +120,7 @@ func sortResults(res model.Vector) {
 func TestSidecarNotReady(t *testing.T) {
 	t.Parallel()
 
-	e, err := e2e.NewDockerEnvironment("e2e_test_query")
+	e, err := e2e.NewDockerEnvironment("e2e_test_query_sidecar_not_ready")
 	testutil.Ok(t, err)
 	t.Cleanup(e2ethanos.CleanScenario(t, e))
 


### PR DESCRIPTION
Signed-off-by: Matej Gera <matejgera@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [X] Change is not relevant to the end user.

## Changes

As a part of https://github.com/thanos-io/thanos/pull/5066, we have detected some data races. One of them is occurring due to concurrent write / read of bucket store's label set, excerpt:
```
12:05:39 store-gw-1: ==================
12:05:39 store-gw-1: WARNING: DATA RACE
12:05:39 store-gw-1: Read at 0x00c0001c2450 by goroutine 36:
12:05:39 store-gw-1: github.com/thanos-io/thanos/pkg/store.(*BucketStore).LabelSet()
12:05:39 store-gw-1: /go/src/github.com/thanos-io/thanos/pkg/store/bucket.go:687 +0x3d
12:05:39 store-gw-1: main.runStore.func6()
12:05:39 store-gw-1: /go/src/github.com/thanos-io/thanos/cmd/thanos/store.go:393 +0x1d8
12:05:39 store-gw-1: github.com/thanos-io/thanos/pkg/info.(*InfoServer).Info()
...
12:05:39 store-gw-1: Previous write at 0x00c0001c2450 by goroutine 110:
12:05:39 store-gw-1: github.com/thanos-io/thanos/pkg/store.(*BucketStore).SyncBlocks()
12:05:39 store-gw-1: /go/src/github.com/thanos-io/thanos/pkg/store/bucket.go:511 +0xcc4
...
```

In addition, I simplified the Info server method defaults.

## Verification

Ran tests locally with https://github.com/thanos-io/thanos/pull/5066; data race not being detected anymore.
