### PR TITLE
receive: fix deadlock on interrupt in routerOnly mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 ## Unreleased
 
 ### Fixed
+- [#5339](https://github.com/thanos-io/thanos/pull/5339) Receive: Fix deadlock on interrupt in routerOnly mode
 
 ### Added
 


### PR DESCRIPTION
Hi,

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Currently, the receive component blocks indefinitely in router mode when the Thanos process is interrupted because of unclosed channel.

## Verification

- start the receive component in router mode
- send SIGINT
- verify that before the change the process does not exit
- verify that after fix process does exit

## How to reproduce it

Start the thanos receive component in router mode with the `--receive.hashrings-file` flag and hit `ctrl + c`
```
# Create empty hashring file
$ cat /tmp/test.json
[{}]

$ ./thanos receive --label 'tenant="test"' --receive.hashrings-file=/tmp/test.json
level=info ts=2022-05-07T15:25:40.124359Z caller=receive.go:118 component=receive mode=RouterOnly msg="running receive"
level=info ts=2022-05-07T15:25:40.124404Z caller=options.go:27 component=receive protocol=HTTP msg="disabled TLS, key and cert must be set to enable"
level=info ts=2022-05-07T15:25:40.124493Z caller=receive.go:649 component=receive msg="default tenant data dir already present, not attempting to migrate storage"
level=info ts=2022-05-07T15:25:40.125746Z caller=receive.go:282 component=receive msg="starting receiver"
level=info ts=2022-05-07T15:25:40.1259Z caller=intrumentation.go:75 component=receive msg="changing probe status" status=healthy
level=info ts=2022-05-07T15:25:40.125954Z caller=http.go:73 component=receive service=http/server component=receive msg="listening for requests and metrics" address=0.0.0.0:10902
level=info ts=2022-05-07T15:25:40.125983Z caller=options.go:27 component=receive protocol=gRPC msg="disabled TLS, key and cert must be set to enable"
level=info ts=2022-05-07T15:25:40.126018Z caller=handler.go:223 component=receive component=receive-handler msg="Start listening for connections" address=0.0.0.0:19291
level=info ts=2022-05-07T15:25:40.125898Z caller=receive.go:415 component=receive msg="the hashring initialized with config watcher."
level=info ts=2022-05-07T15:25:40.126251Z caller=tls_config.go:195 component=receive service=http/server component=receive msg="TLS is disabled." http2=false
level=info ts=2022-05-07T15:25:40.126442Z caller=handler.go:250 component=receive component=receive-handler msg="Serving plain HTTP" address=0.0.0.0:19291
level=warn ts=2022-05-07T15:25:40.126404Z caller=intrumentation.go:67 component=receive msg="changing probe status" status=not-ready reason="hashring has changed; server is not ready to receive web requests"
level=info ts=2022-05-07T15:25:40.126554Z caller=receive.go:465 component=receive msg="hashring has changed; server is not ready to receive web requests"
level=info ts=2022-05-07T15:25:40.126574Z caller=receive.go:472 component=receive msg="server has reloaded, ready to start accepting requests"
level=info ts=2022-05-07T15:25:40.126592Z caller=intrumentation.go:56 component=receive msg="changing probe status" status=ready
level=info ts=2022-05-07T15:25:40.127062Z caller=receive.go:369 component=receive msg="listening for StoreAPI and WritableStoreAPI gRPC" address=0.0.0.0:10901
level=info ts=2022-05-07T15:25:40.127172Z caller=grpc.go:131 component=receive service=gRPC/server component=receive msg="listening for serving gRPC" address=0.0.0.0:10901
^Clevel=info ts=2022-05-07T15:25:44.542766Z caller=main.go:169 msg="caught signal. Exiting." signal=interrupt
level=warn ts=2022-05-07T15:25:44.542825Z caller=intrumentation.go:67 component=receive msg="changing probe status" status=not-ready reason=null
level=info ts=2022-05-07T15:25:44.542847Z caller=http.go:84 component=receive service=http/server component=receive msg="internal server is shutting down" err=null
level=info ts=2022-05-07T15:25:44.544218Z caller=http.go:103 component=receive service=http/server component=receive msg="internal server is shutdown gracefully" err=null
level=info ts=2022-05-07T15:25:44.544276Z caller=intrumentation.go:81 component=receive msg="changing probe status" status=not-healthy reason=null```