### PR TITLE
Added support for ppc64le

### DIFF
--- a/.promu.yml
+++ b/.promu.yml
@@ -20,3 +20,4 @@ crossbuild:
     - linux/arm64
     - windows/amd64
     - freebsd/amd64
+    - linux/ppc64le

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 
 - [#5220](https://github.com/thanos-io/thanos/pull/5220) Query Frontend: Add `--query-frontend.forward-header` flag, forward headers to downstream querier.
 - [#5250](https://github.com/thanos-io/thanos/pull/5250/files) Querier: Expose Query and QueryRange APIs through GRPC.
+- [#5290](https://github.com/thanos-io/thanos/pull/5290) Add support for ppc64le
 
 ### Changed
 

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ else
 	echo >&2 "only support amd64, arm64 or ppc64le arch" && exit 1
 endif
 DOCKER_ARCHS       ?= amd64 arm64 ppc64le
-# Generate two target: docker-xxx-amd64, docker-xxx-arm64, docker-xxx-ppc64le.
+# Generate three targets: docker-xxx-amd64, docker-xxx-arm64, docker-xxx-ppc64le.
 # Run make docker-xxx -n to see the result with dry run.
 BUILD_DOCKER_ARCHS = $(addprefix docker-build-,$(DOCKER_ARCHS))
 TEST_DOCKER_ARCHS  = $(addprefix docker-test-,$(DOCKER_ARCHS))

--- a/Makefile
+++ b/Makefile
@@ -26,13 +26,16 @@ else ifeq ($(arch), arm64)
 	# arm64
 	BASE_DOCKER_SHA=${arm64}
 else ifeq ($(arch), aarch64)
-	# arm64
-	BASE_DOCKER_SHA=${arm64}
+        # arm64
+        BASE_DOCKER_SHA=${arm64}
+else ifeq ($(arch), ppc64le)
+	# ppc64le
+	BASE_DOCKER_SHA=${ppc64le}
 else
-	echo >&2 "only support amd64 or arm64 arch" && exit 1
+	echo >&2 "only support amd64, arm64 or ppc64le arch" && exit 1
 endif
-DOCKER_ARCHS       ?= amd64 arm64
-# Generate two target: docker-xxx-amd64, docker-xxx-arm64.
+DOCKER_ARCHS       ?= amd64 arm64 ppc64le
+# Generate two target: docker-xxx-amd64, docker-xxx-arm64, docker-xxx-ppc64le.
 # Run make docker-xxx -n to see the result with dry run.
 BUILD_DOCKER_ARCHS = $(addprefix docker-build-,$(DOCKER_ARCHS))
 TEST_DOCKER_ARCHS  = $(addprefix docker-test-,$(DOCKER_ARCHS))
@@ -157,7 +160,7 @@ ifeq ($(GIT_BRANCH), main)
 crossbuild: | $(PROMU)
 	@echo ">> crossbuilding all binaries"
 	# we only care about below two for the main branch
-	$(PROMU) crossbuild -v -p linux/amd64 -p linux/arm64
+	$(PROMU) crossbuild -v -p linux/amd64 -p linux/arm64 -p linux/ppc64le
 else
 crossbuild: | $(PROMU)
 	@echo ">> crossbuilding all binaries"

--- a/scripts/installprotoc.sh
+++ b/scripts/installprotoc.sh
@@ -21,6 +21,7 @@ is_supported_platform() {
     linux/amd64) found=0 ;;
     linux/i386) found=0 ;;
     linux/arm64) found=0 ;;
+    linux/ppc64le) found=0 ;;
   esac
   return $found
 }
@@ -37,6 +38,7 @@ adjust_arch() {
     amd64) ARCH=x86_64 ;;
     i386) ARCH=x86_32 ;;
     arm64) ARCH=aarch_64 ;;
+    ppc64le) ARCH=ppcle_64 ;;
   esac
   true
 }


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

This is not a change content-wise, but added further functionality by providing docker images for ppc64le CPU architecture

This is relevant for the users that rely / work on ppc64le infrastructure

## Verification

Checked make crossbuild, docker and docker-multi-stage
