### PR TITLE
query-frontend: improve docs on requestes excluded from cache

### DIFF
--- a/docs/components/query-frontend.md
+++ b/docs/components/query-frontend.md
@@ -39,8 +39,10 @@ Query Frontend supports caching query results and reuses them on subsequent quer
 ### Excluded from caching
 
 * Requests that support deduplication and having it disabled with `dedup=false`. Read more about deduplication in [Dedup documentation](query.md#deduplication-enabled).
-* Requests that specify store matchers.
-* Requests were the caching is explicitely disabled.
+* Requests that specify Store Matchers.
+* Requests where downstream queriers set the header `Cache-Control=no-store` in the response:
+  * Requests with a partial **response**.
+  * Requests with other warnings.
 
 #### In-memory
 


### PR DESCRIPTION
Signed-off-by: Douglas Camata <159076+douglascamata@users.noreply.github.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->
After a small conversation in [#thanos in the CNCF slack](https://cloud-native.slack.com/archives/CK5RSSC10/p1651569775707589), I decided to open a PR to better explain the cases where the Query Frontend will not cache the response.

Related PRs: #1984 and #3109.
