### PR TITLE
groupcache: reduce log severity

### DIFF
--- a/pkg/cache/groupcache.go
+++ b/pkg/cache/groupcache.go
@@ -281,13 +281,13 @@ func (c *Groupcache) Fetch(ctx context.Context, keys []string) map[string][]byte
 		codec := galaxycache.ByteCodec{}
 
 		if err := c.galaxy.Get(ctx, k, &codec); err != nil {
-			level.Error(c.logger).Log("msg", "failed fetching data from groupcache", "err", err, "key", k)
+			level.Debug(c.logger).Log("msg", "failed fetching data from groupcache", "err", err, "key", k)
 			continue
 		}
 
 		retrievedData, _, err := codec.MarshalBinary()
 		if err != nil {
-			level.Error(c.logger).Log("msg", "failed retrieving data", "err", err, "key", k)
+			level.Debug(c.logger).Log("msg", "failed retrieving data", "err", err, "key", k)
 			continue
 		}
 


### PR DESCRIPTION
Sometimes certain operations can fail with some error(-s) being expected
e.g. a deletion marker might or might not exist. Thus, these log lines
could get triggered even though nothing bad is happening. Since the
expected errors are known only at the very end, near the call site, and
because `error`s are already logged in other places, and because these
Fetch()/Store() functions are working in best-effort scenario, I propose
reducing the severity of these log lines to `debug`.

Fixes https://github.com/thanos-io/thanos/issues/5265.

