### PR TITLE
Tracing: Remove forgotten debug line

### DIFF
--- a/pkg/tracing/grpc.go
+++ b/pkg/tracing/grpc.go
@@ -6,7 +6,6 @@ package tracing
 import (
 	"context"
 
-	"github.com/davecgh/go-spew/spew"
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware/v2"
 	grpc_opentracing "github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/tracing"
 	opentracing "github.com/opentracing/opentracing-go"
@@ -38,7 +37,6 @@ func StreamServerInterceptor(tracer opentracing.Tracer) grpc.StreamServerInterce
 	return func(srv interface{}, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 		// Add our own tracer.
 		wrappedStream := grpc_middleware.WrapServerStream(stream)
-		spew.Println("wrapped ctx", stream.Context())
 		wrappedStream.WrappedContext = ContextWithTracer(stream.Context(), tracer)
 
 		return interceptor(srv, wrappedStream, info, handler)


### PR DESCRIPTION
Signed-off-by: Matej Gera <matejgera@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [X] Change is not relevant to the end user.

## Changes

There's an extra line to print which was used for debugging and forgotten in https://github.com/thanos-io/thanos/pull/4838, now spams logs. Removing.

## Verification

/
<!-- How you tested it? How do you know it works? -->
