### PR TITLE
sidecar/compact/store/receiver - Add the prefix option to buckets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 
 ## Unreleased
 
+- [#5337](https://github.com/thanos-io/thanos/pull/5337) Thanos Object Store: Add the `prefix` option to buckets
+
 ### Fixed
 - [#5339](https://github.com/thanos-io/thanos/pull/5339) Receive: Fix deadlock on interrupt in routerOnly mode
 - [#5357](https://github.com/thanos-io/thanos/pull/5357) Store: fix groupcache handling of slashes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,14 +10,13 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 
 ## Unreleased
 
-- [#5337](https://github.com/thanos-io/thanos/pull/5337) Thanos Object Store: Add the `prefix` option to buckets
-
 ### Fixed
 - [#5339](https://github.com/thanos-io/thanos/pull/5339) Receive: Fix deadlock on interrupt in routerOnly mode
 - [#5357](https://github.com/thanos-io/thanos/pull/5357) Store: fix groupcache handling of slashes
 
 ### Added
 
+- [#5337](https://github.com/thanos-io/thanos/pull/5337) Thanos Object Store: Add the `prefix` option to buckets
 - [#5352](https://github.com/thanos-io/thanos/pull/5352) Cache: Add cache metrics to groupcache.
 - [#5391](https://github.com/thanos-io/thanos/pull/5391) Receive: Add relabeling support.
 

--- a/docs/components/receive.md
+++ b/docs/components/receive.md
@@ -44,6 +44,7 @@ type: GCS
 config:
   bucket: ""
   service_account: ""
+prefix: ""
 ```
 
 The example content of `hashring.json`:

--- a/docs/components/sidecar.md
+++ b/docs/components/sidecar.md
@@ -56,6 +56,7 @@ type: GCS
 config:
   bucket: ""
   service_account: ""
+prefix: ""
 ```
 
 ## Upload compacted blocks

--- a/docs/components/store.md
+++ b/docs/components/store.md
@@ -15,6 +15,7 @@ type: GCS
 config:
   bucket: ""
   service_account: ""
+prefix: ""
 ```
 
 In general, an average of 6 MB of local disk space is required per TSDB block stored in the object storage bucket, but for high cardinality blocks with large label set it can even go up to 30MB and more. It is for the pre-computed index, which includes symbols and postings offsets as well as metadata JSON.

--- a/docs/components/tools.md
+++ b/docs/components/tools.md
@@ -101,6 +101,7 @@ type: GCS
 config:
   bucket: ""
   service_account: ""
+prefix: ""
 ```
 
 Bucket can be extended to add more subcommands that will be helpful when working with object storage buckets by adding a new command within [`/cmd/thanos/tools_bucket.go`](../../cmd/thanos/tools_bucket.go)  .
@@ -601,6 +602,7 @@ type: GCS
 config:
   bucket: ""
   service_account: ""
+prefix: ""
 ```
 
 ```$ mdox-exec="thanos tools bucket downsample --help"
@@ -675,6 +677,7 @@ type: GCS
 config:
   bucket: ""
   service_account: ""
+prefix: ""
 ```
 
 ```$ mdox-exec="thanos tools bucket mark --help"

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -64,7 +64,6 @@ type: S3
 config:
   bucket: ""
   endpoint: ""
-  prefix: ""
   region: ""
   aws_sdk_auth: false
   access_key: ""
@@ -333,7 +332,6 @@ config:
   storage_account_key: ""
   container: ""
   endpoint: ""
-  prefix: ""
   max_retries: 0
   msi_resource: ""
   user_assigned_id: ""
@@ -388,7 +386,6 @@ config:
   password: ""
   domain_id: ""
   domain_name: ""
-  prefix: ""
   project_id: ""
   project_name: ""
   project_domain_id: ""
@@ -416,7 +413,6 @@ config:
   region: ""
   app_id: ""
   endpoint: ""
-  prefix: ""
   secret_key: ""
   secret_id: ""
   http_config:
@@ -448,7 +444,6 @@ config:
   bucket: ""
   access_key_id: ""
   access_key_secret: ""
-  prefix: ""
 ```
 
 Use --objstore.config-file to reference to this configuration file.
@@ -464,7 +459,6 @@ config:
   endpoint: ""
   access_key: ""
   secret_key: ""
-  prefix: ""
 ```
 
 #### Filesystem
@@ -477,7 +471,6 @@ NOTE: This storage type is experimental and might be inefficient. It is NOT advi
 type: FILESYSTEM
 config:
   directory: ""
-  prefix: ""
 ```
 
 ### How to add a new client to Thanos?

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -63,6 +63,7 @@ NOTE: Minio client was mainly for AWS S3, but it can be configured against other
 type: S3
 config:
   bucket: ""
+  prefix: ""
   endpoint: ""
   region: ""
   aws_sdk_auth: false

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -102,7 +102,7 @@ At a minimum, you will need to provide a value for the `bucket`, `endpoint`, `ac
 
 However if you set `aws_sdk_auth: true` Thanos will use the default authentication methods of the AWS SDK for go based on [known environment variables](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html) (`AWS_PROFILE`, `AWS_WEB_IDENTITY_TOKEN_FILE` ... etc) and known AWS config files (~/.aws/config). If you turn this on, then the `bucket` and `endpoint` are the required config keys.
 
-The field `prefix` can be used to transparently use prefixes in your S3 bucket. That way, you may point distinct Thanos instances to the same bucket, while avoiding one instance messing with the data from another instance. This allows multiple Thanos deployments to use the same bucket without having to list all the files in it when you point Thanos store to the bucket (even when you are using tenants feature).
+The field `prefix` can be used to transparently use prefixes in your S3 bucket. This allows you to separate blocks coming from different sources into paths with different prefixes, making it easier to understand what's going on (i.e. you don't have to use Thanos tooling to know from where which blocks came).
 
 The AWS region to endpoint mapping can be found in this [link](https://docs.aws.amazon.com/general/latest/gr/s3.html).
 

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -96,6 +96,7 @@ config:
     kms_encryption_context: {}
     encryption_key: ""
   sts_endpoint: ""
+prefix: ""
 ```
 
 At a minimum, you will need to provide a value for the `bucket`, `endpoint`, `access_key`, and `secret_key` keys. The rest of the keys are optional.
@@ -257,6 +258,7 @@ type: GCS
 config:
   bucket: ""
   service_account: ""
+prefix: ""
 ```
 
 ##### Using GOOGLE_APPLICATION_CREDENTIALS
@@ -358,6 +360,7 @@ config:
       key_file: ""
       server_name: ""
       insecure_skip_verify: false
+prefix: ""
 ```
 
 If `msi_resource` is used, authentication is done via system-assigned managed identity. The value for Azure should be `https://<storage-account-name>.blob.core.windows.net`.
@@ -398,6 +401,7 @@ config:
   connect_timeout: 10s
   timeout: 5m
   use_dynamic_large_objects: false
+prefix: ""
 ```
 
 #### Tencent COS
@@ -423,6 +427,7 @@ config:
     max_idle_conns: 100
     max_idle_conns_per_host: 100
     max_conns_per_host: 0
+prefix: ""
 ```
 
 The `secret_key` and `secret_id` field is required. The `http_config` field is optional for optimize HTTP transport settings. There are two ways to configure the required bucket information:
@@ -444,6 +449,7 @@ config:
   bucket: ""
   access_key_id: ""
   access_key_secret: ""
+prefix: ""
 ```
 
 Use --objstore.config-file to reference to this configuration file.
@@ -459,6 +465,7 @@ config:
   endpoint: ""
   access_key: ""
   secret_key: ""
+prefix: ""
 ```
 
 #### Filesystem
@@ -471,6 +478,7 @@ NOTE: This storage type is experimental and might be inefficient. It is NOT advi
 type: FILESYSTEM
 config:
   directory: ""
+prefix: ""
 ```
 
 ### How to add a new client to Thanos?

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -63,7 +63,6 @@ NOTE: Minio client was mainly for AWS S3, but it can be configured against other
 type: S3
 config:
   bucket: ""
-  prefix: ""
   endpoint: ""
   region: ""
   aws_sdk_auth: false

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -103,6 +103,8 @@ At a minimum, you will need to provide a value for the `bucket`, `endpoint`, `ac
 
 However if you set `aws_sdk_auth: true` Thanos will use the default authentication methods of the AWS SDK for go based on [known environment variables](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html) (`AWS_PROFILE`, `AWS_WEB_IDENTITY_TOKEN_FILE` ... etc) and known AWS config files (~/.aws/config). If you turn this on, then the `bucket` and `endpoint` are the required config keys.
 
+The field `prefix` can be used to transparently use bucket prefixes in your S3 bucket. That way, you may point distinct Thanos instances to the same bucket, while avoiding one instance messing with the data from another instance. This will allow multiple Thanos deployments to use the same bucket without 
+
 The AWS region to endpoint mapping can be found in this [link](https://docs.aws.amazon.com/general/latest/gr/s3.html).
 
 Make sure you use a correct signature version. Currently AWS requires signature v4, so it needs `signature_version2: false`. If you don't specify it, you will get an `Access Denied` error. On the other hand, several S3 compatible APIs use `signature_version2: true`.

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -103,7 +103,7 @@ At a minimum, you will need to provide a value for the `bucket`, `endpoint`, `ac
 
 However if you set `aws_sdk_auth: true` Thanos will use the default authentication methods of the AWS SDK for go based on [known environment variables](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html) (`AWS_PROFILE`, `AWS_WEB_IDENTITY_TOKEN_FILE` ... etc) and known AWS config files (~/.aws/config). If you turn this on, then the `bucket` and `endpoint` are the required config keys.
 
-The field `prefix` can be used to transparently use bucket prefixes in your S3 bucket. That way, you may point distinct Thanos instances to the same bucket, while avoiding one instance messing with the data from another instance. This will allow multiple Thanos deployments to use the same bucket without 
+The field `prefix` can be used to transparently use prefixes in your S3 bucket. That way, you may point distinct Thanos instances to the same bucket, while avoiding one instance messing with the data from another instance. This allows multiple Thanos deployments to use the same bucket without having to list all the files in it when you point Thanos store to the bucket (even when you are using tenants feature).
 
 The AWS region to endpoint mapping can be found in this [link](https://docs.aws.amazon.com/general/latest/gr/s3.html).
 

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -64,6 +64,7 @@ type: S3
 config:
   bucket: ""
   endpoint: ""
+  prefix: ""
   region: ""
   aws_sdk_auth: false
   access_key: ""
@@ -330,6 +331,7 @@ config:
   storage_account_key: ""
   container: ""
   endpoint: ""
+  prefix: ""
   max_retries: 0
   msi_resource: ""
   user_assigned_id: ""
@@ -384,6 +386,7 @@ config:
   password: ""
   domain_id: ""
   domain_name: ""
+  prefix: ""
   project_id: ""
   project_name: ""
   project_domain_id: ""
@@ -411,6 +414,7 @@ config:
   region: ""
   app_id: ""
   endpoint: ""
+  prefix: ""
   secret_key: ""
   secret_id: ""
   http_config:
@@ -442,6 +446,7 @@ config:
   bucket: ""
   access_key_id: ""
   access_key_secret: ""
+  prefix: ""
 ```
 
 Use --objstore.config-file to reference to this configuration file.
@@ -457,6 +462,7 @@ config:
   endpoint: ""
   access_key: ""
   secret_key: ""
+  prefix: ""
 ```
 
 #### Filesystem
@@ -469,6 +475,7 @@ NOTE: This storage type is experimental and might be inefficient. It is NOT advi
 type: FILESYSTEM
 config:
   directory: ""
+  prefix: ""
 ```
 
 ### How to add a new client to Thanos?

--- a/pkg/objstore/client/factory.go
+++ b/pkg/objstore/client/factory.go
@@ -82,8 +82,9 @@ func NewBucket(logger log.Logger, confContentYaml []byte, reg prometheus.Registe
 		return nil, errors.Wrap(err, fmt.Sprintf("create %s client", bucketConf.Type))
 	}
 
-	prefix := PrefixFromConfig(string(confContentYaml))
+	prefix := prefixFromConfig(confContentYaml)
 	var prefixedBucket objstore.Bucket
+
 	if validPrefix(prefix) {
 		prefixedBucket = objstore.NewPrefixedBucket(bucket, prefix)
 		level.Debug(logger).Log("msg", "using prefix on bucket access", "prefix", prefix)
@@ -99,9 +100,10 @@ func validPrefix(prefix string) bool {
 	return len(prefix) > 0
 }
 
-func PrefixFromConfig(confYaml string) string {
+func prefixFromConfig(confYaml []byte) string {
 	bucketConf := &BucketConfig{}
-	err := yaml.UnmarshalStrict([]byte(confYaml), &bucketConf)
+	err := yaml.UnmarshalStrict(confYaml, &bucketConf)
+
 	if err != nil {
 		return ""
 	}

--- a/pkg/objstore/client/factory.go
+++ b/pkg/objstore/client/factory.go
@@ -83,7 +83,7 @@ func NewBucket(logger log.Logger, confContentYaml []byte, reg prometheus.Registe
 	}
 
 	prefix := prefixFromConfig(confContentYaml, bucketConf)
-	
+
 	return objstore.NewTracingBucket(objstore.BucketWithMetrics(bucket.Name(), objstore.NewPrefixedBucket(bucket, prefix), reg)), nil
 }
 

--- a/pkg/objstore/client/factory.go
+++ b/pkg/objstore/client/factory.go
@@ -87,8 +87,9 @@ func NewBucket(logger log.Logger, confContentYaml []byte, reg prometheus.Registe
 	}
 
 	var prefixedBucket objstore.Bucket
-	if ValidPrefix(bucketConf.Config.Prefix) {
+	if validPrefix(bucketConf.Config.Prefix) {
 		prefixedBucket = objstore.NewPrefixedBucket(bucket, bucketConf.Config.Prefix)
+		level.Debug(logger).Log("msg", "using prefix on bucket access", "prefix", bucketConf.Config.Prefix)
 	} else {
 		prefixedBucket = bucket
 	}
@@ -96,7 +97,7 @@ func NewBucket(logger log.Logger, confContentYaml []byte, reg prometheus.Registe
 	return objstore.NewTracingBucket(objstore.BucketWithMetrics(bucket.Name(), prefixedBucket, reg)), nil
 }
 
-func ValidPrefix(prefix string) bool {
+func validPrefix(prefix string) bool {
 	prefix = strings.Replace(prefix, "/", "", -1)
 	return len(prefix) > 0
 }

--- a/pkg/objstore/client/factory.go
+++ b/pkg/objstore/client/factory.go
@@ -88,12 +88,6 @@ func NewBucket(logger log.Logger, confContentYaml []byte, reg prometheus.Registe
 }
 
 func prefixFromConfig(confYaml []byte, bucketConf *BucketConfig) string {
-	err := yaml.UnmarshalStrict(confYaml, &bucketConf)
-
-	if err != nil {
-		return ""
-	}
-
 	prefix, ok := bucketConf.Config.(map[interface{}]interface{})["prefix"]
 	if !ok {
 		return ""

--- a/pkg/objstore/client/factory.go
+++ b/pkg/objstore/client/factory.go
@@ -40,7 +40,11 @@ const (
 
 type BucketConfig struct {
 	Type   ObjProvider `yaml:"type"`
-	Config interface{} `yaml:"config"`
+	Config Config      `yaml:"config"`
+}
+
+type Config struct {
+	Prefix string `yaml:"prefix" default:""`
 }
 
 // NewBucket initializes and returns new object storage clients.
@@ -81,5 +85,7 @@ func NewBucket(logger log.Logger, confContentYaml []byte, reg prometheus.Registe
 	if err != nil {
 		return nil, errors.Wrap(err, fmt.Sprintf("create %s client", bucketConf.Type))
 	}
-	return objstore.NewTracingBucket(objstore.BucketWithMetrics(bucket.Name(), bucket, reg)), nil
+
+	prefixedBucket := objstore.NewPrefixedBucket(bucket, bucketConf.Config.Prefix)
+	return objstore.NewTracingBucket(objstore.BucketWithMetrics(bucket.Name(), prefixedBucket, reg)), nil
 }

--- a/pkg/objstore/client/factory.go
+++ b/pkg/objstore/client/factory.go
@@ -86,6 +86,17 @@ func NewBucket(logger log.Logger, confContentYaml []byte, reg prometheus.Registe
 		return nil, errors.Wrap(err, fmt.Sprintf("create %s client", bucketConf.Type))
 	}
 
-	prefixedBucket := objstore.NewPrefixedBucket(bucket, bucketConf.Config.Prefix)
+	var prefixedBucket objstore.Bucket
+	if ValidPrefix(bucketConf.Config.Prefix) {
+		prefixedBucket = objstore.NewPrefixedBucket(bucket, bucketConf.Config.Prefix)
+	} else {
+		prefixedBucket = bucket
+	}
+
 	return objstore.NewTracingBucket(objstore.BucketWithMetrics(bucket.Name(), prefixedBucket, reg)), nil
+}
+
+func ValidPrefix(prefix string) bool {
+	prefix = strings.Replace(prefix, "/", "", -1)
+	return len(prefix) > 0
 }

--- a/pkg/objstore/client/factory.go
+++ b/pkg/objstore/client/factory.go
@@ -41,6 +41,7 @@ const (
 type BucketConfig struct {
 	Type   ObjProvider `yaml:"type"`
 	Config interface{} `yaml:"config"`
+	Prefix string      `yaml:"prefix" default:""`
 }
 
 // NewBucket initializes and returns new object storage clients.
@@ -82,16 +83,5 @@ func NewBucket(logger log.Logger, confContentYaml []byte, reg prometheus.Registe
 		return nil, errors.Wrap(err, fmt.Sprintf("create %s client", bucketConf.Type))
 	}
 
-	prefix := prefixFromConfig(bucketConf)
-
-	return objstore.NewTracingBucket(objstore.BucketWithMetrics(bucket.Name(), objstore.NewPrefixedBucket(bucket, prefix), reg)), nil
-}
-
-func prefixFromConfig(bucketConf *BucketConfig) string {
-	prefix, ok := bucketConf.Config.(map[interface{}]interface{})["prefix"]
-	if !ok {
-		return ""
-	}
-
-	return prefix.(string)
+	return objstore.NewTracingBucket(objstore.BucketWithMetrics(bucket.Name(), objstore.NewPrefixedBucket(bucket, bucketConf.Prefix), reg)), nil
 }

--- a/pkg/objstore/client/factory.go
+++ b/pkg/objstore/client/factory.go
@@ -82,12 +82,12 @@ func NewBucket(logger log.Logger, confContentYaml []byte, reg prometheus.Registe
 		return nil, errors.Wrap(err, fmt.Sprintf("create %s client", bucketConf.Type))
 	}
 
-	prefix := prefixFromConfig(confContentYaml, bucketConf)
+	prefix := prefixFromConfig(bucketConf)
 
 	return objstore.NewTracingBucket(objstore.BucketWithMetrics(bucket.Name(), objstore.NewPrefixedBucket(bucket, prefix), reg)), nil
 }
 
-func prefixFromConfig(confYaml []byte, bucketConf *BucketConfig) string {
+func prefixFromConfig(bucketConf *BucketConfig) string {
 	prefix, ok := bucketConf.Config.(map[interface{}]interface{})["prefix"]
 	if !ok {
 		return ""

--- a/pkg/objstore/objtesting/foreach.go
+++ b/pkg/objstore/objtesting/foreach.go
@@ -64,6 +64,7 @@ func ForeachStore(t *testing.T, testFn func(t *testing.T, bkt objstore.Bucket)) 
 		b, err := filesystem.NewBucket(dir)
 		testutil.Ok(t, err)
 		testFn(t, b)
+		testFn(t, objstore.NewPrefixedBucket(b, "some_prefix"))
 	})
 
 	// Optional GCS.
@@ -77,6 +78,7 @@ func ForeachStore(t *testing.T, testFn func(t *testing.T, bkt objstore.Bucket)) 
 
 			// TODO(bwplotka): Add goleak when https://github.com/GoogleCloudPlatform/google-cloud-go/issues/1025 is resolved.
 			testFn(t, bkt)
+			testFn(t, objstore.NewPrefixedBucket(bkt, "some_prefix"))
 		})
 	}
 
@@ -109,6 +111,7 @@ func ForeachStore(t *testing.T, testFn func(t *testing.T, bkt objstore.Bucket)) 
 			defer closeFn()
 
 			testFn(t, bkt)
+			testFn(t, objstore.NewPrefixedBucket(bkt, "some_prefix"))
 		})
 	}
 
@@ -122,6 +125,7 @@ func ForeachStore(t *testing.T, testFn func(t *testing.T, bkt objstore.Bucket)) 
 			defer closeFn()
 
 			testFn(t, container)
+			testFn(t, objstore.NewPrefixedBucket(container, "some_prefix"))
 		})
 	}
 
@@ -135,6 +139,7 @@ func ForeachStore(t *testing.T, testFn func(t *testing.T, bkt objstore.Bucket)) 
 			defer closeFn()
 
 			testFn(t, bkt)
+			testFn(t, objstore.NewPrefixedBucket(bkt, "some_prefix"))
 		})
 	}
 
@@ -148,6 +153,7 @@ func ForeachStore(t *testing.T, testFn func(t *testing.T, bkt objstore.Bucket)) 
 			defer closeFn()
 
 			testFn(t, bkt)
+			testFn(t, objstore.NewPrefixedBucket(bkt, "some_prefix"))
 		})
 	}
 
@@ -161,6 +167,7 @@ func ForeachStore(t *testing.T, testFn func(t *testing.T, bkt objstore.Bucket)) 
 			defer closeFn()
 
 			testFn(t, bkt)
+			testFn(t, objstore.NewPrefixedBucket(bkt, "some_prefix"))
 		})
 	}
 }

--- a/pkg/objstore/objtesting/foreach.go
+++ b/pkg/objstore/objtesting/foreach.go
@@ -95,6 +95,7 @@ func ForeachStore(t *testing.T, testFn func(t *testing.T, bkt objstore.Bucket)) 
 			// This needs to be investigated more.
 
 			testFn(t, bkt)
+			testFn(t, objstore.NewPrefixedBucket(bkt, "some_prefix"))
 		})
 	}
 

--- a/pkg/objstore/prefixed_bucket.go
+++ b/pkg/objstore/prefixed_bucket.go
@@ -1,3 +1,6 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
 package objstore
 
 import (

--- a/pkg/objstore/prefixed_bucket.go
+++ b/pkg/objstore/prefixed_bucket.go
@@ -31,6 +31,7 @@ func conditionalPrefix(prefix, name string) string {
 	if len(name) > 0 {
 		return withPrefix(prefix, name)
 	}
+
 	return name
 }
 

--- a/pkg/objstore/prefixed_bucket.go
+++ b/pkg/objstore/prefixed_bucket.go
@@ -15,6 +15,13 @@ func NewPrefixedBucket(bkt Bucket, prefix string) Bucket {
 	return pbkt
 }
 
+func conditionalPrefix(prefix, name string) string {
+	if len(name) > 0 && len(prefix) > 0 {
+		return prefix + "/" + name
+	}
+	return name
+}
+
 func withPrefix(prefix, name string) string {
 	return prefix + "/" + name
 }
@@ -27,17 +34,17 @@ func (p *PrefixedBucket) Close() error {
 // object name including the prefix of the inspected directory.
 // Entries are passed to function in sorted order.
 func (p *PrefixedBucket) Iter(ctx context.Context, dir string, f func(string) error, options ...IterOption) error {
-	return p.bkt.Iter(ctx, withPrefix(p.prefix, dir), f, options...)
+	return p.bkt.Iter(ctx, conditionalPrefix(p.prefix, dir), f, options...)
 }
 
 // Get returns a reader for the given object name.
 func (p *PrefixedBucket) Get(ctx context.Context, name string) (io.ReadCloser, error) {
-	return p.bkt.Get(ctx, withPrefix(p.prefix, name))
+	return p.bkt.Get(ctx, conditionalPrefix(p.prefix, name))
 }
 
 // GetRange returns a new range reader for the given object name and range.
 func (p *PrefixedBucket) GetRange(ctx context.Context, name string, off int64, length int64) (io.ReadCloser, error) {
-	return p.bkt.GetRange(ctx, withPrefix(p.prefix, name), off, length)
+	return p.bkt.GetRange(ctx, conditionalPrefix(p.prefix, name), off, length)
 }
 
 // Exists checks if the given object exists in the bucket.
@@ -52,7 +59,7 @@ func (p *PrefixedBucket) IsObjNotFoundErr(err error) bool {
 
 // Attributes returns information about the specified object.
 func (p PrefixedBucket) Attributes(ctx context.Context, name string) (ObjectAttributes, error) {
-	return p.bkt.Attributes(ctx, withPrefix(p.prefix, name))
+	return p.bkt.Attributes(ctx, conditionalPrefix(p.prefix, name))
 }
 
 // func (p *PrefixedBucket) Attributes(ctx context.Context, name string) (ObjectAttributes, error) {

--- a/pkg/objstore/prefixed_bucket.go
+++ b/pkg/objstore/prefixed_bucket.go
@@ -12,19 +12,8 @@ type PrefixedBucket struct {
 }
 
 func NewPrefixedBucket(bkt Bucket, prefix string) Bucket {
-	pbkt := &PrefixedBucket{bkt: bkt, prefix: PrefixFormater(prefix)}
+	pbkt := &PrefixedBucket{bkt: bkt, prefix: strings.Trim(prefix, "/")}
 	return pbkt
-}
-
-func PrefixFormater(prefix string) string {
-	formatedPrefix := prefix
-	if prefix[len(prefix)-1:] == "/" {
-		formatedPrefix = prefix[0 : len(prefix)-1]
-	}
-	if prefix[0:1] == "/" {
-		formatedPrefix = formatedPrefix[1:]
-	}
-	return formatedPrefix
 }
 
 func conditionalPrefix(prefix, name string) string {

--- a/pkg/objstore/prefixed_bucket.go
+++ b/pkg/objstore/prefixed_bucket.go
@@ -12,19 +12,19 @@ type PrefixedBucket struct {
 }
 
 func NewPrefixedBucket(bkt Bucket, prefix string) Bucket {
-	pbkt := &PrefixedBucket{bkt: bkt, prefix: strings.Trim(prefix, "/")}
+	pbkt := &PrefixedBucket{bkt: bkt, prefix: strings.Trim(prefix, DirDelim)}
 	return pbkt
 }
 
 func conditionalPrefix(prefix, name string) string {
 	if len(name) > 0 && len(prefix) > 0 {
-		return prefix + "/" + name
+		return prefix + DirDelim + name
 	}
 	return name
 }
 
 func withPrefix(prefix, name string) string {
-	return prefix + "/" + name
+	return prefix + DirDelim + name
 }
 
 func (p *PrefixedBucket) Close() error {
@@ -39,7 +39,7 @@ func (p *PrefixedBucket) Iter(ctx context.Context, dir string, f func(string) er
 		pdir := withPrefix(p.prefix, dir)
 
 		return p.bkt.Iter(ctx, pdir, func(s string) error {
-			return f(strings.TrimPrefix(s, p.prefix+"/"))
+			return f(strings.TrimPrefix(s, p.prefix+DirDelim))
 		}, options...)
 	}
 	return p.bkt.Iter(ctx, dir, f, options...)

--- a/pkg/objstore/prefixed_bucket.go
+++ b/pkg/objstore/prefixed_bucket.go
@@ -15,8 +15,16 @@ type PrefixedBucket struct {
 }
 
 func NewPrefixedBucket(bkt Bucket, prefix string) Bucket {
-	pbkt := &PrefixedBucket{bkt: bkt, prefix: strings.Trim(prefix, DirDelim)}
-	return pbkt
+	if validPrefix(prefix) {
+		return &PrefixedBucket{bkt: bkt, prefix: strings.Trim(prefix, DirDelim)}
+	}
+
+	return bkt
+}
+
+func validPrefix(prefix string) bool {
+	prefix = strings.Replace(prefix, "/", "", -1)
+	return len(prefix) > 0
 }
 
 func conditionalPrefix(prefix, name string) string {

--- a/pkg/objstore/prefixed_bucket.go
+++ b/pkg/objstore/prefixed_bucket.go
@@ -28,8 +28,8 @@ func validPrefix(prefix string) bool {
 }
 
 func conditionalPrefix(prefix, name string) string {
-	if len(name) > 0 && len(prefix) > 0 {
-		return prefix + DirDelim + name
+	if len(name) > 0 {
+		return withPrefix(prefix, name)
 	}
 	return name
 }
@@ -46,14 +46,11 @@ func (p *PrefixedBucket) Close() error {
 // object name including the prefix of the inspected directory.
 // Entries are passed to function in sorted order.
 func (p *PrefixedBucket) Iter(ctx context.Context, dir string, f func(string) error, options ...IterOption) error {
-	if len(p.prefix) > 0 {
-		pdir := withPrefix(p.prefix, dir)
+	pdir := withPrefix(p.prefix, dir)
 
-		return p.bkt.Iter(ctx, pdir, func(s string) error {
-			return f(strings.TrimPrefix(s, p.prefix+DirDelim))
-		}, options...)
-	}
-	return p.bkt.Iter(ctx, dir, f, options...)
+	return p.bkt.Iter(ctx, pdir, func(s string) error {
+		return f(strings.TrimPrefix(s, p.prefix+DirDelim))
+	}, options...)
 }
 
 // Get returns a reader for the given object name.

--- a/pkg/objstore/prefixed_bucket.go
+++ b/pkg/objstore/prefixed_bucket.go
@@ -35,13 +35,14 @@ func (p *PrefixedBucket) Close() error {
 // object name including the prefix of the inspected directory.
 // Entries are passed to function in sorted order.
 func (p *PrefixedBucket) Iter(ctx context.Context, dir string, f func(string) error, options ...IterOption) error {
-	pdir := withPrefix(p.prefix, dir)
 	if len(p.prefix) > 0 {
+		pdir := withPrefix(p.prefix, dir)
+
 		return p.bkt.Iter(ctx, pdir, func(s string) error {
-			return f(strings.Join(strings.Split(s, p.prefix+"/")[1:], "/"))
+			return f(strings.TrimPrefix(s, p.prefix+"/"))
 		}, options...)
 	}
-	return p.bkt.Iter(ctx, pdir, f)
+	return p.bkt.Iter(ctx, dir, f, options...)
 }
 
 // Get returns a reader for the given object name.

--- a/pkg/objstore/prefixed_bucket_test.go
+++ b/pkg/objstore/prefixed_bucket_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
 package objstore
 
 import (

--- a/pkg/objstore/prefixed_bucket_test.go
+++ b/pkg/objstore/prefixed_bucket_test.go
@@ -1,0 +1,8 @@
+package objstore
+
+import "testing"
+
+func TestPrefixedBucket_AcceptanceTest(t *testing.T) {
+	bkt := NewPrefixedBucket(NewInMemBucket(), "someprefix/anotherprefix")
+	AcceptanceTest(t, bkt)
+}

--- a/pkg/objstore/prefixed_bucket_test.go
+++ b/pkg/objstore/prefixed_bucket_test.go
@@ -10,27 +10,36 @@ import (
 )
 
 func TestPrefixedBucket_Acceptance(t *testing.T) {
-	bkt := NewPrefixedBucket(NewInMemBucket(), "/someprefix/anotherprefix/")
+	prefix := "/someprefix/anotherprefix/"
+	bkt := NewPrefixedBucket(NewInMemBucket(), prefix)
 	AcceptanceTest(t, bkt)
+	UsesPrefixTest(t, bkt, prefix)
 
-	bkt = NewPrefixedBucket(NewInMemBucket(), "someprefix/anotherprefix/")
+	prefix = "someprefix/anotherprefix/"
+	bkt = NewPrefixedBucket(NewInMemBucket(), prefix)
 	AcceptanceTest(t, bkt)
+	UsesPrefixTest(t, bkt, prefix)
 
-	bkt = NewPrefixedBucket(NewInMemBucket(), "someprefix/anotherprefix")
+	prefix = "someprefix/anotherprefix"
+	bkt = NewPrefixedBucket(NewInMemBucket(), prefix)
 	AcceptanceTest(t, bkt)
+	UsesPrefixTest(t, bkt, prefix)
 
-	bkt = NewPrefixedBucket(NewInMemBucket(), "someprefix/")
+	prefix = "someprefix/"
+	bkt = NewPrefixedBucket(NewInMemBucket(), prefix)
 	AcceptanceTest(t, bkt)
+	UsesPrefixTest(t, bkt, prefix)
 
-	bkt = NewPrefixedBucket(NewInMemBucket(), "someprefix")
+	prefix = "someprefix"
+	bkt = NewPrefixedBucket(NewInMemBucket(), prefix)
 	AcceptanceTest(t, bkt)
+	UsesPrefixTest(t, bkt, prefix)
 }
 
-func TestPrefixedBucket_UsesPrefix(t *testing.T) {
-	bkt := NewInMemBucket()
-	bkt.Upload(context.Background(), "our_prefix/file1.jpg", strings.NewReader("@test-data1"))
+func UsesPrefixTest(t *testing.T, bkt Bucket, prefix string) {
+	bkt.Upload(context.Background(), strings.Trim(prefix, "/")+"/file1.jpg", strings.NewReader("@test-data1"))
 
-	pBkt := NewPrefixedBucket(bkt, "our_prefix")
+	pBkt := NewPrefixedBucket(bkt, prefix)
 	rc1, err := pBkt.Get(context.Background(), "file1.jpg")
 
 	testutil.Ok(t, err)
@@ -38,4 +47,10 @@ func TestPrefixedBucket_UsesPrefix(t *testing.T) {
 	content, err := ioutil.ReadAll(rc1)
 	testutil.Ok(t, err)
 	testutil.Equals(t, "@test-data1", string(content))
+
+	// Upload
+	// Delete
+	// GetRange
+	// Exists
+	// IsObjNotFoundErr
 }

--- a/pkg/objstore/prefixed_bucket_test.go
+++ b/pkg/objstore/prefixed_bucket_test.go
@@ -5,4 +5,16 @@ import "testing"
 func TestPrefixedBucket_AcceptanceTest(t *testing.T) {
 	bkt := NewPrefixedBucket(NewInMemBucket(), "/someprefix/anotherprefix/")
 	AcceptanceTest(t, bkt)
+
+	bkt = NewPrefixedBucket(NewInMemBucket(), "someprefix/anotherprefix/")
+	AcceptanceTest(t, bkt)
+
+	bkt = NewPrefixedBucket(NewInMemBucket(), "someprefix/anotherprefix")
+	AcceptanceTest(t, bkt)
+
+	bkt = NewPrefixedBucket(NewInMemBucket(), "someprefix/")
+	AcceptanceTest(t, bkt)
+
+	bkt = NewPrefixedBucket(NewInMemBucket(), "someprefix")
+	AcceptanceTest(t, bkt)
 }

--- a/pkg/objstore/prefixed_bucket_test.go
+++ b/pkg/objstore/prefixed_bucket_test.go
@@ -12,33 +12,28 @@ import (
 
 func TestPrefixedBucket_Acceptance(t *testing.T) {
 	prefix := "/someprefix/anotherprefix/"
-	bkt := NewPrefixedBucket(NewInMemBucket(), prefix)
-	AcceptanceTest(t, bkt)
-	UsesPrefixTest(t, bkt, prefix)
+	AcceptanceTest(t, NewPrefixedBucket(NewInMemBucket(), prefix))
+	UsesPrefixTest(t, NewInMemBucket(), prefix)
 
 	prefix = "someprefix/anotherprefix/"
-	bkt = NewPrefixedBucket(NewInMemBucket(), prefix)
-	AcceptanceTest(t, bkt)
-	UsesPrefixTest(t, bkt, prefix)
+	AcceptanceTest(t, NewPrefixedBucket(NewInMemBucket(), prefix))
+	UsesPrefixTest(t, NewInMemBucket(), prefix)
 
 	prefix = "someprefix/anotherprefix"
-	bkt = NewPrefixedBucket(NewInMemBucket(), prefix)
-	AcceptanceTest(t, bkt)
-	UsesPrefixTest(t, bkt, prefix)
+	AcceptanceTest(t, NewPrefixedBucket(NewInMemBucket(), prefix))
+	UsesPrefixTest(t, NewInMemBucket(), prefix)
 
 	prefix = "someprefix/"
-	bkt = NewPrefixedBucket(NewInMemBucket(), prefix)
-	AcceptanceTest(t, bkt)
-	UsesPrefixTest(t, bkt, prefix)
+	AcceptanceTest(t, NewPrefixedBucket(NewInMemBucket(), prefix))
+	UsesPrefixTest(t, NewInMemBucket(), prefix)
 
 	prefix = "someprefix"
-	bkt = NewPrefixedBucket(NewInMemBucket(), prefix)
-	AcceptanceTest(t, bkt)
-	UsesPrefixTest(t, bkt, prefix)
+	AcceptanceTest(t, NewPrefixedBucket(NewInMemBucket(), prefix))
+	UsesPrefixTest(t, NewInMemBucket(), prefix)
 }
 
 func UsesPrefixTest(t *testing.T, bkt Bucket, prefix string) {
-	bkt.Upload(context.Background(), strings.Trim(prefix, "/")+"/file1.jpg", strings.NewReader("test-data1"))
+	testutil.Ok(t, bkt.Upload(context.Background(), strings.Trim(prefix, "/")+"/file1.jpg", strings.NewReader("test-data1")))
 
 	pBkt := NewPrefixedBucket(bkt, prefix)
 	rc1, err := pBkt.Get(context.Background(), "file1.jpg")
@@ -50,7 +45,7 @@ func UsesPrefixTest(t *testing.T, bkt Bucket, prefix string) {
 	testutil.Ok(t, err)
 	testutil.Equals(t, "test-data1", string(content))
 
-	pBkt.Upload(context.Background(), "file2.jpg", strings.NewReader("test-data2"))
+	testutil.Ok(t, pBkt.Upload(context.Background(), "file2.jpg", strings.NewReader("test-data2")))
 	rc2, err := bkt.Get(context.Background(), strings.Trim(prefix, "/")+"/file2.jpg")
 	testutil.Ok(t, err)
 
@@ -60,10 +55,8 @@ func UsesPrefixTest(t *testing.T, bkt Bucket, prefix string) {
 	testutil.Ok(t, err)
 	testutil.Equals(t, "test-data2", string(contentUpload))
 
-	pBkt.Delete(context.Background(), "file2.jpg")
+	testutil.Ok(t, pBkt.Delete(context.Background(), "file2.jpg"))
 	_, err = bkt.Get(context.Background(), strings.Trim(prefix, "/")+"/file2.jpg")
-	testutil.Ok(t, err)
-
 	testutil.NotOk(t, err)
 	testutil.Assert(t, pBkt.IsObjNotFoundErr(err), "expected not found error got %s", err)
 
@@ -82,7 +75,7 @@ func UsesPrefixTest(t *testing.T, bkt Bucket, prefix string) {
 	testutil.Ok(t, err)
 	testutil.Assert(t, attrs.Size == 10, "expected size to be equal to 10")
 
-	bkt.Upload(context.Background(), strings.Trim(prefix, "/")+"/dir/file1.jpg", strings.NewReader("test-data1"))
+	testutil.Ok(t, bkt.Upload(context.Background(), strings.Trim(prefix, "/")+"/dir/file1.jpg", strings.NewReader("test-data1")))
 	seen := []string{}
 	testutil.Ok(t, pBkt.Iter(context.Background(), "", func(fn string) error {
 		seen = append(seen, fn)

--- a/pkg/objstore/prefixed_bucket_test.go
+++ b/pkg/objstore/prefixed_bucket_test.go
@@ -42,6 +42,7 @@ func UsesPrefixTest(t *testing.T, bkt Bucket, prefix string) {
 
 	pBkt := NewPrefixedBucket(bkt, prefix)
 	rc1, err := pBkt.Get(context.Background(), "file1.jpg")
+	testutil.Ok(t, err)
 
 	testutil.Ok(t, err)
 	defer func() { testutil.Ok(t, rc1.Close()) }()
@@ -51,6 +52,7 @@ func UsesPrefixTest(t *testing.T, bkt Bucket, prefix string) {
 
 	pBkt.Upload(context.Background(), "file2.jpg", strings.NewReader("test-data2"))
 	rc2, err := bkt.Get(context.Background(), strings.Trim(prefix, "/")+"/file2.jpg")
+	testutil.Ok(t, err)
 
 	testutil.Ok(t, err)
 	defer func() { testutil.Ok(t, rc2.Close()) }()
@@ -60,6 +62,7 @@ func UsesPrefixTest(t *testing.T, bkt Bucket, prefix string) {
 
 	pBkt.Delete(context.Background(), "file2.jpg")
 	_, err = bkt.Get(context.Background(), strings.Trim(prefix, "/")+"/file2.jpg")
+	testutil.Ok(t, err)
 
 	testutil.NotOk(t, err)
 	testutil.Assert(t, pBkt.IsObjNotFoundErr(err), "expected not found error got %s", err)

--- a/pkg/objstore/prefixed_bucket_test.go
+++ b/pkg/objstore/prefixed_bucket_test.go
@@ -3,6 +3,6 @@ package objstore
 import "testing"
 
 func TestPrefixedBucket_AcceptanceTest(t *testing.T) {
-	bkt := NewPrefixedBucket(NewInMemBucket(), "someprefix/anotherprefix")
+	bkt := NewPrefixedBucket(NewInMemBucket(), "/someprefix/anotherprefix/")
 	AcceptanceTest(t, bkt)
 }

--- a/pkg/objstore/prefixed_bucket_test.go
+++ b/pkg/objstore/prefixed_bucket_test.go
@@ -14,25 +14,18 @@ import (
 )
 
 func TestPrefixedBucket_Acceptance(t *testing.T) {
-	prefix := "/someprefix/anotherprefix/"
-	AcceptanceTest(t, NewPrefixedBucket(NewInMemBucket(), prefix))
-	UsesPrefixTest(t, NewInMemBucket(), prefix)
 
-	prefix = "someprefix/anotherprefix/"
-	AcceptanceTest(t, NewPrefixedBucket(NewInMemBucket(), prefix))
-	UsesPrefixTest(t, NewInMemBucket(), prefix)
+	prefixes := []string{
+		"/someprefix/anotherprefix/",
+		"someprefix/anotherprefix/",
+		"someprefix/anotherprefix",
+		"someprefix/",
+		"someprefix"}
 
-	prefix = "someprefix/anotherprefix"
-	AcceptanceTest(t, NewPrefixedBucket(NewInMemBucket(), prefix))
-	UsesPrefixTest(t, NewInMemBucket(), prefix)
-
-	prefix = "someprefix/"
-	AcceptanceTest(t, NewPrefixedBucket(NewInMemBucket(), prefix))
-	UsesPrefixTest(t, NewInMemBucket(), prefix)
-
-	prefix = "someprefix"
-	AcceptanceTest(t, NewPrefixedBucket(NewInMemBucket(), prefix))
-	UsesPrefixTest(t, NewInMemBucket(), prefix)
+	for _, prefix := range prefixes {
+		AcceptanceTest(t, NewPrefixedBucket(NewInMemBucket(), prefix))
+		UsesPrefixTest(t, NewInMemBucket(), prefix)
+	}
 }
 
 func UsesPrefixTest(t *testing.T, bkt Bucket, prefix string) {
@@ -50,8 +43,6 @@ func UsesPrefixTest(t *testing.T, bkt Bucket, prefix string) {
 
 	testutil.Ok(t, pBkt.Upload(context.Background(), "file2.jpg", strings.NewReader("test-data2")))
 	rc2, err := bkt.Get(context.Background(), strings.Trim(prefix, "/")+"/file2.jpg")
-	testutil.Ok(t, err)
-
 	testutil.Ok(t, err)
 	defer func() { testutil.Ok(t, rc2.Close()) }()
 	contentUpload, err := ioutil.ReadAll(rc2)

--- a/pkg/objstore/prefixed_bucket_test.go
+++ b/pkg/objstore/prefixed_bucket_test.go
@@ -38,7 +38,7 @@ func TestPrefixedBucket_Acceptance(t *testing.T) {
 }
 
 func UsesPrefixTest(t *testing.T, bkt Bucket, prefix string) {
-	bkt.Upload(context.Background(), strings.Trim(prefix, "/")+"/file1.jpg", strings.NewReader("@test-data1"))
+	bkt.Upload(context.Background(), strings.Trim(prefix, "/")+"/file1.jpg", strings.NewReader("test-data1"))
 
 	pBkt := NewPrefixedBucket(bkt, prefix)
 	rc1, err := pBkt.Get(context.Background(), "file1.jpg")
@@ -47,16 +47,16 @@ func UsesPrefixTest(t *testing.T, bkt Bucket, prefix string) {
 	defer func() { testutil.Ok(t, rc1.Close()) }()
 	content, err := ioutil.ReadAll(rc1)
 	testutil.Ok(t, err)
-	testutil.Equals(t, "@test-data1", string(content))
+	testutil.Equals(t, "test-data1", string(content))
 
-	pBkt.Upload(context.Background(), "file2.jpg", strings.NewReader("@test-data2"))
+	pBkt.Upload(context.Background(), "file2.jpg", strings.NewReader("test-data2"))
 	rc2, err := bkt.Get(context.Background(), strings.Trim(prefix, "/")+"/file2.jpg")
 
 	testutil.Ok(t, err)
 	defer func() { testutil.Ok(t, rc2.Close()) }()
 	contentUpload, err := ioutil.ReadAll(rc2)
 	testutil.Ok(t, err)
-	testutil.Equals(t, "@test-data2", string(contentUpload))
+	testutil.Equals(t, "test-data2", string(contentUpload))
 
 	pBkt.Delete(context.Background(), "file2.jpg")
 	_, err = bkt.Get(context.Background(), strings.Trim(prefix, "/")+"/file2.jpg")
@@ -69,7 +69,7 @@ func UsesPrefixTest(t *testing.T, bkt Bucket, prefix string) {
 	defer func() { testutil.Ok(t, rc3.Close()) }()
 	content, err = ioutil.ReadAll(rc3)
 	testutil.Ok(t, err)
-	testutil.Equals(t, "tes", string(content))
+	testutil.Equals(t, "est", string(content))
 
 	ok, err := pBkt.Exists(context.Background(), "file1.jpg")
 	testutil.Ok(t, err)
@@ -77,9 +77,9 @@ func UsesPrefixTest(t *testing.T, bkt Bucket, prefix string) {
 
 	attrs, err := pBkt.Attributes(context.Background(), "file1.jpg")
 	testutil.Ok(t, err)
-	testutil.Assert(t, attrs.Size == 11, "expected size to be equal to 11")
+	testutil.Assert(t, attrs.Size == 10, "expected size to be equal to 10")
 
-	bkt.Upload(context.Background(), strings.Trim(prefix, "/")+"/dir/file1.jpg", strings.NewReader("@test-data1"))
+	bkt.Upload(context.Background(), strings.Trim(prefix, "/")+"/dir/file1.jpg", strings.NewReader("test-data1"))
 	seen := []string{}
 	testutil.Ok(t, pBkt.Iter(context.Background(), "", func(fn string) error {
 		seen = append(seen, fn)


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

This PR is another try to do the proposed on #1318
Some decisions had to be made in order for making it work, and those will be highlighted with comments in the code.
Although we used PR https://github.com/thanos-io/thanos/pull/3289 to understand where could we make this implementation, we rewrote everything from scratch.

Many thanks for the author of PR 3289 :)

## Verification

We've added unit tests, and added the prefix test to all e2e tests.