### PR TITLE
cache: add timeout for groupcache's fetch operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 ### Changed
 
 - [#5205](https://github.com/thanos-io/thanos/pull/5205) Rule: Add ruler labels as external labels in stateless ruler mode.
+- [#5206](https://github.com/thanos-io/thanos/pull/5206) Cache: add timeout for groupcache's fetch operation
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 ### Fixed
 
 ### Changed
+
 - [#5205](https://github.com/thanos-io/thanos/pull/5205) Rule: Add ruler labels as external labels in stateless ruler mode.
 
 ### Removed

--- a/docs/components/store.md
+++ b/docs/components/store.md
@@ -442,7 +442,7 @@ In the `peers` section it is possible to use the prefix form to automatically lo
 
 Note that there must be no trailing slash in the `peers` configuration i.e. one of the strings must be identical to `self_url` and others should have the same form. Without this, loading data from peers may fail.
 
-If timeout is set to zero then there is no timeout for fetching and fetching's lifetime is equal to the lifetime to the original request's lifetime. It is recommended to keep it more than zero. It is generally preferred to keep this value higher because the fetching operation potentially includes loading that data from remote object storage.
+If timeout is set to zero then there is no timeout for fetching and fetching's lifetime is equal to the lifetime to the original request's lifetime. It is recommended to keep it higher than zero. It is generally preferred to keep this value higher because the fetching operation potentially includes loading of data from remote object storage.
 
 ## Index Header
 

--- a/docs/components/store.md
+++ b/docs/components/store.md
@@ -429,7 +429,7 @@ config:
     - http://10.123.22.100:8080
   groupcache_group: test_group
   dns_interval: 1s
-  timeout: 500ms
+  timeout: 2s
 ```
 
 In this case, three Thanos Store nodes are running in the same group meaning that they all point to the same remote object storage.
@@ -442,7 +442,7 @@ In the `peers` section it is possible to use the prefix form to automatically lo
 
 Note that there must be no trailing slash in the `peers` configuration i.e. one of the strings must be identical to `self_url` and others should have the same form. Without this, loading data from peers may fail.
 
-If timeout is set to zero then there is no timeout for fetching and fetching's lifetime is equal to the lifetime to the original request's lifetime. It is recommended to keep it more than zero.
+If timeout is set to zero then there is no timeout for fetching and fetching's lifetime is equal to the lifetime to the original request's lifetime. It is recommended to keep it more than zero. It is generally preferred to keep this value higher because the fetching operation potentially includes loading that data from remote object storage.
 
 ## Index Header
 

--- a/docs/components/store.md
+++ b/docs/components/store.md
@@ -429,6 +429,7 @@ config:
     - http://10.123.22.100:8080
   groupcache_group: test_group
   dns_interval: 1s
+  timeout: 500ms
 ```
 
 In this case, three Thanos Store nodes are running in the same group meaning that they all point to the same remote object storage.
@@ -440,6 +441,8 @@ In this case, three Thanos Store nodes are running in the same group meaning tha
 In the `peers` section it is possible to use the prefix form to automatically look up the peers using DNS. For example, you could use `dns+http://store.thanos.consul.svc:8080` to automatically look up healthy nodes from Consul using its DNS interface.
 
 Note that there must be no trailing slash in the `peers` configuration i.e. one of the strings must be identical to `self_url` and others should have the same form. Without this, loading data from peers may fail.
+
+If timeout is set to zero then there is no timeout for fetching and fetching's lifetime is equal to the lifetime to the original request's lifetime. It is recommended to keep it more than zero.
 
 ## Index Header
 

--- a/pkg/cache/groupcache.go
+++ b/pkg/cache/groupcache.go
@@ -62,7 +62,7 @@ type GroupcacheConfig struct {
 	DNSInterval time.Duration `yaml:"dns_interval"`
 
 	// Timeout specifies the read/write timeout.
-	Timeout time.Duration
+	Timeout time.Duration `yaml:"timeout"`
 }
 
 var (

--- a/pkg/cache/groupcache.go
+++ b/pkg/cache/groupcache.go
@@ -70,7 +70,7 @@ var (
 		MaxSize:       250 * 1024 * 1024,
 		DNSSDResolver: dns.GolangResolverType,
 		DNSInterval:   1 * time.Minute,
-		Timeout:       500 * time.Millisecond,
+		Timeout:       2 * time.Second,
 	}
 )
 

--- a/pkg/cache/groupcache.go
+++ b/pkg/cache/groupcache.go
@@ -36,6 +36,7 @@ type Groupcache struct {
 	galaxy   *galaxycache.Galaxy
 	universe *galaxycache.Universe
 	logger   log.Logger
+	timeout  time.Duration
 }
 
 // GroupcacheConfig holds the in-memory cache config.
@@ -59,6 +60,9 @@ type GroupcacheConfig struct {
 
 	// How often we should resolve the addresses.
 	DNSInterval time.Duration `yaml:"dns_interval"`
+
+	// Timeout specifies the read/write timeout.
+	Timeout time.Duration
 }
 
 var (
@@ -66,6 +70,7 @@ var (
 		MaxSize:       250 * 1024 * 1024,
 		DNSSDResolver: dns.GolangResolverType,
 		DNSInterval:   1 * time.Minute,
+		Timeout:       500 * time.Millisecond,
 	}
 )
 
@@ -255,6 +260,7 @@ func NewGroupcacheWithConfig(logger log.Logger, reg prometheus.Registerer, conf 
 		logger:   logger,
 		galaxy:   galaxy,
 		universe: universe,
+		timeout:  conf.Timeout,
 	}, nil
 }
 
@@ -264,6 +270,12 @@ func (c *Groupcache) Store(ctx context.Context, data map[string][]byte, ttl time
 
 func (c *Groupcache) Fetch(ctx context.Context, keys []string) map[string][]byte {
 	data := map[string][]byte{}
+
+	if c.timeout != 0 {
+		timeoutCtx, cancel := context.WithTimeout(ctx, c.timeout)
+		ctx = timeoutCtx
+		defer cancel()
+	}
 
 	for _, k := range keys {
 		codec := galaxycache.ByteCodec{}


### PR DESCRIPTION
Add a timeout for groupcache's fetch operation. It is useful when there
are network errors - if loading from a peer fails then we still might
have a chance to be able to load data from remote object storage
ourselves.

Signed-off-by: Giedrius Statkevičius <giedrius.statkevicius@vinted.com>


* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Added creation of a new context with the specified deadline if it is not zero.

## Verification

N/A