### PR TITLE
Ruler: Fix WAL directory in stateless mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 
 ### Fixed
 
+- [#5242](https://github.com/thanos-io/thanos/pull/5242) Ruler: Make ruler use the correct WAL directory.
+
 ### Added
 
 - [#5220](https://github.com/thanos-io/thanos/pull/5220) Query Frontend: Add `--query-frontend.forward-header` flag, forward headers to downstream querier.

--- a/cmd/thanos/rule.go
+++ b/cmd/thanos/rule.go
@@ -357,11 +357,10 @@ func runRule(
 			return errors.Wrapf(err, "failed to parse remote write config %v", string(rwCfgYAML))
 		}
 
-		walDir := filepath.Join(conf.dataDir, "wal")
 		// flushDeadline is set to 1m, but it is for metadata watcher only so not used here.
 		remoteStore := remote.NewStorage(logger, reg, func() (int64, error) {
 			return 0, nil
-		}, walDir, 1*time.Minute, nil)
+		}, conf.dataDir, 1*time.Minute, nil)
 		if err := remoteStore.ApplyConfig(&config.Config{
 			GlobalConfig: config.GlobalConfig{
 				ExternalLabels: labelsTSDBToProm(conf.lset),
@@ -371,7 +370,7 @@ func runRule(
 			return errors.Wrap(err, "applying config to remote storage")
 		}
 
-		agentDB, err = agent.Open(logger, reg, remoteStore, walDir, agentOpts)
+		agentDB, err = agent.Open(logger, reg, remoteStore, conf.dataDir, agentOpts)
 		if err != nil {
 			return errors.Wrap(err, "start remote write agent db")
 		}


### PR DESCRIPTION
Signed-off-by: Matej Gera <matejgera@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes
When running the Thanos ruler in stateless mode, the WAL directory that is passed to the agent is not constructed correctly. See this output when starting ruler:
```
level=info ts=2022-03-17T12:40:21.537774846Z caller=db.go:306 msg="replaying WAL, this may take a while" dir=/var/thanos/rule/wal/wal
level=info ts=2022-03-17T12:40:21.537966759Z caller=db.go:357 msg="WAL segment loaded" segment=0 maxSegment=0
```
Notice the `dir` key in the log line, which contains extra sub-directory, ending in `wal/wal`. 

The suggested fix is to provide the 'base' data directory instead of WAL directory, since the full WAL path is built by the agent.

We are also presuming this might have cause us seeing some gaps in data, since stateless ruler could not longer read data from the previous WAL directory, since it was reading from the `wal/wal` "sub-subdirectory".

Also credit goes to @saswatamcode for pairing with me on this issue!

## Verification

<!-- How you tested it? How do you know it works? -->

Stateless ruler tests are passing.
