### PR TITLE
bump codemirror and promql editor to the last version

### DIFF
--- a/pkg/ui/react-app/package-lock.json
+++ b/pkg/ui/react-app/package-lock.json
@@ -8,27 +8,22 @@
       "name": "graph",
       "version": "0.1.0",
       "dependencies": {
-        "@codemirror/autocomplete": "^0.19.5",
-        "@codemirror/closebrackets": "^0.19.0",
-        "@codemirror/commands": "^0.19.5",
-        "@codemirror/comment": "^0.19.0",
-        "@codemirror/highlight": "^0.19.6",
-        "@codemirror/history": "^0.19.0",
-        "@codemirror/language": "^0.19.3",
-        "@codemirror/lint": "^0.19.3",
-        "@codemirror/matchbrackets": "^0.19.3",
-        "@codemirror/search": "^0.19.2",
-        "@codemirror/state": "^0.19.5",
-        "@codemirror/view": "^0.19.15",
+        "@codemirror/autocomplete": "^6.0.4",
+        "@codemirror/commands": "^6.0.1",
+        "@codemirror/language": "^6.2.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/search": "^6.0.0",
+        "@codemirror/state": "^6.1.0",
+        "@codemirror/view": "^6.0.3",
         "@forevolve/bootstrap-dark": "^1.0.0",
         "@fortawesome/fontawesome-svg-core": "^1.2.34",
         "@fortawesome/free-solid-svg-icons": "^5.15.2",
         "@fortawesome/react-fontawesome": "^0.1.14",
         "@nexucis/fuzzy": "^0.3.0",
         "@nexucis/kvsearch": "^0.5.0",
+        "@prometheus-io/codemirror-promql": "^0.37.0-rc.1",
         "@reach/router": "^1.3.4",
         "bootstrap": "^4.6.0",
-        "codemirror-promql": "^0.19.0",
         "css.escape": "^1.5.1",
         "downshift": "^6.1.0",
         "i": "^0.3.7",
@@ -2012,182 +2007,77 @@
       "dev": true
     },
     "node_modules/@codemirror/autocomplete": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-0.19.12.tgz",
-      "integrity": "sha512-zUQYo5gMdv7vhxlKoAY/vnNCGzlE9AU7+P649v3ovpQpoFdo3U1Nt01EJqFb4Sfaw6l1U/Elc9Iksd1lDy+MVw==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.0.4.tgz",
+      "integrity": "sha512-uP7UodCRykPNwSAN+wYa/AS9gJI/V47echCAXUYgCgBXy3l19nwO7W/d29COtG/dfAsjBOhMDeh3Ms8Y5VZbrA==",
       "dependencies": {
-        "@codemirror/language": "^0.19.0",
-        "@codemirror/state": "^0.19.4",
-        "@codemirror/text": "^0.19.2",
-        "@codemirror/tooltip": "^0.19.12",
-        "@codemirror/view": "^0.19.0",
-        "@lezer/common": "^0.15.0"
-      }
-    },
-    "node_modules/@codemirror/closebrackets": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/closebrackets/-/closebrackets-0.19.0.tgz",
-      "integrity": "sha512-dFWX5OEVYWRNtGaifSbwIAlymnRRjxWMiMbffbAjF7p0zfGHDbdGkiT56q3Xud63h5/tQdSo5dK1iyNTzHz5vg==",
-      "dependencies": {
-        "@codemirror/language": "^0.19.0",
-        "@codemirror/rangeset": "^0.19.0",
-        "@codemirror/state": "^0.19.0",
-        "@codemirror/text": "^0.19.0",
-        "@codemirror/view": "^0.19.0"
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/common": "^1.0.0"
+      },
+      "peerDependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/common": "^1.0.0"
       }
     },
     "node_modules/@codemirror/commands": {
-      "version": "0.19.5",
-      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-0.19.5.tgz",
-      "integrity": "sha512-8PZOtx7d/GbKhFYA88zs2wINDtaUgj3pEjLYScKTd/Vsyw8qOp86tJQQNnMFTRZj/ISQl9Lbg3aAmHvroMqspw==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.0.1.tgz",
+      "integrity": "sha512-iNHDByicYqQjs0Wo1MKGfqNbMYMyhS9WV6EwMVwsHXImlFemgEUC+c5X22bXKBStN3qnwg4fArNZM+gkv22baQ==",
       "dependencies": {
-        "@codemirror/language": "^0.19.0",
-        "@codemirror/matchbrackets": "^0.19.0",
-        "@codemirror/state": "^0.19.2",
-        "@codemirror/text": "^0.19.0",
-        "@codemirror/view": "^0.19.0",
-        "@lezer/common": "^0.15.0"
-      }
-    },
-    "node_modules/@codemirror/comment": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/comment/-/comment-0.19.0.tgz",
-      "integrity": "sha512-3hqAd0548fxqOBm4khFMcXVIivX8p0bSlbAuZJ6PNoUn/0wXhxkxowPp0FmFzU2+y37Z+ZQF5cRB5EREWPRIiQ==",
-      "dependencies": {
-        "@codemirror/state": "^0.19.0",
-        "@codemirror/text": "^0.19.0",
-        "@codemirror/view": "^0.19.0"
-      }
-    },
-    "node_modules/@codemirror/gutter": {
-      "version": "0.19.4",
-      "resolved": "https://registry.npmjs.org/@codemirror/gutter/-/gutter-0.19.4.tgz",
-      "integrity": "sha512-zcDtGafuzLs9mvSBqHVuLNbS4UpHBo1+DRY6NtZfC31bV8abDxOPgokq2+6UsVPQp+RA1LgmPHatp4gOYSM+cA==",
-      "dependencies": {
-        "@codemirror/rangeset": "^0.19.0",
-        "@codemirror/state": "^0.19.0",
-        "@codemirror/view": "^0.19.0"
-      }
-    },
-    "node_modules/@codemirror/highlight": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@codemirror/highlight/-/highlight-0.19.6.tgz",
-      "integrity": "sha512-+eibu6on9quY8uN3xJ/n3rH+YIDLlpX7YulVmFvqAIz/ukRQ5tWaBmB7fMixHmnmRIRBRZgB8rNtonuMwZSAHQ==",
-      "dependencies": {
-        "@codemirror/language": "^0.19.0",
-        "@codemirror/rangeset": "^0.19.0",
-        "@codemirror/state": "^0.19.0",
-        "@codemirror/view": "^0.19.0",
-        "@lezer/common": "^0.15.0",
-        "style-mod": "^4.0.0"
-      }
-    },
-    "node_modules/@codemirror/history": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/history/-/history-0.19.0.tgz",
-      "integrity": "sha512-E0H+lncH66IMDhaND9jgkjE7s0dhYfjCPmS+Ig2Yes9I8+UIEecIdObj8c8HPCFGctGg3fxXqRAw2mdHl2Wouw==",
-      "dependencies": {
-        "@codemirror/state": "^0.19.0",
-        "@codemirror/view": "^0.19.0"
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/common": "^1.0.0"
       }
     },
     "node_modules/@codemirror/language": {
-      "version": "0.19.7",
-      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-0.19.7.tgz",
-      "integrity": "sha512-pNNUtYWMIMG0lUSKyUXJr8U0rFiCKsKFXbA2Oj17PC+S1FY99hV0z1vcntW67ekAIZw9DMEUQnLsKBuIbAUX7Q==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.2.0.tgz",
+      "integrity": "sha512-tabB0Ef/BflwoEmTB4a//WZ9P90UQyne9qWB9YFsmeS4bnEqSys7UpGk/da1URMXhyfuzWCwp+AQNMhvu8SfnA==",
       "dependencies": {
-        "@codemirror/state": "^0.19.0",
-        "@codemirror/text": "^0.19.0",
-        "@codemirror/view": "^0.19.0",
-        "@lezer/common": "^0.15.5",
-        "@lezer/lr": "^0.15.0"
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0",
+        "style-mod": "^4.0.0"
       }
     },
     "node_modules/@codemirror/lint": {
-      "version": "0.19.3",
-      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-0.19.3.tgz",
-      "integrity": "sha512-+c39s05ybD2NjghxkPFsUbH/qBL0cdzKmtHbzUm0RVspeL2OiP7uHYJ6J5+Qr9RjMIPWzcqSauRqxfmCrctUfg==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.0.0.tgz",
+      "integrity": "sha512-nUUXcJW1Xp54kNs+a1ToPLK8MadO0rMTnJB8Zk4Z8gBdrN0kqV7uvUraU/T2yqg+grDNR38Vmy/MrhQN/RgwiA==",
       "dependencies": {
-        "@codemirror/gutter": "^0.19.4",
-        "@codemirror/panel": "^0.19.0",
-        "@codemirror/rangeset": "^0.19.1",
-        "@codemirror/state": "^0.19.4",
-        "@codemirror/tooltip": "^0.19.5",
-        "@codemirror/view": "^0.19.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
         "crelt": "^1.0.5"
       }
     },
-    "node_modules/@codemirror/matchbrackets": {
-      "version": "0.19.3",
-      "resolved": "https://registry.npmjs.org/@codemirror/matchbrackets/-/matchbrackets-0.19.3.tgz",
-      "integrity": "sha512-ljkrBxaLgh8jesroUiBa57pdEwqJamxkukXrJpL9LdyFZVJaF+9TldhztRaMsMZO1XnCSSHQ9sg32iuHo7Sc2g==",
-      "dependencies": {
-        "@codemirror/language": "^0.19.0",
-        "@codemirror/state": "^0.19.0",
-        "@codemirror/view": "^0.19.0",
-        "@lezer/common": "^0.15.0"
-      }
-    },
-    "node_modules/@codemirror/panel": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/panel/-/panel-0.19.0.tgz",
-      "integrity": "sha512-LJuu49xnuhaAztlhnLJQ57ddOirSyf8/lnl7twsQUG/05RkxodBZ9F7q8r5AOLqOkaQOy9WySEKX1Ur8lD9Q5w==",
-      "dependencies": {
-        "@codemirror/state": "^0.19.0",
-        "@codemirror/view": "^0.19.0"
-      }
-    },
-    "node_modules/@codemirror/rangeset": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@codemirror/rangeset/-/rangeset-0.19.6.tgz",
-      "integrity": "sha512-wYtgGnW2Jtrh2nj7vpcBoEZib+jfyilrLN6w7YMTzzSRN8xXhYRorOUg4VQIa1JwFcMQrjSCkIdqXsDqOX1cYg==",
-      "dependencies": {
-        "@codemirror/state": "^0.19.0"
-      }
-    },
     "node_modules/@codemirror/search": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-0.19.2.tgz",
-      "integrity": "sha512-TrRxUxyJ/a7HXtUvMZhgkOUbKE1xO33UhXjn1XACEHKWhgovw1vEeEEti9dZejN8/QOOFJed39InUxmp7oQ8HA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.0.0.tgz",
+      "integrity": "sha512-rL0rd3AhI0TAsaJPUaEwC63KHLO7KL0Z/dYozXj6E7L3wNHRyx7RfE0/j5HsIf912EE5n2PCb4Vg0rGYmDv4UQ==",
       "dependencies": {
-        "@codemirror/panel": "^0.19.0",
-        "@codemirror/rangeset": "^0.19.0",
-        "@codemirror/state": "^0.19.2",
-        "@codemirror/text": "^0.19.0",
-        "@codemirror/view": "^0.19.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
         "crelt": "^1.0.5"
       }
     },
     "node_modules/@codemirror/state": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-0.19.6.tgz",
-      "integrity": "sha512-sqIQZE9VqwQj7D4c2oz9mfLhlT1ElAzGB5lO1lE33BPyrdNy1cJyCIOecT4cn4VeJOFrnjOeu+IftZ3zqdFETw==",
-      "dependencies": {
-        "@codemirror/text": "^0.19.0"
-      }
-    },
-    "node_modules/@codemirror/text": {
-      "version": "0.19.5",
-      "resolved": "https://registry.npmjs.org/@codemirror/text/-/text-0.19.5.tgz",
-      "integrity": "sha512-Syu5Xc7tZzeUAM/y4fETkT0zgGr48rDG+w4U38bPwSIUr+L9S/7w2wDE1WGNzjaZPz12F6gb1gxWiSTg9ocLow=="
-    },
-    "node_modules/@codemirror/tooltip": {
-      "version": "0.19.13",
-      "resolved": "https://registry.npmjs.org/@codemirror/tooltip/-/tooltip-0.19.13.tgz",
-      "integrity": "sha512-7vgvjQjwFQ9hPejw2s+w3UR1XAYjQ5M0F9HRwutXkZHP1tBFV7LnNJ3xBD7F9SR9kAh8WgdL3BpUsEwX1aqoQg==",
-      "dependencies": {
-        "@codemirror/state": "^0.19.0",
-        "@codemirror/view": "^0.19.0"
-      }
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.1.0.tgz",
+      "integrity": "sha512-qbUr94DZTe6/V1VS7LDLz11rM/1t/nJxR1El4I6UaxDEdc0aZZvq6JCLJWiRmUf95NRAnDH6fhXn+PWp9wGCIg=="
     },
     "node_modules/@codemirror/view": {
-      "version": "0.19.40",
-      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-0.19.40.tgz",
-      "integrity": "sha512-0CQV99+/nIKTVVbDs0XjW4Rkp8TobzJBXRaUHF6mOroVjuIBBcolE1eAGVEU5LrCS44C798jiP4r/HhLDNS+rw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.0.3.tgz",
+      "integrity": "sha512-1gDBymhbx2DZzwnR/rNUu1LiQqjxBJtFiB+4uLR6tHQ6vKhTIwUsP5uZUQ7SM7JxVx3UihMynnTqjcsC+mczZg==",
       "dependencies": {
-        "@codemirror/rangeset": "^0.19.5",
-        "@codemirror/state": "^0.19.3",
-        "@codemirror/text": "^0.19.0",
+        "@codemirror/state": "^6.0.0",
         "style-mod": "^4.0.0",
         "w3c-keyname": "^2.2.4"
       }
@@ -3740,16 +3630,24 @@
       }
     },
     "node_modules/@lezer/common": {
-      "version": "0.15.11",
-      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-0.15.11.tgz",
-      "integrity": "sha512-vv0nSdIaVCRcJ8rPuDdsrNVfBOYe/4Szr/LhF929XyDmBndLDuWiCCHooGlGlJfzELyO608AyDhVsuX/ZG36NA=="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.0.0.tgz",
+      "integrity": "sha512-ohydQe+Hb+w4oMDvXzs8uuJd2NoA3D8YDcLiuDsLqH+yflDTPEpgCsWI3/6rH5C3BAedtH1/R51dxENldQceEA=="
+    },
+    "node_modules/@lezer/highlight": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.0.0.tgz",
+      "integrity": "sha512-nsCnNtim90UKsB5YxoX65v3GEIw3iCHw9RM2DtdgkiqAbKh9pCdvi8AWNwkYf10Lu6fxNhXPpkpHbW6mihhvJA==",
+      "dependencies": {
+        "@lezer/common": "^1.0.0"
+      }
     },
     "node_modules/@lezer/lr": {
-      "version": "0.15.4",
-      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-0.15.4.tgz",
-      "integrity": "sha512-vwgG80sihEGJn6wJp6VijXrnzVai/KPva/OzYKaWvIx0IiXKjoMQ8UAwcgpSBwfS4Fbz3IKOX/cCNXU3r1FvpQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.2.0.tgz",
+      "integrity": "sha512-TgEpfm9br2SX8JwtwKT8HsQZKuFkLRg6g+IRxObk9nVKQLKnkP3oMh+QGcTBL9GQsfQ2ADtKPbj2iGSMf3ytiA==",
       "dependencies": {
-        "@lezer/common": "^0.15.0"
+        "@lezer/common": "^1.0.0"
       }
     },
     "node_modules/@nexucis/fuzzy": {
@@ -3924,6 +3822,35 @@
       "dev": true,
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@prometheus-io/codemirror-promql": {
+      "version": "0.37.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@prometheus-io/codemirror-promql/-/codemirror-promql-0.37.0-rc.1.tgz",
+      "integrity": "sha512-xKPfR5a6QGX47gavJYui2YOYopXwOOiT/uUAOZ7m6rEZTeg1txtuomQ1E3SYS8A4Soq54KJvlCZemcZtSwmQ2A==",
+      "dependencies": {
+        "@prometheus-io/lezer-promql": "^0.37.0-rc.1",
+        "lru-cache": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@prometheus-io/lezer-promql": {
+      "version": "0.37.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@prometheus-io/lezer-promql/-/lezer-promql-0.37.0-rc.1.tgz",
+      "integrity": "sha512-E37+NepTuYODk2BEms/2qwYbpFyNKr5mDIGcX26GxHhmY5NMCp1ZKsTBIUKAU9urY25w4c/ncryW6KVG8Vd4rw==",
+      "peerDependencies": {
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
       }
     },
     "node_modules/@reach/router": {
@@ -6535,26 +6462,6 @@
       },
       "engines": {
         "node": ">= 4.0"
-      }
-    },
-    "node_modules/codemirror-promql": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/codemirror-promql/-/codemirror-promql-0.19.0.tgz",
-      "integrity": "sha512-SUomAfs8S2+UihtCYMEG7e+5DYCDJTJiTOJjqSXSAylHacgyx5z/V20vA4KA7uSe+KHgKXxjM6R9ZOfkz4SJPg==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "peerDependencies": {
-        "@codemirror/autocomplete": "^0.19.9",
-        "@codemirror/highlight": "^0.19.6",
-        "@codemirror/language": "^0.19.7",
-        "@codemirror/lint": "^0.19.3",
-        "@codemirror/state": "^0.19.6",
-        "@codemirror/view": "^0.19.27",
-        "@lezer/common": "^0.15.11"
       }
     },
     "node_modules/collect-v8-coverage": {
@@ -19613,6 +19520,7 @@
     },
     "node_modules/w3c-keyname": {
       "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.4.tgz",
       "integrity": "sha512-tOhfEwEzFLJzf6d1ZPkYfGj+FWhIpBux9ppoP3rlclw3Z0BZv3N7b7030Z1kYth+6rDuAsXUFr+d0VE6Ed1ikw=="
     },
     "node_modules/w3c-xmlserializer": {
@@ -21921,182 +21829,71 @@
       "dev": true
     },
     "@codemirror/autocomplete": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-0.19.12.tgz",
-      "integrity": "sha512-zUQYo5gMdv7vhxlKoAY/vnNCGzlE9AU7+P649v3ovpQpoFdo3U1Nt01EJqFb4Sfaw6l1U/Elc9Iksd1lDy+MVw==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.0.4.tgz",
+      "integrity": "sha512-uP7UodCRykPNwSAN+wYa/AS9gJI/V47echCAXUYgCgBXy3l19nwO7W/d29COtG/dfAsjBOhMDeh3Ms8Y5VZbrA==",
       "requires": {
-        "@codemirror/language": "^0.19.0",
-        "@codemirror/state": "^0.19.4",
-        "@codemirror/text": "^0.19.2",
-        "@codemirror/tooltip": "^0.19.12",
-        "@codemirror/view": "^0.19.0",
-        "@lezer/common": "^0.15.0"
-      }
-    },
-    "@codemirror/closebrackets": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/closebrackets/-/closebrackets-0.19.0.tgz",
-      "integrity": "sha512-dFWX5OEVYWRNtGaifSbwIAlymnRRjxWMiMbffbAjF7p0zfGHDbdGkiT56q3Xud63h5/tQdSo5dK1iyNTzHz5vg==",
-      "requires": {
-        "@codemirror/language": "^0.19.0",
-        "@codemirror/rangeset": "^0.19.0",
-        "@codemirror/state": "^0.19.0",
-        "@codemirror/text": "^0.19.0",
-        "@codemirror/view": "^0.19.0"
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/common": "^1.0.0"
       }
     },
     "@codemirror/commands": {
-      "version": "0.19.5",
-      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-0.19.5.tgz",
-      "integrity": "sha512-8PZOtx7d/GbKhFYA88zs2wINDtaUgj3pEjLYScKTd/Vsyw8qOp86tJQQNnMFTRZj/ISQl9Lbg3aAmHvroMqspw==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.0.1.tgz",
+      "integrity": "sha512-iNHDByicYqQjs0Wo1MKGfqNbMYMyhS9WV6EwMVwsHXImlFemgEUC+c5X22bXKBStN3qnwg4fArNZM+gkv22baQ==",
       "requires": {
-        "@codemirror/language": "^0.19.0",
-        "@codemirror/matchbrackets": "^0.19.0",
-        "@codemirror/state": "^0.19.2",
-        "@codemirror/text": "^0.19.0",
-        "@codemirror/view": "^0.19.0",
-        "@lezer/common": "^0.15.0"
-      }
-    },
-    "@codemirror/comment": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/comment/-/comment-0.19.0.tgz",
-      "integrity": "sha512-3hqAd0548fxqOBm4khFMcXVIivX8p0bSlbAuZJ6PNoUn/0wXhxkxowPp0FmFzU2+y37Z+ZQF5cRB5EREWPRIiQ==",
-      "requires": {
-        "@codemirror/state": "^0.19.0",
-        "@codemirror/text": "^0.19.0",
-        "@codemirror/view": "^0.19.0"
-      }
-    },
-    "@codemirror/gutter": {
-      "version": "0.19.4",
-      "resolved": "https://registry.npmjs.org/@codemirror/gutter/-/gutter-0.19.4.tgz",
-      "integrity": "sha512-zcDtGafuzLs9mvSBqHVuLNbS4UpHBo1+DRY6NtZfC31bV8abDxOPgokq2+6UsVPQp+RA1LgmPHatp4gOYSM+cA==",
-      "requires": {
-        "@codemirror/rangeset": "^0.19.0",
-        "@codemirror/state": "^0.19.0",
-        "@codemirror/view": "^0.19.0"
-      }
-    },
-    "@codemirror/highlight": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@codemirror/highlight/-/highlight-0.19.6.tgz",
-      "integrity": "sha512-+eibu6on9quY8uN3xJ/n3rH+YIDLlpX7YulVmFvqAIz/ukRQ5tWaBmB7fMixHmnmRIRBRZgB8rNtonuMwZSAHQ==",
-      "requires": {
-        "@codemirror/language": "^0.19.0",
-        "@codemirror/rangeset": "^0.19.0",
-        "@codemirror/state": "^0.19.0",
-        "@codemirror/view": "^0.19.0",
-        "@lezer/common": "^0.15.0",
-        "style-mod": "^4.0.0"
-      }
-    },
-    "@codemirror/history": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/history/-/history-0.19.0.tgz",
-      "integrity": "sha512-E0H+lncH66IMDhaND9jgkjE7s0dhYfjCPmS+Ig2Yes9I8+UIEecIdObj8c8HPCFGctGg3fxXqRAw2mdHl2Wouw==",
-      "requires": {
-        "@codemirror/state": "^0.19.0",
-        "@codemirror/view": "^0.19.0"
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/common": "^1.0.0"
       }
     },
     "@codemirror/language": {
-      "version": "0.19.7",
-      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-0.19.7.tgz",
-      "integrity": "sha512-pNNUtYWMIMG0lUSKyUXJr8U0rFiCKsKFXbA2Oj17PC+S1FY99hV0z1vcntW67ekAIZw9DMEUQnLsKBuIbAUX7Q==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.2.0.tgz",
+      "integrity": "sha512-tabB0Ef/BflwoEmTB4a//WZ9P90UQyne9qWB9YFsmeS4bnEqSys7UpGk/da1URMXhyfuzWCwp+AQNMhvu8SfnA==",
       "requires": {
-        "@codemirror/state": "^0.19.0",
-        "@codemirror/text": "^0.19.0",
-        "@codemirror/view": "^0.19.0",
-        "@lezer/common": "^0.15.5",
-        "@lezer/lr": "^0.15.0"
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0",
+        "style-mod": "^4.0.0"
       }
     },
     "@codemirror/lint": {
-      "version": "0.19.3",
-      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-0.19.3.tgz",
-      "integrity": "sha512-+c39s05ybD2NjghxkPFsUbH/qBL0cdzKmtHbzUm0RVspeL2OiP7uHYJ6J5+Qr9RjMIPWzcqSauRqxfmCrctUfg==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.0.0.tgz",
+      "integrity": "sha512-nUUXcJW1Xp54kNs+a1ToPLK8MadO0rMTnJB8Zk4Z8gBdrN0kqV7uvUraU/T2yqg+grDNR38Vmy/MrhQN/RgwiA==",
       "requires": {
-        "@codemirror/gutter": "^0.19.4",
-        "@codemirror/panel": "^0.19.0",
-        "@codemirror/rangeset": "^0.19.1",
-        "@codemirror/state": "^0.19.4",
-        "@codemirror/tooltip": "^0.19.5",
-        "@codemirror/view": "^0.19.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
         "crelt": "^1.0.5"
       }
     },
-    "@codemirror/matchbrackets": {
-      "version": "0.19.3",
-      "resolved": "https://registry.npmjs.org/@codemirror/matchbrackets/-/matchbrackets-0.19.3.tgz",
-      "integrity": "sha512-ljkrBxaLgh8jesroUiBa57pdEwqJamxkukXrJpL9LdyFZVJaF+9TldhztRaMsMZO1XnCSSHQ9sg32iuHo7Sc2g==",
-      "requires": {
-        "@codemirror/language": "^0.19.0",
-        "@codemirror/state": "^0.19.0",
-        "@codemirror/view": "^0.19.0",
-        "@lezer/common": "^0.15.0"
-      }
-    },
-    "@codemirror/panel": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/panel/-/panel-0.19.0.tgz",
-      "integrity": "sha512-LJuu49xnuhaAztlhnLJQ57ddOirSyf8/lnl7twsQUG/05RkxodBZ9F7q8r5AOLqOkaQOy9WySEKX1Ur8lD9Q5w==",
-      "requires": {
-        "@codemirror/state": "^0.19.0",
-        "@codemirror/view": "^0.19.0"
-      }
-    },
-    "@codemirror/rangeset": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@codemirror/rangeset/-/rangeset-0.19.6.tgz",
-      "integrity": "sha512-wYtgGnW2Jtrh2nj7vpcBoEZib+jfyilrLN6w7YMTzzSRN8xXhYRorOUg4VQIa1JwFcMQrjSCkIdqXsDqOX1cYg==",
-      "requires": {
-        "@codemirror/state": "^0.19.0"
-      }
-    },
     "@codemirror/search": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-0.19.2.tgz",
-      "integrity": "sha512-TrRxUxyJ/a7HXtUvMZhgkOUbKE1xO33UhXjn1XACEHKWhgovw1vEeEEti9dZejN8/QOOFJed39InUxmp7oQ8HA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.0.0.tgz",
+      "integrity": "sha512-rL0rd3AhI0TAsaJPUaEwC63KHLO7KL0Z/dYozXj6E7L3wNHRyx7RfE0/j5HsIf912EE5n2PCb4Vg0rGYmDv4UQ==",
       "requires": {
-        "@codemirror/panel": "^0.19.0",
-        "@codemirror/rangeset": "^0.19.0",
-        "@codemirror/state": "^0.19.2",
-        "@codemirror/text": "^0.19.0",
-        "@codemirror/view": "^0.19.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
         "crelt": "^1.0.5"
       }
     },
     "@codemirror/state": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-0.19.6.tgz",
-      "integrity": "sha512-sqIQZE9VqwQj7D4c2oz9mfLhlT1ElAzGB5lO1lE33BPyrdNy1cJyCIOecT4cn4VeJOFrnjOeu+IftZ3zqdFETw==",
-      "requires": {
-        "@codemirror/text": "^0.19.0"
-      }
-    },
-    "@codemirror/text": {
-      "version": "0.19.5",
-      "resolved": "https://registry.npmjs.org/@codemirror/text/-/text-0.19.5.tgz",
-      "integrity": "sha512-Syu5Xc7tZzeUAM/y4fETkT0zgGr48rDG+w4U38bPwSIUr+L9S/7w2wDE1WGNzjaZPz12F6gb1gxWiSTg9ocLow=="
-    },
-    "@codemirror/tooltip": {
-      "version": "0.19.13",
-      "resolved": "https://registry.npmjs.org/@codemirror/tooltip/-/tooltip-0.19.13.tgz",
-      "integrity": "sha512-7vgvjQjwFQ9hPejw2s+w3UR1XAYjQ5M0F9HRwutXkZHP1tBFV7LnNJ3xBD7F9SR9kAh8WgdL3BpUsEwX1aqoQg==",
-      "requires": {
-        "@codemirror/state": "^0.19.0",
-        "@codemirror/view": "^0.19.0"
-      }
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.1.0.tgz",
+      "integrity": "sha512-qbUr94DZTe6/V1VS7LDLz11rM/1t/nJxR1El4I6UaxDEdc0aZZvq6JCLJWiRmUf95NRAnDH6fhXn+PWp9wGCIg=="
     },
     "@codemirror/view": {
-      "version": "0.19.40",
-      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-0.19.40.tgz",
-      "integrity": "sha512-0CQV99+/nIKTVVbDs0XjW4Rkp8TobzJBXRaUHF6mOroVjuIBBcolE1eAGVEU5LrCS44C798jiP4r/HhLDNS+rw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.0.3.tgz",
+      "integrity": "sha512-1gDBymhbx2DZzwnR/rNUu1LiQqjxBJtFiB+4uLR6tHQ6vKhTIwUsP5uZUQ7SM7JxVx3UihMynnTqjcsC+mczZg==",
       "requires": {
-        "@codemirror/rangeset": "^0.19.5",
-        "@codemirror/state": "^0.19.3",
-        "@codemirror/text": "^0.19.0",
+        "@codemirror/state": "^6.0.0",
         "style-mod": "^4.0.0",
         "w3c-keyname": "^2.2.4"
       }
@@ -23281,16 +23078,24 @@
       }
     },
     "@lezer/common": {
-      "version": "0.15.11",
-      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-0.15.11.tgz",
-      "integrity": "sha512-vv0nSdIaVCRcJ8rPuDdsrNVfBOYe/4Szr/LhF929XyDmBndLDuWiCCHooGlGlJfzELyO608AyDhVsuX/ZG36NA=="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.0.0.tgz",
+      "integrity": "sha512-ohydQe+Hb+w4oMDvXzs8uuJd2NoA3D8YDcLiuDsLqH+yflDTPEpgCsWI3/6rH5C3BAedtH1/R51dxENldQceEA=="
+    },
+    "@lezer/highlight": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.0.0.tgz",
+      "integrity": "sha512-nsCnNtim90UKsB5YxoX65v3GEIw3iCHw9RM2DtdgkiqAbKh9pCdvi8AWNwkYf10Lu6fxNhXPpkpHbW6mihhvJA==",
+      "requires": {
+        "@lezer/common": "^1.0.0"
+      }
     },
     "@lezer/lr": {
-      "version": "0.15.4",
-      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-0.15.4.tgz",
-      "integrity": "sha512-vwgG80sihEGJn6wJp6VijXrnzVai/KPva/OzYKaWvIx0IiXKjoMQ8UAwcgpSBwfS4Fbz3IKOX/cCNXU3r1FvpQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.2.0.tgz",
+      "integrity": "sha512-TgEpfm9br2SX8JwtwKT8HsQZKuFkLRg6g+IRxObk9nVKQLKnkP3oMh+QGcTBL9GQsfQ2ADtKPbj2iGSMf3ytiA==",
       "requires": {
-        "@lezer/common": "^0.15.0"
+        "@lezer/common": "^1.0.0"
       }
     },
     "@nexucis/fuzzy": {
@@ -23396,6 +23201,21 @@
           "dev": true
         }
       }
+    },
+    "@prometheus-io/codemirror-promql": {
+      "version": "0.37.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@prometheus-io/codemirror-promql/-/codemirror-promql-0.37.0-rc.1.tgz",
+      "integrity": "sha512-xKPfR5a6QGX47gavJYui2YOYopXwOOiT/uUAOZ7m6rEZTeg1txtuomQ1E3SYS8A4Soq54KJvlCZemcZtSwmQ2A==",
+      "requires": {
+        "@prometheus-io/lezer-promql": "^0.37.0-rc.1",
+        "lru-cache": "^6.0.0"
+      }
+    },
+    "@prometheus-io/lezer-promql": {
+      "version": "0.37.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@prometheus-io/lezer-promql/-/lezer-promql-0.37.0-rc.1.tgz",
+      "integrity": "sha512-E37+NepTuYODk2BEms/2qwYbpFyNKr5mDIGcX26GxHhmY5NMCp1ZKsTBIUKAU9urY25w4c/ncryW6KVG8Vd4rw==",
+      "requires": {}
     },
     "@reach/router": {
       "version": "1.3.4",
@@ -25422,14 +25242,6 @@
         "@types/q": "^1.5.1",
         "chalk": "^2.4.1",
         "q": "^1.1.2"
-      }
-    },
-    "codemirror-promql": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/codemirror-promql/-/codemirror-promql-0.19.0.tgz",
-      "integrity": "sha512-SUomAfs8S2+UihtCYMEG7e+5DYCDJTJiTOJjqSXSAylHacgyx5z/V20vA4KA7uSe+KHgKXxjM6R9ZOfkz4SJPg==",
-      "requires": {
-        "lru-cache": "^6.0.0"
       }
     },
     "collect-v8-coverage": {
@@ -35070,6 +34882,7 @@
     },
     "w3c-keyname": {
       "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.4.tgz",
       "integrity": "sha512-tOhfEwEzFLJzf6d1ZPkYfGj+FWhIpBux9ppoP3rlclw3Z0BZv3N7b7030Z1kYth+6rDuAsXUFr+d0VE6Ed1ikw=="
     },
     "w3c-xmlserializer": {

--- a/pkg/ui/react-app/package.json
+++ b/pkg/ui/react-app/package.json
@@ -3,27 +3,24 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@codemirror/autocomplete": "^0.19.5",
-    "@codemirror/closebrackets": "^0.19.0",
-    "@codemirror/commands": "^0.19.5",
-    "@codemirror/comment": "^0.19.0",
-    "@codemirror/highlight": "^0.19.6",
-    "@codemirror/history": "^0.19.0",
-    "@codemirror/language": "^0.19.3",
-    "@codemirror/lint": "^0.19.3",
-    "@codemirror/matchbrackets": "^0.19.3",
-    "@codemirror/search": "^0.19.2",
-    "@codemirror/state": "^0.19.5",
-    "@codemirror/view": "^0.19.15",
+    "@codemirror/autocomplete": "^6.0.4",
+    "@codemirror/commands": "^6.0.1",
+    "@codemirror/language": "^6.2.0",
+    "@codemirror/lint": "^6.0.0",
+    "@codemirror/search": "^6.0.0",
+    "@codemirror/state": "^6.1.0",
+    "@codemirror/view": "^6.0.3",
     "@forevolve/bootstrap-dark": "^1.0.0",
     "@fortawesome/fontawesome-svg-core": "^1.2.34",
     "@fortawesome/free-solid-svg-icons": "^5.15.2",
     "@fortawesome/react-fontawesome": "^0.1.14",
+    "@lezer/common": "^1.0.0",
+    "@lezer/highlight": "^1.0.0",
     "@nexucis/fuzzy": "^0.3.0",
     "@nexucis/kvsearch": "^0.5.0",
+    "@prometheus-io/codemirror-promql": "^0.37.0-rc.1",
     "@reach/router": "^1.3.4",
     "bootstrap": "^4.6.0",
-    "codemirror-promql": "^0.19.0",
     "css.escape": "^1.5.1",
     "downshift": "^6.1.0",
     "i": "^0.3.7",
@@ -106,8 +103,12 @@
       "enzyme-to-json/serializer"
     ],
     "transformIgnorePatterns": [
-      "/node_modules/(?!codemirror-promql).+(js|jsx)$"
-    ]
+      "<rootDir>/node_modules/(?!@prometheus-io/codemirror-promql)/",
+      "<rootDir>/node_modules/(?!@prometheus-io/lezer-promql)/"
+    ],
+    "moduleNameMapper": {
+      "lezer-promql": "<rootDir>/node_modules/@prometheus-io/lezer-promql/dist/index.cjs"
+    }
   },
   "optionalDependencies": {
     "fsevents": "^2.3.2"

--- a/pkg/ui/react-app/src/pages/graph/CMTheme.tsx
+++ b/pkg/ui/react-app/src/pages/graph/CMTheme.tsx
@@ -4,8 +4,9 @@
    https://github.com/prometheus/prometheus/blob/main/LICENSE.
 */
 
-import { HighlightStyle, tags } from '@codemirror/highlight';
 import { EditorView } from '@codemirror/view';
+import { HighlightStyle } from '@codemirror/language';
+import { tags } from '@lezer/highlight';
 
 export const baseTheme = EditorView.theme({
   '&': {


### PR DESCRIPTION
This PR is following changes initially made in prometheus : https://github.com/prometheus/prometheus/pull/10841

After this PR, hopefully dependabot should be able to handle the update of the dependencies around `codemirror` and `@prometheus-io/codemirror` :)

Signed-off-by: Augustin Husson <husson.augustin@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
