### PR TITLE
Endpoint: Refactor get clients methods

### DIFF
--- a/pkg/query/endpointset_test.go
+++ b/pkg/query/endpointset_test.go
@@ -1193,7 +1193,6 @@ func TestDeadlockLocking(t *testing.T) {
 		metadata: &endpointMetadata{
 			&infopb.InfoResponse{},
 		},
-		clients: &endpointClients{},
 	}
 
 	g := &errgroup.Group{}

--- a/test/e2e/query_test.go
+++ b/test/e2e/query_test.go
@@ -1276,7 +1276,7 @@ func TestSidecarAlignmentPushdown(t *testing.T) {
 func TestGrpcInstantQuery(t *testing.T) {
 	t.Parallel()
 
-	e, err := e2e.NewDockerEnvironment("e2e_test_query_grpc_api")
+	e, err := e2e.NewDockerEnvironment("e2e_test_query_grpc_api_instant")
 	testutil.Ok(t, err)
 	t.Cleanup(e2ethanos.CleanScenario(t, e))
 
@@ -1382,7 +1382,7 @@ func TestGrpcInstantQuery(t *testing.T) {
 func TestGrpcQueryRange(t *testing.T) {
 	t.Parallel()
 
-	e, err := e2e.NewDockerEnvironment("e2e_test_query_grpc_api")
+	e, err := e2e.NewDockerEnvironment("e2e_test_query_grpc_api_range")
 	testutil.Ok(t, err)
 	t.Cleanup(e2ethanos.CleanScenario(t, e))
 


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes
Upon reports from #5458 I looked at our endpoint set logic and I believe there is potential for buggy behavior with respect to clients.

How the code works now is that an `endpointRef` includes a `clients` struct, where we build the clients 'ahead of time', depending on components metadata and on which APIs it exposes. However, the metadata can change in some cases (i.e. for some components, the storage might or might not [be ready](https://github.com/thanos-io/thanos/blob/main/cmd/thanos/receive.go#L364) - depending on this probe, we're either returning store metadata or not). This in turn affects if the client is [created or removed.](https://github.com/thanos-io/thanos/blob/5f6ee25d7a8059632e09240068fe1a019cb47245/pkg/query/endpointset.go#L642)

I believe there's a race hidden. When a proxy store then calls [`Series()` method on the store clients](https://github.com/thanos-io/thanos/blob/main/pkg/store/proxy.go#L314), some clients might have been removed mid-query (i.e. set to `nil`), resulting in a panic (as I presume is happening in #5458). This is due to the fact that the store clients refer to the pre-built `clients` in `endpointRef`. But because there's no guarantee the client is there (since an update might have occurred while a proxy query was in progress), this might result in a panic.

The proposal here is to rather just keep the metadata as part of the `endpointRef` and build clients on-the-fly, depending on available metadata. This way, the client is always available for the duration of a whole proxy store operation (but if it's e.g. not active anymore, will not be included for the next proxy query).

Fixes (potentially) #5458.

<!-- Enumerate changes you made -->

## Verification

I wasn't not able to verify this is indeed problem with #5458, since it's not easy to reproduce, but it seems plausible to me. I'm also wondering if anyone has performance concerns doing it this way vs. 'pre-building' the clients on update.
