### PR TITLE
Query Frontend: dynamic horizontal query sharding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 ### Added
 * [#5654](https://github.com/thanos-io/thanos/pull/5654) Query: add `--grpc-compression` flag that controls the compression used in gRPC client. With the flag it is now possible to compress the traffic between Query and StoreAPI nodes - you get lower network usage in exchange for a bit higher CPU/RAM usage.
 - [#5650](https://github.com/thanos-io/thanos/pull/5650) Query Frontend: Add sharded queries metrics.
-- [#5658](https://github.com/thanos-io/thanos/pull/5658) Query Frontend: Introduce new parameters to implement more dynamic horizontal query splitting.
+- [#5658](https://github.com/thanos-io/thanos/pull/5658) Query Frontend: Introduce new optional parameters (`query-range.min-split-interval`, `query-range.max-split-interval`, `query-range.horizontal-shards`) to implement more dynamic horizontal query splitting.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 ### Added
 * [#5654](https://github.com/thanos-io/thanos/pull/5654) Query: add `--grpc-compression` flag that controls the compression used in gRPC client. With the flag it is now possible to compress the traffic between Query and StoreAPI nodes - you get lower network usage in exchange for a bit higher CPU/RAM usage.
 - [#5650](https://github.com/thanos-io/thanos/pull/5650) Query Frontend: Add sharded queries metrics.
-- [#5658](https://github.com/thanos-io/thanos/pull/5658) Query/Query Frontend: Introduce new parameters to implement more dynamic horizontal query splitting.
+- [#5658](https://github.com/thanos-io/thanos/pull/5658) Query Frontend: Introduce new parameters to implement more dynamic horizontal query splitting.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 ### Added
 * [#5654](https://github.com/thanos-io/thanos/pull/5654) Query: add `--grpc-compression` flag that controls the compression used in gRPC client. With the flag it is now possible to compress the traffic between Query and StoreAPI nodes - you get lower network usage in exchange for a bit higher CPU/RAM usage.
 - [#5650](https://github.com/thanos-io/thanos/pull/5650) Query Frontend: Add sharded queries metrics.
+- [#5658](https://github.com/thanos-io/thanos/pull/5658) Query/Query Frontend: Introduce new parameters to implement more dynamic horizontal query splitting.
 
 ### Changed
 

--- a/cmd/thanos/query_frontend.go
+++ b/cmd/thanos/query_frontend.go
@@ -73,8 +73,13 @@ func registerQueryFrontend(app *extkingpin.App) {
 	cmd.Flag("query-range.request-downsampled", "Make additional query for downsampled data in case of empty or incomplete response to range request.").
 		Default("true").BoolVar(&cfg.QueryRangeConfig.RequestDownsampled)
 
-	cmd.Flag("query-range.split-interval", "Split query range requests by an interval and execute in parallel, it should be greater than 0 when query-range.response-cache-config is configured.").
+	cmd.Flag("query-range.split-interval", "Split query range requests by an interval and execute in parallel, it should be greater than 0 when query-range.response-cache-config is configured."+
+		"When used in conjunction with query-range.min-split-interval this becomes the upper boundary interval to split queries into.").
 		Default("24h").DurationVar(&cfg.QueryRangeConfig.SplitQueriesByInterval)
+
+	cmd.Flag("query-range.min-split-interval", "Split query range requests by at least this interval."+
+		"It also should be less than query-range.split-interval.").
+		Default("0").DurationVar(&cfg.QueryRangeConfig.MinQuerySplitInterval)
 
 	cmd.Flag("query-range.max-retries-per-request", "Maximum number of retries for a single query range request; beyond this, the downstream error is returned.").
 		Default("5").IntVar(&cfg.QueryRangeConfig.MaxRetries)

--- a/cmd/thanos/query_frontend.go
+++ b/cmd/thanos/query_frontend.go
@@ -81,7 +81,7 @@ func registerQueryFrontend(app *extkingpin.App) {
 		"One should also set query-range.split-min-horizontal-shards to a value greater than 1 to enable splitting.").
 		Default("0").DurationVar(&cfg.QueryRangeConfig.MinQuerySplitInterval)
 
-	cmd.Flag("query-range.max-split-interval", "Split query range bellow this interval in query-range.horizontal-shards. Queries with a range longer than this value will be split in multiple requests of this length.").
+	cmd.Flag("query-range.max-split-interval", "Split query range below this interval in query-range.horizontal-shards. Queries with a range longer than this value will be split in multiple requests of this length.").
 		Default("0").DurationVar(&cfg.QueryRangeConfig.MaxQuerySplitInterval)
 
 	cmd.Flag("query-range.horizontal-shards", "Split queries in this many requests when query duration is below query-range.max-split-interval.").

--- a/cmd/thanos/query_frontend.go
+++ b/cmd/thanos/query_frontend.go
@@ -76,15 +76,15 @@ func registerQueryFrontend(app *extkingpin.App) {
 	cmd.Flag("query-range.split-interval", "Split query range requests by an interval and execute in parallel, it should be greater than 0 when query-range.response-cache-config is configured.").
 		Default("24h").DurationVar(&cfg.QueryRangeConfig.SplitQueriesByInterval)
 
-	cmd.Flag("query-range.split-threshold", "Split query range requests which duration are over this threshold. Using this parameter is not allowed with query-range.split-interval. "+
+	cmd.Flag("query-range.min-split-interval", "Split query range requests which duration are over this threshold. Using this parameter is not allowed with query-range.split-interval. "+
 		"One should also set query-range.split-min-horizontal-shards to a value greater than 1 to enable splitting.").
-		Default("0").DurationVar(&cfg.QueryRangeConfig.QuerySplitThresholdInterval)
+		Default("0").DurationVar(&cfg.QueryRangeConfig.MinQuerySplitInterval)
 
 	cmd.Flag("query-range.max-split-interval", "Split query range requests using this interval. If the query duration is shorter than this value, then use query-range.split-min-horizontal-shards to split query.").
 		Default("0").DurationVar(&cfg.QueryRangeConfig.MaxQuerySplitInterval)
 
-	cmd.Flag("query-range.split-min-horizontal-shards", "Split queries in at least this amount of vertical shards, only when query duration is below query-range.max-split-interval.").
-		Default("0").Int64Var(&cfg.QueryRangeConfig.MinHorizontalShards)
+	cmd.Flag("query-range.horizontal-shards", "Split queries in at least this amount of vertical shards, only when query duration is below query-range.max-split-interval.").
+		Default("0").Int64Var(&cfg.QueryRangeConfig.HorizontalShards)
 
 	cmd.Flag("query-range.max-retries-per-request", "Maximum number of retries for a single query range request; beyond this, the downstream error is returned.").
 		Default("5").IntVar(&cfg.QueryRangeConfig.MaxRetries)

--- a/cmd/thanos/query_frontend.go
+++ b/cmd/thanos/query_frontend.go
@@ -76,14 +76,15 @@ func registerQueryFrontend(app *extkingpin.App) {
 	cmd.Flag("query-range.split-interval", "Split query range requests by an interval and execute in parallel, it should be greater than 0 when query-range.response-cache-config is configured.").
 		Default("24h").DurationVar(&cfg.QueryRangeConfig.SplitQueriesByInterval)
 
-	cmd.Flag("query-range.min-split-interval", "Split query range requests which duration are over this threshold. Using this parameter is not allowed with query-range.split-interval. "+
+	cmd.Flag("query-range.min-split-interval", "Split query range requests above this interval in query-range.horizontal-shards requests of equal range. "+
+		"Using this parameter is not allowed with query-range.split-interval. "+
 		"One should also set query-range.split-min-horizontal-shards to a value greater than 1 to enable splitting.").
 		Default("0").DurationVar(&cfg.QueryRangeConfig.MinQuerySplitInterval)
 
-	cmd.Flag("query-range.max-split-interval", "Split query range requests using this interval. If the query duration is shorter than this value, then use query-range.split-min-horizontal-shards to split query.").
+	cmd.Flag("query-range.max-split-interval", "Split query range bellow this interval in query-range.horizontal-shards. Queries with a range longer than this value will be split in multiple requests of this length.").
 		Default("0").DurationVar(&cfg.QueryRangeConfig.MaxQuerySplitInterval)
 
-	cmd.Flag("query-range.horizontal-shards", "Split queries in at least this amount of vertical shards, only when query duration is below query-range.max-split-interval.").
+	cmd.Flag("query-range.horizontal-shards", "Split queries in this many requests when query duration is below query-range.max-split-interval.").
 		Default("0").Int64Var(&cfg.QueryRangeConfig.HorizontalShards)
 
 	cmd.Flag("query-range.max-retries-per-request", "Maximum number of retries for a single query range request; beyond this, the downstream error is returned.").

--- a/cmd/thanos/query_frontend.go
+++ b/cmd/thanos/query_frontend.go
@@ -76,9 +76,15 @@ func registerQueryFrontend(app *extkingpin.App) {
 	cmd.Flag("query-range.split-interval", "Split query range requests by an interval and execute in parallel, it should be greater than 0 when query-range.response-cache-config is configured.").
 		Default("24h").DurationVar(&cfg.QueryRangeConfig.SplitQueriesByInterval)
 
-	cmd.Flag("query-range.min-split-interval", "Split query range requests by at least this interval."+
-		"It also should be less than query-range.split-interval.").
-		Default("0").DurationVar(&cfg.QueryRangeConfig.MinQuerySplitInterval)
+	cmd.Flag("query-range.split-threshold", "Split query range requests which duration are over this threshold. Using this parameter is not allowed with query-range.split-interval. "+
+		"One should also set query-range.split-min-horizontal-shards to a value greater than 1 to enable splitting.").
+		Default("0").DurationVar(&cfg.QueryRangeConfig.QuerySplitThresholdInterval)
+
+	cmd.Flag("query-range.max-split-interval", "Split query range requests using this interval. If the query duration is shorter than this value, then use query-range.split-min-horizontal-shards to split query.").
+		Default("0").DurationVar(&cfg.QueryRangeConfig.MaxQuerySplitInterval)
+
+	cmd.Flag("query-range.split-min-horizontal-shards", "Split queries in at least this amount of vertical shards, only when query duration is below query-range.max-split-interval.").
+		Default("0").Int64Var(&cfg.QueryRangeConfig.MinHorizontalShards)
 
 	cmd.Flag("query-range.max-retries-per-request", "Maximum number of retries for a single query range request; beyond this, the downstream error is returned.").
 		Default("5").IntVar(&cfg.QueryRangeConfig.MaxRetries)

--- a/cmd/thanos/query_frontend.go
+++ b/cmd/thanos/query_frontend.go
@@ -73,8 +73,7 @@ func registerQueryFrontend(app *extkingpin.App) {
 	cmd.Flag("query-range.request-downsampled", "Make additional query for downsampled data in case of empty or incomplete response to range request.").
 		Default("true").BoolVar(&cfg.QueryRangeConfig.RequestDownsampled)
 
-	cmd.Flag("query-range.split-interval", "Split query range requests by an interval and execute in parallel, it should be greater than 0 when query-range.response-cache-config is configured."+
-		"When used in conjunction with query-range.min-split-interval this becomes the upper boundary interval to split queries into.").
+	cmd.Flag("query-range.split-interval", "Split query range requests by an interval and execute in parallel, it should be greater than 0 when query-range.response-cache-config is configured.").
 		Default("24h").DurationVar(&cfg.QueryRangeConfig.SplitQueriesByInterval)
 
 	cmd.Flag("query-range.min-split-interval", "Split query range requests by at least this interval."+

--- a/docs/components/query-frontend.md
+++ b/docs/components/query-frontend.md
@@ -290,6 +290,10 @@ Flags:
                                  Maximum number of retries for a single query
                                  range request; beyond this, the downstream
                                  error is returned.
+      --query-range.min-split-interval=0
+                                 Split query range requests by at least this
+                                 interval.It also should be less than
+                                 query-range.split-interval.
       --query-range.partial-response
                                  Enable partial response for query range
                                  requests if no partial_response param is
@@ -315,7 +319,9 @@ Flags:
                                  Split query range requests by an interval and
                                  execute in parallel, it should be greater than
                                  0 when query-range.response-cache-config is
-                                 configured.
+                                 configured.When used in conjunction with
+                                 query-range.min-split-interval this becomes the
+                                 upper boundary interval to split queries into.
       --request.logging-config=<content>
                                  Alternative to 'request.logging-config-file'
                                  flag (mutually exclusive). Content of YAML file

--- a/docs/components/query-frontend.md
+++ b/docs/components/query-frontend.md
@@ -295,7 +295,7 @@ Flags:
                                  range request; beyond this, the downstream
                                  error is returned.
       --query-range.max-split-interval=0
-                                 Split query range bellow this interval in
+                                 Split query range below this interval in
                                  query-range.horizontal-shards. Queries with a
                                  range longer than this value will be split in
                                  multiple requests of this length.

--- a/docs/components/query-frontend.md
+++ b/docs/components/query-frontend.md
@@ -281,9 +281,9 @@ Flags:
                                  cache-ability. Note: Grafana dashboards do that
                                  by default.
       --query-range.horizontal-shards=0
-                                 Split queries in at least this amount of
-                                 vertical shards, only when query duration is
-                                 below query-range.max-split-interval.
+                                 Split queries in this many requests when query
+                                 duration is below
+                                 query-range.max-split-interval.
       --query-range.max-query-length=0
                                  Limit the query time range (end - start time)
                                  in the query-frontend, 0 disables it.
@@ -295,16 +295,16 @@ Flags:
                                  range request; beyond this, the downstream
                                  error is returned.
       --query-range.max-split-interval=0
-                                 Split query range requests using this interval.
-                                 If the query duration is shorter than this
-                                 value, then use
-                                 query-range.split-min-horizontal-shards to
-                                 split query.
+                                 Split query range bellow this interval in
+                                 query-range.horizontal-shards. Queries with a
+                                 range longer than this value will be split in
+                                 multiple requests of this length.
       --query-range.min-split-interval=0
-                                 Split query range requests which duration are
-                                 over this threshold. Using this parameter is
-                                 not allowed with query-range.split-interval.
-                                 One should also set
+                                 Split query range requests above this interval
+                                 in query-range.horizontal-shards requests of
+                                 equal range. Using this parameter is not
+                                 allowed with query-range.split-interval. One
+                                 should also set
                                  query-range.split-min-horizontal-shards to a
                                  value greater than 1 to enable splitting.
       --query-range.partial-response

--- a/docs/components/query-frontend.md
+++ b/docs/components/query-frontend.md
@@ -280,6 +280,10 @@ Flags:
                                  and end with their step for better
                                  cache-ability. Note: Grafana dashboards do that
                                  by default.
+      --query-range.horizontal-shards=0
+                                 Split queries in at least this amount of
+                                 vertical shards, only when query duration is
+                                 below query-range.max-split-interval.
       --query-range.max-query-length=0
                                  Limit the query time range (end - start time)
                                  in the query-frontend, 0 disables it.
@@ -296,6 +300,13 @@ Flags:
                                  value, then use
                                  query-range.split-min-horizontal-shards to
                                  split query.
+      --query-range.min-split-interval=0
+                                 Split query range requests which duration are
+                                 over this threshold. Using this parameter is
+                                 not allowed with query-range.split-interval.
+                                 One should also set
+                                 query-range.split-min-horizontal-shards to a
+                                 value greater than 1 to enable splitting.
       --query-range.partial-response
                                  Enable partial response for query range
                                  requests if no partial_response param is
@@ -322,17 +333,6 @@ Flags:
                                  execute in parallel, it should be greater than
                                  0 when query-range.response-cache-config is
                                  configured.
-      --query-range.split-min-horizontal-shards=0
-                                 Split queries in at least this amount of
-                                 vertical shards, only when query duration is
-                                 below query-range.max-split-interval.
-      --query-range.split-threshold=0
-                                 Split query range requests which duration are
-                                 over this threshold. Using this parameter is
-                                 not allowed with query-range.split-interval.
-                                 One should also set
-                                 query-range.split-min-horizontal-shards to a
-                                 value greater than 1 to enable splitting.
       --request.logging-config=<content>
                                  Alternative to 'request.logging-config-file'
                                  flag (mutually exclusive). Content of YAML file

--- a/docs/components/query-frontend.md
+++ b/docs/components/query-frontend.md
@@ -290,10 +290,12 @@ Flags:
                                  Maximum number of retries for a single query
                                  range request; beyond this, the downstream
                                  error is returned.
-      --query-range.min-split-interval=0
-                                 Split query range requests by at least this
-                                 interval.It also should be less than
-                                 query-range.split-interval.
+      --query-range.max-split-interval=0
+                                 Split query range requests using this interval.
+                                 If the query duration is shorter than this
+                                 value, then use
+                                 query-range.split-min-horizontal-shards to
+                                 split query.
       --query-range.partial-response
                                  Enable partial response for query range
                                  requests if no partial_response param is
@@ -319,9 +321,18 @@ Flags:
                                  Split query range requests by an interval and
                                  execute in parallel, it should be greater than
                                  0 when query-range.response-cache-config is
-                                 configured.When used in conjunction with
-                                 query-range.min-split-interval this becomes the
-                                 upper boundary interval to split queries into.
+                                 configured.
+      --query-range.split-min-horizontal-shards=0
+                                 Split queries in at least this amount of
+                                 vertical shards, only when query duration is
+                                 below query-range.max-split-interval.
+      --query-range.split-threshold=0
+                                 Split query range requests which duration are
+                                 over this threshold. Using this parameter is
+                                 not allowed with query-range.split-interval.
+                                 One should also set
+                                 query-range.split-min-horizontal-shards to a
+                                 value greater than 1 to enable splitting.
       --request.logging-config=<content>
                                  Alternative to 'request.logging-config-file'
                                  flag (mutually exclusive). Content of YAML file

--- a/pkg/queryfrontend/config.go
+++ b/pkg/queryfrontend/config.go
@@ -219,6 +219,7 @@ type QueryRangeConfig struct {
 	AlignRangeWithStep     bool
 	RequestDownsampled     bool
 	SplitQueriesByInterval time.Duration
+	MinQuerySplitInterval  time.Duration
 	MaxRetries             int
 	Limits                 *cortexvalidation.Limits
 }

--- a/pkg/queryfrontend/config.go
+++ b/pkg/queryfrontend/config.go
@@ -245,8 +245,8 @@ type LabelsConfig struct {
 // Validate a fully initialized config.
 func (cfg *Config) Validate() error {
 	if cfg.QueryRangeConfig.ResultsCacheConfig != nil {
-		if cfg.QueryRangeConfig.SplitQueriesByInterval <= 0 || cfg.QueryRangeConfig.QuerySplitThresholdInterval <= 0 {
-			return errors.New("split queries interval should be greater than 0 when caching is enabled")
+		if cfg.QueryRangeConfig.SplitQueriesByInterval <= 0 && cfg.QueryRangeConfig.QuerySplitThresholdInterval <= 0 {
+			return errors.New("split queries  or split threshold interval should be greater than 0 when caching is enabled")
 		}
 		if err := cfg.QueryRangeConfig.ResultsCacheConfig.Validate(querier.Config{}); err != nil {
 			return errors.Wrap(err, "invalid ResultsCache config for query_range tripperware")

--- a/pkg/queryfrontend/config.go
+++ b/pkg/queryfrontend/config.go
@@ -219,6 +219,7 @@ type QueryRangeConfig struct {
 	AlignRangeWithStep     bool
 	RequestDownsampled     bool
 	SplitQueriesByInterval time.Duration
+	MaxHorizontalShards    int
 	MinQuerySplitInterval  time.Duration
 	MaxRetries             int
 	Limits                 *cortexvalidation.Limits
@@ -249,6 +250,10 @@ func (cfg *Config) Validate() error {
 		if err := cfg.QueryRangeConfig.ResultsCacheConfig.Validate(querier.Config{}); err != nil {
 			return errors.Wrap(err, "invalid ResultsCache config for query_range tripperware")
 		}
+	}
+
+	if cfg.QueryRangeConfig.MinQuerySplitInterval != 0 && cfg.QueryRangeConfig.SplitQueriesByInterval != 0 {
+		return errors.New("split queries interval and dynamic query split interval cannot be set at the same time")
 	}
 
 	if cfg.LabelsConfig.ResultsCacheConfig != nil {

--- a/pkg/queryfrontend/config.go
+++ b/pkg/queryfrontend/config.go
@@ -246,7 +246,7 @@ type LabelsConfig struct {
 func (cfg *Config) Validate() error {
 	if cfg.QueryRangeConfig.ResultsCacheConfig != nil {
 		if cfg.QueryRangeConfig.SplitQueriesByInterval <= 0 && !cfg.isDynamicSplitSet() {
-			return errors.New("split queries  or split threshold interval should be greater than 0 when caching is enabled")
+			return errors.New("split queries or split threshold interval should be greater than 0 when caching is enabled")
 		}
 		if err := cfg.QueryRangeConfig.ResultsCacheConfig.Validate(querier.Config{}); err != nil {
 			return errors.Wrap(err, "invalid ResultsCache config for query_range tripperware")
@@ -258,8 +258,8 @@ func (cfg *Config) Validate() error {
 	}
 
 	if cfg.isDynamicSplitSet() {
-		err := cfg.validateDynamicSplitParams()
-		if err != nil {
+
+		if err := cfg.validateDynamicSplitParams(); err != nil {
 			return err
 		}
 	}

--- a/pkg/queryfrontend/config_test.go
+++ b/pkg/queryfrontend/config_test.go
@@ -4,9 +4,10 @@
 package queryfrontend
 
 import (
-	"github.com/thanos-io/thanos/pkg/testutil"
 	"testing"
 	"time"
+
+	"github.com/thanos-io/thanos/pkg/testutil"
 )
 
 func TestConfig_Validate(t *testing.T) {
@@ -22,12 +23,35 @@ func TestConfig_Validate(t *testing.T) {
 			name: "invalid query range options",
 			config: Config{
 				QueryRangeConfig: QueryRangeConfig{
-					SplitQueriesByInterval: 10 * time.Hour,
-					MaxHorizontalShards:    10,
-					MinQuerySplitInterval:  1 * time.Hour,
+					SplitQueriesByInterval:      10 * time.Hour,
+					MinHorizontalShards:         10,
+					QuerySplitThresholdInterval: 1 * time.Hour,
 				},
 			},
 			err: "split queries interval and dynamic query split interval cannot be set at the same time",
+		},
+		{
+			name: "invalid parameters for dynamic query range split",
+			config: Config{
+				QueryRangeConfig: QueryRangeConfig{
+					SplitQueriesByInterval:      0,
+					MinHorizontalShards:         0,
+					QuerySplitThresholdInterval: 1 * time.Hour,
+				},
+			},
+			err: "min horizontal shards should be greater than 0 when query split threshold is enabled",
+		},
+		{
+			name: "invalid parameters for dynamic query range split - 2",
+			config: Config{
+				QueryRangeConfig: QueryRangeConfig{
+					SplitQueriesByInterval:      0,
+					MinHorizontalShards:         10,
+					MaxQuerySplitInterval:       0,
+					QuerySplitThresholdInterval: 1 * time.Hour,
+				},
+			},
+			err: "max query split interval should be greater than 0 when query split threshold is enabled",
 		},
 	}
 
@@ -42,5 +66,4 @@ func TestConfig_Validate(t *testing.T) {
 			}
 		})
 	}
-
 }

--- a/pkg/queryfrontend/config_test.go
+++ b/pkg/queryfrontend/config_test.go
@@ -1,0 +1,46 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package queryfrontend
+
+import (
+	"github.com/thanos-io/thanos/pkg/testutil"
+	"testing"
+	"time"
+)
+
+func TestConfig_Validate(t *testing.T) {
+
+	type testCase struct {
+		name   string
+		config Config
+		err    string
+	}
+
+	testCases := []testCase{
+		{
+			name: "invalid query range options",
+			config: Config{
+				QueryRangeConfig: QueryRangeConfig{
+					SplitQueriesByInterval: 10 * time.Hour,
+					MaxHorizontalShards:    10,
+					MinQuerySplitInterval:  1 * time.Hour,
+				},
+			},
+			err: "split queries interval and dynamic query split interval cannot be set at the same time",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.config.Validate()
+			if tc.err != "" {
+				testutil.NotOk(t, err)
+				testutil.Equals(t, tc.err, err.Error())
+			} else {
+				testutil.Ok(t, err)
+			}
+		})
+	}
+
+}

--- a/pkg/queryfrontend/config_test.go
+++ b/pkg/queryfrontend/config_test.go
@@ -4,6 +4,9 @@
 package queryfrontend
 
 import (
+	"fmt"
+	"github.com/thanos-io/thanos/internal/cortex/chunk/cache"
+	"github.com/thanos-io/thanos/internal/cortex/querier/queryrange"
 	"testing"
 	"time"
 
@@ -53,6 +56,27 @@ func TestConfig_Validate(t *testing.T) {
 			},
 			err: "max query split interval should be greater than 0 when query split threshold is enabled",
 		},
+		{
+			name: "valid config with caching",
+			config: Config{
+				DownstreamURL: "localhost:8080",
+				QueryRangeConfig: QueryRangeConfig{
+					SplitQueriesByInterval:      10 * time.Hour,
+					MinHorizontalShards:         0,
+					MaxQuerySplitInterval:       0,
+					QuerySplitThresholdInterval: 0,
+					ResultsCacheConfig: &queryrange.ResultsCacheConfig{
+						CacheConfig:                cache.Config{},
+						Compression:                "",
+						CacheQueryableSamplesStats: false,
+					},
+				},
+				LabelsConfig: LabelsConfig{
+					DefaultTimeRange: day,
+				},
+			},
+			err: "",
+		},
 	}
 
 	for _, tc := range testCases {
@@ -63,6 +87,7 @@ func TestConfig_Validate(t *testing.T) {
 				testutil.Equals(t, tc.err, err.Error())
 			} else {
 				testutil.Ok(t, err)
+				fmt.Println(err)
 			}
 		})
 	}

--- a/pkg/queryfrontend/config_test.go
+++ b/pkg/queryfrontend/config_test.go
@@ -5,11 +5,11 @@ package queryfrontend
 
 import (
 	"fmt"
-	"github.com/thanos-io/thanos/internal/cortex/chunk/cache"
-	"github.com/thanos-io/thanos/internal/cortex/querier/queryrange"
 	"testing"
 	"time"
 
+	"github.com/thanos-io/thanos/internal/cortex/chunk/cache"
+	"github.com/thanos-io/thanos/internal/cortex/querier/queryrange"
 	"github.com/thanos-io/thanos/pkg/testutil"
 )
 

--- a/pkg/queryfrontend/config_test.go
+++ b/pkg/queryfrontend/config_test.go
@@ -26,9 +26,10 @@ func TestConfig_Validate(t *testing.T) {
 			name: "invalid query range options",
 			config: Config{
 				QueryRangeConfig: QueryRangeConfig{
-					SplitQueriesByInterval:      10 * time.Hour,
-					MinHorizontalShards:         10,
-					QuerySplitThresholdInterval: 1 * time.Hour,
+					SplitQueriesByInterval: 10 * time.Hour,
+					HorizontalShards:       10,
+					MinQuerySplitInterval:  1 * time.Hour,
+					MaxQuerySplitInterval:  day,
 				},
 			},
 			err: "split queries interval and dynamic query split interval cannot be set at the same time",
@@ -37,9 +38,9 @@ func TestConfig_Validate(t *testing.T) {
 			name: "invalid parameters for dynamic query range split",
 			config: Config{
 				QueryRangeConfig: QueryRangeConfig{
-					SplitQueriesByInterval:      0,
-					MinHorizontalShards:         0,
-					QuerySplitThresholdInterval: 1 * time.Hour,
+					SplitQueriesByInterval: 0,
+					HorizontalShards:       0,
+					MinQuerySplitInterval:  1 * time.Hour,
 				},
 			},
 			err: "min horizontal shards should be greater than 0 when query split threshold is enabled",
@@ -48,23 +49,38 @@ func TestConfig_Validate(t *testing.T) {
 			name: "invalid parameters for dynamic query range split - 2",
 			config: Config{
 				QueryRangeConfig: QueryRangeConfig{
-					SplitQueriesByInterval:      0,
-					MinHorizontalShards:         10,
-					MaxQuerySplitInterval:       0,
-					QuerySplitThresholdInterval: 1 * time.Hour,
+					SplitQueriesByInterval: 0,
+					HorizontalShards:       10,
+					MaxQuerySplitInterval:  0,
+					MinQuerySplitInterval:  1 * time.Hour,
 				},
 			},
 			err: "max query split interval should be greater than 0 when query split threshold is enabled",
+		},
+		{
+			name: "invalid parameters for dynamic query range split - 3",
+			config: Config{
+				QueryRangeConfig: QueryRangeConfig{
+					SplitQueriesByInterval: 0,
+					HorizontalShards:       10,
+					MaxQuerySplitInterval:  1 * time.Hour,
+					MinQuerySplitInterval:  0,
+				},
+				LabelsConfig: LabelsConfig{
+					DefaultTimeRange: day,
+				},
+			},
+			err: "min query split interval should be greater than 0 when query split threshold is enabled",
 		},
 		{
 			name: "valid config with caching",
 			config: Config{
 				DownstreamURL: "localhost:8080",
 				QueryRangeConfig: QueryRangeConfig{
-					SplitQueriesByInterval:      10 * time.Hour,
-					MinHorizontalShards:         0,
-					MaxQuerySplitInterval:       0,
-					QuerySplitThresholdInterval: 0,
+					SplitQueriesByInterval: 10 * time.Hour,
+					HorizontalShards:       0,
+					MaxQuerySplitInterval:  0,
+					MinQuerySplitInterval:  0,
 					ResultsCacheConfig: &queryrange.ResultsCacheConfig{
 						CacheConfig:                cache.Config{},
 						Compression:                "",

--- a/pkg/queryfrontend/roundtrip.go
+++ b/pkg/queryfrontend/roundtrip.go
@@ -179,7 +179,7 @@ func newQueryRangeTripperware(
 		)
 	}
 
-	if config.SplitQueriesByInterval != 0 || config.QuerySplitThresholdInterval != 0 {
+	if config.SplitQueriesByInterval != 0 || config.MinQuerySplitInterval != 0 {
 		queryIntervalFn := dynamicIntervalFn(config)
 
 		queryRangeMiddleware = append(
@@ -248,8 +248,8 @@ func dynamicIntervalFn(config QueryRangeConfig) queryrange.IntervalFn {
 			return config.MaxQuerySplitInterval
 		}
 
-		// if the query duration is less than max interval, we split it equally in MinHorizontalShards.
-		return time.Duration(queryInterval.Milliseconds()/config.MinHorizontalShards) * time.Millisecond
+		// if the query duration is less than max interval, we split it equally in HorizontalShards.
+		return time.Duration(queryInterval.Milliseconds()/config.HorizontalShards) * time.Millisecond
 	}
 }
 

--- a/pkg/queryfrontend/roundtrip.go
+++ b/pkg/queryfrontend/roundtrip.go
@@ -243,12 +243,12 @@ func dynamicIntervalFn(config QueryRangeConfig) queryrange.IntervalFn {
 		}
 
 		queryInterval := time.Duration(r.GetEnd()-r.GetStart()) * time.Millisecond
-		// if the query is multiple of max interval, we use the max interval to split.
+		// If the query is multiple of max interval, we use the max interval to split.
 		if queryInterval/config.MaxQuerySplitInterval >= 2 {
 			return config.MaxQuerySplitInterval
 		}
 
-		// if the query duration is less than max interval, we split it equally in HorizontalShards.
+		// If the query duration is less than max interval, we split it equally in HorizontalShards.
 		return time.Duration(queryInterval.Milliseconds()/config.HorizontalShards) * time.Millisecond
 	}
 }

--- a/pkg/queryfrontend/roundtrip.go
+++ b/pkg/queryfrontend/roundtrip.go
@@ -248,8 +248,12 @@ func dynamicIntervalFn(config QueryRangeConfig) queryrange.IntervalFn {
 			return config.MaxQuerySplitInterval
 		}
 
-		// If the query duration is less than max interval, we split it equally in HorizontalShards.
-		return time.Duration(queryInterval.Milliseconds()/config.HorizontalShards) * time.Millisecond
+		if queryInterval > config.MinQuerySplitInterval {
+			// If the query duration is less than max interval, we split it equally in HorizontalShards.
+			return time.Duration(queryInterval.Milliseconds()/config.HorizontalShards) * time.Millisecond
+		}
+
+		return config.MinQuerySplitInterval
 	}
 }
 

--- a/pkg/queryfrontend/roundtrip_test.go
+++ b/pkg/queryfrontend/roundtrip_test.go
@@ -351,11 +351,11 @@ func TestRoundTripSplitIntervalMiddleware(t *testing.T) {
 			tpw, err := NewTripperware(
 				Config{
 					QueryRangeConfig: QueryRangeConfig{
-						Limits:                      defaultLimits,
-						SplitQueriesByInterval:      tc.splitInterval,
-						QuerySplitThresholdInterval: tc.querySplitThreshold,
-						MaxQuerySplitInterval:       tc.maxSplitInterval,
-						MinHorizontalShards:         tc.minHorizontalShards,
+						Limits:                 defaultLimits,
+						SplitQueriesByInterval: tc.splitInterval,
+						MinQuerySplitInterval:  tc.querySplitThreshold,
+						MaxQuerySplitInterval:  tc.maxSplitInterval,
+						HorizontalShards:       tc.minHorizontalShards,
 					},
 					LabelsConfig: LabelsConfig{
 						Limits:                 defaultLimits,

--- a/pkg/queryfrontend/roundtrip_test.go
+++ b/pkg/queryfrontend/roundtrip_test.go
@@ -306,14 +306,6 @@ func TestRoundTripSplitIntervalMiddleware(t *testing.T) {
 			expected:            2,
 		},
 		{
-			name:          "split to 2 requests, due to split interval",
-			req:           testRequest,
-			handlerFunc:   promqlResults,
-			codec:         queryRangeCodec,
-			splitInterval: 1 * time.Hour,
-			expected:      2,
-		},
-		{
 			name:          "labels request won't be split",
 			req:           testLabelsRequest,
 			handlerFunc:   labelsResults,

--- a/pkg/queryfrontend/roundtrip_test.go
+++ b/pkg/queryfrontend/roundtrip_test.go
@@ -306,6 +306,17 @@ func TestRoundTripSplitIntervalMiddleware(t *testing.T) {
 			expected:            2,
 		},
 		{
+			name:                "split to 2 requests, due to maxSplitInterval",
+			req:                 testRequest,
+			handlerFunc:         promqlResults,
+			codec:               queryRangeCodec,
+			splitInterval:       0,
+			querySplitThreshold: 2 * time.Hour,
+			maxSplitInterval:    4 * time.Hour,
+			minHorizontalShards: 4,
+			expected:            1,
+		},
+		{
 			name:          "labels request won't be split",
 			req:           testLabelsRequest,
 			handlerFunc:   labelsResults,


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Summary

This is a possible solution for the issue #5617.
Closes #5617.

## Changes

- Adds new CLI parameter for QFE to allow a lower boundary for query horizontal split
- When queries have a duration above this threshold, they will be split into either a minimum number of horizontal shards or an upper bound interval (for longer queries).

## Verification

The modification was only on the Query Range middleware, I introduced more test cases to test the new behavior.
I also added more validation for new parameters and tests to cover it. 

