### PR TITLE
Refactor EndpointSet

### DIFF
--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -420,6 +420,7 @@ func runQuery(
 
 	var (
 		endpoints = query.NewEndpointSet(
+			time.Now,
 			logger,
 			reg,
 			func() (specs []*query.GRPCEndpointSpec) {

--- a/pkg/query/endpointset.go
+++ b/pkg/query/endpointset.go
@@ -241,29 +241,28 @@ func (c *endpointSetNodeCollector) Collect(ch chan<- prometheus.Metric) {
 // EndpointSet maintains a set of active Thanos endpoints. It is backed up by Endpoint Specifications that are dynamically fetched on
 // every Update() call.
 type EndpointSet struct {
+	now    nowFunc
 	logger log.Logger
 
 	// Endpoint specifications can change dynamically. If some component is missing from the list, we assume it is no longer
 	// accessible and we close gRPC client for it, unless it is strict.
-	endpointSpec        func() []*GRPCEndpointSpec
-	dialOpts            []grpc.DialOption
-	gRPCInfoCallTimeout time.Duration
+	endpointSpec             func() []*GRPCEndpointSpec
+	dialOpts                 []grpc.DialOption
+	gRPCInfoCallTimeout      time.Duration
+	unhealthyEndpointTimeout time.Duration
 
-	updateMtx            sync.Mutex
-	endpointsMtx         sync.RWMutex
-	endpointsStatusesMtx sync.RWMutex
+	updateMtx sync.Mutex
 
-	// Main map of stores currently used for fanout.
+	endpointsMtx    sync.RWMutex
 	endpoints       map[string]*endpointRef
 	endpointsMetric *endpointSetNodeCollector
-
-	// Map of statuses used only by UI.
-	endpointStatuses         map[string]*EndpointStatus
-	unhealthyEndpointTimeout time.Duration
 }
+
+type nowFunc func() time.Time
 
 // NewEndpointSet returns a new set of Thanos APIs.
 func NewEndpointSet(
+	now nowFunc,
 	logger log.Logger,
 	reg *prometheus.Registry,
 	endpointSpecs func() []*GRPCEndpointSpec,
@@ -283,17 +282,18 @@ func NewEndpointSet(
 		endpointSpecs = func() []*GRPCEndpointSpec { return nil }
 	}
 
-	es := &EndpointSet{
-		logger:                   log.With(logger, "component", "endpointset"),
+	return &EndpointSet{
+		now:             now,
+		logger:          log.With(logger, "component", "endpointset"),
+		endpointsMetric: endpointsMetric,
+
 		dialOpts:                 dialOpts,
-		endpointsMetric:          endpointsMetric,
 		gRPCInfoCallTimeout:      5 * time.Second,
-		endpoints:                make(map[string]*endpointRef),
-		endpointStatuses:         make(map[string]*EndpointStatus),
 		unhealthyEndpointTimeout: unhealthyEndpointTimeout,
-		endpointSpec:             endpointSpecs,
+
+		endpointSpec: endpointSpecs,
+		endpoints:    make(map[string]*endpointRef),
 	}
-	return es
 }
 
 // Update updates the endpoint set. It fetches current list of endpoint specs from function and updates the fresh metadata
@@ -302,39 +302,44 @@ func (e *EndpointSet) Update(ctx context.Context) {
 	e.updateMtx.Lock()
 	defer e.updateMtx.Unlock()
 
-	e.endpointsMtx.RLock()
-	endpoints := make(map[string]*endpointRef, len(e.endpoints))
-	for addr, er := range e.endpoints {
-		endpoints[addr] = er
+	currentEndpoints := e.endpointRefs()
+	level.Debug(e.logger).Log("msg", "starting to update API endpoints", "cachedEndpoints", len(currentEndpoints))
+
+	endpointSpecs := make(map[string]*GRPCEndpointSpec)
+	for _, spec := range e.endpointSpec() {
+		if _, duplicate := endpointSpecs[spec.Addr()]; duplicate {
+			continue
+		}
+		endpointSpecs[spec.Addr()] = spec
 	}
-	e.endpointsMtx.RUnlock()
 
-	level.Debug(e.logger).Log("msg", "starting to update API endpoints", "cachedEndpoints", len(endpoints))
+	var wg sync.WaitGroup
+	for _, spec := range endpointSpecs {
+		wg.Add(1)
+		go func(spec *GRPCEndpointSpec) {
+			defer wg.Done()
 
-	activeEndpoints := e.getActiveEndpoints(ctx, endpoints)
-	level.Debug(e.logger).Log("msg", "checked requested endpoints", "activeEndpoints", len(activeEndpoints), "cachedEndpoints", len(endpoints))
+			ctx, cancel := context.WithTimeout(ctx, e.gRPCInfoCallTimeout)
+			defer cancel()
+			e.updateEndpoint(ctx, spec)
+		}(spec)
+	}
 
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		e.pruneEndpoints(endpointSpecs)
+	}()
+	wg.Wait()
+
+	e.pruneTimedOutEndpoints()
+
+	newEndpoints := e.endpointRefs()
+	level.Debug(e.logger).Log("msg", "updated endpoints", "activeEndpoints", len(newEndpoints))
+
+	// Update stats
 	stats := newEndpointAPIStats()
-
-	// Close endpoints which are not active this time (are not in active endpoints map).
-	for addr, er := range endpoints {
-		if _, ok := activeEndpoints[addr]; ok {
-			stats[er.ComponentType()][labelpb.PromLabelSetsToString(er.LabelSets())]++
-			continue
-		}
-
-		er.Close()
-		delete(endpoints, addr)
-		e.updateEndpointStatus(er, errors.New(unhealthyEndpointMessage))
-		level.Info(er.logger).Log("msg", unhealthyEndpointMessage, "address", addr, "extLset", labelpb.PromLabelSetsToString(er.LabelSets()))
-	}
-
-	// Add endpoints that are not yet in activeEndpoints map.
-	for addr, er := range activeEndpoints {
-		if _, ok := endpoints[addr]; ok {
-			continue
-		}
-
+	for addr, er := range e.getQueryableEndpointRefs() {
 		extLset := labelpb.PromLabelSetsToString(er.LabelSets())
 
 		// All producers that expose StoreAPI should have unique external labels. Check all which connect to our Querier.
@@ -345,28 +350,125 @@ func (e *EndpointSet) Update(ctx context.Context) {
 				"address", addr, "extLset", extLset, "duplicates", fmt.Sprintf("%v", stats[component.Sidecar][extLset]+stats[component.Rule][extLset]+1))
 		}
 		stats[er.ComponentType()][extLset]++
-
-		endpoints[addr] = er
-		e.updateEndpointStatus(er, nil)
-
-		level.Info(e.logger).Log("msg", fmt.Sprintf("adding new %v with %+v", er.ComponentType(), er.apisPresent()), "address", addr, "extLset", extLset)
+		if _, ok := currentEndpoints[er.addr]; !ok {
+			level.Info(e.logger).Log("msg", fmt.Sprintf("adding new %v with %+v", er.ComponentType(), er.apisPresent()), "address", addr, "extLset", extLset)
+		}
 	}
 
 	e.endpointsMetric.Update(stats)
-	e.endpointsMtx.Lock()
-	e.endpoints = endpoints
-	e.endpointsMtx.Unlock()
+}
 
-	e.cleanUpEndpointStatuses(endpoints)
+func (e *EndpointSet) updateEndpoint(ctx context.Context, spec *GRPCEndpointSpec) {
+	e.endpointsMtx.RLock()
+	er, exists := e.endpoints[spec.Addr()]
+	e.endpointsMtx.RUnlock()
+
+	if !exists {
+		var err error
+		er, err = e.newEndpointRef(ctx, e.logger, spec, e.dialOpts...)
+		if err != nil {
+			level.Warn(e.logger).Log("msg", "update of node failed", "err", err, "address", spec.Addr())
+			return
+		}
+	}
+
+	metadata, err := spec.Metadata(ctx, infopb.NewInfoClient(er.cc), storepb.NewStoreClient(er.cc))
+	if err != nil {
+		level.Warn(e.logger).Log("msg", "update of node failed", "err", errors.Wrap(err, "getting metadata"), "address", spec.Addr())
+	}
+	er.update(e.now, metadata, err)
+	if !exists {
+		e.addEndpoint(spec, er)
+	}
+}
+
+func (e *EndpointSet) pruneEndpoints(nextEndpoints map[string]*GRPCEndpointSpec) {
+	obsoleteEndpoints := make(map[string]*endpointRef)
+	for addr, er := range e.endpointRefs() {
+		if _, ok := nextEndpoints[addr]; !ok {
+			obsoleteEndpoints[addr] = er
+		}
+	}
+
+	for _, er := range obsoleteEndpoints {
+		e.removeEndpoint(er)
+	}
+}
+
+// pruneTimedOutEndpoints removes unhealthy endpoints for which the last
+// successful health chech is older than the unhealthyEndpointTimeout.
+// Strict endpoints are not removed.
+func (e *EndpointSet) pruneTimedOutEndpoints() {
+	endpoints := e.endpointRefs()
+
+	now := e.now()
+	for _, er := range endpoints {
+		if er.isStrict {
+			continue
+		}
+
+		if now.Sub(er.created) < e.unhealthyEndpointTimeout {
+			continue
+		}
+
+		lastCheck := er.getStatus().LastCheck
+		if now.Sub(lastCheck) >= e.unhealthyEndpointTimeout {
+			e.removeEndpoint(er)
+		}
+	}
+}
+
+func (e *EndpointSet) addEndpoint(spec *GRPCEndpointSpec, er *endpointRef) {
+	e.endpointsMtx.Lock()
+	defer e.endpointsMtx.Unlock()
+
+	e.endpoints[spec.Addr()] = er
+}
+
+func (e *EndpointSet) removeEndpoint(er *endpointRef) {
+	e.endpointsMtx.Lock()
+	defer e.endpointsMtx.Unlock()
+
+	if _, ok := e.endpoints[er.Addr()]; ok {
+		level.Info(er.logger).Log("msg", unhealthyEndpointMessage, "address", er.Addr(), "extLset", labelpb.PromLabelSetsToString(er.LabelSets()))
+		delete(e.endpoints, er.Addr())
+	}
+	er.Close()
+}
+
+// endpointsMap returns a map from endpoint address to *endpointRef.
+func (e *EndpointSet) endpointRefs() map[string]*endpointRef {
+	e.endpointsMtx.RLock()
+	defer e.endpointsMtx.RUnlock()
+
+	endpoints := make(map[string]*endpointRef, len(e.endpoints))
+	for addr, er := range e.endpoints {
+		endpoints[addr] = er
+	}
+
+	return endpoints
+}
+
+func (e *EndpointSet) getQueryableEndpointRefs() map[string]*endpointRef {
+	e.endpointsMtx.RLock()
+	defer e.endpointsMtx.RUnlock()
+
+	endpoints := make(map[string]*endpointRef)
+	for addr, er := range e.endpoints {
+		if er.isQueryable() {
+			endpoints[addr] = er
+		}
+	}
+
+	return endpoints
 }
 
 // GetStoreClients returns a list of all active stores.
 func (e *EndpointSet) GetStoreClients() []store.Client {
-	e.endpointsMtx.RLock()
-	defer e.endpointsMtx.RUnlock()
+	endpoints := e.getQueryableEndpointRefs()
 
-	stores := make([]store.Client, 0, len(e.endpoints))
-	for _, er := range e.endpoints {
+	stores := make([]store.Client, 0, len(endpoints))
+	for _, er := range endpoints {
 		if er.HasStoreAPI() {
 			// Make a new endpointRef with store client.
 			stores = append(stores, &endpointRef{
@@ -381,11 +483,10 @@ func (e *EndpointSet) GetStoreClients() []store.Client {
 
 // GetQueryAPIClients returns a list of all active query API clients.
 func (e *EndpointSet) GetQueryAPIClients() []querypb.QueryClient {
-	e.endpointsMtx.RLock()
-	defer e.endpointsMtx.RUnlock()
+	endpoints := e.getQueryableEndpointRefs()
 
-	stores := make([]querypb.QueryClient, 0, len(e.endpoints))
-	for _, er := range e.endpoints {
+	stores := make([]querypb.QueryClient, 0, len(endpoints))
+	for _, er := range endpoints {
 		if er.HasQueryAPI() {
 			stores = append(stores, querypb.NewQueryClient(er.cc))
 		}
@@ -395,11 +496,10 @@ func (e *EndpointSet) GetQueryAPIClients() []querypb.QueryClient {
 
 // GetRulesClients returns a list of all active rules clients.
 func (e *EndpointSet) GetRulesClients() []rulespb.RulesClient {
-	e.endpointsMtx.RLock()
-	defer e.endpointsMtx.RUnlock()
+	endpoints := e.getQueryableEndpointRefs()
 
-	rules := make([]rulespb.RulesClient, 0, len(e.endpoints))
-	for _, er := range e.endpoints {
+	rules := make([]rulespb.RulesClient, 0, len(endpoints))
+	for _, er := range endpoints {
 		if er.HasRulesAPI() {
 			rules = append(rules, rulespb.NewRulesClient(er.cc))
 		}
@@ -409,11 +509,10 @@ func (e *EndpointSet) GetRulesClients() []rulespb.RulesClient {
 
 // GetTargetsClients returns a list of all active targets clients.
 func (e *EndpointSet) GetTargetsClients() []targetspb.TargetsClient {
-	e.endpointsMtx.RLock()
-	defer e.endpointsMtx.RUnlock()
+	endpoints := e.getQueryableEndpointRefs()
 
-	targets := make([]targetspb.TargetsClient, 0, len(e.endpoints))
-	for _, er := range e.endpoints {
+	targets := make([]targetspb.TargetsClient, 0, len(endpoints))
+	for _, er := range endpoints {
 		if er.HasTargetsAPI() {
 			targets = append(targets, targetspb.NewTargetsClient(er.cc))
 		}
@@ -423,11 +522,10 @@ func (e *EndpointSet) GetTargetsClients() []targetspb.TargetsClient {
 
 // GetMetricMetadataClients returns a list of all active metadata clients.
 func (e *EndpointSet) GetMetricMetadataClients() []metadatapb.MetadataClient {
-	e.endpointsMtx.RLock()
-	defer e.endpointsMtx.RUnlock()
+	endpoints := e.getQueryableEndpointRefs()
 
-	metadataClients := make([]metadatapb.MetadataClient, 0, len(e.endpoints))
-	for _, er := range e.endpoints {
+	metadataClients := make([]metadatapb.MetadataClient, 0, len(endpoints))
+	for _, er := range endpoints {
 		if er.HasMetricMetadataAPI() {
 			metadataClients = append(metadataClients, metadatapb.NewMetadataClient(er.cc))
 		}
@@ -437,11 +535,10 @@ func (e *EndpointSet) GetMetricMetadataClients() []metadatapb.MetadataClient {
 
 // GetExemplarsStores returns a list of all active exemplars stores.
 func (e *EndpointSet) GetExemplarsStores() []*exemplarspb.ExemplarStore {
-	e.endpointsMtx.RLock()
-	defer e.endpointsMtx.RUnlock()
+	endpoints := e.getQueryableEndpointRefs()
 
-	exemplarStores := make([]*exemplarspb.ExemplarStore, 0, len(e.endpoints))
-	for _, er := range e.endpoints {
+	exemplarStores := make([]*exemplarspb.ExemplarStore, 0, len(endpoints))
+	for _, er := range endpoints {
 		if er.HasExemplarsAPI() {
 			exemplarStores = append(exemplarStores, &exemplarspb.ExemplarStore{
 				ExemplarsClient: exemplarspb.NewExemplarsClient(er.cc),
@@ -462,136 +559,16 @@ func (e *EndpointSet) Close() {
 	e.endpoints = map[string]*endpointRef{}
 }
 
-func (e *EndpointSet) getActiveEndpoints(ctx context.Context, endpoints map[string]*endpointRef) map[string]*endpointRef {
-	var (
-		activeEndpoints = make(map[string]*endpointRef, len(endpoints))
-		mtx             sync.Mutex
-		wg              sync.WaitGroup
-
-		endpointAddrSet = make(map[string]struct{})
-	)
-
-	// Gather healthy endpoints map concurrently using info API. Build new clients if does not exist already.
-	for _, es := range e.endpointSpec() {
-		if _, ok := endpointAddrSet[es.Addr()]; ok {
-			continue
-		}
-		endpointAddrSet[es.Addr()] = struct{}{}
-
-		wg.Add(1)
-		go func(spec *GRPCEndpointSpec) {
-			defer wg.Done()
-
-			addr := spec.Addr()
-
-			ctx, cancel := context.WithTimeout(ctx, e.gRPCInfoCallTimeout)
-			defer cancel()
-
-			er, seenAlready := endpoints[addr]
-			if !seenAlready {
-				// New endpoint or was unactive and was removed in the past - create the new one.
-				conn, err := grpc.DialContext(ctx, addr, e.dialOpts...)
-				if err != nil {
-					e.updateEndpointStatus(&endpointRef{addr: addr}, err)
-					level.Warn(e.logger).Log("msg", "update of node failed", "err", errors.Wrap(err, "dialing connection"), "address", addr)
-					return
-				}
-
-				// Assume that StoreAPI is also exposed because if call to info service fails we will call info method of storeAPI.
-				// It will be overwritten to null if not present.
-				er = &endpointRef{
-					cc:     conn,
-					addr:   addr,
-					logger: e.logger,
-				}
-			}
-
-			metadata, err := spec.Metadata(ctx, infopb.NewInfoClient(er.cc), storepb.NewStoreClient(er.cc))
-			if err != nil {
-				if !seenAlready && !spec.IsStrictStatic() {
-					// Close only if new and not a strict static node.
-					// Inactive `e.endpoints` will be closed later on.
-					er.Close()
-				}
-
-				e.updateEndpointStatus(er, err)
-				level.Warn(e.logger).Log("msg", "update of node failed", "err", errors.Wrap(err, "getting metadata"), "address", addr)
-
-				if !spec.IsStrictStatic() {
-					return
-				}
-
-				// Still keep it around if static & strict mode enabled.
-				// Assume that it expose storeAPI and cover all complete possible time range.
-				if !seenAlready {
-					metadata = &endpointMetadata{
-						&infopb.InfoResponse{
-							Store: &infopb.StoreInfo{
-								MinTime: math.MinInt64,
-								MaxTime: math.MaxInt64,
-							},
-						},
-					}
-					er.Update(metadata)
-				}
-
-				mtx.Lock()
-				defer mtx.Unlock()
-
-				activeEndpoints[addr] = er
-				return
-			}
-
-			er.Update(metadata)
-			e.updateEndpointStatus(er, nil)
-
-			mtx.Lock()
-			defer mtx.Unlock()
-
-			activeEndpoints[addr] = er
-		}(es)
-	}
-	wg.Wait()
-
-	return activeEndpoints
-}
-
-func (e *EndpointSet) updateEndpointStatus(er *endpointRef, err error) {
-	e.endpointsStatusesMtx.Lock()
-	defer e.endpointsStatusesMtx.Unlock()
-
-	status := EndpointStatus{Name: er.addr}
-	prev, ok := e.endpointStatuses[er.addr]
-	if ok {
-		status = *prev
-	} else {
-		mint, maxt := er.TimeRange()
-		status.MinTime = mint
-		status.MaxTime = maxt
-	}
-
-	if err == nil {
-		status.LastCheck = time.Now()
-		mint, maxt := er.TimeRange()
-		status.LabelSets = er.LabelSets()
-		status.ComponentType = er.ComponentType()
-		status.MinTime = mint
-		status.MaxTime = maxt
-		status.LastError = nil
-	} else {
-		status.LastError = &stringError{originalErr: err}
-	}
-
-	e.endpointStatuses[er.addr] = &status
-}
-
 func (e *EndpointSet) GetEndpointStatus() []EndpointStatus {
-	e.endpointsStatusesMtx.RLock()
-	defer e.endpointsStatusesMtx.RUnlock()
+	e.endpointsMtx.RLock()
+	defer e.endpointsMtx.RUnlock()
 
-	statuses := make([]EndpointStatus, 0, len(e.endpointStatuses))
-	for _, v := range e.endpointStatuses {
-		statuses = append(statuses, *v)
+	statuses := make([]EndpointStatus, 0, len(e.endpoints))
+	for _, v := range e.endpoints {
+		status := v.getStatus()
+		if status != nil {
+			statuses = append(statuses, *status)
+		}
 	}
 
 	sort.Slice(statuses, func(i, j int) bool {
@@ -600,46 +577,101 @@ func (e *EndpointSet) GetEndpointStatus() []EndpointStatus {
 	return statuses
 }
 
-func (e *EndpointSet) cleanUpEndpointStatuses(endpoints map[string]*endpointRef) {
-	e.endpointsStatusesMtx.Lock()
-	defer e.endpointsStatusesMtx.Unlock()
-
-	now := time.Now()
-	for addr, status := range e.endpointStatuses {
-		if _, ok := endpoints[addr]; ok {
-			continue
-		}
-
-		if now.Sub(status.LastCheck) >= e.unhealthyEndpointTimeout {
-			delete(e.endpointStatuses, addr)
-		}
-	}
-}
-
 type endpointRef struct {
 	storepb.StoreClient
 
-	mtx  sync.RWMutex
-	cc   *grpc.ClientConn
-	addr string
+	mtx      sync.RWMutex
+	cc       *grpc.ClientConn
+	addr     string
+	isStrict bool
 
-	// Metadata can change during runtime.
+	created  time.Time
 	metadata *endpointMetadata
+	status   *EndpointStatus
 
 	logger log.Logger
 }
 
-func (er *endpointRef) Update(metadata *endpointMetadata) {
-	er.mtx.Lock()
-	defer er.mtx.Unlock()
+// newEndpointRef creates a new endpointRef with a gRPC channel to the given the IP address.
+// The call to newEndpointRef will return an error if establishing the channel fails.
+func (e *EndpointSet) newEndpointRef(ctx context.Context, logger log.Logger, spec *GRPCEndpointSpec, dialOpts ...grpc.DialOption) (*endpointRef, error) {
+	conn, err := grpc.DialContext(ctx, spec.Addr(), dialOpts...)
+	if err != nil {
+		return nil, errors.Wrap(err, "dialing connection")
+	}
 
-	er.metadata = metadata
+	return &endpointRef{
+		logger:   logger,
+		created:  e.now(),
+		addr:     spec.Addr(),
+		isStrict: spec.IsStrictStatic(),
+		cc:       conn,
+	}, nil
+}
+
+// update sets the metadata and status of the endpoint ref based on the info response value and error.
+func (er *endpointRef) update(now nowFunc, metadata *endpointMetadata, err error) {
+	er.mtx.RLock()
+	defer er.mtx.RUnlock()
+
+	er.updateMetadata(metadata, err)
+	er.updateStatus(now, err)
+}
+
+// updateStatus updates the endpointRef status based on the info call error.
+func (er *endpointRef) updateStatus(now nowFunc, err error) {
+	mint, maxt := er.timeRange()
+	if er.status == nil {
+		er.status = &EndpointStatus{Name: er.addr}
+	}
+
+	if err == nil {
+		er.status.LastCheck = now()
+		er.status.LabelSets = er.labelSets()
+		er.status.ComponentType = er.componentType()
+		er.status.MinTime = mint
+		er.status.MaxTime = maxt
+		er.status.LastError = nil
+	} else {
+		er.status.LastError = &stringError{originalErr: err}
+	}
+}
+
+// updateMetadata sets the metadata for an endpoint ref based on the info call result and the info call error.
+// When an info call for an endpoint fails, we preserve metadata from the previous state.
+// If the is new and has no previous state, we assume it is a Store covering the complete time range.
+func (er *endpointRef) updateMetadata(metadata *endpointMetadata, err error) {
+	if err == nil {
+		er.metadata = metadata
+	}
+
+	if err != nil && er.metadata == nil {
+		er.metadata = maxRangeStoreMetadata()
+	}
+}
+
+func (er *endpointRef) getStatus() *EndpointStatus {
+	er.mtx.RLock()
+	defer er.mtx.RUnlock()
+
+	return er.status
+}
+
+// isQueryable returns true if an endpointRef should be used for querying.
+// A strict endpointRef is always queriable. A non-strict endpointRef
+// is queryable if the last health check (info call) succeeded.
+func (er *endpointRef) isQueryable() bool {
+	return er.isStrict || er.getStatus().LastError == nil
 }
 
 func (er *endpointRef) ComponentType() component.Component {
 	er.mtx.RLock()
 	defer er.mtx.RUnlock()
 
+	return er.componentType()
+}
+
+func (er *endpointRef) componentType() component.Component {
 	if er.metadata == nil {
 		return component.UnknownStoreAPI
 	}
@@ -693,6 +725,10 @@ func (er *endpointRef) LabelSets() []labels.Labels {
 	er.mtx.RLock()
 	defer er.mtx.RUnlock()
 
+	return er.labelSets()
+}
+
+func (er *endpointRef) labelSets() []labels.Labels {
 	if er.metadata == nil {
 		return make([]labels.Labels, 0)
 	}
@@ -715,6 +751,10 @@ func (er *endpointRef) TimeRange() (mint, maxt int64) {
 	er.mtx.RLock()
 	defer er.mtx.RUnlock()
 
+	return er.timeRange()
+}
+
+func (er *endpointRef) timeRange() (int64, int64) {
 	if er.metadata == nil || er.metadata.Store == nil {
 		return math.MinInt64, math.MaxInt64
 	}
@@ -776,4 +816,15 @@ func newEndpointAPIStats() map[component.Component]map[string]int {
 		nodes[component.FromProto(storepb.StoreType(i))] = map[string]int{}
 	}
 	return nodes
+}
+
+func maxRangeStoreMetadata() *endpointMetadata {
+	return &endpointMetadata{
+		InfoResponse: &infopb.InfoResponse{
+			Store: &infopb.StoreInfo{
+				MinTime: math.MinInt64,
+				MaxTime: math.MaxInt64,
+			},
+		},
+	}
 }

--- a/pkg/query/endpointset_test.go
+++ b/pkg/query/endpointset_test.go
@@ -12,6 +12,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/thanos-io/thanos/pkg/store"
+
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
@@ -19,7 +22,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/thanos-io/thanos/pkg/component"
 	"github.com/thanos-io/thanos/pkg/info/infopb"
-	"github.com/thanos-io/thanos/pkg/store"
 	"github.com/thanos-io/thanos/pkg/store/labelpb"
 	"github.com/thanos-io/thanos/pkg/store/storepb"
 	"github.com/thanos-io/thanos/pkg/testutil"
@@ -80,28 +82,52 @@ var (
 )
 
 type mockedEndpoint struct {
-	infoDelay time.Duration
+	infoDelay <-chan time.Time
 	info      infopb.InfoResponse
+	err       error
+}
+
+func (c *mockedEndpoint) setResponseError(err error) {
+	c.err = err
 }
 
 func (c *mockedEndpoint) Info(ctx context.Context, r *infopb.InfoRequest) (*infopb.InfoResponse, error) {
-	if c.infoDelay > 0 {
-		time.Sleep(c.infoDelay)
+	if c.err != nil {
+		return nil, c.err
 	}
 
+	if c.infoDelay != nil {
+		select {
+		case <-ctx.Done():
+		case <-c.infoDelay:
+		}
+
+	}
 	return &c.info, nil
 }
 
 type mockedStoreSrv struct {
-	infoDelay time.Duration
+	infoDelay <-chan time.Time
 	info      storepb.InfoResponse
+	err       error
 }
 
-func (s *mockedStoreSrv) Info(context.Context, *storepb.InfoRequest) (*storepb.InfoResponse, error) {
-	if s.infoDelay > 0 {
-		time.Sleep(s.infoDelay)
+func (s *mockedStoreSrv) setResponseError(err error) {
+	s.err = err
+}
+
+func (s *mockedStoreSrv) Info(ctx context.Context, _ *storepb.InfoRequest) (*storepb.InfoResponse, error) {
+	if s.err != nil {
+		return nil, s.err
 	}
 
+	if s.infoDelay != nil {
+		select {
+		case <-ctx.Done():
+		case <-s.infoDelay:
+		}
+
+	}
 	return &s.info, nil
 }
 func (s *mockedStoreSrv) Series(*storepb.SeriesRequest, storepb.Store_SeriesServer) error {
@@ -125,11 +151,14 @@ type APIs struct {
 type testEndpointMeta struct {
 	*infopb.InfoResponse
 	extlsetFn func(addr string) []labelpb.ZLabelSet
-	infoDelay time.Duration
+	infoDelay <-chan time.Time
+	err       error
 }
 
 type testEndpoints struct {
 	srvs        map[string]*grpc.Server
+	endpoints   map[string]*mockedEndpoint
+	stores      map[string]*mockedStoreSrv
 	orderAddrs  []string
 	exposedAPIs map[string]*APIs
 }
@@ -156,6 +185,8 @@ func componentTypeToStoreType(componentType string) storepb.StoreType {
 func startTestEndpoints(testEndpointMeta []testEndpointMeta) (*testEndpoints, error) {
 	e := &testEndpoints{
 		srvs:        map[string]*grpc.Server{},
+		endpoints:   map[string]*mockedEndpoint{},
+		stores:      map[string]*mockedStoreSrv{},
 		exposedAPIs: map[string]*APIs{},
 	}
 
@@ -171,6 +202,7 @@ func startTestEndpoints(testEndpointMeta []testEndpointMeta) (*testEndpoints, er
 		addr := listener.Addr().String()
 
 		storeSrv := &mockedStoreSrv{
+			err: meta.err,
 			info: storepb.InfoResponse{
 				LabelSets: meta.extlsetFn(listener.Addr().String()),
 				StoreType: componentTypeToStoreType(meta.ComponentType),
@@ -184,6 +216,7 @@ func startTestEndpoints(testEndpointMeta []testEndpointMeta) (*testEndpoints, er
 		}
 
 		endpointSrv := &mockedEndpoint{
+			err: meta.err,
 			info: infopb.InfoResponse{
 				LabelSets:      meta.extlsetFn(listener.Addr().String()),
 				Store:          meta.Store,
@@ -204,6 +237,8 @@ func startTestEndpoints(testEndpointMeta []testEndpointMeta) (*testEndpoints, er
 
 		e.exposedAPIs[addr] = exposedAPIs(meta.ComponentType)
 		e.srvs[addr] = srv
+		e.endpoints[addr] = endpointSrv
+		e.stores[addr] = storeSrv
 		e.orderAddrs = append(e.orderAddrs, listener.Addr().String())
 	}
 
@@ -233,8 +268,293 @@ func (e *testEndpoints) CloseOne(addr string) {
 	delete(e.srvs, addr)
 }
 
-func TestEndpointSet_Update(t *testing.T) {
+func TestEndpointSetUpdate(t *testing.T) {
+	testCases := []struct {
+		name      string
+		endpoints []testEndpointMeta
+		strict    bool
 
+		expectedEndpoints int
+	}{
+		{
+			name: "available endpoint",
+			endpoints: []testEndpointMeta{
+				{
+					InfoResponse: sidecarInfo,
+					extlsetFn: func(addr string) []labelpb.ZLabelSet {
+						return labelpb.ZLabelSetsFromPromLabels(
+							labels.FromStrings("addr", addr, "a", "b"),
+						)
+					},
+				},
+			},
+			expectedEndpoints: 1,
+		},
+		{
+			name: "unavailable endpoint",
+			endpoints: []testEndpointMeta{
+				{
+					err:          fmt.Errorf("endpoint unavailable"),
+					InfoResponse: sidecarInfo,
+					extlsetFn: func(addr string) []labelpb.ZLabelSet {
+						return labelpb.ZLabelSetsFromPromLabels(
+							labels.FromStrings("addr", addr, "a", "b"),
+						)
+					},
+				},
+			},
+			expectedEndpoints: 0,
+		},
+		{
+			name: "slow endpoint",
+			endpoints: []testEndpointMeta{
+				{
+					infoDelay:    time.After(5 * time.Second),
+					InfoResponse: sidecarInfo,
+					extlsetFn: func(addr string) []labelpb.ZLabelSet {
+						return labelpb.ZLabelSetsFromPromLabels(
+							labels.FromStrings("addr", addr, "a", "b"),
+						)
+					},
+				},
+			},
+			expectedEndpoints: 0,
+		},
+		{
+			name: "strict endpoint",
+			endpoints: []testEndpointMeta{
+				{
+					InfoResponse: sidecarInfo,
+					extlsetFn: func(addr string) []labelpb.ZLabelSet {
+						return labelpb.ZLabelSetsFromPromLabels(
+							labels.FromStrings("addr", addr, "a", "b"),
+						)
+					},
+				},
+			},
+			strict:            true,
+			expectedEndpoints: 1,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			endpoints, err := startTestEndpoints(tc.endpoints)
+			testutil.Ok(t, err)
+			defer endpoints.Close()
+
+			updateTime := time.Now()
+			discoveredEndpointAddr := endpoints.EndpointAddresses()
+			endpointSet := makeEndpointSet(discoveredEndpointAddr, tc.strict, func() time.Time { return updateTime })
+			defer endpointSet.Close()
+
+			// Initial update.
+			endpointSet.Update(context.Background())
+			testutil.Equals(t, 1, len(endpointSet.GetEndpointStatus()))
+			testutil.Equals(t, tc.expectedEndpoints, len(endpointSet.GetStoreClients()))
+
+			updateTime = updateTime.Add(2 * time.Minute)
+			endpointSet.Update(context.Background())
+			testutil.Equals(t, tc.expectedEndpoints, len(endpointSet.GetEndpointStatus()))
+			testutil.Equals(t, tc.expectedEndpoints, len(endpointSet.GetStoreClients()))
+		})
+	}
+}
+
+func TestEndpointSetUpdate_DuplicateSpecs(t *testing.T) {
+	endpoints, err := startTestEndpoints([]testEndpointMeta{
+		{
+			InfoResponse: sidecarInfo,
+			extlsetFn: func(addr string) []labelpb.ZLabelSet {
+				return labelpb.ZLabelSetsFromPromLabels(
+					labels.FromStrings("addr", addr, "a", "b"),
+				)
+			},
+		},
+	})
+	testutil.Ok(t, err)
+	defer endpoints.Close()
+
+	discoveredEndpointAddr := endpoints.EndpointAddresses()
+	discoveredEndpointAddr = append(discoveredEndpointAddr, discoveredEndpointAddr[0])
+
+	endpointSet := makeEndpointSet(discoveredEndpointAddr, false, time.Now)
+	endpointSet.gRPCInfoCallTimeout = 1 * time.Second
+	defer endpointSet.Close()
+
+	// Initial update.
+	endpointSet.Update(context.Background())
+	testutil.Equals(t, 1, len(endpointSet.endpoints))
+}
+
+func TestEndpointSetUpdate_EndpointGoingAway(t *testing.T) {
+	endpoints, err := startTestEndpoints([]testEndpointMeta{
+		{
+			InfoResponse: sidecarInfo,
+			extlsetFn: func(addr string) []labelpb.ZLabelSet {
+				return labelpb.ZLabelSetsFromPromLabels(
+					labels.FromStrings("addr", addr, "a", "b"),
+				)
+			},
+		},
+	})
+	testutil.Ok(t, err)
+	defer endpoints.Close()
+
+	discoveredEndpointAddr := endpoints.EndpointAddresses()
+	endpointSet := makeEndpointSet(discoveredEndpointAddr, false, time.Now)
+	endpointSet.gRPCInfoCallTimeout = 1 * time.Second
+	defer endpointSet.Close()
+
+	// Initial update.
+	endpointSet.Update(context.Background())
+	testutil.Equals(t, 1, len(endpointSet.GetEndpointStatus()))
+	testutil.Equals(t, 1, len(endpointSet.GetStoreClients()))
+
+	endpoints.CloseOne(discoveredEndpointAddr[0])
+	endpointSet.Update(context.Background())
+	testutil.Equals(t, 1, len(endpointSet.GetEndpointStatus()))
+	testutil.Equals(t, 0, len(endpointSet.GetStoreClients()))
+}
+
+func TestEndpointSetUpdate_EndpointComingOnline(t *testing.T) {
+	endpoints, err := startTestEndpoints([]testEndpointMeta{
+		{
+			err:          fmt.Errorf("endpoint unavailable"),
+			InfoResponse: sidecarInfo,
+			extlsetFn: func(addr string) []labelpb.ZLabelSet {
+				return nil
+			},
+		},
+	})
+	testutil.Ok(t, err)
+	defer endpoints.Close()
+
+	discoveredEndpointAddr := endpoints.EndpointAddresses()
+	endpointSet := makeEndpointSet(discoveredEndpointAddr, false, time.Now)
+	defer endpointSet.Close()
+
+	// Initial update.
+	endpointSet.Update(context.Background())
+	testutil.Equals(t, 1, len(endpointSet.GetEndpointStatus()))
+	testutil.Equals(t, 0, len(endpointSet.GetStoreClients()))
+
+	srvAddr := discoveredEndpointAddr[0]
+	endpoints.endpoints[srvAddr].setResponseError(nil)
+	endpointSet.Update(context.Background())
+	testutil.Equals(t, 1, len(endpointSet.GetEndpointStatus()))
+	testutil.Equals(t, 1, len(endpointSet.GetStoreClients()))
+}
+
+func TestEndpointSetUpdate_StrictEndpointMetadata(t *testing.T) {
+	info := sidecarInfo
+	info.Store.MinTime = 111
+	info.Store.MaxTime = 222
+	endpoints, err := startTestEndpoints([]testEndpointMeta{
+		{
+			err:          fmt.Errorf("endpoint unavailable"),
+			InfoResponse: info,
+			extlsetFn: func(addr string) []labelpb.ZLabelSet {
+				return nil
+			},
+		},
+	})
+	testutil.Ok(t, err)
+	defer endpoints.Close()
+
+	discoveredEndpointAddr := endpoints.EndpointAddresses()
+	endpointSet := makeEndpointSet(discoveredEndpointAddr, true, time.Now)
+	defer endpointSet.Close()
+
+	addr := discoveredEndpointAddr[0]
+	// Initial update.
+	endpointSet.Update(context.Background())
+	testutil.Equals(t, 1, len(endpointSet.GetEndpointStatus()))
+	testutil.Equals(t, int64(math.MinInt64), endpointSet.endpoints[addr].metadata.Store.MinTime)
+	testutil.Equals(t, int64(math.MaxInt64), endpointSet.endpoints[addr].metadata.Store.MaxTime)
+
+	endpoints.endpoints[addr].setResponseError(nil)
+	endpointSet.Update(context.Background())
+	testutil.Equals(t, 1, len(endpointSet.GetEndpointStatus()))
+	testutil.Equals(t, info.Store.MinTime, endpointSet.endpoints[addr].metadata.Store.MinTime)
+	testutil.Equals(t, info.Store.MaxTime, endpointSet.endpoints[addr].metadata.Store.MaxTime)
+
+	endpoints.CloseOne(addr)
+	endpointSet.Update(context.Background())
+	testutil.Equals(t, 1, len(endpointSet.GetEndpointStatus()))
+	testutil.Equals(t, info.Store.MinTime, endpointSet.endpoints[addr].metadata.Store.MinTime)
+	testutil.Equals(t, info.Store.MaxTime, endpointSet.endpoints[addr].metadata.Store.MaxTime)
+}
+
+func TestEndpointSetUpdate_PruneInactiveEndpoints(t *testing.T) {
+	testCases := []struct {
+		name      string
+		endpoints []testEndpointMeta
+		strict    bool
+
+		expectedEndpoints int
+	}{
+		{
+			name:   "non-strict endpoint",
+			strict: false,
+			endpoints: []testEndpointMeta{
+				{
+					InfoResponse: sidecarInfo,
+					extlsetFn: func(addr string) []labelpb.ZLabelSet {
+						return labelpb.ZLabelSetsFromPromLabels(
+							labels.FromStrings("addr", addr, "a", "b"),
+						)
+					},
+				},
+			},
+			expectedEndpoints: 0,
+		},
+		{
+			name:   "strict endpoint",
+			strict: true,
+			endpoints: []testEndpointMeta{
+				{
+					InfoResponse: sidecarInfo,
+					extlsetFn: func(addr string) []labelpb.ZLabelSet {
+						return labelpb.ZLabelSetsFromPromLabels(
+							labels.FromStrings("addr", addr, "a", "b"),
+						)
+					},
+				},
+			},
+			expectedEndpoints: 1,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			endpoints, err := startTestEndpoints(tc.endpoints)
+			testutil.Ok(t, err)
+			defer endpoints.Close()
+
+			updateTime := time.Now()
+			discoveredEndpointAddr := endpoints.EndpointAddresses()
+			endpointSet := makeEndpointSet(discoveredEndpointAddr, tc.strict, func() time.Time { return updateTime })
+			defer endpointSet.Close()
+
+			endpointSet.Update(context.Background())
+			testutil.Equals(t, 1, len(endpointSet.GetEndpointStatus()))
+			testutil.Equals(t, 1, len(endpointSet.GetStoreClients()))
+
+			addr := discoveredEndpointAddr[0]
+			endpoints.endpoints[addr].setResponseError(errors.New("failed info request"))
+			endpoints.stores[addr].setResponseError(errors.New("failed info request"))
+			endpointSet.Update(context.Background())
+
+			updateTime = updateTime.Add(10 * time.Minute)
+			endpointSet.Update(context.Background())
+			testutil.Equals(t, tc.expectedEndpoints, len(endpointSet.GetEndpointStatus()))
+			testutil.Equals(t, tc.expectedEndpoints, len(endpointSet.GetStoreClients()))
+		})
+	}
+}
+
+func TestEndpointSet_Update(t *testing.T) {
 	endpoints, err := startTestEndpoints([]testEndpointMeta{
 		{
 			InfoResponse: sidecarInfo,
@@ -295,7 +615,7 @@ func TestEndpointSet_Update(t *testing.T) {
 
 	// Testing if duplicates can cause weird results.
 	discoveredEndpointAddr = append(discoveredEndpointAddr, discoveredEndpointAddr[0])
-	endpointSet := NewEndpointSet(nil, nil,
+	endpointSet := NewEndpointSet(time.Now, nil, nil,
 		func() (specs []*GRPCEndpointSpec) {
 			for _, addr := range discoveredEndpointAddr {
 				specs = append(specs, NewGRPCEndpointSpec(addr, false))
@@ -316,8 +636,8 @@ func TestEndpointSet_Update(t *testing.T) {
 	// Should not matter how many of these we run.
 	endpointSet.Update(context.Background())
 	endpointSet.Update(context.Background())
-	testutil.Equals(t, 2, len(endpointSet.endpoints))
-	testutil.Equals(t, 3, len(endpointSet.endpointStatuses))
+	testutil.Equals(t, 2, len(endpointSet.GetStoreClients()))
+	testutil.Equals(t, 3, len(endpointSet.GetEndpointStatus()))
 
 	for addr, e := range endpointSet.endpoints {
 		testutil.Equals(t, addr, e.addr)
@@ -340,18 +660,17 @@ func TestEndpointSet_Update(t *testing.T) {
 	testutil.Equals(t, expected, endpointSet.endpointsMetric.storeNodes)
 
 	// Remove address from discovered and reset last check, which should ensure cleanup of status on next update.
-	endpointSet.endpointStatuses[discoveredEndpointAddr[2]].LastCheck = time.Now().Add(-4 * time.Minute)
+	endpointSet.endpoints[discoveredEndpointAddr[1]].status.LastCheck = time.Now().Add(-4 * time.Minute)
 	discoveredEndpointAddr = discoveredEndpointAddr[:len(discoveredEndpointAddr)-2]
 	endpointSet.Update(context.Background())
-	testutil.Equals(t, 2, len(endpointSet.endpointStatuses))
+	testutil.Equals(t, 2, len(endpointSet.endpoints))
 
 	endpoints.CloseOne(discoveredEndpointAddr[0])
 	delete(expected[component.Sidecar], fmt.Sprintf("{a=\"b\"},{addr=\"%s\"}", discoveredEndpointAddr[0]))
 
 	// We expect Update to tear down store client for closed store server.
 	endpointSet.Update(context.Background())
-	testutil.Equals(t, 1, len(endpointSet.endpoints), "only one service should respond just fine, so we expect one client to be ready.")
-	testutil.Equals(t, 2, len(endpointSet.endpointStatuses))
+	testutil.Equals(t, 1, len(endpointSet.GetStoreClients()), "only one service should respond just fine, so we expect one client to be ready.")
 
 	addr := discoveredEndpointAddr[1]
 	st, ok := endpointSet.endpoints[addr]
@@ -601,7 +920,7 @@ func TestEndpointSet_Update(t *testing.T) {
 
 	// New stores should be loaded.
 	endpointSet.Update(context.Background())
-	testutil.Equals(t, 1+len(endpoint2.srvs), len(endpointSet.endpoints))
+	testutil.Equals(t, 1+len(endpoint2.srvs), len(endpointSet.GetStoreClients()))
 
 	// Check stats.
 	expected = newEndpointAPIStats()
@@ -629,13 +948,13 @@ func TestEndpointSet_Update(t *testing.T) {
 	endpoints.CloseOne(discoveredEndpointAddr[1])
 	endpointSet.Update(context.Background())
 
-	for addr, e := range endpointSet.endpoints {
+	for addr, e := range endpointSet.getQueryableEndpointRefs() {
 		testutil.Equals(t, addr, e.addr)
 		assertRegisteredAPIs(t, endpoint2.exposedAPIs[addr], e)
 	}
 
 	// Check statuses.
-	testutil.Equals(t, 2+len(endpoint2.srvs), len(endpointSet.endpointStatuses))
+	testutil.Equals(t, 2+len(endpoint2.srvs), len(endpointSet.GetEndpointStatus()))
 }
 
 func TestEndpointSet_Update_NoneAvailable(t *testing.T) {
@@ -678,7 +997,7 @@ func TestEndpointSet_Update_NoneAvailable(t *testing.T) {
 	endpoints.CloseOne(initialEndpointAddr[0])
 	endpoints.CloseOne(initialEndpointAddr[1])
 
-	endpointSet := NewEndpointSet(nil, nil,
+	endpointSet := NewEndpointSet(time.Now, nil, nil,
 		func() (specs []*GRPCEndpointSpec) {
 			for _, addr := range initialEndpointAddr {
 				specs = append(specs, NewGRPCEndpointSpec(addr, false))
@@ -687,15 +1006,17 @@ func TestEndpointSet_Update_NoneAvailable(t *testing.T) {
 		},
 		testGRPCOpts, time.Minute)
 	endpointSet.gRPCInfoCallTimeout = 2 * time.Second
+	defer endpointSet.Close()
 
 	// Should not matter how many of these we run.
 	endpointSet.Update(context.Background())
 	endpointSet.Update(context.Background())
-	testutil.Equals(t, 0, len(endpointSet.endpoints), "none of services should respond just fine, so we expect no client to be ready.")
+	testutil.Equals(t, 0, len(endpointSet.GetStoreClients()), "none of services should respond just fine, so we expect no client to be ready.")
 
 	// Leak test will ensure that we don't keep client connection around.
 	expected := newEndpointAPIStats()
 	testutil.Equals(t, expected, endpointSet.endpointsMetric.storeNodes)
+
 }
 
 // TestEndpoint_Update_QuerierStrict tests what happens when the strict mode is enabled/disabled.
@@ -776,7 +1097,7 @@ func TestEndpoint_Update_QuerierStrict(t *testing.T) {
 					},
 				}
 			},
-			infoDelay: 2 * time.Second,
+			infoDelay: time.After(2 * time.Second),
 		},
 	})
 
@@ -787,7 +1108,7 @@ func TestEndpoint_Update_QuerierStrict(t *testing.T) {
 
 	staticEndpointAddr := discoveredEndpointAddr[0]
 	slowStaticEndpointAddr := discoveredEndpointAddr[2]
-	endpointSet := NewEndpointSet(nil, nil, func() (specs []*GRPCEndpointSpec) {
+	endpointSet := NewEndpointSet(time.Now, nil, nil, func() (specs []*GRPCEndpointSpec) {
 		return []*GRPCEndpointSpec{
 			NewGRPCEndpointSpec(discoveredEndpointAddr[0], true),
 			NewGRPCEndpointSpec(discoveredEndpointAddr[1], false),
@@ -830,10 +1151,10 @@ func TestEndpoint_Update_QuerierStrict(t *testing.T) {
 	endpointSet.Update(context.Background())
 
 	// Check that the information is the same.
-	testutil.Equals(t, 2, len(endpointSet.endpoints), "two static clients must remain available")
+	testutil.Equals(t, 2, len(endpointSet.GetStoreClients()), "two static clients must remain available")
 	testutil.Equals(t, curMin, endpointSet.endpoints[staticEndpointAddr].metadata.Store.MinTime, "minimum time reported by the store node is different")
 	testutil.Equals(t, curMax, endpointSet.endpoints[staticEndpointAddr].metadata.Store.MaxTime, "minimum time reported by the store node is different")
-	testutil.NotOk(t, endpointSet.endpointStatuses[staticEndpointAddr].LastError.originalErr)
+	testutil.NotOk(t, endpointSet.endpoints[staticEndpointAddr].getStatus().LastError.originalErr)
 
 	testutil.Equals(t, updatedCurMin, endpointSet.endpoints[slowStaticEndpointAddr].metadata.Store.MinTime, "minimum time reported by the store node is different")
 	testutil.Equals(t, updatedCurMax, endpointSet.endpoints[slowStaticEndpointAddr].metadata.Store.MaxTime, "minimum time reported by the store node is different")
@@ -965,7 +1286,7 @@ func TestEndpointSet_APIs_Discovery(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			currentState := 0
 
-			endpointSet := NewEndpointSet(nil, nil,
+			endpointSet := NewEndpointSet(time.Now, nil, nil,
 				func() []*GRPCEndpointSpec {
 					if tc.states[currentState].endpointSpec == nil {
 						return nil
@@ -1098,9 +1419,6 @@ func TestUpdateEndpointStateLastError(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		mockedEndpointSet := &EndpointSet{
-			endpointStatuses: map[string]*EndpointStatus{},
-		}
 		mockEndpointRef := &endpointRef{
 			addr: "mockedStore",
 			metadata: &endpointMetadata{
@@ -1108,18 +1426,15 @@ func TestUpdateEndpointStateLastError(t *testing.T) {
 			},
 		}
 
-		mockedEndpointSet.updateEndpointStatus(mockEndpointRef, tc.InputError)
+		mockEndpointRef.update(time.Now, mockEndpointRef.metadata, tc.InputError)
 
-		b, err := json.Marshal(mockedEndpointSet.endpointStatuses["mockedStore"].LastError)
+		b, err := json.Marshal(mockEndpointRef.getStatus().LastError)
 		testutil.Ok(t, err)
 		testutil.Equals(t, tc.ExpectedLastErr, string(b))
 	}
 }
 
 func TestUpdateEndpointStateForgetsPreviousErrors(t *testing.T) {
-	mockEndpointSet := &EndpointSet{
-		endpointStatuses: map[string]*EndpointStatus{},
-	}
 	mockEndpointRef := &endpointRef{
 		addr: "mockedStore",
 		metadata: &endpointMetadata{
@@ -1127,18 +1442,32 @@ func TestUpdateEndpointStateForgetsPreviousErrors(t *testing.T) {
 		},
 	}
 
-	mockEndpointSet.updateEndpointStatus(mockEndpointRef, errors.New("test err"))
+	mockEndpointRef.update(time.Now, mockEndpointRef.metadata, errors.New("test err"))
 
-	b, err := json.Marshal(mockEndpointSet.endpointStatuses["mockedStore"].LastError)
+	b, err := json.Marshal(mockEndpointRef.getStatus().LastError)
 	testutil.Ok(t, err)
 	testutil.Equals(t, `"test err"`, string(b))
 
 	// updating status without and error should clear the previous one.
-	mockEndpointSet.updateEndpointStatus(mockEndpointRef, nil)
+	mockEndpointRef.update(time.Now, mockEndpointRef.metadata, nil)
 
-	b, err = json.Marshal(mockEndpointSet.endpointStatuses["mockedStore"].LastError)
+	b, err = json.Marshal(mockEndpointRef.getStatus().LastError)
 	testutil.Ok(t, err)
 	testutil.Equals(t, `null`, string(b))
+}
+
+func makeEndpointSet(discoveredEndpointAddr []string, strict bool, now nowFunc) *EndpointSet {
+	endpointSet := NewEndpointSet(now, nil, nil,
+		func() (specs []*GRPCEndpointSpec) {
+			for _, addr := range discoveredEndpointAddr {
+				specs = append(specs, NewGRPCEndpointSpec(addr, strict))
+			}
+			return specs
+		},
+		testGRPCOpts, time.Minute)
+	endpointSet.gRPCInfoCallTimeout = 1 * time.Second
+
+	return endpointSet
 }
 
 func exposedAPIs(c string) *APIs {
@@ -1204,9 +1533,9 @@ func TestDeadlockLocking(t *testing.T) {
 			if time.Now().After(deadline) {
 				break
 			}
-			mockEndpointRef.Update(&endpointMetadata{
+			mockEndpointRef.update(time.Now, &endpointMetadata{
 				InfoResponse: &infopb.InfoResponse{},
-			})
+			}, nil)
 		}
 		return nil
 	})

--- a/pkg/store/labelpb/label.go
+++ b/pkg/store/labelpb/label.go
@@ -73,6 +73,25 @@ func ZLabelSetsToPromLabelSets(lss ...ZLabelSet) []labels.Labels {
 	return res
 }
 
+// ZLabelSetsFromPromLabels converts []labels.labels to []labelpb.ZLabelSet.
+func ZLabelSetsFromPromLabels(lss ...labels.Labels) []ZLabelSet {
+	sets := make([]ZLabelSet, 0, len(lss))
+	for _, ls := range lss {
+		set := ZLabelSet{
+			Labels: make([]ZLabel, 0, len(ls)),
+		}
+		for _, lbl := range ls {
+			set.Labels = append(set.Labels, ZLabel{
+				Name:  lbl.Name,
+				Value: lbl.Value,
+			})
+		}
+		sets = append(sets, set)
+	}
+
+	return sets
+}
+
 // ZLabel is a Label (also easily transformable to Prometheus labels.Labels) that can be unmarshalled from protobuf
 // reusing the same memory address for string bytes.
 // NOTE: While unmarshalling it uses exactly same bytes that were allocated for protobuf. This mean that *whole* protobuf


### PR DESCRIPTION
This commit refactors the EndpointSet struct in order to make it easier
to understand and work with.

Signed-off-by: Filip Petkovski <filip.petkovsky@gmail.com>

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

* Refactor endpointset.go.
* Add additional tests to help understand specific behavior of EndpointSet.

## Verification

Unit tests and manual testing.