### PR TITLE
Query: remove verbose info log

### DIFF
--- a/pkg/store/proxy.go
+++ b/pkg/store/proxy.go
@@ -468,15 +468,6 @@ func startStreamSeriesSet(
 		bytesProcessed := 0
 
 		defer func() {
-			if shardInfo != nil {
-				level.Info(logger).Log("msg", "Done fetching series",
-					"series", seriesStats.Series,
-					"chunks", seriesStats.Chunks,
-					"samples", seriesStats.Samples,
-					"bytes", bytesProcessed,
-				)
-			}
-
 			span.SetTag("processed.series", seriesStats.Series)
 			span.SetTag("processed.chunks", seriesStats.Chunks)
 			span.SetTag("processed.samples", seriesStats.Samples)


### PR DESCRIPTION
An info log used for debugging purposes was accidentally left in
the Querier. This commit removes it.

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

Remove verbose info log.

## Verification

Ran the code locally.