### PR TITLE
Alert Compliance: Fix wrong ruler configuration

### DIFF
--- a/test/e2e/compatibility_test.go
+++ b/test/e2e/compatibility_test.go
@@ -150,6 +150,7 @@ func TestAlertCompliance(t *testing.T) {
 			// Use default resend delay and eval interval, as the compliance spec requires this.
 			WithResendDelay("1m").
 			WithEvalInterval("1m").
+			WithoutReplicaLabel().
 			InitTSDB(filepath.Join(rFuture.InternalDir(), "rules"), []httpconfig.Config{
 				{
 					EndpointsConfig: httpconfig.EndpointsConfig{

--- a/test/e2e/compatibility_test.go
+++ b/test/e2e/compatibility_test.go
@@ -150,7 +150,7 @@ func TestAlertCompliance(t *testing.T) {
 			// Use default resend delay and eval interval, as the compliance spec requires this.
 			WithResendDelay("1m").
 			WithEvalInterval("1m").
-			WithoutReplicaLabel().
+			WithReplicaLabel("").
 			InitTSDB(filepath.Join(rFuture.InternalDir(), "rules"), []httpconfig.Config{
 				{
 					EndpointsConfig: httpconfig.EndpointsConfig{

--- a/test/e2e/e2ethanos/services.go
+++ b/test/e2e/e2ethanos/services.go
@@ -494,12 +494,6 @@ func NewRulerBuilder(e e2e.Environment, name string) *RulerBuilder {
 	}
 }
 
-// Force no replica label; by default we use replica label in tests.
-func (r *RulerBuilder) WithoutReplicaLabel() *RulerBuilder {
-	r.replicaLabel = ""
-	return r
-}
-
 func (r *RulerBuilder) WithImage(image string) *RulerBuilder {
 	r.image = image
 	return r

--- a/test/e2e/e2ethanos/services.go
+++ b/test/e2e/e2ethanos/services.go
@@ -494,6 +494,12 @@ func NewRulerBuilder(e e2e.Environment, name string) *RulerBuilder {
 	}
 }
 
+// Force no replica label; by default we use replica label in tests.
+func (r *RulerBuilder) WithoutReplicaLabel() *RulerBuilder {
+	r.replicaLabel = ""
+	return r
+}
+
 func (r *RulerBuilder) WithImage(image string) *RulerBuilder {
 	r.image = image
 	return r


### PR DESCRIPTION
Signed-off-by: Matej Gera <matejgera@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [X] Change is not relevant to the end user.

## Changes

This is a follow-up for https://github.com/thanos-io/thanos/pull/5315. There is one more thing that got mixed up during rebasing, which is that we should not be using replica label for ruler (this causes the test to fail). This change adds configuration to force not using label.

## Verification
Ran the alert compliance test suite locally on top fresh `main`, all tests are passing.

<!-- How you tested it? How do you know it works? -->
