### PR TITLE
Group memcached keys based on server when performing batch gets

### DIFF
--- a/pkg/cacheutil/memcached_client.go
+++ b/pkg/cacheutil/memcached_client.go
@@ -89,10 +89,17 @@ type memcachedClientBackend interface {
 }
 
 // updatableServerSelector extends the interface used for picking a memcached server
-// for a key to allow servers to be updated at runtime.
+// for a key to allow servers to be updated at runtime. It allows the selector used
+// by the client to be mocked in tests.
 type updatableServerSelector interface {
 	memcache.ServerSelector
 
+	// SetServers changes a ServerSelector's set of servers at runtime
+	// and is safe for concurrent use by multiple goroutines.
+	//
+	// SetServers returns an error if any of the server names fail to
+	// resolve. No attempt is made to connect to the server. If any
+	// error occurs, no changes are made to the internal server list.
 	SetServers(servers ...string) error
 }
 

--- a/pkg/cacheutil/memcached_client_test.go
+++ b/pkg/cacheutil/memcached_client_test.go
@@ -389,7 +389,7 @@ func TestMemcachedClient_GetMulti(t *testing.T) {
 	}
 }
 
-func TestMemcachedClient_groupKeysByServer(t *testing.T) {
+func TestMemcachedClient_sortKeysByServer(t *testing.T) {
 	config := defaultMemcachedClientConfig
 	config.Addresses = []string{"127.0.0.1:11211", "127.0.0.2:11211"}
 	backendMock := newMemcachedClientBackendMock()
@@ -417,9 +417,9 @@ func TestMemcachedClient_groupKeysByServer(t *testing.T) {
 		"key6",
 	}
 
-	grouped := client.groupKeysByServer(keys)
-	testutil.Contains(t, grouped, []string{"key1", "key3", "key5"})
-	testutil.Contains(t, grouped, []string{"key2", "key4", "key6"})
+	sorted := client.sortKeysByServer(keys)
+	testutil.Contains(t, sorted, []string{"key1", "key3", "key5"})
+	testutil.Contains(t, sorted, []string{"key2", "key4", "key6"})
 }
 
 type mockAddr string

--- a/pkg/cacheutil/memcached_client_test.go
+++ b/pkg/cacheutil/memcached_client_test.go
@@ -5,6 +5,8 @@ package cacheutil
 
 import (
 	"context"
+	"fmt"
+	"net"
 	"sync"
 	"testing"
 	"time"
@@ -385,6 +387,76 @@ func TestMemcachedClient_GetMulti(t *testing.T) {
 			testutil.Equals(t, float64(testData.mockedGetMultiErrors), prom_testutil.ToFloat64(client.failures.WithLabelValues(opGetMulti, reasonOther)))
 		})
 	}
+}
+
+func TestMemcachedClient_groupKeysByServer(t *testing.T) {
+	config := defaultMemcachedClientConfig
+	config.Addresses = []string{"127.0.0.1:11211", "127.0.0.2:11211"}
+	backendMock := newMemcachedClientBackendMock()
+	selector := &mockServerSelector{
+		serversByKey: map[string]mockAddr{
+			"key1": "127.0.0.1:11211",
+			"key2": "127.0.0.2:11211",
+			"key3": "127.0.0.1:11211",
+			"key4": "127.0.0.2:11211",
+			"key5": "127.0.0.1:11211",
+			"key6": "127.0.0.2:11211",
+		},
+	}
+
+	client, err := newMemcachedClient(log.NewNopLogger(), backendMock, selector, config, nil, "test")
+	testutil.Ok(t, err)
+	defer client.Stop()
+
+	keys := []string{
+		"key1",
+		"key2",
+		"key3",
+		"key4",
+		"key5",
+		"key6",
+	}
+
+	grouped := client.groupKeysByServer(keys)
+	testutil.Contains(t, grouped, []string{"key1", "key3", "key5"})
+	testutil.Contains(t, grouped, []string{"key2", "key4", "key6"})
+}
+
+type mockAddr string
+
+func (m mockAddr) Network() string {
+	return "mock"
+}
+
+func (m mockAddr) String() string {
+	return string(m)
+}
+
+type mockServerSelector struct {
+	serversByKey map[string]mockAddr
+}
+
+func (m *mockServerSelector) PickServer(key string) (net.Addr, error) {
+	if srv, ok := m.serversByKey[key]; ok {
+		return srv, nil
+	}
+
+	panic(fmt.Sprintf("unmapped key: %s", key))
+}
+
+func (m *mockServerSelector) Each(f func(net.Addr) error) error {
+	for k := range m.serversByKey {
+		addr := m.serversByKey[k]
+		if err := f(addr); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *mockServerSelector) SetServers(...string) error {
+	return nil
 }
 
 func prepare(config MemcachedClientConfig, backendMock *memcachedClientBackendMock) (*memcachedClient, error) {

--- a/pkg/testutil/testutil.go
+++ b/pkg/testutil/testutil.go
@@ -110,6 +110,12 @@ func contains(haystack, needle []string) bool {
 		outer := i
 
 		for j := 0; j < len(needle); j++ {
+			// End of the haystack but not the end of the needle, end
+			if outer == len(haystack) {
+				return false
+			}
+
+			// No match, try the next index of the haystack
 			if haystack[outer] != needle[j] {
 				break
 			}

--- a/pkg/testutil/testutil.go
+++ b/pkg/testutil/testutil.go
@@ -87,6 +87,46 @@ func Equals(tb testing.TB, exp, act interface{}, v ...interface{}) {
 	tb.Fatal(sprintfWithLimit("\033[31m%s:%d:"+msg+"\n\n\texp: %#v\n\n\tgot: %#v%s\033[39m\n\n", filepath.Base(file), line, exp, act, diff(exp, act)))
 }
 
+// Contains fails the test if needle is not contained within haystack, if haystack or needle is
+// an empty slice, or if needle is longer than haystack.
+func Contains(tb testing.TB, haystack, needle []string) {
+	_, file, line, _ := runtime.Caller(1)
+
+	if !contains(haystack, needle) {
+		tb.Fatalf(sprintfWithLimit("\033[31m%s:%d: %#v does not contain %#v\033[39m\n\n", filepath.Base(file), line, haystack, needle))
+	}
+}
+
+func contains(haystack, needle []string) bool {
+	if len(haystack) == 0 || len(needle) == 0 {
+		return false
+	}
+
+	if len(haystack) < len(needle) {
+		return false
+	}
+
+	for i := 0; i < len(haystack); i++ {
+		outer := i
+
+		for j := 0; j < len(needle); j++ {
+			if haystack[outer] != needle[j] {
+				break
+			}
+
+			// End of the needle and it still matches, end
+			if j == len(needle)-1 {
+				return true
+			}
+
+			// This element matches between the two slices, try the next one
+			outer++
+		}
+	}
+
+	return false
+}
+
 func sprintfWithLimit(act string, v ...interface{}) string {
 	s := fmt.Sprintf(act, v...)
 	if len(s) > 10000 {

--- a/pkg/testutil/testutil_test.go
+++ b/pkg/testutil/testutil_test.go
@@ -1,0 +1,64 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package testutil
+
+import "testing"
+
+func TestContains(t *testing.T) {
+	tests := map[string]struct {
+		haystack    []string
+		needle      []string
+		shouldMatch bool
+	}{
+		"empty haystack": {
+			haystack:    []string{},
+			needle:      []string{"key1"},
+			shouldMatch: false,
+		},
+
+		"empty needle": {
+			haystack:    []string{"key1", "key2", "key3"},
+			needle:      []string{},
+			shouldMatch: false,
+		},
+
+		"single value needle": {
+			haystack:    []string{"key1", "key2", "key3"},
+			needle:      []string{"key1"},
+			shouldMatch: true,
+		},
+
+		"multiple value needle": {
+			haystack:    []string{"key1", "key2", "key3"},
+			needle:      []string{"key1", "key2"},
+			shouldMatch: true,
+		},
+
+		"same size needle as haystack": {
+			haystack:    []string{"key1", "key2", "key3"},
+			needle:      []string{"key1", "key2", "key3"},
+			shouldMatch: true,
+		},
+
+		"larger needle than haystack": {
+			haystack:    []string{"key1", "key2", "key3"},
+			needle:      []string{"key1", "key2", "key3", "key4"},
+			shouldMatch: false,
+		},
+
+		"needle not contained": {
+			haystack:    []string{"key1", "key2", "key3"},
+			needle:      []string{"key4"},
+			shouldMatch: false,
+		},
+	}
+
+	for testName, testData := range tests {
+		t.Run(testName, func(t *testing.T) {
+			if testData.shouldMatch != contains(testData.haystack, testData.needle) {
+				t.Fatalf("unexpected result testing contains() with %#v", testData)
+			}
+		})
+	}
+}

--- a/pkg/testutil/testutil_test.go
+++ b/pkg/testutil/testutil_test.go
@@ -52,6 +52,12 @@ func TestContains(t *testing.T) {
 			needle:      []string{"key4"},
 			shouldMatch: false,
 		},
+
+		"haystack ends before needle": {
+			haystack:    []string{"key1", "key2", "key3"},
+			needle:      []string{"key3", "key4"},
+			shouldMatch: false,
+		},
 	}
 
 	for testName, testData := range tests {


### PR DESCRIPTION
Signed-off-by: Nick Pillitteri <nick.pillitteri@grafana.com>

## Changes

Order and group keys during batch get operations based on the memcached
server they will be sharded to. This reduces the number of connections
that must be made within each batch of get operations.

## Verification

* Unit tests added
* Ran with changes in Mimir dev cluster

Fixes #5353

* [ ] I added CHANGELOG entry for this change.
* [X] Change is not relevant to the end user.
