### PR TITLE
tools bucket replicate: add support for concurrent bucket replication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 
 - [#5220](https://github.com/thanos-io/thanos/pull/5220) Query Frontend: Add `--query-frontend.forward-header` flag, forward headers to downstream querier.
 - [#5250](https://github.com/thanos-io/thanos/pull/5250/files) Querier: Expose Query and QueryRange APIs through GRPC.
+- [#5280](https://github.com/thanos-io/thanos/pull/5280) Tools: Add support for concurrent bucket replication.
 
 ### Changed
 

--- a/cmd/thanos/tools_bucket.go
+++ b/cmd/thanos/tools_bucket.go
@@ -122,10 +122,11 @@ type bucketWebConfig struct {
 }
 
 type bucketReplicateConfig struct {
-	resolutions []time.Duration
-	compactions []int
-	matcherStrs []string
-	singleRun   bool
+	resolutions    []time.Duration
+	compactions    []int
+	matcherStrs    []string
+	singleRun      bool
+	concurrencyLvl int
 }
 
 type bucketDownsampleConfig struct {
@@ -210,6 +211,7 @@ func (tbc *bucketReplicateConfig) registerBucketReplicateFlag(cmd extkingpin.Fla
 	cmd.Flag("matcher", "Only blocks whose external labels exactly match this matcher will be replicated.").PlaceHolder("key=\"value\"").StringsVar(&tbc.matcherStrs)
 
 	cmd.Flag("single-run", "Run replication only one time, then exit.").Default("false").BoolVar(&tbc.singleRun)
+	cmd.Flag("concurrency-level", "Max number of go-routines to use for replication.").Default("4").IntVar(&tbc.concurrencyLvl)
 
 	return tbc
 }
@@ -735,6 +737,7 @@ func registerBucketReplicate(app extkingpin.AppClause, objStoreConfig *extflag.P
 			objStoreConfig,
 			toObjStoreConfig,
 			tbc.singleRun,
+			tbc.concurrencyLvl,
 			minTime,
 			maxTime,
 			blockIDs,

--- a/docs/components/tools.md
+++ b/docs/components/tools.md
@@ -508,6 +508,8 @@ with Thanos blocks (meta.json has to have Thanos metadata).
 Flags:
       --compaction=1... ...      Only blocks with these compaction levels will
                                  be replicated. Repeated flag.
+      --concurrency-level=4      Max number of go-routines to use for
+                                 replication.
   -h, --help                     Show context-sensitive help (also try
                                  --help-long and --help-man).
       --http-address="0.0.0.0:10902"

--- a/go.mod
+++ b/go.mod
@@ -45,6 +45,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware/providers/kit/v2 v2.0.0-20201002093600-73cf2ae9d891
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.0.0-rc.2.0.20201207153454-9f6bf00c00a7
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
+	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/golang-lru v0.5.4
 	github.com/jpillora/backoff v1.0.0
 	github.com/klauspost/compress v1.13.6
@@ -160,6 +161,7 @@ require (
 	github.com/google/uuid v1.2.0 // indirect
 	github.com/googleapis/gax-go/v2 v2.1.1 // indirect
 	github.com/gorilla/mux v1.8.0 // indirect
+	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/joeshaw/multierror v0.0.0-20140124173710-69b34d4ec901 // indirect
 	github.com/josharian/intern v1.0.0 // indirect

--- a/pkg/replicate/replicator.go
+++ b/pkg/replicate/replicator.go
@@ -84,6 +84,7 @@ func RunReplicate(
 	fromObjStoreConfig *extflag.PathOrContent,
 	toObjStoreConfig *extflag.PathOrContent,
 	singleRun bool,
+	concurrencyLvl int,
 	minTime, maxTime *thanosmodel.TimeOrDurationValue,
 	blockIDs []ulid.ULID,
 	ignoreMarkedForDeletion bool,
@@ -195,10 +196,9 @@ func RunReplicate(
 		logger := log.With(logger, "replication-run-id", runID.String())
 		level.Info(logger).Log("msg", "running replication attempt")
 
-		if err := newReplicationScheme(logger, metrics, blockFilter, fetcher, fromBkt, toBkt, reg).execute(ctx); err != nil {
+		if err := newReplicationScheme(logger, metrics, blockFilter, fetcher, fromBkt, toBkt, reg).execute(ctx, concurrencyLvl); err != nil {
 			return errors.Wrap(err, "replication execute")
 		}
-
 		return nil
 	}
 

--- a/pkg/replicate/scheme.go
+++ b/pkg/replicate/scheme.go
@@ -225,7 +225,7 @@ func (rs *replicationScheme) execute(ctx context.Context, concurrencyLvl int) er
 	for i := 0; i < concurrencyLvl; i++ {
 		go func(bc <-chan *metadata.Meta, errs chan<- error) {
 			for b := range bc {
-				if err := rs.ensureBlockIsReplicated(ctx, b.BlockMeta.ULID); err != nil { //TODO tbd if this is thread safe
+				if err := rs.ensureBlockIsReplicated(ctx, b.BlockMeta.ULID); err != nil {
 					errs <- err
 				}
 			}

--- a/pkg/replicate/scheme.go
+++ b/pkg/replicate/scheme.go
@@ -207,7 +207,7 @@ func (rs *replicationScheme) execute(ctx context.Context, concurrencyLvl int) er
 	})
 
 	// iterate over blocks and send them to a channel sequentially
-	iterBlocks := func() <-chan *metadata.Meta {
+	blocksChan := func() <-chan *metadata.Meta {
 		out := make(chan *metadata.Meta)
 		go func() {
 			for _, b := range availableBlocks {
@@ -216,8 +216,7 @@ func (rs *replicationScheme) execute(ctx context.Context, concurrencyLvl int) er
 			close(out)
 		}()
 		return out
-	}
-	bc := iterBlocks()
+	}()
 
 	// fan-out for concurrent replication
 	wg := sync.WaitGroup{}
@@ -231,7 +230,7 @@ func (rs *replicationScheme) execute(ctx context.Context, concurrencyLvl int) er
 				}
 			}
 			wg.Done()
-		}(bc, errs)
+		}(blocksChan, errs)
 	}
 	go func() {
 		wg.Wait()

--- a/pkg/replicate/scheme_test.go
+++ b/pkg/replicate/scheme_test.go
@@ -394,7 +394,8 @@ func TestReplicationSchemeAll(t *testing.T) {
 
 		r := newReplicationScheme(logger, newReplicationMetrics(nil), filter, fetcher, objstore.WithNoopInstr(originBucket), targetBucket, nil)
 
-		err = r.execute(ctx)
+		concurrencyLvl := 4
+		err = r.execute(ctx, concurrencyLvl)
 		testutil.Ok(t, err)
 
 		c.assert(ctx, t, originBucket, targetBucket)


### PR DESCRIPTION
fixes: https://github.com/thanos-io/thanos/issues/4278

Signed-off-by: Michal Wasilewski <mwasilewski@gmx.com>



<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

The current implementation of bucket replication is serial, i.e. there's a loop which iterates over blocks and synchronizes them between a source and destination bucket, one block at a time. This PR switches to a pipeline based approach which allows for concurrent replication.

The pipeline consists of three stages. The first stage is a single goroutine which sends pointers to blocks that need to be synchronized to an unbuffered channel. The second stage consists of multiple goroutines which receive pointers to blocks from the upstream channel and execute replication for each received pointer. The level of concurrency of this stage can be controlled with a cli config option. The default concurrency level is 4 and it's an arbitrary number. This default should work even on single threaded CPUs because goroutines are used. Any errors that happen in the second stage are sent to a channel which is then read from by the third stage. The third stage aggregates the errors using a multierror object. Once all executions from the second stage are finished the function returns the multierror object which also implements the `error` interface from the stdlib.

## Verification

<!-- How you tested it? How do you know it works? -->
