### PR TITLE
Receive: add per request limits for remote write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#5475](https://github.com/thanos-io/thanos/pull/5475) Compact/Store: Added `--block-files-concurrency` allowing to configure number of go routines for download/upload block files during compaction.
 - [#5470](https://github.com/thanos-io/thanos/pull/5470) Receive: Implement exposing TSDB stats for all tenants
 - [#5493](https://github.com/thanos-io/thanos/pull/5493) Compact: Added `--compact.blocks-fetch-concurrency` allowing to configure number of go routines for download blocks during compactions.
+- [#5527](https://github.com/thanos-io/thanos/pull/5527) Receive: Add per request limits for remote write.
 
 ### Changed
 

--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -863,6 +863,8 @@ func (rc *receiveConfig) registerFlag(cmd extkingpin.FlagClause) {
 
 	rc.reqLogConfig = extkingpin.RegisterRequestLoggingFlags(cmd)
 
+	// TODO(douglascamata): allow all these limits to be configured per tenant
+	// and move the configuration to a file.
 	cmd.Flag("receive.write-request-limits.max-series",
 		"The maximum amount of series accepted in remote write requests.").
 		Default("0").Int64Var(&rc.writeSeriesLimit)

--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -864,7 +864,8 @@ func (rc *receiveConfig) registerFlag(cmd extkingpin.FlagClause) {
 	rc.reqLogConfig = extkingpin.RegisterRequestLoggingFlags(cmd)
 
 	// TODO(douglascamata): allow all these limits to be configured per tenant
-	// and move the configuration to a file.
+	// and move the configuration to a file. Then this is done, remove the
+	// "hidden" modifier on all these flags.
 	cmd.Flag("receive.write-request-limits.max-series",
 		"The maximum amount of series accepted in remote write requests."+
 			"The default is no limit, represented by 0.").

--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -198,25 +198,26 @@ func runReceive(
 	)
 	writer := receive.NewWriter(log.With(logger, "component", "receive-writer"), dbs)
 	webHandler := receive.NewHandler(log.With(logger, "component", "receive-handler"), &receive.Options{
-		Writer:                writer,
-		ListenAddress:         conf.rwAddress,
-		Registry:              reg,
-		Endpoint:              conf.endpoint,
-		TenantHeader:          conf.tenantHeader,
-		TenantField:           conf.tenantField,
-		DefaultTenantID:       conf.defaultTenantID,
-		ReplicaHeader:         conf.replicaHeader,
-		ReplicationFactor:     conf.replicationFactor,
-		RelabelConfigs:        relabelConfig,
-		ReceiverMode:          receiveMode,
-		Tracer:                tracer,
-		TLSConfig:             rwTLSConfig,
-		DialOpts:              dialOpts,
-		ForwardTimeout:        time.Duration(*conf.forwardTimeout),
-		TSDBStats:             dbs,
-		WriteSeriesLimit:      conf.writeSeriesLimit,
-		WriteSamplesLimit:     conf.writeSamplesLimit,
-		WriteRequestSizeLimit: conf.writeRequestSizeLimit,
+		Writer:                       writer,
+		ListenAddress:                conf.rwAddress,
+		Registry:                     reg,
+		Endpoint:                     conf.endpoint,
+		TenantHeader:                 conf.tenantHeader,
+		TenantField:                  conf.tenantField,
+		DefaultTenantID:              conf.defaultTenantID,
+		ReplicaHeader:                conf.replicaHeader,
+		ReplicationFactor:            conf.replicationFactor,
+		RelabelConfigs:               relabelConfig,
+		ReceiverMode:                 receiveMode,
+		Tracer:                       tracer,
+		TLSConfig:                    rwTLSConfig,
+		DialOpts:                     dialOpts,
+		ForwardTimeout:               time.Duration(*conf.forwardTimeout),
+		TSDBStats:                    dbs,
+		WriteSeriesLimit:             conf.writeSeriesLimit,
+		WriteSamplesLimit:            conf.writeSamplesLimit,
+		WriteRequestSizeLimit:        conf.writeRequestSizeLimit,
+		WriteRequestConcurrencyLimit: conf.writeRequestConcurrencyLimit,
 	})
 
 	grpcProbe := prober.NewGRPC()
@@ -767,9 +768,10 @@ type receiveConfig struct {
 	reqLogConfig      *extflag.PathOrContent
 	relabelConfigPath *extflag.PathOrContent
 
-	writeSeriesLimit      int
-	writeSamplesLimit     int
-	writeRequestSizeLimit int
+	writeSeriesLimit             int
+	writeSamplesLimit            int
+	writeRequestSizeLimit        int
+	writeRequestConcurrencyLimit int
 }
 
 func (rc *receiveConfig) registerFlag(cmd extkingpin.FlagClause) {
@@ -872,6 +874,10 @@ func (rc *receiveConfig) registerFlag(cmd extkingpin.FlagClause) {
 	cmd.Flag("receive.request-limits.max-size-bytes",
 		"The maximum size (in bytes) of remote write requests.").
 		Default("0").IntVar(&rc.writeRequestSizeLimit)
+
+	cmd.Flag("receive.request-limits.max-concurrency",
+		"The maximum size (in bytes) of remote write requests.").
+		Default("0").IntVar(&rc.writeRequestConcurrencyLimit)
 }
 
 // determineMode returns the ReceiverMode that this receiver is configured to run in.

--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -768,9 +768,9 @@ type receiveConfig struct {
 	reqLogConfig      *extflag.PathOrContent
 	relabelConfigPath *extflag.PathOrContent
 
-	writeSeriesLimit             int
-	writeSamplesLimit            int
-	writeRequestSizeLimit        int
+	writeSeriesLimit             int64
+	writeSamplesLimit            int64
+	writeRequestSizeLimit        int64
 	writeRequestConcurrencyLimit int
 }
 
@@ -865,15 +865,15 @@ func (rc *receiveConfig) registerFlag(cmd extkingpin.FlagClause) {
 
 	cmd.Flag("receive.write-request-limits.max-series",
 		"The maximum amount of series accepted in remote write requests.").
-		Default("0").IntVar(&rc.writeSeriesLimit)
+		Default("0").Int64Var(&rc.writeSeriesLimit)
 
 	cmd.Flag("receive.write-request-limits.max-samples",
 		"The maximum amount of samples accepted in remote write requests.").
-		Default("0").IntVar(&rc.writeSamplesLimit)
+		Default("0").Int64Var(&rc.writeSamplesLimit)
 
 	cmd.Flag("receive.write-request-limits.max-size-bytes",
 		"The maximum size (in bytes) of remote write requests.").
-		Default("0").IntVar(&rc.writeRequestSizeLimit)
+		Default("0").Int64Var(&rc.writeRequestSizeLimit)
 
 	cmd.Flag("receive.write-request-limits.max-concurrency",
 		"The maximum size (in bytes) of remote write requests.").

--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -882,7 +882,7 @@ func (rc *receiveConfig) registerFlag(cmd extkingpin.FlagClause) {
 		Default("0").Hidden().Int64Var(&rc.writeRequestSizeLimit)
 
 	cmd.Flag("receive.write-request-limits.max-concurrency",
-		"The maximum size (in bytes) of remote write requests."+
+		"The maximum amount of remote write requests that will be concurrently processed while others wait."+
 			"The default is no limit, represented by 0.").
 		Default("0").Hidden().IntVar(&rc.writeRequestConcurrencyLimit)
 }

--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -866,20 +866,24 @@ func (rc *receiveConfig) registerFlag(cmd extkingpin.FlagClause) {
 	// TODO(douglascamata): allow all these limits to be configured per tenant
 	// and move the configuration to a file.
 	cmd.Flag("receive.write-request-limits.max-series",
-		"The maximum amount of series accepted in remote write requests.").
-		Default("0").Int64Var(&rc.writeSeriesLimit)
+		"The maximum amount of series accepted in remote write requests."+
+			"The default is no limit, represented by 0.").
+		Default("0").Hidden().Int64Var(&rc.writeSeriesLimit)
 
 	cmd.Flag("receive.write-request-limits.max-samples",
-		"The maximum amount of samples accepted in remote write requests.").
-		Default("0").Int64Var(&rc.writeSamplesLimit)
+		"The maximum amount of samples accepted in remote write requests."+
+			"The default is no limit, represented by 0.").
+		Default("0").Hidden().Int64Var(&rc.writeSamplesLimit)
 
 	cmd.Flag("receive.write-request-limits.max-size-bytes",
-		"The maximum size (in bytes) of remote write requests.").
-		Default("0").Int64Var(&rc.writeRequestSizeLimit)
+		"The maximum size (in bytes) of remote write requests."+
+			"The default is no limit, represented by 0.").
+		Default("0").Hidden().Int64Var(&rc.writeRequestSizeLimit)
 
 	cmd.Flag("receive.write-request-limits.max-concurrency",
-		"The maximum size (in bytes) of remote write requests.").
-		Default("0").IntVar(&rc.writeRequestConcurrencyLimit)
+		"The maximum size (in bytes) of remote write requests."+
+			"The default is no limit, represented by 0.").
+		Default("0").Hidden().IntVar(&rc.writeRequestConcurrencyLimit)
 }
 
 // determineMode returns the ReceiverMode that this receiver is configured to run in.

--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -863,7 +863,7 @@ func (rc *receiveConfig) registerFlag(cmd extkingpin.FlagClause) {
 
 	rc.reqLogConfig = extkingpin.RegisterRequestLoggingFlags(cmd)
 
-	// TODO(douglascamata): allow all these limits to be configured per tenant
+	// TODO(douglascamata): Allow all these limits to be configured per tenant
 	// and move the configuration to a file. Then this is done, remove the
 	// "hidden" modifier on all these flags.
 	cmd.Flag("receive.write-request-limits.max-series",

--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -863,19 +863,19 @@ func (rc *receiveConfig) registerFlag(cmd extkingpin.FlagClause) {
 
 	rc.reqLogConfig = extkingpin.RegisterRequestLoggingFlags(cmd)
 
-	cmd.Flag("receive.request-limits.max-series",
+	cmd.Flag("receive.write-request-limits.max-series",
 		"The maximum amount of series accepted in remote write requests.").
 		Default("0").IntVar(&rc.writeSeriesLimit)
 
-	cmd.Flag("receive.request-limits.max-samples",
+	cmd.Flag("receive.write-request-limits.max-samples",
 		"The maximum amount of samples accepted in remote write requests.").
 		Default("0").IntVar(&rc.writeSamplesLimit)
 
-	cmd.Flag("receive.request-limits.max-size-bytes",
+	cmd.Flag("receive.write-request-limits.max-size-bytes",
 		"The maximum size (in bytes) of remote write requests.").
 		Default("0").IntVar(&rc.writeRequestSizeLimit)
 
-	cmd.Flag("receive.request-limits.max-concurrency",
+	cmd.Flag("receive.write-request-limits.max-concurrency",
 		"The maximum size (in bytes) of remote write requests.").
 		Default("0").IntVar(&rc.writeRequestConcurrencyLimit)
 }

--- a/docs/components/receive.md
+++ b/docs/components/receive.md
@@ -81,24 +81,16 @@ With such configuration any receive listens for remote write on `<ip>10908/api/v
 
 ### Request limits
 
-Thanos Receive supports setting limits on the incoming remote write request sizes.
-These limits should help you to prevent a single tenant from being able to send
-big requests and possibly crash the Receive.
+Thanos Receive supports setting limits on the incoming remote write request sizes. These limits should help you to prevent a single tenant from being able to send big requests and possibly crash the Receive.
 
-These limits are applied per request and can be configured with the following
-command line arguments:
+These limits are applied per request and can be configured with the following command line arguments:
 
 - `--receive.write-request-limits.max-size-bytes`: the maximum body size.
-- `--receive.write-request-limits.max-concurrency`: the maximum amount remote write
-  requests that will be concurrently processed while others wait.
-- `--receive.write-request-limits.max-series`: the maximum amount of series in a
-  single remote write request.
-- `--receive.write-request-limits.max-samples`: the maximum amount of samples in a
-  single remote write request (summed from all series).
+- `--receive.write-request-limits.max-concurrency`: the maximum amount remote write requests that will be concurrently processed while others wait.
+- `--receive.write-request-limits.max-series`: the maximum amount of series in a single remote write request.
+- `--receive.write-request-limits.max-samples`: the maximum amount of samples in a single remote write request (summed from all series).
 
-Any request above these limits will cause an 413 HTTP response (_Entity Too Large_)
-and should not be retried without modifications. It's up to remote write clients to
-split up the data and retry or completely drop it.
+Any request above these limits will cause an 413 HTTP response (*Entity Too Large*) and should not be retried without modifications. It's up to remote write clients to split up the data and retry or completely drop it.
 
 By default all these limits are disabled.
 
@@ -208,6 +200,18 @@ Flags:
       --receive.tenant-label-name="tenant_id"
                                  Label name through which the tenant will be
                                  announced.
+      --receive.write-request-limits.max-concurrency=0
+                                 The maximum size (in bytes) of remote write
+                                 requests.
+      --receive.write-request-limits.max-samples=0
+                                 The maximum amount of samples accepted in
+                                 remote write requests.
+      --receive.write-request-limits.max-series=0
+                                 The maximum amount of series accepted in remote
+                                 write requests.
+      --receive.write-request-limits.max-size-bytes=0
+                                 The maximum size (in bytes) of remote write
+                                 requests.
       --remote-write.address="0.0.0.0:19291"
                                  Address to listen on for remote write requests.
       --remote-write.client-server-name=""

--- a/docs/components/receive.md
+++ b/docs/components/receive.md
@@ -79,7 +79,7 @@ With such configuration any receive listens for remote write on `<ip>10908/api/v
 
 ## Limiting
 
-### Request limits
+### Request limits (work in progress)
 
 Thanos Receive supports setting limits on the incoming remote write request sizes. These limits should help you to prevent a single tenant from being able to send big requests and possibly crash the Receive.
 
@@ -93,6 +93,8 @@ These limits are applied per request and can be configured with the following co
 Any request above these limits will cause an 413 HTTP response (*Entity Too Large*) and should not be retried without modifications. It's up to remote write clients to split up the data and retry or completely drop it.
 
 By default all these limits are disabled.
+
+**IMPORTANT**: this feature is a work-in-progress and it might change in the near future, i.e. configuration might move to a file to allow easy configuration of different request limits per tenant.
 
 ## Flags
 

--- a/docs/components/receive.md
+++ b/docs/components/receive.md
@@ -200,18 +200,6 @@ Flags:
       --receive.tenant-label-name="tenant_id"
                                  Label name through which the tenant will be
                                  announced.
-      --receive.write-request-limits.max-concurrency=0
-                                 The maximum size (in bytes) of remote write
-                                 requests.
-      --receive.write-request-limits.max-samples=0
-                                 The maximum amount of samples accepted in
-                                 remote write requests.
-      --receive.write-request-limits.max-series=0
-                                 The maximum amount of series accepted in remote
-                                 write requests.
-      --receive.write-request-limits.max-size-bytes=0
-                                 The maximum size (in bytes) of remote write
-                                 requests.
       --remote-write.address="0.0.0.0:19291"
                                  Address to listen on for remote write requests.
       --remote-write.client-server-name=""

--- a/docs/components/receive.md
+++ b/docs/components/receive.md
@@ -89,6 +89,8 @@ These limits are applied per request and can be configured with the following
 command line arguments:
 
 - `--receive.write-request-limits.max-size-bytes`: the maximum body size.
+- `--receive.write-request-limits.max-concurrency`: the maximum amount remote write
+  requests that will be concurrently processed while others wait.
 - `--receive.write-request-limits.max-series`: the maximum amount of series in a
   single remote write request.
 - `--receive.write-request-limits.max-samples`: the maximum amount of samples in a

--- a/docs/components/receive.md
+++ b/docs/components/receive.md
@@ -77,6 +77,29 @@ The example content of `hashring.json`:
 
 With such configuration any receive listens for remote write on `<ip>10908/api/v1/receive` and will forward to correct one in hashring if needed for tenancy and replication.
 
+## Limiting
+
+### Request limits
+
+Thanos Receive supports setting limits on the incoming remote write request sizes.
+These limits should help you to prevent a single tenant from being able to send
+big requests and possibly crash the Receive.
+
+These limits are applied per request and can be configured with the following
+command line arguments:
+
+- `--receive.request-limits.max-size-bytes`: the maximum body size.
+- `--receive.request-limits.max-series`: the maximum amount of series in a single
+  remote write request.
+- `--receive.request-limits.max-samples`: the maximum amount of samples in a single
+  remote write request (summed from all series).
+
+Any request above these limits will cause an 413 HTTP response (_Entity Too Large_)
+and should not be retried without modifications. It's up to remote write clients to
+split up the data and retry or completely drop it.
+
+By default all these limits are disabled.
+
 ## Flags
 
 ```$ mdox-exec="thanos receive --help"

--- a/docs/components/receive.md
+++ b/docs/components/receive.md
@@ -86,7 +86,7 @@ Thanos Receive supports setting limits on the incoming remote write request size
 These limits are applied per request and can be configured with the following command line arguments:
 
 - `--receive.write-request-limits.max-size-bytes`: the maximum body size.
-- `--receive.write-request-limits.max-concurrency`: the maximum amount remote write requests that will be concurrently processed while others wait.
+- `--receive.write-request-limits.max-concurrency`: the maximum amount of remote write requests that will be concurrently processed while others wait.
 - `--receive.write-request-limits.max-series`: the maximum amount of series in a single remote write request.
 - `--receive.write-request-limits.max-samples`: the maximum amount of samples in a single remote write request (summed from all series).
 

--- a/docs/components/receive.md
+++ b/docs/components/receive.md
@@ -88,11 +88,11 @@ big requests and possibly crash the Receive.
 These limits are applied per request and can be configured with the following
 command line arguments:
 
-- `--receive.request-limits.max-size-bytes`: the maximum body size.
-- `--receive.request-limits.max-series`: the maximum amount of series in a single
-  remote write request.
-- `--receive.request-limits.max-samples`: the maximum amount of samples in a single
-  remote write request (summed from all series).
+- `--receive.write-request-limits.max-size-bytes`: the maximum body size.
+- `--receive.write-request-limits.max-series`: the maximum amount of series in a
+  single remote write request.
+- `--receive.write-request-limits.max-samples`: the maximum amount of samples in a
+  single remote write request (summed from all series).
 
 Any request above these limits will cause an 413 HTTP response (_Entity Too Large_)
 and should not be retried without modifications. It's up to remote write clients to

--- a/pkg/receive/handler.go
+++ b/pkg/receive/handler.go
@@ -403,8 +403,8 @@ func (h *Handler) receiveHTTP(w http.ResponseWriter, r *http.Request) {
 	var err error
 	span, ctx := tracing.StartSpan(r.Context(), "receive_http")
 	defer span.Finish()
-	tenant := r.Header.Get(h.options.TenantHeader)
 
+	tenant := r.Header.Get(h.options.TenantHeader)
 	if tenant == "" {
 		tenant = h.options.DefaultTenantID
 	}

--- a/pkg/receive/handler_test.go
+++ b/pkg/receive/handler_test.go
@@ -690,7 +690,6 @@ func TestReceiveQuorum(t *testing.T) {
 	}
 }
 
-// TODO(dougalscamata): continue here
 func TestReceiveWriteRequestLimits(t *testing.T) {
 	for _, tc := range []struct {
 		name          string

--- a/pkg/receive/handler_test.go
+++ b/pkg/receive/handler_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/alecthomas/units"
 	"github.com/go-kit/log"
 	"github.com/gogo/protobuf/proto"
 	"github.com/golang/snappy"
@@ -738,7 +739,7 @@ func TestReceiveWriteRequestLimits(t *testing.T) {
 			}
 			handlers, _ := newTestHandlerHashring(appendables, 1)
 			handler := handlers[0]
-			handler.requestLimiter = newRequestLimiter(1*1024*1024, 20, 200, nil)
+			handler.requestLimiter = newRequestLimiter(int64(1*units.Megabyte), 20, 200, nil)
 			tenant := "test"
 
 			wreq := &prompb.WriteRequest{

--- a/pkg/receive/handler_test.go
+++ b/pkg/receive/handler_test.go
@@ -738,9 +738,7 @@ func TestReceiveWriteRequestLimits(t *testing.T) {
 			}
 			handlers, _ := newTestHandlerHashring(appendables, 1)
 			handler := handlers[0]
-			handler.options.WriteRequestSizeLimit = 1 * 1024 * 1024
-			handler.options.WriteSamplesLimit = 200
-			handler.options.WriteSeriesLimit = 20
+			handler.requestLimiter = newRequestLimiter(1*1024*1024, 20, 200, nil)
 			tenant := "test"
 
 			wreq := &prompb.WriteRequest{

--- a/pkg/receive/handler_test.go
+++ b/pkg/receive/handler_test.go
@@ -736,8 +736,14 @@ func TestReceiveWriteRequestLimits(t *testing.T) {
 				{
 					appender: newFakeAppender(nil, nil, nil),
 				},
+				{
+					appender: newFakeAppender(nil, nil, nil),
+				},
+				{
+					appender: newFakeAppender(nil, nil, nil),
+				},
 			}
-			handlers, _ := newTestHandlerHashring(appendables, 1)
+			handlers, _ := newTestHandlerHashring(appendables, 3)
 			handler := handlers[0]
 			handler.requestLimiter = newRequestLimiter(int64(1*units.Megabyte), 20, 200, nil)
 			tenant := "test"

--- a/pkg/receive/handler_test.go
+++ b/pkg/receive/handler_test.go
@@ -696,67 +696,47 @@ func TestReceiveWriteRequestLimits(t *testing.T) {
 		status        int
 		amountSeries  int
 		amountSamples int
-		appendables   []*fakeAppendable
 	}{
 		{
 			name:         "Request above limit of series",
 			status:       http.StatusRequestEntityTooLarge,
 			amountSeries: 21,
-			appendables: []*fakeAppendable{
-				{
-					appender: newFakeAppender(nil, nil, nil),
-				},
-			},
 		},
 		{
 			name:         "Request under the limit of series",
 			status:       http.StatusOK,
 			amountSeries: 20,
-			appendables: []*fakeAppendable{
-				{
-					appender: newFakeAppender(nil, nil, nil),
-				},
-			},
 		},
 		{
 			name:          "Request above limit of samples (series * samples)",
 			status:        http.StatusRequestEntityTooLarge,
 			amountSeries:  30,
 			amountSamples: 15,
-			appendables: []*fakeAppendable{
-				{
-					appender: newFakeAppender(nil, nil, nil),
-				},
-			},
 		},
 		{
 			name:          "Request under the limit of samples (series * samples)",
 			status:        http.StatusOK,
 			amountSeries:  10,
 			amountSamples: 2,
-			appendables: []*fakeAppendable{
-				{
-					appender: newFakeAppender(nil, nil, nil),
-				},
-			},
 		},
 		{
 			name:          "Request above body size limit",
 			status:        http.StatusRequestEntityTooLarge,
 			amountSeries:  300,
 			amountSamples: 150,
-			appendables: []*fakeAppendable{
-				{
-					appender: newFakeAppender(nil, nil, nil),
-				},
-			},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			if tc.amountSamples == 0 {
 				tc.amountSamples = 1
 			}
-			handlers, _ := newTestHandlerHashring(tc.appendables, 1)
+
+			appendables := []*fakeAppendable{
+				{
+					appender: newFakeAppender(nil, nil, nil),
+				},
+			}
+			handlers, _ := newTestHandlerHashring(appendables, 1)
 			handler := handlers[0]
 			handler.options.WriteRequestSizeLimit = 1 * 1024 * 1024
 			handler.options.WriteSamplesLimit = 200

--- a/pkg/receive/limiter.go
+++ b/pkg/receive/limiter.go
@@ -1,3 +1,6 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
 package receive
 
 import (

--- a/pkg/receive/limiter.go
+++ b/pkg/receive/limiter.go
@@ -1,0 +1,93 @@
+package receive
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+const (
+	seriesLimitName    = "series"
+	samplesLimitName   = "samples"
+	sizeBytesLimitName = "body_size"
+)
+
+type requestLimiter struct {
+	sizeBytesLimit   int64
+	seriesLimit      int64
+	samplesLimit     int64
+	limitsHit        *prometheus.SummaryVec
+	configuredLimits *prometheus.GaugeVec
+}
+
+func newRequestLimiter(sizeBytesLimit, seriesLimit, samplesLimit int64, reg prometheus.Registerer) requestLimiter {
+	limiter := requestLimiter{
+		sizeBytesLimit: sizeBytesLimit,
+		seriesLimit:    seriesLimit,
+		samplesLimit:   samplesLimit,
+		limitsHit: promauto.With(reg).NewSummaryVec(
+			prometheus.SummaryOpts{
+				Namespace:  "thanos",
+				Subsystem:  "receive",
+				Name:       "write_limits_hit",
+				Help:       "The number of times a request was refused due to a remote write limit.",
+				Objectives: map[float64]float64{0.50: 0.1, 0.95: 0.1, 0.99: 0.001},
+			}, []string{"tenant", "limit"},
+		),
+		configuredLimits: promauto.With(reg).NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: "thanos",
+				Subsystem: "receive",
+				Name:      "write_limits",
+				Help:      "The configured write limits.",
+			}, []string{"limit"},
+		),
+	}
+	limiter.configuredLimits.WithLabelValues(sizeBytesLimitName).Set(float64(sizeBytesLimit))
+	limiter.configuredLimits.WithLabelValues(seriesLimitName).Set(float64(seriesLimit))
+	limiter.configuredLimits.WithLabelValues(samplesLimitName).Set(float64(samplesLimit))
+	return limiter
+}
+
+func (l *requestLimiter) AllowSizeBytes(tenant string, contentLengthBytes int64) bool {
+	if l.sizeBytesLimit <= 0 {
+		return true
+	}
+
+	// This happens when the content length is unknown, then we allow it.
+	if contentLengthBytes < 0 {
+		return true
+	}
+	allowed := l.sizeBytesLimit >= contentLengthBytes
+	if !allowed {
+		l.limitsHit.
+			WithLabelValues(tenant, sizeBytesLimitName).
+			Observe(float64(contentLengthBytes - l.sizeBytesLimit))
+	}
+	return allowed
+}
+
+func (l *requestLimiter) AllowSeries(tenant string, amount int64) bool {
+	if l.seriesLimit <= 0 {
+		return true
+	}
+	allowed := l.seriesLimit >= amount
+	if !allowed {
+		l.limitsHit.
+			WithLabelValues(tenant, seriesLimitName).
+			Observe(float64(amount - l.seriesLimit))
+	}
+	return allowed
+}
+
+func (l *requestLimiter) AllowSamples(tenant string, amount int64) bool {
+	if l.samplesLimit <= 0 {
+		return true
+	}
+	allowed := l.samplesLimit >= amount
+	if !allowed {
+		l.limitsHit.
+			WithLabelValues(tenant, samplesLimitName).
+			Observe(float64(amount - l.samplesLimit))
+	}
+	return allowed
+}

--- a/pkg/receive/limiter.go
+++ b/pkg/receive/limiter.go
@@ -32,7 +32,7 @@ func newRequestLimiter(sizeBytesLimit, seriesLimit, samplesLimit int64, reg prom
 				Namespace:  "thanos",
 				Subsystem:  "receive",
 				Name:       "write_limits_hit",
-				Help:       "The number of times a request was refused due to a remote write limit.",
+				Help:       "Summary of how much beyond the limit a refused remote write request was.",
 				Objectives: map[float64]float64{0.50: 0.1, 0.95: 0.1, 0.99: 0.001},
 			}, []string{"tenant", "limit"},
 		),

--- a/pkg/receive/limiter.go
+++ b/pkg/receive/limiter.go
@@ -32,7 +32,7 @@ func newRequestLimiter(sizeBytesLimit, seriesLimit, samplesLimit int64, reg prom
 				Namespace:  "thanos",
 				Subsystem:  "receive",
 				Name:       "write_limits_hit",
-				Help:       "Summary of how much beyond the limit a refused remote write request was.",
+				Help:       "Summary of how far beyond the limit a refused remote write request was.",
 				Objectives: map[float64]float64{0.50: 0.1, 0.95: 0.1, 0.99: 0.001},
 			}, []string{"tenant", "limit"},
 		),

--- a/pkg/receive/limiter_test.go
+++ b/pkg/receive/limiter_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
 package receive
 
 import (

--- a/pkg/receive/limiter_test.go
+++ b/pkg/receive/limiter_test.go
@@ -3,9 +3,7 @@
 
 package receive
 
-import (
-	"testing"
-)
+import "testing"
 
 func TestRequestLimiter_AllowRequestBodySizeBytes(t *testing.T) {
 	tests := []struct {

--- a/pkg/receive/limiter_test.go
+++ b/pkg/receive/limiter_test.go
@@ -1,0 +1,149 @@
+package receive
+
+import (
+	"testing"
+)
+
+func TestRequestLimiter_AllowRequestBodySizeBytes(t *testing.T) {
+	tests := []struct {
+		name          string
+		sizeByteLimit int64
+		sizeBytes     int64
+		want          bool
+	}{
+		{
+			name:          "Allowed when request size limit is < 0",
+			sizeByteLimit: -1,
+			sizeBytes:     30000,
+			want:          true,
+		},
+		{
+			name:          "Allowed when request size limit is 0",
+			sizeByteLimit: 0,
+			sizeBytes:     30000,
+			want:          true,
+		},
+		{
+			name:          "Allowed when under request size limit",
+			sizeByteLimit: 50000,
+			sizeBytes:     30000,
+			want:          true,
+		},
+		{
+			name:          "Allowed when equal to the request size limit",
+			sizeByteLimit: 30000,
+			sizeBytes:     30000,
+			want:          true,
+		},
+		{
+			name:          "Not allowed when above the request size limit",
+			sizeByteLimit: 30000,
+			sizeBytes:     30001,
+			want:          false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			l := newRequestLimiter(tt.sizeByteLimit, 0, 0, nil)
+			if got := l.AllowSizeBytes("tenant", tt.sizeBytes); got != tt.want {
+				t.Errorf("unexpected AllowRequestBodySizeBytes result (body size: %v), got %v, want %v", tt.sizeBytes, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRequestLimiter_AllowSeries(t *testing.T) {
+	tests := []struct {
+		name        string
+		seriesLimit int64
+		series      int64
+		want        bool
+	}{
+		{
+			name:        "Allowed when series limit is < 0",
+			seriesLimit: -1,
+			series:      30000,
+			want:        true,
+		},
+		{
+			name:        "Allowed when series limit is 0",
+			seriesLimit: 0,
+			series:      30000,
+			want:        true,
+		},
+		{
+			name:        "Allowed when under series limit",
+			seriesLimit: 50000,
+			series:      30000,
+			want:        true,
+		},
+		{
+			name:        "Allowed when equal to the series limit",
+			seriesLimit: 30000,
+			series:      30000,
+			want:        true,
+		},
+		{
+			name:        "Not allowed when above the series limit",
+			seriesLimit: 30000,
+			series:      30001,
+			want:        false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			l := newRequestLimiter(0, tt.seriesLimit, 0, nil)
+			if got := l.AllowSeries("tenant", tt.series); got != tt.want {
+				t.Errorf("unexpected AllowSeries result (series: %v), got %v, want %v", tt.series, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRequestLimiter_AllowSamples(t *testing.T) {
+	tests := []struct {
+		name         string
+		samplesLimit int64
+		samples      int64
+		want         bool
+	}{
+		{
+			name:         "Allowed when samples limit is < 0",
+			samplesLimit: -1,
+			samples:      30000,
+			want:         true,
+		},
+		{
+			name:         "Allowed when samples limit is 0",
+			samplesLimit: 0,
+			samples:      30000,
+			want:         true,
+		},
+		{
+			name:         "Allowed when under samples limit",
+			samplesLimit: 50000,
+			samples:      30000,
+			want:         true,
+		},
+		{
+			name:         "Allowed when equal to the samples limit",
+			samplesLimit: 30000,
+			samples:      30000,
+			want:         true,
+		},
+		{
+			name:         "Not allowed when above the samples limit",
+			samplesLimit: 30000,
+			samples:      30001,
+			want:         false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			l := newRequestLimiter(0, 0, tt.samplesLimit, nil)
+			if got := l.AllowSamples("tenant", tt.samples); got != tt.want {
+				t.Errorf("unexpected AllowSamples result (samples: %v), got %v, want %v", tt.samples, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: Douglas Camata <159076+douglascamata@users.noreply.github.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Implement write requests size limits in Thanos Receive. 

These limits are applied per request and can be configured with the following
command line arguments:

- `--receive.write-request-limits.max-size-bytes`: the maximum body size.
- `--receive.write-request-limits.max-series`: the maximum amount of series in a
  single remote write request.
- `--receive.write-request-limits.max-samples`: the maximum amount of samples in a
  single remote write request (summed from all series).

Any request above these limits will cause an 413 HTTP response (_Entity Too Large_)
and should not be retried without modifications. It's up to remote write clients to
split up the data and retry or completely drop it.

Another limit that was added to control concurrency on the remote write requests:

- `--receive.write-request-limits.max-concurrency`: the maximum amount remote write
  requests that will be concurrently processed while others wait.

**By default all these limits are disabled.** 

The flags are also hidden until per-tenant configuration in a file is implemented. A mention that this feature is WIP and might change whenever the per-tenant configuration file lands is present in the Receive docs.

This is a part of the work planned in #5404.

## Verification

- [x] Added some cases to the Receive's handler tests and they pass.
- [x] Running it locally.

## Future work

- Add support for per-tenant limit configuration