### PR TITLE
Fixing Race condition Introduced by #5493 

### DIFF
--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -1029,7 +1029,7 @@ func (cg *Group) compact(ctx context.Context, dir string, planner Planner, comp 
 
 		func(ctx context.Context, meta *metadata.Meta) {
 			g.Go(func() error {
-				tracing.DoInSpanWithErr(ctx, "compaction_block_download", func(ctx context.Context) error {
+				err := tracing.DoInSpanWithErr(ctx, "compaction_block_download", func(ctx context.Context) error {
 					err = block.Download(ctx, cg.logger, cg.bkt, meta.ULID, bdir, objstore.WithFetchConcurrency(cg.blockFilesConcurrency))
 					return err
 				}, opentracing.Tags{"block.id": meta.ULID})

--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -773,8 +773,7 @@ func (cg *Group) Compact(ctx context.Context, dir string, planner Planner, comp 
 		return false, ulid.ULID{}, errors.Wrap(err, "create compaction group dir")
 	}
 
-	var err error
-	tracing.DoInSpanWithErr(ctx, "compaction_group", func(ctx context.Context) error {
+	err := tracing.DoInSpanWithErr(ctx, "compaction_group", func(ctx context.Context) (err error) {
 		shouldRerun, compID, err = cg.compact(ctx, subDir, planner, comp)
 		return err
 	}, opentracing.Tags{"group.key": cg.Key()})
@@ -977,7 +976,7 @@ func RepairIssue347(ctx context.Context, logger log.Logger, bkt objstore.Bucket,
 	return nil
 }
 
-func (cg *Group) compact(ctx context.Context, dir string, planner Planner, comp Compactor) (shouldRerun bool, compID ulid.ULID, err error) {
+func (cg *Group) compact(ctx context.Context, dir string, planner Planner, comp Compactor) (shouldRerun bool, compID ulid.ULID, _ error) {
 	cg.mtx.Lock()
 	defer cg.mtx.Unlock()
 
@@ -994,11 +993,10 @@ func (cg *Group) compact(ctx context.Context, dir string, planner Planner, comp 
 	}
 
 	var toCompact []*metadata.Meta
-	tracing.DoInSpanWithErr(ctx, "compaction_planning", func(ctx context.Context) error {
-		toCompact, err = planner.Plan(ctx, cg.metasByMinTime)
-		return err
-	})
-	if err != nil {
+	if err := tracing.DoInSpanWithErr(ctx, "compaction_planning", func(ctx context.Context) (e error) {
+		toCompact, e = planner.Plan(ctx, cg.metasByMinTime)
+		return e
+	}); err != nil {
 		return false, ulid.ULID{}, errors.Wrap(err, "plan compaction")
 	}
 	if len(toCompact) == 0 {
@@ -1029,21 +1027,18 @@ func (cg *Group) compact(ctx context.Context, dir string, planner Planner, comp 
 
 		func(ctx context.Context, meta *metadata.Meta) {
 			g.Go(func() error {
-				err := tracing.DoInSpanWithErr(ctx, "compaction_block_download", func(ctx context.Context) error {
-					err = block.Download(ctx, cg.logger, cg.bkt, meta.ULID, bdir, objstore.WithFetchConcurrency(cg.blockFilesConcurrency))
-					return err
-				}, opentracing.Tags{"block.id": meta.ULID})
-				if err != nil {
+				if err := tracing.DoInSpanWithErr(ctx, "compaction_block_download", func(ctx context.Context) error {
+					return block.Download(ctx, cg.logger, cg.bkt, meta.ULID, bdir, objstore.WithFetchConcurrency(cg.blockFilesConcurrency))
+				}, opentracing.Tags{"block.id": meta.ULID}); err != nil {
 					return retry(errors.Wrapf(err, "download block %s", meta.ULID))
 				}
 
 				// Ensure all input blocks are valid.
 				var stats block.HealthStats
-				tracing.DoInSpanWithErr(ctx, "compaction_block_health_stats", func(ctx context.Context) error {
-					stats, err = block.GatherIndexHealthStats(cg.logger, filepath.Join(bdir, block.IndexFilename), meta.MinTime, meta.MaxTime)
-					return err
-				}, opentracing.Tags{"block.id": meta.ULID})
-				if err != nil {
+				if err := tracing.DoInSpanWithErr(ctx, "compaction_block_health_stats", func(ctx context.Context) (e error) {
+					stats, e = block.GatherIndexHealthStats(cg.logger, filepath.Join(bdir, block.IndexFilename), meta.MinTime, meta.MaxTime)
+					return e
+				}, opentracing.Tags{"block.id": meta.ULID}); err != nil {
 					return errors.Wrapf(err, "gather index issues for block %s", bdir)
 				}
 
@@ -1077,11 +1072,10 @@ func (cg *Group) compact(ctx context.Context, dir string, planner Planner, comp 
 	level.Info(cg.logger).Log("msg", "downloaded and verified blocks; compacting blocks", "plan", fmt.Sprintf("%v", toCompactDirs), "duration", time.Since(begin), "duration_ms", time.Since(begin).Milliseconds())
 
 	begin = time.Now()
-	tracing.DoInSpanWithErr(ctx, "compaction", func(ctx context.Context) error {
-		compID, err = comp.Compact(dir, toCompactDirs, nil)
-		return err
-	})
-	if err != nil {
+	if err := tracing.DoInSpanWithErr(ctx, "compaction", func(ctx context.Context) (e error) {
+		compID, e = comp.Compact(dir, toCompactDirs, nil)
+		return e
+	}); err != nil {
 		return false, ulid.ULID{}, halt(errors.Wrapf(err, "compact blocks %v", toCompactDirs))
 	}
 	if compID == (ulid.ULID{}) {
@@ -1122,9 +1116,8 @@ func (cg *Group) compact(ctx context.Context, dir string, planner Planner, comp 
 	}
 
 	// Ensure the output block is valid.
-	tracing.DoInSpanWithErr(ctx, "compaction_verify_index", func(ctx context.Context) error {
-		err = block.VerifyIndex(cg.logger, index, newMeta.MinTime, newMeta.MaxTime)
-		return err
+	err = tracing.DoInSpanWithErr(ctx, "compaction_verify_index", func(ctx context.Context) error {
+		return block.VerifyIndex(cg.logger, index, newMeta.MinTime, newMeta.MaxTime)
 	})
 	if !cg.acceptMalformedIndex && err != nil {
 		return false, ulid.ULID{}, halt(errors.Wrapf(err, "invalid result block %s", bdir))
@@ -1140,9 +1133,8 @@ func (cg *Group) compact(ctx context.Context, dir string, planner Planner, comp 
 
 	begin = time.Now()
 
-	tracing.DoInSpanWithErr(ctx, "compaction_block_upload", func(ctx context.Context) error {
-		err = block.Upload(ctx, cg.logger, cg.bkt, bdir, cg.hashFunc, objstore.WithUploadConcurrency(cg.blockFilesConcurrency))
-		return err
+	err = tracing.DoInSpanWithErr(ctx, "compaction_block_upload", func(ctx context.Context) error {
+		return block.Upload(ctx, cg.logger, cg.bkt, bdir, cg.hashFunc, objstore.WithUploadConcurrency(cg.blockFilesConcurrency))
 	})
 	if err != nil {
 		return false, ulid.ULID{}, retry(errors.Wrapf(err, "upload of %s failed", compID))
@@ -1153,9 +1145,8 @@ func (cg *Group) compact(ctx context.Context, dir string, planner Planner, comp 
 	// into the next planning cycle.
 	// Eventually the block we just uploaded should get synced into the group again (including sync-delay).
 	for _, meta := range toCompact {
-		tracing.DoInSpanWithErr(ctx, "compaction_block_delete", func(ctx context.Context) error {
-			err = cg.deleteBlock(meta.ULID, filepath.Join(dir, meta.ULID.String()))
-			return err
+		err = tracing.DoInSpanWithErr(ctx, "compaction_block_delete", func(ctx context.Context) error {
+			return cg.deleteBlock(meta.ULID, filepath.Join(dir, meta.ULID.String()))
 		}, opentracing.Tags{"block.id": meta.ULID})
 		if err != nil {
 			return false, ulid.ULID{}, retry(errors.Wrapf(err, "mark old block for deletion from bucket"))

--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -1024,7 +1024,6 @@ func (cg *Group) compact(ctx context.Context, dir string, planner Planner, comp 
 			}
 			uniqueSources[s] = struct{}{}
 		}
-
 		func(ctx context.Context, meta *metadata.Meta) {
 			g.Go(func() error {
 				if err := tracing.DoInSpanWithErr(ctx, "compaction_block_download", func(ctx context.Context) error {

--- a/pkg/compact/compact_e2e_test.go
+++ b/pkg/compact/compact_e2e_test.go
@@ -139,7 +139,7 @@ func TestSyncer_GarbageCollect_e2e(t *testing.T) {
 		testutil.Ok(t, sy.GarbageCollect(ctx))
 
 		// Only the level 3 block, the last source block in both resolutions should be left.
-		grouper := NewDefaultGrouper(nil, bkt, false, false, nil, blocksMarkedForDeletion, garbageCollectedBlocks, blockMarkedForNoCompact, metadata.NoneFunc, 1, 1)
+		grouper := NewDefaultGrouper(nil, bkt, false, false, nil, blocksMarkedForDeletion, garbageCollectedBlocks, blockMarkedForNoCompact, metadata.NoneFunc, 10, 10)
 		groups, err := grouper.Groups(sy.Metas())
 		testutil.Ok(t, err)
 
@@ -214,7 +214,7 @@ func testGroupCompactE2e(t *testing.T, mergeFunc storage.VerticalChunkSeriesMerg
 		testutil.Ok(t, err)
 
 		planner := NewPlanner(logger, []int64{1000, 3000}, noCompactMarkerFilter)
-		grouper := NewDefaultGrouper(logger, bkt, false, false, reg, blocksMarkedForDeletion, garbageCollectedBlocks, blocksMaredForNoCompact, metadata.NoneFunc, 1, 1)
+		grouper := NewDefaultGrouper(logger, bkt, false, false, reg, blocksMarkedForDeletion, garbageCollectedBlocks, blocksMaredForNoCompact, metadata.NoneFunc, 10, 10)
 		bComp, err := NewBucketCompactor(logger, sy, grouper, planner, comp, dir, bkt, 2, true)
 		testutil.Ok(t, err)
 

--- a/pkg/tracing/tracing.go
+++ b/pkg/tracing/tracing.go
@@ -76,13 +76,15 @@ func StartSpan(ctx context.Context, operationName string, opts ...opentracing.St
 // DoInSpanWtihErr executes function doFn inside new span with `operationName` name and hooking as child to a span found within given context if any.
 // It uses opentracing.Tracer propagated in context. If no found, it uses noop tracer notification.
 // It logs the error inside the new span created, which differentiates it from DoInSpan and DoWithSpan.
-func DoInSpanWithErr(ctx context.Context, operationName string, doFn func(context.Context) error, opts ...opentracing.StartSpanOption) {
+func DoInSpanWithErr(ctx context.Context, operationName string, doFn func(context.Context) error, opts ...opentracing.StartSpanOption) error {
 	span, newCtx := StartSpan(ctx, operationName, opts...)
 	defer span.Finish()
 	err := doFn(newCtx)
 	if err != nil {
 		ext.LogError(span, err)
 	}
+
+	return err
 }
 
 // DoInSpan executes function doFn inside new span with `operationName` name and hooking as child to a span found within given context if any.


### PR DESCRIPTION
## Changes
Fixing race condition introduced by https://github.com/thanos-io/thanos/pull/5493 (sorry about that)

Fail on cortex project: https://github.com/cortexproject/cortex/runs/7347409636?check_suite_focus=true
```
$ go test ./pkg/compact -test.run '^\QTestGroupCompactPenaltyDedupE2E\E$/^\Qfilesystem\E$' --race

WARNING: DATA RACE
Write at 0x00c0009b26a0 by goroutine 104:
  github.com/thanos-io/thanos/pkg/compact.(*Group).compact.func2.1.1()
      /Users/approtas/workspaces/cortex-dev/vendor/github.com/thanos-io/thanos/pkg/compact/compact.go:1033 +0x237
  github.com/thanos-io/thanos/pkg/tracing.DoInSpanWithErr()
      /Users/approtas/workspaces/cortex-dev/vendor/github.com/thanos-io/thanos/pkg/tracing/tracing.go:82 +0x145
  github.com/thanos-io/thanos/pkg/compact.(*Group).compact.func2.1()
      /Users/approtas/workspaces/cortex-dev/vendor/github.com/thanos-io/thanos/pkg/compact/compact.go:1032 +0x236
  golang.org/x/sync/errgroup.(*Group).Go.func1()
      /Users/approtas/workspaces/cortex-dev/vendor/golang.org/x/sync/errgroup/errgroup.go:75 +0x91

Previous write at 0x00c0009b26a0 by goroutine 11:
  github.com/thanos-io/thanos/pkg/compact.(*Group).compact.func2.1.1()
      /Users/approtas/workspaces/cortex-dev/vendor/github.com/thanos-io/thanos/pkg/compact/compact.go:1033 +0x237
  github.com/thanos-io/thanos/pkg/tracing.DoInSpanWithErr()
      /Users/approtas/workspaces/cortex-dev/vendor/github.com/thanos-io/thanos/pkg/tracing/tracing.go:82 +0x145
  github.com/thanos-io/thanos/pkg/compact.(*Group).compact.func2.1()
      /Users/approtas/workspaces/cortex-dev/vendor/github.com/thanos-io/thanos/pkg/compact/compact.go:1032 +0x236
  golang.org/x/sync/errgroup.(*Group).Go.func1()
      /Users/approtas/workspaces/cortex-dev/vendor/golang.org/x/sync/errgroup/errgroup.go:75 +0x91

Goroutine 104 (running) created at:
  golang.org/x/sync/errgroup.(*Group).Go()
      /Users/approtas/workspaces/cortex-dev/vendor/golang.org/x/sync/errgroup/errgroup.go:72 +0x130
  github.com/thanos-io/thanos/pkg/compact.(*Group).compact.func2()
      /Users/approtas/workspaces/cortex-dev/vendor/github.com/thanos-io/thanos/pkg/compact/compact.go:1031 +0x1bc
  github.com/thanos-io/thanos/pkg/compact.(*Group).compact()
      /Users/approtas/workspaces/cortex-dev/vendor/github.com/thanos-io/thanos/pkg/compact/compact.go:1068 +0xc24
  github.com/thanos-io/thanos/pkg/compact.(*Group).Compact.func2()
      /Users/approtas/workspaces/cortex-dev/vendor/github.com/thanos-io/thanos/pkg/compact/compact.go:778 +0xf5
  github.com/thanos-io/thanos/pkg/tracing.DoInSpanWithErr()
      /Users/approtas/workspaces/cortex-dev/vendor/github.com/thanos-io/thanos/pkg/tracing/tracing.go:82 +0x145
  github.com/thanos-io/thanos/pkg/compact.(*Group).Compact()
      /Users/approtas/workspaces/cortex-dev/vendor/github.com/thanos-io/thanos/pkg/compact/compact.go:777 +0x424
  github.com/thanos-io/thanos/pkg/compact.(*BucketCompactor).Compact.func2()
      /Users/approtas/workspaces/cortex-dev/vendor/github.com/thanos-io/thanos/pkg/compact/compact.go:1257 +0x217

Goroutine 11 (running) created at:
  golang.org/x/sync/errgroup.(*Group).Go()
      /Users/approtas/workspaces/cortex-dev/vendor/golang.org/x/sync/errgroup/errgroup.go:72 +0x130
  github.com/thanos-io/thanos/pkg/compact.(*Group).compact.func2()
      /Users/approtas/workspaces/cortex-dev/vendor/github.com/thanos-io/thanos/pkg/compact/compact.go:1031 +0x1bc
  github.com/thanos-io/thanos/pkg/compact.(*Group).compact()
      /Users/approtas/workspaces/cortex-dev/vendor/github.com/thanos-io/thanos/pkg/compact/compact.go:1068 +0xc24
  github.com/thanos-io/thanos/pkg/compact.(*Group).Compact.func2()
      /Users/approtas/workspaces/cortex-dev/vendor/github.com/thanos-io/thanos/pkg/compact/compact.go:778 +0xf5
  github.com/thanos-io/thanos/pkg/tracing.DoInSpanWithErr()
      /Users/approtas/workspaces/cortex-dev/vendor/github.com/thanos-io/thanos/pkg/tracing/tracing.go:82 +0x145
  github.com/thanos-io/thanos/pkg/compact.(*Group).Compact()
      /Users/approtas/workspaces/cortex-dev/vendor/github.com/thanos-io/thanos/pkg/compact/compact.go:777 +0x424
  github.com/thanos-io/thanos/pkg/compact.(*BucketCompactor).Compact.func2()
      /Users/approtas/workspaces/cortex-dev/vendor/github.com/thanos-io/thanos/pkg/compact/compact.go:1257 +0x217
==================
==================
WARNING: DATA RACE
Write at 0x00c00083c3a0 by goroutine 45:
  github.com/thanos-io/thanos/pkg/compact.(*Group).compact.func2.1.2()
      /Users/approtas/workspaces/cortex-dev/vendor/github.com/thanos-io/thanos/pkg/compact/compact.go:1043 +0x204
  github.com/thanos-io/thanos/pkg/tracing.DoInSpanWithErr()
      /Users/approtas/workspaces/cortex-dev/vendor/github.com/thanos-io/thanos/pkg/tracing/tracing.go:82 +0x145
  github.com/thanos-io/thanos/pkg/compact.(*Group).compact.func2.1()
      /Users/approtas/workspaces/cortex-dev/vendor/github.com/thanos-io/thanos/pkg/compact/compact.go:1042 +0x556
  golang.org/x/sync/errgroup.(*Group).Go.func1()
      /Users/approtas/workspaces/cortex-dev/vendor/golang.org/x/sync/errgroup/errgroup.go:75 +0x91

Previous write at 0x00c00083c3a0 by goroutine 110:
  github.com/thanos-io/thanos/pkg/compact.(*Group).compact.func2.1.1()
      /Users/approtas/workspaces/cortex-dev/vendor/github.com/thanos-io/thanos/pkg/compact/compact.go:1033 +0x237
  github.com/thanos-io/thanos/pkg/tracing.DoInSpanWithErr()
      /Users/approtas/workspaces/cortex-dev/vendor/github.com/thanos-io/thanos/pkg/tracing/tracing.go:82 +0x145
  github.com/thanos-io/thanos/pkg/compact.(*Group).compact.func2.1()
      /Users/approtas/workspaces/cortex-dev/vendor/github.com/thanos-io/thanos/pkg/compact/compact.go:1032 +0x236
  golang.org/x/sync/errgroup.(*Group).Go.func1()
      /Users/approtas/workspaces/cortex-dev/vendor/golang.org/x/sync/errgroup/errgroup.go:75 +0x91

Goroutine 45 (running) created at:
  golang.org/x/sync/errgroup.(*Group).Go()
      /Users/approtas/workspaces/cortex-dev/vendor/golang.org/x/sync/errgroup/errgroup.go:72 +0x130
  github.com/thanos-io/thanos/pkg/compact.(*Group).compact.func2()
      /Users/approtas/workspaces/cortex-dev/vendor/github.com/thanos-io/thanos/pkg/compact/compact.go:1031 +0x1bc
  github.com/thanos-io/thanos/pkg/compact.(*Group).compact()
      /Users/approtas/workspaces/cortex-dev/vendor/github.com/thanos-io/thanos/pkg/compact/compact.go:1068 +0xc24
  github.com/thanos-io/thanos/pkg/compact.(*Group).Compact.func2()
      /Users/approtas/workspaces/cortex-dev/vendor/github.com/thanos-io/thanos/pkg/compact/compact.go:778 +0xf5
  github.com/thanos-io/thanos/pkg/tracing.DoInSpanWithErr()
      /Users/approtas/workspaces/cortex-dev/vendor/github.com/thanos-io/thanos/pkg/tracing/tracing.go:82 +0x145
  github.com/thanos-io/thanos/pkg/compact.(*Group).Compact()
      /Users/approtas/workspaces/cortex-dev/vendor/github.com/thanos-io/thanos/pkg/compact/compact.go:777 +0x424
  github.com/thanos-io/thanos/pkg/compact.(*BucketCompactor).Compact.func2()
      /Users/approtas/workspaces/cortex-dev/vendor/github.com/thanos-io/thanos/pkg/compact/compact.go:1257 +0x217

Goroutine 110 (running) created at:
  golang.org/x/sync/errgroup.(*Group).Go()
      /Users/approtas/workspaces/cortex-dev/vendor/golang.org/x/sync/errgroup/errgroup.go:72 +0x130
  github.com/thanos-io/thanos/pkg/compact.(*Group).compact.func2()
      /Users/approtas/workspaces/cortex-dev/vendor/github.com/thanos-io/thanos/pkg/compact/compact.go:1031 +0x1bc
  github.com/thanos-io/thanos/pkg/compact.(*Group).compact()
      /Users/approtas/workspaces/cortex-dev/vendor/github.com/thanos-io/thanos/pkg/compact/compact.go:1068 +0xc24
  github.com/thanos-io/thanos/pkg/compact.(*Group).Compact.func2()
      /Users/approtas/workspaces/cortex-dev/vendor/github.com/thanos-io/thanos/pkg/compact/compact.go:778 +0xf5
  github.com/thanos-io/thanos/pkg/tracing.DoInSpanWithErr()
      /Users/approtas/workspaces/cortex-dev/vendor/github.com/thanos-io/thanos/pkg/tracing/tracing.go:82 +0x145
  github.com/thanos-io/thanos/pkg/compact.(*Group).Compact()
      /Users/approtas/workspaces/cortex-dev/vendor/github.com/thanos-io/thanos/pkg/compact/compact.go:777 +0x424
  github.com/thanos-io/thanos/pkg/compact.(*BucketCompactor).Compact.func2()
      /Users/approtas/workspaces/cortex-dev/vendor/github.com/thanos-io/thanos/pkg/compact/compact.go:1257 +0x217
==================
--- FAIL: TestCompactor_ShouldSkipOutOrOrderBlocks (1.37s)
    testing.go:1152: race detected during execution of test
FAIL
FAIL	github.com/cortexproject/cortex/pkg/compactor	2.302s
FAIL
```