### PR TITLE
Filter external labels from matchers on LabelValues/LabelNames

### DIFF
--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -1254,7 +1254,7 @@ func (s *BucketStore) LabelNames(ctx context.Context, req *storepb.LabelNamesReq
 		if len(reqBlockMatchers) > 0 && !b.matchRelabelLabels(reqBlockMatchers) {
 			continue
 		}
-		// filter ext labels
+		// Filter external labels from matchers.
 		reqSeriesMatchersNoExtLabels, ok := b.FilterExtLabelsMatchers(reqSeriesMatchers)
 		if !ok {
 			continue
@@ -1347,17 +1347,16 @@ func (s *BucketStore) LabelNames(ctx context.Context, req *storepb.LabelNamesReq
 }
 
 func (b *bucketBlock) FilterExtLabelsMatchers(matchers []*labels.Matcher) ([]*labels.Matcher, bool) {
-	// we filter external labels from matchers
-	// so it won't try to match series on them.
+	// We filter external labels from matchers so we won't try to match series on them.
 	var result []*labels.Matcher
 	for _, m := range matchers {
-		// get value of external label from block
+		// Get value of external label from block.
 		v := b.extLset.Get(m.Name)
-		// if value is empty string the matcher is a valid one since it's not part of external labels
+		// If value is empty string the matcher is a valid one since it's not part of external labels.
 		if v == "" {
 			result = append(result, m)
 		} else if v != "" && v != m.Value {
-			// if matcher is external label but value is different we don't want to look in block anyway
+			// If matcher is external label but value is different we don't want to look in block anyway.
 			return []*labels.Matcher{}, false
 		}
 	}
@@ -1405,7 +1404,7 @@ func (s *BucketStore) LabelValues(ctx context.Context, req *storepb.LabelValuesR
 		if len(reqBlockMatchers) > 0 && !b.matchRelabelLabels(reqBlockMatchers) {
 			continue
 		}
-		// filter ext labels
+		// Filter external labels from matchers.
 		reqSeriesMatchersNoExtLabels, ok := b.FilterExtLabelsMatchers(reqSeriesMatchers)
 		if !ok {
 			continue

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -1349,7 +1349,7 @@ func (s *BucketStore) LabelNames(ctx context.Context, req *storepb.LabelNamesReq
 func (b *bucketBlock) FilterExtLabelsMatchers(matchers []*labels.Matcher) ([]*labels.Matcher, bool) {
 	// we filter external labels from matchers
 	// so it won't try to match series on them.
-	var result []*labels.Matcher	
+	var result []*labels.Matcher
 	for _, m := range matchers {
 		// get value of external label from block
 		v := b.extLset.Get(m.Name)
@@ -1405,7 +1405,7 @@ func (s *BucketStore) LabelValues(ctx context.Context, req *storepb.LabelValuesR
 		if len(reqBlockMatchers) > 0 && !b.matchRelabelLabels(reqBlockMatchers) {
 			continue
 		}
-				// filter ext labels
+		// filter ext labels
 		reqSeriesMatchersNoExtLabels, ok := b.FilterExtLabelsMatchers(reqSeriesMatchers)
 		if !ok {
 			continue

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -1254,6 +1254,11 @@ func (s *BucketStore) LabelNames(ctx context.Context, req *storepb.LabelNamesReq
 		if len(reqBlockMatchers) > 0 && !b.matchRelabelLabels(reqBlockMatchers) {
 			continue
 		}
+		// filter ext labels
+		reqSeriesMatchersNoExtLabels, ok := b.FilterExtLabelsMatchers(reqSeriesMatchers)
+		if !ok {
+			continue
+		}
 
 		resHints.AddQueriedBlock(b.meta.ULID)
 
@@ -1270,7 +1275,7 @@ func (s *BucketStore) LabelNames(ctx context.Context, req *storepb.LabelNamesReq
 			defer runutil.CloseWithLogOnErr(s.logger, indexr, "label names")
 
 			var result []string
-			if len(reqSeriesMatchers) == 0 {
+			if len(reqSeriesMatchersNoExtLabels) == 0 {
 				// Do it via index reader to have pending reader registered correctly.
 				// LabelNames are already sorted.
 				res, err := indexr.block.indexHeaderReader.LabelNames()
@@ -1288,7 +1293,7 @@ func (s *BucketStore) LabelNames(ctx context.Context, req *storepb.LabelNamesReq
 
 				result = strutil.MergeSlices(res, extRes)
 			} else {
-				seriesSet, _, err := blockSeries(newCtx, b.extLset, indexr, nil, reqSeriesMatchers, nil, seriesLimiter, true, req.Start, req.End, nil, nil)
+				seriesSet, _, err := blockSeries(newCtx, b.extLset, indexr, nil, reqSeriesMatchersNoExtLabels, nil, seriesLimiter, true, req.Start, req.End, nil, nil)
 				if err != nil {
 					return errors.Wrapf(err, "fetch series for block %s", b.meta.ULID)
 				}
@@ -1341,6 +1346,25 @@ func (s *BucketStore) LabelNames(ctx context.Context, req *storepb.LabelNamesReq
 	}, nil
 }
 
+func (b *bucketBlock) FilterExtLabelsMatchers(matchers []*labels.Matcher) ([]*labels.Matcher, bool) {
+	// we filter external labels from matchers
+	// so it won't try to match series on them.
+	var result []*labels.Matcher	
+	for _, m := range matchers {
+		// get value of external label from block
+		v := b.extLset.Get(m.Name)
+		// if value is empty string the matcher is a valid one since it's not part of external labels
+		if v == "" {
+			result = append(result, m)
+		} else if v != "" && v != m.Value {
+			// if matcher is external label but value is different we don't want to look in block anyway
+			return []*labels.Matcher{}, false
+		}
+	}
+
+	return result, true
+}
+
 // LabelValues implements the storepb.StoreServer interface.
 func (s *BucketStore) LabelValues(ctx context.Context, req *storepb.LabelValuesRequest) (*storepb.LabelValuesResponse, error) {
 	reqSeriesMatchers, err := storepb.MatchersToPromMatchers(req.Matchers...)
@@ -1366,16 +1390,6 @@ func (s *BucketStore) LabelValues(ctx context.Context, req *storepb.LabelValuesR
 		}
 	}
 
-	// If we have series matchers, add <labelName> != "" matcher, to only select series that have given label name.
-	if len(reqSeriesMatchers) > 0 {
-		m, err := labels.NewMatcher(labels.MatchNotEqual, req.Label, "")
-		if err != nil {
-			return nil, status.Error(codes.InvalidArgument, err.Error())
-		}
-
-		reqSeriesMatchers = append(reqSeriesMatchers, m)
-	}
-
 	s.mtx.RLock()
 
 	var mtx sync.Mutex
@@ -1390,6 +1404,21 @@ func (s *BucketStore) LabelValues(ctx context.Context, req *storepb.LabelValuesR
 		}
 		if len(reqBlockMatchers) > 0 && !b.matchRelabelLabels(reqBlockMatchers) {
 			continue
+		}
+				// filter ext labels
+		reqSeriesMatchersNoExtLabels, ok := b.FilterExtLabelsMatchers(reqSeriesMatchers)
+		if !ok {
+			continue
+		}
+
+		// If we have series matchers, add <labelName> != "" matcher, to only select series that have given label name.
+		if len(reqSeriesMatchersNoExtLabels) > 0 {
+			m, err := labels.NewMatcher(labels.MatchNotEqual, req.Label, "")
+			if err != nil {
+				return nil, status.Error(codes.InvalidArgument, err.Error())
+			}
+
+			reqSeriesMatchersNoExtLabels = append(reqSeriesMatchersNoExtLabels, m)
 		}
 
 		resHints.AddQueriedBlock(b.meta.ULID)
@@ -1406,7 +1435,7 @@ func (s *BucketStore) LabelValues(ctx context.Context, req *storepb.LabelValuesR
 			defer runutil.CloseWithLogOnErr(s.logger, indexr, "label values")
 
 			var result []string
-			if len(reqSeriesMatchers) == 0 {
+			if len(reqSeriesMatchersNoExtLabels) == 0 {
 				// Do it via index reader to have pending reader registered correctly.
 				res, err := indexr.block.indexHeaderReader.LabelValues(req.Label)
 				if err != nil {
@@ -1419,7 +1448,7 @@ func (s *BucketStore) LabelValues(ctx context.Context, req *storepb.LabelValuesR
 				}
 				result = res
 			} else {
-				seriesSet, _, err := blockSeries(newCtx, b.extLset, indexr, nil, reqSeriesMatchers, nil, seriesLimiter, true, req.Start, req.End, nil, nil)
+				seriesSet, _, err := blockSeries(newCtx, b.extLset, indexr, nil, reqSeriesMatchersNoExtLabels, nil, seriesLimiter, true, req.Start, req.End, nil, nil)
 				if err != nil {
 					return errors.Wrapf(err, "fetch series for block %s", b.meta.ULID)
 				}

--- a/pkg/store/bucket_test.go
+++ b/pkg/store/bucket_test.go
@@ -206,7 +206,7 @@ func TestBucketFilterExtLabelsMatchers(t *testing.T) {
 			},
 		},
 	}
-	b, err := newBucketBlock(context.Background(), log.NewNopLogger(), newBucketStoreMetrics(nil), meta, bkt, path.Join(dir, blockID.String()), nil, nil, nil, nil)
+	b, _ := newBucketBlock(context.Background(), log.NewNopLogger(), newBucketStoreMetrics(nil), meta, bkt, path.Join(dir, blockID.String()), nil, nil, nil, nil)
 	ms := []*labels.Matcher{
 		{Type: labels.MatchNotEqual, Name: "a", Value: "b"},
 	}

--- a/pkg/store/bucket_test.go
+++ b/pkg/store/bucket_test.go
@@ -207,31 +207,31 @@ func TestBucketFilterExtLabelsMatchers(t *testing.T) {
 		},
 	}
 	b, err := newBucketBlock(context.Background(), log.NewNopLogger(), newBucketStoreMetrics(nil), meta, bkt, path.Join(dir, blockID.String()), nil, nil, nil, nil)
-	ms := []*labels.Matcher {
+	ms := []*labels.Matcher{
 		{Type: labels.MatchNotEqual, Name: "a", Value: "b"},
-		}
+	}
 	res, _ := b.FilterExtLabelsMatchers(ms)
 	testutil.Equals(t, len(res), 0)
 
-	ms = []*labels.Matcher {
+	ms = []*labels.Matcher{
 		{Type: labels.MatchNotEqual, Name: "a", Value: "a"},
-		}
+	}
 	_, ok := b.FilterExtLabelsMatchers(ms)
 	testutil.Equals(t, ok, false)
 
-	ms = []*labels.Matcher {
+	ms = []*labels.Matcher{
 		{Type: labels.MatchNotEqual, Name: "a", Value: "a"},
-			{Type: labels.MatchNotEqual, Name: "c", Value: "d"},
-		}
+		{Type: labels.MatchNotEqual, Name: "c", Value: "d"},
+	}
 	res, _ = b.FilterExtLabelsMatchers(ms)
 	testutil.Equals(t, len(res), 0)
 
-	ms = []*labels.Matcher {
+	ms = []*labels.Matcher{
 		{Type: labels.MatchNotEqual, Name: "a2", Value: "a"},
-		}
+	}
 	res, _ = b.FilterExtLabelsMatchers(ms)
 	testutil.Equals(t, len(res), 1)
-	testutil.Equals(t, res, ms)	
+	testutil.Equals(t, res, ms)
 }
 
 func TestBucketBlock_matchLabels(t *testing.T) {


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Filter external labels from matchers in `LabelValues` and `LabelNames` rpcs.
We noticed super high memory spikes in `storegateway` for the label apis and noticed that if there're matchers store will try to fetch series for postings. 
When using `prom-label-proxy` to enforce `tenant_id` label for example, it's propagating to matchers and so going to slow path, since `tenant_id` or any other external label is only presented on `meta.json`, all series would have to be fetched resulting in huge memory spikes (~50Gb and more).

By filtering external labels from matchers we ensure this won't happen and also filtering the blocks that have those external labels but with different values.
<img width="1345" alt="Screen Shot 2022-08-15 at 18 52 44" src="https://user-images.githubusercontent.com/22003688/184669837-54e2935f-1d2e-4ac5-9e53-5669d938b6bf.png">

Tested locally and it solved the issue.

## Verification

<!-- How you tested it? How do you know it works? -->
