### PR TITLE
Tracing: Add Jaeger B3 header support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 
 ## Unreleased
 - [#5453](https://github.com/thanos-io/thanos/pull/5453) Compact: Skip erroneous empty non `*AggrChunk` chunks during 1h downsampling of 5m resolution blocks.
+- [#5553](https://github.com/thanos-io/thanos/pull/5553) Tracing: Add Jaeger B3 header support.
 
 ### Fixed
 - [#5502](https://github.com/thanos-io/thanos/pull/5502) Receive: Handle exemplar storage errors as conflict error.

--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -95,6 +95,7 @@ config:
   agent_host: ""
   agent_port: 0
   traceid_128bit: false
+  use_b3_headers: false
 ```
 
 ### Google Cloud (formerly Stackdriver)


### PR DESCRIPTION
* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Jaeger tracing uses its own HTTP/GRPC header to perform context
propagation between services - "uber-trace-id". However, Jaeger
tracing clients also support context propagation via the B3 header
format (as popularized by Zipkin tracing).

This commit adds support for configuring the B3 header format within
thanos tracing. The main motivation for doing this is interoperability
with other systems that may call into or out of Thanos components - for
example, Grafana or Envoy - both of which support Jaeger tracing, but
use B3 headers instead of the Jaeger-specific "uber-trace-id" format headers.

Unfortunately, we cannot directly toggle this as an option or configure
it via the environment; the jaeger-go library requires us to pass it in
as an option when we call `NewTracer`. In order to facilitate this, we
extend the `ParseConfigFromYaml` file to not only return a _Jaeger_
configuration object, but the actual YAML configuration object as well.
This allows us to check and see if the user requested this kind of
header propagation, and we can then construct the necessary additional
options to `NewTracer`.

Of course, this is all legacy configuration in many ways. The tracing
world is rapidly moving towards OpenTelemetry and W3C headers for
context propagation. However, there is still utility in supporting B3
headers until everyone (including Thanos!) finishes their OpenTelemetry
migration projects.

## Verification

Programmatically testing this change is tricky, because we need to actually
inspect the headers of the HTTP and GRPC requests that flow through the
system with tracing enabled. I was able to verify that this worked through
manual testing via the query frontend:

1. I started a local ngrok tunnel, which allows me to intercept requests
   between the query frontend and a downstream querier (I configured it
   statically for port 10904, which is one of the querier ports).
2. I launched a local OpenTelemetry Collector and Jaeger all-in-one image
   to receive and display traces.
3. I modified `scripts/quickstart.sh` to:
  - Add a query frontend, with the `query-frontend.downstream-url` pointed
    to the intercepting `ngrok` tunnel.
  - Add appropriate tracing configurations for all components.

Once those modifications were in place and launched with `make quickstart`,
I was able to write queries in the query frontend, see that the intercepted
API calls to the downstream querier contained tracing headers in the
expected format, and verify that the traces were ingested into the Jaeger
backend via the OpenTelemetry collector (the OpenTelemetry collector was not
strictly necessary, but I prefer to use it while debugging).

Screenshot showing the intercepted API request, with correct B3 headers:
<img width="836" alt="Screen Shot 2022-07-29 at 11 16 35 AM" src="https://user-images.githubusercontent.com/1781907/181804792-34b64c8f-8148-4431-9b9c-ead099b14bd2.png">

Screenshot of the complete trace ingested to the Jaeger backend, with
correct context-propagation and parent/child span relationships preserved:
<img width="1506" alt="Screen Shot 2022-07-29 at 11 16 44 AM" src="https://user-images.githubusercontent.com/1781907/181804861-00a2253e-d31c-4ce0-8694-00f28ac5ab53.png">
