### PR TITLE
Receiver: Fix labels debug logging in writer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#5534](https://github.com/thanos-io/thanos/pull/5534) Query: Set struct return by query api alerts same as prometheus api.
 - [#5554](https://github.com/thanos-io/thanos/pull/5554) Query/Receiver: Fix querying exemplars from multi-tenant receivers.
 - [#5583](https://github.com/thanos-io/thanos/pull/5583) Query: fix data race between Respond() and query/queryRange functions. Fixes [#5410](https://github.com/thanos-io/thanos/pull/5410).
+- [#5642](https://github.com/thanos-io/thanos/pull/5642) Receive: Log labels correctly in writer debug messages.
 
 ### Added
 

--- a/pkg/receive/writer.go
+++ b/pkg/receive/writer.go
@@ -78,16 +78,17 @@ func (r *Writer) Write(ctx context.Context, tenantID string, wreq *prompb.WriteR
 		// Check if time series labels are valid. If not, skip the time series
 		// and report the error.
 		if err := labelpb.ValidateLabels(t.Labels); err != nil {
+			lset := &labelpb.ZLabelSet{Labels: t.Labels}
 			switch err {
 			case labelpb.ErrOutOfOrderLabels:
 				numLabelsOutOfOrder++
-				level.Debug(tLogger).Log("msg", "Out of order labels in the label set", "lset", t.Labels)
+				level.Debug(tLogger).Log("msg", "Out of order labels in the label set", "lset", lset.String())
 			case labelpb.ErrDuplicateLabels:
 				numLabelsDuplicates++
-				level.Debug(tLogger).Log("msg", "Duplicate labels in the label set", "lset", t.Labels)
+				level.Debug(tLogger).Log("msg", "Duplicate labels in the label set", "lset", lset.String())
 			case labelpb.ErrEmptyLabels:
 				numLabelsEmpty++
-				level.Debug(tLogger).Log("msg", "Labels with empty name in the label set", "lset", t.Labels)
+				level.Debug(tLogger).Log("msg", "Labels with empty name in the label set", "lset", lset.String())
 			default:
 				level.Debug(tLogger).Log("msg", "Error validating labels", "err", err)
 			}


### PR DESCRIPTION
Signed-off-by: Matej Gera <matejgera@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [X] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

We're seeing a bunch of `unsupported value type` lines in our logs. This fixes the issue by first converting the labels to string.

## Verification

Ran local test and confirmed debug logs are correct.
