### PR TITLE
query: Set struct return by query api alerts same as prometheus api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 
 ### Fixed
 - [#5502](https://github.com/thanos-io/thanos/pull/5502) Receive: Handle exemplar storage errors as conflict error.
+- [#5534](https://github.com/thanos-io/thanos/pull/5534) Query: Set struct return by query api alerts same as prometheus api
 
 ### Added
 

--- a/pkg/api/query/v1.go
+++ b/pkg/api/query/v1.go
@@ -794,7 +794,9 @@ func NewAlertsHandler(client rules.UnaryClient, enablePartialResponse bool) func
 			return nil, nil, &api.ApiError{Typ: api.ErrorInternal, Err: errors.Errorf("error retrieving rules: %v", err)}
 		}
 
-		var resp struct{ Alerts []*rulespb.AlertInstance }
+		var resp struct {
+			Alerts []*rulespb.AlertInstance `json:"alerts"`
+		}
 		for _, g := range groups.Groups {
 			for _, r := range g.Rules {
 				a := r.GetAlert()


### PR DESCRIPTION
Query alerts api  (/api/v1/alerts) return a list of items in object Alerts
There is a difference between api object return by Prometheus `alerts` and Thanos `Alerts`: 
A uppercase in Thanos, a lowercase in prometheus

Example of return json object: 
Thanos -> Alerts:
`json 
{"status":"success","data":{"Alerts":[..]}}
`
Prometheus -> alerts:
`json 
{"status":"success","data":{"alerts":[..]}}
`

It can be usefull to have the same struc of object. Our usecase is to use nagstamon to scrape alerts. Nagstamon can scrape prometheus, so we want to use type prometheus to get information on Thanos. This functionnality is broken due to uppercase on 'Alerts'

This PR is linked to this one which implements alerts api on thanos -> #5315

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

Override representation of Alerts Object in json by using `json:"alerts"

## Verification

I build thanos with my commit, and try on my kubernetes cluster with the new version (Docker image: `audig/thanos:pr-5534`), i've checked the response of `/api/v1/alerts` and i've now an json with `alerts`
![tempsnip](https://user-images.githubusercontent.com/3289045/180493438-553e8e79-dbe3-451c-a805-079b55185701.png)


My use case with nagstamon is ok, i can get information about alerts in thanos with a prometheus connection type
