### PR TITLE
Enforce memcached concurrency limit with unbatched requests

### DIFF
--- a/pkg/cacheutil/memcached_client_test.go
+++ b/pkg/cacheutil/memcached_client_test.go
@@ -14,7 +14,9 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	prom_testutil "github.com/prometheus/client_golang/prometheus/testutil"
+	"go.uber.org/atomic"
 
+	"github.com/thanos-io/thanos/pkg/gate"
 	"github.com/thanos-io/thanos/pkg/model"
 	"github.com/thanos-io/thanos/pkg/testutil"
 )
@@ -179,13 +181,14 @@ func TestMemcachedClient_SetAsyncWithCustomMaxItemSize(t *testing.T) {
 
 func TestMemcachedClient_GetMulti(t *testing.T) {
 	tests := map[string]struct {
-		maxBatchSize          int
-		maxConcurrency        int
-		mockedGetMultiErrors  int
-		initialItems          []memcache.Item
-		getKeys               []string
-		expectedHits          map[string][]byte
-		expectedGetMultiCount int
+		maxBatchSize           int
+		maxConcurrency         int
+		mockedGetMultiErrors   int
+		initialItems           []memcache.Item
+		getKeys                []string
+		expectedHits           map[string][]byte
+		expectedGetMultiCount  int
+		expectedGateStartCount int
 	}{
 		"should fetch keys in a single batch if the input keys is <= the max batch size": {
 			maxBatchSize:   2,
@@ -199,7 +202,8 @@ func TestMemcachedClient_GetMulti(t *testing.T) {
 				"key-1": []byte("value-1"),
 				"key-2": []byte("value-2"),
 			},
-			expectedGetMultiCount: 1,
+			expectedGetMultiCount:  1,
+			expectedGateStartCount: 1,
 		},
 		"should fetch keys in multiple batches if the input keys is > the max batch size": {
 			maxBatchSize:   2,
@@ -215,7 +219,8 @@ func TestMemcachedClient_GetMulti(t *testing.T) {
 				"key-2": []byte("value-2"),
 				"key-3": []byte("value-3"),
 			},
-			expectedGetMultiCount: 2,
+			expectedGetMultiCount:  2,
+			expectedGateStartCount: 2,
 		},
 		"should fetch keys in multiple batches on input keys exact multiple of batch size": {
 			maxBatchSize:   2,
@@ -233,7 +238,8 @@ func TestMemcachedClient_GetMulti(t *testing.T) {
 				"key-3": []byte("value-3"),
 				"key-4": []byte("value-4"),
 			},
-			expectedGetMultiCount: 2,
+			expectedGetMultiCount:  2,
+			expectedGateStartCount: 2,
 		},
 		"should fetch keys in multiple batches on input keys exact multiple of batch size with max concurrency disabled (0)": {
 			maxBatchSize:   2,
@@ -251,7 +257,8 @@ func TestMemcachedClient_GetMulti(t *testing.T) {
 				"key-3": []byte("value-3"),
 				"key-4": []byte("value-4"),
 			},
-			expectedGetMultiCount: 2,
+			expectedGetMultiCount:  2,
+			expectedGateStartCount: 0,
 		},
 		"should fetch keys in multiple batches on input keys exact multiple of batch size with max concurrency lower than the batches": {
 			maxBatchSize:   1,
@@ -269,7 +276,8 @@ func TestMemcachedClient_GetMulti(t *testing.T) {
 				"key-3": []byte("value-3"),
 				"key-4": []byte("value-4"),
 			},
-			expectedGetMultiCount: 4,
+			expectedGetMultiCount:  4,
+			expectedGateStartCount: 4,
 		},
 		"should fetch keys in a single batch if max batch size is disabled (0)": {
 			maxBatchSize:   0,
@@ -287,7 +295,8 @@ func TestMemcachedClient_GetMulti(t *testing.T) {
 				"key-3": []byte("value-3"),
 				"key-4": []byte("value-4"),
 			},
-			expectedGetMultiCount: 1,
+			expectedGetMultiCount:  1,
+			expectedGateStartCount: 1,
 		},
 		"should fetch keys in a single batch if max batch size is disabled (0) and max concurrency is disabled (0)": {
 			maxBatchSize:   0,
@@ -305,7 +314,8 @@ func TestMemcachedClient_GetMulti(t *testing.T) {
 				"key-3": []byte("value-3"),
 				"key-4": []byte("value-4"),
 			},
-			expectedGetMultiCount: 1,
+			expectedGetMultiCount:  1,
+			expectedGateStartCount: 0,
 		},
 		"should return no hits on all keys missing": {
 			maxBatchSize:   2,
@@ -319,7 +329,8 @@ func TestMemcachedClient_GetMulti(t *testing.T) {
 				"key-1": []byte("value-1"),
 				"key-2": []byte("value-2"),
 			},
-			expectedGetMultiCount: 2,
+			expectedGetMultiCount:  2,
+			expectedGateStartCount: 2,
 		},
 		"should return no hits on partial errors while fetching batches and no items found": {
 			maxBatchSize:         2,
@@ -330,9 +341,10 @@ func TestMemcachedClient_GetMulti(t *testing.T) {
 				{Key: "key-2", Value: []byte("value-2")},
 				{Key: "key-3", Value: []byte("value-3")},
 			},
-			getKeys:               []string{"key-5", "key-6", "key-7"},
-			expectedHits:          map[string][]byte{},
-			expectedGetMultiCount: 2,
+			getKeys:                []string{"key-5", "key-6", "key-7"},
+			expectedHits:           map[string][]byte{},
+			expectedGetMultiCount:  2,
+			expectedGateStartCount: 2,
 		},
 		"should return no hits on all errors while fetching batches": {
 			maxBatchSize:         2,
@@ -343,9 +355,10 @@ func TestMemcachedClient_GetMulti(t *testing.T) {
 				{Key: "key-2", Value: []byte("value-2")},
 				{Key: "key-3", Value: []byte("value-3")},
 			},
-			getKeys:               []string{"key-5", "key-6", "key-7"},
-			expectedHits:          nil,
-			expectedGetMultiCount: 2,
+			getKeys:                []string{"key-5", "key-6", "key-7"},
+			expectedHits:           nil,
+			expectedGetMultiCount:  2,
+			expectedGateStartCount: 2,
 		},
 	}
 
@@ -364,6 +377,9 @@ func TestMemcachedClient_GetMulti(t *testing.T) {
 			testutil.Ok(t, err)
 			defer client.Stop()
 
+			// Replace the default gate with a counting version to allow checking the number of calls.
+			client.getMultiGate = newCountingGate(client.getMultiGate)
+
 			// Populate memcached with the initial items.
 			for _, item := range testData.initialItems {
 				testutil.Ok(t, client.SetAsync(ctx, item.Key, item.Value, time.Second))
@@ -379,6 +395,9 @@ func TestMemcachedClient_GetMulti(t *testing.T) {
 			backendMock.lock.Lock()
 			defer backendMock.lock.Unlock()
 			testutil.Equals(t, testData.expectedGetMultiCount, backendMock.getMultiCount)
+
+			// Ensure the client has interacted with the gate as expected.
+			testutil.Equals(t, uint32(testData.expectedGateStartCount), client.getMultiGate.(*countingGate).Count())
 
 			// Ensure metrics are tracked.
 			testutil.Equals(t, float64(testData.expectedGetMultiCount), prom_testutil.ToFloat64(client.operations.WithLabelValues(opGetMulti)))
@@ -450,6 +469,32 @@ func (c *memcachedClientBackendMock) waitItems(expected int) error {
 	}
 
 	return errors.New("timeout expired while waiting for items in the memcached mock")
+}
+
+// countingGate implements gate.Gate and counts the number of times Start is called
+type countingGate struct {
+	wrapped gate.Gate
+	count   *atomic.Uint32
+}
+
+func newCountingGate(g gate.Gate) gate.Gate {
+	return &countingGate{
+		wrapped: g,
+		count:   atomic.NewUint32(0),
+	}
+}
+
+func (c *countingGate) Start(ctx context.Context) error {
+	c.count.Inc()
+	return c.wrapped.Start(ctx)
+}
+
+func (c *countingGate) Done() {
+	c.wrapped.Done()
+}
+
+func (c *countingGate) Count() uint32 {
+	return c.count.Load()
 }
 
 func TestMultipleClientsCanUseSameRegistry(t *testing.T) {

--- a/pkg/cacheutil/memcached_client_test.go
+++ b/pkg/cacheutil/memcached_client_test.go
@@ -471,7 +471,7 @@ func (c *memcachedClientBackendMock) waitItems(expected int) error {
 	return errors.New("timeout expired while waiting for items in the memcached mock")
 }
 
-// countingGate implements gate.Gate and counts the number of times Start is called
+// countingGate implements gate.Gate and counts the number of times Start is called.
 type countingGate struct {
 	wrapped gate.Gate
 	count   *atomic.Uint32


### PR DESCRIPTION
Signed-off-by: Nick Pillitteri <nick.pillitteri@grafana.com>

## Changes

This ensures that requests that are _not_ split into batches still count
towards the concurrency limit that the client enforces.

This fixes an issue introduced in #5301.

Noticed by @pracucci here https://github.com/grafana/mimir/pull/1837#pullrequestreview-969942998

## Verification

Unit tests added.

* [ ] I added CHANGELOG entry for this change.
* [X] Change is not relevant to the end user.