### PR TITLE
Cache vertical shards in query frontend

### DIFF
--- a/pkg/queryfrontend/cache.go
+++ b/pkg/queryfrontend/cache.go
@@ -33,11 +33,19 @@ func (t thanosCacheKeyGenerator) GenerateCacheKey(userID string, r queryrange.Re
 		i := 0
 		for ; i < len(t.resolutions) && t.resolutions[i] > tr.MaxSourceResolution; i++ {
 		}
-		return fmt.Sprintf("fe:%s:%s:%d:%d:%d", userID, tr.Query, tr.Step, currentInterval, i)
+		shardInfoKey := generateShardInfoKey(tr)
+		return fmt.Sprintf("fe:%s:%s:%d:%d:%d:%s", userID, tr.Query, tr.Step, currentInterval, i, shardInfoKey)
 	case *ThanosLabelsRequest:
 		return fmt.Sprintf("fe:%s:%s:%s:%d", userID, tr.Label, tr.Matchers, currentInterval)
 	case *ThanosSeriesRequest:
 		return fmt.Sprintf("fe:%s:%s:%d", userID, tr.Matchers, currentInterval)
 	}
 	return fmt.Sprintf("fe:%s:%s:%d:%d", userID, r.GetQuery(), r.GetStep(), currentInterval)
+}
+
+func generateShardInfoKey(r *ThanosQueryRangeRequest) string {
+	if r.ShardInfo == nil {
+		return "-"
+	}
+	return fmt.Sprintf("%d:%d", r.ShardInfo.TotalShards, r.ShardInfo.ShardIndex)
 }

--- a/pkg/queryfrontend/cache_test.go
+++ b/pkg/queryfrontend/cache_test.go
@@ -37,7 +37,7 @@ func TestGenerateCacheKey(t *testing.T) {
 				Start: 0,
 				Step:  60 * seconds,
 			},
-			expected: "fe::up:60000:0:2",
+			expected: "fe::up:60000:0:2:-",
 		},
 		{
 			name: "10s step",
@@ -46,7 +46,7 @@ func TestGenerateCacheKey(t *testing.T) {
 				Start: 0,
 				Step:  10 * seconds,
 			},
-			expected: "fe::up:10000:0:2",
+			expected: "fe::up:10000:0:2:-",
 		},
 		{
 			name: "1m downsampling resolution",
@@ -56,7 +56,7 @@ func TestGenerateCacheKey(t *testing.T) {
 				Step:                10 * seconds,
 				MaxSourceResolution: 60 * seconds,
 			},
-			expected: "fe::up:10000:0:2",
+			expected: "fe::up:10000:0:2:-",
 		},
 		{
 			name: "5m downsampling resolution, different cache key",
@@ -66,7 +66,7 @@ func TestGenerateCacheKey(t *testing.T) {
 				Step:                10 * seconds,
 				MaxSourceResolution: 300 * seconds,
 			},
-			expected: "fe::up:10000:0:1",
+			expected: "fe::up:10000:0:1:-",
 		},
 		{
 			name: "1h downsampling resolution, different cache key",
@@ -76,7 +76,7 @@ func TestGenerateCacheKey(t *testing.T) {
 				Step:                10 * seconds,
 				MaxSourceResolution: hour,
 			},
-			expected: "fe::up:10000:0:0",
+			expected: "fe::up:10000:0:0:-",
 		},
 		{
 			name: "label names, no matcher",
@@ -134,7 +134,9 @@ func TestGenerateCacheKey(t *testing.T) {
 			expected: `fe::up:[[foo="bar"] [baz="qux"]]:0`,
 		},
 	} {
-		key := splitter.GenerateCacheKey("", tc.req)
-		testutil.Equals(t, tc.expected, key)
+		t.Run(tc.name, func(t *testing.T) {
+			key := splitter.GenerateCacheKey("", tc.req)
+			testutil.Equals(t, tc.expected, key)
+		})
 	}
 }

--- a/pkg/queryfrontend/roundtrip.go
+++ b/pkg/queryfrontend/roundtrip.go
@@ -191,6 +191,13 @@ func newQueryRangeTripperware(
 		)
 	}
 
+	if numShards > 0 {
+		queryRangeMiddleware = append(
+			queryRangeMiddleware,
+			PromQLShardingMiddleware(querysharding.NewQueryAnalyzer(), numShards, limits, codec, reg),
+		)
+	}
+
 	if config.ResultsCacheConfig != nil {
 		queryCacheMiddleware, _, err := queryrange.NewResultsCacheMiddleware(
 			logger,
@@ -219,13 +226,6 @@ func newQueryRangeTripperware(
 			queryRangeMiddleware,
 			queryrange.InstrumentMiddleware("retry", m),
 			queryrange.NewRetryMiddleware(logger, config.MaxRetries, queryrange.NewRetryMiddlewareMetrics(reg)),
-		)
-	}
-
-	if numShards > 0 {
-		queryRangeMiddleware = append(
-			queryRangeMiddleware,
-			PromQLShardingMiddleware(querysharding.NewQueryAnalyzer(), numShards, limits, codec, reg),
 		)
 	}
 


### PR DESCRIPTION
The vertical sharding middleware is currently executed after the
caching middleware. Because of this, individual vertical shards are
not getting cached when the succeed. Caching is only done when the
entire requests including all shards complete successfully.

This commit moves the vertical sharding middleware before the caching
middleware. It also modifies caching keys to contain the total shards
and the shard number so that each vertical shard gets an independent
caching key.

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

Enable caching in query frontend for individual vertical shards.

## Verification

Added unit tests and tests locally by purposefully causing failures in queriers.