### PR TITLE
stalebot: add generic label to avoid stalebot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -11,6 +11,7 @@ exemptLabels:
   # issue is being reminded.
   - reminder
   - 'state: someone-working-on-it' 
+  - 'dont-go-stale' 
 
 # Set to true to ignore issues in a project (defaults to false)
 exemptProjects: false


### PR DESCRIPTION
Add a generic label which tells stalebot not to close issues marked with
it.

Signed-off-by: Giedrius Statkevičius <giedrius.statkevicius@vinted.com>
