### PR TITLE
E2E Tests: Use default HTTP config for minio tests

### DIFF
--- a/test/e2e/e2ethanos/services.go
+++ b/test/e2e/e2ethanos/services.go
@@ -967,19 +967,20 @@ func genCerts(certPath, privkeyPath, caPath, serverName string) error {
 }
 
 func NewS3Config(bucket, endpoint, basePath string) s3.Config {
+	httpDefaultConf := s3.DefaultConfig.HTTPConfig
+	httpDefaultConf.TLSConfig = exthttp.TLSConfig{
+		CAFile:   filepath.Join(basePath, "certs", "CAs", "ca.crt"),
+		CertFile: filepath.Join(basePath, "certs", "public.crt"),
+		KeyFile:  filepath.Join(basePath, "certs", "private.key"),
+	}
+
 	return s3.Config{
-		Bucket:    bucket,
-		AccessKey: e2edb.MinioAccessKey,
-		SecretKey: e2edb.MinioSecretKey,
-		Endpoint:  endpoint,
-		Insecure:  false,
-		HTTPConfig: exthttp.HTTPConfig{
-			TLSConfig: exthttp.TLSConfig{
-				CAFile:   filepath.Join(basePath, "certs", "CAs", "ca.crt"),
-				CertFile: filepath.Join(basePath, "certs", "public.crt"),
-				KeyFile:  filepath.Join(basePath, "certs", "private.key"),
-			},
-		},
+		Bucket:           bucket,
+		AccessKey:        e2edb.MinioAccessKey,
+		SecretKey:        e2edb.MinioSecretKey,
+		Endpoint:         endpoint,
+		Insecure:         false,
+		HTTPConfig:       httpDefaultConf,
 		BucketLookupType: s3.AutoLookup,
 	}
 }


### PR DESCRIPTION
Signed-off-by: Matej Gera <matejgera@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [X] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

Use the same default HTTP config as we use for S3 in tests. Although tests are working, we've been seeing some output indicating `minio` might be struggling (#5474) and I assume this might be due to improper HTTP client config. After the change, I've seen decrease in client-related error messages from `minio` during a test run.

## Verification

Tests ran locally :ok_hand: 
