### PR TITLE
UI: Added Additional Stats for BlockViewer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#5357](https://github.com/thanos-io/thanos/pull/5357) Store: fix groupcache handling of slashes
 
 ### Added
-
+- [#5369](https://github.com/thanos-io/thanos/pull/5369) Thanos UI: Added Additional Stats for BlockViewer
 - [#5352](https://github.com/thanos-io/thanos/pull/5352) Cache: Add cache metrics to groupcache.
 
 ### Changed

--- a/pkg/ui/react-app/src/thanos/pages/blocks/SourceView.test.tsx
+++ b/pkg/ui/react-app/src/thanos/pages/blocks/SourceView.test.tsx
@@ -16,14 +16,13 @@ describe('Blocks SourceView', () => {
     },
     gridMinTime: 1596096000000,
     gridMaxTime: 1595108031471,
-    blockSearch: '',
-    compactionLevel: 0,
+    blockCount: {},
   };
 
   const sourceView = mount(<SourceView {...defaultProps} />);
 
   it('renders a paragraph with title', () => {
-    const title = sourceView.find('div > span');
+    const title = sourceView.find('div > span').first();
     expect(title).toHaveLength(1);
     expect(title.text()).toEqual(source);
   });

--- a/pkg/ui/react-app/src/thanos/pages/blocks/SourceView.tsx
+++ b/pkg/ui/react-app/src/thanos/pages/blocks/SourceView.tsx
@@ -1,23 +1,18 @@
-import React, { FC } from 'react';
+import React, { FC, useRef, useState } from 'react';
 import { Block, BlocksPool } from './block';
 import { BlockSpan } from './BlockSpan';
 import styles from './blocks.module.css';
-import { getBlockByUlid, getBlocksByCompactionLevel } from './helpers';
+import { Tooltip } from 'reactstrap';
 
 export const BlocksRow: FC<{
   blocks: Block[];
   gridMinTime: number;
   gridMaxTime: number;
   selectBlock: React.Dispatch<React.SetStateAction<Block | undefined>>;
-  blockSearch: string;
-  compactionLevel: number;
-}> = ({ blocks, gridMinTime, gridMaxTime, selectBlock, blockSearch, compactionLevel }) => {
-  let filteredBlocks = getBlockByUlid(blocks, blockSearch);
-  filteredBlocks = getBlocksByCompactionLevel(filteredBlocks, compactionLevel);
-
+}> = ({ blocks, gridMinTime, gridMaxTime, selectBlock }) => {
   return (
     <div className={styles.row}>
-      {filteredBlocks.map<JSX.Element>((b) => (
+      {blocks.map<JSX.Element>((b) => (
         <BlockSpan selectBlock={selectBlock} block={b} gridMaxTime={gridMaxTime} gridMinTime={gridMinTime} key={b.ulid} />
       ))}
     </div>
@@ -30,24 +25,24 @@ export interface SourceViewProps {
   gridMinTime: number;
   gridMaxTime: number;
   selectBlock: React.Dispatch<React.SetStateAction<Block | undefined>>;
-  blockSearch: string;
-  compactionLevel: number;
+  blockCount: { [key: string]: number };
 }
 
-export const SourceView: FC<SourceViewProps> = ({
-  data,
-  title,
-  gridMaxTime,
-  gridMinTime,
-  selectBlock,
-  blockSearch,
-  compactionLevel,
-}) => {
+export const SourceView: FC<SourceViewProps> = ({ data, title, gridMaxTime, gridMinTime, selectBlock, blockCount }) => {
+  const linkRef = useRef<HTMLSpanElement>();
+  const [open, setOpen] = useState(false);
+  const toggle = () => setOpen(!open);
+
   return (
     <>
       <div className={styles.source}>
         <div className={styles.title} title={title}>
-          <span>{title}</span>
+          <span ref={linkRef as React.RefObject<HTMLSpanElement>}>{title}</span>
+          {linkRef.current && (
+            <Tooltip placement="right" isOpen={open} target={linkRef.current} toggle={toggle} autohide={false}>
+              Blocks Count: {blockCount[title]}
+            </Tooltip>
+          )}
         </div>
         <div className={styles.rowsContainer}>
           {Object.keys(data).map((k) => (
@@ -59,8 +54,6 @@ export const SourceView: FC<SourceViewProps> = ({
                   key={`${k}-${i}`}
                   gridMaxTime={gridMaxTime}
                   gridMinTime={gridMinTime}
-                  blockSearch={blockSearch}
-                  compactionLevel={compactionLevel}
                 />
               ))}
             </React.Fragment>

--- a/pkg/ui/react-app/src/thanos/pages/blocks/blocks.module.css
+++ b/pkg/ui/react-app/src/thanos/pages/blocks/blocks.module.css
@@ -2,8 +2,8 @@
   display: flex;
   --top: 72px;
   min-height: calc(100vh - var(--top));
-  position: relative;
-  z-index: 1;
+  column-count: 20;
+  column-width: 1px;
 }
 
 .grid {
@@ -43,6 +43,32 @@
   padding: 2em;
   box-shadow: 0 10px 20px rgba(0, 0, 0, 0.19), 0 6px 6px rgba(0, 0, 0, 0.23);
 }
+
+.blockStats {
+  background-color: #333;
+  overflow: hidden;
+  position: fixed;
+  bottom: 0;
+  width: 100%;
+  margin-left: -15px;
+}
+
+.blockStats span {
+  float: left;
+  display: block;
+  color: #f2f2f2;
+  width: 50%;
+  text-align: center;
+  padding: 10px 12px;
+  text-decoration: none;
+  font-size: 15px;
+}
+
+.blockStats span:hover {
+  background-color: #ddd;
+  color: black;
+}
+
 
 .detailsTop {
   width: 100%;
@@ -96,13 +122,13 @@
 }
 
 .title > span {
-  display: block;
-  width: 8vw;
+  display: inline-block;
+  width: 10vw;
   margin: 0;
+  padding: 2px 2px;
   text-align: center;
   text-overflow: ellipsis;
   overflow: hidden;
-  box-sizing: border-box;
 }
 
 .rowsContainer {
@@ -189,14 +215,4 @@
 }
 .level-6 {
   background: var(--level-6);
-}
-
-.blockInput {
-  margin-bottom: 12px;
-}
-
-.blockFilter {
-  display: flex;
-  flex-direction: row;
-  align-items: center;
 }


### PR DESCRIPTION
Signed-off-by: Adithya Krishna <adikrish@redhat.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.

## Changes

This PR Fixes #3219 

- Added number of blocks
- Last refresh
- Added number of blocks in each group

## Verification

<!-- How you tested it? How do you know it works? -->
