### PR TITLE
Docs: Remove Katacoda links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,7 +74,7 @@ The following section explains various suggestions and procedures to note during
 
 It's key to get familiarized with the style guide and mechanics of Thanos, especially if your contribution touches more than one component of the Thanos distributed system. We recommend:
 
-* Reading the [getting started docs](docs/getting-started.md) and working through them, or alternatively working through the [Thanos tutorial](https://katacoda.com/thanos).
+* Reading the [getting started docs](docs/getting-started.md) and working through them.
 * Familiarizing yourself with our [coding style guidelines.](docs/contributing/coding-style-guide.md).
 * Familiarizing yourself with the [Makefile](Makefile) commands, for example `format`, `build`, `proto`, `docker` and `test`. `make help` will print most of available commands with relevant details.
 * Spin up a prebuilt dev environment using Gitpod.io [![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/thanos-io/thanos)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -79,7 +79,6 @@ If you want to add yourself to this list, let us know!
 
 ## Deploying Thanos
 
-* [WIP] Detailed, free, in-browser interactive tutorial [as Katacoda Thanos Course](https://katacoda.com/thanos/courses/thanos/1-globalview)
 * [Quick Tutorial](quick-tutorial.md) on Thanos website.
 
 ## Operating

--- a/docs/quick-tutorial.md
+++ b/docs/quick-tutorial.md
@@ -1,9 +1,5 @@
 # Quick Tutorial
 
-Feel free to check the free, in-browser interactive tutorial [as Katacoda Thanos Course](https://katacoda.com/thanos/courses/thanos) We will be progressively updating our Katacoda Course with more scenarios.
-
-On top of this feel free to go through our tutorial presented here:
-
 ## Prometheus
 
 Thanos is based on Prometheus. With Thanos you use more or less Prometheus features depending on the deployment model, however Prometheus always stays as integral foundation for *collecting metrics* and alerting using local data.

--- a/tutorials/katacoda/README.md
+++ b/tutorials/katacoda/README.md
@@ -4,16 +4,4 @@ Definitions of our courses for Katacoda.
 
 ## Development
 
-Process of adding / editing tutorials:
-
-1. Sign up to [Katacoda website](https://katacoda.com).
-2. Link your fork of Thanos to your account, see [this](https://www.katacoda.community/essentials/author-profile.html#github).
-3. Add / edit tutorials.
-4. Push to `main` branch of your fork.
-   * You should see the updated preview of the tutorials on https://katacoda.com/<your-profile>.
-5. Make a PR to Thanos repo.
-6. Once PR is merged the official profile https://katacoda.com/thanos will be updated.
-
-Find more docs [here](https://katacoda.com/docs)
-
-Thanos repo is hooked to [this](https://katacoda.com/thanos) Katacoda account.
+We are currently in process of moving to an alternative interactive tutorial platform, since Katacoda has been decomissioned. Follow [this issue](https://github.com/thanos-io/thanos/issues/5385) to learn more.


### PR DESCRIPTION
Signed-off-by: Matej Gera <matejgera@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [X] Change is not relevant to the end user.

## Changes

Docs CI now started to fail, since Katacoda has been decommissioned and the links no longer work. This is temporary until we figure out our migration or other alternative in https://github.com/thanos-io/thanos/issues/5385.

## Verification

/ 
