### PR TITLE
receive: remove sort on label hashing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#5205](https://github.com/thanos-io/thanos/pull/5205) Rule: Add ruler labels as external labels in stateless ruler mode.
 - [#5206](https://github.com/thanos-io/thanos/pull/5206) Cache: add timeout for groupcache's fetch operation.
 - [#5218](https://github.com/thanos-io/thanos/pull/5218) Tools: Run bucket downsample tools continuously.
+- [#5224](https://github.com/thanos-io/thanos/pull/5224) Receive: Remove sort on label hashing
 
 ### Removed
 

--- a/pkg/receive/hashring.go
+++ b/pkg/receive/hashring.go
@@ -6,7 +6,6 @@ package receive
 import (
 	"context"
 	"fmt"
-	"sort"
 	"sync"
 
 	"github.com/pkg/errors"
@@ -66,8 +65,6 @@ func (s simpleHashring) GetN(tenant string, ts *prompb.TimeSeries, n uint64) (st
 	if n >= uint64(len(s)) {
 		return "", &insufficientNodesError{have: uint64(len(s)), want: n + 1}
 	}
-
-	sort.Slice(ts.Labels, func(i, j int) bool { return ts.Labels[i].Name < ts.Labels[j].Name })
 
 	return s[(labelpb.HashWithPrefix(tenant, ts.Labels)+n)%uint64(len(s))], nil
 }


### PR DESCRIPTION
* [X] I added CHANGELOG entry for this change.

## Changes

I removed the sort on labels before hashinf them when using an hashring. The Prometheus [remote write specification](https://docs.google.com/document/d/1LPhVRSFkGNSuU1fBd81ulhsCPR4hkSZyyBj1SZ8fWOM/edit#heading=h.3he8womg60lm) stand that:

> MUST have label names sorted in lexicographical order

So I'm wondering if it's necessary to keep the sort on the receive side tor Thanos infrastructure with two "router only" receivers. I've done a pprof and I see that the sort code is using around 8% of CPU time, so it could be a significant optimization if we can skip it:

![Screenshot from 2022-03-09 15-10-49](https://user-images.githubusercontent.com/6660525/157458480-b866e0e8-84b8-4bfc-b1a4-dd620e4101f5.png)

## Verification

We are using the patched version for some time on our receivers and confirmed a reduction in resource consumption. We didn't see any side-effect.
