### PR TITLE
Implement concurrent exemplar selects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 
 ### Fixed
 - [#5502](https://github.com/thanos-io/thanos/pull/5502) Receive: Handle exemplar storage errors as conflict error.
-- [#5534](https://github.com/thanos-io/thanos/pull/5534) Query: Set struct return by query api alerts same as prometheus api
+- [#5534](https://github.com/thanos-io/thanos/pull/5534) Query: Set struct return by query api alerts same as prometheus api.
+- [#5550](https://github.com/thanos-io/thanos/pull/5534) Query/Receive: Retrieve exemplars concurrently from all TSDBs.
 
 ### Added
 


### PR DESCRIPTION
Exemplars are currently fetched with a mixture of serial and concurrent
selects. Selects in multi-tsdb are done serially, while the exemplar
proxy fans out, waits for all responses and then forwards all exemplars
upstream.

This commit modifies the fanout mechanism to send exemplars concurrently
from both multi-tsdb and the exemplar proxy as soon as they are received.

Signed-off-by: Filip Petkovski <filip.petkovsky@gmail.com>

Fixes https://github.com/thanos-io/thanos/issues/5444

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Retrieve exemplars concurrently from multi-tsdb.

## Verification

With unit tests. Still trying to find a good setup to test this out.