### PR TITLE
Receiver: Handle storage exemplar multi-error

### DIFF
--- a/pkg/receive/handler.go
+++ b/pkg/receive/handler.go
@@ -815,6 +815,9 @@ func isConflict(err error) bool {
 		err == storage.ErrDuplicateSampleForTimestamp ||
 		err == storage.ErrOutOfOrderSample ||
 		err == storage.ErrOutOfBounds ||
+		err == storage.ErrDuplicateExemplar ||
+		err == storage.ErrOutOfOrderExemplar ||
+		err == storage.ErrExemplarLabelLength ||
 		status.Code(err) == codes.AlreadyExists
 }
 

--- a/pkg/receive/handler_test.go
+++ b/pkg/receive/handler_test.go
@@ -105,6 +105,16 @@ func TestDetermineWriteErrorCause(t *testing.T) {
 			exp:       errConflict,
 		},
 		{
+			name: "matching multierror (exemplar error)",
+			err: errutil.NonNilMultiError([]error{
+				storage.ErrExemplarLabelLength,
+				errors.New("foo"),
+				errors.New("bar"),
+			}),
+			threshold: 1,
+			exp:       errConflict,
+		},
+		{
 			name: "matching but below threshold multierror",
 			err: errutil.NonNilMultiError([]error{
 				storage.ErrOutOfOrderSample,
@@ -138,6 +148,19 @@ func TestDetermineWriteErrorCause(t *testing.T) {
 			}),
 			threshold: 2,
 			exp:       errNotReady,
+		},
+		{
+			name: "matching multierror many, one above threshold (exemplar error)",
+			err: errutil.NonNilMultiError([]error{
+				tsdb.ErrNotReady,
+				tsdb.ErrNotReady,
+				storage.ErrDuplicateExemplar,
+				storage.ErrDuplicateSampleForTimestamp,
+				storage.ErrExemplarLabelLength,
+				errors.New("foo"),
+			}),
+			threshold: 2,
+			exp:       errConflict,
 		},
 		{
 			name: "matching multierror many, both above threshold, conflict have precedence",


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Currently, we are not considering exemplar storage errors to be conflict errors within our multi-error logic. This means that in cases when the majority of the errors comes from exemplar storage errors, these will 'fall through' and it will be determined that the error cause is internal server error (which would also cause Prometheus to retry remote write, which is not what we want in case of conflict-like storage error).

This PR proposes to handle exemplar storage errors the same way we handle sample storage errors - these should be considered conflict errors and handled appropriately in the multi-error logic as well.

## Verification

Added unit tests.