### PR TITLE
Remove usage of `io/ioutil`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -395,7 +395,8 @@ github.com/prometheus/client_golang/prometheus.{DefaultGatherer,DefBuckets,NewUn
 github.com/prometheus/client_golang/prometheus.{NewCounter,NewCounterVec,NewCounterVec,NewGauge,NewGaugeVec,NewGaugeFunc,\
 NewHistorgram,NewHistogramVec,NewSummary,NewSummaryVec}=github.com/prometheus/client_golang/prometheus/promauto.{NewCounter,\
 NewCounterVec,NewCounterVec,NewGauge,NewGaugeVec,NewGaugeFunc,NewHistorgram,NewHistogramVec,NewSummary,NewSummaryVec},\
-sync/atomic=go.uber.org/atomic,github.com/cortexproject/cortex=github.com/thanos-io/thanos/internal/cortex" $(shell go list ./... | grep -v "internal/cortex")
+sync/atomic=go.uber.org/atomic,github.com/cortexproject/cortex=github.com/thanos-io/thanos/internal/cortex,\
+io/ioutil.{Discard,NopCloser,ReadAll,ReadDir,ReadFile,TempDir,TempFile,Writefile}" $(shell go list ./... | grep -v "internal/cortex")
 	@$(FAILLINT) -paths "fmt.{Print,Println,Sprint}" -ignore-tests ./...
 	@echo ">> linting all of the Go files GOGC=${GOGC}"
 	@$(GOLANGCI_LINT) run

--- a/cmd/thanos/main_test.go
+++ b/cmd/thanos/main_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"strings"
@@ -105,7 +104,7 @@ func (b *erroringBucket) Name() string {
 // Testing for https://github.com/thanos-io/thanos/issues/4960.
 func TestRegression4960_Deadlock(t *testing.T) {
 	logger := log.NewLogfmtLogger(os.Stderr)
-	dir, err := ioutil.TempDir("", "test-compact-cleanup")
+	dir, err := os.MkdirTemp("", "test-compact-cleanup")
 	testutil.Ok(t, err)
 	defer func() { testutil.Ok(t, os.RemoveAll(dir)) }()
 
@@ -168,7 +167,7 @@ func TestRegression4960_Deadlock(t *testing.T) {
 
 func TestCleanupDownsampleCacheFolder(t *testing.T) {
 	logger := log.NewLogfmtLogger(os.Stderr)
-	dir, err := ioutil.TempDir("", "test-compact-cleanup")
+	dir, err := os.MkdirTemp("", "test-compact-cleanup")
 	testutil.Ok(t, err)
 	defer func() { testutil.Ok(t, os.RemoveAll(dir)) }()
 

--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -5,7 +5,6 @@ package main
 
 import (
 	"context"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"path"
@@ -718,7 +717,7 @@ func migrateLegacyStorage(logger log.Logger, dataDir, defaultTenantID string) er
 
 	level.Info(logger).Log("msg", "found legacy storage, migrating to multi-tsdb layout with default tenant", "defaultTenantID", defaultTenantID)
 
-	files, err := ioutil.ReadDir(dataDir)
+	files, err := os.ReadDir(dataDir)
 	if err != nil {
 		return errors.Wrapf(err, "read legacy data dir: %v", dataDir)
 	}

--- a/cmd/thanos/tools_bucket.go
+++ b/cmd/thanos/tools_bucket.go
@@ -10,7 +10,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -1153,7 +1152,7 @@ func registerBucketRewrite(app extkingpin.AppClause, objStoreConfig *extflag.Pat
 		ctx, cancel := context.WithCancel(context.Background())
 		g.Add(func() error {
 			chunkPool := chunkenc.NewPool()
-			changeLog := compactv2.NewChangeLog(ioutil.Discard)
+			changeLog := compactv2.NewChangeLog(io.Discard)
 			stubCounter := promauto.With(nil).NewCounter(prometheus.CounterOpts{})
 			for _, id := range ids {
 				// Delete series from block & modify.

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -18,7 +18,7 @@ package api
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -44,7 +44,7 @@ func TestRespondSuccess(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error on test request: %s", err)
 	}
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	defer func() { testutil.Ok(t, resp.Body.Close()) }()
 	if err != nil {
 		t.Fatalf("Error reading response body: %s", err)
@@ -81,7 +81,7 @@ func TestRespondError(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error on test request: %s", err)
 	}
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	defer func() { testutil.Ok(t, resp.Body.Close()) }()
 	if err != nil {
 		t.Fatalf("Error reading response body: %s", err)

--- a/pkg/api/blocks/v1_test.go
+++ b/pkg/api/blocks/v1_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -94,7 +93,7 @@ func testEndpoint(t *testing.T, test endpointTestCase, name string, responseComp
 
 func TestMarkBlockEndpoint(t *testing.T) {
 	ctx := context.Background()
-	tmpDir, err := ioutil.TempDir("", "test-read-mark")
+	tmpDir, err := os.MkdirTemp("", "test-read-mark")
 	testutil.Ok(t, err)
 
 	// create block

--- a/pkg/api/query/v1_test.go
+++ b/pkg/api/query/v1_test.go
@@ -21,11 +21,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"math/rand"
 	"net/http"
 	"net/url"
+	"os"
 	"reflect"
 	"strings"
 	"testing"
@@ -680,7 +680,7 @@ func TestMetadataEndpoints(t *testing.T) {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "prometheus-test")
+	dir, err := os.MkdirTemp("", "prometheus-test")
 	testutil.Ok(t, err)
 
 	const chunkRange int64 = 600_000

--- a/pkg/block/block_test.go
+++ b/pkg/block/block_test.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"strings"
@@ -81,7 +80,7 @@ func TestUpload(t *testing.T) {
 
 	ctx := context.Background()
 
-	tmpDir, err := ioutil.TempDir("", "test-block-upload")
+	tmpDir, err := os.MkdirTemp("", "test-block-upload")
 	testutil.Ok(t, err)
 	defer func() { testutil.Ok(t, os.RemoveAll(tmpDir)) }()
 
@@ -234,7 +233,7 @@ func TestDelete(t *testing.T) {
 	defer testutil.TolerantVerifyLeak(t)
 	ctx := context.Background()
 
-	tmpDir, err := ioutil.TempDir("", "test-block-delete")
+	tmpDir, err := os.MkdirTemp("", "test-block-delete")
 	testutil.Ok(t, err)
 	defer func() { testutil.Ok(t, os.RemoveAll(tmpDir)) }()
 
@@ -281,7 +280,7 @@ func TestMarkForDeletion(t *testing.T) {
 	defer testutil.TolerantVerifyLeak(t)
 	ctx := context.Background()
 
-	tmpDir, err := ioutil.TempDir("", "test-block-mark-for-delete")
+	tmpDir, err := os.MkdirTemp("", "test-block-mark-for-delete")
 	testutil.Ok(t, err)
 	defer func() { testutil.Ok(t, os.RemoveAll(tmpDir)) }()
 
@@ -337,7 +336,7 @@ func TestMarkForNoCompact(t *testing.T) {
 	defer testutil.TolerantVerifyLeak(t)
 	ctx := context.Background()
 
-	tmpDir, err := ioutil.TempDir("", "test-block-mark-for-no-compact")
+	tmpDir, err := os.MkdirTemp("", "test-block-mark-for-no-compact")
 	testutil.Ok(t, err)
 	defer func() { testutil.Ok(t, os.RemoveAll(tmpDir)) }()
 
@@ -397,7 +396,7 @@ func TestHashDownload(t *testing.T) {
 
 	ctx := context.Background()
 
-	tmpDir, err := ioutil.TempDir("", "test-block-download")
+	tmpDir, err := os.MkdirTemp("", "test-block-download")
 	testutil.Ok(t, err)
 	t.Cleanup(func() {
 		testutil.Ok(t, os.RemoveAll(tmpDir))
@@ -493,7 +492,7 @@ func TestUploadCleanup(t *testing.T) {
 
 	ctx := context.Background()
 
-	tmpDir, err := ioutil.TempDir("", "test-block-upload")
+	tmpDir, err := os.MkdirTemp("", "test-block-upload")
 	testutil.Ok(t, err)
 	defer func() { testutil.Ok(t, os.RemoveAll(tmpDir)) }()
 

--- a/pkg/block/fetcher.go
+++ b/pkg/block/fetcher.go
@@ -6,7 +6,7 @@ package block
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"os"
 	"path"
 	"path/filepath"
@@ -267,7 +267,7 @@ func (f *BaseFetcher) loadMeta(ctx context.Context, id ulid.ULID) (*metadata.Met
 
 	defer runutil.CloseWithLogOnErr(f.logger, r, "close bkt meta get")
 
-	metaContent, err := ioutil.ReadAll(r)
+	metaContent, err := io.ReadAll(r)
 	if err != nil {
 		return nil, errors.Wrapf(err, "read meta file: %v", metaFile)
 	}
@@ -391,7 +391,7 @@ func (f *BaseFetcher) fetchMetadata(ctx context.Context) (interface{}, error) {
 
 	// Best effort cleanup of disk-cached metas.
 	if f.cacheDir != "" {
-		fis, err := ioutil.ReadDir(f.cacheDir)
+		fis, err := os.ReadDir(f.cacheDir)
 		names := make([]string, 0, len(fis))
 		for _, fi := range fis {
 			names = append(names, fi.Name())

--- a/pkg/block/fetcher_test.go
+++ b/pkg/block/fetcher_test.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path"
@@ -68,7 +67,7 @@ func TestMetaFetcher_Fetch(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 		defer cancel()
 
-		dir, err := ioutil.TempDir("", "test-meta-fetcher")
+		dir, err := os.MkdirTemp("", "test-meta-fetcher")
 		testutil.Ok(t, err)
 		defer func() { testutil.Ok(t, os.RemoveAll(dir)) }()
 

--- a/pkg/block/index_test.go
+++ b/pkg/block/index_test.go
@@ -5,7 +5,6 @@ package block
 
 import (
 	"context"
-	"io/ioutil"
 	"math"
 	"os"
 	"path/filepath"
@@ -25,7 +24,7 @@ import (
 func TestRewrite(t *testing.T) {
 	ctx := context.Background()
 
-	tmpDir, err := ioutil.TempDir("", "test-indexheader")
+	tmpDir, err := os.MkdirTemp("", "test-indexheader")
 	testutil.Ok(t, err)
 	defer func() { testutil.Ok(t, os.RemoveAll(tmpDir)) }()
 
@@ -88,7 +87,7 @@ func TestRewrite(t *testing.T) {
 }
 
 func TestGatherIndexHealthStatsReturnsOutOfOrderChunksErr(t *testing.T) {
-	blockDir, err := ioutil.TempDir("", "test-ooo-index")
+	blockDir, err := os.MkdirTemp("", "test-ooo-index")
 	testutil.Ok(t, err)
 
 	err = testutil.PutOutOfOrderIndex(blockDir, 0, math.MaxInt64)

--- a/pkg/block/indexheader/binary_reader.go
+++ b/pkg/block/indexheader/binary_reader.go
@@ -10,7 +10,6 @@ import (
 	"hash"
 	"hash/crc32"
 	"io"
-	"io/ioutil"
 	"math"
 	"os"
 	"path/filepath"
@@ -143,7 +142,7 @@ func newChunkedIndexReader(ctx context.Context, bkt objstore.BucketReader, id ul
 		return nil, 0, errors.Wrapf(err, "get TOC from object storage of %s", indexFilepath)
 	}
 
-	b, err := ioutil.ReadAll(rc)
+	b, err := io.ReadAll(rc)
 	if err != nil {
 		runutil.CloseWithErrCapture(&err, rc, "close reader")
 		return nil, 0, errors.Wrapf(err, "get header from object storage of %s", indexFilepath)
@@ -185,7 +184,7 @@ func (r *chunkedIndexReader) readTOC() (*index.TOC, error) {
 		return nil, errors.Wrapf(err, "get TOC from object storage of %s", r.path)
 	}
 
-	tocBytes, err := ioutil.ReadAll(rc)
+	tocBytes, err := io.ReadAll(rc)
 	if err != nil {
 		runutil.CloseWithErrCapture(&err, rc, "close toc reader")
 		return nil, errors.Wrapf(err, "get TOC from object storage of %s", r.path)

--- a/pkg/block/indexheader/header_test.go
+++ b/pkg/block/indexheader/header_test.go
@@ -6,7 +6,6 @@ package indexheader
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"math"
 	"os"
 	"path/filepath"
@@ -32,7 +31,7 @@ import (
 func TestReaders(t *testing.T) {
 	ctx := context.Background()
 
-	tmpDir, err := ioutil.TempDir("", "test-indexheader")
+	tmpDir, err := os.MkdirTemp("", "test-indexheader")
 	testutil.Ok(t, err)
 	defer func() { testutil.Ok(t, os.RemoveAll(tmpDir)) }()
 
@@ -333,7 +332,7 @@ func prepareIndexV2Block(t testing.TB, tmpDir string, bkt objstore.Bucket) *meta
 func BenchmarkBinaryWrite(t *testing.B) {
 	ctx := context.Background()
 
-	tmpDir, err := ioutil.TempDir("", "bench-indexheader")
+	tmpDir, err := os.MkdirTemp("", "bench-indexheader")
 	testutil.Ok(t, err)
 	defer func() { testutil.Ok(t, os.RemoveAll(tmpDir)) }()
 
@@ -352,7 +351,7 @@ func BenchmarkBinaryWrite(t *testing.B) {
 
 func BenchmarkBinaryReader(t *testing.B) {
 	ctx := context.Background()
-	tmpDir, err := ioutil.TempDir("", "bench-indexheader")
+	tmpDir, err := os.MkdirTemp("", "bench-indexheader")
 	testutil.Ok(t, err)
 	defer func() { testutil.Ok(t, os.RemoveAll(tmpDir)) }()
 
@@ -385,7 +384,7 @@ func benchmarkBinaryReaderLookupSymbol(b *testing.B, numSeries int) {
 	ctx := context.Background()
 	logger := log.NewNopLogger()
 
-	tmpDir, err := ioutil.TempDir("", "benchmark-lookupsymbol")
+	tmpDir, err := os.MkdirTemp("", "benchmark-lookupsymbol")
 	testutil.Ok(b, err)
 	defer func() { testutil.Ok(b, os.RemoveAll(tmpDir)) }()
 

--- a/pkg/block/indexheader/lazy_binary_reader_test.go
+++ b/pkg/block/indexheader/lazy_binary_reader_test.go
@@ -5,7 +5,6 @@ package indexheader
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sync"
@@ -27,7 +26,7 @@ import (
 func TestNewLazyBinaryReader_ShouldFailIfUnableToBuildIndexHeader(t *testing.T) {
 	ctx := context.Background()
 
-	tmpDir, err := ioutil.TempDir("", "test-indexheader")
+	tmpDir, err := os.MkdirTemp("", "test-indexheader")
 	testutil.Ok(t, err)
 	defer func() { testutil.Ok(t, os.RemoveAll(tmpDir)) }()
 
@@ -42,7 +41,7 @@ func TestNewLazyBinaryReader_ShouldFailIfUnableToBuildIndexHeader(t *testing.T) 
 func TestNewLazyBinaryReader_ShouldBuildIndexHeaderFromBucket(t *testing.T) {
 	ctx := context.Background()
 
-	tmpDir, err := ioutil.TempDir("", "test-indexheader")
+	tmpDir, err := os.MkdirTemp("", "test-indexheader")
 	testutil.Ok(t, err)
 	defer func() { testutil.Ok(t, os.RemoveAll(tmpDir)) }()
 
@@ -83,7 +82,7 @@ func TestNewLazyBinaryReader_ShouldBuildIndexHeaderFromBucket(t *testing.T) {
 func TestNewLazyBinaryReader_ShouldRebuildCorruptedIndexHeader(t *testing.T) {
 	ctx := context.Background()
 
-	tmpDir, err := ioutil.TempDir("", "test-indexheader")
+	tmpDir, err := os.MkdirTemp("", "test-indexheader")
 	testutil.Ok(t, err)
 	defer func() { testutil.Ok(t, os.RemoveAll(tmpDir)) }()
 
@@ -101,7 +100,7 @@ func TestNewLazyBinaryReader_ShouldRebuildCorruptedIndexHeader(t *testing.T) {
 
 	// Write a corrupted index-header for the block.
 	headerFilename := filepath.Join(tmpDir, blockID.String(), block.IndexHeaderFilename)
-	testutil.Ok(t, ioutil.WriteFile(headerFilename, []byte("xxx"), os.ModePerm))
+	testutil.Ok(t, os.WriteFile(headerFilename, []byte("xxx"), os.ModePerm))
 
 	m := NewLazyBinaryReaderMetrics(nil)
 	r, err := NewLazyBinaryReader(ctx, log.NewNopLogger(), bkt, tmpDir, blockID, 3, m, nil)
@@ -123,7 +122,7 @@ func TestNewLazyBinaryReader_ShouldRebuildCorruptedIndexHeader(t *testing.T) {
 func TestLazyBinaryReader_ShouldReopenOnUsageAfterClose(t *testing.T) {
 	ctx := context.Background()
 
-	tmpDir, err := ioutil.TempDir("", "test-indexheader")
+	tmpDir, err := os.MkdirTemp("", "test-indexheader")
 	testutil.Ok(t, err)
 	defer func() { testutil.Ok(t, os.RemoveAll(tmpDir)) }()
 
@@ -175,7 +174,7 @@ func TestLazyBinaryReader_ShouldReopenOnUsageAfterClose(t *testing.T) {
 func TestLazyBinaryReader_unload_ShouldReturnErrorIfNotIdle(t *testing.T) {
 	ctx := context.Background()
 
-	tmpDir, err := ioutil.TempDir("", "test-indexheader")
+	tmpDir, err := os.MkdirTemp("", "test-indexheader")
 	testutil.Ok(t, err)
 	defer func() { testutil.Ok(t, os.RemoveAll(tmpDir)) }()
 
@@ -226,7 +225,7 @@ func TestLazyBinaryReader_LoadUnloadRaceCondition(t *testing.T) {
 
 	ctx := context.Background()
 
-	tmpDir, err := ioutil.TempDir("", "test-indexheader")
+	tmpDir, err := os.MkdirTemp("", "test-indexheader")
 	testutil.Ok(t, err)
 	defer func() { testutil.Ok(t, os.RemoveAll(tmpDir)) }()
 

--- a/pkg/block/indexheader/reader_pool_test.go
+++ b/pkg/block/indexheader/reader_pool_test.go
@@ -5,7 +5,6 @@ package indexheader
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -42,7 +41,7 @@ func TestReaderPool_NewBinaryReader(t *testing.T) {
 
 	ctx := context.Background()
 
-	tmpDir, err := ioutil.TempDir("", "test-indexheader")
+	tmpDir, err := os.MkdirTemp("", "test-indexheader")
 	testutil.Ok(t, err)
 	defer func() { testutil.Ok(t, os.RemoveAll(tmpDir)) }()
 
@@ -80,7 +79,7 @@ func TestReaderPool_ShouldCloseIdleLazyReaders(t *testing.T) {
 
 	ctx := context.Background()
 
-	tmpDir, err := ioutil.TempDir("", "test-indexheader")
+	tmpDir, err := os.MkdirTemp("", "test-indexheader")
 	testutil.Ok(t, err)
 	defer func() { testutil.Ok(t, os.RemoveAll(tmpDir)) }()
 

--- a/pkg/block/metadata/hash_test.go
+++ b/pkg/block/metadata/hash_test.go
@@ -4,7 +4,6 @@
 package metadata
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -14,10 +13,10 @@ import (
 )
 
 func TestHashSmoke(t *testing.T) {
-	dir, err := ioutil.TempDir("", "testhash")
+	dir, err := os.MkdirTemp("", "testhash")
 	testutil.Ok(t, err)
 	t.Cleanup(func() { os.RemoveAll(dir) })
-	f, err := ioutil.TempFile(dir, "hash")
+	f, err := os.CreateTemp(dir, "hash")
 	testutil.Ok(t, err)
 
 	_, err = f.Write([]byte("test"))

--- a/pkg/block/metadata/markers.go
+++ b/pkg/block/metadata/markers.go
@@ -6,7 +6,7 @@ package metadata
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"path"
 
 	"github.com/go-kit/log"
@@ -100,7 +100,7 @@ func ReadMarker(ctx context.Context, logger log.Logger, bkt objstore.Instrumente
 	}
 	defer runutil.CloseWithLogOnErr(logger, r, "close bkt marker reader")
 
-	metaContent, err := ioutil.ReadAll(r)
+	metaContent, err := io.ReadAll(r)
 	if err != nil {
 		return errors.Wrapf(err, "read file: %s", markerFile)
 	}

--- a/pkg/block/metadata/markers_test.go
+++ b/pkg/block/metadata/markers_test.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -29,7 +28,7 @@ func TestMain(m *testing.M) {
 func TestReadMarker(t *testing.T) {
 	ctx := context.Background()
 
-	tmpDir, err := ioutil.TempDir("", "test-read-mark")
+	tmpDir, err := os.MkdirTemp("", "test-read-mark")
 	testutil.Ok(t, err)
 	defer func() { testutil.Ok(t, os.RemoveAll(tmpDir)) }()
 

--- a/pkg/block/metadata/meta_test.go
+++ b/pkg/block/metadata/meta_test.go
@@ -5,7 +5,7 @@ package metadata
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/oklog/ulid"
@@ -35,7 +35,7 @@ func TestMeta_ReadWrite(t *testing.T) {
 	}
 }
 `, b.String())
-		_, err := Read(ioutil.NopCloser(&b))
+		_, err := Read(io.NopCloser(&b))
 		testutil.NotOk(t, err)
 		testutil.Equals(t, "unexpected meta file version 0", err.Error())
 	})
@@ -125,7 +125,7 @@ func TestMeta_ReadWrite(t *testing.T) {
 	}
 }
 `, b.String())
-		retMeta, err := Read(ioutil.NopCloser(&b))
+		retMeta, err := Read(io.NopCloser(&b))
 		testutil.Ok(t, err)
 		testutil.Equals(t, m1, *retMeta)
 	})
@@ -203,7 +203,7 @@ func TestMeta_ReadWrite(t *testing.T) {
 	}
 }
 `, b.String())
-		retMeta, err := Read(ioutil.NopCloser(&b))
+		retMeta, err := Read(io.NopCloser(&b))
 		testutil.Ok(t, err)
 
 		// We expect map to be empty but allocated.

--- a/pkg/cache/groupcache.go
+++ b/pkg/cache/groupcache.go
@@ -8,7 +8,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"path/filepath"
@@ -209,7 +209,7 @@ func NewGroupcacheWithConfig(logger log.Logger, reg prometheus.Registerer, conf 
 				}
 				defer runutil.CloseWithLogOnErr(logger, rc, "closing get")
 
-				b, err := ioutil.ReadAll(rc)
+				b, err := io.ReadAll(rc)
 				if err != nil {
 					return err
 				}
@@ -242,7 +242,7 @@ func NewGroupcacheWithConfig(logger log.Logger, reg prometheus.Registerer, conf 
 				}
 				defer runutil.CloseWithLogOnErr(logger, rc, "closing get_range")
 
-				b, err := ioutil.ReadAll(rc)
+				b, err := io.ReadAll(rc)
 				if err != nil {
 					return err
 				}
@@ -278,7 +278,7 @@ func (c *unsafeByteCodec) MarshalBinary() ([]byte, time.Time, error) {
 
 // UnmarshalBinary to provided data so they share the same backing array
 // this is a generally unsafe performance optimization, but safe in our
-// case because we always use ioutil.ReadAll(). That is fine though
+// case because we always use io.ReadAll(). That is fine though
 // because later that slice remains in our local cache.
 // Used https://github.com/vimeo/galaxycache/pull/23/files as inspiration.
 // TODO(GiedriusS): figure out if pooling could be used somehow by hooking into

--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -6,7 +6,6 @@ package compact
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"math"
 	"os"
 	"path/filepath"
@@ -927,7 +926,7 @@ func RepairIssue347(ctx context.Context, logger log.Logger, bkt objstore.Bucket,
 
 	level.Info(logger).Log("msg", "Repairing block broken by https://github.com/prometheus/tsdb/issues/347", "id", ie.id, "err", issue347Err)
 
-	tmpdir, err := ioutil.TempDir("", fmt.Sprintf("repair-issue-347-id-%s-", ie.id))
+	tmpdir, err := os.MkdirTemp("", fmt.Sprintf("repair-issue-347-id-%s-", ie.id))
 	if err != nil {
 		return err
 	}

--- a/pkg/compact/compact_e2e_test.go
+++ b/pkg/compact/compact_e2e_test.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -186,7 +185,7 @@ func testGroupCompactE2e(t *testing.T, mergeFunc storage.VerticalChunkSeriesMerg
 		defer cancel()
 
 		// Create fresh, empty directory for actual test.
-		dir, err := ioutil.TempDir("", "test-compact")
+		dir, err := os.MkdirTemp("", "test-compact")
 		testutil.Ok(t, err)
 		defer func() { testutil.Ok(t, os.RemoveAll(dir)) }()
 
@@ -431,7 +430,7 @@ type blockgenSpec struct {
 }
 
 func createAndUpload(t testing.TB, bkt objstore.Bucket, blocks []blockgenSpec, blocksWithOutOfOrderChunks []blockgenSpec) (metas []*metadata.Meta) {
-	prepareDir, err := ioutil.TempDir("", "test-compact-prepare")
+	prepareDir, err := os.MkdirTemp("", "test-compact-prepare")
 	testutil.Ok(t, err)
 	defer func() { testutil.Ok(t, os.RemoveAll(prepareDir)) }()
 

--- a/pkg/compact/compact_test.go
+++ b/pkg/compact/compact_test.go
@@ -8,7 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"path"
 	"testing"
 	"time"
@@ -143,7 +143,7 @@ func TestGroupMaxMinTime(t *testing.T) {
 
 func BenchmarkGatherNoCompactionMarkFilter_Filter(b *testing.B) {
 	ctx := context.TODO()
-	logger := log.NewLogfmtLogger(ioutil.Discard)
+	logger := log.NewLogfmtLogger(io.Discard)
 
 	m := extprom.NewTxGaugeVec(nil, prometheus.GaugeOpts{}, []string{"state"})
 

--- a/pkg/compact/downsample/downsample_test.go
+++ b/pkg/compact/downsample/downsample_test.go
@@ -4,7 +4,6 @@
 package downsample
 
 import (
-	"io/ioutil"
 	"math"
 	"os"
 	"path/filepath"
@@ -433,7 +432,7 @@ func TestDownsample(t *testing.T) {
 		t.Run(tcase.name, func(t *testing.T) {
 			logger := log.NewLogfmtLogger(os.Stderr)
 
-			dir, err := ioutil.TempDir("", "downsample-raw")
+			dir, err := os.MkdirTemp("", "downsample-raw")
 			testutil.Ok(t, err)
 			defer func() { testutil.Ok(t, os.RemoveAll(dir)) }()
 
@@ -508,7 +507,7 @@ func TestDownsample(t *testing.T) {
 
 func TestDownsampleAggrAndEmptyXORChunks(t *testing.T) {
 	logger := log.NewLogfmtLogger(os.Stderr)
-	dir, err := ioutil.TempDir("", "downsample-mixed")
+	dir, err := os.MkdirTemp("", "downsample-mixed")
 	testutil.Ok(t, err)
 	defer func() { testutil.Ok(t, os.RemoveAll(dir)) }()
 
@@ -539,7 +538,7 @@ func TestDownsampleAggrAndEmptyXORChunks(t *testing.T) {
 
 func TestDownsampleAggrAndNonEmptyXORChunks(t *testing.T) {
 	logger := log.NewLogfmtLogger(os.Stderr)
-	dir, err := ioutil.TempDir("", "downsample-mixed")
+	dir, err := os.MkdirTemp("", "downsample-mixed")
 	testutil.Ok(t, err)
 	defer func() { testutil.Ok(t, os.RemoveAll(dir)) }()
 

--- a/pkg/compact/planner_test.go
+++ b/pkg/compact/planner_test.go
@@ -6,7 +6,6 @@ package compact
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -352,7 +351,7 @@ func TestPlanners_Plan_Compatibility(t *testing.T) {
 
 			// For compatibility.
 			t.Run("tsdbPlannerAdapter", func(t *testing.T) {
-				dir, err := ioutil.TempDir("", "test-compact")
+				dir, err := os.MkdirTemp("", "test-compact")
 				testutil.Ok(t, err)
 				defer func() { testutil.Ok(t, os.RemoveAll(dir)) }()
 
@@ -436,7 +435,7 @@ func TestRangeWithFailedCompactionWontGetSelected(t *testing.T) {
 			c.metas[1].Compaction.Failed = true
 			// For compatibility.
 			t.Run("tsdbPlannerAdapter", func(t *testing.T) {
-				dir, err := ioutil.TempDir("", "test-compact")
+				dir, err := os.MkdirTemp("", "test-compact")
 				testutil.Ok(t, err)
 				defer func() { testutil.Ok(t, os.RemoveAll(dir)) }()
 

--- a/pkg/compactv2/compactor_test.go
+++ b/pkg/compactv2/compactor_test.go
@@ -6,7 +6,6 @@ package compactv2
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
 	"math"
 	"os"
 	"path/filepath"
@@ -589,7 +588,7 @@ func TestCompactor_WriteSeries_e2e(t *testing.T) {
 		},
 	} {
 		t.Run(tcase.name, func(t *testing.T) {
-			tmpDir, err := ioutil.TempDir("", "test-series-writer")
+			tmpDir, err := os.MkdirTemp("", "test-series-writer")
 			testutil.Ok(t, err)
 			defer func() { testutil.Ok(t, os.RemoveAll(tmpDir)) }()
 

--- a/pkg/dedup/iter_test.go
+++ b/pkg/dedup/iter_test.go
@@ -5,7 +5,7 @@ package dedup
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math"
 	"math/rand"
 	"sort"
@@ -501,7 +501,7 @@ func BenchmarkDedupSeriesIterator(b *testing.B) {
 			t, _ := it.At()
 			total += t
 		}
-		fmt.Fprint(ioutil.Discard, total)
+		fmt.Fprint(io.Discard, total)
 	}
 	b.Run("equal", func(b *testing.B) {
 		var s1, s2 []sample

--- a/pkg/exthttp/tlsconfig.go
+++ b/pkg/exthttp/tlsconfig.go
@@ -7,7 +7,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
+	"os"
 )
 
 // TLSConfig configures the options for TLS connections.
@@ -60,7 +60,7 @@ func NewTLSConfig(cfg *TLSConfig) (*tls.Config, error) {
 
 // readCAFile reads the CA cert file from disk.
 func readCAFile(f string) ([]byte, error) {
-	data, err := ioutil.ReadFile(f)
+	data, err := os.ReadFile(f)
 	if err != nil {
 		return nil, fmt.Errorf("unable to load specified CA cert %s: %s", f, err)
 	}

--- a/pkg/logging/http_test.go
+++ b/pkg/logging/http_test.go
@@ -6,7 +6,6 @@ package logging
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -44,7 +43,7 @@ func TestHTTPServerMiddleware(t *testing.T) {
 	hm(w, req)
 
 	resp := w.Result()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	testutil.Ok(t, err)
 
 	testutil.Equals(t, 200, resp.StatusCode)
@@ -59,7 +58,7 @@ func TestHTTPServerMiddleware(t *testing.T) {
 	hm(w, req)
 
 	resp = w.Result()
-	body, err = ioutil.ReadAll(resp.Body)
+	body, err = io.ReadAll(resp.Body)
 	testutil.Ok(t, err)
 
 	testutil.Equals(t, 200, resp.StatusCode)
@@ -74,7 +73,7 @@ func TestHTTPServerMiddleware(t *testing.T) {
 	hm(w, req)
 
 	resp = w.Result()
-	body, err = ioutil.ReadAll(resp.Body)
+	body, err = io.ReadAll(resp.Body)
 	testutil.Ok(t, err)
 
 	testutil.Equals(t, 200, resp.StatusCode)

--- a/pkg/promclient/promclient.go
+++ b/pkg/promclient/promclient.go
@@ -10,7 +10,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -131,7 +130,7 @@ func (c *Client) req2xx(ctx context.Context, u *url.URL, method string) (_ []byt
 	}
 	defer runutil.ExhaustCloseWithErrCapture(&err, resp.Body, "%s: close body", req.URL.String())
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, resp.StatusCode, errors.Wrap(err, "read body")
 	}
@@ -283,7 +282,7 @@ func (c *Client) ConfiguredFlags(ctx context.Context, base *url.URL) (Flags, err
 	}
 	defer runutil.ExhaustCloseWithLogOnErr(c.logger, resp.Body, "query body")
 
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return Flags{}, errors.New("failed to read body")
 	}
@@ -335,7 +334,7 @@ func (c *Client) Snapshot(ctx context.Context, base *url.URL, skipHead bool) (st
 	}
 	defer runutil.ExhaustCloseWithLogOnErr(c.logger, resp.Body, "query body")
 
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", errors.New("failed to read body")
 	}

--- a/pkg/promclient/promclient_e2e_test.go
+++ b/pkg/promclient/promclient_e2e_test.go
@@ -6,7 +6,6 @@ package promclient
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"path"
@@ -116,7 +115,7 @@ func TestSnapshot_e2e(t *testing.T) {
 		_, err = os.Stat(path.Join(p.Dir(), dir, id.String()))
 		testutil.Ok(t, err)
 
-		files, err := ioutil.ReadDir(path.Join(p.Dir(), dir))
+		files, err := os.ReadDir(path.Join(p.Dir(), dir))
 		testutil.Ok(t, err)
 
 		for _, f := range files {

--- a/pkg/query/querier_test.go
+++ b/pkg/query/querier_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"math"
 	"os"
 	"reflect"
@@ -678,7 +677,7 @@ func testSelectResponse(t *testing.T, expected []series, res storage.SeriesSet) 
 }
 
 func jsonToSeries(t *testing.T, filename string) []series {
-	file, err := ioutil.ReadFile(filename)
+	file, err := os.ReadFile(filename)
 	testutil.Ok(t, err)
 
 	data := Response{}

--- a/pkg/query/query_bench_test.go
+++ b/pkg/query/query_bench_test.go
@@ -6,7 +6,6 @@ package query
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -40,7 +39,7 @@ func BenchmarkQuerySelect(b *testing.B) {
 }
 
 func benchQuerySelect(t testutil.TB, totalSamples, totalSeries int, dedup bool) {
-	tmpDir, err := ioutil.TempDir("", "testorbench-queryselect")
+	tmpDir, err := os.MkdirTemp("", "testorbench-queryselect")
 	testutil.Ok(t, err)
 	defer func() { testutil.Ok(t, os.RemoveAll(tmpDir)) }()
 

--- a/pkg/query/test.go
+++ b/pkg/query/test.go
@@ -6,8 +6,8 @@ package query
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"math"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -106,7 +106,7 @@ func newTest(t testing.TB, input string) (*test, error) {
 }
 
 func newTestFromFile(t testing.TB, filename string) (*test, error) {
-	content, err := ioutil.ReadFile(filepath.Clean(filename))
+	content, err := os.ReadFile(filepath.Clean(filename))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/queryfrontend/labels_codec.go
+++ b/pkg/queryfrontend/labels_codec.go
@@ -7,7 +7,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	io "io"
 	"math"
 	"net/http"
 	"net/url"
@@ -208,13 +208,13 @@ func (c labelsCodec) EncodeRequest(ctx context.Context, r queryrange.Request) (*
 
 func (c labelsCodec) DecodeResponse(ctx context.Context, r *http.Response, req queryrange.Request) (queryrange.Response, error) {
 	if r.StatusCode/100 != 2 {
-		body, _ := ioutil.ReadAll(r.Body)
+		body, _ := io.ReadAll(r.Body)
 		return nil, httpgrpc.Errorf(r.StatusCode, string(body))
 	}
 	log, _ := spanlogger.New(ctx, "ParseQueryResponse") //nolint:ineffassign,staticcheck
 	defer log.Finish()
 
-	buf, err := ioutil.ReadAll(r.Body)
+	buf, err := io.ReadAll(r.Body)
 	if err != nil {
 		log.Error(err) //nolint:errcheck
 		return nil, httpgrpc.Errorf(http.StatusInternalServerError, "error decoding response: %v", err)
@@ -276,7 +276,7 @@ func (c labelsCodec) EncodeResponse(ctx context.Context, res queryrange.Response
 		Header: http.Header{
 			"Content-Type": []string{"application/json"},
 		},
-		Body:       ioutil.NopCloser(bytes.NewBuffer(b)),
+		Body:       io.NopCloser(bytes.NewBuffer(b)),
 		StatusCode: http.StatusOK,
 	}
 	return &resp, nil

--- a/pkg/queryfrontend/labels_codec_test.go
+++ b/pkg/queryfrontend/labels_codec_test.go
@@ -8,7 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	io "io"
 	"net/http"
 	"testing"
 	"time"
@@ -351,26 +351,26 @@ func TestLabelsCodec_DecodeResponse(t *testing.T) {
 		{
 			name:          "prometheus request, invalid for labelsCodec",
 			req:           &queryrange.PrometheusRequest{},
-			res:           http.Response{StatusCode: 200, Body: ioutil.NopCloser(bytes.NewBuffer([]byte("foo")))},
+			res:           http.Response{StatusCode: 200, Body: io.NopCloser(bytes.NewBuffer([]byte("foo")))},
 			expectedError: httpgrpc.Errorf(http.StatusInternalServerError, "invalid request type"),
 		},
 		{
 			name:          "thanos query range request, invalid for labelsCodec",
 			req:           &ThanosQueryRangeRequest{},
-			res:           http.Response{StatusCode: 200, Body: ioutil.NopCloser(bytes.NewBuffer([]byte("foo")))},
+			res:           http.Response{StatusCode: 200, Body: io.NopCloser(bytes.NewBuffer([]byte("foo")))},
 			expectedError: httpgrpc.Errorf(http.StatusInternalServerError, "invalid request type"),
 		},
 		{
 			name:             "thanos labels request",
 			req:              &ThanosLabelsRequest{},
-			res:              http.Response{StatusCode: 200, Body: ioutil.NopCloser(bytes.NewBuffer(labelsData))},
+			res:              http.Response{StatusCode: 200, Body: io.NopCloser(bytes.NewBuffer(labelsData))},
 			expectedResponse: labelResponse,
 		},
 		{
 			name: "thanos labels request with HTTP headers",
 			req:  &ThanosLabelsRequest{},
 			res: http.Response{
-				StatusCode: 200, Body: ioutil.NopCloser(bytes.NewBuffer(labelsDataWithHeaders)),
+				StatusCode: 200, Body: io.NopCloser(bytes.NewBuffer(labelsDataWithHeaders)),
 				Header: map[string][]string{
 					cacheControlHeader: {noStoreValue},
 				},
@@ -380,14 +380,14 @@ func TestLabelsCodec_DecodeResponse(t *testing.T) {
 		{
 			name:             "thanos series request",
 			req:              &ThanosSeriesRequest{},
-			res:              http.Response{StatusCode: 200, Body: ioutil.NopCloser(bytes.NewBuffer(seriesData))},
+			res:              http.Response{StatusCode: 200, Body: io.NopCloser(bytes.NewBuffer(seriesData))},
 			expectedResponse: seriesResponse,
 		},
 		{
 			name: "thanos series request with HTTP headers",
 			req:  &ThanosSeriesRequest{},
 			res: http.Response{
-				StatusCode: 200, Body: ioutil.NopCloser(bytes.NewBuffer(seriesDataWithHeaders)),
+				StatusCode: 200, Body: io.NopCloser(bytes.NewBuffer(seriesDataWithHeaders)),
 				Header: map[string][]string{
 					cacheControlHeader: {noStoreValue},
 				},
@@ -720,7 +720,7 @@ func makeQueryRangeResponses(size int) ([]queryrange.Response, []queryrange.Resp
 
 func makeResponse(data []byte, withHeader bool) *http.Response {
 	r := &http.Response{
-		StatusCode: 200, Body: ioutil.NopCloser(bytes.NewBuffer(data)),
+		StatusCode: 200, Body: io.NopCloser(bytes.NewBuffer(data)),
 	}
 
 	if withHeader {

--- a/pkg/receive/config.go
+++ b/pkg/receive/config.go
@@ -8,7 +8,7 @@ import (
 	"crypto/md5"
 	"encoding/binary"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"time"
@@ -286,7 +286,7 @@ func readFile(logger log.Logger, path string) ([]byte, error) {
 		}
 	}()
 
-	return ioutil.ReadAll(fd)
+	return io.ReadAll(fd)
 }
 
 // parseConfig parses the raw configuration content and returns a HashringConfig.

--- a/pkg/receive/config_test.go
+++ b/pkg/receive/config_test.go
@@ -5,7 +5,6 @@ package receive
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -49,7 +48,7 @@ func TestValidateConfig(t *testing.T) {
 			content, err := json.Marshal(tc.cfg)
 			testutil.Ok(t, err)
 
-			tmpfile, err := ioutil.TempFile("", "configwatcher_test.*.json")
+			tmpfile, err := os.CreateTemp("", "configwatcher_test.*.json")
 			testutil.Ok(t, err)
 
 			defer func() {

--- a/pkg/receive/handler.go
+++ b/pkg/receive/handler.go
@@ -463,7 +463,7 @@ func (h *Handler) receiveHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// ioutil.ReadAll dynamically adjust the byte slice for read data, starting from 512B.
+	// io.ReadAll dynamically adjust the byte slice for read data, starting from 512B.
 	// Since this is receive hot path, grow upfront saving allocations and CPU time.
 	compressed := bytes.Buffer{}
 	if r.ContentLength >= 0 {

--- a/pkg/receive/handler_test.go
+++ b/pkg/receive/handler_test.go
@@ -7,7 +7,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math"
 	"math/rand"
 	"net/http"
@@ -1247,7 +1247,7 @@ func serializeSeriesWithOneSample(t testing.TB, series [][]labelpb.ZLabel) []byt
 }
 
 func benchmarkHandlerMultiTSDBReceiveRemoteWrite(b testutil.TB) {
-	dir, err := ioutil.TempDir("", "test_receive")
+	dir, err := os.MkdirTemp("", "test_receive")
 	testutil.Ok(b, err)
 	defer func() { testutil.Ok(b, os.RemoveAll(dir)) }()
 
@@ -1351,7 +1351,7 @@ func benchmarkHandlerMultiTSDBReceiveRemoteWrite(b testutil.TB) {
 				b.ResetTimer()
 				for i := 0; i < n; i++ {
 					r := httptest.NewRecorder()
-					handler.receiveHTTP(r, &http.Request{ContentLength: int64(len(tcase.writeRequest)), Body: ioutil.NopCloser(bytes.NewReader(tcase.writeRequest))})
+					handler.receiveHTTP(r, &http.Request{ContentLength: int64(len(tcase.writeRequest)), Body: io.NopCloser(bytes.NewReader(tcase.writeRequest))})
 					testutil.Equals(b, http.StatusOK, r.Code, "got non 200 error: %v", r.Body.String())
 				}
 			})
@@ -1375,7 +1375,7 @@ func benchmarkHandlerMultiTSDBReceiveRemoteWrite(b testutil.TB) {
 
 			// First request should be fine, since we don't change timestamp, rest is wrong.
 			r := httptest.NewRecorder()
-			handler.receiveHTTP(r, &http.Request{ContentLength: int64(len(tcase.writeRequest)), Body: ioutil.NopCloser(bytes.NewReader(tcase.writeRequest))})
+			handler.receiveHTTP(r, &http.Request{ContentLength: int64(len(tcase.writeRequest)), Body: io.NopCloser(bytes.NewReader(tcase.writeRequest))})
 			testutil.Equals(b, http.StatusOK, r.Code, "got non 200 error: %v", r.Body.String())
 
 			b.Run("conflict errors", func(b testutil.TB) {
@@ -1383,9 +1383,9 @@ func benchmarkHandlerMultiTSDBReceiveRemoteWrite(b testutil.TB) {
 				b.ResetTimer()
 				for i := 0; i < n; i++ {
 					r := httptest.NewRecorder()
-					handler.receiveHTTP(r, &http.Request{ContentLength: int64(len(tcase.writeRequest)), Body: ioutil.NopCloser(bytes.NewReader(tcase.writeRequest))})
+					handler.receiveHTTP(r, &http.Request{ContentLength: int64(len(tcase.writeRequest)), Body: io.NopCloser(bytes.NewReader(tcase.writeRequest))})
 					testutil.Equals(b, http.StatusConflict, r.Code, "%v-%s", i, func() string {
-						b, _ := ioutil.ReadAll(r.Body)
+						b, _ := io.ReadAll(r.Body)
 						return string(b)
 					}())
 				}

--- a/pkg/receive/multitsdb.go
+++ b/pkg/receive/multitsdb.go
@@ -5,7 +5,6 @@ package receive
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -141,7 +140,7 @@ func (t *MultiTSDB) Open() error {
 		return err
 	}
 
-	files, err := ioutil.ReadDir(t.dataDir)
+	files, err := os.ReadDir(t.dataDir)
 	if err != nil {
 		return err
 	}
@@ -339,7 +338,7 @@ func (t *MultiTSDB) Sync(ctx context.Context) (int, error) {
 }
 
 func (t *MultiTSDB) RemoveLockFilesIfAny() error {
-	fis, err := ioutil.ReadDir(t.dataDir)
+	fis, err := os.ReadDir(t.dataDir)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil

--- a/pkg/receive/multitsdb_test.go
+++ b/pkg/receive/multitsdb_test.go
@@ -6,7 +6,6 @@ package receive
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -31,7 +30,7 @@ import (
 )
 
 func TestMultiTSDB(t *testing.T) {
-	dir, err := ioutil.TempDir("", "test")
+	dir, err := os.MkdirTemp("", "test")
 	testutil.Ok(t, err)
 	defer func() { testutil.Ok(t, os.RemoveAll(dir)) }()
 
@@ -437,7 +436,7 @@ func TestMultiTSDBPrune(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			dir, err := ioutil.TempDir("", "multitsdb-prune")
+			dir, err := os.MkdirTemp("", "multitsdb-prune")
 			testutil.Ok(t, err)
 			defer func() { testutil.Ok(t, os.RemoveAll(dir)) }()
 
@@ -507,7 +506,7 @@ func TestMultiTSDBStats(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			dir, err := ioutil.TempDir("", "tsdb-stats")
+			dir, err := os.MkdirTemp("", "tsdb-stats")
 			testutil.Ok(t, err)
 			defer func() { testutil.Ok(t, os.RemoveAll(dir)) }()
 
@@ -562,7 +561,7 @@ func appendSample(m *MultiTSDB, tenant string, timestamp time.Time) error {
 }
 
 func BenchmarkMultiTSDB(b *testing.B) {
-	dir, err := ioutil.TempDir("", "multitsdb")
+	dir, err := os.MkdirTemp("", "multitsdb")
 	testutil.Ok(b, err)
 	defer func() { testutil.Ok(b, os.RemoveAll(dir)) }()
 

--- a/pkg/receive/writer_test.go
+++ b/pkg/receive/writer_test.go
@@ -6,7 +6,6 @@ package receive
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -122,7 +121,7 @@ func TestWriter(t *testing.T) {
 
 	for testName, testData := range tests {
 		t.Run(testName, func(t *testing.T) {
-			dir, err := ioutil.TempDir("", "test")
+			dir, err := os.MkdirTemp("", "test")
 			testutil.Ok(t, err)
 			defer func() { testutil.Ok(t, os.RemoveAll(dir)) }()
 
@@ -185,7 +184,7 @@ func BenchmarkWriterTimeSeriesWith10Labels_100(b *testing.B)  { benchmarkWriter(
 func BenchmarkWriterTimeSeriesWith10Labels_1000(b *testing.B) { benchmarkWriter(b, 10, 1000) }
 
 func benchmarkWriter(b *testing.B, labelsNum int, seriesNum int) {
-	dir, err := ioutil.TempDir("", "bench-writer")
+	dir, err := os.MkdirTemp("", "bench-writer")
 	testutil.Ok(b, err)
 	defer func() { testutil.Ok(b, os.RemoveAll(dir)) }()
 

--- a/pkg/reloader/reloader.go
+++ b/pkg/reloader/reloader.go
@@ -59,7 +59,6 @@ import (
 	"crypto/sha256"
 	"hash"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -280,7 +279,7 @@ func (r *Reloader) apply(ctx context.Context) error {
 		}
 		cfgHash = h.Sum(nil)
 		if r.cfgOutputFile != "" {
-			b, err := ioutil.ReadFile(r.cfgFile)
+			b, err := os.ReadFile(r.cfgFile)
 			if err != nil {
 				return errors.Wrap(err, "read file")
 			}
@@ -293,7 +292,7 @@ func (r *Reloader) apply(ctx context.Context) error {
 				}
 				defer runutil.CloseWithLogOnErr(r.logger, zr, "gzip reader close")
 
-				b, err = ioutil.ReadAll(zr)
+				b, err = io.ReadAll(zr)
 				if err != nil {
 					return errors.Wrap(err, "read compressed config file")
 				}
@@ -308,7 +307,7 @@ func (r *Reloader) apply(ctx context.Context) error {
 			defer func() {
 				_ = os.Remove(tmpFile)
 			}()
-			if err := ioutil.WriteFile(tmpFile, b, 0644); err != nil {
+			if err := os.WriteFile(tmpFile, b, 0644); err != nil {
 				return errors.Wrap(err, "write file")
 			}
 			if err := os.Rename(tmpFile, r.cfgOutputFile); err != nil {

--- a/pkg/reloader/reloader_test.go
+++ b/pkg/reloader/reloader_test.go
@@ -6,7 +6,6 @@ package reloader
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
@@ -60,7 +59,7 @@ func TestReloader_ConfigApply(t *testing.T) {
 	reloadURL, err := url.Parse(fmt.Sprintf("http://%s", l.Addr().String()))
 	testutil.Ok(t, err)
 
-	dir, err := ioutil.TempDir("", "reloader-cfg-test")
+	dir, err := os.MkdirTemp("", "reloader-cfg-test")
 	testutil.Ok(t, err)
 	defer func() { testutil.Ok(t, os.RemoveAll(dir)) }()
 
@@ -86,7 +85,7 @@ func TestReloader_ConfigApply(t *testing.T) {
 	testutil.NotOk(t, err)
 	testutil.Assert(t, strings.HasSuffix(err.Error(), "no such file or directory"), "expect error since there is no input config.")
 
-	testutil.Ok(t, ioutil.WriteFile(input, []byte(`
+	testutil.Ok(t, os.WriteFile(input, []byte(`
 config:
   a: 1
   b: $(TEST_RELOADER_THANOS_ENV)
@@ -124,7 +123,7 @@ Outer:
 
 		if reloadsSeen == 1 {
 			// Initial apply seen (without doing nothing).
-			f, err := ioutil.ReadFile(output)
+			f, err := os.ReadFile(output)
 			testutil.Ok(t, err)
 			testutil.Equals(t, `
 config:
@@ -134,7 +133,7 @@ config:
 `, string(f))
 
 			// Change config, expect reload in another iteration.
-			testutil.Ok(t, ioutil.WriteFile(input, []byte(`
+			testutil.Ok(t, os.WriteFile(input, []byte(`
 config:
   a: changed
   b: $(TEST_RELOADER_THANOS_ENV)
@@ -142,7 +141,7 @@ config:
 `), os.ModePerm))
 		} else if reloadsSeen == 2 {
 			// Another apply, ensure we see change.
-			f, err := ioutil.ReadFile(output)
+			f, err := os.ReadFile(output)
 			testutil.Ok(t, err)
 			testutil.Equals(t, `
 config:
@@ -183,7 +182,7 @@ faulty_config:
   a: 1
 `)
 
-	dir, err := ioutil.TempDir("", "reloader-cfg-test")
+	dir, err := os.MkdirTemp("", "reloader-cfg-test")
 	testutil.Ok(t, err)
 	defer func() { testutil.Ok(t, os.RemoveAll(dir)) }()
 
@@ -200,7 +199,7 @@ faulty_config:
 	srv := &http.Server{}
 
 	srv.Handler = http.HandlerFunc(func(resp http.ResponseWriter, r *http.Request) {
-		f, err := ioutil.ReadFile(output)
+		f, err := os.ReadFile(output)
 		testutil.Ok(t, err)
 
 		if string(f) == string(faultyConfig) {
@@ -227,7 +226,7 @@ faulty_config:
 		DelayInterval: 1 * time.Millisecond,
 	})
 
-	testutil.Ok(t, ioutil.WriteFile(input, correctConfig, os.ModePerm))
+	testutil.Ok(t, os.WriteFile(input, correctConfig, os.ModePerm))
 
 	rctx, cancel2 := context.WithCancel(ctx)
 	g := sync.WaitGroup{}
@@ -252,24 +251,24 @@ faulty_config:
 
 		if reloadsSeen == 1 && !faulty {
 			// Initial apply seen (without doing anything).
-			f, err := ioutil.ReadFile(output)
+			f, err := os.ReadFile(output)
 			testutil.Ok(t, err)
 			testutil.Equals(t, string(correctConfig), string(f))
 
 			// Change to a faulty config
-			testutil.Ok(t, ioutil.WriteFile(input, faultyConfig, os.ModePerm))
+			testutil.Ok(t, os.WriteFile(input, faultyConfig, os.ModePerm))
 			faulty = true
 		} else if reloadsSeen == 1 && faulty {
 			// Faulty config will trigger a reload, but reload failed
-			f, err := ioutil.ReadFile(output)
+			f, err := os.ReadFile(output)
 			testutil.Ok(t, err)
 			testutil.Equals(t, string(faultyConfig), string(f))
 
 			// Rollback config
-			testutil.Ok(t, ioutil.WriteFile(input, correctConfig, os.ModePerm))
+			testutil.Ok(t, os.WriteFile(input, correctConfig, os.ModePerm))
 		} else if reloadsSeen >= 2 {
 			// Rollback to previous config should trigger a reload
-			f, err := ioutil.ReadFile(output)
+			f, err := os.ReadFile(output)
 			testutil.Ok(t, err)
 			testutil.Equals(t, string(correctConfig), string(f))
 
@@ -316,9 +315,9 @@ func TestReloader_DirectoriesApply(t *testing.T) {
 	tempRule3File := path.Join(ruleDir, "rule3.yaml")
 	tempRule4File := path.Join(ruleDir, "rule4.yaml")
 
-	testutil.Ok(t, ioutil.WriteFile(tempRule1File, []byte("rule1-changed"), os.ModePerm))
-	testutil.Ok(t, ioutil.WriteFile(tempRule3File, []byte("rule3-changed"), os.ModePerm))
-	testutil.Ok(t, ioutil.WriteFile(tempRule4File, []byte("rule4-changed"), os.ModePerm))
+	testutil.Ok(t, os.WriteFile(tempRule1File, []byte("rule1-changed"), os.ModePerm))
+	testutil.Ok(t, os.WriteFile(tempRule3File, []byte("rule3-changed"), os.ModePerm))
+	testutil.Ok(t, os.WriteFile(tempRule4File, []byte("rule4-changed"), os.ModePerm))
 
 	defer func() { testutil.Ok(t, os.RemoveAll(ruleDir)) }()
 
@@ -355,10 +354,10 @@ func TestReloader_DirectoriesApply(t *testing.T) {
 	// ├─ rule3-001.yaml -> rule3-source.yaml
 	// └─ rule3-source.yaml
 	// The reloader watches 2 directories: dir and dir/rule-dir.
-	testutil.Ok(t, ioutil.WriteFile(path.Join(dir, "rule1.yaml"), []byte("rule"), os.ModePerm))
-	testutil.Ok(t, ioutil.WriteFile(path.Join(dir2, "rule3-source.yaml"), []byte("rule3"), os.ModePerm))
+	testutil.Ok(t, os.WriteFile(path.Join(dir, "rule1.yaml"), []byte("rule"), os.ModePerm))
+	testutil.Ok(t, os.WriteFile(path.Join(dir2, "rule3-source.yaml"), []byte("rule3"), os.ModePerm))
 	testutil.Ok(t, os.Symlink(path.Join(dir2, "rule3-source.yaml"), path.Join(dir2, "rule3-001.yaml")))
-	testutil.Ok(t, ioutil.WriteFile(path.Join(dir2, "rule-dir", "rule4.yaml"), []byte("rule4"), os.ModePerm))
+	testutil.Ok(t, os.WriteFile(path.Join(dir2, "rule-dir", "rule4.yaml"), []byte("rule4"), os.ModePerm))
 
 	stepFunc := func(rel int) {
 		t.Log("Performing step number", rel)
@@ -375,7 +374,7 @@ func TestReloader_DirectoriesApply(t *testing.T) {
 			// │  └─ rule4.yaml
 			// ├─ rule3-001.yaml -> rule3-source.yaml
 			// └─ rule3-source.yaml
-			testutil.Ok(t, ioutil.WriteFile(path.Join(dir, "rule2.yaml"), []byte("rule2"), os.ModePerm))
+			testutil.Ok(t, os.WriteFile(path.Join(dir, "rule2.yaml"), []byte("rule2"), os.ModePerm))
 		case 1:
 			// Update rule1.yaml.
 			//
@@ -544,10 +543,10 @@ func TestReloaderDirectoriesApplyBasedOnWatchInterval(t *testing.T) {
 	// └─ rule3-source.yaml
 	//
 	// The reloader watches 2 directories: dir and dir/rule-dir.
-	testutil.Ok(t, ioutil.WriteFile(path.Join(dir, "rule1.yaml"), []byte("rule"), os.ModePerm))
-	testutil.Ok(t, ioutil.WriteFile(path.Join(dir2, "rule3-source.yaml"), []byte("rule3"), os.ModePerm))
+	testutil.Ok(t, os.WriteFile(path.Join(dir, "rule1.yaml"), []byte("rule"), os.ModePerm))
+	testutil.Ok(t, os.WriteFile(path.Join(dir2, "rule3-source.yaml"), []byte("rule3"), os.ModePerm))
 	testutil.Ok(t, os.Symlink(path.Join(dir2, "rule3-source.yaml"), path.Join(dir2, "rule3-001.yaml")))
-	testutil.Ok(t, ioutil.WriteFile(path.Join(dir2, "rule-dir", "rule4.yaml"), []byte("rule4"), os.ModePerm))
+	testutil.Ok(t, os.WriteFile(path.Join(dir2, "rule-dir", "rule4.yaml"), []byte("rule4"), os.ModePerm))
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	g := sync.WaitGroup{}
@@ -608,7 +607,7 @@ func TestReloaderDirectoriesApplyBasedOnWatchInterval(t *testing.T) {
 				// │  └─ rule4.yaml
 				// ├─ rule3-001.yaml -> rule3-source.yaml
 				// └─ rule3-source.yaml (*)
-				testutil.Ok(t, ioutil.WriteFile(path.Join(dir2, "rule3-source.yaml"), []byte("rule3-changed"), os.ModePerm))
+				testutil.Ok(t, os.WriteFile(path.Join(dir2, "rule3-source.yaml"), []byte("rule3-changed"), os.ModePerm))
 			}
 
 			if rel > 1 {
@@ -645,7 +644,7 @@ func TestReloader_ConfigApplyWithWatchIntervalEqualsZero(t *testing.T) {
 	reloadURL, err := url.Parse(fmt.Sprintf("http://%s", l.Addr().String()))
 	testutil.Ok(t, err)
 
-	dir, err := ioutil.TempDir("", "reloader-cfg-test")
+	dir, err := os.MkdirTemp("", "reloader-cfg-test")
 	testutil.Ok(t, err)
 	defer func() { testutil.Ok(t, os.RemoveAll(dir)) }()
 
@@ -666,7 +665,7 @@ func TestReloader_ConfigApplyWithWatchIntervalEqualsZero(t *testing.T) {
 		DelayInterval: 1 * time.Millisecond,
 	})
 
-	testutil.Ok(t, ioutil.WriteFile(input, []byte(`
+	testutil.Ok(t, os.WriteFile(input, []byte(`
 config:
   a: 1
   b: 2
@@ -690,7 +689,7 @@ Outer:
 		}
 		if reloads.Load().(int) == 0 {
 			// Initial apply seen (without doing nothing).
-			f, err := ioutil.ReadFile(output)
+			f, err := os.ReadFile(output)
 			testutil.Ok(t, err)
 			testutil.Equals(t, `
 config:

--- a/pkg/replicate/scheme.go
+++ b/pkg/replicate/scheme.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"path"
 	"sort"
 
@@ -242,13 +241,13 @@ func (rs *replicationScheme) ensureBlockIsReplicated(ctx context.Context, id uli
 	}
 
 	// TODO(bwplotka): Allow injecting custom labels as shipper does.
-	originMetaFileContent, err := ioutil.ReadAll(originMetaFile)
+	originMetaFileContent, err := io.ReadAll(originMetaFile)
 	if err != nil {
 		return errors.Wrap(err, "read origin meta file")
 	}
 
 	if targetMetaFile != nil && !rs.toBkt.IsObjNotFoundErr(err) {
-		targetMetaFileContent, err := ioutil.ReadAll(targetMetaFile)
+		targetMetaFileContent, err := io.ReadAll(targetMetaFile)
 		if err != nil {
 			return errors.Wrap(err, "read target meta file")
 		}

--- a/pkg/rules/manager.go
+++ b/pkg/rules/manager.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -333,7 +332,7 @@ func (m *Manager) Update(evalInterval time.Duration, files []string) error {
 	}
 
 	for _, fn := range files {
-		b, err := ioutil.ReadFile(filepath.Clean(fn))
+		b, err := os.ReadFile(filepath.Clean(fn))
 		if err != nil {
 			errs.Add(err)
 			continue
@@ -365,7 +364,7 @@ func (m *Manager) Update(evalInterval time.Duration, files []string) error {
 				errs.Add(errors.Wrapf(err, "create %s", filepath.Dir(newFn)))
 				continue
 			}
-			if err := ioutil.WriteFile(newFn, b, os.ModePerm); err != nil {
+			if err := os.WriteFile(newFn, b, os.ModePerm); err != nil {
 				errs.Add(errors.Wrapf(err, "write file %v", newFn))
 				continue
 			}

--- a/pkg/rules/manager_test.go
+++ b/pkg/rules/manager_test.go
@@ -6,7 +6,6 @@ package rules
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -55,11 +54,11 @@ func (n nopQueryable) Querier(_ context.Context, _, _ int64) (storage.Querier, e
 
 // Regression test against https://github.com/thanos-io/thanos/issues/1779.
 func TestRun_Subqueries(t *testing.T) {
-	dir, err := ioutil.TempDir("", "test_rule_run")
+	dir, err := os.MkdirTemp("", "test_rule_run")
 	testutil.Ok(t, err)
 	defer func() { testutil.Ok(t, os.RemoveAll(dir)) }()
 
-	testutil.Ok(t, ioutil.WriteFile(filepath.Join(dir, "rule.yaml"), []byte(`
+	testutil.Ok(t, os.WriteFile(filepath.Join(dir, "rule.yaml"), []byte(`
 groups:
 - name: "rule with subquery"
   partial_response_strategy: "warn"
@@ -109,9 +108,9 @@ groups:
 }
 
 func TestUpdate_Error_UpdatePartial(t *testing.T) {
-	dir, err := ioutil.TempDir("", "test_rule_rule_groups")
+	dir, err := os.MkdirTemp("", "test_rule_rule_groups")
 	testutil.Ok(t, err)
-	dataDir, err := ioutil.TempDir("", "test_rule_data")
+	dataDir, err := os.MkdirTemp("", "test_rule_data")
 	testutil.Ok(t, err)
 	defer func() {
 		testutil.Ok(t, os.RemoveAll(dir))
@@ -120,14 +119,14 @@ func TestUpdate_Error_UpdatePartial(t *testing.T) {
 	err = os.MkdirAll(filepath.Join(dir, "subdir"), 0775)
 	testutil.Ok(t, err)
 
-	testutil.Ok(t, ioutil.WriteFile(filepath.Join(dir, "no_strategy.yaml"), []byte(`
+	testutil.Ok(t, os.WriteFile(filepath.Join(dir, "no_strategy.yaml"), []byte(`
 groups:
 - name: "something1"
   rules:
   - alert: "some"
     expr: "up"
 `), os.ModePerm))
-	testutil.Ok(t, ioutil.WriteFile(filepath.Join(dir, "abort.yaml"), []byte(`
+	testutil.Ok(t, os.WriteFile(filepath.Join(dir, "abort.yaml"), []byte(`
 groups:
 - name: "something2"
   partial_response_strategy: "abort"
@@ -135,7 +134,7 @@ groups:
   - alert: "some"
     expr: "up"
 `), os.ModePerm))
-	testutil.Ok(t, ioutil.WriteFile(filepath.Join(dir, "warn.yaml"), []byte(`
+	testutil.Ok(t, os.WriteFile(filepath.Join(dir, "warn.yaml"), []byte(`
 groups:
 - name: "something3"
   partial_response_strategy: "warn"
@@ -143,7 +142,7 @@ groups:
   - alert: "some"
     expr: "up"
 `), os.ModePerm))
-	testutil.Ok(t, ioutil.WriteFile(filepath.Join(dir, "wrong.yaml"), []byte(`
+	testutil.Ok(t, os.WriteFile(filepath.Join(dir, "wrong.yaml"), []byte(`
 groups:
 - name: "something4"
   partial_response_strategy: "afafsdgsdgs" # Err 1
@@ -151,7 +150,7 @@ groups:
   - alert: "some"
     expr: "up"
 `), os.ModePerm))
-	testutil.Ok(t, ioutil.WriteFile(filepath.Join(dir, "combined.yaml"), []byte(`
+	testutil.Ok(t, os.WriteFile(filepath.Join(dir, "combined.yaml"), []byte(`
 groups:
 - name: "something5"
   partial_response_strategy: "warn"
@@ -169,7 +168,7 @@ groups:
     expr: "up"
 `), os.ModePerm))
 	// Same filename as the first rule file but different path.
-	testutil.Ok(t, ioutil.WriteFile(filepath.Join(dir, "subdir", "no_strategy.yaml"), []byte(`
+	testutil.Ok(t, os.WriteFile(filepath.Join(dir, "subdir", "no_strategy.yaml"), []byte(`
 groups:
 - name: "something8"
   rules:
@@ -320,7 +319,7 @@ func TestConfigRuleAdapterUnmarshalMarshalYAML(t *testing.T) {
 }
 
 func TestManager_Rules(t *testing.T) {
-	dir, err := ioutil.TempDir("", "test_rule_run")
+	dir, err := os.MkdirTemp("", "test_rule_run")
 	testutil.Ok(t, err)
 	defer func() { testutil.Ok(t, os.RemoveAll(dir)) }()
 
@@ -357,11 +356,11 @@ func TestManager_Rules(t *testing.T) {
 }
 
 func TestManagerUpdateWithNoRules(t *testing.T) {
-	dir, err := ioutil.TempDir("", "test_rule_rule_groups")
+	dir, err := os.MkdirTemp("", "test_rule_rule_groups")
 	testutil.Ok(t, err)
 	defer func() { testutil.Ok(t, os.RemoveAll(dir)) }()
 
-	testutil.Ok(t, ioutil.WriteFile(filepath.Join(dir, "no_strategy.yaml"), []byte(`
+	testutil.Ok(t, os.WriteFile(filepath.Join(dir, "no_strategy.yaml"), []byte(`
 groups:
 - name: "something1"
   rules:
@@ -403,11 +402,11 @@ groups:
 }
 
 func TestManagerRunRulesWithRuleGroupLimit(t *testing.T) {
-	dir, err := ioutil.TempDir("", "test_rule_rule_groups")
+	dir, err := os.MkdirTemp("", "test_rule_rule_groups")
 	testutil.Ok(t, err)
 	t.Cleanup(func() { testutil.Ok(t, os.RemoveAll(dir)) })
 	filename := filepath.Join(dir, "with_limit.yaml")
-	testutil.Ok(t, ioutil.WriteFile(filename, []byte(`
+	testutil.Ok(t, os.WriteFile(filename, []byte(`
 groups:
 - name: "something1"
   interval: 1ms

--- a/pkg/runutil/runutil.go
+++ b/pkg/runutil/runutil.go
@@ -52,7 +52,6 @@ package runutil
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -128,7 +127,7 @@ func CloseWithLogOnErr(logger log.Logger, closer io.Closer, format string, a ...
 
 // ExhaustCloseWithLogOnErr closes the io.ReadCloser with a log message on error but exhausts the reader before.
 func ExhaustCloseWithLogOnErr(logger log.Logger, r io.ReadCloser, format string, a ...interface{}) {
-	_, err := io.Copy(ioutil.Discard, r)
+	_, err := io.Copy(io.Discard, r)
 	if err != nil {
 		level.Warn(logger).Log("msg", "failed to exhaust reader, performance may be impeded", "err", err)
 	}
@@ -149,7 +148,7 @@ func CloseWithErrCapture(err *error, closer io.Closer, format string, a ...inter
 
 // ExhaustCloseWithErrCapture closes the io.ReadCloser with error capture but exhausts the reader before.
 func ExhaustCloseWithErrCapture(err *error, r io.ReadCloser, format string, a ...interface{}) {
-	_, copyErr := io.Copy(ioutil.Discard, r)
+	_, copyErr := io.Copy(io.Discard, r)
 
 	CloseWithErrCapture(err, r, format, a...)
 
@@ -165,7 +164,7 @@ func ExhaustCloseWithErrCapture(err *error, r io.ReadCloser, format string, a ..
 // dir except for the ignoreDirs directories.
 // NOTE: DeleteAll is not idempotent.
 func DeleteAll(dir string, ignoreDirs ...string) error {
-	entries, err := ioutil.ReadDir(dir)
+	entries, err := os.ReadDir(dir)
 	if os.IsNotExist(err) {
 		return nil
 	}

--- a/pkg/runutil/runutil_test.go
+++ b/pkg/runutil/runutil_test.go
@@ -5,7 +5,6 @@ package runutil
 
 import (
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -126,7 +125,7 @@ func TestCloseMoreThanOnce(t *testing.T) {
 }
 
 func TestDeleteAll(t *testing.T) {
-	dir, err := ioutil.TempDir("", "example")
+	dir, err := os.MkdirTemp("", "example")
 	testutil.Ok(t, err)
 
 	t.Cleanup(func() {
@@ -167,7 +166,7 @@ func TestDeleteAll(t *testing.T) {
 }
 
 func TestDeleteAll_ShouldReturnNoErrorIfDirectoryDoesNotExists(t *testing.T) {
-	dir, err := ioutil.TempDir("", "example")
+	dir, err := os.MkdirTemp("", "example")
 	testutil.Ok(t, err)
 	testutil.Ok(t, os.RemoveAll(dir))
 

--- a/pkg/shipper/shipper.go
+++ b/pkg/shipper/shipper.go
@@ -8,7 +8,6 @@ package shipper
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
 	"math"
 	"os"
 	"path"
@@ -370,7 +369,7 @@ func (s *Shipper) upload(ctx context.Context, meta *metadata.Meta) error {
 // blockMetasFromOldest returns the block meta of each block found in dir
 // sorted by minTime asc.
 func (s *Shipper) blockMetasFromOldest() (metas []*metadata.Meta, _ error) {
-	fis, err := ioutil.ReadDir(s.dir)
+	fis, err := os.ReadDir(s.dir)
 	if err != nil {
 		return nil, errors.Wrap(err, "read dir")
 	}
@@ -410,7 +409,7 @@ func hardlinkBlock(src, dst string) error {
 		return errors.Wrap(err, "create chunks dir")
 	}
 
-	fis, err := ioutil.ReadDir(filepath.Join(src, block.ChunksDirname))
+	fis, err := os.ReadDir(filepath.Join(src, block.ChunksDirname))
 	if err != nil {
 		return errors.Wrap(err, "read chunk dir")
 	}

--- a/pkg/shipper/shipper_e2e_test.go
+++ b/pkg/shipper/shipper_e2e_test.go
@@ -7,7 +7,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"math/rand"
 	"os"
 	"path"
@@ -39,7 +39,7 @@ func TestShipper_SyncBlocks_e2e(t *testing.T) {
 		metrics := prometheus.NewRegistry()
 		metricsBucket := objstore.BucketWithMetrics("test", bkt, metrics)
 
-		dir, err := ioutil.TempDir("", "shipper-e2e-test")
+		dir, err := os.MkdirTemp("", "shipper-e2e-test")
 		testutil.Ok(t, err)
 		defer func() {
 			testutil.Ok(t, os.RemoveAll(dir))
@@ -95,8 +95,8 @@ func TestShipper_SyncBlocks_e2e(t *testing.T) {
 			metab, err := json.Marshal(&meta)
 			testutil.Ok(t, err)
 
-			testutil.Ok(t, ioutil.WriteFile(tmp+"/meta.json", metab, 0666))
-			testutil.Ok(t, ioutil.WriteFile(tmp+"/index", []byte("indexcontents"), 0666))
+			testutil.Ok(t, os.WriteFile(tmp+"/meta.json", metab, 0666))
+			testutil.Ok(t, os.WriteFile(tmp+"/index", []byte("indexcontents"), 0666))
 
 			// Running shipper while a block is being written to temp dir should not trigger uploads.
 			b, err := shipper.Sync(ctx)
@@ -111,8 +111,8 @@ func TestShipper_SyncBlocks_e2e(t *testing.T) {
 			testutil.Equals(t, &Meta{Version: MetaVersion1, Uploaded: ids}, shipMeta)
 
 			testutil.Ok(t, os.MkdirAll(tmp+"/chunks", 0777))
-			testutil.Ok(t, ioutil.WriteFile(tmp+"/chunks/0001", []byte("chunkcontents1"), 0666))
-			testutil.Ok(t, ioutil.WriteFile(tmp+"/chunks/0002", []byte("chunkcontents2"), 0666))
+			testutil.Ok(t, os.WriteFile(tmp+"/chunks/0001", []byte("chunkcontents1"), 0666))
+			testutil.Ok(t, os.WriteFile(tmp+"/chunks/0002", []byte("chunkcontents2"), 0666))
 
 			testutil.Ok(t, os.Rename(tmp, bdir))
 
@@ -184,7 +184,7 @@ func TestShipper_SyncBlocks_e2e(t *testing.T) {
 		for fn, exp := range expFiles {
 			rc, err := bkt.Get(ctx, fn)
 			testutil.Ok(t, err)
-			act, err := ioutil.ReadAll(rc)
+			act, err := io.ReadAll(rc)
 			testutil.Ok(t, err)
 			testutil.Ok(t, rc.Close())
 			testutil.Equals(t, string(exp), string(act))
@@ -198,7 +198,7 @@ func TestShipper_SyncBlocks_e2e(t *testing.T) {
 
 func TestShipper_SyncBlocksWithMigrating_e2e(t *testing.T) {
 	e2eutil.ForeachPrometheus(t, func(t testing.TB, p *e2eutil.Prometheus) {
-		dir, err := ioutil.TempDir("", "shipper-e2e-test")
+		dir, err := os.MkdirTemp("", "shipper-e2e-test")
 		testutil.Ok(t, err)
 		defer func() {
 			testutil.Ok(t, os.RemoveAll(dir))
@@ -270,8 +270,8 @@ func TestShipper_SyncBlocksWithMigrating_e2e(t *testing.T) {
 			metab, err := json.Marshal(&meta)
 			testutil.Ok(t, err)
 
-			testutil.Ok(t, ioutil.WriteFile(tmp+"/meta.json", metab, 0666))
-			testutil.Ok(t, ioutil.WriteFile(tmp+"/index", []byte("indexcontents"), 0666))
+			testutil.Ok(t, os.WriteFile(tmp+"/meta.json", metab, 0666))
+			testutil.Ok(t, os.WriteFile(tmp+"/index", []byte("indexcontents"), 0666))
 
 			// Running shipper while a block is being written to temp dir should not trigger uploads.
 			b, err := shipper.Sync(ctx)
@@ -286,8 +286,8 @@ func TestShipper_SyncBlocksWithMigrating_e2e(t *testing.T) {
 			testutil.Equals(t, &Meta{Version: MetaVersion1, Uploaded: ids}, shipMeta)
 
 			testutil.Ok(t, os.MkdirAll(tmp+"/chunks", 0777))
-			testutil.Ok(t, ioutil.WriteFile(tmp+"/chunks/0001", []byte("chunkcontents1"), 0666))
-			testutil.Ok(t, ioutil.WriteFile(tmp+"/chunks/0002", []byte("chunkcontents2"), 0666))
+			testutil.Ok(t, os.WriteFile(tmp+"/chunks/0001", []byte("chunkcontents1"), 0666))
+			testutil.Ok(t, os.WriteFile(tmp+"/chunks/0002", []byte("chunkcontents2"), 0666))
 
 			testutil.Ok(t, os.Rename(tmp, bdir))
 
@@ -341,7 +341,7 @@ func TestShipper_SyncBlocksWithMigrating_e2e(t *testing.T) {
 		for fn, exp := range expFiles {
 			rc, err := bkt.Get(ctx, fn)
 			testutil.Ok(t, err)
-			act, err := ioutil.ReadAll(rc)
+			act, err := io.ReadAll(rc)
 			testutil.Ok(t, err)
 			testutil.Ok(t, rc.Close())
 			testutil.Equals(t, string(exp), string(act))
@@ -357,7 +357,7 @@ func TestShipper_SyncBlocksWithMigrating_e2e(t *testing.T) {
 func TestShipper_SyncOverlapBlocks_e2e(t *testing.T) {
 	p, err := e2eutil.NewPrometheus()
 	testutil.Ok(t, err)
-	dir, err := ioutil.TempDir("", "shipper-e2e-test")
+	dir, err := os.MkdirTemp("", "shipper-e2e-test")
 	testutil.Ok(t, err)
 	defer func() {
 		testutil.Ok(t, os.RemoveAll(dir))
@@ -437,8 +437,8 @@ func TestShipper_SyncOverlapBlocks_e2e(t *testing.T) {
 		metab, err := json.Marshal(&m[i])
 		testutil.Ok(t, err)
 
-		testutil.Ok(t, ioutil.WriteFile(tmp[i]+"/meta.json", metab, 0666))
-		testutil.Ok(t, ioutil.WriteFile(tmp[i]+"/index", []byte("indexcontents"), 0666))
+		testutil.Ok(t, os.WriteFile(tmp[i]+"/meta.json", metab, 0666))
+		testutil.Ok(t, os.WriteFile(tmp[i]+"/index", []byte("indexcontents"), 0666))
 
 		// Running shipper while a block is being written to temp dir should not trigger uploads.
 		b, err := shipper.Sync(ctx)
@@ -453,8 +453,8 @@ func TestShipper_SyncOverlapBlocks_e2e(t *testing.T) {
 		testutil.Equals(t, &Meta{Version: MetaVersion1, Uploaded: ids}, shipMeta)
 
 		testutil.Ok(t, os.MkdirAll(tmp[i]+"/chunks", 0777))
-		testutil.Ok(t, ioutil.WriteFile(tmp[i]+"/chunks/0001", []byte("chunkcontents1"), 0666))
-		testutil.Ok(t, ioutil.WriteFile(tmp[i]+"/chunks/0002", []byte("chunkcontents2"), 0666))
+		testutil.Ok(t, os.WriteFile(tmp[i]+"/chunks/0001", []byte("chunkcontents1"), 0666))
+		testutil.Ok(t, os.WriteFile(tmp[i]+"/chunks/0002", []byte("chunkcontents2"), 0666))
 
 		testutil.Ok(t, os.Rename(tmp[i], bdir))
 
@@ -497,7 +497,7 @@ func TestShipper_SyncOverlapBlocks_e2e(t *testing.T) {
 	for fn, exp := range expFiles {
 		rc, err := bkt.Get(ctx, fn)
 		testutil.Ok(t, err)
-		act, err := ioutil.ReadAll(rc)
+		act, err := io.ReadAll(rc)
 		testutil.Ok(t, err)
 		testutil.Ok(t, rc.Close())
 		testutil.Equals(t, string(exp), string(act))

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -10,7 +10,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"os"
 	"path"
@@ -533,7 +532,7 @@ func (s *BucketStore) InitialSync(ctx context.Context) error {
 		return errors.Wrap(err, "sync block")
 	}
 
-	fis, err := ioutil.ReadDir(s.dir)
+	fis, err := os.ReadDir(s.dir)
 	if err != nil {
 		return errors.Wrap(err, "read dir")
 	}

--- a/pkg/store/bucket_e2e_test.go
+++ b/pkg/store/bucket_e2e_test.go
@@ -6,7 +6,6 @@ package store
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -485,7 +484,7 @@ func TestBucketStore_e2e(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		dir, err := ioutil.TempDir("", "test_bucketstore_e2e")
+		dir, err := os.MkdirTemp("", "test_bucketstore_e2e")
 		testutil.Ok(t, err)
 		defer func() { testutil.Ok(t, os.RemoveAll(dir)) }()
 
@@ -540,7 +539,7 @@ func TestBucketStore_ManyParts_e2e(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		dir, err := ioutil.TempDir("", "test_bucketstore_e2e")
+		dir, err := os.MkdirTemp("", "test_bucketstore_e2e")
 		testutil.Ok(t, err)
 		defer func() { testutil.Ok(t, os.RemoveAll(dir)) }()
 
@@ -562,7 +561,7 @@ func TestBucketStore_TimePartitioning_e2e(t *testing.T) {
 	defer cancel()
 	bkt := objstore.NewInMemBucket()
 
-	dir, err := ioutil.TempDir("", "test_bucket_time_part_e2e")
+	dir, err := os.MkdirTemp("", "test_bucket_time_part_e2e")
 	testutil.Ok(t, err)
 	defer func() { testutil.Ok(t, os.RemoveAll(dir)) }()
 
@@ -649,7 +648,7 @@ func TestBucketStore_Series_ChunksLimiter_e2e(t *testing.T) {
 			defer cancel()
 			bkt := objstore.NewInMemBucket()
 
-			dir, err := ioutil.TempDir("", "test_bucket_chunks_limiter_e2e")
+			dir, err := os.MkdirTemp("", "test_bucket_chunks_limiter_e2e")
 			testutil.Ok(t, err)
 			defer func() { testutil.Ok(t, os.RemoveAll(dir)) }()
 
@@ -686,7 +685,7 @@ func TestBucketStore_LabelNames_e2e(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		dir, err := ioutil.TempDir("", "test_bucketstore_label_names_e2e")
+		dir, err := os.MkdirTemp("", "test_bucketstore_label_names_e2e")
 		testutil.Ok(t, err)
 		defer func() { testutil.Ok(t, os.RemoveAll(dir)) }()
 
@@ -788,7 +787,7 @@ func TestBucketStore_LabelValues_e2e(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		dir, err := ioutil.TempDir("", "test_bucketstore_label_values_e2e")
+		dir, err := os.MkdirTemp("", "test_bucketstore_label_values_e2e")
 		testutil.Ok(t, err)
 		defer func() { testutil.Ok(t, os.RemoveAll(dir)) }()
 

--- a/pkg/store/bucket_test.go
+++ b/pkg/store/bucket_test.go
@@ -9,7 +9,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"math/rand"
 	"os"
@@ -192,7 +191,7 @@ func TestBucketBlock_Property(t *testing.T) {
 func TestBucketBlock_matchLabels(t *testing.T) {
 	defer testutil.TolerantVerifyLeak(t)
 
-	dir, err := ioutil.TempDir("", "bucketblock-test")
+	dir, err := os.MkdirTemp("", "bucketblock-test")
 	testutil.Ok(t, err)
 	defer testutil.Ok(t, os.RemoveAll(dir))
 
@@ -589,7 +588,7 @@ func TestBucketStore_Info(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	dir, err := ioutil.TempDir("", "bucketstore-test")
+	dir, err := os.MkdirTemp("", "bucketstore-test")
 	testutil.Ok(t, err)
 
 	defer testutil.Ok(t, os.RemoveAll(dir))
@@ -654,7 +653,7 @@ func TestBucketStore_Sharding(t *testing.T) {
 	ctx := context.Background()
 	logger := log.NewNopLogger()
 
-	dir, err := ioutil.TempDir("", "test-sharding-prepare")
+	dir, err := os.MkdirTemp("", "test-sharding-prepare")
 	testutil.Ok(t, err)
 	defer func() { testutil.Ok(t, os.RemoveAll(dir)) }()
 
@@ -683,7 +682,7 @@ func TestBucketStore_Sharding(t *testing.T) {
 		return
 	}
 
-	dir2, err := ioutil.TempDir("", "test-sharding2")
+	dir2, err := os.MkdirTemp("", "test-sharding2")
 	testutil.Ok(t, err)
 	defer func() { testutil.Ok(t, os.RemoveAll(dir2)) }()
 
@@ -831,7 +830,7 @@ func testSharding(t *testing.T, reuseDisk string, bkt objstore.Bucket, all ...ul
 
 			if dir == "" {
 				var err error
-				dir, err = ioutil.TempDir("", "test-sharding")
+				dir, err = os.MkdirTemp("", "test-sharding")
 				testutil.Ok(t, err)
 				defer func() { testutil.Ok(t, os.RemoveAll(dir)) }()
 			}
@@ -1014,7 +1013,7 @@ func TestReadIndexCache_LoadSeries(t *testing.T) {
 func TestBucketIndexReader_ExpandedPostings(t *testing.T) {
 	tb := testutil.NewTB(t)
 
-	tmpDir, err := ioutil.TempDir("", "test-expanded-postings")
+	tmpDir, err := os.MkdirTemp("", "test-expanded-postings")
 	testutil.Ok(tb, err)
 	defer func() { testutil.Ok(tb, os.RemoveAll(tmpDir)) }()
 
@@ -1033,7 +1032,7 @@ func TestBucketIndexReader_ExpandedPostings(t *testing.T) {
 func BenchmarkBucketIndexReader_ExpandedPostings(b *testing.B) {
 	tb := testutil.NewTB(b)
 
-	tmpDir, err := ioutil.TempDir("", "bench-expanded-postings")
+	tmpDir, err := os.MkdirTemp("", "bench-expanded-postings")
 	testutil.Ok(tb, err)
 	defer func() { testutil.Ok(tb, os.RemoveAll(tmpDir)) }()
 
@@ -1216,7 +1215,7 @@ func BenchmarkBucketSkipChunksSeries(b *testing.B) {
 func benchBucketSeries(t testutil.TB, skipChunk bool, samplesPerSeries, totalSeries int, requestedRatios ...float64) {
 	const numOfBlocks = 4
 
-	tmpDir, err := ioutil.TempDir("", "testorbench-bucketseries")
+	tmpDir, err := os.MkdirTemp("", "testorbench-bucketseries")
 	testutil.Ok(t, err)
 	defer func() { testutil.Ok(t, os.RemoveAll(tmpDir)) }()
 
@@ -1380,7 +1379,7 @@ func (m *mockedPool) Put(b *[]byte) {
 
 // Regression test against: https://github.com/thanos-io/thanos/issues/2147.
 func TestBucketSeries_OneBlock_InMemIndexCacheSegfault(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "segfault-series")
+	tmpDir, err := os.MkdirTemp("", "segfault-series")
 	testutil.Ok(t, err)
 	defer func() { testutil.Ok(t, os.RemoveAll(tmpDir)) }()
 
@@ -1631,7 +1630,7 @@ func TestSeries_RequestAndResponseHints(t *testing.T) {
 func TestSeries_ErrorUnmarshallingRequestHints(t *testing.T) {
 	tb := testutil.NewTB(t)
 
-	tmpDir, err := ioutil.TempDir("", "test-series-hints-enabled")
+	tmpDir, err := os.MkdirTemp("", "test-series-hints-enabled")
 	testutil.Ok(t, err)
 	defer func() { testutil.Ok(t, os.RemoveAll(tmpDir)) }()
 
@@ -1692,7 +1691,7 @@ func TestSeries_ErrorUnmarshallingRequestHints(t *testing.T) {
 func TestSeries_BlockWithMultipleChunks(t *testing.T) {
 	tb := testutil.NewTB(t)
 
-	tmpDir, err := ioutil.TempDir("", "test-block-with-multiple-chunks")
+	tmpDir, err := os.MkdirTemp("", "test-block-with-multiple-chunks")
 	testutil.Ok(t, err)
 	defer func() { testutil.Ok(t, os.RemoveAll(tmpDir)) }()
 
@@ -1872,7 +1871,7 @@ func setupStoreForHintsTest(t *testing.T) (testutil.TB, *BucketStore, []*storepb
 
 	closers := []func(){}
 
-	tmpDir, err := ioutil.TempDir("", "test-hints")
+	tmpDir, err := os.MkdirTemp("", "test-hints")
 	testutil.Ok(t, err)
 	closers = append(closers, func() { testutil.Ok(t, os.RemoveAll(tmpDir)) })
 
@@ -2121,7 +2120,7 @@ func BenchmarkBucketBlock_readChunkRange(b *testing.B) {
 		readLengths = []int64{300, 500, 1000, 5000, 10000, 30000, 50000, 100000, 300000, 1500000}
 	)
 
-	tmpDir, err := ioutil.TempDir("", "benchmark")
+	tmpDir, err := os.MkdirTemp("", "benchmark")
 	testutil.Ok(b, err)
 	b.Cleanup(func() {
 		testutil.Ok(b, os.RemoveAll(tmpDir))
@@ -2186,7 +2185,7 @@ func prepareBucket(b *testing.B, resolutionLevel compact.ResolutionLevel) (*buck
 		logger = log.NewNopLogger()
 	)
 
-	tmpDir, err := ioutil.TempDir("", "benchmark")
+	tmpDir, err := os.MkdirTemp("", "benchmark")
 	testutil.Ok(b, err)
 	b.Cleanup(func() {
 		testutil.Ok(b, os.RemoveAll(tmpDir))

--- a/pkg/store/cache/caching_bucket.go
+++ b/pkg/store/cache/caching_bucket.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"strconv"
 	"sync"
 	"time"
@@ -390,7 +389,7 @@ func (cb *CachingBucket) cachedGetRange(ctx context.Context, name string, offset
 		}
 	}
 
-	return ioutil.NopCloser(newSubrangesReader(cfg.SubrangeSize, offsetKeys, hits, offset, length)), nil
+	return io.NopCloser(newSubrangesReader(cfg.SubrangeSize, offsetKeys, hits, offset, length)), nil
 }
 
 type rng struct {

--- a/pkg/store/cache/caching_bucket_test.go
+++ b/pkg/store/cache/caching_bucket_test.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"sort"
 	"strings"
 	"sync"
@@ -256,7 +255,7 @@ func verifyGetRange(t *testing.T, cachingBucket *CachingBucket, name string, off
 	r, err := cachingBucket.GetRange(context.Background(), name, offset, length)
 	testutil.Ok(t, err)
 
-	read, err := ioutil.ReadAll(r)
+	read, err := io.ReadAll(r)
 	testutil.Ok(t, err)
 	testutil.Equals(t, expectedLength, int64(len(read)))
 
@@ -619,7 +618,7 @@ func verifyGet(t *testing.T, cb *CachingBucket, file string, expectedData []byte
 	} else {
 		testutil.Ok(t, err)
 		defer runutil.CloseWithLogOnErr(nil, r, "verifyGet")
-		data, err := ioutil.ReadAll(r)
+		data, err := io.ReadAll(r)
 		testutil.Ok(t, err)
 		testutil.Equals(t, expectedData, data)
 

--- a/pkg/store/labelpb/label_test.go
+++ b/pkg/store/labelpb/label_test.go
@@ -5,7 +5,7 @@ package labelpb
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"reflect"
 	"sort"
 	"strings"
@@ -127,7 +127,7 @@ func testInjectExtLabels(tb testutil.TB) {
 			), x)
 		}
 	}
-	fmt.Fprint(ioutil.Discard, x)
+	fmt.Fprint(io.Discard, x)
 }
 
 var (

--- a/pkg/store/multitsdb_test.go
+++ b/pkg/store/multitsdb_test.go
@@ -6,7 +6,6 @@ package store
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"math"
 	"math/rand"
 	"os"
@@ -62,7 +61,7 @@ type mockedStartTimeDB struct {
 func (db *mockedStartTimeDB) StartTime() (int64, error) { return db.startTime, nil }
 
 func benchMultiTSDBSeries(t testutil.TB, totalSamples, totalSeries int, flushToBlocks bool) {
-	tmpDir, err := ioutil.TempDir("", "testorbench-multitsdbseries")
+	tmpDir, err := os.MkdirTemp("", "testorbench-multitsdbseries")
 	testutil.Ok(t, err)
 	defer func() { testutil.Ok(t, os.RemoveAll(tmpDir)) }()
 

--- a/pkg/store/postings_codec_test.go
+++ b/pkg/store/postings_codec_test.go
@@ -5,7 +5,6 @@ package store
 
 import (
 	"context"
-	"io/ioutil"
 	"math"
 	"math/rand"
 	"os"
@@ -22,7 +21,7 @@ import (
 )
 
 func TestDiffVarintCodec(t *testing.T) {
-	chunksDir, err := ioutil.TempDir("", "diff_varint_codec")
+	chunksDir, err := os.MkdirTemp("", "diff_varint_codec")
 	testutil.Ok(t, err)
 
 	headOpts := tsdb.DefaultHeadOptions()

--- a/pkg/store/prometheus.go
+++ b/pkg/store/prometheus.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"path"
@@ -549,7 +548,7 @@ func (p *PrometheusStore) startPromRemoteRead(ctx context.Context, q *prompb.Que
 	}
 	if presp.StatusCode/100 != 2 {
 		// Best effort read.
-		b, err := ioutil.ReadAll(presp.Body)
+		b, err := io.ReadAll(presp.Body)
 		if err != nil {
 			level.Error(p.logger).Log("msg", "failed to read response from non 2XX remote read request", "err", err)
 		}

--- a/pkg/store/proxy_test.go
+++ b/pkg/store/proxy_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"math/rand"
 	"os"
@@ -1741,7 +1740,7 @@ func BenchmarkProxySeries(b *testing.B) {
 }
 
 func benchProxySeries(t testutil.TB, totalSamples, totalSeries int) {
-	tmpDir, err := ioutil.TempDir("", "testorbench-proxyseries")
+	tmpDir, err := os.MkdirTemp("", "testorbench-proxyseries")
 	testutil.Ok(t, err)
 	defer func() { testutil.Ok(t, os.RemoveAll(tmpDir)) }()
 

--- a/pkg/store/tsdb_test.go
+++ b/pkg/store/tsdb_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"math/rand"
 	"os"
@@ -230,7 +229,7 @@ func (s *delegatorServer) Delegate(c io.Closer) {
 func TestTSDBStore_SeriesAccessWithDelegateClosing(t *testing.T) {
 	t.Skip(skipMessage)
 
-	tmpDir, err := ioutil.TempDir("", "test")
+	tmpDir, err := os.MkdirTemp("", "test")
 	testutil.Ok(t, err)
 	t.Cleanup(func() {
 		testutil.Ok(t, os.RemoveAll(tmpDir))
@@ -403,7 +402,7 @@ func TestTSDBStore_SeriesAccessWithDelegateClosing(t *testing.T) {
 func TestTSDBStore_SeriesAccessWithoutDelegateClosing(t *testing.T) {
 	t.Skip(skipMessage)
 
-	tmpDir, err := ioutil.TempDir("", "test")
+	tmpDir, err := os.MkdirTemp("", "test")
 	testutil.Ok(t, err)
 	t.Cleanup(func() {
 		testutil.Ok(t, os.RemoveAll(tmpDir))
@@ -531,7 +530,7 @@ func BenchmarkTSDBStoreSeries(b *testing.B) {
 }
 
 func benchTSDBStoreSeries(t testutil.TB, totalSamples, totalSeries int) {
-	tmpDir, err := ioutil.TempDir("", "testorbench-testtsdbseries")
+	tmpDir, err := os.MkdirTemp("", "testorbench-testtsdbseries")
 	testutil.Ok(t, err)
 	t.Cleanup(func() {
 		testutil.Ok(t, os.RemoveAll(tmpDir))

--- a/pkg/testutil/e2eutil/prometheus.go
+++ b/pkg/testutil/e2eutil/prometheus.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"math"
 	"math/rand"
 	"net/http"
@@ -88,7 +87,7 @@ type Prometheus struct {
 }
 
 func NewTSDB() (*tsdb.DB, error) {
-	dir, err := ioutil.TempDir("", "prometheus-test")
+	dir, err := os.MkdirTemp("", "prometheus-test")
 	if err != nil {
 		return nil, err
 	}
@@ -333,7 +332,7 @@ func CreateEmptyBlock(dir string, mint, maxt int64, extLset labels.Labels, resol
 		return ulid.ULID{}, err
 	}
 
-	if err := ioutil.WriteFile(path.Join(dir, uid.String(), "meta.json"), b, os.ModePerm); err != nil {
+	if err := os.WriteFile(path.Join(dir, uid.String(), "meta.json"), b, os.ModePerm); err != nil {
 		return ulid.ULID{}, errors.Wrap(err, "saving meta.json")
 	}
 

--- a/pkg/tls/options.go
+++ b/pkg/tls/options.go
@@ -6,7 +6,6 @@ package tls
 import (
 	"crypto/tls"
 	"crypto/x509"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sync"
@@ -46,7 +45,7 @@ func NewServerConfig(logger log.Logger, cert, key, clientCA string) (*tls.Config
 	tlsCfg.GetCertificate = mngr.getCertificate
 
 	if clientCA != "" {
-		caPEM, err := ioutil.ReadFile(filepath.Clean(clientCA))
+		caPEM, err := os.ReadFile(filepath.Clean(clientCA))
 		if err != nil {
 			return nil, errors.Wrap(err, "reading client CA")
 		}
@@ -103,7 +102,7 @@ func (m *serverTLSManager) getCertificate(clientHello *tls.ClientHelloInfo) (*tl
 func NewClientConfig(logger log.Logger, cert, key, caCert, serverName string, skipVerify bool) (*tls.Config, error) {
 	var certPool *x509.CertPool
 	if caCert != "" {
-		caPEM, err := ioutil.ReadFile(filepath.Clean(caCert))
+		caPEM, err := os.ReadFile(filepath.Clean(caCert))
 		if err != nil {
 			return nil, errors.Wrap(err, "reading client CA")
 		}

--- a/pkg/verifier/index_issue.go
+++ b/pkg/verifier/index_issue.go
@@ -5,7 +5,6 @@ package verifier
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -43,7 +42,7 @@ func (IndexKnownIssues) VerifyRepair(ctx Context, idMatcher func(ulid.ULID) bool
 			continue
 		}
 
-		tmpdir, err := ioutil.TempDir("", fmt.Sprintf("index-issue-block-%s-", id))
+		tmpdir, err := os.MkdirTemp("", fmt.Sprintf("index-issue-block-%s-", id))
 		if err != nil {
 			return err
 		}

--- a/pkg/verifier/safe_delete.go
+++ b/pkg/verifier/safe_delete.go
@@ -6,7 +6,6 @@ package verifier
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -51,7 +50,7 @@ func BackupAndDelete(ctx Context, id ulid.ULID) error {
 	}
 
 	// Create a tempdir to locally store TSDB block.
-	tempdir, err := ioutil.TempDir("", fmt.Sprintf("safe-delete-%s", id.String()))
+	tempdir, err := os.MkdirTemp("", fmt.Sprintf("safe-delete-%s", id.String()))
 	if err != nil {
 		return err
 	}

--- a/scripts/copyright/copyright.go
+++ b/scripts/copyright/copyright.go
@@ -5,7 +5,6 @@ package main
 
 import (
 	"bytes"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -51,7 +50,7 @@ func applyLicenseToProtoAndGo() error {
 			return nil
 		}
 
-		b, err := ioutil.ReadFile(filepath.Clean(path))
+		b, err := os.ReadFile(filepath.Clean(path))
 		if err != nil {
 			return err
 		}
@@ -77,7 +76,7 @@ func writeLicence(cr copyright, path string, b []byte) error {
 		var bb bytes.Buffer
 		_, _ = bb.Write(cr)
 		_, _ = bb.Write(b)
-		if err := ioutil.WriteFile(path, bb.Bytes(), 0600); err != nil {
+		if err := os.WriteFile(path, bb.Bytes(), 0600); err != nil {
 			return err
 		}
 	}

--- a/test/e2e/compatibility_test.go
+++ b/test/e2e/compatibility_test.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -76,7 +75,7 @@ scrape_configs:
 	time.Sleep(10 * time.Minute)
 
 	t.Run("receive", func(t *testing.T) {
-		testutil.Ok(t, ioutil.WriteFile(filepath.Join(compliance.Dir(), "receive.yaml"),
+		testutil.Ok(t, os.WriteFile(filepath.Join(compliance.Dir(), "receive.yaml"),
 			[]byte(promQLCompatConfig(prom, queryReceive, []string{"prometheus", "receive", "tenant_id"})), os.ModePerm))
 
 		testutil.Ok(t, compliance.Exec(e2e.NewCommand(
@@ -86,7 +85,7 @@ scrape_configs:
 		)))
 	})
 	t.Run("sidecar", func(t *testing.T) {
-		testutil.Ok(t, ioutil.WriteFile(filepath.Join(compliance.Dir(), "sidecar.yaml"),
+		testutil.Ok(t, os.WriteFile(filepath.Join(compliance.Dir(), "sidecar.yaml"),
 			[]byte(promQLCompatConfig(prom, querySidecar, []string{"prometheus"})), os.ModePerm))
 
 		testutil.Ok(t, compliance.Exec(e2e.NewCommand(
@@ -187,7 +186,7 @@ func TestAlertCompliance(t *testing.T) {
 			}()
 			testutil.Equals(t, http.StatusOK, resp.StatusCode)
 		}
-		testutil.Ok(t, ioutil.WriteFile(filepath.Join(compliance.Dir(), "test-thanos.yaml"), []byte(alertCompatConfig(receive, query)), os.ModePerm))
+		testutil.Ok(t, os.WriteFile(filepath.Join(compliance.Dir(), "test-thanos.yaml"), []byte(alertCompatConfig(receive, query)), os.ModePerm))
 
 		fmt.Println(alertCompatConfig(receive, query))
 

--- a/test/e2e/e2ethanos/services.go
+++ b/test/e2e/e2ethanos/services.go
@@ -10,7 +10,6 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	"net"
 	"os"
@@ -102,12 +101,12 @@ func NewPrometheus(e e2e.Environment, name, promConfig, webConfig, promImage str
 		return e2e.NewErrInstrumentedRunnable(name, errors.Wrap(err, "create prometheus dir"))
 	}
 
-	if err := ioutil.WriteFile(filepath.Join(f.Dir(), "prometheus.yml"), []byte(promConfig), 0600); err != nil {
+	if err := os.WriteFile(filepath.Join(f.Dir(), "prometheus.yml"), []byte(promConfig), 0600); err != nil {
 		return e2e.NewErrInstrumentedRunnable(name, errors.Wrap(err, "creating prom config"))
 	}
 
 	if len(webConfig) > 0 {
-		if err := ioutil.WriteFile(filepath.Join(f.Dir(), "web-config.yml"), []byte(webConfig), 0600); err != nil {
+		if err := os.WriteFile(filepath.Join(f.Dir(), "web-config.yml"), []byte(webConfig), 0600); err != nil {
 			return e2e.NewErrInstrumentedRunnable(name, errors.Wrap(err, "creating web-config"))
 		}
 	}
@@ -378,7 +377,7 @@ func (q *QuerierBuilder) collectArgs() ([]string, error) {
 			return nil, err
 		}
 
-		if err := ioutil.WriteFile(q.Dir()+"/filesd.yaml", b, 0600); err != nil {
+		if err := os.WriteFile(q.Dir()+"/filesd.yaml", b, 0600); err != nil {
 			return nil, errors.Wrap(err, "creating query SD config failed")
 		}
 
@@ -506,7 +505,7 @@ func (r *ReceiveBuilder) Init() e2e.InstrumentedRunnable {
 			return e2e.NewErrInstrumentedRunnable(r.Name(), errors.Wrapf(err, "generate hashring file: %v", hashring))
 		}
 
-		if err := ioutil.WriteFile(filepath.Join(r.Dir(), "hashrings.json"), b, 0600); err != nil {
+		if err := os.WriteFile(filepath.Join(r.Dir(), "hashrings.json"), b, 0600); err != nil {
 			return e2e.NewErrInstrumentedRunnable(r.Name(), errors.Wrap(err, "creating receive config"))
 		}
 
@@ -666,7 +665,7 @@ route:
 receivers:
 - name: 'null'
 `
-	if err := ioutil.WriteFile(filepath.Join(f.Dir(), "config.yaml"), []byte(config), 0600); err != nil {
+	if err := os.WriteFile(filepath.Join(f.Dir(), "config.yaml"), []byte(config), 0600); err != nil {
 		return e2e.NewErrInstrumentedRunnable(name, errors.Wrap(err, "creating alertmanager config file failed"))
 	}
 
@@ -840,7 +839,7 @@ http {
 		return e2e.NewErrInstrumentedRunnable(name, errors.Wrap(err, "create store dir"))
 	}
 
-	if err := ioutil.WriteFile(filepath.Join(f.Dir(), "nginx.conf"), []byte(conf), 0600); err != nil {
+	if err := os.WriteFile(filepath.Join(f.Dir(), "nginx.conf"), []byte(conf), 0600); err != nil {
 		return e2e.NewErrInstrumentedRunnable(name, errors.Wrap(err, "creating nginx config file failed"))
 	}
 
@@ -1003,7 +1002,7 @@ func genCerts(certPath, privkeyPath, caPath, serverName string) error {
 		Type:  "CERTIFICATE",
 		Bytes: caBytes,
 	})
-	err = ioutil.WriteFile(caPath, caPEM, 0644)
+	err = os.WriteFile(caPath, caPEM, 0644)
 	if err != nil {
 		return err
 	}
@@ -1017,7 +1016,7 @@ func genCerts(certPath, privkeyPath, caPath, serverName string) error {
 		Type:  "CERTIFICATE",
 		Bytes: certBytes,
 	})
-	err = ioutil.WriteFile(certPath, certPEM, 0644)
+	err = os.WriteFile(certPath, certPEM, 0644)
 	if err != nil {
 		return err
 	}
@@ -1026,7 +1025,7 @@ func genCerts(certPath, privkeyPath, caPath, serverName string) error {
 		Type:  "RSA PRIVATE KEY",
 		Bytes: x509.MarshalPKCS1PrivateKey(certPrivKey),
 	})
-	err = ioutil.WriteFile(privkeyPath, certPrivKeyPEM, 0644)
+	err = os.WriteFile(privkeyPath, certPrivKeyPEM, 0644)
 	if err != nil {
 		return err
 	}

--- a/test/e2e/info_api_test.go
+++ b/test/e2e/info_api_test.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"path"
 	"testing"
@@ -136,7 +136,7 @@ func TestInfo(t *testing.T) {
 			return err
 		}
 
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		defer runutil.CloseWithErrCapture(&err, resp.Body, "response body close")
 
 		var res struct {

--- a/test/e2e/rule_test.go
+++ b/test/e2e/rule_test.go
@@ -8,7 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -133,7 +133,7 @@ type rulesResp struct {
 
 func createRuleFile(t *testing.T, path, content string) {
 	t.Helper()
-	err := ioutil.WriteFile(path, []byte(content), 0666)
+	err := os.WriteFile(path, []byte(content), 0666)
 	testutil.Ok(t, err)
 }
 
@@ -146,7 +146,7 @@ func createRuleFiles(t *testing.T, dir string) {
 }
 
 func reloadRulesHTTP(t *testing.T, ctx context.Context, endpoint string) {
-	req, err := http.NewRequestWithContext(ctx, "POST", "http://"+endpoint+"/-/reload", ioutil.NopCloser(bytes.NewReader(nil)))
+	req, err := http.NewRequestWithContext(ctx, "POST", "http://"+endpoint+"/-/reload", io.NopCloser(bytes.NewReader(nil)))
 	testutil.Ok(t, err)
 	resp, err := http.DefaultClient.Do(req)
 	testutil.Ok(t, err)
@@ -164,7 +164,7 @@ func checkReloadSuccessful(t *testing.T, ctx context.Context, endpoint string, e
 	errCount := 0
 
 	testutil.Ok(t, runutil.Retry(5*time.Second, ctx.Done(), func() error {
-		req, err := http.NewRequestWithContext(ctx, "GET", "http://"+endpoint+"/api/v1/rules", ioutil.NopCloser(bytes.NewReader(nil)))
+		req, err := http.NewRequestWithContext(ctx, "GET", "http://"+endpoint+"/api/v1/rules", io.NopCloser(bytes.NewReader(nil)))
 		if err != nil {
 			errCount++
 			return err
@@ -181,7 +181,7 @@ func checkReloadSuccessful(t *testing.T, ctx context.Context, endpoint string, e
 			return errors.Newf("statuscode is not 200, got %d", resp.StatusCode)
 		}
 
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			errCount++
 			return errors.Wrapf(err, "error reading body")
@@ -214,14 +214,14 @@ func checkReloadSuccessful(t *testing.T, ctx context.Context, endpoint string, e
 }
 
 func rulegroupCorrectData(t *testing.T, ctx context.Context, endpoint string) {
-	req, err := http.NewRequestWithContext(ctx, "GET", "http://"+endpoint+"/api/v1/rules", ioutil.NopCloser(bytes.NewReader(nil)))
+	req, err := http.NewRequestWithContext(ctx, "GET", "http://"+endpoint+"/api/v1/rules", io.NopCloser(bytes.NewReader(nil)))
 	testutil.Ok(t, err)
 	resp, err := http.DefaultClient.Do(req)
 	testutil.Ok(t, err)
 	testutil.Equals(t, 200, resp.StatusCode)
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	testutil.Ok(t, err)
 
 	var data = rulesResp{}
@@ -252,7 +252,7 @@ func writeTargets(t *testing.T, path string, addrs ...string) {
 	b, err := yaml.Marshal([]*targetgroup.Group{{Targets: tgs}})
 	testutil.Ok(t, err)
 
-	testutil.Ok(t, ioutil.WriteFile(path+".tmp", b, 0660))
+	testutil.Ok(t, os.WriteFile(path+".tmp", b, 0660))
 	testutil.Ok(t, os.Rename(path+".tmp", path))
 }
 

--- a/test/e2e/tls_test.go
+++ b/test/e2e/tls_test.go
@@ -11,7 +11,6 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	"net"
 	"os"
@@ -41,14 +40,14 @@ func TestGRPCServerCertAutoRotate(t *testing.T) {
 	logger := log.NewLogfmtLogger(os.Stderr)
 	expMessage := "hello world"
 
-	tmpDirClt, err := ioutil.TempDir("", "test-tls-clt")
+	tmpDirClt, err := os.MkdirTemp("", "test-tls-clt")
 	testutil.Ok(t, err)
 	defer func() { testutil.Ok(t, os.RemoveAll(tmpDirClt)) }()
 	caClt := filepath.Join(tmpDirClt, "ca")
 	certClt := filepath.Join(tmpDirClt, "cert")
 	keyClt := filepath.Join(tmpDirClt, "key")
 
-	tmpDirSrv, err := ioutil.TempDir("", "test-tls-srv")
+	tmpDirSrv, err := os.MkdirTemp("", "test-tls-srv")
 	testutil.Ok(t, err)
 	defer func() { testutil.Ok(t, os.RemoveAll(tmpDirSrv)) }()
 	caSrv := filepath.Join(tmpDirSrv, "ca")
@@ -131,7 +130,7 @@ func genCerts(t *testing.T, certPath, privkeyPath, caPath string) {
 	// When the CA private file exists don't overwrite it but
 	// use it to extract the private key to be used for signing the certificate.
 	if _, err := os.Stat(caSrvPriv); !os.IsNotExist(err) {
-		d, err := ioutil.ReadFile(caSrvPriv)
+		d, err := os.ReadFile(caSrvPriv)
 		testutil.Ok(t, err)
 		caPrivKey, err = x509.ParsePKCS1PrivateKey(d)
 		testutil.Ok(t, err)
@@ -154,8 +153,8 @@ func genCerts(t *testing.T, certPath, privkeyPath, caPath string) {
 			Type:  "CERTIFICATE",
 			Bytes: caBytes,
 		})
-		testutil.Ok(t, ioutil.WriteFile(caPath, caPEM, 0644))
-		testutil.Ok(t, ioutil.WriteFile(caSrvPriv, x509.MarshalPKCS1PrivateKey(caPrivKey), 0644))
+		testutil.Ok(t, os.WriteFile(caPath, caPEM, 0644))
+		testutil.Ok(t, os.WriteFile(caSrvPriv, x509.MarshalPKCS1PrivateKey(caPrivKey), 0644))
 	}
 
 	if certPath != "" {
@@ -164,7 +163,7 @@ func genCerts(t *testing.T, certPath, privkeyPath, caPath string) {
 			Type:  "CERTIFICATE",
 			Bytes: certBytes,
 		}))
-		testutil.Ok(t, ioutil.WriteFile(certPath, certPEM.Bytes(), 0644))
+		testutil.Ok(t, os.WriteFile(certPath, certPEM.Bytes(), 0644))
 	}
 
 	if privkeyPath != "" {
@@ -173,7 +172,7 @@ func genCerts(t *testing.T, certPath, privkeyPath, caPath string) {
 			Type:  "RSA PRIVATE KEY",
 			Bytes: x509.MarshalPKCS1PrivateKey(certPrivKey),
 		}))
-		testutil.Ok(t, ioutil.WriteFile(privkeyPath, certPrivKeyPEM.Bytes(), 0644))
+		testutil.Ok(t, os.WriteFile(privkeyPath, certPrivKeyPEM.Bytes(), 0644))
 	}
 }
 

--- a/test/e2e/tools_bucket_web_test.go
+++ b/test/e2e/tools_bucket_web_test.go
@@ -6,7 +6,7 @@ package e2e_test
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -234,7 +234,7 @@ func TestToolsBucketWebWithTimeAndRelabelFilter(t *testing.T) {
 			return errors.Newf("statuscode is not 200, got %d", resp.StatusCode)
 		}
 
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return errors.Wrapf(err, "error reading body")
 		}


### PR DESCRIPTION
This PR removes all usage of `io/ioutil` within Thanos, and replaces them with equivalent `os` or `io` methods, and adds a faillint rule for the same. Have skipped the vendored cortex package from this.

The reason for this is that `io/ioutil` has been deprecated since Go 1.16: https://go.dev/doc/go1.16#ioutil

Noticed this from https://github.com/prometheus/client_golang/pull/1096 🙂 

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

- Replaced `ioutil.*` with `io.*` and `os.*`.

## Verification

Built locally.