### PR TITLE
ruler: add metric thanos alert sent by alert name

### DIFF
--- a/pkg/alert/alert_test.go
+++ b/pkg/alert/alert_test.go
@@ -156,7 +156,10 @@ func TestSenderSendsOk(t *testing.T) {
 	}
 	s := NewSender(nil, nil, []*Alertmanager{NewAlertmanager(nil, poster, time.Minute, APIv1)})
 
-	s.Send(context.Background(), []*notifier.Alert{{}, {}})
+	s.Send(context.Background(), []*notifier.Alert{
+		{Labels: labels.FromStrings("alertname", "test")}, {
+			Labels: labels.FromStrings("alertname", "test"),
+		}})
 
 	assertSameHosts(t, poster.urls, poster.seen)
 
@@ -166,6 +169,9 @@ func TestSenderSendsOk(t *testing.T) {
 	testutil.Equals(t, 2, int(promtestutil.ToFloat64(s.sent.WithLabelValues(poster.urls[1].Host))))
 	testutil.Equals(t, 0, int(promtestutil.ToFloat64(s.errs.WithLabelValues(poster.urls[1].Host))))
 	testutil.Equals(t, 0, int(promtestutil.ToFloat64(s.dropped)))
+
+	testutil.Equals(t, 2, int(promtestutil.ToFloat64(s.sentByAlertName.WithLabelValues(poster.urls[0].Host, "test"))))
+	testutil.Equals(t, 2, int(promtestutil.ToFloat64(s.sentByAlertName.WithLabelValues(poster.urls[1].Host, "test"))))
 }
 
 func TestSenderSendsOneFails(t *testing.T) {


### PR DESCRIPTION
Hello thanos team,

It will be great to have the total number of alerts sent by alertmanager and by alert name.  It will be useful to make some stats about how often an alert is triggered.

I'm not sure that if it's relevant to add another metric, and about the name too.

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Adding metric: Total number of alerts sent by alertmanager and alert name.

## Verification

Trigger an alert
Check the metric thanos_alert_sender_alerts_sent_by_alertname_total in  thanos ruler metrics endpoint
