### PR TITLE
Remove empty RuleGroups in api/v1/rules when using matchers

### DIFF
--- a/pkg/rules/rules.go
+++ b/pkg/rules/rules.go
@@ -86,26 +86,26 @@ func filterRules(ruleGroups []*rulespb.RuleGroup, matcherSets [][]*labels.Matche
 		return ruleGroups
 	}
 
-	gc := 0 // Group count.
+	groupCount := 0
 	for _, g := range ruleGroups {
-		rc := 0 // Rule count.
+		ruleCount := 0
 		for _, r := range g.Rules {
 			// Filter rules based on matcher.
 			rl := r.GetLabels()
 			if matches(matcherSets, rl) {
-				g.Rules[rc] = r
-				rc++
+				g.Rules[ruleCount] = r
+				ruleCount++
 			}
 		}
-		g.Rules = g.Rules[:rc]
+		g.Rules = g.Rules[:ruleCount]
 
 		// Filter groups based on number of rules.
 		if len(g.Rules) != 0 {
-			ruleGroups[gc] = g
-			gc++
+			ruleGroups[groupCount] = g
+			groupCount++
 		}
 	}
-	ruleGroups = ruleGroups[:gc]
+	ruleGroups = ruleGroups[:groupCount]
 
 	return ruleGroups
 }

--- a/pkg/rules/rules.go
+++ b/pkg/rules/rules.go
@@ -86,15 +86,21 @@ func filterRules(ruleGroups []*rulespb.RuleGroup, matcherSets [][]*labels.Matche
 		return ruleGroups
 	}
 
-	for _, g := range ruleGroups {
-		filteredRules := g.Rules[:0]
-		for _, r := range g.Rules {
+	for i := 0; i < len(ruleGroups); i++ {
+		filteredRules := ruleGroups[i].Rules[:0]
+		for _, r := range ruleGroups[i].Rules {
 			rl := r.GetLabels()
 			if matches(matcherSets, rl) {
 				filteredRules = append(filteredRules, r)
 			}
 		}
-		g.Rules = filteredRules
+
+		ruleGroups[i].Rules = filteredRules
+		// Filter Groups which do not have any rules.
+		if len(ruleGroups[i].Rules) == 0 {
+			ruleGroups = append(ruleGroups[:i], ruleGroups[i+1:]...)
+			i-- // -1 as the slice just got shorter
+		}
 	}
 
 	return ruleGroups

--- a/pkg/rules/rules.go
+++ b/pkg/rules/rules.go
@@ -86,22 +86,26 @@ func filterRules(ruleGroups []*rulespb.RuleGroup, matcherSets [][]*labels.Matche
 		return ruleGroups
 	}
 
-	for i := 0; i < len(ruleGroups); i++ {
-		filteredRules := ruleGroups[i].Rules[:0]
-		for _, r := range ruleGroups[i].Rules {
+	gc := 0 // Group count.
+	for _, g := range ruleGroups {
+		rc := 0 // Rule count.
+		for _, r := range g.Rules {
+			// Filter rules based on matcher.
 			rl := r.GetLabels()
 			if matches(matcherSets, rl) {
-				filteredRules = append(filteredRules, r)
+				g.Rules[rc] = r
+				rc++
 			}
 		}
+		g.Rules = g.Rules[:rc]
 
-		ruleGroups[i].Rules = filteredRules
-		// Filter Groups which do not have any rules.
-		if len(ruleGroups[i].Rules) == 0 {
-			ruleGroups = append(ruleGroups[:i], ruleGroups[i+1:]...)
-			i-- // -1 as the slice just got shorter
+		// Filter groups based on number of rules.
+		if len(g.Rules) != 0 {
+			ruleGroups[gc] = g
+			gc++
 		}
 	}
+	ruleGroups = ruleGroups[:gc]
 
 	return ruleGroups
 }

--- a/pkg/rules/rules_test.go
+++ b/pkg/rules/rules_test.go
@@ -1112,10 +1112,7 @@ func TestFilterRules(t *testing.T) {
 					},
 				},
 			},
-			want: []*rulespb.RuleGroup{{
-				Name:  "a",
-				Rules: []*rulespb.Rule{},
-			}},
+			want: []*rulespb.RuleGroup{},
 		},
 		{
 			name:        "single group with templated labels",
@@ -1140,10 +1137,7 @@ func TestFilterRules(t *testing.T) {
 					},
 				},
 			},
-			want: []*rulespb.RuleGroup{{
-				Name:  "a",
-				Rules: []*rulespb.Rule{},
-			}},
+			want: []*rulespb.RuleGroup{},
 		},
 		{
 			name:        "multiple group with labeled rules and matcher",
@@ -1258,16 +1252,7 @@ func TestFilterRules(t *testing.T) {
 					},
 				},
 			},
-			want: []*rulespb.RuleGroup{
-				{
-					Name:  "a",
-					Rules: []*rulespb.Rule{},
-				},
-				{
-					Name:  "b",
-					Rules: []*rulespb.Rule{},
-				},
-			},
+			want: []*rulespb.RuleGroup{},
 		},
 		{
 			name:        "multiple group with templated labels",
@@ -1296,16 +1281,7 @@ func TestFilterRules(t *testing.T) {
 					},
 				},
 			},
-			want: []*rulespb.RuleGroup{
-				{
-					Name:  "a",
-					Rules: []*rulespb.Rule{},
-				},
-				{
-					Name:  "b",
-					Rules: []*rulespb.Rule{},
-				},
-			},
+			want: []*rulespb.RuleGroup{},
 		},
 		{
 			name:        "multiple group with templated labels and non templated matcher",
@@ -1334,16 +1310,7 @@ func TestFilterRules(t *testing.T) {
 					},
 				},
 			},
-			want: []*rulespb.RuleGroup{
-				{
-					Name:  "a",
-					Rules: []*rulespb.Rule{},
-				},
-				{
-					Name:  "b",
-					Rules: []*rulespb.Rule{},
-				},
-			},
+			want: []*rulespb.RuleGroup{},
 		},
 		{
 			name:        "multiple group with regex matcher",


### PR DESCRIPTION
This PR ensures that RuleGroups without any Rules are not returned in api/v1/rules response, when filtering Rules via label matchers. 

A use case for this is when implementing tenancy on top of this endpoint, and ensuring tenants don't see another tenant's Rules or RuleGroups. 

When not using label matchers all RuleGroups are returned, irrespective of the number of Rules.

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

- Update `filterRules` method to remove empty Rule groups after filtering
- Update tests

## Verification

Tested locally + unit tests.