### PR TITLE
objstore: Download and Upload block files in parallel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#5424](https://github.com/thanos-io/thanos/pull/5424) Receive: Export metrics regarding size of remote write requests.
 - [#5420](https://github.com/thanos-io/thanos/pull/5420) Receive: Automatically remove stale tenants.
 - [#5472](https://github.com/thanos-io/thanos/pull/5472) Receive: add new tenant metrics to example dashboard.
+- [#5475](https://github.com/thanos-io/thanos/pull/5475) Compact/Store: Added `--block-fetch-concurrency` allowing to configure number of go routines for download block files during compaction.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#5420](https://github.com/thanos-io/thanos/pull/5420) Receive: Automatically remove stale tenants.
 - [#5472](https://github.com/thanos-io/thanos/pull/5472) Receive: add new tenant metrics to example dashboard.
 - [#5475](https://github.com/thanos-io/thanos/pull/5475) Compact/Store: Added `--block-fetch-concurrency` allowing to configure number of go routines for download block files during compaction.
+- [#5475](https://github.com/thanos-io/thanos/pull/5475) Compact/Store: Added `--block-files-concurrency` allowing to configure number of go routines for download block files during compaction.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#5472](https://github.com/thanos-io/thanos/pull/5472) Receive: add new tenant metrics to example dashboard.
 - [#5475](https://github.com/thanos-io/thanos/pull/5475) Compact/Store: Added `--block-fetch-concurrency` allowing to configure number of go routines for download block files during compaction.
 - [#5475](https://github.com/thanos-io/thanos/pull/5475) Compact/Store: Added `--block-files-concurrency` allowing to configure number of go routines for download block files during compaction.
+- [#5475](https://github.com/thanos-io/thanos/pull/5475) Compact/Store: Added `--block-files-concurrency` allowing to configure number of go routines for download/upload block files during compaction.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#5440](https://github.com/thanos-io/thanos/pull/5440) HTTP metrics: export number of in-flight HTTP requests.
 - [#5424](https://github.com/thanos-io/thanos/pull/5424) Receive: Export metrics regarding size of remote write requests.
 - [#5420](https://github.com/thanos-io/thanos/pull/5420) Receive: Automatically remove stale tenants.
-- [#5475](https://github.com/thanos-io/thanos/pull/5475) Compact/Store: Added `--block-files-concurrency` allowing to configure number of go routines for upload/download block files during compaction.
+- [#5472](https://github.com/thanos-io/thanos/pull/5472) Receive: add new tenant metrics to example dashboard.
+- [#5475](https://github.com/thanos-io/thanos/pull/5475) Compact/Store: Added `--block-files-concurrency` allowing to configure number of go routines for download/upload block files during compaction.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#5440](https://github.com/thanos-io/thanos/pull/5440) HTTP metrics: export number of in-flight HTTP requests.
 - [#5424](https://github.com/thanos-io/thanos/pull/5424) Receive: Export metrics regarding size of remote write requests.
 - [#5420](https://github.com/thanos-io/thanos/pull/5420) Receive: Automatically remove stale tenants.
-- [#5472](https://github.com/thanos-io/thanos/pull/5472) Receive: add new tenant metrics to example dashboard.
-- [#5475](https://github.com/thanos-io/thanos/pull/5475) Compact/Store: Added `--block-fetch-concurrency` allowing to configure number of go routines for download block files during compaction.
-- [#5475](https://github.com/thanos-io/thanos/pull/5475) Compact/Store: Added `--block-files-concurrency` allowing to configure number of go routines for download block files during compaction.
-- [#5475](https://github.com/thanos-io/thanos/pull/5475) Compact/Store: Added `--block-files-concurrency` allowing to configure number of go routines for download/upload block files during compaction.
+- [#5475](https://github.com/thanos-io/thanos/pull/5475) Compact/Store: Added `--block-files-concurrency` allowing to configure number of go routines for upload/download block files during compaction.
 
 ### Changed
 

--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -349,6 +349,7 @@ func runCompact(
 		compactMetrics.garbageCollectedBlocks,
 		compactMetrics.blocksMarked.WithLabelValues(metadata.NoCompactMarkFilename, metadata.OutOfOrderChunksNoCompactReason),
 		metadata.HashFunc(conf.hashFunc),
+		conf.blockFetchConcurrency,
 	)
 	tsdbPlanner := compact.NewPlanner(logger, levels, noCompactMarkerFilter)
 	planner := compact.WithLargeTotalIndexSizeFilter(
@@ -630,6 +631,7 @@ type compactConfig struct {
 	waitInterval                                   time.Duration
 	disableDownsampling                            bool
 	blockMetaFetchConcurrency                      int
+	blockFetchConcurrency                          int
 	blockViewerSyncBlockInterval                   time.Duration
 	blockViewerSyncBlockTimeout                    time.Duration
 	cleanupBlocksInterval                          time.Duration
@@ -688,6 +690,8 @@ func (cc *compactConfig) registerFlag(cmd extkingpin.FlagClause) {
 
 	cmd.Flag("block-meta-fetch-concurrency", "Number of goroutines to use when fetching block metadata from object storage.").
 		Default("32").IntVar(&cc.blockMetaFetchConcurrency)
+	cmd.Flag("block-fetch-concurrency", "Number of goroutines to use when fetching block files from object storage.").
+		Default("1").IntVar(&cc.blockFetchConcurrency)
 	cmd.Flag("block-viewer.global.sync-block-interval", "Repeat interval for syncing the blocks between local and remote view for /global Block Viewer UI.").
 		Default("1m").DurationVar(&cc.blockViewerSyncBlockInterval)
 	cmd.Flag("block-viewer.global.sync-block-timeout", "Maximum time for syncing the blocks between local and remote view for /global Block Viewer UI.").

--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -349,7 +349,7 @@ func runCompact(
 		compactMetrics.garbageCollectedBlocks,
 		compactMetrics.blocksMarked.WithLabelValues(metadata.NoCompactMarkFilename, metadata.OutOfOrderChunksNoCompactReason),
 		metadata.HashFunc(conf.hashFunc),
-		conf.blockFetchConcurrency,
+		conf.blockFilesConcurrency,
 	)
 	tsdbPlanner := compact.NewPlanner(logger, levels, noCompactMarkerFilter)
 	planner := compact.WithLargeTotalIndexSizeFilter(
@@ -631,7 +631,7 @@ type compactConfig struct {
 	waitInterval                                   time.Duration
 	disableDownsampling                            bool
 	blockMetaFetchConcurrency                      int
-	blockFetchConcurrency                          int
+	blockFilesConcurrency                          int
 	blockViewerSyncBlockInterval                   time.Duration
 	blockViewerSyncBlockTimeout                    time.Duration
 	cleanupBlocksInterval                          time.Duration
@@ -690,8 +690,8 @@ func (cc *compactConfig) registerFlag(cmd extkingpin.FlagClause) {
 
 	cmd.Flag("block-meta-fetch-concurrency", "Number of goroutines to use when fetching block metadata from object storage.").
 		Default("32").IntVar(&cc.blockMetaFetchConcurrency)
-	cmd.Flag("block-fetch-concurrency", "Number of goroutines to use when fetching block files from object storage.").
-		Default("1").IntVar(&cc.blockFetchConcurrency)
+	cmd.Flag("block-files-concurrency", "Number of goroutines to use when fetching/uploading block files from object storage.").
+		Default("1").IntVar(&cc.blockFilesConcurrency)
 	cmd.Flag("block-viewer.global.sync-block-interval", "Repeat interval for syncing the blocks between local and remote view for /global Block Viewer UI.").
 		Default("1m").DurationVar(&cc.blockViewerSyncBlockInterval)
 	cmd.Flag("block-viewer.global.sync-block-timeout", "Maximum time for syncing the blocks between local and remote view for /global Block Viewer UI.").

--- a/docs/components/compact.md
+++ b/docs/components/compact.md
@@ -279,9 +279,10 @@ usage: thanos compact [<flags>]
 Continuously compacts blocks in an object store bucket.
 
 Flags:
-      --block-fetch-concurrency=1
-                                Number of goroutines to use when fetching block
-                                files from object storage.
+      --block-files-concurrency=1
+                                Number of goroutines to use when
+                                fetching/uploading block files from object
+                                storage.
       --block-meta-fetch-concurrency=32
                                 Number of goroutines to use when fetching block
                                 metadata from object storage.

--- a/docs/components/compact.md
+++ b/docs/components/compact.md
@@ -279,6 +279,9 @@ usage: thanos compact [<flags>]
 Continuously compacts blocks in an object store bucket.
 
 Flags:
+      --block-fetch-concurrency=1
+                                Number of goroutines to use when fetching block
+                                files from object storage.
       --block-meta-fetch-concurrency=32
                                 Number of goroutines to use when fetching block
                                 metadata from object storage.

--- a/go.mod
+++ b/go.mod
@@ -86,7 +86,7 @@ require (
 	golang.org/x/crypto v0.0.0-20220411220226-7b82a4e95df4
 	golang.org/x/net v0.0.0-20220425223048-2871e0cb64e4
 	golang.org/x/oauth2 v0.0.0-20220411215720-9780585627b5
-	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
+	golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f
 	golang.org/x/text v0.3.7
 	google.golang.org/api v0.78.0
 	google.golang.org/genproto v0.0.0-20220429170224-98d788798c3e

--- a/go.sum
+++ b/go.sum
@@ -2262,8 +2262,9 @@ golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20200930132711-30421366ff76/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f h1:Ax0t5p6N38Ga0dThY21weqDEyz2oklo4IvDkpigvkD8=
+golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20170830134202-bb24a47a89ea/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/pkg/block/block.go
+++ b/pkg/block/block.go
@@ -45,7 +45,7 @@ const (
 // Download downloads directory that is mean to be block directory. If any of the files
 // have a hash calculated in the meta file and it matches with what is in the destination path then
 // we do not download it. We always re-download the meta file.
-func Download(ctx context.Context, logger log.Logger, bucket objstore.Bucket, id ulid.ULID, dst string, options ...objstore.DownloadDirOption) error {
+func Download(ctx context.Context, logger log.Logger, bucket objstore.Bucket, id ulid.ULID, dst string, options ...objstore.DownloadOption) error {
 	if err := os.MkdirAll(dst, 0750); err != nil {
 		return errors.Wrap(err, "create dir")
 	}
@@ -94,13 +94,13 @@ func Download(ctx context.Context, logger log.Logger, bucket objstore.Bucket, id
 
 // Upload uploads a TSDB block to the object storage. It verifies basic
 // features of Thanos block.
-func Upload(ctx context.Context, logger log.Logger, bkt objstore.Bucket, bdir string, hf metadata.HashFunc, options ...objstore.UploadDirOption) error {
+func Upload(ctx context.Context, logger log.Logger, bkt objstore.Bucket, bdir string, hf metadata.HashFunc, options ...objstore.UploadOption) error {
 	return upload(ctx, logger, bkt, bdir, hf, true, options...)
 }
 
 // UploadPromBlock uploads a TSDB block to the object storage. It assumes
 // the block is used in Prometheus so it doesn't check Thanos external labels.
-func UploadPromBlock(ctx context.Context, logger log.Logger, bkt objstore.Bucket, bdir string, hf metadata.HashFunc, options ...objstore.UploadDirOption) error {
+func UploadPromBlock(ctx context.Context, logger log.Logger, bkt objstore.Bucket, bdir string, hf metadata.HashFunc, options ...objstore.UploadOption) error {
 	return upload(ctx, logger, bkt, bdir, hf, false, options...)
 }
 
@@ -108,7 +108,7 @@ func UploadPromBlock(ctx context.Context, logger log.Logger, bkt objstore.Bucket
 // It makes sure cleanup is done on error to avoid partial block uploads.
 // TODO(bplotka): Ensure bucket operations have reasonable backoff retries.
 // NOTE: Upload updates `meta.Thanos.File` section.
-func upload(ctx context.Context, logger log.Logger, bkt objstore.Bucket, bdir string, hf metadata.HashFunc, checkExternalLabels bool, options ...objstore.UploadDirOption) error {
+func upload(ctx context.Context, logger log.Logger, bkt objstore.Bucket, bdir string, hf metadata.HashFunc, checkExternalLabels bool, options ...objstore.UploadOption) error {
 	df, err := os.Stat(bdir)
 	if err != nil {
 		return err

--- a/pkg/block/block.go
+++ b/pkg/block/block.go
@@ -45,7 +45,7 @@ const (
 // Download downloads directory that is mean to be block directory. If any of the files
 // have a hash calculated in the meta file and it matches with what is in the destination path then
 // we do not download it. We always re-download the meta file.
-func Download(ctx context.Context, logger log.Logger, bucket objstore.Bucket, id ulid.ULID, dst string) error {
+func Download(ctx context.Context, logger log.Logger, bucket objstore.Bucket, id ulid.ULID, dst string, options ...objstore.DownloadDirOption) error {
 	if err := os.MkdirAll(dst, 0750); err != nil {
 		return errors.Wrap(err, "create dir")
 	}
@@ -74,7 +74,7 @@ func Download(ctx context.Context, logger log.Logger, bucket objstore.Bucket, id
 		}
 	}
 
-	if err := objstore.DownloadDir(ctx, logger, bucket, id.String(), id.String(), dst, ignoredPaths...); err != nil {
+	if err := objstore.DownloadDir(ctx, logger, bucket, id.String(), id.String(), dst, append(options, objstore.WithDownloadIgnoredPaths(ignoredPaths...))...); err != nil {
 		return err
 	}
 

--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -913,7 +913,7 @@ func (cg *Group) areBlocksOverlapping(include *metadata.Meta, exclude ...*metada
 }
 
 // RepairIssue347 repairs the https://github.com/prometheus/tsdb/issues/347 issue when having issue347Error.
-func RepairIssue347(ctx context.Context, logger log.Logger, bkt objstore.Bucket, blocksMarkedForDeletion prometheus.Counter, blockFilesConcurrency int, issue347Err error) error {
+func RepairIssue347(ctx context.Context, logger log.Logger, bkt objstore.Bucket, blocksMarkedForDeletion prometheus.Counter, issue347Err error) error {
 	ie, ok := errors.Cause(issue347Err).(Issue347Error)
 	if !ok {
 		return errors.Errorf("Given error is not an issue347 error: %v", issue347Err)
@@ -953,7 +953,7 @@ func RepairIssue347(ctx context.Context, logger log.Logger, bkt objstore.Bucket,
 	}
 
 	level.Info(logger).Log("msg", "uploading repaired block", "newID", resid)
-	if err = block.Upload(ctx, logger, bkt, filepath.Join(tmpdir, resid.String()), metadata.NoneFunc, objstore.WithUploadConcurrency(blockFilesConcurrency)); err != nil {
+	if err = block.Upload(ctx, logger, bkt, filepath.Join(tmpdir, resid.String()), metadata.NoneFunc); err != nil {
 		return retry(errors.Wrapf(err, "upload of %s failed", resid))
 	}
 
@@ -1245,7 +1245,7 @@ func (c *BucketCompactor) Compact(ctx context.Context) (rerr error) {
 					}
 
 					if IsIssue347Error(err) {
-						if err := RepairIssue347(workCtx, c.logger, c.bkt, c.sy.metrics.blocksMarkedForDeletion, g.blockFilesConcurrency, err); err == nil {
+						if err := RepairIssue347(workCtx, c.logger, c.bkt, c.sy.metrics.blocksMarkedForDeletion, err); err == nil {
 							mtx.Lock()
 							finishedAllGroups = false
 							mtx.Unlock()

--- a/pkg/compact/compact_e2e_test.go
+++ b/pkg/compact/compact_e2e_test.go
@@ -139,7 +139,7 @@ func TestSyncer_GarbageCollect_e2e(t *testing.T) {
 		testutil.Ok(t, sy.GarbageCollect(ctx))
 
 		// Only the level 3 block, the last source block in both resolutions should be left.
-		grouper := NewDefaultGrouper(nil, bkt, false, false, nil, blocksMarkedForDeletion, garbageCollectedBlocks, blockMarkedForNoCompact, metadata.NoneFunc)
+		grouper := NewDefaultGrouper(nil, bkt, false, false, nil, blocksMarkedForDeletion, garbageCollectedBlocks, blockMarkedForNoCompact, metadata.NoneFunc, 1)
 		groups, err := grouper.Groups(sy.Metas())
 		testutil.Ok(t, err)
 
@@ -214,7 +214,7 @@ func testGroupCompactE2e(t *testing.T, mergeFunc storage.VerticalChunkSeriesMerg
 		testutil.Ok(t, err)
 
 		planner := NewPlanner(logger, []int64{1000, 3000}, noCompactMarkerFilter)
-		grouper := NewDefaultGrouper(logger, bkt, false, false, reg, blocksMarkedForDeletion, garbageCollectedBlocks, blocksMaredForNoCompact, metadata.NoneFunc)
+		grouper := NewDefaultGrouper(logger, bkt, false, false, reg, blocksMarkedForDeletion, garbageCollectedBlocks, blocksMaredForNoCompact, metadata.NoneFunc, 1)
 		bComp, err := NewBucketCompactor(logger, sy, grouper, planner, comp, dir, bkt, 2, true)
 		testutil.Ok(t, err)
 

--- a/pkg/compact/compact_test.go
+++ b/pkg/compact/compact_test.go
@@ -210,7 +210,7 @@ func TestRetentionProgressCalculate(t *testing.T) {
 
 	var bkt objstore.Bucket
 	temp := promauto.With(reg).NewCounter(prometheus.CounterOpts{Name: "test_metric_for_group", Help: "this is a test metric for compact progress tests"})
-	grouper := NewDefaultGrouper(logger, bkt, false, false, reg, temp, temp, temp, "")
+	grouper := NewDefaultGrouper(logger, bkt, false, false, reg, temp, temp, temp, "", 1)
 
 	type groupedResult map[string]float64
 
@@ -376,7 +376,7 @@ func TestCompactProgressCalculate(t *testing.T) {
 
 	var bkt objstore.Bucket
 	temp := promauto.With(reg).NewCounter(prometheus.CounterOpts{Name: "test_metric_for_group", Help: "this is a test metric for compact progress tests"})
-	grouper := NewDefaultGrouper(logger, bkt, false, false, reg, temp, temp, temp, "")
+	grouper := NewDefaultGrouper(logger, bkt, false, false, reg, temp, temp, temp, "", 1)
 
 	for _, tcase := range []struct {
 		testName string
@@ -498,7 +498,7 @@ func TestDownsampleProgressCalculate(t *testing.T) {
 
 	var bkt objstore.Bucket
 	temp := promauto.With(reg).NewCounter(prometheus.CounterOpts{Name: "test_metric_for_group", Help: "this is a test metric for downsample progress tests"})
-	grouper := NewDefaultGrouper(logger, bkt, false, false, reg, temp, temp, temp, "")
+	grouper := NewDefaultGrouper(logger, bkt, false, false, reg, temp, temp, temp, "", 1)
 
 	for _, tcase := range []struct {
 		testName string

--- a/pkg/objstore/objstore.go
+++ b/pkg/objstore/objstore.go
@@ -121,10 +121,10 @@ func ApplyIterOptions(options ...IterOption) IterParams {
 	return out
 }
 
-// DownloadOption configures the provided params.
+// DownloadDirOption configures the provided params.
 type DownloadDirOption func(params *DownloadDirParams)
 
-// DownloadParams holds the Download() parameters and is used by objstore clients implementations.
+// DownloadDirParams holds the DownloadDir() parameters and is used by objstore clients implementations.
 type DownloadDirParams struct {
 	concurrency  int
 	ignoredPaths []string
@@ -154,7 +154,7 @@ func applyDownloadDirOptions(options ...DownloadDirOption) DownloadDirParams {
 	return out
 }
 
-// DownloadOption configures the provided params.
+// UploadDirOption configures the provided params.
 type UploadDirOption func(params *UploadDirParams)
 
 // UploadDirParams holds the UploadDir() parameters and is used by objstore clients implementations.
@@ -162,7 +162,7 @@ type UploadDirParams struct {
 	concurrency int
 }
 
-// WithUploadConcurrency is an option to set the concurrency of the download operation.
+// WithUploadConcurrency is an option to set the concurrency of the upload operation.
 func WithUploadConcurrency(concurrency int) UploadDirOption {
 	return func(params *UploadDirParams) {
 		params.concurrency = concurrency

--- a/pkg/objstore/objstore.go
+++ b/pkg/objstore/objstore.go
@@ -144,7 +144,7 @@ func WithFetchConcurrency(concurrency int) DownloadDirOption {
 	}
 }
 
-func ApplyDownloadOptions(options ...DownloadDirOption) DownloadDirParams {
+func applyDownloadOptions(options ...DownloadDirOption) DownloadDirParams {
 	out := DownloadDirParams{
 		concurrency: 1,
 	}
@@ -293,7 +293,7 @@ func DownloadDir(ctx context.Context, logger log.Logger, bkt BucketReader, origi
 	if err := os.MkdirAll(dst, 0750); err != nil {
 		return errors.Wrap(err, "create dir")
 	}
-	opts := ApplyDownloadOptions(options...)
+	opts := applyDownloadOptions(options...)
 
 	g, ctx := errgroup.WithContext(ctx)
 	guard := make(chan struct{}, opts.concurrency)

--- a/pkg/objstore/objstore.go
+++ b/pkg/objstore/objstore.go
@@ -159,8 +159,7 @@ type UploadDirOption func(params *UploadDirParams)
 
 // UploadDirParams holds the UploadDir() parameters and is used by objstore clients implementations.
 type UploadDirParams struct {
-	concurrency  int
-	ignoredPaths []string
+	concurrency int
 }
 
 // WithUploadConcurrency is an option to set the concurrency of the download operation.

--- a/pkg/objstore/objstore.go
+++ b/pkg/objstore/objstore.go
@@ -235,6 +235,9 @@ func NopCloserWithSize(r io.Reader) io.ReadCloser {
 func UploadDir(ctx context.Context, logger log.Logger, bkt Bucket, srcdir, dstdir string, options ...UploadOption) error {
 	df, err := os.Stat(srcdir)
 	opts := applyUploadOptions(options...)
+
+	// The derived Context is canceled the first time a function passed to Go returns a non-nil error or the first
+	// time Wait returns, whichever occurs first.
 	g, ctx := errgroup.WithContext(ctx)
 	g.SetLimit(opts.concurrency)
 
@@ -334,6 +337,8 @@ func DownloadDir(ctx context.Context, logger log.Logger, bkt BucketReader, origi
 	}
 	opts := applyDownloadOptions(options...)
 
+	// The derived Context is canceled the first time a function passed to Go returns a non-nil error or the first
+	// time Wait returns, whichever occurs first.
 	g, ctx := errgroup.WithContext(ctx)
 	g.SetLimit(opts.concurrency)
 

--- a/pkg/objstore/objstore_test.go
+++ b/pkg/objstore/objstore_test.go
@@ -9,10 +9,12 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/go-kit/log"
 	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
 	promtest "github.com/prometheus/client_golang/prometheus/testutil"
 	"go.uber.org/atomic"
 
@@ -93,18 +95,56 @@ func TestTracingReader(t *testing.T) {
 	testutil.Equals(t, int64(11), size)
 }
 
-func TestDownloadDirConcurrency(t *testing.T) {
-	m := BucketWithMetrics("", NewInMemBucket(), nil)
+func TestDownloadUploadDirConcurrency(t *testing.T) {
+	r := prometheus.NewRegistry()
+	m := BucketWithMetrics("", NewInMemBucket(), r)
 	tempDir := t.TempDir()
 
 	testutil.Ok(t, m.Upload(context.Background(), "dir/obj1", bytes.NewReader([]byte("1"))))
 	testutil.Ok(t, m.Upload(context.Background(), "dir/obj2", bytes.NewReader([]byte("2"))))
 	testutil.Ok(t, m.Upload(context.Background(), "dir/obj3", bytes.NewReader([]byte("3"))))
 
+	testutil.Ok(t, promtest.GatherAndCompare(r, strings.NewReader(`
+		# HELP thanos_objstore_bucket_operations_total Total number of all attempted operations against a bucket.
+        # TYPE thanos_objstore_bucket_operations_total counter
+        thanos_objstore_bucket_operations_total{bucket="",operation="attributes"} 0
+        thanos_objstore_bucket_operations_total{bucket="",operation="delete"} 0
+        thanos_objstore_bucket_operations_total{bucket="",operation="exists"} 0
+        thanos_objstore_bucket_operations_total{bucket="",operation="get"} 0
+        thanos_objstore_bucket_operations_total{bucket="",operation="get_range"} 0
+        thanos_objstore_bucket_operations_total{bucket="",operation="iter"} 0
+        thanos_objstore_bucket_operations_total{bucket="",operation="upload"} 3
+		`), `thanos_objstore_bucket_operations_total`))
+
 	testutil.Ok(t, DownloadDir(context.Background(), log.NewNopLogger(), m, "dir/", "dir/", tempDir, WithFetchConcurrency(10)))
 	i, err := ioutil.ReadDir(tempDir)
 	testutil.Ok(t, err)
 	testutil.Assert(t, len(i) == 3)
+	testutil.Ok(t, promtest.GatherAndCompare(r, strings.NewReader(`
+		# HELP thanos_objstore_bucket_operations_total Total number of all attempted operations against a bucket.
+        # TYPE thanos_objstore_bucket_operations_total counter
+        thanos_objstore_bucket_operations_total{bucket="",operation="attributes"} 0
+        thanos_objstore_bucket_operations_total{bucket="",operation="delete"} 0
+        thanos_objstore_bucket_operations_total{bucket="",operation="exists"} 0
+        thanos_objstore_bucket_operations_total{bucket="",operation="get"} 3
+        thanos_objstore_bucket_operations_total{bucket="",operation="get_range"} 0
+        thanos_objstore_bucket_operations_total{bucket="",operation="iter"} 1
+        thanos_objstore_bucket_operations_total{bucket="",operation="upload"} 3
+		`), `thanos_objstore_bucket_operations_total`))
+
+	testutil.Ok(t, UploadDir(context.Background(), log.NewNopLogger(), m, tempDir, "/dir-copy", WithUploadConcurrency(10)))
+
+	testutil.Ok(t, promtest.GatherAndCompare(r, strings.NewReader(`
+		# HELP thanos_objstore_bucket_operations_total Total number of all attempted operations against a bucket.
+        # TYPE thanos_objstore_bucket_operations_total counter
+        thanos_objstore_bucket_operations_total{bucket="",operation="attributes"} 0
+        thanos_objstore_bucket_operations_total{bucket="",operation="delete"} 0
+        thanos_objstore_bucket_operations_total{bucket="",operation="exists"} 0
+        thanos_objstore_bucket_operations_total{bucket="",operation="get"} 3
+        thanos_objstore_bucket_operations_total{bucket="",operation="get_range"} 0
+        thanos_objstore_bucket_operations_total{bucket="",operation="iter"} 1
+        thanos_objstore_bucket_operations_total{bucket="",operation="upload"} 6
+		`), `thanos_objstore_bucket_operations_total`))
 }
 
 func TestTimingTracingReader(t *testing.T) {


### PR DESCRIPTION
Hi...

We were doing some tests on the thanos compactor on cortex and we noticed that for very big tenants the compactor was mostly waiting the blocks to be downloaded but at the same time it was not using all the network or disk available capacity.

Looking at the thanos code we noticed that the blocks and chunks are being downloaded one by one so we decided to test 2 changes (`Download chunks in parallel` and `Download blocks in parallel`) that seems to have improved a lot the compaction time.

On or test case we were compacting 6 blocks ~ 200GB each as as we can see below we were taking ~45 minutes to download each block at ~80 MiB/s (almost 7 hours to download all the blocks)

![Screen Shot 2022-07-05 at 3 11 31 PM](https://user-images.githubusercontent.com/4027760/177425644-5c58bad2-3685-4c02-b48e-ca3165bef809.png)
 
* Download chunks in parallel

This change already improved the download time quite a bit from 45min per block to ~10 min per block at ~ 580 MiB/s.

![Screen Shot 2022-07-05 at 3 13 55 PM](https://user-images.githubusercontent.com/4027760/177425918-e04fc597-92ca-449d-baf3-edc62a7bb7ac.png)

We can still see the 10 min gaps between blocks where thanos is reading the index (GatherIndexHealthStats).

* `Download blocks in parallel`

This change tries to take advantage of the time thanos is reading the index to continue to download blocks.

![Screen Shot 2022-07-05 at 3 20 53 PM](https://user-images.githubusercontent.com/4027760/177426768-9088f548-d0b5-4f29-80ad-8e1cf60d0d83.png)

With both change the time required to download and read the index of all blocks decreased from almost 7 hours to ~1 hour.

PS: We may wanna limit the download concurrency.

## Changes
* Download chunks in parallel
* * `Download blocks in parallel`
<!-- Enumerate changes you made -->

## Verification

draft
