### PR TITLE
query: Close() after using query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 
 ### Changed
 
+- [#5410](https://github.com/thanos-io/thanos/pull/5410) Query: Close() after using query. This should reduce bumps in memory allocations.
+
 ### Removed
 
 ## [v0.26.0](https://github.com/thanos-io/thanos/tree/release-0.26) - 2022.05.05

--- a/pkg/api/query/grpc.go
+++ b/pkg/api/query/grpc.go
@@ -83,6 +83,7 @@ func (g *GRPCAPI) Query(request *querypb.QueryRequest, server querypb.Query_Quer
 	if err != nil {
 		return err
 	}
+	defer qry.Close()
 
 	result := qry.Exec(ctx)
 	if err := server.Send(querypb.NewQueryWarningsResponse(result.Warnings)); err != nil {
@@ -155,6 +156,7 @@ func (g *GRPCAPI) QueryRange(request *querypb.QueryRangeRequest, srv querypb.Que
 	if err != nil {
 		return err
 	}
+	defer qry.Close()
 
 	result := qry.Exec(ctx)
 	if err := srv.Send(querypb.NewQueryRangeWarningsResponse(result.Warnings)); err != nil {

--- a/pkg/api/query/v1.go
+++ b/pkg/api/query/v1.go
@@ -348,6 +348,7 @@ func (qapi *QueryAPI) query(r *http.Request) (interface{}, []error, *api.ApiErro
 	if err != nil {
 		return nil, nil, &api.ApiError{Typ: api.ErrorBadData, Err: err}
 	}
+	defer qry.Close()
 
 	tracing.DoInSpan(ctx, "query_gate_ismyturn", func(ctx context.Context) {
 		err = qapi.gate.Start(ctx)
@@ -470,6 +471,7 @@ func (qapi *QueryAPI) queryRange(r *http.Request) (interface{}, []error, *api.Ap
 	if err != nil {
 		return nil, nil, &api.ApiError{Typ: api.ErrorBadData, Err: err}
 	}
+	defer qry.Close()
 
 	tracing.DoInSpan(ctx, "query_gate_ismyturn", func(ctx context.Context) {
 		err = qapi.gate.Start(ctx)


### PR DESCRIPTION
This should reduce memory usage because Close() returns points back to a
sync.Pool.

Signed-off-by: Giedrius Statkevičius <giedrius.statkevicius@vinted.com>
