### PR TITLE
Fix changed-docs grep regex

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ include .busybox-versions
 
 FILES_TO_FMT      ?= $(shell find . -path ./vendor -prune -o -path ./internal/cortex -prune -o -name '*.go' -print)
 MD_FILES_TO_FORMAT = $(shell find docs -name "*.md") $(shell find examples -name "*.md") $(filter-out mixin/runbook.md, $(shell find mixin -name "*.md")) $(shell ls *.md)
-FAST_MD_FILES_TO_FORMAT = $(shell git diff --name-only | grep ".md")
+FAST_MD_FILES_TO_FORMAT = $(shell git diff --name-only | grep "\.md")
 
 DOCKER_IMAGE_REPO ?= quay.io/thanos/thanos
 DOCKER_IMAGE_TAG  ?= $(subst /,-,$(shell git rev-parse --abbrev-ref HEAD))-$(shell date +%Y-%m-%d)-$(shell git rev-parse --short HEAD)


### PR DESCRIPTION
The `changed-docs` command checks for any changed markdown files and runs `mdox` on them.
It used grep with the regex `.md` to filter files by, but this can match any filepath containing "md". 
For e.g, both of these files would be matched, and cause formatting errors.
```
cmd/thanos/receive.go
docs/components/receive.md 
```

This PR updates the regex to `\.md`, so that we only match filepaths containing ".md".

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

- Update regex in Makefile.
## Verification

Tested locally.