### PR TITLE
Route parse errors from sharding through normal api path

### DIFF
--- a/pkg/queryfrontend/shard_query.go
+++ b/pkg/queryfrontend/shard_query.go
@@ -55,11 +55,8 @@ type querySharder struct {
 
 func (s querySharder) Do(ctx context.Context, r queryrange.Request) (queryrange.Response, error) {
 	analysis, err := s.queryAnalyzer.Analyze(r.GetQuery())
-	if err != nil {
-		return nil, err
-	}
 
-	if !analysis.IsShardable() {
+	if err != nil || !analysis.IsShardable() {
 		s.queriesTotal.WithLabelValues("false").Inc()
 		return s.next.Do(ctx, r)
 	}


### PR DESCRIPTION
When the parser used in the querySharder encounters a parse error, it returns that error back through to the API without the normal api error wrapper.  This results in parse errors being sent back with a 500 response code rather than a 400 response code, and the UI (thanos ui, grafana) treats errors as a generic server error rather than a client-side error.

Fixes #5683 

Signed-off-by: Samuel Dufel <samuel.dufel@shopify.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes
Break out of the sharding middleware in the event of a parse error and pass the request along the chain to ensure that all api errors are processed in the same location.

<!-- Enumerate changes you made -->

## Verification
Manually verified api responses before and after the change