### PR TITLE
Fix flaky e2e tests

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -77,7 +77,7 @@ jobs:
       - name: Check out code into the Go module directory.
         uses: actions/checkout@v2
 
-      - uses: actions/cache@v1
+      - uses: actions/cache@v3
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}

--- a/test/e2e/compact_test.go
+++ b/test/e2e/compact_test.go
@@ -761,24 +761,24 @@ func testCompactWithStoreGateway(t *testing.T, penaltyDedup bool) {
 
 		// NOTE: We cannot assert on intermediate `thanos_blocks_meta_` metrics as those are gauge and change dynamically due to many
 		// compaction groups. Wait for at least first compaction iteration (next is in 5m).
-		testutil.Ok(t, c.WaitSumMetrics(e2e.Greater(0), "thanos_compact_iterations_total"))
-		testutil.Ok(t, c.WaitSumMetrics(e2e.Equals(18), "thanos_compact_blocks_cleaned_total"))
-		testutil.Ok(t, c.WaitSumMetrics(e2e.Equals(0), "thanos_compact_block_cleanup_failures_total"))
-		testutil.Ok(t, c.WaitSumMetrics(e2e.Equals(0), "thanos_compact_blocks_marked_total"))
-		testutil.Ok(t, c.WaitSumMetrics(e2e.Equals(0), "thanos_compact_aborted_partial_uploads_deletion_attempts_total"))
-		testutil.Ok(t, c.WaitSumMetrics(e2e.Equals(0), "thanos_compact_group_compactions_total"))
-		testutil.Ok(t, c.WaitSumMetrics(e2e.Equals(0), "thanos_compact_group_vertical_compactions_total"))
-		testutil.Ok(t, c.WaitSumMetrics(e2e.Equals(0), "thanos_compact_group_compactions_failures_total"))
-		testutil.Ok(t, c.WaitSumMetrics(e2e.Equals(7), "thanos_compact_group_compaction_runs_started_total"))
-		testutil.Ok(t, c.WaitSumMetrics(e2e.Equals(7), "thanos_compact_group_compaction_runs_completed_total"))
+		testutil.Ok(t, c.WaitSumMetricsWithOptions(e2e.Greater(0), []string{"thanos_compact_iterations_total"}, e2e.WaitMissingMetrics()))
+		testutil.Ok(t, c.WaitSumMetricsWithOptions(e2e.Equals(18), []string{"thanos_compact_blocks_cleaned_total"}, e2e.WaitMissingMetrics()))
+		testutil.Ok(t, c.WaitSumMetricsWithOptions(e2e.Equals(0), []string{"thanos_compact_block_cleanup_failures_total"}, e2e.WaitMissingMetrics()))
+		testutil.Ok(t, c.WaitSumMetricsWithOptions(e2e.Equals(0), []string{"thanos_compact_blocks_marked_total"}, e2e.WaitMissingMetrics()))
+		testutil.Ok(t, c.WaitSumMetricsWithOptions(e2e.Equals(0), []string{"thanos_compact_aborted_partial_uploads_deletion_attempts_total"}, e2e.WaitMissingMetrics()))
+		testutil.Ok(t, c.WaitSumMetricsWithOptions(e2e.Equals(0), []string{"thanos_compact_group_compactions_total"}, e2e.WaitMissingMetrics()))
+		testutil.Ok(t, c.WaitSumMetricsWithOptions(e2e.Equals(0), []string{"thanos_compact_group_vertical_compactions_total"}, e2e.WaitMissingMetrics()))
+		testutil.Ok(t, c.WaitSumMetricsWithOptions(e2e.Equals(0), []string{"thanos_compact_group_compactions_failures_total"}, e2e.WaitMissingMetrics()))
+		testutil.Ok(t, c.WaitSumMetricsWithOptions(e2e.Equals(7), []string{"thanos_compact_group_compaction_runs_started_total"}, e2e.WaitMissingMetrics()))
+		testutil.Ok(t, c.WaitSumMetricsWithOptions(e2e.Equals(7), []string{"thanos_compact_group_compaction_runs_completed_total"}, e2e.WaitMissingMetrics()))
 
-		testutil.Ok(t, c.WaitSumMetrics(e2e.Equals(0), "thanos_compact_downsample_total"))
-		testutil.Ok(t, c.WaitSumMetrics(e2e.Equals(0), "thanos_compact_downsample_failures_total"))
+		testutil.Ok(t, c.WaitSumMetricsWithOptions(e2e.Equals(0), []string{"thanos_compact_downsample_total"}, e2e.WaitMissingMetrics()))
+		testutil.Ok(t, c.WaitSumMetricsWithOptions(e2e.Equals(0), []string{"thanos_compact_downsample_failures_total"}, e2e.WaitMissingMetrics()))
 
-		testutil.Ok(t, str.WaitSumMetrics(e2e.Equals(float64(len(rawBlockIDs)+8+6-18-2+2)), "thanos_blocks_meta_synced"))
-		testutil.Ok(t, str.WaitSumMetrics(e2e.Equals(0), "thanos_blocks_meta_sync_failures_total"))
+		testutil.Ok(t, str.WaitSumMetricsWithOptions(e2e.Equals(float64(len(rawBlockIDs)+8+6-18-2+2)), []string{"thanos_blocks_meta_synced"}, e2e.WaitMissingMetrics()))
+		testutil.Ok(t, str.WaitSumMetricsWithOptions(e2e.Equals(0), []string{"thanos_blocks_meta_sync_failures_total"}, e2e.WaitMissingMetrics()))
 
-		testutil.Ok(t, c.WaitSumMetrics(e2e.Equals(0), "thanos_compact_halted"))
+		testutil.Ok(t, c.WaitSumMetricsWithOptions(e2e.Equals(0), []string{"thanos_compact_halted"}, e2e.WaitMissingMetrics()))
 		// Make sure compactor does not modify anything else over time.
 		testutil.Ok(t, c.Stop())
 

--- a/test/e2e/compact_test.go
+++ b/test/e2e/compact_test.go
@@ -725,6 +725,7 @@ func testCompactWithStoreGateway(t *testing.T, penaltyDedup bool) {
 				bucketMatcher,
 				operationMatcher,
 			)),
+			e2e.WaitMissingMetrics(),
 		)
 
 		// Make sure compactor does not modify anything else over time.


### PR DESCRIPTION
This PR is an attempt to fix certain common flaky e2e test failures that I've noticed. Many seem to be some form of a race condition, so trying to fix them here.

This addresses following flakes,

- metadata_api_test: https://github.com/thanos-io/thanos/runs/7611817163?check_suite_focus=true
- tools_bucket_web_test: https://github.com/thanos-io/thanos/runs/7611255420?check_suite_focus=true
- compact_test: https://github.com/thanos-io/thanos/runs/7627932577?check_suite_focus=true

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

- Tried to add retries or wait logic to tests mentioned
## Verification

Tested locally.