### PR TITLE
Rule: Error out earlier when building alertmanager config

### DIFF
--- a/pkg/alert/config.go
+++ b/pkg/alert/config.go
@@ -95,7 +95,15 @@ func BuildAlertmanagerConfig(address string, timeout time.Duration) (Alertmanage
 	}
 
 	scheme := parsed.Scheme
+	if scheme == "" {
+		return AlertmanagerConfig{}, errors.New("alertmanagers.url contains empty scheme")
+	}
+
 	host := parsed.Host
+	if host == "" {
+		return AlertmanagerConfig{}, errors.New("alertmanagers.url contains empty host")
+	}
+
 	for _, qType := range []dns.QType{dns.A, dns.SRV, dns.SRVNoA} {
 		prefix := string(qType) + "+"
 		if strings.HasPrefix(strings.ToLower(scheme), prefix) {

--- a/pkg/alert/config_test.go
+++ b/pkg/alert/config_test.go
@@ -133,6 +133,10 @@ func TestBuildAlertmanagerConfiguration(t *testing.T) {
 			err:     true,
 		},
 		{
+			address: "http://user:pass@",
+			err:     true,
+		},
+		{
 			address: "dnssrv+_http._tcp.example.com",
 			err:     true,
 		},

--- a/pkg/alert/config_test.go
+++ b/pkg/alert/config_test.go
@@ -132,6 +132,10 @@ func TestBuildAlertmanagerConfiguration(t *testing.T) {
 			address: "://user:pass@localhost:9093",
 			err:     true,
 		},
+		{
+			address: "dnssrv+_http._tcp.example.com",
+			err:     true,
+		},
 	} {
 		t.Run(tc.address, func(t *testing.T) {
 			cfg, err := BuildAlertmanagerConfig(tc.address, time.Duration(0))


### PR DESCRIPTION
Signed-off-by: Jéssica Lins <jessicaalins@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

^ I haven't added this change to CHANGELOG - not sure if this is relevant - let me know if it is!

## Changes

This tries to solve issue https://github.com/thanos-io/thanos/issues/5186
In case an `alertmanagers.url` has a empty scheme or host, we now error out earlier. This helps preventing the case described in the issue and avoids Thanos Rule erroring out with `unsupported protocol scheme` when trying to post to an URL with empty scheme, for example.

## Verification

* I've added test cases for both empty scheme/empty host.
* Ran `make test-local`
