### PR TITLE
Scripts: Add quickstart script for alert generator compliance test

### DIFF
--- a/scripts/alert-compliance-quickstart.sh
+++ b/scripts/alert-compliance-quickstart.sh
@@ -10,7 +10,7 @@
 # For the test you will need to run Thanos binary built with the latest 'main'
 # branch or with version >= 0.27.0.
 #
-# After all comopnents are running, you can start the alert generator compliance tester
+# After all components are running, you can start the alert generator compliance tester
 # with `thanos-example.yaml`` configuration provided in here:
 # https://github.com/prometheus/compliance/blob/main/alert_generator/test-prometheus.yaml
 set -euo pipefail

--- a/scripts/alert-compliance-quickstart.sh
+++ b/scripts/alert-compliance-quickstart.sh
@@ -25,16 +25,16 @@ export ALERT_COMPLIANCE_RULES
 curl -sNL -o "${ALERT_COMPLIANCE_RULES}" "https://raw.githubusercontent.com/prometheus/compliance/main/alert_generator/rules.yaml"
 
 ${THANOS_EXECUTABLE} receive \
-  --label 'receive_replica="0"' \
+  --label='receive_replica="0"' \
   --tsdb.path="${TMP_DATA}" &
 
 # We make sure to filter out the 'receive_replica' and 'tenant_id' labels,
 # which are added by the receiver (they cannot be present during the test).
 ${THANOS_EXECUTABLE} query \
-  --http-address 0.0.0.0:19192 \
-  --store 0.0.0.0:10901 \
-  --rule 0.0.0.0:20901 \
-  --grpc-address 0.0.0.0:19099 \
+  --http-address=0.0.0.0:19192 \
+  --store=0.0.0.0:10901 \
+  --rule=0.0.0.0:20901 \
+  --grpc-address=0.0.0.0:19099 \
   --query.replica-label="tenant_id" \
   --query.replica-label="receive_replica" &
 

--- a/scripts/alert-compliance-quickstart.sh
+++ b/scripts/alert-compliance-quickstart.sh
@@ -11,8 +11,8 @@
 # branch or with version >= 0.27.0.
 #
 # After all components are running, you can start the alert generator compliance tester
-# with `thanos-example.yaml`` configuration provided in here:
-# https://github.com/prometheus/compliance/blob/main/alert_generator/test-prometheus.yaml
+# with `test-thanos.yaml` configuration provided in here:
+# https://github.com/prometheus/compliance/blob/main/alert_generator/test-thanos.yaml
 set -euo pipefail
 
 trap 'kill 0' SIGTERM

--- a/scripts/alert-compliance-quickstart.sh
+++ b/scripts/alert-compliance-quickstart.sh
@@ -21,28 +21,28 @@ export ALERT_COMPLIANCE_RULES=$(mktemp /tmp/rules-XXXX.yaml)
 
 curl -sNL -o ${ALERT_COMPLIANCE_RULES} "https://raw.githubusercontent.com/prometheus/compliance/main/alert_generator/rules.yaml"
 
- ${THANOS_EXECUTABLE} receive \
-    --label "receive_replica=\"0\"" \
-    --tsdb.path=${TMP_DATA} &
+${THANOS_EXECUTABLE} receive \
+  --label 'receive_replica="0"' \
+  --tsdb.path=${TMP_DATA} &
 
 # We make sure to filter out the 'receive_replica' and 'tenant_id' labels,
 # which are added by the receiver (they cannot be present during the test).
 ${THANOS_EXECUTABLE} query \
-    --http-address 0.0.0.0:19192 \
-    --store 0.0.0.0:10901 \
-    --rule 0.0.0.0:20901 \
-    --grpc-address 0.0.0.0:19099 \
-    --query.replica-label="tenant_id" \
-    --query.replica-label="receive_replica" &
+  --http-address 0.0.0.0:19192 \
+  --store 0.0.0.0:10901 \
+  --rule 0.0.0.0:20901 \
+  --grpc-address 0.0.0.0:19099 \
+  --query.replica-label="tenant_id" \
+  --query.replica-label="receive_replica" &
 
 # Script downloads the compliance test rules into a tmp file that `--rule-file` is pointing to.
 ${THANOS_EXECUTABLE} rule \
-    --rule-file=${ALERT_COMPLIANCE_RULES} \
-    --alertmanagers.url="http://0.0.0.0:8080" \
-    --query=0.0.0.0:19192 \
-    --http-address=0.0.0.0:20902 \
-    --grpc-address=0.0.0.0:20901 \
-    --data-dir=${TMP_DATA} &
+  --rule-file=${ALERT_COMPLIANCE_RULES} \
+  --alertmanagers.url="http://0.0.0.0:8080" \
+  --query=0.0.0.0:19192 \
+  --http-address=0.0.0.0:20902 \
+  --grpc-address=0.0.0.0:20901 \
+  --data-dir=${TMP_DATA} &
 
 sleep 0.5
 

--- a/scripts/alert-compliance-quickstart.sh
+++ b/scripts/alert-compliance-quickstart.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+#
+# This is a script for running the Prometheus Alert Generator Compliance
+# test suite. Read more at: https://github.com/prometheus/compliance/tree/main/alert_generator
+#
+# It is the most minimal setup you can use for testing on a local machine.
+# The script will start all necessary components (receive, ruler, querier)
+# with appropriate confguration.
+#
+# After all comopnents are running, you can start the alert generator compliance tester
+# with `thanos-example.yaml`` configuration provided in here:
+# https://github.com/prometheus/compliance/blob/main/alert_generator/test-prometheus.yaml
+set -euo pipefail
+
+trap 'kill 0' SIGTERM
+
+THANOS_EXECUTABLE=${THANOS_EXECUTABLE:-"thanos"}
+
+export TMP_DATA=$(mktemp -d /tmp/data-XXXX)
+export ALERT_COMPLIANCE_RULES=$(mktemp /tmp/rules-XXXX.yaml)
+
+curl -sNL -o ${ALERT_COMPLIANCE_RULES} "https://raw.githubusercontent.com/prometheus/compliance/main/alert_generator/rules.yaml"
+
+ ${THANOS_EXECUTABLE} receive \
+    --label "receive_replica=\"0\"" \
+    --tsdb.path=${TMP_DATA} &
+
+# We make sure to filter out the 'receive_replica' and 'tenant_id' labels,
+# which are added by the receiver (they cannot be present during the test).
+${THANOS_EXECUTABLE} query \
+    --http-address 0.0.0.0:19192 \
+    --store 0.0.0.0:10901 \
+    --rule 0.0.0.0:20901 \
+    --grpc-address 0.0.0.0:19099 \
+    --query.replica-label="tenant_id" \
+    --query.replica-label="receive_replica" &
+
+# Script downloads the compliance test rules into a tmp file that `--rule-file` is pointing to.
+${THANOS_EXECUTABLE} rule \
+    --rule-file=${ALERT_COMPLIANCE_RULES} \
+    --alertmanagers.url="http://0.0.0.0:8080" \
+    --query=0.0.0.0:19192 \
+    --http-address=0.0.0.0:20902 \
+    --grpc-address=0.0.0.0:20901 \
+    --data-dir=${TMP_DATA} &
+
+sleep 0.5
+
+printf "\nAll services started, you can start the alert compliance tester! Waiting on a signal to quit\n"
+
+wait


### PR DESCRIPTION
Signed-off-by: Matej Gera <matejgera@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [X] Change is not relevant to the end user.

## Changes

We have recently introduced the alert generator compliance test via E2E (see https://github.com/thanos-io/thanos/pull/5315). While this is useful for being able to run the test as part of our E2E suite, I want to propose also adding a separate script to spin up all components for the test run. Couple of reasons why:
- We want to provide example configuration in the [alert generator compliance repo](https://github.com/prometheus/compliance/tree/main/alert_generator) to signal to users that Thanos is compliant. But because the E2E is running inside Docker, the configuration we have in the test is transient and cannot be easily made into a 'runnable' example config
- Users do not need to look within our test files (and having to uncomment the skip call etc.), all is spun up with one script
- Users do not even have to have Go installed (as opposed to E2E test), they can directly run this test with virtually no extra hurdles
- Test is more transparent in a sense that users can observe the behavior (look at the web UIs) of the components, since these are running on the host machine (as opposed to containers without exposed ports).

## Verification
Tested the alert generator compliance suite with the script on my local machine.

<!-- How you tested it? How do you know it works? -->
