### PR TITLE
Append ruler labels as external labels when using stateless ruler mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 ### Fixed
 
 ### Changed
+- [#5205](https://github.com/thanos-io/thanos/pull/5205) Rule: Add ruler labels as external labels in stateless ruler mode.
 
 ### Removed
 

--- a/cmd/thanos/rule.go
+++ b/cmd/thanos/rule.go
@@ -363,7 +363,12 @@ func runRule(
 			return 0, nil
 		}, walDir, 1*time.Minute, nil)
 		if err := remoteStore.ApplyConfig(&config.Config{
-			GlobalConfig:       config.DefaultGlobalConfig,
+			GlobalConfig: config.GlobalConfig{
+				ScrapeInterval:     model.Duration(1 * time.Minute),
+				ScrapeTimeout:      model.Duration(10 * time.Second),
+				EvaluationInterval: model.Duration(1 * time.Minute),
+				ExternalLabels:     labelsTSDBToProm(conf.lset),
+			},
 			RemoteWriteConfigs: rwCfg.RemoteWriteConfigs,
 		}); err != nil {
 			return errors.Wrap(err, "applying config to remote storage")

--- a/cmd/thanos/rule.go
+++ b/cmd/thanos/rule.go
@@ -364,10 +364,7 @@ func runRule(
 		}, walDir, 1*time.Minute, nil)
 		if err := remoteStore.ApplyConfig(&config.Config{
 			GlobalConfig: config.GlobalConfig{
-				ScrapeInterval:     model.Duration(1 * time.Minute),
-				ScrapeTimeout:      model.Duration(10 * time.Second),
-				EvaluationInterval: model.Duration(1 * time.Minute),
-				ExternalLabels:     labelsTSDBToProm(conf.lset),
+				ExternalLabels: labelsTSDBToProm(conf.lset),
 			},
 			RemoteWriteConfigs: rwCfg.RemoteWriteConfigs,
 		}); err != nil {

--- a/test/e2e/rule_test.go
+++ b/test/e2e/rule_test.go
@@ -539,12 +539,14 @@ func TestRule_CanRemoteWriteData(t *testing.T) {
 				"__name__":  "test_absent_metric",
 				"job":       "thanos-receive",
 				"receive":   "1",
+				"replica":   "1",
 				"tenant_id": "default-tenant",
 			},
 			{
 				"__name__":  "test_absent_metric",
 				"job":       "thanos-receive",
 				"receive":   "2",
+				"replica":   "1",
 				"tenant_id": "default-tenant",
 			},
 		})


### PR DESCRIPTION
Signed-off-by: Ben Ye <ben.ye@bytedance.com>

Fixes https://cloud-native.slack.com/archives/CK5RSSC10/p1646228262242149

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

For the stateless ruler mode, we still need to add the `labels` as external labels written to the remote storage.

## Verification

<!-- How you tested it? How do you know it works? -->

Tested it locally and updated the E2E test.
