### PR TITLE
query frontend, store: Add TLS support to redis_client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#5658](https://github.com/thanos-io/thanos/pull/5658) Query Frontend: Introduce new optional parameters (`query-range.min-split-interval`, `query-range.max-split-interval`, `query-range.horizontal-shards`) to implement more dynamic horizontal query splitting.
 - [#5721](https://github.com/thanos-io/thanos/pull/5721) Store: Add metric `thanos_bucket_store_empty_postings_total` for number of empty postings when fetching series.
 - [#5723](https://github.com/thanos-io/thanos/pull/5723) Compactor: Support disable block viewer UI.
+- [#5674](https://github.com/thanos-io/thanos/pull/5674) Query Frontend/Store: Add support connecting to redis using TLS.
 
 ### Changed
 

--- a/docs/components/query-frontend.md
+++ b/docs/components/query-frontend.md
@@ -125,6 +125,13 @@ config:
   get_multi_batch_size: 100
   max_set_multi_concurrency: 100
   set_multi_batch_size: 100
+  tls_enabled: false
+  tls_config:
+    ca_file: ""
+    cert_file: ""
+    key_file: ""
+    server_name: ""
+    insecure_skip_verify: false
   expiration: 24h0m0s
 ```
 

--- a/docs/components/store.md
+++ b/docs/components/store.md
@@ -328,6 +328,13 @@ config:
   get_multi_batch_size: 100
   max_set_multi_concurrency: 100
   set_multi_batch_size: 100
+  tls_enabled: false
+  tls_config:
+    ca_file: ""
+    cert_file: ""
+    key_file: ""
+    server_name: ""
+    insecure_skip_verify: false
 ```
 
 The **required** settings are:
@@ -336,8 +343,8 @@ The **required** settings are:
 
 While the remaining settings are **optional**:
 
-- `username`: the username to connect redis, only redis 6.0 and grater need this field.
-- `password`: the password to connect redis.
+- `username`: the username to connect to redis, only redis 6.0 and grater need this field.
+- `password`: the password to connect to redis.
 - `db`: the database to be selected after connecting to the server.
 - `dial_timeout`: the redis dial timeout.
 - `read_timeout`: the redis read timeout.
@@ -350,6 +357,13 @@ While the remaining settings are **optional**:
 - `get_multi_batch_size`: specifies the maximum size per batch for mget.
 - `max_set_multi_concurrency`: specifies the maximum number of concurrent SetMulti() operations.
 - `set_multi_batch_size`: specifies the maximum size per batch for pipeline set.
+- `tls_enabled`: enables the use of TLS to connect to redis
+- `tls_config`: TLS connection configuration:
+  - `ca_file`: path to Root CA certificate file to use
+  - `cert_file`: path to Client Certificate file to use
+  - `key_file`: path to the Key file for cert_file (NOTE: Both this and `cert_file` must be set if used)
+  - `servername`: Override the server name used to validate the server certificate
+  - `insecure_skip_verify`: Disable certificate verification
 
 ## Caching Bucket
 


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Adds support for TLS connections to redis (Fixes #5310)
Modified original PR #5312 to use NewConfigClient as per [pharau](https://github.com/thanos-io/thanos/pull/5312#discussion_r869511210)
~~Adds tls_client_cert, tls_client_key and tls_ca_cert options for Client Certificate and custom Root CA.~~
Adds tls_enabled and reuses tls_config struct from http to configure specifics.

## Verification
Expanded unit tests to validate new configuration
