### PR TITLE
api: fix race between Respond() and query/queryRange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#5502](https://github.com/thanos-io/thanos/pull/5502) Receive: Handle exemplar storage errors as conflict error.
 - [#5534](https://github.com/thanos-io/thanos/pull/5534) Query: Set struct return by query api alerts same as prometheus api.
 - [#5554](https://github.com/thanos-io/thanos/pull/5554) Query/Receiver: Fix querying exemplars from multi-tenant receivers.
+- [#5583](https://github.com/thanos-io/thanos/pull/5583) Query: fix data race between Respond() and query/queryRange functions. Fixes [#5410](https://github.com/thanos-io/thanos/pull/5410).
 
 ### Added
 

--- a/pkg/api/blocks/v1_test.go
+++ b/pkg/api/blocks/v1_test.go
@@ -71,7 +71,8 @@ func testEndpoint(t *testing.T, test endpointTestCase, name string, responseComp
 			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 		}
 
-		resp, _, apiErr := test.endpoint(req.WithContext(ctx))
+		resp, _, apiErr, releaseResources := test.endpoint(req.WithContext(ctx))
+		defer releaseResources()
 		if apiErr != nil {
 			if test.errType == baseAPI.ErrorNone {
 				t.Fatalf("Unexpected error: %s", apiErr)

--- a/pkg/api/query/v1_test.go
+++ b/pkg/api/query/v1_test.go
@@ -109,7 +109,8 @@ func testEndpoint(t *testing.T, test endpointTestCase, name string, responseComp
 			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 		}
 
-		resp, _, apiErr := test.endpoint(req.WithContext(ctx))
+		resp, _, apiErr, releaseResources := test.endpoint(req.WithContext(ctx))
+		defer releaseResources()
 		if apiErr != nil {
 			if test.errType == baseAPI.ErrorNone {
 				t.Fatalf("Unexpected error: %s", apiErr)
@@ -1781,7 +1782,8 @@ func TestRulesHandler(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			res, errors, apiError := endpoint(req.WithContext(ctx))
+			res, errors, apiError, releaseResources := endpoint(req.WithContext(ctx))
+			defer releaseResources()
 			if errors != nil {
 				t.Fatalf("Unexpected errors: %s", errors)
 				return

--- a/pkg/api/rule/v1.go
+++ b/pkg/api/rule/v1.go
@@ -57,8 +57,8 @@ func (rapi *RuleAPI) Register(r *route.Router, tracer opentracing.Tracer, logger
 
 	instr := api.GetInstr(tracer, logger, ins, logMiddleware, rapi.disableCORS)
 
-	r.Get("/alerts", instr("alerts", func(r *http.Request) (interface{}, []error, *api.ApiError) {
-		return struct{ Alerts []*rulespb.AlertInstance }{Alerts: rapi.alerts.Active()}, nil, nil
+	r.Get("/alerts", instr("alerts", func(r *http.Request) (interface{}, []error, *api.ApiError, func()) {
+		return struct{ Alerts []*rulespb.AlertInstance }{Alerts: rapi.alerts.Active()}, nil, nil, func() {}
 	}))
 	r.Get("/rules", instr("rules", qapi.NewRulesHandler(rapi.ruleGroups, false)))
 }

--- a/pkg/api/status/v1.go
+++ b/pkg/api/status/v1.go
@@ -68,20 +68,20 @@ func (sapi *StatusAPI) Register(r *route.Router, tracer opentracing.Tracer, logg
 	r.Get("/api/v1/status/tsdb", instr("tsdb_status", sapi.httpServeStats))
 }
 
-func (sapi *StatusAPI) httpServeStats(r *http.Request) (interface{}, []error, *api.ApiError) {
+func (sapi *StatusAPI) httpServeStats(r *http.Request) (interface{}, []error, *api.ApiError, func()) {
 	stats, sterr := sapi.getTSDBStats(r, labels.MetricName)
 	if sterr != nil {
-		return nil, nil, sterr
+		return nil, nil, sterr, func() {}
 	}
 
 	result := make([]TSDBStatus, 0, len(stats))
 	if len(stats) == 0 {
-		return result, nil, nil
+		return result, nil, nil, func() {}
 	}
 
 	metrics, err := sapi.registry.Gather()
 	if err != nil {
-		return nil, []error{err}, nil
+		return nil, []error{err}, nil, func() {}
 	}
 
 	tenantChunks := make(map[string]int64)
@@ -121,5 +121,5 @@ func (sapi *StatusAPI) httpServeStats(r *http.Request) (interface{}, []error, *a
 			},
 		})
 	}
-	return result, nil, nil
+	return result, nil, nil, func() {}
 }


### PR DESCRIPTION
Fix a data race between Respond() and query/queryRange functions by
returning an extra optional function from instrumented functions that
releases the resources i.e. calls Close().

Cannot reproduce the following race:

```
==================
WARNING: DATA RACE
Write at 0x00c00566fa00 by goroutine 562:
  github.com/prometheus/prometheus/promql.(*evaluator).eval()
      /home/giedrius/go/pkg/mod/github.com/vinted/prometheus@v1.8.2-0.20220808145920-5c879a061105/promql/engine.go:1450 +0x8044
  github.com/prometheus/prometheus/promql.(*evaluator).rangeEval()
      /home/giedrius/go/pkg/mod/github.com/vinted/prometheus@v1.8.2-0.20220808145920-5c879a061105/promql/engine.go:1060 +0x2684
  github.com/prometheus/prometheus/promql.(*evaluator).eval()
      /home/giedrius/go/pkg/mod/github.com/vinted/prometheus@v1.8.2-0.20220808145920-5c879a061105/promql/engine.go:1281 +0x42a4
  github.com/prometheus/prometheus/promql.(*evaluator).rangeEval()
      /home/giedrius/go/pkg/mod/github.com/vinted/prometheus@v1.8.2-0.20220808145920-5c879a061105/promql/engine.go:1060 +0x2684
  github.com/prometheus/prometheus/promql.(*evaluator).eval()
      /home/giedrius/go/pkg/mod/github.com/vinted/prometheus@v1.8.2-0.20220808145920-5c879a061105/promql/engine.go:1281 +0x42a4
  github.com/prometheus/prometheus/promql.(*evaluator).Eval()
      /home/giedrius/go/pkg/mod/github.com/vinted/prometheus@v1.8.2-0.20220808145920-5c879a061105/promql/engine.go:989 +0xf5
  github.com/prometheus/prometheus/promql.(*Engine).execEvalStmt()
      /home/giedrius/go/pkg/mod/github.com/vinted/prometheus@v1.8.2-0.20220808145920-5c879a061105/promql/engine.go:645 +0xa77
  github.com/prometheus/prometheus/promql.(*Engine).exec()
      /home/giedrius/go/pkg/mod/github.com/vinted/prometheus@v1.8.2-0.20220808145920-5c879a061105/promql/engine.go:595 +0x71e
  github.com/prometheus/prometheus/promql.(*query).Exec()
      /home/giedrius/go/pkg/mod/github.com/vinted/prometheus@v1.8.2-0.20220808145920-5c879a061105/promql/engine.go:197 +0x250
  github.com/thanos-io/thanos/pkg/api/query.(*QueryAPI).query()
      /home/giedrius/dev/thanos/pkg/api/query/v1.go:387 +0xbf2
  github.com/thanos-io/thanos/pkg/api/query.(*QueryAPI).query-fm()

  ...
  Previous read at 0x00c00566fa00 by goroutine 570:
  github.com/prometheus/prometheus/promql.(*Point).MarshalJSON()
      <autogenerated>:1 +0x4e
  encoding/json.addrMarshalerEncoder()
      /usr/lib/go-1.19/src/encoding/json/encode.go:495 +0x1af
  encoding/json.condAddrEncoder.encode()
      /usr/lib/go-1.19/src/encoding/json/encode.go:959 +0x94
  encoding/json.condAddrEncoder.encode-fm()
      <autogenerated>:1 +0xa4
  encoding/json.arrayEncoder.encode()
      /usr/lib/go-1.19/src/encoding/json/encode.go:915 +0x10e
  encoding/json.arrayEncoder.encode-fm()
      <autogenerated>:1 +0x90
  encoding/json.sliceEncoder.encode()

```

Should fix #5501.

Signed-off-by: Giedrius Statkevičius <giedrius.statkevicius@vinted.com>
