### PR TITLE
Receiver: Add benchmark for receive writer

### DIFF
--- a/pkg/receive/writer_test.go
+++ b/pkg/receive/writer_test.go
@@ -5,6 +5,7 @@ package receive
 
 import (
 	"context"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"strings"
@@ -173,4 +174,81 @@ func TestWriter(t *testing.T) {
 			}
 		})
 	}
+}
+
+func BenchmarkWriterTimeSeriesWithSingleLabel_10(b *testing.B)   { benchmarkWriter(b, 1, 10) }
+func BenchmarkWriterTimeSeriesWithSingleLabel_100(b *testing.B)  { benchmarkWriter(b, 1, 100) }
+func BenchmarkWriterTimeSeriesWithSingleLabel_1000(b *testing.B) { benchmarkWriter(b, 1, 1000) }
+
+func BenchmarkWriterTimeSeriesWith10Labels_10(b *testing.B)   { benchmarkWriter(b, 10, 10) }
+func BenchmarkWriterTimeSeriesWith10Labels_100(b *testing.B)  { benchmarkWriter(b, 10, 100) }
+func BenchmarkWriterTimeSeriesWith10Labels_1000(b *testing.B) { benchmarkWriter(b, 10, 1000) }
+
+func benchmarkWriter(b *testing.B, labelsNum int, seriesNum int) {
+	dir, err := ioutil.TempDir("", "test")
+	testutil.Ok(b, err)
+	defer func() { testutil.Ok(b, os.RemoveAll(dir)) }()
+
+	logger := log.NewNopLogger()
+
+	m := NewMultiTSDB(dir, logger, prometheus.NewRegistry(), &tsdb.Options{
+		MinBlockDuration:      (2 * time.Hour).Milliseconds(),
+		MaxBlockDuration:      (2 * time.Hour).Milliseconds(),
+		RetentionDuration:     (6 * time.Hour).Milliseconds(),
+		NoLockfile:            true,
+		MaxExemplars:          0,
+		EnableExemplarStorage: true,
+	},
+		labels.FromStrings("replica", "01"),
+		"tenant_id",
+		nil,
+		false,
+		metadata.NoneFunc,
+	)
+	defer func() { testutil.Ok(b, m.Close()) }()
+
+	testutil.Ok(b, m.Flush())
+	testutil.Ok(b, m.Open())
+
+	app, err := m.TenantAppendable("foo")
+	testutil.Ok(b, err)
+
+	w := NewWriter(logger, m)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	testutil.Ok(b, runutil.Retry(1*time.Second, ctx.Done(), func() error {
+		_, err = app.Appender(context.Background())
+		return err
+	}))
+
+	timeSeries := generateLabelsAndSeries(labelsNum, seriesNum)
+
+	wreq := &prompb.WriteRequest{
+		Timeseries: timeSeries,
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_ = w.Write(ctx, "foo", wreq)
+	}
+}
+
+func generateLabelsAndSeries(labelsNum int, seriesNum int) []prompb.TimeSeries {
+	// Generate some labels first.
+	l := make([]labelpb.ZLabel, 0, labelsNum)
+	l = append(l, labelpb.ZLabel{Name: "__name__", Value: "test"})
+	for i := 0; i < labelsNum; i++ {
+		l = append(l, labelpb.ZLabel{Name: fmt.Sprintf("label_%q", rune('a'-1+i)), Value: fmt.Sprintf("%d", i)})
+	}
+
+	ts := make([]prompb.TimeSeries, 0, seriesNum)
+	for j := 0; j < seriesNum; j++ {
+		ts = append(ts, prompb.TimeSeries{Labels: l, Samples: []prompb.Sample{{Value: 1, Timestamp: 10}}})
+	}
+
+	return ts
 }

--- a/pkg/receive/writer_test.go
+++ b/pkg/receive/writer_test.go
@@ -185,7 +185,7 @@ func BenchmarkWriterTimeSeriesWith10Labels_100(b *testing.B)  { benchmarkWriter(
 func BenchmarkWriterTimeSeriesWith10Labels_1000(b *testing.B) { benchmarkWriter(b, 10, 1000) }
 
 func benchmarkWriter(b *testing.B, labelsNum int, seriesNum int) {
-	dir, err := ioutil.TempDir("", "test")
+	dir, err := ioutil.TempDir("", "bench-writer")
 	testutil.Ok(b, err)
 	defer func() { testutil.Ok(b, os.RemoveAll(dir)) }()
 
@@ -237,16 +237,16 @@ func benchmarkWriter(b *testing.B, labelsNum int, seriesNum int) {
 	}
 }
 
-func generateLabelsAndSeries(labelsNum int, seriesNum int) []prompb.TimeSeries {
+func generateLabelsAndSeries(numLabels int, numSeries int) []prompb.TimeSeries {
 	// Generate some labels first.
-	l := make([]labelpb.ZLabel, 0, labelsNum)
+	l := make([]labelpb.ZLabel, 0, numLabels)
 	l = append(l, labelpb.ZLabel{Name: "__name__", Value: "test"})
-	for i := 0; i < labelsNum; i++ {
+	for i := 0; i < numLabels; i++ {
 		l = append(l, labelpb.ZLabel{Name: fmt.Sprintf("label_%q", rune('a'-1+i)), Value: fmt.Sprintf("%d", i)})
 	}
 
-	ts := make([]prompb.TimeSeries, 0, seriesNum)
-	for j := 0; j < seriesNum; j++ {
+	ts := make([]prompb.TimeSeries, 0, numSeries)
+	for j := 0; j < numSeries; j++ {
 		ts = append(ts, prompb.TimeSeries{Labels: l, Samples: []prompb.Sample{{Value: 1, Timestamp: 10}}})
 	}
 


### PR DESCRIPTION
Signed-off-by: Matej Gera <matejgera@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Off the back of the discussion on https://github.com/thanos-io/thanos/pull/5508#discussion_r923067652, I thought it would be good add some benchmarks for receive writer, to help us reason about changes in the writer (given this is the crucial piece of remote write path).

## Verification

Results:
```
goos: linux
goarch: amd64
pkg: github.com/thanos-io/thanos/pkg/receive
cpu: Intel(R) Core(TM) i7-9850H CPU @ 2.60GHz
BenchmarkWriterTimeSeriesWithSingleLabel_10-12            297813              3568 ns/op             411 B/op          9 allocs/op
BenchmarkWriterTimeSeriesWithSingleLabel_100-12            47799             21589 ns/op             412 B/op          9 allocs/op
BenchmarkWriterTimeSeriesWithSingleLabel_1000-12            5859            193874 ns/op             453 B/op          9 allocs/op
BenchmarkWriterTimeSeriesWith10Labels_10-12               219638              5028 ns/op             410 B/op          9 allocs/op
BenchmarkWriterTimeSeriesWith10Labels_100-12               34004             33783 ns/op             412 B/op          9 allocs/op
BenchmarkWriterTimeSeriesWith10Labels_1000-12               3147            344160 ns/op             458 B/op          9 allocs/op
PASS
ok      github.com/thanos-io/thanos/pkg/receive 31.432s
```

<!-- How you tested it? How do you know it works? -->
