### PR TITLE
receive: Expose write chunk queue as flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#5527](https://github.com/thanos-io/thanos/pull/5527) Receive: Add per request limits for remote write.
 - [#5520](https://github.com/thanos-io/thanos/pull/5520) Receive: Meta-monitoring based active series limiting
 - [#5555](https://github.com/thanos-io/thanos/pull/5555) Query: Added `--query.active-query-path` flag, allowing the user to configure the directory to create an active query tracking file, `queries.active`, for different resolution.
+- [#5566](https://github.com/thanos-io/thanos/pull/5566) Receive: Added experimental support to enable chunk write queue via `--tsdb.write-queue-size` flag.
 
 ### Changed
 


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

This change proposes to expose, via the hidden `--tsdb.write-queue-size` flag a chunk write queue for `receive`
which was upstreamed to TSDB via https://github.com/prometheus/prometheus/pull/10051.

For clarification, at the time this feature was contributed, the queue was enabled by default but this was subsequently 
made opt-in via https://github.com/prometheus/prometheus/pull/10425 for the reasons discussed/reported in https://github.com/prometheus/prometheus/issues/10377

There were some follow on improvements in:

* https://github.com/prometheus/prometheus/pull/10873
* https://github.com/prometheus/prometheus/pull/10874

<!-- Enumerate changes you made -->

## Verification

I ran a three load test against Thanos Receive pushing two million active series oover a period of 4hrs ramping up and reaching peak within 1hr:

1. `v0.27.0` release with 6 receivers
2. `v0.27.0` release with 12 receivers
3. This branch with the queue enabled at 20m

They are displayed on the following graphs from left to right.

Shows a significant reduction in error rate on the last run:

<img width="1920" alt="Screenshot 2022-08-03 at 15 58 47" src="https://user-images.githubusercontent.com/5781491/182642517-cc7b6285-3c38-4889-8509-1931d81cfc5e.png">

Shows we generally see a correlation between higher error rates and increase in the head chunks metrics.
This appears to be correlated with the duration (latency spikes) in receive and replication.

<img width="1774" alt="Screenshot 2022-08-03 at 16 00 11" src="https://user-images.githubusercontent.com/5781491/182642702-2f4a8db9-bbf9-49ea-9832-38b1ef4458c5.png">

The result of enabling the queue appears to be great reduction in p90 latency and slight improvement in the p99 taking most request within the default 5s timeout for replication.

<img width="1863" alt="Screenshot 2022-08-03 at 16 01 08" src="https://user-images.githubusercontent.com/5781491/182643014-1f22758f-46ed-4575-a6e3-93e40d3178d6.png">


Other things to note was that there was no measurable regression in our query path SLOs due to enabling this feature. 
Memory remained stable throughout and we even avoided the spike we saw when running with 6 replicas on the latest release. 

<img width="1781" alt="Screenshot 2022-08-03 at 16 11 09" src="https://user-images.githubusercontent.com/5781491/182643795-320ec4c3-e21c-41d4-ba2a-e6dbc9c92577.png">

<!-- How you tested it? How do you know it works? -->
