### PR TITLE
Ensure memcached batched requests handle context cancelation

### DIFF
--- a/pkg/cacheutil/cacheutil_test.go
+++ b/pkg/cacheutil/cacheutil_test.go
@@ -4,11 +4,73 @@
 package cacheutil
 
 import (
+	"context"
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus"
+	"go.uber.org/atomic"
 	"go.uber.org/goleak"
+
+	"github.com/thanos-io/thanos/pkg/gate"
+	"github.com/thanos-io/thanos/pkg/testutil"
 )
 
 func TestMain(m *testing.M) {
 	goleak.VerifyTestMain(m)
+}
+
+func TestDoWithBatch(t *testing.T) {
+	tests := map[string]struct {
+		items           []string
+		batchSize       int
+		expectedBatches int
+		concurrency     gate.Gate
+	}{
+		"no items": {
+			items:           []string{},
+			batchSize:       2,
+			expectedBatches: 0,
+			concurrency:     nil,
+		},
+
+		"fewer than batch size": {
+			items:           []string{"key1"},
+			batchSize:       2,
+			expectedBatches: 1,
+			concurrency:     nil,
+		},
+
+		"perfect sized for batch": {
+			items:           []string{"key1", "key2", "key3", "key4"},
+			batchSize:       2,
+			expectedBatches: 2,
+			concurrency:     nil,
+		},
+
+		"odd sized for batch": {
+			items:           []string{"key1", "key2", "key3", "key4", "key5"},
+			batchSize:       2,
+			expectedBatches: 3,
+			concurrency:     nil,
+		},
+
+		"odd sized with concurrency limit": {
+			items:           []string{"key1", "key2", "key3", "key4", "key5"},
+			batchSize:       2,
+			expectedBatches: 3,
+			concurrency:     gate.New(prometheus.NewPedanticRegistry(), 1),
+		},
+	}
+
+	for testName, testData := range tests {
+		t.Run(testName, func(t *testing.T) {
+			actualBatches := atomic.Int64{}
+			_ = doWithBatch(context.Background(), len(testData.items), testData.batchSize, testData.concurrency, func(startIndex, endIndex int) error {
+				actualBatches.Inc()
+				return nil
+			})
+
+			testutil.Equals(t, int64(testData.expectedBatches), actualBatches.Load())
+		})
+	}
 }

--- a/pkg/cacheutil/memcached_client.go
+++ b/pkg/cacheutil/memcached_client.go
@@ -470,7 +470,7 @@ func (c *memcachedClient) getMultiBatched(ctx context.Context, keys []string) ([
 	// NOTE: we are not closing the results channel here on purpose. doWithBatch will start
 	// goroutines to fetch data and write the results back to the `results` channel. If we
 	// close the channel when this method exits before all goroutines have finished writing
-	// (such as when our context is cancelled) they will panic trying to write to a closed
+	// (such as when our context is canceled) they will panic trying to write to a closed
 	// channel. Instead, we let the GC take care of cleaning the channel up when it is no
 	// longer referenced by this method or the workers in doWithBatch.
 
@@ -494,7 +494,7 @@ func (c *memcachedClient) getMultiBatched(ctx context.Context, keys []string) ([
 	for i := 0; i < numResults; i++ {
 		select {
 		case <-ctx.Done():
-			// If the context is cancelled, it's possible not all batches will be run by doWithBatch,
+			// If the context is canceled, it's possible not all batches will be run by doWithBatch,
 			// so we should avoid waiting on the results channel here. This ensures that we don't block
 			// indefinitely waiting results that will never come.
 			return nil, ctx.Err()
@@ -517,7 +517,7 @@ func (c *memcachedClient) getMultiSingle(ctx context.Context, keys []string) (it
 
 	select {
 	case <-ctx.Done():
-		// Make sure our context hasn't been cancelled before fetching cache items using
+		// Make sure our context hasn't been canceled before fetching cache items using
 		// cache client backend.
 		return nil, ctx.Err()
 	default:

--- a/pkg/cacheutil/memcached_client_test.go
+++ b/pkg/cacheutil/memcached_client_test.go
@@ -486,9 +486,8 @@ func TestMemcachedClient_GetMulti_ContextCancelled(t *testing.T) {
 	defer client.Stop()
 
 	// Immediately cancel the context that will be used for the GetMulti request. This will
-	// ensure that the underlying batching doesn't actually take place and won't generate any
-	// results. We're making sure that we don't block forever waiting for results that will
-	// not be generated. If we did, this test would hang.
+	// ensure that the method called by the batching logic (getMultiSingle) returns immediately
+	// instead of calling the underlying memcached client (which blocks forever in this test).
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 

--- a/pkg/cacheutil/memcached_client_test.go
+++ b/pkg/cacheutil/memcached_client_test.go
@@ -140,7 +140,7 @@ func TestMemcachedClient_SetAsync(t *testing.T) {
 	testutil.Ok(t, client.SetAsync(ctx, "key-2", []byte("value-2"), time.Second))
 	testutil.Ok(t, backendMock.waitItems(2))
 
-	actual, err := client.getMultiSingle([]string{"key-1", "key-2"})
+	actual, err := client.getMultiSingle(ctx, []string{"key-1", "key-2"})
 	testutil.Ok(t, err)
 	testutil.Equals(t, []byte("value-1"), actual["key-1"].Value)
 	testutil.Equals(t, []byte("value-2"), actual["key-2"].Value)
@@ -166,7 +166,7 @@ func TestMemcachedClient_SetAsyncWithCustomMaxItemSize(t *testing.T) {
 	testutil.Ok(t, client.SetAsync(ctx, "key-2", []byte("value-2-too-long-to-be-stored"), time.Second))
 	testutil.Ok(t, backendMock.waitItems(1))
 
-	actual, err := client.getMultiSingle([]string{"key-1", "key-2"})
+	actual, err := client.getMultiSingle(ctx, []string{"key-1", "key-2"})
 	testutil.Ok(t, err)
 	testutil.Equals(t, []byte("value-1"), actual["key-1"].Value)
 	testutil.Equals(t, (*memcache.Item)(nil), actual["key-2"])
@@ -465,4 +465,54 @@ func TestMultipleClientsCanUseSameRegistry(t *testing.T) {
 	client2, err := NewMemcachedClientWithConfig(log.NewNopLogger(), "b", config, reg)
 	testutil.Ok(t, err)
 	defer client2.Stop()
+}
+
+func TestMemcachedClient_GetMulti_ContextCancelled(t *testing.T) {
+	config := defaultMemcachedClientConfig
+	config.Addresses = []string{"127.0.0.1:11211"}
+	config.MaxGetMultiBatchSize = 2
+	config.MaxGetMultiConcurrency = 2
+
+	// Create a new context that will be used for our "blocking" backend so that we can
+	// actually stop it at the end of the test and not leak goroutines.
+	backendCtx, backendCancel := context.WithCancel(context.Background())
+	defer backendCancel()
+
+	selector := &MemcachedJumpHashSelector{}
+	backendMock := newMemcachedClientBlockingMock(backendCtx)
+
+	client, err := newMemcachedClient(log.NewNopLogger(), backendMock, selector, config, prometheus.NewPedanticRegistry(), "test")
+	testutil.Ok(t, err)
+	defer client.Stop()
+
+	// Immediately cancel the context that will be used for the GetMulti request. This will
+	// ensure that the underlying batching doesn't actually take place and won't generate any
+	// results. We're making sure that we don't block forever waiting for results that will
+	// not be generated. If we did, this test would hang.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	items := client.GetMulti(ctx, []string{"key1", "key2", "key3", "key4"})
+	testutil.Equals(t, 0, len(items))
+}
+
+type memcachedClientBlockingMock struct {
+	ctx context.Context
+}
+
+func newMemcachedClientBlockingMock(ctx context.Context) *memcachedClientBlockingMock {
+	return &memcachedClientBlockingMock{ctx: ctx}
+}
+
+func (c *memcachedClientBlockingMock) GetMulti([]string) (map[string]*memcache.Item, error) {
+	// Block until this backend client is explicitly stopped so that we can ensure the memcached
+	// client won't be blocked waiting for results that will never be returned.
+	select {
+	case <-c.ctx.Done():
+		return nil, nil
+	}
+}
+
+func (c *memcachedClientBlockingMock) Set(*memcache.Item) error {
+	return nil
 }

--- a/pkg/cacheutil/memcached_client_test.go
+++ b/pkg/cacheutil/memcached_client_test.go
@@ -507,10 +507,8 @@ func newMemcachedClientBlockingMock(ctx context.Context) *memcachedClientBlockin
 func (c *memcachedClientBlockingMock) GetMulti([]string) (map[string]*memcache.Item, error) {
 	// Block until this backend client is explicitly stopped so that we can ensure the memcached
 	// client won't be blocked waiting for results that will never be returned.
-	select {
-	case <-c.ctx.Done():
-		return nil, nil
-	}
+	<-c.ctx.Done()
+	return nil, nil
 }
 
 func (c *memcachedClientBlockingMock) Set(*memcache.Item) error {


### PR DESCRIPTION
## Changes

Ensure that when the context used for Memcached GetMulti is canceled,
getMultiBatched does not hang waiting for results that will never be
generated (since the batched requests will not run if the context has
been canceled).

Fixes an issue introduced in #5301

Signed-off-by: Nick Pillitteri <nick.pillitteri@grafana.com>

* [ ] I added CHANGELOG entry for this change.
* [X] Change is not relevant to the end user.

## Verification

Unit tests run. Store-gateway end-to-end tests run. Tested in Mimir dev environment to ensure goroutines waiting for results do not leak when request context is cancelled.

/cc @wiardvanrij 