### PR TITLE
Announce sharding in ruler and store proxy

### DIFF
--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -666,8 +666,9 @@ func runQuery(
 				if httpProbe.IsReady() {
 					mint, maxt := proxy.TimeRange()
 					return &infopb.StoreInfo{
-						MinTime: mint,
-						MaxTime: maxt,
+						MinTime:          mint,
+						MaxTime:          maxt,
+						SupportsSharding: true,
 					}
 				}
 				return nil

--- a/cmd/thanos/rule.go
+++ b/cmd/thanos/rule.go
@@ -607,8 +607,9 @@ func runRule(
 				if httpProbe.IsReady() {
 					mint, maxt := tsdbStore.TimeRange()
 					return &infopb.StoreInfo{
-						MinTime: mint,
-						MaxTime: maxt,
+						MinTime:          mint,
+						MaxTime:          maxt,
+						SupportsSharding: true,
 					}
 				}
 				return nil


### PR DESCRIPTION
The ruler and store proxy currently support series sharding
through the components that they use. Rulers use the TSDB module
which has support for sharding, and store proxies will either receive
sharded data, or will shard the data if the downstream store doesn't 
support sharding. However, this capability is not
announced to the querier.

This commit modifies their Info calls to indicate to queriers
that they doesn't need to shard the response they receive from rulers
and other store proxies.

Signed-off-by: Filip Petkovski <filip.petkovsky@gmail.com>

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

Announce series sharding capability in ruler and store proxy to avoid
sharding the data again in queriers. 

## Verification

Code audit and some manual testing.
