### PR TITLE
Ruler: Change default evaluation interval to 1m

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 ### Changed
 
 - [#5410](https://github.com/thanos-io/thanos/pull/5410) Query: Close() after using query. This should reduce bumps in memory allocations.
+- [#5417](https://github.com/thanos-io/thanos/pull/5417) Ruler: Change default evaluation interval to 1 minute.
 
 ### Removed
 

--- a/cmd/thanos/rule.go
+++ b/cmd/thanos/rule.go
@@ -125,7 +125,7 @@ func registerRule(app *extkingpin.App) {
 	cmd.Flag("resend-delay", "Minimum amount of time to wait before resending an alert to Alertmanager.").
 		Default("1m").DurationVar(&conf.resendDelay)
 	cmd.Flag("eval-interval", "The default evaluation interval to use.").
-		Default("30s").DurationVar(&conf.evalInterval)
+		Default("1m").DurationVar(&conf.evalInterval)
 
 	conf.rwConfig = extflag.RegisterPathOrContent(cmd, "remote-write.config", "YAML config for the remote-write configurations, that specify servers where samples should be sent to (see https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_write). This automatically enables stateless mode for ruler and no series will be stored in the ruler's TSDB. If an empty config (or file) is provided, the flag is ignored and ruler is run with its own TSDB.", extflag.WithEnvSubstitution())
 

--- a/docs/components/rule.md
+++ b/docs/components/rule.md
@@ -310,7 +310,7 @@ Flags:
                                  record's value. The URL path is used as a
                                  prefix for the regular Alertmanager API path.
       --data-dir="data/"         data directory
-      --eval-interval=30s        The default evaluation interval to use.
+      --eval-interval=1m         The default evaluation interval to use.
       --grpc-address="0.0.0.0:10901"
                                  Listen ip:port address for gRPC endpoints
                                  (StoreAPI). Make sure this address is routable


### PR DESCRIPTION
Signed-off-by: Matej Gera <matejgera@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [X] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

As we're in the process of making our alerting compliant with the [Prometheus alerting compliance specification](https://github.com/prometheus/compliance/blob/main/alert_generator/specification.md#executing-an-alerting-rule), I have noticed we are using the default rule evaluation interval of `30s` whereas the spec requires this to be `1m` (referring to evaluation):
```
This MUST be done at regular intervals and the interval MUST be the interval from the parent <rule_group> of this alerting rule, which MUST default to 1 minute if not specified in the config.
```

I could not find any historical reasons for the difference between Thanos and Prometheus, I assume there is no practical reason for the difference and possibly this difference has been there since the initial implementation of ruler.

## Verification

/
