### PR TITLE
Switch to prometheus notifier.Alert

### DIFF
--- a/cmd/thanos/rule.go
+++ b/cmd/thanos/rule.go
@@ -30,6 +30,7 @@ import (
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/relabel"
+	"github.com/prometheus/prometheus/notifier"
 	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/rules"
 	"github.com/prometheus/prometheus/storage"
@@ -465,13 +466,13 @@ func runRule(
 	{
 		// Run rule evaluation and alert notifications.
 		notifyFunc := func(ctx context.Context, expr string, alerts ...*rules.Alert) {
-			res := make([]*alert.Alert, 0, len(alerts))
+			res := make([]*notifier.Alert, 0, len(alerts))
 			for _, alrt := range alerts {
 				// Only send actually firing alerts.
 				if alrt.State == rules.StatePending {
 					continue
 				}
-				a := &alert.Alert{
+				a := &notifier.Alert{
 					StartsAt:     alrt.FiredAt,
 					Labels:       alrt.Labels,
 					Annotations:  alrt.Annotations,

--- a/pkg/alert/alert_test.go
+++ b/pkg/alert/alert_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/relabel"
+	"github.com/prometheus/prometheus/notifier"
 
 	"github.com/thanos-io/thanos/pkg/testutil"
 )
@@ -28,7 +29,7 @@ func TestQueue_Pop_all_Pushed(t *testing.T) {
 
 	q := NewQueue(nil, nil, qcapacity, batchsize, nil, nil, nil)
 	for i := 0; i < pushes; i++ {
-		q.Push([]*Alert{
+		q.Push([]*notifier.Alert{
 			{},
 			{},
 		})
@@ -47,7 +48,7 @@ func TestQueue_Pop_all_Pushed(t *testing.T) {
 func TestQueue_Push_Relabelled(t *testing.T) {
 	q := NewQueue(nil, nil, 10, 10, labels.FromStrings("a", "1", "replica", "A"), []string{"b", "replica"}, nil)
 
-	q.Push([]*Alert{
+	q.Push([]*notifier.Alert{
 		{Labels: labels.FromStrings("b", "2", "c", "3")},
 		{Labels: labels.FromStrings("c", "3")},
 		{Labels: labels.FromStrings("a", "2")},
@@ -74,7 +75,7 @@ func TestQueue_Push_Relabelled_Alerts(t *testing.T) {
 		},
 	)
 
-	q.Push([]*Alert{
+	q.Push([]*notifier.Alert{
 		{Labels: labels.FromMap(map[string]string{
 			"a": "abc",
 		})},
@@ -134,7 +135,7 @@ func TestSenderSendsOk(t *testing.T) {
 	}
 	s := NewSender(nil, nil, []*Alertmanager{NewAlertmanager(nil, poster, time.Minute, APIv1)})
 
-	s.Send(context.Background(), []*Alert{{}, {}})
+	s.Send(context.Background(), []*notifier.Alert{{}, {}})
 
 	assertSameHosts(t, poster.urls, poster.seen)
 
@@ -161,7 +162,7 @@ func TestSenderSendsOneFails(t *testing.T) {
 	}
 	s := NewSender(nil, nil, []*Alertmanager{NewAlertmanager(nil, poster, time.Minute, APIv1)})
 
-	s.Send(context.Background(), []*Alert{{}, {}})
+	s.Send(context.Background(), []*notifier.Alert{{}, {}})
 
 	assertSameHosts(t, poster.urls, poster.seen)
 
@@ -182,7 +183,7 @@ func TestSenderSendsAllFail(t *testing.T) {
 	}
 	s := NewSender(nil, nil, []*Alertmanager{NewAlertmanager(nil, poster, time.Minute, APIv1)})
 
-	s.Send(context.Background(), []*Alert{{}, {}})
+	s.Send(context.Background(), []*notifier.Alert{{}, {}})
 
 	assertSameHosts(t, poster.urls, poster.seen)
 


### PR DESCRIPTION
Signed-off-by: Ben Ye <ben.ye@bytedance.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

Switch to prometheus struct `notifier.Alert` instead of maintaining the same `alert.Alert` in Thanos.

## Verification

<!-- How you tested it? How do you know it works? -->
