### PR TITLE
ui: fix an expression param in a link to an alert in the rules page

### DIFF
--- a/pkg/ui/react-app/src/pages/rules/RulesContent.tsx
+++ b/pkg/ui/react-app/src/pages/rules/RulesContent.tsx
@@ -22,12 +22,12 @@ export interface RulesMap {
   groups: RuleGroup[];
 }
 
-const GraphExpressionLink: FC<{ expr: string; title: string }> = (props) => {
+const GraphExpressionLink: FC<{ expr: string; text: string; title: string }> = (props) => {
   return (
     <>
       <strong>{props.title}:</strong>
       <a className="ml-4" href={createExternalExpressionLink(props.expr)}>
-        {props.expr}
+        {props.text}
       </a>
       <br />
     </>
@@ -84,8 +84,8 @@ export const RulesContent: FC<RouteComponentProps & RulesContentProps> = ({ resp
                     <tr key={i}>
                       {r.alerts ? (
                         <td className="rule-cell">
-                          <GraphExpressionLink title="alert" expr={r.name} />
-                          <GraphExpressionLink title="expr" expr={r.query} />
+                          <GraphExpressionLink title="alert" text={r.name} expr={`ALERTS{alertname="${r.name}"}`} />
+                          <GraphExpressionLink title="expr" text={r.query} expr={r.query} />
                           {r.duration > 0 && (
                             <div>
                               <strong>for:</strong> {formatDuration(r.duration * 1000)}
@@ -111,8 +111,8 @@ export const RulesContent: FC<RouteComponentProps & RulesContentProps> = ({ resp
                         </td>
                       ) : (
                         <td>
-                          <GraphExpressionLink title="record" expr={r.name} />
-                          <GraphExpressionLink title="expr" expr={r.query} />
+                          <GraphExpressionLink title="record" text={r.name} expr={r.name} />
+                          <GraphExpressionLink title="expr" text={r.query} expr={r.query} />
                         </td>
                       )}
                       <td>

--- a/scripts/cleanup-white-noise.sh
+++ b/scripts/cleanup-white-noise.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 SED_BIN=${SED_BIN:-sed}
 
 ${SED_BIN} -i 's/[ \t]*$//' "$@"


### PR DESCRIPTION
Signed-off-by: Rostislav Benes <r.dee.b.b@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Alert's url in the rules page now points to ALERTS

Recreated instead of #5413