### PR TITLE
docs: Fix broken link to introduction blog

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -122,7 +122,7 @@ See up to date [jsonnet mixins](https://github.com/thanos-io/thanos/tree/main/mi
 
 * 2018:
 
-  * [Introduction blog post](https://improbable.io/games/blog/thanos-prometheus-at-scale)
+  * [Introduction blog post](https://improbable.io/blog/thanos-prometheus-at-scale)
   * [Monzo user story](https://monzo.com/blog/2018/07/27/how-we-monitor-monzo)
   * [Banzai Cloud hand's on](https://banzaicloud.com/blog/hands-on-thanos/)
   * [uSwitch user story](https://medium.com/uswitch-labs/making-prometheus-more-awesome-with-thanos-fbec8c6c28ad)


### PR DESCRIPTION
Signed-off-by: jmjf <jamee.mikell@gmail.com>

Fix broken link to "Introduction blog post" in docs/getting-started.md

- [ ] I added CHANGELOG entry for this change.
- [x ] Change is not relevant to the end user.

## Changes

* Found correct article.
* Changed URL for "Introduction blog post" to point to correct URL.
* Net change: deleted "games" node from URL.

## Verification

Not sure how much verification you want, but I'll aim for too much. Please let me know if I should perform other checks.

* When previewing markdown in local VS Code, clicking the link opens the correct page. (PASS)
* When running `make check-docs` in Gitpod from my repo, change does not introduce errors. (PASS)
  * **Before change**: `make check-docs` in Gitpod returns 403 errors for `getting-started.md` lines 128, 118, 117, and 111 and `docs/proposals-done/201901-read-write...` line 39 ("some caveats" link). No error for line 115 (changed line) because the URL redirects to https://ims.improbable.io/insights.
  * **After change**: `make check-docs` returns the same errors.
* When running `make build` in Gitpod from my repo, change does not introduce any errors. (PASS)
  * **Before change**: `make build` returns no errors.
  * **After change**: `make build` returns no errors.

I also checked all the 403 links listed above and they work from the browser, so host is probably rejecting scripted reads.
