### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/cmd/thanos/main_test.go
+++ b/cmd/thanos/main_test.go
@@ -104,9 +104,7 @@ func (b *erroringBucket) Name() string {
 // Testing for https://github.com/thanos-io/thanos/issues/4960.
 func TestRegression4960_Deadlock(t *testing.T) {
 	logger := log.NewLogfmtLogger(os.Stderr)
-	dir, err := os.MkdirTemp("", "test-compact-cleanup")
-	testutil.Ok(t, err)
-	defer func() { testutil.Ok(t, os.RemoveAll(dir)) }()
+	dir := t.TempDir()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
@@ -114,6 +112,7 @@ func TestRegression4960_Deadlock(t *testing.T) {
 	bkt := objstore.WithNoopInstr(objstore.NewInMemBucket())
 	bkt = &erroringBucket{bkt: bkt}
 	var id, id2, id3 ulid.ULID
+	var err error
 	{
 		id, err = e2eutil.CreateBlock(
 			ctx,
@@ -167,15 +166,14 @@ func TestRegression4960_Deadlock(t *testing.T) {
 
 func TestCleanupDownsampleCacheFolder(t *testing.T) {
 	logger := log.NewLogfmtLogger(os.Stderr)
-	dir, err := os.MkdirTemp("", "test-compact-cleanup")
-	testutil.Ok(t, err)
-	defer func() { testutil.Ok(t, os.RemoveAll(dir)) }()
+	dir := t.TempDir()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
 	bkt := objstore.WithNoopInstr(objstore.NewInMemBucket())
 	var id ulid.ULID
+	var err error
 	{
 		id, err = e2eutil.CreateBlock(
 			ctx,

--- a/pkg/api/blocks/v1_test.go
+++ b/pkg/api/blocks/v1_test.go
@@ -93,8 +93,7 @@ func testEndpoint(t *testing.T, test endpointTestCase, name string, responseComp
 
 func TestMarkBlockEndpoint(t *testing.T) {
 	ctx := context.Background()
-	tmpDir, err := os.MkdirTemp("", "test-read-mark")
-	testutil.Ok(t, err)
+	tmpDir := t.TempDir()
 
 	// create block
 	b1, err := e2eutil.CreateBlock(ctx, tmpDir, []labels.Labels{

--- a/pkg/api/query/v1_test.go
+++ b/pkg/api/query/v1_test.go
@@ -25,7 +25,6 @@ import (
 	"math/rand"
 	"net/http"
 	"net/url"
-	"os"
 	"reflect"
 	"strings"
 	"testing"
@@ -680,8 +679,7 @@ func TestMetadataEndpoints(t *testing.T) {
 		},
 	}
 
-	dir, err := os.MkdirTemp("", "prometheus-test")
-	testutil.Ok(t, err)
+	dir := t.TempDir()
 
 	const chunkRange int64 = 600_000
 	var series []storage.Series
@@ -699,7 +697,7 @@ func TestMetadataEndpoints(t *testing.T) {
 		series = append(series, storage.NewListSeries(lbl, samples))
 	}
 
-	_, err = tsdb.CreateBlock(series, dir, chunkRange, log.NewNopLogger())
+	_, err := tsdb.CreateBlock(series, dir, chunkRange, log.NewNopLogger())
 	testutil.Ok(t, err)
 
 	opts := tsdb.DefaultOptions()

--- a/pkg/block/block_test.go
+++ b/pkg/block/block_test.go
@@ -80,9 +80,7 @@ func TestUpload(t *testing.T) {
 
 	ctx := context.Background()
 
-	tmpDir, err := os.MkdirTemp("", "test-block-upload")
-	testutil.Ok(t, err)
-	defer func() { testutil.Ok(t, os.RemoveAll(tmpDir)) }()
+	tmpDir := t.TempDir()
 
 	bkt := objstore.NewInMemBucket()
 	b1, err := e2eutil.CreateBlock(ctx, tmpDir, []labels.Labels{
@@ -233,9 +231,7 @@ func TestDelete(t *testing.T) {
 	defer testutil.TolerantVerifyLeak(t)
 	ctx := context.Background()
 
-	tmpDir, err := os.MkdirTemp("", "test-block-delete")
-	testutil.Ok(t, err)
-	defer func() { testutil.Ok(t, os.RemoveAll(tmpDir)) }()
+	tmpDir := t.TempDir()
 
 	bkt := objstore.NewInMemBucket()
 	{
@@ -280,9 +276,7 @@ func TestMarkForDeletion(t *testing.T) {
 	defer testutil.TolerantVerifyLeak(t)
 	ctx := context.Background()
 
-	tmpDir, err := os.MkdirTemp("", "test-block-mark-for-delete")
-	testutil.Ok(t, err)
-	defer func() { testutil.Ok(t, os.RemoveAll(tmpDir)) }()
+	tmpDir := t.TempDir()
 
 	for _, tcase := range []struct {
 		name      string
@@ -336,9 +330,7 @@ func TestMarkForNoCompact(t *testing.T) {
 	defer testutil.TolerantVerifyLeak(t)
 	ctx := context.Background()
 
-	tmpDir, err := os.MkdirTemp("", "test-block-mark-for-no-compact")
-	testutil.Ok(t, err)
-	defer func() { testutil.Ok(t, os.RemoveAll(tmpDir)) }()
+	tmpDir := t.TempDir()
 
 	for _, tcase := range []struct {
 		name      string
@@ -396,11 +388,7 @@ func TestHashDownload(t *testing.T) {
 
 	ctx := context.Background()
 
-	tmpDir, err := os.MkdirTemp("", "test-block-download")
-	testutil.Ok(t, err)
-	t.Cleanup(func() {
-		testutil.Ok(t, os.RemoveAll(tmpDir))
-	})
+	tmpDir := t.TempDir()
 
 	bkt := objstore.NewInMemBucket()
 	r := prometheus.NewRegistry()
@@ -492,9 +480,7 @@ func TestUploadCleanup(t *testing.T) {
 
 	ctx := context.Background()
 
-	tmpDir, err := os.MkdirTemp("", "test-block-upload")
-	testutil.Ok(t, err)
-	defer func() { testutil.Ok(t, os.RemoveAll(tmpDir)) }()
+	tmpDir := t.TempDir()
 
 	bkt := objstore.NewInMemBucket()
 	b1, err := e2eutil.CreateBlock(ctx, tmpDir, []labels.Labels{

--- a/pkg/block/fetcher_test.go
+++ b/pkg/block/fetcher_test.go
@@ -67,9 +67,7 @@ func TestMetaFetcher_Fetch(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 		defer cancel()
 
-		dir, err := os.MkdirTemp("", "test-meta-fetcher")
-		testutil.Ok(t, err)
-		defer func() { testutil.Ok(t, os.RemoveAll(dir)) }()
+		dir := t.TempDir()
 
 		var ulidToDelete ulid.ULID
 		r := prometheus.NewRegistry()

--- a/pkg/block/index_test.go
+++ b/pkg/block/index_test.go
@@ -24,9 +24,7 @@ import (
 func TestRewrite(t *testing.T) {
 	ctx := context.Background()
 
-	tmpDir, err := os.MkdirTemp("", "test-indexheader")
-	testutil.Ok(t, err)
-	defer func() { testutil.Ok(t, os.RemoveAll(tmpDir)) }()
+	tmpDir := t.TempDir()
 
 	b, err := e2eutil.CreateBlock(ctx, tmpDir, []labels.Labels{
 		{{Name: "a", Value: "1"}},
@@ -87,10 +85,9 @@ func TestRewrite(t *testing.T) {
 }
 
 func TestGatherIndexHealthStatsReturnsOutOfOrderChunksErr(t *testing.T) {
-	blockDir, err := os.MkdirTemp("", "test-ooo-index")
-	testutil.Ok(t, err)
+	blockDir := t.TempDir()
 
-	err = testutil.PutOutOfOrderIndex(blockDir, 0, math.MaxInt64)
+	err := testutil.PutOutOfOrderIndex(blockDir, 0, math.MaxInt64)
 	testutil.Ok(t, err)
 
 	stats, err := GatherIndexHealthStats(log.NewLogfmtLogger(os.Stderr), blockDir+"/"+IndexFilename, 0, math.MaxInt64)

--- a/pkg/block/indexheader/header_test.go
+++ b/pkg/block/indexheader/header_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"math"
-	"os"
 	"path/filepath"
 	"strconv"
 	"testing"
@@ -31,9 +30,7 @@ import (
 func TestReaders(t *testing.T) {
 	ctx := context.Background()
 
-	tmpDir, err := os.MkdirTemp("", "test-indexheader")
-	testutil.Ok(t, err)
-	defer func() { testutil.Ok(t, os.RemoveAll(tmpDir)) }()
+	tmpDir := t.TempDir()
 
 	bkt, err := filesystem.NewBucket(filepath.Join(tmpDir, "bkt"))
 	testutil.Ok(t, err)
@@ -332,9 +329,7 @@ func prepareIndexV2Block(t testing.TB, tmpDir string, bkt objstore.Bucket) *meta
 func BenchmarkBinaryWrite(t *testing.B) {
 	ctx := context.Background()
 
-	tmpDir, err := os.MkdirTemp("", "bench-indexheader")
-	testutil.Ok(t, err)
-	defer func() { testutil.Ok(t, os.RemoveAll(tmpDir)) }()
+	tmpDir := t.TempDir()
 
 	bkt, err := filesystem.NewBucket(filepath.Join(tmpDir, "bkt"))
 	testutil.Ok(t, err)
@@ -351,9 +346,7 @@ func BenchmarkBinaryWrite(t *testing.B) {
 
 func BenchmarkBinaryReader(t *testing.B) {
 	ctx := context.Background()
-	tmpDir, err := os.MkdirTemp("", "bench-indexheader")
-	testutil.Ok(t, err)
-	defer func() { testutil.Ok(t, os.RemoveAll(tmpDir)) }()
+	tmpDir := t.TempDir()
 
 	bkt, err := filesystem.NewBucket(filepath.Join(tmpDir, "bkt"))
 	testutil.Ok(t, err)
@@ -384,9 +377,7 @@ func benchmarkBinaryReaderLookupSymbol(b *testing.B, numSeries int) {
 	ctx := context.Background()
 	logger := log.NewNopLogger()
 
-	tmpDir, err := os.MkdirTemp("", "benchmark-lookupsymbol")
-	testutil.Ok(b, err)
-	defer func() { testutil.Ok(b, os.RemoveAll(tmpDir)) }()
+	tmpDir := b.TempDir()
 
 	bkt, err := filesystem.NewBucket(filepath.Join(tmpDir, "bkt"))
 	testutil.Ok(b, err)

--- a/pkg/block/indexheader/lazy_binary_reader_test.go
+++ b/pkg/block/indexheader/lazy_binary_reader_test.go
@@ -26,9 +26,7 @@ import (
 func TestNewLazyBinaryReader_ShouldFailIfUnableToBuildIndexHeader(t *testing.T) {
 	ctx := context.Background()
 
-	tmpDir, err := os.MkdirTemp("", "test-indexheader")
-	testutil.Ok(t, err)
-	defer func() { testutil.Ok(t, os.RemoveAll(tmpDir)) }()
+	tmpDir := t.TempDir()
 
 	bkt, err := filesystem.NewBucket(filepath.Join(tmpDir, "bkt"))
 	testutil.Ok(t, err)
@@ -41,9 +39,7 @@ func TestNewLazyBinaryReader_ShouldFailIfUnableToBuildIndexHeader(t *testing.T) 
 func TestNewLazyBinaryReader_ShouldBuildIndexHeaderFromBucket(t *testing.T) {
 	ctx := context.Background()
 
-	tmpDir, err := os.MkdirTemp("", "test-indexheader")
-	testutil.Ok(t, err)
-	defer func() { testutil.Ok(t, os.RemoveAll(tmpDir)) }()
+	tmpDir := t.TempDir()
 
 	bkt, err := filesystem.NewBucket(filepath.Join(tmpDir, "bkt"))
 	testutil.Ok(t, err)
@@ -82,9 +78,7 @@ func TestNewLazyBinaryReader_ShouldBuildIndexHeaderFromBucket(t *testing.T) {
 func TestNewLazyBinaryReader_ShouldRebuildCorruptedIndexHeader(t *testing.T) {
 	ctx := context.Background()
 
-	tmpDir, err := os.MkdirTemp("", "test-indexheader")
-	testutil.Ok(t, err)
-	defer func() { testutil.Ok(t, os.RemoveAll(tmpDir)) }()
+	tmpDir := t.TempDir()
 
 	bkt, err := filesystem.NewBucket(filepath.Join(tmpDir, "bkt"))
 	testutil.Ok(t, err)
@@ -122,9 +116,7 @@ func TestNewLazyBinaryReader_ShouldRebuildCorruptedIndexHeader(t *testing.T) {
 func TestLazyBinaryReader_ShouldReopenOnUsageAfterClose(t *testing.T) {
 	ctx := context.Background()
 
-	tmpDir, err := os.MkdirTemp("", "test-indexheader")
-	testutil.Ok(t, err)
-	defer func() { testutil.Ok(t, os.RemoveAll(tmpDir)) }()
+	tmpDir := t.TempDir()
 
 	bkt, err := filesystem.NewBucket(filepath.Join(tmpDir, "bkt"))
 	testutil.Ok(t, err)
@@ -174,9 +166,7 @@ func TestLazyBinaryReader_ShouldReopenOnUsageAfterClose(t *testing.T) {
 func TestLazyBinaryReader_unload_ShouldReturnErrorIfNotIdle(t *testing.T) {
 	ctx := context.Background()
 
-	tmpDir, err := os.MkdirTemp("", "test-indexheader")
-	testutil.Ok(t, err)
-	defer func() { testutil.Ok(t, os.RemoveAll(tmpDir)) }()
+	tmpDir := t.TempDir()
 
 	bkt, err := filesystem.NewBucket(filepath.Join(tmpDir, "bkt"))
 	testutil.Ok(t, err)
@@ -225,9 +215,7 @@ func TestLazyBinaryReader_LoadUnloadRaceCondition(t *testing.T) {
 
 	ctx := context.Background()
 
-	tmpDir, err := os.MkdirTemp("", "test-indexheader")
-	testutil.Ok(t, err)
-	defer func() { testutil.Ok(t, os.RemoveAll(tmpDir)) }()
+	tmpDir := t.TempDir()
 
 	bkt, err := filesystem.NewBucket(filepath.Join(tmpDir, "bkt"))
 	testutil.Ok(t, err)

--- a/pkg/block/indexheader/reader_pool_test.go
+++ b/pkg/block/indexheader/reader_pool_test.go
@@ -5,7 +5,6 @@ package indexheader
 
 import (
 	"context"
-	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -41,9 +40,7 @@ func TestReaderPool_NewBinaryReader(t *testing.T) {
 
 	ctx := context.Background()
 
-	tmpDir, err := os.MkdirTemp("", "test-indexheader")
-	testutil.Ok(t, err)
-	defer func() { testutil.Ok(t, os.RemoveAll(tmpDir)) }()
+	tmpDir := t.TempDir()
 
 	bkt, err := filesystem.NewBucket(filepath.Join(tmpDir, "bkt"))
 	testutil.Ok(t, err)
@@ -79,9 +76,7 @@ func TestReaderPool_ShouldCloseIdleLazyReaders(t *testing.T) {
 
 	ctx := context.Background()
 
-	tmpDir, err := os.MkdirTemp("", "test-indexheader")
-	testutil.Ok(t, err)
-	defer func() { testutil.Ok(t, os.RemoveAll(tmpDir)) }()
+	tmpDir := t.TempDir()
 
 	bkt, err := filesystem.NewBucket(filepath.Join(tmpDir, "bkt"))
 	testutil.Ok(t, err)

--- a/pkg/block/metadata/hash_test.go
+++ b/pkg/block/metadata/hash_test.go
@@ -13,9 +13,7 @@ import (
 )
 
 func TestHashSmoke(t *testing.T) {
-	dir, err := os.MkdirTemp("", "testhash")
-	testutil.Ok(t, err)
-	t.Cleanup(func() { os.RemoveAll(dir) })
+	dir := t.TempDir()
 	f, err := os.CreateTemp(dir, "hash")
 	testutil.Ok(t, err)
 

--- a/pkg/block/metadata/markers_test.go
+++ b/pkg/block/metadata/markers_test.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"os"
 	"path"
 	"testing"
 	"time"
@@ -28,9 +27,7 @@ func TestMain(m *testing.M) {
 func TestReadMarker(t *testing.T) {
 	ctx := context.Background()
 
-	tmpDir, err := os.MkdirTemp("", "test-read-mark")
-	testutil.Ok(t, err)
-	defer func() { testutil.Ok(t, os.RemoveAll(tmpDir)) }()
+	tmpDir := t.TempDir()
 
 	bkt := objstore.WithNoopInstr(objstore.NewInMemBucket())
 	t.Run(DeletionMarkFilename, func(t *testing.T) {

--- a/pkg/compact/compact_e2e_test.go
+++ b/pkg/compact/compact_e2e_test.go
@@ -185,9 +185,7 @@ func testGroupCompactE2e(t *testing.T, mergeFunc storage.VerticalChunkSeriesMerg
 		defer cancel()
 
 		// Create fresh, empty directory for actual test.
-		dir, err := os.MkdirTemp("", "test-compact")
-		testutil.Ok(t, err)
-		defer func() { testutil.Ok(t, os.RemoveAll(dir)) }()
+		dir := t.TempDir()
 
 		logger := log.NewLogfmtLogger(os.Stderr)
 
@@ -430,9 +428,7 @@ type blockgenSpec struct {
 }
 
 func createAndUpload(t testing.TB, bkt objstore.Bucket, blocks []blockgenSpec, blocksWithOutOfOrderChunks []blockgenSpec) (metas []*metadata.Meta) {
-	prepareDir, err := os.MkdirTemp("", "test-compact-prepare")
-	testutil.Ok(t, err)
-	defer func() { testutil.Ok(t, os.RemoveAll(prepareDir)) }()
+	prepareDir := t.TempDir()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 	defer cancel()

--- a/pkg/compact/downsample/downsample_test.go
+++ b/pkg/compact/downsample/downsample_test.go
@@ -432,9 +432,7 @@ func TestDownsample(t *testing.T) {
 		t.Run(tcase.name, func(t *testing.T) {
 			logger := log.NewLogfmtLogger(os.Stderr)
 
-			dir, err := os.MkdirTemp("", "downsample-raw")
-			testutil.Ok(t, err)
-			defer func() { testutil.Ok(t, os.RemoveAll(dir)) }()
+			dir := t.TempDir()
 
 			// Ideally we would use tsdb.HeadBlock here for less dependency on our own code. However,
 			// it cannot accept the counter signal sample with the same timestamp as the previous sample.
@@ -507,9 +505,7 @@ func TestDownsample(t *testing.T) {
 
 func TestDownsampleAggrAndEmptyXORChunks(t *testing.T) {
 	logger := log.NewLogfmtLogger(os.Stderr)
-	dir, err := os.MkdirTemp("", "downsample-mixed")
-	testutil.Ok(t, err)
-	defer func() { testutil.Ok(t, os.RemoveAll(dir)) }()
+	dir := t.TempDir()
 
 	ser := &series{lset: labels.FromStrings("__name__", "a")}
 	aggr := map[AggrType][]sample{
@@ -538,9 +534,7 @@ func TestDownsampleAggrAndEmptyXORChunks(t *testing.T) {
 
 func TestDownsampleAggrAndNonEmptyXORChunks(t *testing.T) {
 	logger := log.NewLogfmtLogger(os.Stderr)
-	dir, err := os.MkdirTemp("", "downsample-mixed")
-	testutil.Ok(t, err)
-	defer func() { testutil.Ok(t, os.RemoveAll(dir)) }()
+	dir := t.TempDir()
 
 	ser := &series{lset: labels.FromStrings("__name__", "a")}
 	aggr := map[AggrType][]sample{

--- a/pkg/compactv2/compactor_test.go
+++ b/pkg/compactv2/compactor_test.go
@@ -588,9 +588,7 @@ func TestCompactor_WriteSeries_e2e(t *testing.T) {
 		},
 	} {
 		t.Run(tcase.name, func(t *testing.T) {
-			tmpDir, err := os.MkdirTemp("", "test-series-writer")
-			testutil.Ok(t, err)
-			defer func() { testutil.Ok(t, os.RemoveAll(tmpDir)) }()
+			tmpDir := t.TempDir()
 
 			chunkPool := chunkenc.NewPool()
 

--- a/pkg/query/query_bench_test.go
+++ b/pkg/query/query_bench_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -39,9 +38,7 @@ func BenchmarkQuerySelect(b *testing.B) {
 }
 
 func benchQuerySelect(t testutil.TB, totalSamples, totalSeries int, dedup bool) {
-	tmpDir, err := os.MkdirTemp("", "testorbench-queryselect")
-	testutil.Ok(t, err)
-	defer func() { testutil.Ok(t, os.RemoveAll(tmpDir)) }()
+	tmpDir := t.TempDir()
 
 	const numOfReplicas = 2
 

--- a/pkg/receive/handler_test.go
+++ b/pkg/receive/handler_test.go
@@ -1271,9 +1271,7 @@ func serializeSeriesWithOneSample(t testing.TB, series [][]labelpb.ZLabel) []byt
 }
 
 func benchmarkHandlerMultiTSDBReceiveRemoteWrite(b testutil.TB) {
-	dir, err := os.MkdirTemp("", "test_receive")
-	testutil.Ok(b, err)
-	defer func() { testutil.Ok(b, os.RemoveAll(dir)) }()
+	dir := b.TempDir()
 
 	handlers, _ := newTestHandlerHashring([]*fakeAppendable{nil}, 1)
 	handler := handlers[0]

--- a/pkg/receive/multitsdb_test.go
+++ b/pkg/receive/multitsdb_test.go
@@ -30,9 +30,7 @@ import (
 )
 
 func TestMultiTSDB(t *testing.T) {
-	dir, err := os.MkdirTemp("", "test")
-	testutil.Ok(t, err)
-	defer func() { testutil.Ok(t, os.RemoveAll(dir)) }()
+	dir := t.TempDir()
 
 	logger := log.NewLogfmtLogger(os.Stderr)
 	t.Run("run fresh", func(t *testing.T) {
@@ -436,9 +434,7 @@ func TestMultiTSDBPrune(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			dir, err := os.MkdirTemp("", "multitsdb-prune")
-			testutil.Ok(t, err)
-			defer func() { testutil.Ok(t, os.RemoveAll(dir)) }()
+			dir := t.TempDir()
 
 			m := NewMultiTSDB(dir, log.NewNopLogger(), prometheus.NewRegistry(),
 				&tsdb.Options{
@@ -506,9 +502,7 @@ func TestMultiTSDBStats(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			dir, err := os.MkdirTemp("", "tsdb-stats")
-			testutil.Ok(t, err)
-			defer func() { testutil.Ok(t, os.RemoveAll(dir)) }()
+			dir := t.TempDir()
 
 			m := NewMultiTSDB(dir, log.NewNopLogger(), prometheus.NewRegistry(),
 				&tsdb.Options{
@@ -561,9 +555,7 @@ func appendSample(m *MultiTSDB, tenant string, timestamp time.Time) error {
 }
 
 func BenchmarkMultiTSDB(b *testing.B) {
-	dir, err := os.MkdirTemp("", "multitsdb")
-	testutil.Ok(b, err)
-	defer func() { testutil.Ok(b, os.RemoveAll(dir)) }()
+	dir := b.TempDir()
 
 	m := NewMultiTSDB(dir, log.NewNopLogger(), prometheus.NewRegistry(), &tsdb.Options{
 		MinBlockDuration:  (2 * time.Hour).Milliseconds(),

--- a/pkg/receive/writer_test.go
+++ b/pkg/receive/writer_test.go
@@ -6,7 +6,6 @@ package receive
 import (
 	"context"
 	"fmt"
-	"os"
 	"strings"
 	"testing"
 	"time"
@@ -209,9 +208,7 @@ func TestWriter(t *testing.T) {
 
 	for testName, testData := range tests {
 		t.Run(testName, func(t *testing.T) {
-			dir, err := os.MkdirTemp("", "test")
-			testutil.Ok(t, err)
-			defer func() { testutil.Ok(t, os.RemoveAll(dir)) }()
+			dir := t.TempDir()
 
 			logger := log.NewNopLogger()
 
@@ -282,9 +279,7 @@ func BenchmarkWriterTimeSeriesWith10Labels_100(b *testing.B)  { benchmarkWriter(
 func BenchmarkWriterTimeSeriesWith10Labels_1000(b *testing.B) { benchmarkWriter(b, 10, 1000) }
 
 func benchmarkWriter(b *testing.B, labelsNum int, seriesNum int) {
-	dir, err := os.MkdirTemp("", "bench-writer")
-	testutil.Ok(b, err)
-	defer func() { testutil.Ok(b, os.RemoveAll(dir)) }()
+	dir := b.TempDir()
 
 	logger := log.NewNopLogger()
 

--- a/pkg/reloader/reloader_test.go
+++ b/pkg/reloader/reloader_test.go
@@ -59,9 +59,7 @@ func TestReloader_ConfigApply(t *testing.T) {
 	reloadURL, err := url.Parse(fmt.Sprintf("http://%s", l.Addr().String()))
 	testutil.Ok(t, err)
 
-	dir, err := os.MkdirTemp("", "reloader-cfg-test")
-	testutil.Ok(t, err)
-	defer func() { testutil.Ok(t, os.RemoveAll(dir)) }()
+	dir := t.TempDir()
 
 	testutil.Ok(t, os.Mkdir(filepath.Join(dir, "in"), os.ModePerm))
 	testutil.Ok(t, os.Mkdir(filepath.Join(dir, "out"), os.ModePerm))
@@ -182,9 +180,7 @@ faulty_config:
   a: 1
 `)
 
-	dir, err := os.MkdirTemp("", "reloader-cfg-test")
-	testutil.Ok(t, err)
-	defer func() { testutil.Ok(t, os.RemoveAll(dir)) }()
+	dir := t.TempDir()
 
 	testutil.Ok(t, os.Mkdir(filepath.Join(dir, "in"), os.ModePerm))
 	testutil.Ok(t, os.Mkdir(filepath.Join(dir, "out"), os.ModePerm))
@@ -318,8 +314,6 @@ func TestReloader_DirectoriesApply(t *testing.T) {
 	testutil.Ok(t, os.WriteFile(tempRule1File, []byte("rule1-changed"), os.ModePerm))
 	testutil.Ok(t, os.WriteFile(tempRule3File, []byte("rule3-changed"), os.ModePerm))
 	testutil.Ok(t, os.WriteFile(tempRule4File, []byte("rule4-changed"), os.ModePerm))
-
-	defer func() { testutil.Ok(t, os.RemoveAll(ruleDir)) }()
 
 	dir := t.TempDir()
 	dir2 := t.TempDir()
@@ -644,9 +638,7 @@ func TestReloader_ConfigApplyWithWatchIntervalEqualsZero(t *testing.T) {
 	reloadURL, err := url.Parse(fmt.Sprintf("http://%s", l.Addr().String()))
 	testutil.Ok(t, err)
 
-	dir, err := os.MkdirTemp("", "reloader-cfg-test")
-	testutil.Ok(t, err)
-	defer func() { testutil.Ok(t, os.RemoveAll(dir)) }()
+	dir := t.TempDir()
 
 	testutil.Ok(t, os.Mkdir(filepath.Join(dir, "in"), os.ModePerm))
 	testutil.Ok(t, os.Mkdir(filepath.Join(dir, "out"), os.ModePerm))

--- a/pkg/rules/manager_test.go
+++ b/pkg/rules/manager_test.go
@@ -54,9 +54,7 @@ func (n nopQueryable) Querier(_ context.Context, _, _ int64) (storage.Querier, e
 
 // Regression test against https://github.com/thanos-io/thanos/issues/1779.
 func TestRun_Subqueries(t *testing.T) {
-	dir, err := os.MkdirTemp("", "test_rule_run")
-	testutil.Ok(t, err)
-	defer func() { testutil.Ok(t, os.RemoveAll(dir)) }()
+	dir := t.TempDir()
 
 	testutil.Ok(t, os.WriteFile(filepath.Join(dir, "rule.yaml"), []byte(`
 groups:
@@ -108,15 +106,10 @@ groups:
 }
 
 func TestUpdate_Error_UpdatePartial(t *testing.T) {
-	dir, err := os.MkdirTemp("", "test_rule_rule_groups")
-	testutil.Ok(t, err)
-	dataDir, err := os.MkdirTemp("", "test_rule_data")
-	testutil.Ok(t, err)
-	defer func() {
-		testutil.Ok(t, os.RemoveAll(dir))
-		testutil.Ok(t, os.RemoveAll(dataDir))
-	}()
-	err = os.MkdirAll(filepath.Join(dir, "subdir"), 0775)
+	dir := t.TempDir()
+	dataDir := t.TempDir()
+
+	err := os.MkdirAll(filepath.Join(dir, "subdir"), 0775)
 	testutil.Ok(t, err)
 
 	testutil.Ok(t, os.WriteFile(filepath.Join(dir, "no_strategy.yaml"), []byte(`
@@ -319,9 +312,7 @@ func TestConfigRuleAdapterUnmarshalMarshalYAML(t *testing.T) {
 }
 
 func TestManager_Rules(t *testing.T) {
-	dir, err := os.MkdirTemp("", "test_rule_run")
-	testutil.Ok(t, err)
-	defer func() { testutil.Ok(t, os.RemoveAll(dir)) }()
+	dir := t.TempDir()
 
 	curr, err := os.Getwd()
 	testutil.Ok(t, err)
@@ -356,9 +347,7 @@ func TestManager_Rules(t *testing.T) {
 }
 
 func TestManagerUpdateWithNoRules(t *testing.T) {
-	dir, err := os.MkdirTemp("", "test_rule_rule_groups")
-	testutil.Ok(t, err)
-	defer func() { testutil.Ok(t, os.RemoveAll(dir)) }()
+	dir := t.TempDir()
 
 	testutil.Ok(t, os.WriteFile(filepath.Join(dir, "no_strategy.yaml"), []byte(`
 groups:
@@ -390,7 +379,7 @@ groups:
 	thanosRuleMgr.Run()
 	t.Cleanup(thanosRuleMgr.Stop)
 
-	err = thanosRuleMgr.Update(1*time.Second, []string{
+	err := thanosRuleMgr.Update(1*time.Second, []string{
 		filepath.Join(dir, "no_strategy.yaml"),
 	})
 	testutil.Ok(t, err)
@@ -402,9 +391,7 @@ groups:
 }
 
 func TestManagerRunRulesWithRuleGroupLimit(t *testing.T) {
-	dir, err := os.MkdirTemp("", "test_rule_rule_groups")
-	testutil.Ok(t, err)
-	t.Cleanup(func() { testutil.Ok(t, os.RemoveAll(dir)) })
+	dir := t.TempDir()
 	filename := filepath.Join(dir, "with_limit.yaml")
 	testutil.Ok(t, os.WriteFile(filename, []byte(`
 groups:

--- a/pkg/runutil/runutil_test.go
+++ b/pkg/runutil/runutil_test.go
@@ -125,12 +125,7 @@ func TestCloseMoreThanOnce(t *testing.T) {
 }
 
 func TestDeleteAll(t *testing.T) {
-	dir, err := os.MkdirTemp("", "example")
-	testutil.Ok(t, err)
-
-	t.Cleanup(func() {
-		testutil.Ok(t, os.RemoveAll(dir))
-	})
+	dir := t.TempDir()
 
 	f, err := os.Create(filepath.Join(dir, "file1"))
 	testutil.Ok(t, err)
@@ -166,8 +161,7 @@ func TestDeleteAll(t *testing.T) {
 }
 
 func TestDeleteAll_ShouldReturnNoErrorIfDirectoryDoesNotExists(t *testing.T) {
-	dir, err := os.MkdirTemp("", "example")
-	testutil.Ok(t, err)
+	dir := t.TempDir()
 	testutil.Ok(t, os.RemoveAll(dir))
 
 	// Calling DeleteAll() on a non-existent directory should return no error.

--- a/pkg/shipper/shipper_e2e_test.go
+++ b/pkg/shipper/shipper_e2e_test.go
@@ -39,11 +39,7 @@ func TestShipper_SyncBlocks_e2e(t *testing.T) {
 		metrics := prometheus.NewRegistry()
 		metricsBucket := objstore.BucketWithMetrics("test", bkt, metrics)
 
-		dir, err := os.MkdirTemp("", "shipper-e2e-test")
-		testutil.Ok(t, err)
-		defer func() {
-			testutil.Ok(t, os.RemoveAll(dir))
-		}()
+		dir := t.TempDir()
 
 		extLset := labels.FromStrings("prometheus", "prom-1")
 		shipper := New(log.NewLogfmtLogger(os.Stderr), nil, dir, metricsBucket, func() labels.Labels { return extLset }, metadata.TestSource, false, false, metadata.NoneFunc)
@@ -198,11 +194,7 @@ func TestShipper_SyncBlocks_e2e(t *testing.T) {
 
 func TestShipper_SyncBlocksWithMigrating_e2e(t *testing.T) {
 	e2eutil.ForeachPrometheus(t, func(t testing.TB, p *e2eutil.Prometheus) {
-		dir, err := os.MkdirTemp("", "shipper-e2e-test")
-		testutil.Ok(t, err)
-		defer func() {
-			testutil.Ok(t, os.RemoveAll(dir))
-		}()
+		dir := t.TempDir()
 
 		bkt := objstore.NewInMemBucket()
 
@@ -357,11 +349,7 @@ func TestShipper_SyncBlocksWithMigrating_e2e(t *testing.T) {
 func TestShipper_SyncOverlapBlocks_e2e(t *testing.T) {
 	p, err := e2eutil.NewPrometheus()
 	testutil.Ok(t, err)
-	dir, err := os.MkdirTemp("", "shipper-e2e-test")
-	testutil.Ok(t, err)
-	defer func() {
-		testutil.Ok(t, os.RemoveAll(dir))
-	}()
+	dir := t.TempDir()
 
 	bkt := objstore.NewInMemBucket()
 

--- a/pkg/store/bucket_e2e_test.go
+++ b/pkg/store/bucket_e2e_test.go
@@ -484,9 +484,7 @@ func TestBucketStore_e2e(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		dir, err := os.MkdirTemp("", "test_bucketstore_e2e")
-		testutil.Ok(t, err)
-		defer func() { testutil.Ok(t, os.RemoveAll(dir)) }()
+		dir := t.TempDir()
 
 		s := prepareStoreWithTestBlocks(t, dir, bkt, false, NewChunksLimiterFactory(0), NewSeriesLimiterFactory(0), emptyRelabelConfig, allowAllFilterConf)
 
@@ -539,9 +537,7 @@ func TestBucketStore_ManyParts_e2e(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		dir, err := os.MkdirTemp("", "test_bucketstore_e2e")
-		testutil.Ok(t, err)
-		defer func() { testutil.Ok(t, os.RemoveAll(dir)) }()
+		dir := t.TempDir()
 
 		s := prepareStoreWithTestBlocks(t, dir, bkt, true, NewChunksLimiterFactory(0), NewSeriesLimiterFactory(0), emptyRelabelConfig, allowAllFilterConf)
 
@@ -561,9 +557,7 @@ func TestBucketStore_TimePartitioning_e2e(t *testing.T) {
 	defer cancel()
 	bkt := objstore.NewInMemBucket()
 
-	dir, err := os.MkdirTemp("", "test_bucket_time_part_e2e")
-	testutil.Ok(t, err)
-	defer func() { testutil.Ok(t, os.RemoveAll(dir)) }()
+	dir := t.TempDir()
 
 	hourAfter := time.Now().Add(1 * time.Hour)
 	filterMaxTime := model.TimeOrDurationValue{Time: &hourAfter}
@@ -648,9 +642,7 @@ func TestBucketStore_Series_ChunksLimiter_e2e(t *testing.T) {
 			defer cancel()
 			bkt := objstore.NewInMemBucket()
 
-			dir, err := os.MkdirTemp("", "test_bucket_chunks_limiter_e2e")
-			testutil.Ok(t, err)
-			defer func() { testutil.Ok(t, os.RemoveAll(dir)) }()
+			dir := t.TempDir()
 
 			s := prepareStoreWithTestBlocks(t, dir, bkt, false, newCustomChunksLimiterFactory(testData.maxChunksLimit, testData.code), newCustomSeriesLimiterFactory(testData.maxSeriesLimit, testData.code), emptyRelabelConfig, allowAllFilterConf)
 			testutil.Ok(t, s.store.SyncBlocks(ctx))
@@ -665,7 +657,7 @@ func TestBucketStore_Series_ChunksLimiter_e2e(t *testing.T) {
 
 			s.cache.SwapWith(noopCache{})
 			srv := newStoreSeriesServer(ctx)
-			err = s.store.Series(req, srv)
+			err := s.store.Series(req, srv)
 
 			if testData.expectedErr == "" {
 				testutil.Ok(t, err)
@@ -685,9 +677,7 @@ func TestBucketStore_LabelNames_e2e(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		dir, err := os.MkdirTemp("", "test_bucketstore_label_names_e2e")
-		testutil.Ok(t, err)
-		defer func() { testutil.Ok(t, os.RemoveAll(dir)) }()
+		dir := t.TempDir()
 
 		s := prepareStoreWithTestBlocks(t, dir, bkt, false, NewChunksLimiterFactory(0), NewSeriesLimiterFactory(0), emptyRelabelConfig, allowAllFilterConf)
 		s.cache.SwapWith(noopCache{})
@@ -787,9 +777,7 @@ func TestBucketStore_LabelValues_e2e(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		dir, err := os.MkdirTemp("", "test_bucketstore_label_values_e2e")
-		testutil.Ok(t, err)
-		defer func() { testutil.Ok(t, os.RemoveAll(dir)) }()
+		dir := t.TempDir()
 
 		s := prepareStoreWithTestBlocks(t, dir, bkt, false, NewChunksLimiterFactory(0), NewSeriesLimiterFactory(0), emptyRelabelConfig, allowAllFilterConf)
 		s.cache.SwapWith(noopCache{})

--- a/pkg/store/bucket_test.go
+++ b/pkg/store/bucket_test.go
@@ -191,9 +191,7 @@ func TestBucketBlock_Property(t *testing.T) {
 func TestBucketBlock_matchLabels(t *testing.T) {
 	defer testutil.TolerantVerifyLeak(t)
 
-	dir, err := os.MkdirTemp("", "bucketblock-test")
-	testutil.Ok(t, err)
-	defer testutil.Ok(t, os.RemoveAll(dir))
+	dir := t.TempDir()
 
 	bkt, err := filesystem.NewBucket(dir)
 	testutil.Ok(t, err)
@@ -588,10 +586,7 @@ func TestBucketStore_Info(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	dir, err := os.MkdirTemp("", "bucketstore-test")
-	testutil.Ok(t, err)
-
-	defer testutil.Ok(t, os.RemoveAll(dir))
+	dir := t.TempDir()
 
 	chunkPool, err := NewDefaultChunkBytesPool(2e5)
 	testutil.Ok(t, err)
@@ -653,9 +648,7 @@ func TestBucketStore_Sharding(t *testing.T) {
 	ctx := context.Background()
 	logger := log.NewNopLogger()
 
-	dir, err := os.MkdirTemp("", "test-sharding-prepare")
-	testutil.Ok(t, err)
-	defer func() { testutil.Ok(t, os.RemoveAll(dir)) }()
+	dir := t.TempDir()
 
 	bkt := objstore.NewInMemBucket()
 	series := []labels.Labels{labels.FromStrings("a", "1", "b", "1")}
@@ -682,9 +675,7 @@ func TestBucketStore_Sharding(t *testing.T) {
 		return
 	}
 
-	dir2, err := os.MkdirTemp("", "test-sharding2")
-	testutil.Ok(t, err)
-	defer func() { testutil.Ok(t, os.RemoveAll(dir2)) }()
+	dir2 := t.TempDir()
 
 	t.Run("reuse_disk", func(t *testing.T) {
 		testSharding(t, dir2, bkt, id1, id2, id3, id4)
@@ -829,10 +820,7 @@ func testSharding(t *testing.T, reuseDisk string, bkt objstore.Bucket, all ...ul
 			dir := reuseDisk
 
 			if dir == "" {
-				var err error
-				dir, err = os.MkdirTemp("", "test-sharding")
-				testutil.Ok(t, err)
-				defer func() { testutil.Ok(t, os.RemoveAll(dir)) }()
+				dir = t.TempDir()
 			}
 			relabelConf, err := block.ParseRelabelConfig([]byte(sc.relabel), block.SelectorSupportedRelabelActions)
 			testutil.Ok(t, err)
@@ -1013,9 +1001,7 @@ func TestReadIndexCache_LoadSeries(t *testing.T) {
 func TestBucketIndexReader_ExpandedPostings(t *testing.T) {
 	tb := testutil.NewTB(t)
 
-	tmpDir, err := os.MkdirTemp("", "test-expanded-postings")
-	testutil.Ok(tb, err)
-	defer func() { testutil.Ok(tb, os.RemoveAll(tmpDir)) }()
+	tmpDir := t.TempDir()
 
 	bkt, err := filesystem.NewBucket(filepath.Join(tmpDir, "bkt"))
 	testutil.Ok(tb, err)
@@ -1032,9 +1018,7 @@ func TestBucketIndexReader_ExpandedPostings(t *testing.T) {
 func BenchmarkBucketIndexReader_ExpandedPostings(b *testing.B) {
 	tb := testutil.NewTB(b)
 
-	tmpDir, err := os.MkdirTemp("", "bench-expanded-postings")
-	testutil.Ok(tb, err)
-	defer func() { testutil.Ok(tb, os.RemoveAll(tmpDir)) }()
+	tmpDir := b.TempDir()
 
 	bkt, err := filesystem.NewBucket(filepath.Join(tmpDir, "bkt"))
 	testutil.Ok(tb, err)
@@ -1215,9 +1199,7 @@ func BenchmarkBucketSkipChunksSeries(b *testing.B) {
 func benchBucketSeries(t testutil.TB, skipChunk bool, samplesPerSeries, totalSeries int, requestedRatios ...float64) {
 	const numOfBlocks = 4
 
-	tmpDir, err := os.MkdirTemp("", "testorbench-bucketseries")
-	testutil.Ok(t, err)
-	defer func() { testutil.Ok(t, os.RemoveAll(tmpDir)) }()
+	tmpDir := t.TempDir()
 
 	bkt, err := filesystem.NewBucket(filepath.Join(tmpDir, "bkt"))
 	testutil.Ok(t, err)
@@ -1379,9 +1361,7 @@ func (m *mockedPool) Put(b *[]byte) {
 
 // Regression test against: https://github.com/thanos-io/thanos/issues/2147.
 func TestBucketSeries_OneBlock_InMemIndexCacheSegfault(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "segfault-series")
-	testutil.Ok(t, err)
-	defer func() { testutil.Ok(t, os.RemoveAll(tmpDir)) }()
+	tmpDir := t.TempDir()
 
 	bkt, err := filesystem.NewBucket(filepath.Join(tmpDir, "bkt"))
 	testutil.Ok(t, err)
@@ -1630,9 +1610,7 @@ func TestSeries_RequestAndResponseHints(t *testing.T) {
 func TestSeries_ErrorUnmarshallingRequestHints(t *testing.T) {
 	tb := testutil.NewTB(t)
 
-	tmpDir, err := os.MkdirTemp("", "test-series-hints-enabled")
-	testutil.Ok(t, err)
-	defer func() { testutil.Ok(t, os.RemoveAll(tmpDir)) }()
+	tmpDir := t.TempDir()
 
 	bktDir := filepath.Join(tmpDir, "bkt")
 	bkt, err := filesystem.NewBucket(bktDir)
@@ -1691,9 +1669,7 @@ func TestSeries_ErrorUnmarshallingRequestHints(t *testing.T) {
 func TestSeries_BlockWithMultipleChunks(t *testing.T) {
 	tb := testutil.NewTB(t)
 
-	tmpDir, err := os.MkdirTemp("", "test-block-with-multiple-chunks")
-	testutil.Ok(t, err)
-	defer func() { testutil.Ok(t, os.RemoveAll(tmpDir)) }()
+	tmpDir := t.TempDir()
 
 	// Create a block with 1 series but an high number of samples,
 	// so that they will span across multiple chunks.
@@ -1871,9 +1847,7 @@ func setupStoreForHintsTest(t *testing.T) (testutil.TB, *BucketStore, []*storepb
 
 	closers := []func(){}
 
-	tmpDir, err := os.MkdirTemp("", "test-hints")
-	testutil.Ok(t, err)
-	closers = append(closers, func() { testutil.Ok(t, os.RemoveAll(tmpDir)) })
+	tmpDir := t.TempDir()
 
 	bktDir := filepath.Join(tmpDir, "bkt")
 	bkt, err := filesystem.NewBucket(bktDir)
@@ -2120,11 +2094,7 @@ func BenchmarkBucketBlock_readChunkRange(b *testing.B) {
 		readLengths = []int64{300, 500, 1000, 5000, 10000, 30000, 50000, 100000, 300000, 1500000}
 	)
 
-	tmpDir, err := os.MkdirTemp("", "benchmark")
-	testutil.Ok(b, err)
-	b.Cleanup(func() {
-		testutil.Ok(b, os.RemoveAll(tmpDir))
-	})
+	tmpDir := b.TempDir()
 
 	bkt, err := filesystem.NewBucket(filepath.Join(tmpDir, "bkt"))
 	testutil.Ok(b, err)
@@ -2185,11 +2155,7 @@ func prepareBucket(b *testing.B, resolutionLevel compact.ResolutionLevel) (*buck
 		logger = log.NewNopLogger()
 	)
 
-	tmpDir, err := os.MkdirTemp("", "benchmark")
-	testutil.Ok(b, err)
-	b.Cleanup(func() {
-		testutil.Ok(b, os.RemoveAll(tmpDir))
-	})
+	tmpDir := b.TempDir()
 
 	bkt, err := filesystem.NewBucket(filepath.Join(tmpDir, "bkt"))
 	testutil.Ok(b, err)

--- a/pkg/store/multitsdb_test.go
+++ b/pkg/store/multitsdb_test.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -61,9 +60,7 @@ type mockedStartTimeDB struct {
 func (db *mockedStartTimeDB) StartTime() (int64, error) { return db.startTime, nil }
 
 func benchMultiTSDBSeries(t testutil.TB, totalSamples, totalSeries int, flushToBlocks bool) {
-	tmpDir, err := os.MkdirTemp("", "testorbench-multitsdbseries")
-	testutil.Ok(t, err)
-	defer func() { testutil.Ok(t, os.RemoveAll(tmpDir)) }()
+	tmpDir := t.TempDir()
 
 	const numOfTSDBs = 4
 

--- a/pkg/store/postings_codec_test.go
+++ b/pkg/store/postings_codec_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"math"
 	"math/rand"
-	"os"
 	"strconv"
 	"testing"
 
@@ -21,8 +20,7 @@ import (
 )
 
 func TestDiffVarintCodec(t *testing.T) {
-	chunksDir, err := os.MkdirTemp("", "diff_varint_codec")
-	testutil.Ok(t, err)
+	chunksDir := t.TempDir()
 
 	headOpts := tsdb.DefaultHeadOptions()
 	headOpts.ChunkDirRoot = chunksDir
@@ -31,7 +29,6 @@ func TestDiffVarintCodec(t *testing.T) {
 	testutil.Ok(t, err)
 	defer func() {
 		testutil.Ok(t, h.Close())
-		testutil.Ok(t, os.RemoveAll(chunksDir))
 	}()
 
 	appendTestData(t, h.Appender(context.Background()), 1e6)

--- a/pkg/store/proxy_test.go
+++ b/pkg/store/proxy_test.go
@@ -1740,9 +1740,7 @@ func BenchmarkProxySeries(b *testing.B) {
 }
 
 func benchProxySeries(t testutil.TB, totalSamples, totalSeries int) {
-	tmpDir, err := os.MkdirTemp("", "testorbench-proxyseries")
-	testutil.Ok(t, err)
-	defer func() { testutil.Ok(t, os.RemoveAll(tmpDir)) }()
+	tmpDir := t.TempDir()
 
 	const numOfClients = 4
 

--- a/pkg/store/tsdb_test.go
+++ b/pkg/store/tsdb_test.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"math"
 	"math/rand"
-	"os"
 	"sort"
 	"testing"
 
@@ -229,11 +228,7 @@ func (s *delegatorServer) Delegate(c io.Closer) {
 func TestTSDBStore_SeriesAccessWithDelegateClosing(t *testing.T) {
 	t.Skip(skipMessage)
 
-	tmpDir, err := os.MkdirTemp("", "test")
-	testutil.Ok(t, err)
-	t.Cleanup(func() {
-		testutil.Ok(t, os.RemoveAll(tmpDir))
-	})
+	tmpDir := t.TempDir()
 
 	var (
 		random = rand.New(rand.NewSource(120))
@@ -402,11 +397,7 @@ func TestTSDBStore_SeriesAccessWithDelegateClosing(t *testing.T) {
 func TestTSDBStore_SeriesAccessWithoutDelegateClosing(t *testing.T) {
 	t.Skip(skipMessage)
 
-	tmpDir, err := os.MkdirTemp("", "test")
-	testutil.Ok(t, err)
-	t.Cleanup(func() {
-		testutil.Ok(t, os.RemoveAll(tmpDir))
-	})
+	tmpDir := t.TempDir()
 
 	var (
 		random = rand.New(rand.NewSource(120))
@@ -530,11 +521,7 @@ func BenchmarkTSDBStoreSeries(b *testing.B) {
 }
 
 func benchTSDBStoreSeries(t testutil.TB, totalSamples, totalSeries int) {
-	tmpDir, err := os.MkdirTemp("", "testorbench-testtsdbseries")
-	testutil.Ok(t, err)
-	t.Cleanup(func() {
-		testutil.Ok(t, os.RemoveAll(tmpDir))
-	})
+	tmpDir := t.TempDir()
 
 	// This means 3 blocks and the head.
 	const numOfBlocks = 4

--- a/test/e2e/tls_test.go
+++ b/test/e2e/tls_test.go
@@ -40,16 +40,12 @@ func TestGRPCServerCertAutoRotate(t *testing.T) {
 	logger := log.NewLogfmtLogger(os.Stderr)
 	expMessage := "hello world"
 
-	tmpDirClt, err := os.MkdirTemp("", "test-tls-clt")
-	testutil.Ok(t, err)
-	defer func() { testutil.Ok(t, os.RemoveAll(tmpDirClt)) }()
+	tmpDirClt := t.TempDir()
 	caClt := filepath.Join(tmpDirClt, "ca")
 	certClt := filepath.Join(tmpDirClt, "cert")
 	keyClt := filepath.Join(tmpDirClt, "key")
 
-	tmpDirSrv, err := os.MkdirTemp("", "test-tls-srv")
-	testutil.Ok(t, err)
-	defer func() { testutil.Ok(t, os.RemoveAll(tmpDirSrv)) }()
+	tmpDirSrv := t.TempDir()
 	caSrv := filepath.Join(tmpDirSrv, "ca")
 	certSrv := filepath.Join(tmpDirSrv, "cert")
 	keySrv := filepath.Join(tmpDirSrv, "key")


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

A testing cleanup. 

This pull request replaces `os.MkdirTemp` with `t.TempDir`. We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete. 

This saves us at least 2 lines (error check, and cleanup) on every instance, or in some cases adds cleanup that we forgot.

Reference: https://pkg.go.dev/testing#T.TempDir

```go
func TestFoo(t *testing.T) {
	// before
	tmpDir, err := os.MkdirTemp("", "")
	testutil.Ok(t, err)
	defer func() { testutil.Ok(t, os.RemoveAll(dir)) }()

	// now
	tmpDir := t.TempDir()
}
```

## Verification

Tests passed.