### PR TITLE
Flag to add active query tracker. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#5493](https://github.com/thanos-io/thanos/pull/5493) Compact: Added `--compact.blocks-fetch-concurrency` allowing to configure number of go routines for download blocks during compactions.
 - [#5527](https://github.com/thanos-io/thanos/pull/5527) Receive: Add per request limits for remote write.
 - [#5520](https://github.com/thanos-io/thanos/pull/5520) Receive: Meta-monitoring based active series limiting
+- [#5555](https://github.com/thanos-io/thanos/pull/5555) Query: Added `--query.active-query-path` flag, allowing the user to configure the directory to create an active query tracking file, `queries.active`.   
 
 ### Changed
 
@@ -326,11 +327,11 @@ The binaries published with this release are built with Go1.17.8 to avoid [CVE-2
 
 ### Changed
 
--
+- 
 
 ### Removed
 
--
+- 
 
 ## [v0.20.0](https://github.com/thanos-io/thanos/releases/tag/v0.20.0) - 2021.04.28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#5493](https://github.com/thanos-io/thanos/pull/5493) Compact: Added `--compact.blocks-fetch-concurrency` allowing to configure number of go routines for download blocks during compactions.
 - [#5527](https://github.com/thanos-io/thanos/pull/5527) Receive: Add per request limits for remote write.
 - [#5520](https://github.com/thanos-io/thanos/pull/5520) Receive: Meta-monitoring based active series limiting
-- [#5555](https://github.com/thanos-io/thanos/pull/5555) Query: Added `--query.active-query-path` flag, allowing the user to configure the directory to create an active query tracking file, `queries.active`.
+- [#5555](https://github.com/thanos-io/thanos/pull/5555) Query: Added `--query.active-query-path` flag, allowing the user to configure the directory to create an active query tracking file, `queries.active`, for different resolution.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#5493](https://github.com/thanos-io/thanos/pull/5493) Compact: Added `--compact.blocks-fetch-concurrency` allowing to configure number of go routines for download blocks during compactions.
 - [#5527](https://github.com/thanos-io/thanos/pull/5527) Receive: Add per request limits for remote write.
 - [#5520](https://github.com/thanos-io/thanos/pull/5520) Receive: Meta-monitoring based active series limiting
-- [#5555](https://github.com/thanos-io/thanos/pull/5555) Query: Added `--query.active-query-path` flag, allowing the user to configure the directory to create an active query tracking file, `queries.active`.   
+- [#5555](https://github.com/thanos-io/thanos/pull/5555) Query: Added `--query.active-query-path` flag, allowing the user to configure the directory to create an active query tracking file, `queries.active`.
 
 ### Changed
 
@@ -327,11 +327,11 @@ The binaries published with this release are built with Go1.17.8 to avoid [CVE-2
 
 ### Changed
 
-- 
+-
 
 ### Removed
 
-- 
+-
 
 ## [v0.20.0](https://github.com/thanos-io/thanos/releases/tag/v0.20.0) - 2021.04.28
 

--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -764,8 +764,7 @@ func engineFactory(
 			lookbackDelta = time.Duration(r) * time.Millisecond
 		}
 
-		var queryTracker *promql.ActiveQueryTracker
-		newEngingOpts := promql.EngineOpts{
+		newEngineOpts := promql.EngineOpts{
 			Logger:                   eo.Logger,
 			Reg:                      wrapReg(i),
 			MaxSamples:               eo.MaxSamples,
@@ -775,15 +774,16 @@ func engineFactory(
 			EnableAtModifier:         eo.EnableAtModifier,
 			EnableNegativeOffset:     eo.EnableNegativeOffset,
 		}
+		// An active query tracker will be added only if the user specifies a non-default path.
+		// Otherwise, the nil active query tracker from existing engine options will be used.
 		if activeQueryDir != "" {
 			resActiveQueryDir := filepath.Join(activeQueryDir, getActiveQueryDirBasedOnResolution(r))
-			queryTracker = promql.NewActiveQueryTracker(resActiveQueryDir, maxConcurrentQueries, logger)
-			newEngingOpts.ActiveQueryTracker = queryTracker
+			newEngineOpts.ActiveQueryTracker = promql.NewActiveQueryTracker(resActiveQueryDir, maxConcurrentQueries, logger)
 		} else {
-			newEngingOpts.ActiveQueryTracker = eo.ActiveQueryTracker
+			newEngineOpts.ActiveQueryTracker = eo.ActiveQueryTracker
 		}
 
-		engines[i] = newEngine(newEngingOpts)
+		engines[i] = newEngine(newEngineOpts)
 	}
 	return func(maxSourceResolutionMillis int64) *promql.Engine {
 		for i := len(resolutions) - 1; i >= 1; i-- {

--- a/cmd/thanos/query_test.go
+++ b/cmd/thanos/query_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-kit/log"
 	"github.com/prometheus/prometheus/promql"
 
 	"github.com/thanos-io/thanos/pkg/testutil"
@@ -102,7 +103,8 @@ func TestEngineFactory(t *testing.T) {
 		}
 	)
 	for _, td := range tData {
-		e := engineFactory(mockNewEngine, promql.EngineOpts{LookbackDelta: td.lookbackDelta}, td.dynamicLookbackDelta)
+		e := engineFactory(mockNewEngine, promql.EngineOpts{LookbackDelta: td.lookbackDelta}, td.dynamicLookbackDelta,
+			"", 1, log.NewNopLogger())
 		for _, tc := range td.tcs {
 			got := e(tc.stepMillis)
 			testutil.Equals(t, tc.expect, got)

--- a/docs/components/query.md
+++ b/docs/components/query.md
@@ -255,7 +255,7 @@ Query node exposing PromQL enabled Query API with data retrieved from multiple
 store nodes.
 
 Flags:
-      --alert.query-url=ALERT.QUERY-URL
+      --alert.query-url=ALERT.QUERY-URL  
                                  The external Thanos Query URL that would be set
                                  in all alerts 'Source' field.
       --enable-feature= ...      Comma separated experimental feature names to
@@ -266,16 +266,16 @@ Flags:
                                  prefixed with 'dns+' or 'dnssrv+' to detect
                                  Thanos API servers through respective DNS
                                  lookups.
-      --endpoint-strict=<staticendpoint> ...
+      --endpoint-strict=<staticendpoint> ...  
                                  Addresses of only statically configured Thanos
                                  API servers that are always used, even if the
                                  health check fails. Useful if you have a
                                  caching layer on top.
-      --grpc-address="0.0.0.0:10901"
+      --grpc-address="0.0.0.0:10901"  
                                  Listen ip:port address for gRPC endpoints
                                  (StoreAPI). Make sure this address is routable
                                  from other components.
-      --grpc-client-server-name=""
+      --grpc-client-server-name=""  
                                  Server name to verify the hostname on the
                                  returned gRPC certificates. See
                                  https://tools.ietf.org/html/rfc4366#section-3.1
@@ -285,18 +285,18 @@ Flags:
                                  to the server
       --grpc-client-tls-key=""   TLS Key for the client's certificate
       --grpc-client-tls-secure   Use TLS when talking to the gRPC server
-      --grpc-client-tls-skip-verify
+      --grpc-client-tls-skip-verify  
                                  Disable TLS certificate verification i.e self
                                  signed, signed by fake CA
       --grpc-grace-period=2m     Time to wait after an interrupt received for
                                  GRPC Server.
-      --grpc-server-max-connection-age=60m
+      --grpc-server-max-connection-age=60m  
                                  The grpc server max connection age. This
                                  controls how often to re-read the tls
                                  certificates and redo the TLS handshake
       --grpc-server-tls-cert=""  TLS Certificate for gRPC server, leave blank to
                                  disable TLS
-      --grpc-server-tls-client-ca=""
+      --grpc-server-tls-client-ca=""  
                                  TLS CA to verify clients against. If no client
                                  CA is specified, there is no client
                                  verification on server side. (tls.NoClientCert)
@@ -304,7 +304,7 @@ Flags:
                                  disable TLS
   -h, --help                     Show context-sensitive help (also try
                                  --help-long and --help-man).
-      --http-address="0.0.0.0:10902"
+      --http-address="0.0.0.0:10902"  
                                  Listen host:port for HTTP endpoints.
       --http-grace-period=2m     Time to wait after an interrupt received for
                                  HTTP Server.
@@ -323,10 +323,13 @@ Flags:
                                  LogStartAndFinishCall: Logs the start and
                                  finish call of the requests. NoLogCall: Disable
                                  request logging.
+      --query.active-query-path="."  
+                                 Directory to log currently active queries in
+                                 the queries.active file.
       --query.auto-downsampling  Enable automatic adjustment (step / 5) to what
                                  source of data should be used in store gateways
                                  if no max_source_resolution param is specified.
-      --query.default-evaluation-interval=1m
+      --query.default-evaluation-interval=1m  
                                  Set default evaluation interval for sub
                                  queries.
       --query.default-step=1s    Set default step for range queries. Default
@@ -336,7 +339,7 @@ Flags:
                                  max(rangeSeconds / 250, defaultStep)). This
                                  will not work from Grafana, but Grafana has
                                  __step variable which can be used.
-      --query.lookback-delta=QUERY.LOOKBACK-DELTA
+      --query.lookback-delta=QUERY.LOOKBACK-DELTA  
                                  The maximum lookback duration for retrieving
                                  metrics during expression evaluations. PromQL
                                  always evaluates the query for the certain
@@ -351,10 +354,10 @@ Flags:
                                  it will use the promql default of 5m.
       --query.max-concurrent=20  Maximum number of queries processed
                                  concurrently by query node.
-      --query.max-concurrent-select=4
+      --query.max-concurrent-select=4  
                                  Maximum number of select requests made
                                  concurrently per a query.
-      --query.metadata.default-time-range=0s
+      --query.metadata.default-time-range=0s  
                                  The default metadata time range duration for
                                  retrieving labels through Labels and Series API
                                  when the range parameters are not specified.
@@ -363,24 +366,24 @@ Flags:
       --query.partial-response   Enable partial response for queries if no
                                  partial_response param is specified.
                                  --no-query.partial-response for disabling.
-      --query.replica-label=QUERY.REPLICA-LABEL ...
+      --query.replica-label=QUERY.REPLICA-LABEL ...  
                                  Labels to treat as a replica indicator along
                                  which data is deduplicated. Still you will be
                                  able to query without deduplication using
                                  'dedup=false' parameter. Data includes time
                                  series, recording rules, and alerting rules.
       --query.timeout=2m         Maximum time to process query by query node.
-      --request.logging-config=<content>
+      --request.logging-config=<content>  
                                  Alternative to 'request.logging-config-file'
                                  flag (mutually exclusive). Content of YAML file
                                  with request logging configuration. See format
                                  details:
                                  https://thanos.io/tip/thanos/logging.md/#configuration
-      --request.logging-config-file=<file-path>
+      --request.logging-config-file=<file-path>  
                                  Path to YAML file with request logging
                                  configuration. See format details:
                                  https://thanos.io/tip/thanos/logging.md/#configuration
-      --selector-label=<name>="<value>" ...
+      --selector-label=<name>="<value>" ...  
                                  Query selector labels that will be exposed in
                                  info endpoint (repeated).
       --store=<store> ...        Deprecation Warning - This flag is deprecated
@@ -389,35 +392,35 @@ Flags:
                                  (repeatable). The scheme may be prefixed with
                                  'dns+' or 'dnssrv+' to detect store API servers
                                  through respective DNS lookups.
-      --store-strict=<staticstore> ...
+      --store-strict=<staticstore> ...  
                                  Deprecation Warning - This flag is deprecated
                                  and replaced with `endpoint-strict`. Addresses
                                  of only statically configured store API servers
                                  that are always used, even if the health check
                                  fails. Useful if you have a caching layer on
                                  top.
-      --store.response-timeout=0ms
+      --store.response-timeout=0ms  
                                  If a Store doesn't send any data in this
                                  specified duration then a Store will be ignored
                                  and partial data will be returned if it's
                                  enabled. 0 disables timeout.
-      --store.sd-dns-interval=30s
+      --store.sd-dns-interval=30s  
                                  Interval between DNS resolutions.
-      --store.sd-files=<path> ...
+      --store.sd-files=<path> ...  
                                  Path to files that contain addresses of store
                                  API servers. The path can be a glob pattern
                                  (repeatable).
       --store.sd-interval=5m     Refresh interval to re-read file SD files. It
                                  is used as a resync fallback.
-      --store.unhealthy-timeout=5m
+      --store.unhealthy-timeout=5m  
                                  Timeout before an unhealthy store is cleaned
                                  from the store UI page.
-      --tracing.config=<content>
+      --tracing.config=<content>  
                                  Alternative to 'tracing.config-file' flag
                                  (mutually exclusive). Content of YAML file with
                                  tracing configuration. See format details:
                                  https://thanos.io/tip/thanos/tracing.md/#configuration
-      --tracing.config-file=<file-path>
+      --tracing.config-file=<file-path>  
                                  Path to YAML file with tracing configuration.
                                  See format details:
                                  https://thanos.io/tip/thanos/tracing.md/#configuration

--- a/docs/components/query.md
+++ b/docs/components/query.md
@@ -246,6 +246,10 @@ Example file SD file in YAML:
   - thanos-store.infra:10901
 ```
 
+## Active Query Tracking
+
+`--query.active-query-path` is an option which allows the user to specify a directory which will contain a `queries.active` file to track active queries. To enable this feature, the user has to specify a directory other than "", since that is skipped being the default. Currently, this feature is not covered under the primarily container-based E2E test suite due to container permission issues for creating files.
+
 ## Flags
 
 ```$ mdox-exec="thanos query --help"
@@ -255,7 +259,7 @@ Query node exposing PromQL enabled Query API with data retrieved from multiple
 store nodes.
 
 Flags:
-      --alert.query-url=ALERT.QUERY-URL  
+      --alert.query-url=ALERT.QUERY-URL
                                  The external Thanos Query URL that would be set
                                  in all alerts 'Source' field.
       --enable-feature= ...      Comma separated experimental feature names to
@@ -266,16 +270,16 @@ Flags:
                                  prefixed with 'dns+' or 'dnssrv+' to detect
                                  Thanos API servers through respective DNS
                                  lookups.
-      --endpoint-strict=<staticendpoint> ...  
+      --endpoint-strict=<staticendpoint> ...
                                  Addresses of only statically configured Thanos
                                  API servers that are always used, even if the
                                  health check fails. Useful if you have a
                                  caching layer on top.
-      --grpc-address="0.0.0.0:10901"  
+      --grpc-address="0.0.0.0:10901"
                                  Listen ip:port address for gRPC endpoints
                                  (StoreAPI). Make sure this address is routable
                                  from other components.
-      --grpc-client-server-name=""  
+      --grpc-client-server-name=""
                                  Server name to verify the hostname on the
                                  returned gRPC certificates. See
                                  https://tools.ietf.org/html/rfc4366#section-3.1
@@ -285,18 +289,18 @@ Flags:
                                  to the server
       --grpc-client-tls-key=""   TLS Key for the client's certificate
       --grpc-client-tls-secure   Use TLS when talking to the gRPC server
-      --grpc-client-tls-skip-verify  
+      --grpc-client-tls-skip-verify
                                  Disable TLS certificate verification i.e self
                                  signed, signed by fake CA
       --grpc-grace-period=2m     Time to wait after an interrupt received for
                                  GRPC Server.
-      --grpc-server-max-connection-age=60m  
+      --grpc-server-max-connection-age=60m
                                  The grpc server max connection age. This
                                  controls how often to re-read the tls
                                  certificates and redo the TLS handshake
       --grpc-server-tls-cert=""  TLS Certificate for gRPC server, leave blank to
                                  disable TLS
-      --grpc-server-tls-client-ca=""  
+      --grpc-server-tls-client-ca=""
                                  TLS CA to verify clients against. If no client
                                  CA is specified, there is no client
                                  verification on server side. (tls.NoClientCert)
@@ -304,7 +308,7 @@ Flags:
                                  disable TLS
   -h, --help                     Show context-sensitive help (also try
                                  --help-long and --help-man).
-      --http-address="0.0.0.0:10902"  
+      --http-address="0.0.0.0:10902"
                                  Listen host:port for HTTP endpoints.
       --http-grace-period=2m     Time to wait after an interrupt received for
                                  HTTP Server.
@@ -323,13 +327,13 @@ Flags:
                                  LogStartAndFinishCall: Logs the start and
                                  finish call of the requests. NoLogCall: Disable
                                  request logging.
-      --query.active-query-path="."  
+      --query.active-query-path=""
                                  Directory to log currently active queries in
                                  the queries.active file.
       --query.auto-downsampling  Enable automatic adjustment (step / 5) to what
                                  source of data should be used in store gateways
                                  if no max_source_resolution param is specified.
-      --query.default-evaluation-interval=1m  
+      --query.default-evaluation-interval=1m
                                  Set default evaluation interval for sub
                                  queries.
       --query.default-step=1s    Set default step for range queries. Default
@@ -339,7 +343,7 @@ Flags:
                                  max(rangeSeconds / 250, defaultStep)). This
                                  will not work from Grafana, but Grafana has
                                  __step variable which can be used.
-      --query.lookback-delta=QUERY.LOOKBACK-DELTA  
+      --query.lookback-delta=QUERY.LOOKBACK-DELTA
                                  The maximum lookback duration for retrieving
                                  metrics during expression evaluations. PromQL
                                  always evaluates the query for the certain
@@ -354,10 +358,10 @@ Flags:
                                  it will use the promql default of 5m.
       --query.max-concurrent=20  Maximum number of queries processed
                                  concurrently by query node.
-      --query.max-concurrent-select=4  
+      --query.max-concurrent-select=4
                                  Maximum number of select requests made
                                  concurrently per a query.
-      --query.metadata.default-time-range=0s  
+      --query.metadata.default-time-range=0s
                                  The default metadata time range duration for
                                  retrieving labels through Labels and Series API
                                  when the range parameters are not specified.
@@ -366,24 +370,24 @@ Flags:
       --query.partial-response   Enable partial response for queries if no
                                  partial_response param is specified.
                                  --no-query.partial-response for disabling.
-      --query.replica-label=QUERY.REPLICA-LABEL ...  
+      --query.replica-label=QUERY.REPLICA-LABEL ...
                                  Labels to treat as a replica indicator along
                                  which data is deduplicated. Still you will be
                                  able to query without deduplication using
                                  'dedup=false' parameter. Data includes time
                                  series, recording rules, and alerting rules.
       --query.timeout=2m         Maximum time to process query by query node.
-      --request.logging-config=<content>  
+      --request.logging-config=<content>
                                  Alternative to 'request.logging-config-file'
                                  flag (mutually exclusive). Content of YAML file
                                  with request logging configuration. See format
                                  details:
                                  https://thanos.io/tip/thanos/logging.md/#configuration
-      --request.logging-config-file=<file-path>  
+      --request.logging-config-file=<file-path>
                                  Path to YAML file with request logging
                                  configuration. See format details:
                                  https://thanos.io/tip/thanos/logging.md/#configuration
-      --selector-label=<name>="<value>" ...  
+      --selector-label=<name>="<value>" ...
                                  Query selector labels that will be exposed in
                                  info endpoint (repeated).
       --store=<store> ...        Deprecation Warning - This flag is deprecated
@@ -392,35 +396,35 @@ Flags:
                                  (repeatable). The scheme may be prefixed with
                                  'dns+' or 'dnssrv+' to detect store API servers
                                  through respective DNS lookups.
-      --store-strict=<staticstore> ...  
+      --store-strict=<staticstore> ...
                                  Deprecation Warning - This flag is deprecated
                                  and replaced with `endpoint-strict`. Addresses
                                  of only statically configured store API servers
                                  that are always used, even if the health check
                                  fails. Useful if you have a caching layer on
                                  top.
-      --store.response-timeout=0ms  
+      --store.response-timeout=0ms
                                  If a Store doesn't send any data in this
                                  specified duration then a Store will be ignored
                                  and partial data will be returned if it's
                                  enabled. 0 disables timeout.
-      --store.sd-dns-interval=30s  
+      --store.sd-dns-interval=30s
                                  Interval between DNS resolutions.
-      --store.sd-files=<path> ...  
+      --store.sd-files=<path> ...
                                  Path to files that contain addresses of store
                                  API servers. The path can be a glob pattern
                                  (repeatable).
       --store.sd-interval=5m     Refresh interval to re-read file SD files. It
                                  is used as a resync fallback.
-      --store.unhealthy-timeout=5m  
+      --store.unhealthy-timeout=5m
                                  Timeout before an unhealthy store is cleaned
                                  from the store UI page.
-      --tracing.config=<content>  
+      --tracing.config=<content>
                                  Alternative to 'tracing.config-file' flag
                                  (mutually exclusive). Content of YAML file with
                                  tracing configuration. See format details:
                                  https://thanos.io/tip/thanos/tracing.md/#configuration
-      --tracing.config-file=<file-path>  
+      --tracing.config-file=<file-path>
                                  Path to YAML file with tracing configuration.
                                  See format details:
                                  https://thanos.io/tip/thanos/tracing.md/#configuration

--- a/docs/components/query.md
+++ b/docs/components/query.md
@@ -248,7 +248,7 @@ Example file SD file in YAML:
 
 ## Active Query Tracking
 
-`--query.active-query-path` is an option which allows the user to specify a directory which will contain a `queries.active` file to track active queries. To enable this feature, the user has to specify a directory other than "", since that is skipped being the default. Currently, this feature is not covered under the primarily container-based E2E test suite due to container permission issues for creating files.
+`--query.active-query-path` is an option which allows the user to specify a directory which will contain a `queries.active` file to track active queries. To enable this feature, the user has to specify a directory other than "", since that is skipped being the default.
 
 ## Flags
 


### PR DESCRIPTION
Signed-off-by: Aditi Ahuja <ahuja.aditi@gmail.com>
Fixes #5521 

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes
Added a new flag which creates a `query.active` file in the filepath specified by the flag. 

## Verification

<!-- How you tested it? How do you know it works? -->
