### PR TITLE
QueryFrontend: pre-compile regexp

### DIFF
--- a/pkg/queryfrontend/roundtrip.go
+++ b/pkg/queryfrontend/roundtrip.go
@@ -27,7 +27,7 @@ const (
 	seriesOp       = "series"
 )
 
-var opPattern = regexp.MustCompile("/api/v1/label/.+/values$")
+var labelValuesPattern = regexp.MustCompile("/api/v1/label/.+/values$")
 
 // NewTripperware returns a Tripperware which sends requests to different sub tripperwares based on the query type.
 func NewTripperware(config Config, reg prometheus.Registerer, logger log.Logger) (queryrange.Tripperware, error) {
@@ -122,7 +122,7 @@ func getOperation(r *http.Request) string {
 		case strings.HasSuffix(r.URL.Path, "/api/v1/series"):
 			return seriesOp
 		default:
-			if opPattern.MatchString(r.URL.Path) {
+			if labelValuesPattern.MatchString(r.URL.Path) {
 				return labelValuesOp
 			}
 		}

--- a/pkg/queryfrontend/roundtrip.go
+++ b/pkg/queryfrontend/roundtrip.go
@@ -27,6 +27,8 @@ const (
 	seriesOp       = "series"
 )
 
+var opPattern = regexp.MustCompile("/api/v1/label/.+/values$")
+
 // NewTripperware returns a Tripperware which sends requests to different sub tripperwares based on the query type.
 func NewTripperware(config Config, reg prometheus.Registerer, logger log.Logger) (queryrange.Tripperware, error) {
 	var (
@@ -120,8 +122,7 @@ func getOperation(r *http.Request) string {
 		case strings.HasSuffix(r.URL.Path, "/api/v1/series"):
 			return seriesOp
 		default:
-			matched, err := regexp.MatchString("/api/v1/label/.+/values$", r.URL.Path)
-			if err == nil && matched {
+			if opPattern.MatchString(r.URL.Path) {
 				return labelValuesOp
 			}
 		}


### PR DESCRIPTION
Signed-off-by: Jin Dong <djdongjin95@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->
Pre-compile regexp. Solve #5349.

`regexp.MustCompile` returns `regexp` directly or, if failed, panic.

Another way is:

```go
var opPattern, _ = regexp.Compile("/api/v1/label/.+/values$")
...
if opPattern && opPattern.MatchString(r.URL.Path) {
    return labelValuesOp
}
```

## Verification

<!-- How you tested it? How do you know it works? -->
Unit tests and `make test` succeeded. 