### PR TITLE
Fix proposal on website

### DIFF
--- a/docs/proposals-accepted/202106-automated-per-endpoint-mTLS.md
+++ b/docs/proposals-accepted/202106-automated-per-endpoint-mTLS.md
@@ -1,3 +1,11 @@
+---
+type: proposal
+title: Automated, per-endpoint mTLS
+status: accepted
+owner: Namanl2001
+menu: proposals-accepted
+---
+
 ## Automated, per-endpoint mTLS
 
 * **Owners:**


### PR DESCRIPTION
Currently, the Automated Per Endpoint TLS proposal does not show on the website menu due to lack of frontmatter.
We noticed during discussion with @SrushtiSapkale.
 
* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

- Add frontmatter to per endpoint TLS proposal

## Verification

Tested locally