### PR TITLE
Implement endpoint groups

### DIFF
--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"time"
 
+	"google.golang.org/grpc"
+
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	grpc_logging "github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/logging"
@@ -128,6 +130,9 @@ func registerQuery(app *extkingpin.App) {
 	endpoints := extkingpin.Addrs(cmd.Flag("endpoint", "Addresses of statically configured Thanos API servers (repeatable). The scheme may be prefixed with 'dns+' or 'dnssrv+' to detect Thanos API servers through respective DNS lookups.").
 		PlaceHolder("<endpoint>"))
 
+	endpointGroups := extkingpin.Addrs(cmd.Flag("endpoint-group", "DNS name of statically configured Thanos API server groups (repeatable). Targets resolved from the DNS name will be queried in a round-robin instead of a fanout manner. This flag should be used when connecting a Thanos Query to HA groups of Thanos components.").
+		PlaceHolder("<endpoint-group>"))
+
 	stores := extkingpin.Addrs(cmd.Flag("store", "Deprecation Warning - This flag is deprecated and replaced with `endpoint`. Addresses of statically configured store API servers (repeatable). The scheme may be prefixed with 'dns+' or 'dnssrv+' to detect store API servers through respective DNS lookups.").
 		PlaceHolder("<store>"))
 
@@ -150,6 +155,9 @@ func registerQuery(app *extkingpin.App) {
 
 	strictEndpoints := cmd.Flag("endpoint-strict", "Addresses of only statically configured Thanos API servers that are always used, even if the health check fails. Useful if you have a caching layer on top.").
 		PlaceHolder("<staticendpoint>").Strings()
+
+	strictEndpointGroups := extkingpin.Addrs(cmd.Flag("endpoint-group-strict", "DNS name of statically configured Thanos API server groups (repeatable) that are always used, even if the health check fails.").
+		PlaceHolder("<endpoint-group-strict>"))
 
 	fileSDFiles := cmd.Flag("store.sd-files", "Path to files that contain addresses of store API servers. The path can be a glob pattern (repeatable).").
 		PlaceHolder("<path>").Strings()
@@ -291,6 +299,7 @@ func registerQuery(app *extkingpin.App) {
 			selectorLset,
 			getFlagsMap(cmd.Flags()),
 			*endpoints,
+			*endpointGroups,
 			*stores,
 			*ruleEndpoints,
 			*targetEndpoints,
@@ -312,6 +321,7 @@ func registerQuery(app *extkingpin.App) {
 			*defaultMetadataTimeRange,
 			*strictStores,
 			*strictEndpoints,
+			*strictEndpointGroups,
 			*webDisableCORS,
 			enableQueryPushdown,
 			*alertQueryURL,
@@ -367,6 +377,7 @@ func runQuery(
 	selectorLset labels.Labels,
 	flagsMap map[string]string,
 	endpointAddrs []string,
+	endpointGroupAddrs []string,
 	storeAddrs []string,
 	ruleAddrs []string,
 	targetAddrs []string,
@@ -388,6 +399,7 @@ func runQuery(
 	defaultMetadataTimeRange time.Duration,
 	strictStores []string,
 	strictEndpoints []string,
+	strictEndpointGroups []string,
 	disableCORS bool,
 	enableQueryPushdown bool,
 	alertQueryURL string,
@@ -498,6 +510,20 @@ func runQuery(
 					}
 					tmpSpecs = removeDuplicateEndpointSpecs(logger, duplicatedStores, tmpSpecs)
 					specs = append(specs, tmpSpecs...)
+				}
+
+				for _, eg := range endpointGroupAddrs {
+					addr := fmt.Sprintf("dns:///%s", eg)
+					spec := query.NewGRPCEndpointSpec(addr, false, extgrpc.EndpointGroupGRPCOpts()...)
+					specs = append(specs, spec)
+				}
+
+				for _, eg := range strictEndpointGroups {
+					grpc.WithDisableRetry()
+
+					addr := fmt.Sprintf("dns:///%s", eg)
+					spec := query.NewGRPCEndpointSpec(addr, true, extgrpc.EndpointGroupGRPCOpts()...)
+					specs = append(specs, spec)
 				}
 
 				return specs

--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -517,8 +517,6 @@ func runQuery(
 				}
 
 				for _, eg := range strictEndpointGroups {
-					grpc.WithDisableRetry()
-
 					addr := fmt.Sprintf("dns:///%s", eg)
 					spec := query.NewGRPCEndpointSpec(addr, true, extgrpc.EndpointGroupGRPCOpts()...)
 					specs = append(specs, spec)

--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -128,7 +128,7 @@ func registerQuery(app *extkingpin.App) {
 	endpoints := extkingpin.Addrs(cmd.Flag("endpoint", "Addresses of statically configured Thanos API servers (repeatable). The scheme may be prefixed with 'dns+' or 'dnssrv+' to detect Thanos API servers through respective DNS lookups.").
 		PlaceHolder("<endpoint>"))
 
-	endpointGroups := extkingpin.Addrs(cmd.Flag("endpoint-group", "DNS name of statically configured Thanos API server groups (repeatable). Targets resolved from the DNS name will be queried in a round-robin instead of a fanout manner. This flag should be used when connecting a Thanos Query to HA groups of Thanos components.").
+	endpointGroups := extkingpin.Addrs(cmd.Flag("endpoint-group", "Experimental: DNS name of statically configured Thanos API server groups (repeatable). Targets resolved from the DNS name will be queried in a round-robin, instead of a fanout manner. This flag should be used when connecting a Thanos Query to HA groups of Thanos components.").
 		PlaceHolder("<endpoint-group>"))
 
 	stores := extkingpin.Addrs(cmd.Flag("store", "Deprecation Warning - This flag is deprecated and replaced with `endpoint`. Addresses of statically configured store API servers (repeatable). The scheme may be prefixed with 'dns+' or 'dnssrv+' to detect store API servers through respective DNS lookups.").
@@ -154,7 +154,7 @@ func registerQuery(app *extkingpin.App) {
 	strictEndpoints := cmd.Flag("endpoint-strict", "Addresses of only statically configured Thanos API servers that are always used, even if the health check fails. Useful if you have a caching layer on top.").
 		PlaceHolder("<staticendpoint>").Strings()
 
-	strictEndpointGroups := extkingpin.Addrs(cmd.Flag("endpoint-group-strict", "DNS name of statically configured Thanos API server groups (repeatable) that are always used, even if the health check fails.").
+	strictEndpointGroups := extkingpin.Addrs(cmd.Flag("endpoint-group-strict", "Experimental: DNS name of statically configured Thanos API server groups (repeatable) that are always used, even if the health check fails.").
 		PlaceHolder("<endpoint-group-strict>"))
 
 	fileSDFiles := cmd.Flag("store.sd-files", "Path to files that contain addresses of store API servers. The path can be a glob pattern (repeatable).").

--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -11,8 +11,6 @@ import (
 	"strings"
 	"time"
 
-	"google.golang.org/grpc"
-
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	grpc_logging "github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/logging"

--- a/docs/components/query.md
+++ b/docs/components/query.md
@@ -281,16 +281,16 @@ Flags:
                                  Thanos API servers through respective DNS
                                  lookups.
       --endpoint-group=<endpoint-group> ...
-                                 DNS name of statically configured Thanos API
-                                 server groups (repeatable). Targets resolved
-                                 from the DNS name will be queried in a
-                                 round-robin instead of a fanout manner. This
-                                 flag should be used when connecting a Thanos
-                                 Query to HA groups of Thanos components.
+                                 Experimental: DNS name of statically configured
+                                 Thanos API server groups (repeatable). Targets
+                                 resolved from the DNS name will be queried in
+                                 a round-robin, instead of a fanout manner.
+                                 This flag should be used when connecting a
+                                 Thanos Query to HA groups of Thanos components.
       --endpoint-group-strict=<endpoint-group-strict> ...
-                                 DNS name of statically configured Thanos API
-                                 server groups (repeatable) that are always
-                                 used, even if the health check fails.
+                                 Experimental: DNS name of statically configured
+                                 Thanos API server groups (repeatable) that are
+                                 always used, even if the health check fails.
       --endpoint-strict=<staticendpoint> ...
                                  Addresses of only statically configured Thanos
                                  API servers that are always used, even if

--- a/docs/components/query.md
+++ b/docs/components/query.md
@@ -280,6 +280,17 @@ Flags:
                                  prefixed with 'dns+' or 'dnssrv+' to detect
                                  Thanos API servers through respective DNS
                                  lookups.
+      --endpoint-group=<endpoint-group> ...
+                                 DNS name of statically configured Thanos API
+                                 server groups (repeatable). Targets resolved
+                                 from the DNS name will be queried in a
+                                 round-robin instead of a fanout manner. This
+                                 flag should be used when connecting a Thanos
+                                 Query to HA groups of Thanos components.
+      --endpoint-group-strict=<endpoint-group-strict> ...
+                                 DNS name of statically configured Thanos API
+                                 server groups (repeatable) that are always
+                                 used, even if the health check fails.
       --endpoint-strict=<staticendpoint> ...
                                  Addresses of only statically configured Thanos
                                  API servers that are always used, even if

--- a/pkg/extgrpc/client.go
+++ b/pkg/extgrpc/client.go
@@ -20,6 +20,27 @@ import (
 	"github.com/thanos-io/thanos/pkg/tracing"
 )
 
+// EndpointGroupGRPCOpts creates gRPC dial options for connecting to endpoint groups.
+// For details on retry capabilities, see https://github.com/grpc/proposal/blob/master/A6-client-retries.md#retry-policy-capabilities
+func EndpointGroupGRPCOpts() []grpc.DialOption {
+	serviceConfig := `
+{
+  "loadBalancingPolicy":"round_robin",
+  "retryPolicy": {
+    "maxAttempts": 3,
+    "initialBackoff": "0.1s",
+    "backoffMultiplier": 2,
+    "retryableStatusCodes": [
+  	  "UNAVAILABLE"
+    ]
+  }
+}`
+
+	return []grpc.DialOption{
+		grpc.WithDefaultServiceConfig(serviceConfig),
+	}
+}
+
 // StoreClientGRPCOpts creates gRPC dial options for connecting to a store client.
 func StoreClientGRPCOpts(logger log.Logger, reg *prometheus.Registry, tracer opentracing.Tracer, secure, skipVerify bool, cert, key, caCert, serverName string) ([]grpc.DialOption, error) {
 	grpcMets := grpc_prometheus.NewClientMetrics()


### PR DESCRIPTION
This draft PR illustrates how an HA group of endpoints can be configured in Thanos Query.

Looking for feedback on the approach!

Fixes https://github.com/thanos-io/thanos/issues/5335

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Add the flags `endpoint-group` and `endpoint-group-strict` to Thanos Query for load balancing instead of fanout.

## Verification

<!-- How you tested it? How do you know it works? -->
