### PR TITLE
rule: fix empty $externalLabels when templating labels in rule.

### DIFF
--- a/pkg/rules/manager.go
+++ b/pkg/rules/manager.go
@@ -382,7 +382,7 @@ func (m *Manager) Update(evalInterval time.Duration, files []string) error {
 			continue
 		}
 		// We add external labels in `pkg/alert.Queue`.
-		if err := mgr.Update(evalInterval, fs, nil, m.externalURL); err != nil {
+		if err := mgr.Update(evalInterval, fs, m.extLset, m.externalURL); err != nil {
 			// TODO(bwplotka): Prometheus logs all error details. Fix it upstream to have consistent error handling.
 			errs.Add(errors.Wrapf(err, "strategy %s, update rules", s))
 			continue


### PR DESCRIPTION
Signed-off-by: Rostislav Benes <r.dee.b.b@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

External labels set up by `--label` option of the rule are not passed down when templating labels of alerts or recording rules, so `$externalLabels` is always an empty map.

The `externalLabels` parameter of `Manager.Update` method is used only for templates and should have no additional effect.
