### PR TITLE
Change error cleanup in `objstore.DownloadDir` to delete files not destination dir

### DIFF
--- a/pkg/objstore/objstore.go
+++ b/pkg/objstore/objstore.go
@@ -276,6 +276,7 @@ func DownloadDir(ctx context.Context, logger log.Logger, bkt BucketReader, origi
 		downloadedFiles = append(downloadedFiles, dst)
 		return nil
 	}); err != nil {
+		downloadedFiles = append(downloadedFiles, dst) // Last, clean up the root dst directory.
 		// Best-effort cleanup if the download failed.
 		for _, f := range downloadedFiles {
 			if rerr := os.Remove(f); rerr != nil {

--- a/pkg/objstore/objstore.go
+++ b/pkg/objstore/objstore.go
@@ -255,8 +255,13 @@ func DownloadDir(ctx context.Context, logger log.Logger, bkt BucketReader, origi
 
 	var downloadedFiles []string
 	if err := bkt.Iter(ctx, src, func(name string) error {
+		dst := filepath.Join(dst, filepath.Base(name))
 		if strings.HasSuffix(name, DirDelim) {
-			return DownloadDir(ctx, logger, bkt, originalSrc, name, filepath.Join(dst, filepath.Base(name)), ignoredPaths...)
+			if err := DownloadDir(ctx, logger, bkt, originalSrc, name, dst, ignoredPaths...); err != nil {
+				return err
+			}
+			downloadedFiles = append(downloadedFiles, dst)
+			return nil
 		}
 		for _, ignoredPath := range ignoredPaths {
 			if ignoredPath == strings.TrimPrefix(name, string(originalSrc)+DirDelim) {

--- a/pkg/objstore/objstore_test.go
+++ b/pkg/objstore/objstore_test.go
@@ -137,7 +137,7 @@ func TestDownloadDir_CleanUp(t *testing.T) {
 	testutil.Assert(t, os.IsNotExist(err))
 }
 
-// unreliableBucket implements Bucket and returns an error on every n-th Get
+// unreliableBucket implements Bucket and returns an error on every n-th Get.
 type unreliableBucket struct {
 	Bucket
 

--- a/pkg/objstore/objstore_test.go
+++ b/pkg/objstore/objstore_test.go
@@ -5,10 +5,15 @@ package objstore
 
 import (
 	"bytes"
+	"context"
 	"io"
+	"os"
 	"testing"
 
+	"github.com/go-kit/log"
+	"github.com/pkg/errors"
 	promtest "github.com/prometheus/client_golang/prometheus/testutil"
+	"go.uber.org/atomic"
 
 	"github.com/thanos-io/thanos/pkg/testutil"
 )
@@ -112,4 +117,37 @@ func TestTimingTracingReader(t *testing.T) {
 
 	testutil.Ok(t, err)
 	testutil.Equals(t, int64(11), size)
+}
+
+func TestDownloadDir_CleanUp(t *testing.T) {
+	b := unreliableBucket{
+		Bucket:  NewInMemBucket(),
+		n:       3,
+		current: atomic.NewInt32(0),
+	}
+	tempDir := t.TempDir()
+
+	testutil.Ok(t, b.Upload(context.Background(), "dir/obj1", bytes.NewReader([]byte("1"))))
+	testutil.Ok(t, b.Upload(context.Background(), "dir/obj2", bytes.NewReader([]byte("2"))))
+	testutil.Ok(t, b.Upload(context.Background(), "dir/obj3", bytes.NewReader([]byte("3"))))
+
+	// We exapect the third Get to fail
+	testutil.NotOk(t, DownloadDir(context.Background(), log.NewNopLogger(), b, "dir/", "dir/", tempDir))
+	_, err := os.Stat(tempDir)
+	testutil.Assert(t, os.IsNotExist(err))
+}
+
+// unreliableBucket implements Bucket and returns an error on every n-th Get
+type unreliableBucket struct {
+	Bucket
+
+	n       int32
+	current *atomic.Int32
+}
+
+func (b unreliableBucket) Get(ctx context.Context, name string) (io.ReadCloser, error) {
+	if b.current.Inc()%b.n == 0 {
+		return nil, errors.Errorf("some error message")
+	}
+	return b.Bucket.Get(ctx, name)
 }


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

Change error cleanup in `objstore.DownloadDir` to delete files not directories: 

`dst` is always a directory. If any file after the first fails to download, the cleanup will fail because the destination already contains at least one file. This PR changes the cleanup logic to clean up successfully downloaded files one by one instead of attempting to clean up the whole dst directory.

This PR does not account for the case where there are nested directories. While we can do `os.RemoveAll` on any child directories, it's unsafe. We don't know for sure that all files in child directories were downloaded as a result of _this_ `DownloadDir` call and didn't exist before it. 

## Verification

<!-- How you tested it? How do you know it works? -->
