### PR TITLE
makefile: Fix Makefile support for arm64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,13 +17,16 @@ arch = $(shell uname -m)
 
 # The include .busybox-versions includes the SHA's of all the platforms, which can be used as var.
 ifeq ($(arch), x86_64)
-    # amd64
-    BASE_DOCKER_SHA=${amd64}
+	# amd64
+	BASE_DOCKER_SHA=${amd64}
 else ifeq ($(arch), armv8)
-    # arm64
-    BASE_DOCKER_SHA=${arm64}
+	# arm64
+	BASE_DOCKER_SHA=${arm64}
+else ifeq ($(arch), arm64)
+	# arm64
+	BASE_DOCKER_SHA=${arm64}
 else
-    echo >&2 "only support amd64 or arm64 arch" && exit 1
+	echo >&2 "only support amd64 or arm64 arch" && exit 1
 endif
 DOCKER_ARCHS       ?= amd64 arm64
 # Generate two target: docker-xxx-amd64, docker-xxx-arm64.


### PR DESCRIPTION
Currently the Makefile does not properly detect arm64 architecture
through uname -m. It assumes that all arm64 CPUs will be detected
as armv8.

This improves the detection by handling arm64 as a separate case.

Signed-off-by: fpetkovski <filip.petkovsky@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

* Improve detection of `arm64` architecture in Makefile
* Use tabs instead of spaces in Makefile

<!-- Enumerate changes you made -->

## Verification

Ran make commands locally.

<!-- How you tested it? How do you know it works? -->
