### PR TITLE
Fix miekgdns resolver to work with CNAME records too

### DIFF
--- a/pkg/discovery/dns/miekgdns/resolver.go
+++ b/pkg/discovery/dns/miekgdns/resolver.go
@@ -79,7 +79,7 @@ func (r *Resolver) lookupIPAddr(host string, currIteration, maxIterations int) (
 			// Recursively resolve it.
 			addrs, err := r.lookupIPAddr(addr.Target, currIteration+1, maxIterations)
 			if err != nil {
-				return nil, errors.Wrapf(err, "failed to recursively resolve %s", addr.Target)
+				return nil, errors.Wrapf(err, "recursively resolve %s", addr.Target)
 			}
 			resp = append(resp, addrs...)
 		default:

--- a/pkg/discovery/dns/miekgdns/resolver.go
+++ b/pkg/discovery/dns/miekgdns/resolver.go
@@ -49,11 +49,11 @@ func (r *Resolver) LookupSRV(ctx context.Context, service, proto, name string) (
 	return "", addrs, nil
 }
 
-func (r *Resolver) LookupIPAddr(ctx context.Context, host string) ([]net.IPAddr, error) {
-	return r.lookupIPAddr(ctx, host, 1, 8)
+func (r *Resolver) LookupIPAddr(_ context.Context, host string) ([]net.IPAddr, error) {
+	return r.lookupIPAddr(host, 1, 8)
 }
 
-func (r *Resolver) lookupIPAddr(ctx context.Context, host string, currIteration, maxIterations int) ([]net.IPAddr, error) {
+func (r *Resolver) lookupIPAddr(host string, currIteration, maxIterations int) ([]net.IPAddr, error) {
 	// We want to protect from infinite loops when resolving DNS records recursively.
 	if currIteration > maxIterations {
 		return nil, errors.Errorf("maximum number of recursive iterations reached (%d)", maxIterations)
@@ -77,7 +77,7 @@ func (r *Resolver) lookupIPAddr(ctx context.Context, host string, currIteration,
 			resp = append(resp, net.IPAddr{IP: addr.AAAA})
 		case *dns.CNAME:
 			// Recursively resolve it.
-			addrs, err := r.lookupIPAddr(ctx, addr.Target, currIteration+1, maxIterations)
+			addrs, err := r.lookupIPAddr(addr.Target, currIteration+1, maxIterations)
 			if err != nil {
 				return nil, errors.Wrapf(err, "failed to recursively resolve %s", addr.Target)
 			}

--- a/pkg/discovery/dns/miekgdns/resolver.go
+++ b/pkg/discovery/dns/miekgdns/resolver.go
@@ -50,6 +50,15 @@ func (r *Resolver) LookupSRV(ctx context.Context, service, proto, name string) (
 }
 
 func (r *Resolver) LookupIPAddr(ctx context.Context, host string) ([]net.IPAddr, error) {
+	return r.lookupIPAddr(ctx, host, 1, 8)
+}
+
+func (r *Resolver) lookupIPAddr(ctx context.Context, host string, currIteration, maxIterations int) ([]net.IPAddr, error) {
+	// We want to protect from infinite loops when resolving DNS records recursively.
+	if currIteration > maxIterations {
+		return nil, errors.Errorf("maximum number of recursive iterations reached (%d)", maxIterations)
+	}
+
 	response, err := r.lookupWithSearchPath(host, dns.Type(dns.TypeAAAA))
 	if err != nil || len(response.Answer) == 0 {
 		// Ugly fallback to A lookup.
@@ -66,8 +75,15 @@ func (r *Resolver) LookupIPAddr(ctx context.Context, host string) ([]net.IPAddr,
 			resp = append(resp, net.IPAddr{IP: addr.A})
 		case *dns.AAAA:
 			resp = append(resp, net.IPAddr{IP: addr.AAAA})
+		case *dns.CNAME:
+			// Recursively resolve it.
+			addrs, err := r.lookupIPAddr(ctx, addr.Target, currIteration+1, maxIterations)
+			if err != nil {
+				return nil, errors.Wrapf(err, "failed to recursively resolve %s", addr.Target)
+			}
+			resp = append(resp, addrs...)
 		default:
-			return nil, errors.Errorf("invalid A or AAAA response record %s", record)
+			return nil, errors.Errorf("invalid A, AAAA or CNAME response record %s", record)
 		}
 	}
 	return resp, nil


### PR DESCRIPTION
* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

A mimir user reported in https://github.com/grafana/mimir/issues/1654 that since when Thanos switched memcached client from `golang` to `miekgdns`, the memcached client doesn't resolve CNAME anymore. I manually tried to switch back to `golang` and it resolves the issue.

In this PR I propose to fix `miekgdns` to recursively resolve CNAME until we get A/AAAA records (with a limit to max recursion to avoid infinite loops).

Thoughts?

## Verification

Manually tested.