### PR TITLE
Remove hardcoded labels in store shard matcher and inject unshardable label in query analyzer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#5255](https://github.com/thanos-io/thanos/pull/5296) Query: Use k-way merging for the proxying logic. The proxying sub-system now uses much less resources (~25-80% less CPU usage, ~30-50% less RAM usage according to our benchmarks). Reduces query duration by a few percent on queries with lots of series.
 - [#5690](https://github.com/thanos-io/thanos/pull/5690) Compact: update `--debug.accept-malformed-index` flag to apply to downsampling. Previously the flag only applied to compaction, and fatal errors would still occur when downsampling was attempted.
 - [#5707](https://github.com/thanos-io/thanos/pull/5707) Objstore: Update objstore to latest version which includes a refactored Azure Storage Account implementation with a new SDK.
+- [#5641](https://github.com/thanos-io/thanos/pull/5641) Store: Remove hardcoded labels in shard matcher.
+- [#5641](https://github.com/thanos-io/thanos/pull/5641) Query: Inject unshardable le label in query analyzer.
 
 ### Removed
 

--- a/pkg/querysharding/analyzer_test.go
+++ b/pkg/querysharding/analyzer_test.go
@@ -156,6 +156,11 @@ sum by (container) (
 http_requests_total`,
 			shardingLabels: []string{"cluster", "pod"},
 		},
+		{
+			name:           "histogram quantile",
+			expression:     "histogram_quantile(0.95, sum(rate(metric[1m])) without (le, cluster))",
+			shardingLabels: []string{"cluster"},
+		},
 	}
 
 	for _, test := range nonShardable {

--- a/pkg/store/storepb/shard_info.go
+++ b/pkg/store/storepb/shard_info.go
@@ -42,11 +42,6 @@ func (s *ShardMatcher) MatchesZLabels(zLabels []labelpb.ZLabel) bool {
 
 	*s.buf = (*s.buf)[:0]
 	for _, lbl := range zLabels {
-		// Exclude metric name and le label from sharding
-		if lbl.Name == "__name__" || lbl.Name == "le" {
-			continue
-		}
-
 		if shardByLabel(s.shardingLabelset, lbl, s.by) {
 			*s.buf = append(*s.buf, lbl.Name...)
 			*s.buf = append(*s.buf, sep[0])


### PR DESCRIPTION
Signed-off-by: haanhvu <haanh6594@gmail.com>

fixes #5625

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Remove hardcoded `__name__` label in store shard matcher to make it shardable. Inject unshardable `le` label in query analyzer.

## Verification