### PR TITLE
store: retry bucket store initial sync upon failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 ### Fixed
 - [#5339](https://github.com/thanos-io/thanos/pull/5339) Receive: Fix deadlock on interrupt in routerOnly mode
 - [#5357](https://github.com/thanos-io/thanos/pull/5357) Store: fix groupcache handling of slashes
+- [#5373](https://github.com/thanos-io/thanos/pull/5373) Store: retry bucket store initial sync upon failure
 
 ### Added
 

--- a/cmd/thanos/store.go
+++ b/cmd/thanos/store.go
@@ -365,8 +365,7 @@ func runStore(
 			begin := time.Now()
 
 			err := runutil.RetryWithLog(logger, 2*time.Second, ctx.Done(), func() error {
-				syncErr := bs.InitialSync(ctx)
-				return errors.Wrap(syncErr, "bucket store initial sync")
+				return bs.InitialSync(ctx)
 			})
 
 			if err != nil {

--- a/docs/components/store.md
+++ b/docs/components/store.md
@@ -106,6 +106,12 @@ Flags:
                                  Path to YAML file that contains index cache
                                  configuration. See format details:
                                  https://thanos.io/tip/components/store.md/#index-cache
+      --initial-sync-retry-interval=2s
+                                 Interval between retries for the initial sync
+                                 of the bucket store.
+      --initial-sync-retry-timeout=3m
+                                 Timeout for the initial sync of the bucket
+                                 store.
       --log.format=logfmt        Log format to use. Possible options: logfmt or
                                  json.
       --log.level=info           Log filtering level.


### PR DESCRIPTION
Signed-off-by: shaoyi1997 <e0310084@u.nus.edu>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

This PR fixes [#4810](https://github.com/thanos-io/thanos/issues/4810).

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Currently, initial sync of the bucket store fails without retrying upon a temporary bucket error.
This PR wraps `bs.initialSync` in `runutil.RetryWithLog` and introduces 2 flags, `--initial-sync-retry-interval` and `--initial-sync-retry-timeout`, to allow configuration of the interval and timeout durations for retrying the initial sync.


## Verification

Immediately after starting the minio server, start store ([gist](https://gist.github.com/shaoyi1997/7d7d0eeffff64a88339267ad96a94d11), adapted from `quickstart.sh`)
Store should retry sync and succeed with initial sync
