### PR TITLE
Bump go version in go mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -251,4 +251,4 @@ replace (
 	k8s.io/klog/v2 => github.com/simonpasquier/klog-gokit/v2 v2.0.1
 )
 
-go 1.17
+go 1.18


### PR DESCRIPTION
This is a follow up to #5258, which made the project be built with Go 1.18.

Signed-off-by: Douglas Camata <159076+douglascamata@users.noreply.github.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Update Go version in go.mod. Follows up with work from #5258.

## Verification

<!-- How you tested it? How do you know it works? -->
Built the project with Go 1.18.