### PR TITLE
info: Return store info only when the service is ready

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#5224](https://github.com/thanos-io/thanos/pull/5224) Receive: Remove sort on label hashing
 - [#5231](https://github.com/thanos-io/thanos/pull/5231) Tools: Bucket verify tool ignores blocks with deletion markers.
 - [#5244](https://github.com/thanos-io/thanos/pull/5244) Query: Promote negative offset and `@` modifier to stable features as per Prometheus [#10121](https://github.com/prometheus/prometheus/pull/10121).
+- [#5255](https://github.com/thanos-io/thanos/pull/5255) InfoAPI: Set store API unavailable when stores are not ready.
 
 ### Removed
 

--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -661,11 +661,14 @@ func runQuery(
 			component.Query.String(),
 			info.WithLabelSetFunc(func() []labelpb.ZLabelSet { return proxy.LabelSet() }),
 			info.WithStoreInfoFunc(func() *infopb.StoreInfo {
-				minTime, maxTime := proxy.TimeRange()
-				return &infopb.StoreInfo{
-					MinTime: minTime,
-					MaxTime: maxTime,
+				if httpProbe.IsReady() {
+					mint, maxt := proxy.TimeRange()
+					return &infopb.StoreInfo{
+						MinTime: mint,
+						MaxTime: maxt,
+					}
 				}
+				return nil
 			}),
 			info.WithExemplarsInfoFunc(),
 			info.WithRulesInfoFunc(),

--- a/cmd/thanos/rule.go
+++ b/cmd/thanos/rule.go
@@ -604,11 +604,14 @@ func runRule(
 				return tsdbStore.LabelSet()
 			}),
 			info.WithStoreInfoFunc(func() *infopb.StoreInfo {
-				mint, maxt := tsdbStore.TimeRange()
-				return &infopb.StoreInfo{
-					MinTime: mint,
-					MaxTime: maxt,
+				if httpProbe.IsReady() {
+					mint, maxt := tsdbStore.TimeRange()
+					return &infopb.StoreInfo{
+						MinTime: mint,
+						MaxTime: maxt,
+					}
 				}
+				return nil
 			}),
 		)
 		options = append(options, grpcserver.WithServer(store.RegisterStoreServer(tsdbStore)))

--- a/cmd/thanos/sidecar.go
+++ b/cmd/thanos/sidecar.go
@@ -265,11 +265,14 @@ func runSidecar(
 				return promStore.LabelSet()
 			}),
 			info.WithStoreInfoFunc(func() *infopb.StoreInfo {
-				mint, maxt := promStore.Timestamps()
-				return &infopb.StoreInfo{
-					MinTime: mint,
-					MaxTime: maxt,
+				if httpProbe.IsReady() {
+					mint, maxt := promStore.Timestamps()
+					return &infopb.StoreInfo{
+						MinTime: mint,
+						MaxTime: maxt,
+					}
 				}
+				return nil
 			}),
 			info.WithExemplarsInfoFunc(),
 			info.WithRulesInfoFunc(),

--- a/cmd/thanos/store.go
+++ b/cmd/thanos/store.go
@@ -390,11 +390,14 @@ func runStore(
 			return bs.LabelSet()
 		}),
 		info.WithStoreInfoFunc(func() *infopb.StoreInfo {
-			mint, maxt := bs.TimeRange()
-			return &infopb.StoreInfo{
-				MinTime: mint,
-				MaxTime: maxt,
+			if httpProbe.IsReady() {
+				mint, maxt := bs.TimeRange()
+				return &infopb.StoreInfo{
+					MinTime: mint,
+					MaxTime: maxt,
+				}
 			}
+			return nil
 		}),
 	)
 

--- a/pkg/prober/http.go
+++ b/pkg/prober/http.go
@@ -32,7 +32,7 @@ func (p *HTTPProbe) HealthyHandler(logger log.Logger) http.HandlerFunc {
 
 // ReadyHandler returns a HTTP Handler which responds readiness checks.
 func (p *HTTPProbe) ReadyHandler(logger log.Logger) http.HandlerFunc {
-	return p.handler(logger, p.isReady)
+	return p.handler(logger, p.IsReady)
 }
 
 func (p *HTTPProbe) handler(logger log.Logger, c check) http.HandlerFunc {
@@ -47,8 +47,8 @@ func (p *HTTPProbe) handler(logger log.Logger, c check) http.HandlerFunc {
 	}
 }
 
-// isReady returns true if component is ready.
-func (p *HTTPProbe) isReady() bool {
+// IsReady returns true if component is ready.
+func (p *HTTPProbe) IsReady() bool {
 	ready := p.ready.Load()
 	return ready > 0
 }

--- a/pkg/prober/http_test.go
+++ b/pkg/prober/http_test.go
@@ -27,7 +27,7 @@ func TestHTTPProberHealthInitialState(t *testing.T) {
 func TestHTTPProberReadinessInitialState(t *testing.T) {
 	p := NewHTTP()
 
-	testutil.Assert(t, !p.isReady(), "initially should not be ready")
+	testutil.Assert(t, !p.IsReady(), "initially should not be ready")
 }
 
 func TestHTTPProberHealthyStatusSetting(t *testing.T) {
@@ -49,11 +49,11 @@ func TestHTTPProberReadyStatusSetting(t *testing.T) {
 
 	p.Ready()
 
-	testutil.Assert(t, p.isReady(), "should be ready")
+	testutil.Assert(t, p.IsReady(), "should be ready")
 
 	p.NotReady(testError)
 
-	testutil.Assert(t, !p.isReady(), "should not be ready")
+	testutil.Assert(t, !p.IsReady(), "should not be ready")
 }
 
 func TestHTTPProberMuxRegistering(t *testing.T) {


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Store only returns store info when its status is ready.
This is helpful in our scenario:
When a prometheus itself is down (due to storage error), the pod readiness check failed and the endpoint got removed from the service. However, because of our CNI solution, the IPVS service backend will remain for 10m(same as the pod terminationGraceSeconds) so that the Thanos Query can still connect to the sidecar for 10m, producing a lot of Query partial errors.

Once the sidecar detects that Prometheus is down, it should let the Query know that it is not available for serving any requests because it is not ready. Same for other stores.

## Verification

<!-- How you tested it? How do you know it works? -->
