### PR TITLE
query-frontend: Don't cache request with dedup=false 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 
 ### Fixed
 - [#5281](https://github.com/thanos-io/thanos/pull/5281) Blocks: Use correct separators for filesystem paths and object storage paths respectively.
+- [#5300](https://github.com/thanos-io/thanos/pull/5300) Query: Ignore cache on queries with deduplication off.
 
 ### Added
 

--- a/docs/components/query-frontend.md
+++ b/docs/components/query-frontend.md
@@ -36,6 +36,12 @@ Query Frontend supports a retry mechanism to retry query when HTTP requests are 
 
 Query Frontend supports caching query results and reuses them on subsequent queries. If the cached results are incomplete, Query Frontend calculates the required subqueries and executes them in parallel on downstream queriers. Query Frontend can optionally align queries with their step parameter to improve the cacheability of the query results. Currently, in-memory cache (fifo cache) and memcached are supported.
 
+### Excluded from caching
+
+* Requests that support deduplication and having it disabled with `dedup=false`. Read more about deduplication in [Dedup documentation](./query.md#deduplication-enabled).
+* Requests that specify store matchers.
+* Requests were the caching is explicitely disabled.
+
 #### In-memory
 
 ```yaml mdox-exec="go run scripts/cfggen/main.go --name=queryfrontend.InMemoryResponseCacheConfig"

--- a/docs/components/query-frontend.md
+++ b/docs/components/query-frontend.md
@@ -38,7 +38,7 @@ Query Frontend supports caching query results and reuses them on subsequent quer
 
 ### Excluded from caching
 
-* Requests that support deduplication and having it disabled with `dedup=false`. Read more about deduplication in [Dedup documentation](./query.md#deduplication-enabled).
+* Requests that support deduplication and having it disabled with `dedup=false`. Read more about deduplication in [Dedup documentation](query.md#deduplication-enabled).
 * Requests that specify store matchers.
 * Requests were the caching is explicitely disabled.
 

--- a/pkg/queryfrontend/labels_codec_test.go
+++ b/pkg/queryfrontend/labels_codec_test.go
@@ -28,7 +28,7 @@ func TestLabelsCodec_DecodeRequest(t *testing.T) {
 		url             string
 		partialResponse bool
 		expectedError   error
-		expectedRequest ThanosRequest
+		expectedRequest ThanosRequestStoreMatcherGetter
 	}{
 		{
 			name:            "label_names cannot parse start",

--- a/pkg/queryfrontend/queryrange_codec.go
+++ b/pkg/queryfrontend/queryrange_codec.go
@@ -192,7 +192,7 @@ func parseDurationMillis(s string) (int64, error) {
 }
 
 func parseEnableDedupParam(s string) (bool, error) {
-	enableDeduplication := true
+	enableDeduplication := true // Deduplication is enabled by default.
 	if s != "" {
 		var err error
 		enableDeduplication, err = strconv.ParseBool(s)

--- a/pkg/queryfrontend/request.go
+++ b/pkg/queryfrontend/request.go
@@ -13,9 +13,9 @@ import (
 	"github.com/prometheus/prometheus/model/timestamp"
 )
 
-// TODO(yeya24): add partial result when needed.
-// ThanosRequest is a common interface defined for specific thanos requests.
-type ThanosRequest interface {
+// ThanosRequestStoreMatcherGetter is a an interface for store matching that all request share.
+// TODO(yeya24): Add partial result when needed.
+type ThanosRequestStoreMatcherGetter interface {
 	GetStoreMatchers() [][]*labels.Matcher
 }
 

--- a/pkg/queryfrontend/request.go
+++ b/pkg/queryfrontend/request.go
@@ -24,6 +24,11 @@ type RequestHeader struct {
 	Values []string
 }
 
+// ThanosRequestDedup is a an interface for all requests that share setting deduplication.
+type ThanosRequestDedup interface {
+	IsDedupEnabled() bool
+}
+
 type ThanosQueryRangeRequest struct {
 	Path                string
 	Start               int64
@@ -40,6 +45,12 @@ type ThanosQueryRangeRequest struct {
 	CachingOptions      queryrange.CachingOptions
 	Headers             []*RequestHeader
 }
+
+// IsDedupEnabled returns true if deduplication is enabled.
+func (r *ThanosQueryRangeRequest) IsDedupEnabled() bool { return r.Dedup }
+
+// GetStoreMatchers returns store matches.
+func (r *ThanosQueryRangeRequest) GetStoreMatchers() [][]*labels.Matcher { return r.StoreMatchers }
 
 // GetStart returns the start timestamp of the request in milliseconds.
 func (r *ThanosQueryRangeRequest) GetStart() int64 { return r.Start }
@@ -102,8 +113,6 @@ func (r *ThanosQueryRangeRequest) String() string { return "" }
 // which is not used in thanos.
 func (r *ThanosQueryRangeRequest) ProtoMessage() {}
 
-func (r *ThanosQueryRangeRequest) GetStoreMatchers() [][]*labels.Matcher { return r.StoreMatchers }
-
 type ThanosLabelsRequest struct {
 	Start           int64
 	End             int64
@@ -115,6 +124,9 @@ type ThanosLabelsRequest struct {
 	CachingOptions  queryrange.CachingOptions
 	Headers         []*RequestHeader
 }
+
+// GetStoreMatchers returns store matches.
+func (r *ThanosLabelsRequest) GetStoreMatchers() [][]*labels.Matcher { return r.StoreMatchers }
 
 // GetStart returns the start timestamp of the request in milliseconds.
 func (r *ThanosLabelsRequest) GetStart() int64 { return r.Start }
@@ -173,8 +185,6 @@ func (r *ThanosLabelsRequest) String() string { return "" }
 // which is not used in thanos.
 func (r *ThanosLabelsRequest) ProtoMessage() {}
 
-func (r *ThanosLabelsRequest) GetStoreMatchers() [][]*labels.Matcher { return r.StoreMatchers }
-
 type ThanosSeriesRequest struct {
 	Path            string
 	Start           int64
@@ -187,6 +197,12 @@ type ThanosSeriesRequest struct {
 	CachingOptions  queryrange.CachingOptions
 	Headers         []*RequestHeader
 }
+
+// IsDedupEnabled returns true if deduplication is enabled.
+func (r *ThanosSeriesRequest) IsDedupEnabled() bool { return r.Dedup }
+
+// GetStoreMatchers returns store matches.
+func (r *ThanosSeriesRequest) GetStoreMatchers() [][]*labels.Matcher { return r.StoreMatchers }
 
 // GetStart returns the start timestamp of the request in milliseconds.
 func (r *ThanosSeriesRequest) GetStart() int64 { return r.Start }
@@ -243,5 +259,3 @@ func (r *ThanosSeriesRequest) String() string { return "" }
 // ProtoMessage implements proto.Message interface required by queryrange.Request,
 // which is not used in thanos.
 func (r *ThanosSeriesRequest) ProtoMessage() {}
-
-func (r *ThanosSeriesRequest) GetStoreMatchers() [][]*labels.Matcher { return r.StoreMatchers }

--- a/pkg/queryfrontend/roundtrip.go
+++ b/pkg/queryfrontend/roundtrip.go
@@ -275,10 +275,8 @@ func newLabelsTripperware(
 }
 
 // shouldCache controls what kind of Thanos request should be cached.
-// Don't cache:
-// * if StoreMatchers are set (since it is debug option).
-// * if Dedup is disabled (this is done only for debugging).
-// * Caching option disables cache.
+// For more information about requests that skip caching logic, please visit
+// the query-frontend documentation.
 func shouldCache(r queryrange.Request) bool {
 	if thanosReqStoreMatcherGettable, ok := r.(ThanosRequestStoreMatcherGetter); ok {
 		if len(thanosReqStoreMatcherGettable.GetStoreMatchers()) > 0 {

--- a/pkg/queryfrontend/roundtrip.go
+++ b/pkg/queryfrontend/roundtrip.go
@@ -276,7 +276,7 @@ func newLabelsTripperware(
 
 // Don't go to response cache if StoreMatchers are set.
 func shouldCache(r queryrange.Request) bool {
-	if thanosReq, ok := r.(ThanosRequest); ok {
+	if thanosReq, ok := r.(ThanosRequestStoreMatcherGetter); ok {
 		if len(thanosReq.GetStoreMatchers()) > 0 {
 			return false
 		}

--- a/pkg/queryfrontend/roundtrip.go
+++ b/pkg/queryfrontend/roundtrip.go
@@ -274,10 +274,20 @@ func newLabelsTripperware(
 	}, nil
 }
 
-// Don't go to response cache if StoreMatchers are set.
+// shouldCache controls what kind of Thanos request should be cached.
+// Don't cache:
+// * if StoreMatchers are set (since it is debug option).
+// * if Dedup is disabled (this is done only for debugging).
+// * Caching option disables cache.
 func shouldCache(r queryrange.Request) bool {
-	if thanosReq, ok := r.(ThanosRequestStoreMatcherGetter); ok {
-		if len(thanosReq.GetStoreMatchers()) > 0 {
+	if thanosReqStoreMatcherGettable, ok := r.(ThanosRequestStoreMatcherGetter); ok {
+		if len(thanosReqStoreMatcherGettable.GetStoreMatchers()) > 0 {
+			return false
+		}
+	}
+
+	if thanosReqDedup, ok := r.(ThanosRequestDedup); ok {
+		if !thanosReqDedup.IsDedupEnabled() {
 			return false
 		}
 	}

--- a/pkg/queryfrontend/roundtrip_test.go
+++ b/pkg/queryfrontend/roundtrip_test.go
@@ -381,15 +381,16 @@ func TestRoundTripQueryRangeCacheMiddleware(t *testing.T) {
 		End:                 2 * hour,
 		Step:                10 * seconds,
 		MaxSourceResolution: 1 * seconds,
+		Dedup:               true, // Deduplication is enabled by default.
 	}
 
-	testRequestWithDedup := &ThanosQueryRangeRequest{
+	testRequestWithoutDedup := &ThanosQueryRangeRequest{
 		Path:                "/api/v1/query_range",
 		Start:               0,
 		End:                 2 * hour,
 		Step:                10 * seconds,
 		MaxSourceResolution: 1 * seconds,
-		Dedup:               true,
+		Dedup:               false,
 	}
 
 	// Non query range request, won't be cached.
@@ -398,6 +399,7 @@ func TestRoundTripQueryRangeCacheMiddleware(t *testing.T) {
 		Start: 0,
 		End:   2 * hour,
 		Step:  10 * seconds,
+		Dedup: true,
 	}
 
 	// Same query params as testRequest, different maxSourceResolution
@@ -408,6 +410,7 @@ func TestRoundTripQueryRangeCacheMiddleware(t *testing.T) {
 		End:                 2 * hour,
 		Step:                10 * seconds,
 		MaxSourceResolution: 10 * seconds,
+		Dedup:               true,
 	}
 
 	// Same query params as testRequest, different maxSourceResolution
@@ -418,6 +421,7 @@ func TestRoundTripQueryRangeCacheMiddleware(t *testing.T) {
 		End:                 2 * hour,
 		Step:                10 * seconds,
 		MaxSourceResolution: 1 * hour,
+		Dedup:               true,
 	}
 
 	// Same query params as testRequest, but with storeMatchers
@@ -428,6 +432,7 @@ func TestRoundTripQueryRangeCacheMiddleware(t *testing.T) {
 		Step:                10 * seconds,
 		MaxSourceResolution: 1 * seconds,
 		StoreMatchers:       [][]*labels.Matcher{{labels.MustNewMatcher(labels.MatchEqual, "foo", "bar")}},
+		Dedup:               true,
 	}
 
 	cacheConf := &queryrange.ResultsCacheConfig{
@@ -466,7 +471,7 @@ func TestRoundTripQueryRangeCacheMiddleware(t *testing.T) {
 	}{
 		{name: "first request", req: testRequest, expected: 1},
 		{name: "same request as the first one, directly use cache", req: testRequest, expected: 1},
-		{name: "same request as the first one but with dedup enabled, should not use cache", req: testRequestWithDedup, expected: 2},
+		{name: "same request as the first one but with dedup disabled, should not use cache", req: testRequestWithoutDedup, expected: 2},
 		{name: "non query range request won't be cached", req: testRequestInstant, expected: 3},
 		{name: "do it again", req: testRequestInstant, expected: 4},
 		{name: "different max source resolution but still same level", req: testRequestSameLevelDownsampling, expected: 4},
@@ -479,8 +484,9 @@ func TestRoundTripQueryRangeCacheMiddleware(t *testing.T) {
 				Start: 0,
 				End:   25 * hour,
 				Step:  10 * seconds,
+				Dedup: true,
 			},
-			expected: 7,
+			expected: 8,
 		},
 		{
 			name: "same query as the previous one",
@@ -489,8 +495,9 @@ func TestRoundTripQueryRangeCacheMiddleware(t *testing.T) {
 				Start: 0,
 				End:   25 * hour,
 				Step:  10 * seconds,
+				Dedup: true,
 			},
-			expected: 7,
+			expected: 8,
 		},
 	} {
 		if !t.Run(tc.name, func(t *testing.T) {
@@ -618,9 +625,7 @@ func TestRoundTripLabelsCacheMiddleware(t *testing.T) {
 			expected: 8,
 		},
 	} {
-
-		t.Run(tc.name, func(t *testing.T) {
-
+		if !t.Run(tc.name, func(t *testing.T) {
 			ctx := user.InjectOrgID(context.Background(), "1")
 			httpReq, err := NewThanosLabelsCodec(true, 24*time.Hour).EncodeRequest(ctx, tc.req)
 			testutil.Ok(t, err)
@@ -629,8 +634,9 @@ func TestRoundTripLabelsCacheMiddleware(t *testing.T) {
 			testutil.Ok(t, err)
 
 			testutil.Equals(t, tc.expected, *res)
-		})
-
+		}) {
+			break
+		}
 	}
 }
 
@@ -641,6 +647,15 @@ func TestRoundTripSeriesCacheMiddleware(t *testing.T) {
 		Start:    0,
 		End:      2 * hour,
 		Matchers: [][]*labels.Matcher{{labels.MustNewMatcher(labels.MatchEqual, "foo", "bar")}},
+		Dedup:    true,
+	}
+
+	testRequestWithoutDedup := &ThanosSeriesRequest{
+		Path:     "/api/v1/series",
+		Start:    0,
+		End:      2 * hour,
+		Matchers: [][]*labels.Matcher{{labels.MustNewMatcher(labels.MatchEqual, "foo", "bar")}},
+		Dedup:    false,
 	}
 
 	// Different matchers set with the first request.
@@ -649,10 +664,11 @@ func TestRoundTripSeriesCacheMiddleware(t *testing.T) {
 		Start:    0,
 		End:      2 * hour,
 		Matchers: [][]*labels.Matcher{{labels.MustNewMatcher(labels.MatchEqual, "foo", "baz")}},
+		Dedup:    true,
 	}
 
 	// Same query params as testRequest, but with storeMatchers
-	testRequestWithStoreMatchers := &ThanosLabelsRequest{
+	testRequestWithStoreMatchers := &ThanosSeriesRequest{
 		Path:          "/api/v1/series",
 		Start:         0,
 		End:           2 * hour,
@@ -695,12 +711,12 @@ func TestRoundTripSeriesCacheMiddleware(t *testing.T) {
 	}{
 		{name: "first request", req: testRequest, expected: 1},
 		{name: "same request as the first one, directly use cache", req: testRequest, expected: 1},
-		{name: "different series request, not use cache", req: testRequest2, expected: 2},
-		{name: "storeMatchers requests won't go to cache", req: testRequestWithStoreMatchers, expected: 3},
+		{name: "same request as the first one but with dedup disabled, should not use cache", req: testRequestWithoutDedup, expected: 2},
+		{name: "different series request, not use cache", req: testRequest2, expected: 3},
+		{name: "storeMatchers requests won't go to cache", req: testRequestWithStoreMatchers, expected: 4},
 	} {
 
-		t.Run(tc.name, func(t *testing.T) {
-
+		if !t.Run(tc.name, func(t *testing.T) {
 			ctx := user.InjectOrgID(context.Background(), "1")
 			httpReq, err := NewThanosLabelsCodec(true, 24*time.Hour).EncodeRequest(ctx, tc.req)
 			testutil.Ok(t, err)
@@ -709,8 +725,9 @@ func TestRoundTripSeriesCacheMiddleware(t *testing.T) {
 			testutil.Ok(t, err)
 
 			testutil.Equals(t, tc.expected, *res)
-		})
-
+		}) {
+			break
+		}
 	}
 }
 

--- a/test/e2e/query_frontend_test.go
+++ b/test/e2e/query_frontend_test.go
@@ -109,7 +109,9 @@ func TestQueryFrontend(t *testing.T) {
 			timestamp.FromTime(now.Add(-time.Hour)),
 			timestamp.FromTime(now.Add(time.Hour)),
 			14,
-			promclient.QueryOptions{},
+			promclient.QueryOptions{
+				Deduplicate: true,
+			},
 			func(res model.Matrix) error {
 				if len(res) == 0 {
 					return errors.Errorf("expected some results, got nothing")
@@ -151,7 +153,9 @@ func TestQueryFrontend(t *testing.T) {
 			timestamp.FromTime(now.Add(-time.Hour)),
 			timestamp.FromTime(now.Add(time.Hour)),
 			14,
-			promclient.QueryOptions{},
+			promclient.QueryOptions{
+				Deduplicate: true,
+			},
 			func(res model.Matrix) error {
 				if len(res) == 0 {
 					return errors.Errorf("expected some results, got nothing")
@@ -196,7 +200,9 @@ func TestQueryFrontend(t *testing.T) {
 			timestamp.FromTime(now.Add(-time.Hour)),
 			timestamp.FromTime(now.Add(24*time.Hour)),
 			14,
-			promclient.QueryOptions{},
+			promclient.QueryOptions{
+				Deduplicate: true,
+			},
 			func(res model.Matrix) error {
 				if len(res) == 0 {
 					return errors.Errorf("expected some results, got nothing")
@@ -459,7 +465,9 @@ func TestQueryFrontendMemcachedCache(t *testing.T) {
 		timestamp.FromTime(now.Add(-time.Hour)),
 		timestamp.FromTime(now.Add(time.Hour)),
 		14,
-		promclient.QueryOptions{},
+		promclient.QueryOptions{
+			Deduplicate: true,
+		},
 		func(res model.Matrix) error {
 			if len(res) == 0 {
 				return errors.Errorf("expected some results, got nothing")
@@ -489,7 +497,9 @@ func TestQueryFrontendMemcachedCache(t *testing.T) {
 		timestamp.FromTime(now.Add(-time.Hour)),
 		timestamp.FromTime(now.Add(time.Hour)),
 		14,
-		promclient.QueryOptions{},
+		promclient.QueryOptions{
+			Deduplicate: true,
+		},
 		func(res model.Matrix) error {
 			if len(res) == 0 {
 				return errors.Errorf("expected some results, got nothing")


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Summary

Currently there's a problem with the query-frontend regarding caching and playing with the dedup setting. This is the scenario that reproduces the problem:

1. An API request with a given query is sent to the the query-frontend with dedup off
2. The API will cache it
3. An API request to run the same query is sent again, but with dedup on
4. The API will return the previously cached result **with dedup off**

It happens because the cache key doesn't include the value of the dedup setting. 

This can creates confusion, because the consumer of the API will be getting wrong data. On top of this, adding the time range to the play creates different caching artefacts where the problem occurs and doesn't occur.

This PR aims to fix this scenario in the most simple way possible: by skipping cache logic when dedup is off and mentioning this in the documentation of the query-frontend component.

## Changes

* Update query-frontend to skip cache for requests with dedupe off
* Add explanation in the query-frontend documentation about requests where caching logic is skipped
* Added a test scenario to ensure dedup off queries aren't cached

## Verification

<!-- How you tested it? How do you know it works? -->

- `go test` 