### PR TITLE
Rule: Fix e2e test flake

### DIFF
--- a/test/e2e/rule_test.go
+++ b/test/e2e/rule_test.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -17,6 +16,7 @@ import (
 	"time"
 
 	"github.com/efficientgo/e2e"
+	"github.com/pkg/errors"
 	common_cfg "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/config"

--- a/test/e2e/rule_test.go
+++ b/test/e2e/rule_test.go
@@ -16,11 +16,11 @@ import (
 	"time"
 
 	"github.com/efficientgo/e2e"
-	"github.com/pkg/errors"
 	common_cfg "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/discovery/targetgroup"
+	"github.com/thanos-io/thanos/pkg/errors"
 	"gopkg.in/yaml.v2"
 
 	"github.com/thanos-io/thanos/pkg/alert"
@@ -178,13 +178,13 @@ func checkReloadSuccessful(t *testing.T, ctx context.Context, endpoint string, e
 
 		if resp.StatusCode != 200 {
 			errCount++
-			return errors.Errorf("statuscode is not 200, got %d", resp.StatusCode)
+			return errors.Newf("statuscode is not 200, got %d", resp.StatusCode)
 		}
 
 		body, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
 			errCount++
-			return errors.Wrap(err, "error reading body")
+			return errors.Wrapf(err, "error reading body")
 		}
 
 		if err := resp.Body.Close(); err != nil {
@@ -194,12 +194,12 @@ func checkReloadSuccessful(t *testing.T, ctx context.Context, endpoint string, e
 
 		if err := json.Unmarshal(body, &data); err != nil {
 			errCount++
-			return errors.Wrap(err, "error unmarshaling body")
+			return errors.Wrapf(err, "error unmarshaling body")
 		}
 
 		if data.Status != "success" {
 			errCount++
-			return errors.Errorf("response status is not success, got %s", data.Status)
+			return errors.Newf("response status is not success, got %s", data.Status)
 		}
 
 		if len(data.Data.Groups) == expectedRulegroupCount {
@@ -207,7 +207,7 @@ func checkReloadSuccessful(t *testing.T, ctx context.Context, endpoint string, e
 		}
 
 		errCount++
-		return errors.Errorf("different number of rulegroups: expected %d, got %d", expectedRulegroupCount, len(data.Data.Groups))
+		return errors.Newf("different number of rulegroups: expected %d, got %d", expectedRulegroupCount, len(data.Data.Groups))
 	}))
 
 	testutil.Assert(t, len(data.Data.Groups) == expectedRulegroupCount, fmt.Sprintf("expected there to be %d rule groups but got %d. encountered %d errors", expectedRulegroupCount, len(data.Data.Groups), errCount))

--- a/test/e2e/rule_test.go
+++ b/test/e2e/rule_test.go
@@ -160,7 +160,7 @@ func reloadRulesSignal(t *testing.T, r e2e.InstrumentedRunnable) {
 }
 
 func checkReloadSuccessful(t *testing.T, ctx context.Context, endpoint string, expectedRulegroupCount int) {
-	var data = rulesResp{}
+	data := rulesResp{}
 	errCount := 0
 
 	testutil.Ok(t, runutil.Retry(5*time.Second, ctx.Done(), func() error {


### PR DESCRIPTION
This PR fixes a Ruler e2e test flake which occurs during the `"signal reload works"` test, for example [here](https://github.com/thanos-io/thanos/runs/7605318868?check_suite_focus=true). 

Suspecting that this is due to a race condition, where we check for the number of RuleGroups from API response, right after sending a SIGHUP signal to Ruler container, in which case Ruler has not had a chance to fully run `RuleManager.Update` yet.

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

- Changed `checkReloadSuccessful` to retry request after 5 seconds, if number of RuleGroups does not match, instead of failing directly. Retries till context deadline

## Verification
Tested locally.
<!-- How you tested it? How do you know it works? -->
