### PR TITLE
Receiver: Fix data race in writer (label set copying)

### DIFF
--- a/pkg/store/labelpb/label_test.go
+++ b/pkg/store/labelpb/label_test.go
@@ -209,6 +209,18 @@ func BenchmarkTransformWithAndWithoutCopy(b *testing.B) {
 			ret = ZLabelsToPromLabels(lbls)
 		}
 	})
+	b.Run("ZLabelsToPromLabelsWithDeepCopy", func(b *testing.B) {
+		b.ReportAllocs()
+		lbls := make([]ZLabel, num)
+		for i := 0; i < num; i++ {
+			lbls[i] = ZLabel{Name: fmt.Sprintf(fmtLbl, i), Value: fmt.Sprintf(fmtLbl, i)}
+		}
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			ret = ZLabelsToPromLabels(DeepCopy(lbls))
+		}
+	})
 }
 
 func TestSortZLabelSets(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Matej Gera <matejgera@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

This is continuation of fixes detected during work on #4664.

We appear to be hitting a data race due to some concurrent read / write in write request's labels. See output:
```
 WARNING: DATA RACE
 Read at 0x00c000cc4f00 by goroutine 40:
 runtime.racereadrange()
 <autogenerated>:1 +0x1b
 github.com/thanos-io/thanos/pkg/store/storepb.(*WriteRequest).Size()
 /go/src/github.com/thanos-io/thanos/pkg/store/storepb/rpc.pb.go:2011 +0x224
 github.com/thanos-io/thanos/pkg/store/storepb.(*WriteRequest).Marshal()
 /go/src/github.com/thanos-io/thanos/pkg/store/storepb/rpc.pb.go:1204 +0x30
 google.golang.org/protobuf/internal/impl.legacyMarshal()
 /go/pkg/mod/google.golang.org/protobuf@v1.28.0/internal/impl/legacy_message.go:404 +0xbe
 google.golang.org/protobuf/proto.MarshalOptions.marshal()
 /go/pkg/mod/google.golang.org/protobuf@v1.28.0/proto/encode.go:163 +0x3b9
 google.golang.org/protobuf/proto.MarshalOptions.MarshalAppend()
 /go/pkg/mod/google.golang.org/protobuf@v1.28.0/proto/encode.go:122 +0xa5
 github.com/golang/protobuf/proto.marshalAppend()
 /go/pkg/mod/github.com/golang/protobuf@v1.5.2/proto/wire.go:40 +0xe4
 github.com/golang/protobuf/proto.Marshal()
 /go/pkg/mod/github.com/golang/protobuf@v1.5.2/proto/wire.go:23 +0x67
 google.golang.org/grpc/encoding/proto.codec.Marshal()
 /go/pkg/mod/google.golang.org/grpc@v1.40.1/encoding/proto/proto.go:45 +0x68
 google.golang.org/grpc/encoding/proto.(*codec).Marshal()
 <autogenerated>:1 +0x5b
 google.golang.org/grpc.encode()
 /go/pkg/mod/google.golang.org/grpc@v1.40.1/rpc_util.go:594 +0x6a
 google.golang.org/grpc.prepareMsg()
 /go/pkg/mod/google.golang.org/grpc@v1.40.1/stream.go:1603 +0x1ab
 google.golang.org/grpc.(*clientStream).SendMsg()
 /go/pkg/mod/google.golang.org/grpc@v1.40.1/stream.go:784 +0x29b
 google.golang.org/grpc.invoke()
 /go/pkg/mod/google.golang.org/grpc@v1.40.1/call.go:70 +0xfe
 github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors.UnaryClientInterceptor.func1()
 /go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware/v2@v2.0.0-rc.2.0.20201207153454-9f6bf00c00a7/interceptors/client.go:22 +0x29a
 github.com/grpc-ecosystem/go-grpc-middleware/v2.ChainUnaryClient.func1.1.1()
 /go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware/v2@v2.0.0-rc.2.0.20201207153454-9f6bf00c00a7/chain.go:74 +0x112
 github.com/grpc-ecosystem/go-grpc-prometheus.(*ClientMetrics).UnaryClientInterceptor.func1()
 /go/pkg/mod/github.com/grpc-ecosystem/go-grpc-prometheus@v1.2.0/client_metrics.go:112 +0x133
 github.com/grpc-ecosystem/go-grpc-middleware/v2.ChainUnaryClient.func1.1.1()
 /go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware/v2@v2.0.0-rc.2.0.20201207153454-9f6bf00c00a7/chain.go:74 +0x112
 github.com/grpc-ecosystem/go-grpc-middleware/v2.ChainUnaryClient.func1()
 /go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware/v2@v2.0.0-rc.2.0.20201207153454-9f6bf00c00a7/chain.go:83 +0x188
 google.golang.org/grpc.(*ClientConn).Invoke()
 /go/pkg/mod/google.golang.org/grpc@v1.40.1/call.go:35 +0x265
 github.com/thanos-io/thanos/pkg/store/storepb.(*writeableStoreClient).RemoteWrite()
 /go/src/github.com/thanos-io/thanos/pkg/store/storepb/rpc.pb.go:1124 +0xd4
 github.com/thanos-io/thanos/pkg/receive.(*Handler).fanoutForward.func4.2()
 /go/src/github.com/thanos-io/thanos/pkg/receive/handler.go:643 +0x246
 github.com/thanos-io/thanos/pkg/tracing.DoInSpan()
 /go/src/github.com/thanos-io/thanos/pkg/tracing/tracing.go:93 +0x135
 github.com/thanos-io/thanos/pkg/receive.(*Handler).fanoutForward.func4()
 /go/src/github.com/thanos-io/thanos/pkg/receive/handler.go:641 +0x41d
 github.com/thanos-io/thanos/pkg/receive.(*Handler).fanoutForward·dwrap·9()
 /go/src/github.com/thanos-io/thanos/pkg/receive/handler.go:674 +0x58
 Previous write at 0x00c000cc4f00 by goroutine 117:
 github.com/thanos-io/thanos/pkg/store/labelpb.ReAllocZLabelsStrings()
 /go/src/github.com/thanos-io/thanos/pkg/store/labelpb/label.go:50 +0x147
 github.com/thanos-io/thanos/pkg/receive.(*Writer).Write()
 /go/src/github.com/thanos-io/thanos/pkg/receive/writer.go:80 +0x2865
 github.com/thanos-io/thanos/pkg/receive.(*Handler).fanoutForward.func3.1()
 /go/src/github.com/thanos-io/thanos/pkg/receive/handler.go:591 +0xfe
 github.com/thanos-io/thanos/pkg/tracing.DoInSpan()
 /go/src/github.com/thanos-io/thanos/pkg/tracing/tracing.go:93 +0x135
 github.com/thanos-io/thanos/pkg/receive.(*Handler).fanoutForward.func3()
 /go/src/github.com/thanos-io/thanos/pkg/receive/handler.go:590 +0x1ed
 github.com/thanos-io/thanos/pkg/receive.(*Handler).fanoutForward·dwrap·8()
 /go/src/github.com/thanos-io/thanos/pkg/receive/handler.go:601 +0x58
 Goroutine 40 (running) created at:
 github.com/thanos-io/thanos/pkg/receive.(*Handler).fanoutForward()
 /go/src/github.com/thanos-io/thanos/pkg/receive/handler.go:607 +0xd67
 github.com/thanos-io/thanos/pkg/receive.(*Handler).replicate()
 /go/src/github.com/thanos-io/thanos/pkg/receive/handler.go:748 +0x3d3
 github.com/thanos-io/thanos/pkg/receive.(*Handler).fanoutForward.func2.1()
 /go/src/github.com/thanos-io/thanos/pkg/receive/handler.go:564 +0xda
 github.com/thanos-io/thanos/pkg/tracing.DoInSpan()
 /go/src/github.com/thanos-io/thanos/pkg/tracing/tracing.go:93 +0x135
 github.com/thanos-io/thanos/pkg/receive.(*Handler).fanoutForward.func2()
 /go/src/github.com/thanos-io/thanos/pkg/receive/handler.go:563 +0x1cf
 github.com/thanos-io/thanos/pkg/receive.(*Handler).fanoutForward·dwrap·7()
 /go/src/github.com/thanos-io/thanos/pkg/receive/handler.go:574 +0x58
 Goroutine 117 (running) created at:
 github.com/thanos-io/thanos/pkg/receive.(*Handler).fanoutForward()
 /go/src/github.com/thanos-io/thanos/pkg/receive/handler.go:586 +0x1078
 github.com/thanos-io/thanos/pkg/receive.(*Handler).replicate()
 /go/src/github.com/thanos-io/thanos/pkg/receive/handler.go:748 +0x3d3
 github.com/thanos-io/thanos/pkg/receive.(*Handler).fanoutForward.func2.1()
 /go/src/github.com/thanos-io/thanos/pkg/receive/handler.go:564 +0xda
 github.com/thanos-io/thanos/pkg/tracing.DoInSpan()
 /go/src/github.com/thanos-io/thanos/pkg/tracing/tracing.go:93 +0x135
 github.com/thanos-io/thanos/pkg/receive.(*Handler).fanoutForward.func2()
 /go/src/github.com/thanos-io/thanos/pkg/receive/handler.go:563 +0x1cf
 github.com/thanos-io/thanos/pkg/receive.(*Handler).fanoutForward·dwrap·7()
 /go/src/github.com/thanos-io/thanos/pkg/receive/handler.go:574 +0x58
```

Based on the logs, my assumption is that in the handler, we are re-using the `*prompb.WriteRequest` in the `fanoutForward` method - once for the [local node `Write`](https://github.com/thanos-io/thanos/blob/main/pkg/receive/handler.go#L591) and then for the [remote forward in `RemoteWrite`](https://github.com/thanos-io/thanos/blob/main/pkg/receive/handler.go#L644). It seems that doing some reallocation shuffling with the labels can interfere with gRPC message marshalling, as it seem to be re-using the same underlying memory.

The suggestion here is to make a short-lived separate copy of the label set (if ref is not available) before proceeding with the write on the local node. This should ensure we are no longer writing to the same object as we're reading from during marshalling. 

I'm not 100% not sure of performance implications though, seeing this is the main write path for receive.

<!-- Enumerate changes you made -->

## Verification

Rate the E2E reciever tests on top of #5066 with no data race being detected anymore.
