### PR TITLE
Avoided potential panic due to divide by 0

### DIFF
--- a/pkg/tracing/google_cloud/google_cloud.go
+++ b/pkg/tracing/google_cloud/google_cloud.go
@@ -52,9 +52,11 @@ func newTracerProvider(ctx context.Context, logger log.Logger, processor tracesd
 		level.Warn(logger).Log("msg", "detecting resources for tracing provider failed", "err", err)
 	}
 
-	fraction := 1 / float64(sampleFactor)
+	var fraction float64
 	if sampleFactor == 0 {
 		fraction = 0
+	} else {
+		fraction = 1 / float64(sampleFactor)
 	}
 
 	tp := tracesdk.NewTracerProvider(


### PR DESCRIPTION
Signed-off-by: Aditi Ahuja <ahuja.aditi@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes
Earlier, since `fraction` was divided by `sampleFactor` without checking if it was equal to 0, there was the possibility of a panic. Now, it is first checked to be equal to 0 and that case is handled separately. 

## Verification

<!-- How you tested it? How do you know it works? -->
