### PR TITLE
S3: Add config option to enforce the minio DNS lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 ### Added
 
 - [#5337](https://github.com/thanos-io/thanos/pull/5337) Thanos Object Store: Add the `prefix` option to buckets
+- [#5409](https://github.com/thanos-io/thanos/pull/5409) S3: Add option to force DNS style lookup.
 - [#5352](https://github.com/thanos-io/thanos/pull/5352) Cache: Add cache metrics to groupcache.
 - [#5391](https://github.com/thanos-io/thanos/pull/5391) Receive: Add relabeling support.
 

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -89,7 +89,7 @@ config:
   trace:
     enable: false
   list_objects_version: ""
-  dns_style: false
+  bucket_lookup_type: auto
   part_size: 67108864
   sse_config:
     type: ""
@@ -120,7 +120,7 @@ Set `list_objects_version: "v1"` for S3 compatible APIs that don't support ListO
 
 `http_config.tls_config` allows configuring TLS connections. Please refer to the document of [tls_config](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#tls_config) for detailed information on what each option does.
 
-`dns_style` can be set to enforce the DNS style lookup.
+`bucket_lookup_type` can be `auto`, `virtual-hosted` or `path`. Read more about it [here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html).
 
 For debug and testing purposes you can set
 

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -89,6 +89,7 @@ config:
   trace:
     enable: false
   list_objects_version: ""
+  dns_style: false
   part_size: 67108864
   sse_config:
     type: ""
@@ -118,6 +119,8 @@ Please refer to the documentation of [the Transport type](https://golang.org/pkg
 Set `list_objects_version: "v1"` for S3 compatible APIs that don't support ListObjectsV2 (e.g. some versions of Ceph). Default value (`""`) is equivalent to `"v2"`.
 
 `http_config.tls_config` allows configuring TLS connections. Please refer to the document of [tls_config](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#tls_config) for detailed information on what each option does.
+
+`dns_style` can be set to enforce the DNS style lookup.
 
 For debug and testing purposes you can set
 

--- a/pkg/objstore/s3/s3.go
+++ b/pkg/objstore/s3/s3.go
@@ -34,7 +34,50 @@ import (
 
 type ctxKey int
 
+type BucketLookupType int
+
+func (blt BucketLookupType) String() string {
+	return []string{"auto", "virtual-hosted", "path"}[blt]
+}
+
+func (blt BucketLookupType) MinioType() minio.BucketLookupType {
+	return []minio.BucketLookupType{
+		minio.BucketLookupAuto,
+		minio.BucketLookupDNS,
+		minio.BucketLookupPath,
+	}[blt]
+}
+
+func (blt BucketLookupType) MarshalYAML() (interface{}, error) {
+	return blt.String(), nil
+}
+
+func (blt *BucketLookupType) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var lookupType string
+	if err := unmarshal(&lookupType); err != nil {
+		return err
+	}
+
+	switch lookupType {
+	case "auto":
+		*blt = AutoLookup
+		return nil
+	case "virtual-hosted":
+		*blt = VirtualHostLookup
+		return nil
+	case "path":
+		*blt = PathLookup
+		return nil
+	}
+
+	return fmt.Errorf("unsupported bucket lookup type: %s", lookupType)
+}
+
 const (
+	AutoLookup BucketLookupType = iota
+	VirtualHostLookup
+	PathLookup
+
 	// DirDelim is the delimiter used to model a directory structure in an object store bucket.
 	DirDelim = "/"
 
@@ -66,7 +109,8 @@ var DefaultConfig = Config{
 		MaxIdleConnsPerHost:   100,
 		MaxConnsPerHost:       0,
 	},
-	PartSize: 1024 * 1024 * 64, // 64MB.
+	PartSize:         1024 * 1024 * 64, // 64MB.
+	BucketLookupType: AutoLookup,
 }
 
 // Config stores the configuration for s3 bucket.
@@ -83,7 +127,7 @@ type Config struct {
 	HTTPConfig         HTTPConfig        `yaml:"http_config"`
 	TraceConfig        TraceConfig       `yaml:"trace"`
 	ListObjectsVersion string            `yaml:"list_objects_version"`
-	DNSStyle           bool              `yaml:"dns_style"`
+	BucketLookupType   BucketLookupType  `yaml:"bucket_lookup_type"`
 	// PartSize used for multipart upload. Only used if uploaded object size is known and larger than configured PartSize.
 	// NOTE we need to make sure this number does not produce more parts than 10 000.
 	PartSize    uint64    `yaml:"part_size"`
@@ -264,19 +308,13 @@ func NewBucketWithConfig(logger log.Logger, config Config, component string) (*B
 			return nil, err
 		}
 	}
-	var lookup minio.BucketLookupType
-	if config.DNSStyle {
-		lookup = minio.BucketLookupDNS
-	} else {
-		lookup = minio.BucketLookupAuto
-	}
 
 	client, err := minio.New(config.Endpoint, &minio.Options{
 		Creds:        credentials.NewChainCredentials(chain),
 		Secure:       !config.Insecure,
 		Region:       config.Region,
 		Transport:    rt,
-		BucketLookup: lookup,
+		BucketLookup: config.BucketLookupType.MinioType(),
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "initialize s3 client")

--- a/test/e2e/e2ethanos/services.go
+++ b/test/e2e/e2ethanos/services.go
@@ -959,6 +959,7 @@ func NewS3Config(bucket, endpoint, basePath string) s3.Config {
 				KeyFile:  filepath.Join(basePath, "certs", "private.key"),
 			},
 		},
+		BucketLookupType: s3.AutoLookup,
 	}
 }
 


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->
This MR allows to force DNS style lookup, as by default the [minio lib only does this for specific providers](https://github.com/minio/minio-go/blob/78350132c2c9a1d9a9a6815d80d57d42e3c40604/pkg/s3utils/utils.go#L71-L82). In my use case we have S3 running on Ceph with Proxys in front which only allows DNS style requests.
<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change
* [ ] Change is not relevant to the end user

## Changes
1. Add S3 config option to force the DNS lookup
2. Updated docs with the new option
<!-- Enumerate changes you made -->

## Verification
I tested those changes on my Thanos Cluster with a custom S3 Ceph which only allows access via DNS Style requests.
