### PR TITLE
Expose block.GatherFileStats.

### DIFF
--- a/pkg/block/block.go
+++ b/pkg/block/block.go
@@ -136,7 +136,7 @@ func upload(ctx context.Context, logger log.Logger, bkt objstore.Bucket, bdir st
 	}
 
 	metaEncoded := strings.Builder{}
-	meta.Thanos.Files, err = gatherFileStats(bdir, hf, logger)
+	meta.Thanos.Files, err = GatherFileStats(bdir, hf, logger)
 	if err != nil {
 		return errors.Wrap(err, "gather meta file stats")
 	}
@@ -316,8 +316,8 @@ func GetSegmentFiles(blockDir string) []string {
 	return result
 }
 
-// TODO(bwplotka): Gather stats when dirctly uploading files.
-func gatherFileStats(blockDir string, hf metadata.HashFunc, logger log.Logger) (res []metadata.File, _ error) {
+// GatherFileStats returns metadata.File entry for files inside TSDB block (index, chunks, meta.json).
+func GatherFileStats(blockDir string, hf metadata.HashFunc, logger log.Logger) (res []metadata.File, _ error) {
 	files, err := ioutil.ReadDir(filepath.Join(blockDir, ChunksDirname))
 	if err != nil {
 		return nil, errors.Wrapf(err, "read dir %v", filepath.Join(blockDir, ChunksDirname))
@@ -363,7 +363,6 @@ func gatherFileStats(blockDir string, hf metadata.HashFunc, logger log.Logger) (
 	sort.Slice(res, func(i, j int) bool {
 		return strings.Compare(res[i].RelPath, res[j].RelPath) < 0
 	})
-	// TODO(bwplotka): Add optional files like tombstones?
 	return res, err
 }
 


### PR DESCRIPTION
* [na] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

This PR exposes `block.GatherFileStats` function so that it can be used outside of `Upload` function. I've also removed TODOs from it, as I don't think they should be implemented.

## Verification

I haven't changed the function itself, only renamed it.
