### PR TITLE
Receive: Make head series limiting config per tenant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#5255](https://github.com/thanos-io/thanos/pull/5296) Query: Use k-way merging for the proxying logic. The proxying sub-system now uses much less resources (~25-80% less CPU usage, ~30-50% less RAM usage according to our benchmarks). Reduces query duration by a few percent on queries with lots of series.
 - [#5690](https://github.com/thanos-io/thanos/pull/5690) Compact: update `--debug.accept-malformed-index` flag to apply to downsampling. Previously the flag only applied to compaction, and fatal errors would still occur when downsampling was attempted.
 - [#5707](https://github.com/thanos-io/thanos/pull/5707) Objstore: Update objstore to latest version which includes a refactored Azure Storage Account implementation with a new SDK.
+- [#5685](https://github.com/thanos-io/thanos/pull/5685) Receive: Make active/head series limiting configuration per tenant by adding it to new limiting config.
 
 ### Removed
 

--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -370,7 +370,7 @@ func runReceive(
 			ctx, cancel := context.WithCancel(context.Background())
 			g.Add(func() error {
 				return runutil.Repeat(15*time.Second, ctx.Done(), func() error {
-					if err := webHandler.Limiter.HeadSeriesLimiter.QueryMetaMonitoring(ctx, log.With(logger, "component", "receive-meta-monitoring")); err != nil {
+					if err := webHandler.Limiter.HeadSeriesLimiter.QueryMetaMonitoring(ctx); err != nil {
 						level.Error(logger).Log("msg", "failed to query meta-monitoring", "err", err.Error())
 					}
 					return nil

--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -370,7 +370,7 @@ func runReceive(
 			ctx, cancel := context.WithCancel(context.Background())
 			g.Add(func() error {
 				return runutil.Repeat(15*time.Second, ctx.Done(), func() error {
-					if err := webHandler.Limiter.ActiveSeriesLimiter.QueryMetaMonitoring(ctx, log.With(logger, "component", "receive-meta-monitoring")); err != nil {
+					if err := webHandler.Limiter.HeadSeriesLimiter.QueryMetaMonitoring(ctx, log.With(logger, "component", "receive-meta-monitoring")); err != nil {
 						level.Error(logger).Log("msg", "failed to query meta-monitoring", "err", err.Error())
 					}
 					return nil

--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -5,7 +5,6 @@ package main
 
 import (
 	"context"
-	"net/url"
 	"os"
 	"path"
 	"strings"
@@ -206,9 +205,6 @@ func runReceive(
 		}
 	}
 
-	// Impose active series limit only if Receiver is in Router or RouterIngestor mode, and config is provided.
-	seriesLimitSupported := (receiveMode == receive.RouterOnly || receiveMode == receive.RouterIngestor) && conf.maxPerTenantLimit != 0
-
 	dbs := receive.NewMultiTSDB(
 		conf.dataDir,
 		logger,
@@ -222,28 +218,23 @@ func runReceive(
 	)
 	writer := receive.NewWriter(log.With(logger, "component", "receive-writer"), dbs)
 	webHandler := receive.NewHandler(log.With(logger, "component", "receive-handler"), &receive.Options{
-		Writer:                   writer,
-		ListenAddress:            conf.rwAddress,
-		Registry:                 reg,
-		Endpoint:                 conf.endpoint,
-		TenantHeader:             conf.tenantHeader,
-		TenantField:              conf.tenantField,
-		DefaultTenantID:          conf.defaultTenantID,
-		ReplicaHeader:            conf.replicaHeader,
-		ReplicationFactor:        conf.replicationFactor,
-		RelabelConfigs:           relabelConfig,
-		ReceiverMode:             receiveMode,
-		Tracer:                   tracer,
-		TLSConfig:                rwTLSConfig,
-		DialOpts:                 dialOpts,
-		ForwardTimeout:           time.Duration(*conf.forwardTimeout),
-		TSDBStats:                dbs,
-		LimitsConfig:             limitsConfig,
-		SeriesLimitSupported:     seriesLimitSupported,
-		MaxPerTenantLimit:        conf.maxPerTenantLimit,
-		MetaMonitoringUrl:        conf.metaMonitoringUrl,
-		MetaMonitoringHttpClient: conf.metaMonitoringHttpClient,
-		MetaMonitoringLimitQuery: conf.metaMonitoringLimitQuery,
+		Writer:            writer,
+		ListenAddress:     conf.rwAddress,
+		Registry:          reg,
+		Endpoint:          conf.endpoint,
+		TenantHeader:      conf.tenantHeader,
+		TenantField:       conf.tenantField,
+		DefaultTenantID:   conf.defaultTenantID,
+		ReplicaHeader:     conf.replicaHeader,
+		ReplicationFactor: conf.replicationFactor,
+		RelabelConfigs:    relabelConfig,
+		ReceiverMode:      receiveMode,
+		Tracer:            tracer,
+		TLSConfig:         rwTLSConfig,
+		DialOpts:          dialOpts,
+		ForwardTimeout:    time.Duration(*conf.forwardTimeout),
+		TSDBStats:         dbs,
+		LimitsConfig:      limitsConfig,
 	})
 
 	grpcProbe := prober.NewGRPC()
@@ -373,13 +364,13 @@ func runReceive(
 		)
 	}
 
-	if seriesLimitSupported {
+	if len(limitsConfig.WriteLimits.TenantsLimits) != 0 || limitsConfig.WriteLimits.DefaultLimits.HeadSeriesLimit != 0 {
 		level.Info(logger).Log("msg", "setting up periodic (every 15s) meta-monitoring query for limiting cache")
 		{
 			ctx, cancel := context.WithCancel(context.Background())
 			g.Add(func() error {
 				return runutil.Repeat(15*time.Second, ctx.Done(), func() error {
-					if err := webHandler.ActiveSeriesLimit.QueryMetaMonitoring(ctx, log.With(logger, "component", "receive-meta-monitoring")); err != nil {
+					if err := webHandler.Limiter.ActiveSeriesLimiter.QueryMetaMonitoring(ctx, log.With(logger, "component", "receive-meta-monitoring")); err != nil {
 						level.Error(logger).Log("msg", "failed to query meta-monitoring", "err", err.Error())
 					}
 					return nil
@@ -737,11 +728,6 @@ type receiveConfig struct {
 	rwClientServerCA   string
 	rwClientServerName string
 
-	maxPerTenantLimit        uint64
-	metaMonitoringLimitQuery string
-	metaMonitoringUrl        *url.URL
-	metaMonitoringHttpClient *extflag.PathOrContent
-
 	dataDir   string
 	labelStrs []string
 
@@ -841,14 +827,6 @@ func (rc *receiveConfig) registerFlag(cmd extkingpin.FlagClause) {
 	cmd.Flag("receive.grpc-compression", "Compression algorithm to use for gRPC requests to other receivers. Must be one of: "+compressionOptions).Default(snappy.Name).EnumVar(&rc.compression, snappy.Name, compressionNone)
 
 	cmd.Flag("receive.replication-factor", "How many times to replicate incoming write requests.").Default("1").Uint64Var(&rc.replicationFactor)
-
-	cmd.Flag("receive.tenant-limits.max-head-series", "The total number of active (head) series that a tenant is allowed to have within a Receive topology. For more details refer: https://thanos.io/tip/components/receive.md/#limiting").Hidden().Uint64Var(&rc.maxPerTenantLimit)
-
-	cmd.Flag("receive.tenant-limits.meta-monitoring-url", "Meta-monitoring URL which is compatible with Prometheus Query API for active series limiting.").Hidden().URLVar(&rc.metaMonitoringUrl)
-
-	cmd.Flag("receive.tenant-limits.meta-monitoring-query", "PromQL Query to execute against meta-monitoring, to get the current number of active series for each tenant, across Receive replicas.").Default("sum(prometheus_tsdb_head_series) by (tenant)").Hidden().StringVar(&rc.metaMonitoringLimitQuery)
-
-	rc.metaMonitoringHttpClient = extflag.RegisterPathOrContent(cmd, "receive.tenant-limits.meta-monitoring-client", "YAML file or string with http client configs for meta-monitoring.", extflag.WithHidden())
 
 	rc.forwardTimeout = extkingpin.ModelDuration(cmd.Flag("receive-forward-timeout", "Timeout for each forward request.").Default("5s").Hidden())
 

--- a/docs/components/receive.md
+++ b/docs/components/receive.md
@@ -101,16 +101,17 @@ The configuration file follows a few standards:
 
 All the configuration for the remote write endpoint of Receive is contained in the `write` key. Inside it there are 3 subsections:
 
-- `global`: limits and/or gates that are applied considering all the requests.
+- `global`: limits, gates and/or options that are applied considering all the requests.
 - `default`: the default values for limits in case a given tenant doesn't have any specified.
 - `tenants`: the limits for a given tenant.
 
 From the example configuration below, it's understood that:
 
 1. This Receive instance has a max concurrency of 30.
-2. This Receive instance has some default request limits that apply of all tenants, **unless** a given tenant has their own limits (i.e. the `acme` tenant and partially for the `ajax` tenant).
-3. Tenant `acme` has no request limits.
-4. Tenant `ajax` has a request series limit of 50000 and samples limit of 500. Their request size bytes limit is inherited from the default, 1024 bytes.
+2. This Receive instance has head series limiting enabled as it has `meta_monitoring_.*` options in `global`.
+3. This Receive instance has some default request limits as well as head series limits that apply of all tenants, **unless** a given tenant has their own limits (i.e. the `acme` tenant and partially for the `ajax` tenant).
+4. Tenant `acme` has no request limits, but as a higher head_series limit.
+5. Tenant `ajax` has a request series limit of 50000 and samples limit of 500. Their request size bytes limit is inherited from the default, 1024 bytes. Their head series are also inherited from default i.e, 1000.
 
 The next sections explain what each configuration value means.
 
@@ -118,17 +119,21 @@ The next sections explain what each configuration value means.
 write:
   global:
     max_concurrency: 30
+    meta_monitoring_url: "http://localhost:9090"
+    meta_monitoring_limit_query: "sum(prometheus_tsdb_head_series) by (tenant)"
   default:
     request:
       size_bytes_limit: 1024
       series_limit: 1000
       samples_limit: 10
+    head_series_limit: 1000
   tenants:
     acme:
       request:
         size_bytes_limit: 0
         series_limit: 0
         samples_limit: 0
+      head_series_limit: 2000
     ajax:
       request:
         series_limit: 50000
@@ -168,11 +173,15 @@ Thanos Receive, in Router or RouterIngestor mode, supports limiting tenant activ
 
 Every Receive Router/RouterIngestor node, queries meta-monitoring for active series of all tenants, every 15 seconds, and caches the results in a map. This cached result is used to limit all incoming remote write requests.
 
-To use the feature, one should specify the following (hidden) flags:
-- `--receive.tenant-limits.max-head-series`: Specifies the total number of active (head) series for any tenant, across all replicas (including data replication), allowed by Thanos Receive.
-- `--receive.tenant-limits.meta-monitoring-url`: Specifies Prometheus Query API compatible meta-monitoring endpoint.
-- `--receive.tenant-limits.meta-monitoring-query`: Optional flag to specify PromQL query to execute against meta-monitoring.
-- `--receive.tenant-limits.meta-monitoring-client`: Optional YAML file/string specifying HTTP client config for meta-monitoring.
+To use the feature, one should specify the following limiting config options:
+
+Under `global`,
+- `meta_monitoring_url`: Specifies Prometheus Query API compatible meta-monitoring endpoint.
+- `meta_monitoring_limit_query`: Option to specify PromQL query to execute against meta-monitoring. If not specified it is set to `sum(prometheus_tsdb_head_series) by (tenant)` by default.
+- `meta_monitoring_http_client`: Optional YAML field specifying HTTP client config for meta-monitoring.
+
+Under `default` and per `tenant`,
+- `head_series_limit`: Specifies the total number of active (head) series for any tenant, across all replicas (including data replication), allowed by Thanos Receive.
 
 NOTE:
 - It is possible that Receive ingests more active series than the specified limit, as it relies on meta-monitoring, which may not have the latest data for current number of active series of a tenant at all times.

--- a/docs/components/receive.md
+++ b/docs/components/receive.md
@@ -105,12 +105,12 @@ All the configuration for the remote write endpoint of Receive is contained in t
 - `default`: the default values for limits in case a given tenant doesn't have any specified.
 - `tenants`: the limits for a given tenant.
 
-From the example configuration below, it's understood that:
+For a Receive instance with configuration like below, it's understood that:
 
-1. This Receive instance has a max concurrency of 30.
-2. This Receive instance has head series limiting enabled as it has `meta_monitoring_.*` options in `global`.
-3. This Receive instance has some default request limits as well as head series limits that apply of all tenants, **unless** a given tenant has their own limits (i.e. the `acme` tenant and partially for the `ajax` tenant).
-4. Tenant `acme` has no request limits, but as a higher head_series limit.
+1. The Receive instance has a max concurrency of 30.
+2. The Receive instance has head series limiting enabled as it has `meta_monitoring_.*` options in `global`.
+3. The Receive instance has some default request limits as well as head series limits that apply of all tenants, **unless** a given tenant has their own limits (i.e. the `acme` tenant and partially for the `ajax` tenant).
+4. Tenant `acme` has no request limits, but has a higher head_series limit.
 5. Tenant `ajax` has a request series limit of 50000 and samples limit of 500. Their request size bytes limit is inherited from the default, 1024 bytes. Their head series are also inherited from default i.e, 1000.
 
 The next sections explain what each configuration value means.

--- a/docs/components/receive.md
+++ b/docs/components/receive.md
@@ -175,12 +175,12 @@ Every Receive Router/RouterIngestor node, queries meta-monitoring for active ser
 
 To use the feature, one should specify the following limiting config options:
 
-Under `global`,
+Under `global`:
 - `meta_monitoring_url`: Specifies Prometheus Query API compatible meta-monitoring endpoint.
 - `meta_monitoring_limit_query`: Option to specify PromQL query to execute against meta-monitoring. If not specified it is set to `sum(prometheus_tsdb_head_series) by (tenant)` by default.
 - `meta_monitoring_http_client`: Optional YAML field specifying HTTP client config for meta-monitoring.
 
-Under `default` and per `tenant`,
+Under `default` and per `tenant`:
 - `head_series_limit`: Specifies the total number of active (head) series for any tenant, across all replicas (including data replication), allowed by Thanos Receive.
 
 NOTE:

--- a/pkg/httpconfig/http.go
+++ b/pkg/httpconfig/http.go
@@ -86,7 +86,7 @@ type TransportConfig struct {
 	TLSHandshakeTimeout   int64 `yaml:"tls_handshake_timeout"`
 }
 
-var defaultTransportConfig TransportConfig = TransportConfig{
+var DefaultTransportConfig TransportConfig = TransportConfig{
 	MaxIdleConns:          100,
 	MaxIdleConnsPerHost:   2,
 	ResponseHeaderTimeout: 0,
@@ -98,7 +98,7 @@ var defaultTransportConfig TransportConfig = TransportConfig{
 }
 
 func NewClientConfigFromYAML(cfg []byte) (*ClientConfig, error) {
-	conf := &ClientConfig{TransportConfig: defaultTransportConfig}
+	conf := &ClientConfig{TransportConfig: DefaultTransportConfig}
 	if err := yaml.Unmarshal(cfg, conf); err != nil {
 		return nil, err
 	}

--- a/pkg/httpconfig/http.go
+++ b/pkg/httpconfig/http.go
@@ -86,7 +86,7 @@ type TransportConfig struct {
 	TLSHandshakeTimeout   int64 `yaml:"tls_handshake_timeout"`
 }
 
-var DefaultTransportConfig TransportConfig = TransportConfig{
+var defaultTransportConfig TransportConfig = TransportConfig{
 	MaxIdleConns:          100,
 	MaxIdleConnsPerHost:   2,
 	ResponseHeaderTimeout: 0,
@@ -97,8 +97,12 @@ var DefaultTransportConfig TransportConfig = TransportConfig{
 	TLSHandshakeTimeout:   int64(10 * time.Second),
 }
 
+func NewDefaultClientConfig() ClientConfig {
+	return ClientConfig{TransportConfig: defaultTransportConfig}
+}
+
 func NewClientConfigFromYAML(cfg []byte) (*ClientConfig, error) {
-	conf := &ClientConfig{TransportConfig: DefaultTransportConfig}
+	conf := &ClientConfig{TransportConfig: defaultTransportConfig}
 	if err := yaml.Unmarshal(cfg, conf); err != nil {
 		return nil, err
 	}

--- a/pkg/receive/handler.go
+++ b/pkg/receive/handler.go
@@ -417,7 +417,7 @@ func (h *Handler) receiveHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	defer h.Limiter.writeGate.Done()
 
-	under, err := h.Limiter.ActiveSeriesLimiter.isUnderLimit(tenant, tLogger)
+	under, err := h.Limiter.HeadSeriesLimiter.isUnderLimit(tenant, tLogger)
 	if err != nil {
 		level.Error(tLogger).Log("msg", "error while limiting", "err", err.Error())
 	}

--- a/pkg/receive/handler.go
+++ b/pkg/receive/handler.go
@@ -12,18 +12,14 @@ import (
 	stdlog "log"
 	"net"
 	"net/http"
-	"net/url"
 	"sort"
 	"strconv"
 	"sync"
 	"time"
 
-	extflag "github.com/efficientgo/tools/extkingpin"
 	"github.com/thanos-io/thanos/pkg/api"
 	statusapi "github.com/thanos-io/thanos/pkg/api/status"
-	"github.com/thanos-io/thanos/pkg/httpconfig"
 	"github.com/thanos-io/thanos/pkg/logging"
-	"github.com/thanos-io/thanos/pkg/promclient"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
@@ -87,34 +83,23 @@ var (
 
 // Options for the web Handler.
 type Options struct {
-	Writer                   *Writer
-	ListenAddress            string
-	Registry                 *prometheus.Registry
-	TenantHeader             string
-	TenantField              string
-	DefaultTenantID          string
-	ReplicaHeader            string
-	Endpoint                 string
-	ReplicationFactor        uint64
-	ReceiverMode             ReceiverMode
-	Tracer                   opentracing.Tracer
-	TLSConfig                *tls.Config
-	DialOpts                 []grpc.DialOption
-	ForwardTimeout           time.Duration
-	RelabelConfigs           []*relabel.Config
-	TSDBStats                TSDBStats
-	LimitsConfig             *RootLimitsConfig
-	SeriesLimitSupported     bool
-	MaxPerTenantLimit        uint64
-	MetaMonitoringUrl        *url.URL
-	MetaMonitoringHttpClient *extflag.PathOrContent
-	MetaMonitoringLimitQuery string
-}
-
-// activeSeriesLimiter encompasses active series limiting logic.
-type activeSeriesLimiter interface {
-	QueryMetaMonitoring(context.Context, log.Logger) error
-	isUnderLimit(string, log.Logger) (bool, error)
+	Writer            *Writer
+	ListenAddress     string
+	Registry          *prometheus.Registry
+	TenantHeader      string
+	TenantField       string
+	DefaultTenantID   string
+	ReplicaHeader     string
+	Endpoint          string
+	ReplicationFactor uint64
+	ReceiverMode      ReceiverMode
+	Tracer            opentracing.Tracer
+	TLSConfig         *tls.Config
+	DialOpts          []grpc.DialOption
+	ForwardTimeout    time.Duration
+	RelabelConfigs    []*relabel.Config
+	TSDBStats         TSDBStats
+	LimitsConfig      *RootLimitsConfig
 }
 
 // Handler serves a Prometheus remote write receiving HTTP endpoint.
@@ -125,13 +110,12 @@ type Handler struct {
 	options  *Options
 	listener net.Listener
 
-	mtx               sync.RWMutex
-	hashring          Hashring
-	peers             *peerGroup
-	expBackoff        backoff.Backoff
-	peerStates        map[string]*retryState
-	receiverMode      ReceiverMode
-	ActiveSeriesLimit activeSeriesLimiter
+	mtx          sync.RWMutex
+	hashring     Hashring
+	peers        *peerGroup
+	expBackoff   backoff.Backoff
+	peerStates   map[string]*retryState
+	receiverMode ReceiverMode
 
 	forwardRequests   *prometheus.CounterVec
 	replications      *prometheus.CounterVec
@@ -140,7 +124,7 @@ type Handler struct {
 	writeSamplesTotal    *prometheus.HistogramVec
 	writeTimeseriesTotal *prometheus.HistogramVec
 
-	limiter *limiter
+	Limiter *limiter
 }
 
 func NewHandler(logger log.Logger, o *Options) *Handler {
@@ -166,7 +150,7 @@ func NewHandler(logger log.Logger, o *Options) *Handler {
 			Max:    30 * time.Second,
 			Jitter: true,
 		},
-		limiter: newLimiter(o.LimitsConfig, registerer),
+		Limiter: newLimiter(o.LimitsConfig, registerer, o.ReceiverMode, logger),
 		forwardRequests: promauto.With(registerer).NewCounterVec(
 			prometheus.CounterOpts{
 				Name: "thanos_receive_forward_requests_total",
@@ -214,11 +198,6 @@ func NewHandler(logger log.Logger, o *Options) *Handler {
 		h.replicationFactor.Set(float64(o.ReplicationFactor))
 	} else {
 		h.replicationFactor.Set(1)
-	}
-
-	h.ActiveSeriesLimit = NewNopSeriesLimit()
-	if h.options.SeriesLimitSupported {
-		h.ActiveSeriesLimit = NewActiveSeriesLimit(h.options, registerer, h.receiverMode, logger)
 	}
 
 	ins := extpromhttp.NewNopInstrumentationMiddleware()
@@ -429,16 +408,16 @@ func (h *Handler) receiveHTTP(w http.ResponseWriter, r *http.Request) {
 	tLogger := log.With(h.logger, "tenant", tenant)
 
 	tracing.DoInSpan(r.Context(), "receive_write_gate_ismyturn", func(ctx context.Context) {
-		err = h.limiter.writeGate.Start(r.Context())
+		err = h.Limiter.writeGate.Start(r.Context())
 	})
 	if err != nil {
 		level.Error(tLogger).Log("err", err, "msg", "internal server error")
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	defer h.limiter.writeGate.Done()
+	defer h.Limiter.writeGate.Done()
 
-	under, err := h.ActiveSeriesLimit.isUnderLimit(tenant, tLogger)
+	under, err := h.Limiter.ActiveSeriesLimiter.isUnderLimit(tenant, tLogger)
 	if err != nil {
 		level.Error(tLogger).Log("msg", "error while limiting", "err", err.Error())
 	}
@@ -449,7 +428,7 @@ func (h *Handler) receiveHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	requestLimiter := h.limiter.requestLimiter
+	requestLimiter := h.Limiter.requestLimiter
 	// io.ReadAll dynamically adjust the byte slice for read data, starting from 512B.
 	// Since this is receive hot path, grow upfront saving allocations and CPU time.
 	compressed := bytes.Buffer{}
@@ -551,141 +530,6 @@ func (h *Handler) receiveHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	h.writeTimeseriesTotal.WithLabelValues(strconv.Itoa(responseStatusCode), tenant).Observe(float64(len(wreq.Timeseries)))
 	h.writeSamplesTotal.WithLabelValues(strconv.Itoa(responseStatusCode), tenant).Observe(float64(totalSamples))
-}
-
-// activeSeriesLimit implements activeSeriesLimiter interface.
-type activeSeriesLimit struct {
-	mtx                    sync.RWMutex
-	limit                  uint64
-	tenantCurrentSeriesMap map[string]float64
-
-	metaMonitoringURL    *url.URL
-	metaMonitoringClient *http.Client
-	metaMonitoringQuery  string
-
-	configuredTenantLimit prometheus.Gauge
-	limitedRequests       *prometheus.CounterVec
-	metaMonitoringErr     prometheus.Counter
-}
-
-func NewActiveSeriesLimit(o *Options, registerer prometheus.Registerer, r ReceiverMode, logger log.Logger) *activeSeriesLimit {
-	limit := &activeSeriesLimit{
-		limit:               o.MaxPerTenantLimit,
-		metaMonitoringURL:   o.MetaMonitoringUrl,
-		metaMonitoringQuery: o.MetaMonitoringLimitQuery,
-		configuredTenantLimit: promauto.With(registerer).NewGauge(
-			prometheus.GaugeOpts{
-				Name: "thanos_receive_tenant_head_series_limit",
-				Help: "The configured limit for active (head) series of tenants.",
-			},
-		),
-		limitedRequests: promauto.With(registerer).NewCounterVec(
-			prometheus.CounterOpts{
-				Name: "thanos_receive_head_series_limited_requests_total",
-				Help: "The total number of remote write requests that have been dropped due to active series limiting.",
-			}, []string{"tenant"},
-		),
-		metaMonitoringErr: promauto.With(registerer).NewCounter(
-			prometheus.CounterOpts{
-				Name: "thanos_receive_metamonitoring_failed_queries_total",
-				Help: "The total number of meta-monitoring queries that failed while limiting.",
-			},
-		),
-	}
-
-	limit.configuredTenantLimit.Set(float64(o.MaxPerTenantLimit))
-	limit.tenantCurrentSeriesMap = map[string]float64{}
-
-	// Use specified HTTPConfig to make requests to meta-monitoring.
-	httpConfContentYaml, err := o.MetaMonitoringHttpClient.Content()
-	if err != nil {
-		level.Error(logger).Log("msg", "getting http client config", "err", err.Error())
-	}
-
-	httpClientConfig, err := httpconfig.NewClientConfigFromYAML(httpConfContentYaml)
-	if err != nil {
-		level.Error(logger).Log("msg", "parsing http config YAML", "err", err.Error())
-	}
-
-	limit.metaMonitoringClient, err = httpconfig.NewHTTPClient(*httpClientConfig, "meta-mon-for-limit")
-	if err != nil {
-		level.Error(logger).Log("msg", "improper http client config", "err", err.Error())
-	}
-
-	return limit
-}
-
-// QueryMetaMonitoring queries any Prometheus Query API compatible meta-monitoring
-// solution with the configured query for getting current active (head) series of all tenants.
-// It then populates tenantCurrentSeries map with result.
-func (a *activeSeriesLimit) QueryMetaMonitoring(ctx context.Context, logger log.Logger) error {
-	c := promclient.NewWithTracingClient(logger, a.metaMonitoringClient, httpconfig.ThanosUserAgent)
-
-	vectorRes, _, err := c.QueryInstant(ctx, a.metaMonitoringURL, a.metaMonitoringQuery, time.Now(), promclient.QueryOptions{})
-	if err != nil {
-		a.metaMonitoringErr.Inc()
-		return err
-	}
-
-	level.Debug(logger).Log("msg", "successfully queried meta-monitoring", "vectors", len(vectorRes))
-
-	a.mtx.Lock()
-	defer a.mtx.Unlock()
-	// Construct map of tenant name and current HEAD series.
-	for _, e := range vectorRes {
-		for k, v := range e.Metric {
-			if k == "tenant" {
-				a.tenantCurrentSeriesMap[string(v)] = float64(e.Value)
-				level.Debug(logger).Log("msg", "tenant value queried", "tenant", string(v), "value", e.Value)
-			}
-		}
-	}
-
-	return nil
-}
-
-// isUnderLimit ensures that the current number of active series for a tenant does not exceed given limit.
-// It does so in a best-effort way, i.e, in case meta-monitoring is unreachable, it does not impose limits.
-// TODO(saswatamcode): Add capability to configure different limits for different tenants.
-func (a *activeSeriesLimit) isUnderLimit(tenant string, logger log.Logger) (bool, error) {
-	a.mtx.RLock()
-	defer a.mtx.RUnlock()
-	if a.limit == 0 || a.metaMonitoringURL.Host == "" {
-		return true, nil
-	}
-
-	// In such limiting flow, we ingest the first remote write request
-	// and then check meta-monitoring metric to ascertain current active
-	// series. As such metric is updated in intervals, it is possible
-	// that Receive ingests more series than the limit, before detecting that
-	// a tenant has exceeded the set limits.
-	v, ok := a.tenantCurrentSeriesMap[tenant]
-	if !ok {
-		return true, errors.New("tenant not in current series map")
-	}
-
-	if v >= float64(a.limit) {
-		level.Error(logger).Log("msg", "tenant above limit", "currentSeries", v, "limit", a.limit)
-		a.limitedRequests.WithLabelValues(tenant).Inc()
-		return false, nil
-	}
-
-	return true, nil
-}
-
-// nopSeriesLimit implements activeSeriesLimiter interface as no-op.
-type nopSeriesLimit struct{}
-
-func NewNopSeriesLimit() *nopSeriesLimit {
-	return &nopSeriesLimit{}
-}
-
-func (a *nopSeriesLimit) QueryMetaMonitoring(_ context.Context, _ log.Logger) error {
-	return nil
-}
-
-func (a *nopSeriesLimit) isUnderLimit(_ string, _ log.Logger) (bool, error) {
-	return true, nil
 }
 
 // forward accepts a write request, batches its time series by

--- a/pkg/receive/handler.go
+++ b/pkg/receive/handler.go
@@ -417,7 +417,7 @@ func (h *Handler) receiveHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	defer h.Limiter.writeGate.Done()
 
-	under, err := h.Limiter.HeadSeriesLimiter.isUnderLimit(tenant, tLogger)
+	under, err := h.Limiter.HeadSeriesLimiter.isUnderLimit(tenant)
 	if err != nil {
 		level.Error(tLogger).Log("msg", "error while limiting", "err", err.Error())
 	}

--- a/pkg/receive/handler_test.go
+++ b/pkg/receive/handler_test.go
@@ -775,7 +775,7 @@ func TestReceiveWriteRequestLimits(t *testing.T) {
 			handlers, _ := newTestHandlerHashring(appendables, 3)
 			handler := handlers[0]
 			tenant := "test"
-			handler.Limiter = newLimiter(
+			handler.limiter = NewLimiter(
 				&RootLimitsConfig{
 					WriteLimits: WriteLimitsConfig{
 						TenantsLimits: TenantsWriteLimitsConfig{

--- a/pkg/receive/handler_test.go
+++ b/pkg/receive/handler_test.go
@@ -369,6 +369,7 @@ func newTestHandlerHashring(appendables []*fakeAppendable, replicationFactor uin
 			ReplicationFactor: replicationFactor,
 			ForwardTimeout:    5 * time.Second,
 			Writer:            NewWriter(log.NewNopLogger(), newFakeTenantAppendable(appendables[i])),
+			Limiter:           NewLimiter(nil, nil, RouterIngestor, nil),
 		})
 		handlers = append(handlers, h)
 		h.peers = peers

--- a/pkg/receive/handler_test.go
+++ b/pkg/receive/handler_test.go
@@ -775,11 +775,11 @@ func TestReceiveWriteRequestLimits(t *testing.T) {
 			handlers, _ := newTestHandlerHashring(appendables, 3)
 			handler := handlers[0]
 			tenant := "test"
-			handler.limiter = newLimiter(
+			handler.Limiter = newLimiter(
 				&RootLimitsConfig{
-					WriteLimits: writeLimitsConfig{
-						TenantsLimits: tenantsWriteLimitsConfig{
-							tenant: &writeLimitConfig{
+					WriteLimits: WriteLimitsConfig{
+						TenantsLimits: TenantsWriteLimitsConfig{
+							tenant: &WriteLimitConfig{
 								RequestLimits: newEmptyRequestLimitsConfig().
 									SetSizeBytesLimit(int64(1 * units.Megabyte)).
 									SetSeriesLimit(20).
@@ -789,6 +789,8 @@ func TestReceiveWriteRequestLimits(t *testing.T) {
 					},
 				},
 				nil,
+				RouterIngestor,
+				log.NewNopLogger(),
 			)
 
 			wreq := &prompb.WriteRequest{

--- a/pkg/receive/head_series_limiter.go
+++ b/pkg/receive/head_series_limiter.go
@@ -60,7 +60,7 @@ func NewHeadSeriesLimit(w WriteLimitsConfig, registerer prometheus.Registerer, l
 				Help: "The total number of meta-monitoring queries that failed while limiting.",
 			},
 		),
-		logger: log.With(logger, "component", "receive-head-series-limiter"),
+		logger: logger,
 	}
 
 	// Record default limit with empty tenant label.

--- a/pkg/receive/head_series_limiter.go
+++ b/pkg/receive/head_series_limiter.go
@@ -1,0 +1,185 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package receive
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"sync"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/thanos-io/thanos/pkg/errors"
+	"github.com/thanos-io/thanos/pkg/httpconfig"
+	"github.com/thanos-io/thanos/pkg/promclient"
+)
+
+// activeSeriesLimiter encompasses active series limiting logic.
+type activeSeriesLimiter interface {
+	QueryMetaMonitoring(context.Context, log.Logger) error
+	isUnderLimit(string, log.Logger) (bool, error)
+}
+
+// activeSeriesLimit implements activeSeriesLimiter interface.
+type activeSeriesLimit struct {
+	mtx                    sync.RWMutex
+	limit                  map[string]uint64
+	tenantCurrentSeriesMap map[string]float64
+	defaultLimit           uint64
+
+	metaMonitoringURL    *url.URL
+	metaMonitoringClient *http.Client
+	metaMonitoringQuery  string
+
+	configuredTenantLimit  *prometheus.GaugeVec
+	configuredDefaultLimit prometheus.Gauge
+	limitedRequests        *prometheus.CounterVec
+	metaMonitoringErr      prometheus.Counter
+}
+
+func NewActiveSeriesLimit(w WriteLimitsConfig, registerer prometheus.Registerer, logger log.Logger) *activeSeriesLimit {
+	limit := &activeSeriesLimit{
+		metaMonitoringURL:   w.GlobalLimits.metaMonitoringURL,
+		metaMonitoringQuery: w.GlobalLimits.MetaMonitoringLimitQuery,
+		configuredTenantLimit: promauto.With(registerer).NewGaugeVec(
+			prometheus.GaugeOpts{
+				Name: "thanos_receive_tenant_head_series_limit",
+				Help: "The configured limit for active (head) series of tenants.",
+			}, []string{"tenant"},
+		),
+		configuredDefaultLimit: promauto.With(registerer).NewGauge(
+			prometheus.GaugeOpts{
+				Name: "thanos_receive_default_head_series_limit",
+				Help: "The configured default limit for active (head) series of tenants.",
+			},
+		),
+		limitedRequests: promauto.With(registerer).NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "thanos_receive_head_series_limited_requests_total",
+				Help: "The total number of remote write requests that have been dropped due to active series limiting.",
+			}, []string{"tenant"},
+		),
+		metaMonitoringErr: promauto.With(registerer).NewCounter(
+			prometheus.CounterOpts{
+				Name: "thanos_receive_metamonitoring_failed_queries_total",
+				Help: "The total number of meta-monitoring queries that failed while limiting.",
+			},
+		),
+	}
+
+	// Initialize map for configured limits of each tenant.
+	limit.limit = map[string]uint64{}
+	for t, w := range w.TenantsLimits {
+		if w.HeadSeriesLimit != 0 {
+			limit.limit[t] = w.HeadSeriesLimit
+			limit.configuredTenantLimit.WithLabelValues(t).Set(float64(w.HeadSeriesLimit))
+		}
+	}
+
+	if w.DefaultLimits.HeadSeriesLimit != 0 {
+		limit.defaultLimit = w.DefaultLimits.HeadSeriesLimit
+		limit.configuredDefaultLimit.Set(float64(w.DefaultLimits.HeadSeriesLimit))
+	}
+
+	// Initialize map for current head series of each tenant.
+	limit.tenantCurrentSeriesMap = map[string]float64{}
+
+	// Use specified HTTPConfig (if any) to make requests to meta-monitoring.
+	c := httpconfig.ClientConfig{TransportConfig: httpconfig.DefaultTransportConfig}
+	if w.GlobalLimits.MetaMonitoringHTTPClient != nil {
+		c = *w.GlobalLimits.MetaMonitoringHTTPClient
+	}
+
+	var err error
+	limit.metaMonitoringClient, err = httpconfig.NewHTTPClient(c, "meta-mon-for-limit")
+	if err != nil {
+		level.Error(logger).Log("msg", "improper http client config", "err", err.Error())
+	}
+
+	return limit
+}
+
+// QueryMetaMonitoring queries any Prometheus Query API compatible meta-monitoring
+// solution with the configured query for getting current active (head) series of all tenants.
+// It then populates tenantCurrentSeries map with result.
+func (a *activeSeriesLimit) QueryMetaMonitoring(ctx context.Context, logger log.Logger) error {
+	c := promclient.NewWithTracingClient(logger, a.metaMonitoringClient, httpconfig.ThanosUserAgent)
+
+	vectorRes, _, err := c.QueryInstant(ctx, a.metaMonitoringURL, a.metaMonitoringQuery, time.Now(), promclient.QueryOptions{})
+	if err != nil {
+		a.metaMonitoringErr.Inc()
+		return err
+	}
+
+	level.Debug(logger).Log("msg", "successfully queried meta-monitoring", "vectors", len(vectorRes))
+
+	a.mtx.Lock()
+	defer a.mtx.Unlock()
+	// Construct map of tenant name and current head series.
+	for _, e := range vectorRes {
+		for k, v := range e.Metric {
+			if k == "tenant" {
+				a.tenantCurrentSeriesMap[string(v)] = float64(e.Value)
+				level.Debug(logger).Log("msg", "tenant value queried", "tenant", string(v), "value", e.Value)
+			}
+		}
+	}
+
+	return nil
+}
+
+// isUnderLimit ensures that the current number of active series for a tenant does not exceed given limit.
+// It does so in a best-effort way, i.e, in case meta-monitoring is unreachable, it does not impose limits.
+func (a *activeSeriesLimit) isUnderLimit(tenant string, logger log.Logger) (bool, error) {
+	a.mtx.RLock()
+	defer a.mtx.RUnlock()
+	if len(a.limit) == 0 && a.defaultLimit == 0 {
+		return true, nil
+	}
+
+	// In such limiting flow, we ingest the first remote write request
+	// and then check meta-monitoring metric to ascertain current active
+	// series. As such metric is updated in intervals, it is possible
+	// that Receive ingests more series than the limit, before detecting that
+	// a tenant has exceeded the set limits.
+	v, ok := a.tenantCurrentSeriesMap[tenant]
+	if !ok {
+		return true, errors.Newf("tenant not in current series map")
+	}
+
+	// Check if config has specified limits for this tenant. If not specified,
+	// set to default limit.
+	var limit uint64
+	limit, ok = a.limit[tenant]
+	if !ok {
+		limit = a.defaultLimit
+	}
+
+	if v >= float64(limit) {
+		level.Error(logger).Log("msg", "tenant above limit", "currentSeries", v, "limit", limit)
+		a.limitedRequests.WithLabelValues(tenant).Inc()
+		return false, nil
+	}
+
+	return true, nil
+}
+
+// nopSeriesLimit implements activeSeriesLimiter interface as no-op.
+type nopSeriesLimit struct{}
+
+func NewNopSeriesLimit() *nopSeriesLimit {
+	return &nopSeriesLimit{}
+}
+
+func (a *nopSeriesLimit) QueryMetaMonitoring(_ context.Context, _ log.Logger) error {
+	return nil
+}
+
+func (a *nopSeriesLimit) isUnderLimit(_ string, _ log.Logger) (bool, error) {
+	return true, nil
+}

--- a/pkg/receive/limiter.go
+++ b/pkg/receive/limiter.go
@@ -31,7 +31,7 @@ type headSeriesLimiter interface {
 	isUnderLimit(tenant string) (bool, error)
 }
 
-func newLimiter(root *RootLimitsConfig, reg prometheus.Registerer, r ReceiverMode, logger log.Logger) *limiter {
+func NewLimiter(root *RootLimitsConfig, reg prometheus.Registerer, r ReceiverMode, logger log.Logger) *limiter {
 	limiter := &limiter{
 		writeGate:         gate.NewNoop(),
 		requestLimiter:    &noopRequestLimiter{},

--- a/pkg/receive/limiter.go
+++ b/pkg/receive/limiter.go
@@ -4,28 +4,23 @@
 package receive
 
 import (
+	"github.com/go-kit/log"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/thanos-io/thanos/pkg/extprom"
 	"github.com/thanos-io/thanos/pkg/gate"
 )
 
 type limiter struct {
-	requestLimiter requestLimiter
-	writeGate      gate.Gate
-	// TODO: extract active series limiting logic into a self-contained type and
-	// move it here.
+	requestLimiter      requestLimiter
+	writeGate           gate.Gate
+	ActiveSeriesLimiter activeSeriesLimiter
 }
 
-type requestLimiter interface {
-	AllowSizeBytes(tenant string, contentLengthBytes int64) bool
-	AllowSeries(tenant string, amount int64) bool
-	AllowSamples(tenant string, amount int64) bool
-}
-
-func newLimiter(root *RootLimitsConfig, reg prometheus.Registerer) *limiter {
+func newLimiter(root *RootLimitsConfig, reg prometheus.Registerer, r ReceiverMode, logger log.Logger) *limiter {
 	limiter := &limiter{
-		writeGate:      gate.NewNoop(),
-		requestLimiter: &noopRequestLimiter{},
+		writeGate:           gate.NewNoop(),
+		requestLimiter:      &noopRequestLimiter{},
+		ActiveSeriesLimiter: NewNopSeriesLimit(),
 	}
 	if root == nil {
 		return limiter
@@ -42,6 +37,12 @@ func newLimiter(root *RootLimitsConfig, reg prometheus.Registerer) *limiter {
 		)
 	}
 	limiter.requestLimiter = newConfigRequestLimiter(reg, &root.WriteLimits)
+
+	// Impose active series limit only if Receiver is in Router or RouterIngestor mode, and config is provided.
+	seriesLimitSupported := (r == RouterOnly || r == RouterIngestor) && (len(root.WriteLimits.TenantsLimits) != 0 || root.WriteLimits.DefaultLimits.HeadSeriesLimit != 0)
+	if seriesLimitSupported {
+		limiter.ActiveSeriesLimiter = NewActiveSeriesLimit(root.WriteLimits, reg, logger)
+	}
 
 	return limiter
 }

--- a/pkg/receive/limiter.go
+++ b/pkg/receive/limiter.go
@@ -11,16 +11,16 @@ import (
 )
 
 type limiter struct {
-	requestLimiter      requestLimiter
-	writeGate           gate.Gate
-	ActiveSeriesLimiter activeSeriesLimiter
+	requestLimiter    requestLimiter
+	writeGate         gate.Gate
+	HeadSeriesLimiter headSeriesLimiter
 }
 
 func newLimiter(root *RootLimitsConfig, reg prometheus.Registerer, r ReceiverMode, logger log.Logger) *limiter {
 	limiter := &limiter{
-		writeGate:           gate.NewNoop(),
-		requestLimiter:      &noopRequestLimiter{},
-		ActiveSeriesLimiter: NewNopSeriesLimit(),
+		writeGate:         gate.NewNoop(),
+		requestLimiter:    &noopRequestLimiter{},
+		HeadSeriesLimiter: NewNopSeriesLimit(),
 	}
 	if root == nil {
 		return limiter
@@ -41,7 +41,7 @@ func newLimiter(root *RootLimitsConfig, reg prometheus.Registerer, r ReceiverMod
 	// Impose active series limit only if Receiver is in Router or RouterIngestor mode, and config is provided.
 	seriesLimitSupported := (r == RouterOnly || r == RouterIngestor) && (len(root.WriteLimits.TenantsLimits) != 0 || root.WriteLimits.DefaultLimits.HeadSeriesLimit != 0)
 	if seriesLimitSupported {
-		limiter.ActiveSeriesLimiter = NewActiveSeriesLimit(root.WriteLimits, reg, logger)
+		limiter.HeadSeriesLimiter = NewHeadSeriesLimit(root.WriteLimits, reg, logger)
 	}
 
 	return limiter

--- a/pkg/receive/limiter_config.go
+++ b/pkg/receive/limiter_config.go
@@ -85,7 +85,7 @@ type WriteLimitConfig struct {
 	HeadSeriesLimit *uint64 `yaml:"head_series_limit"`
 }
 
-// Utils for initialzing.
+// Utils for initializing.
 func NewEmptyWriteLimitConfig() *WriteLimitConfig {
 	return &WriteLimitConfig{}
 }
@@ -106,7 +106,7 @@ type requestLimitsConfig struct {
 	SamplesLimit   *int64 `yaml:"samples_limit"`
 }
 
-// Utils for initialzing.
+// Utils for initializing.
 func newEmptyRequestLimitsConfig() *requestLimitsConfig {
 	return &requestLimitsConfig{}
 }

--- a/pkg/receive/limiter_config.go
+++ b/pkg/receive/limiter_config.go
@@ -4,14 +4,17 @@
 package receive
 
 import (
+	"net/url"
+
 	"github.com/thanos-io/thanos/pkg/errors"
+	"github.com/thanos-io/thanos/pkg/httpconfig"
 	"gopkg.in/yaml.v2"
 )
 
 // RootLimitsConfig is the root configuration for limits.
 type RootLimitsConfig struct {
 	// WriteLimits hold the limits for writing data.
-	WriteLimits writeLimitsConfig `yaml:"write"`
+	WriteLimits WriteLimitsConfig `yaml:"write"`
 }
 
 // ParseRootLimitConfig parses the root limit configuration. Even though
@@ -21,37 +24,63 @@ func ParseRootLimitConfig(content []byte) (*RootLimitsConfig, error) {
 	if err := yaml.UnmarshalStrict(content, &root); err != nil {
 		return nil, errors.Wrapf(err, "parsing config YAML file")
 	}
+
+	if root.WriteLimits.GlobalLimits.MetaMonitoringURL != "" {
+		u, err := url.Parse(root.WriteLimits.GlobalLimits.MetaMonitoringURL)
+		if err != nil {
+			return nil, errors.Wrapf(err, "parsing meta-monitoring URL")
+		}
+
+		// url.Parse might pass a URL with only path, so need to check here for scheme and host.
+		// As per docs: https://pkg.go.dev/net/url#Parse.
+		if u.Host == "" || u.Scheme == "" {
+			return nil, errors.Newf("%s is not a valid meta-monitoring URL (scheme: %s,host: %s)", u, u.Scheme, u.Host)
+		}
+		root.WriteLimits.GlobalLimits.metaMonitoringURL = u
+	}
+
+	// Set default query if none specified.
+	if root.WriteLimits.GlobalLimits.MetaMonitoringLimitQuery == "" {
+		root.WriteLimits.GlobalLimits.MetaMonitoringLimitQuery = "sum(prometheus_tsdb_head_series) by (tenant)"
+	}
+
 	return &root, nil
 }
 
-type writeLimitsConfig struct {
+type WriteLimitsConfig struct {
 	// GlobalLimits are limits that are shared across all tenants.
-	GlobalLimits globalLimitsConfig `yaml:"global"`
+	GlobalLimits GlobalLimitsConfig `yaml:"global"`
 	// DefaultLimits are the default limits for tenants without specified limits.
-	DefaultLimits defaultLimitsConfig `yaml:"default"`
+	DefaultLimits DefaultLimitsConfig `yaml:"default"`
 	// TenantsLimits are the limits per tenant.
-	TenantsLimits tenantsWriteLimitsConfig `yaml:"tenants"`
+	TenantsLimits TenantsWriteLimitsConfig `yaml:"tenants"`
 }
 
-type globalLimitsConfig struct {
+type GlobalLimitsConfig struct {
 	// MaxConcurrency represents the maximum concurrency during write operations.
 	MaxConcurrency int64 `yaml:"max_concurrency"`
+	// MetaMonitoring options specify the query, url and client for Query API address used in head series limiting.
+	MetaMonitoringURL        string                   `yaml:"meta_monitoring_url"`
+	MetaMonitoringHTTPClient *httpconfig.ClientConfig `yaml:"meta_monitoring_http_client"`
+	MetaMonitoringLimitQuery string                   `yaml:"meta_monitoring_limit_query"`
+
+	metaMonitoringURL *url.URL
 }
 
-type defaultLimitsConfig struct {
+type DefaultLimitsConfig struct {
 	// RequestLimits holds the difficult per-request limits.
 	RequestLimits requestLimitsConfig `yaml:"request"`
-	// HeadSeriesConfig *headSeriesLimiter `yaml:"head_series"`
+	// HeadSeriesLimit specifies the maximum number of head series allowed for any tenant.
+	HeadSeriesLimit uint64 `yaml:"head_series_limit"`
 }
 
-type tenantsWriteLimitsConfig map[string]*writeLimitConfig
+type TenantsWriteLimitsConfig map[string]*WriteLimitConfig
 
-// A tenant might not always have limits configured, so things here must
-// use pointers.
-type writeLimitConfig struct {
+type WriteLimitConfig struct {
 	// RequestLimits holds the difficult per-request limits.
 	RequestLimits *requestLimitsConfig `yaml:"request"`
-	// HeadSeriesConfig *headSeriesLimiter `yaml:"head_series"`
+	// HeadSeriesLimit specifies the maximum number of head series allowed for a tenant.
+	HeadSeriesLimit uint64 `yaml:"head_series_limit"`
 }
 
 type requestLimitsConfig struct {

--- a/pkg/receive/limiter_config.go
+++ b/pkg/receive/limiter_config.go
@@ -47,6 +47,10 @@ func ParseRootLimitConfig(content []byte) (*RootLimitsConfig, error) {
 	return &root, nil
 }
 
+func (r RootLimitsConfig) AreHeadSeriesLimitsConfigured() bool {
+	return r.WriteLimits.GlobalLimits.MetaMonitoringURL != "" && (len(r.WriteLimits.TenantsLimits) != 0 || r.WriteLimits.DefaultLimits.HeadSeriesLimit != 0)
+}
+
 type WriteLimitsConfig struct {
 	// GlobalLimits are limits that are shared across all tenants.
 	GlobalLimits GlobalLimitsConfig `yaml:"global"`

--- a/pkg/receive/limiter_config.go
+++ b/pkg/receive/limiter_config.go
@@ -76,11 +76,28 @@ type DefaultLimitsConfig struct {
 
 type TenantsWriteLimitsConfig map[string]*WriteLimitConfig
 
+// A tenant might not always have limits configured, so things here must
+// use pointers.
 type WriteLimitConfig struct {
 	// RequestLimits holds the difficult per-request limits.
 	RequestLimits *requestLimitsConfig `yaml:"request"`
 	// HeadSeriesLimit specifies the maximum number of head series allowed for a tenant.
-	HeadSeriesLimit uint64 `yaml:"head_series_limit"`
+	HeadSeriesLimit *uint64 `yaml:"head_series_limit"`
+}
+
+// Utils for initialzing.
+func NewEmptyWriteLimitConfig() *WriteLimitConfig {
+	return &WriteLimitConfig{}
+}
+
+func (w *WriteLimitConfig) SetRequestLimits(rl *requestLimitsConfig) *WriteLimitConfig {
+	w.RequestLimits = rl
+	return w
+}
+
+func (w *WriteLimitConfig) SetHeadSeriesLimit(val uint64) *WriteLimitConfig {
+	w.HeadSeriesLimit = &val
+	return w
 }
 
 type requestLimitsConfig struct {
@@ -89,8 +106,24 @@ type requestLimitsConfig struct {
 	SamplesLimit   *int64 `yaml:"samples_limit"`
 }
 
+// Utils for initialzing.
 func newEmptyRequestLimitsConfig() *requestLimitsConfig {
 	return &requestLimitsConfig{}
+}
+
+func (rl *requestLimitsConfig) SetSizeBytesLimit(value int64) *requestLimitsConfig {
+	rl.SizeBytesLimit = &value
+	return rl
+}
+
+func (rl *requestLimitsConfig) SetSeriesLimit(value int64) *requestLimitsConfig {
+	rl.SeriesLimit = &value
+	return rl
+}
+
+func (rl *requestLimitsConfig) SetSamplesLimit(value int64) *requestLimitsConfig {
+	rl.SamplesLimit = &value
+	return rl
 }
 
 // OverlayWith overlays the current configuration with another one. This means
@@ -106,20 +139,5 @@ func (rl *requestLimitsConfig) OverlayWith(other *requestLimitsConfig) *requestL
 	if rl.SizeBytesLimit == nil {
 		rl.SizeBytesLimit = other.SizeBytesLimit
 	}
-	return rl
-}
-
-func (rl *requestLimitsConfig) SetSizeBytesLimit(value int64) *requestLimitsConfig {
-	rl.SizeBytesLimit = &value
-	return rl
-}
-
-func (rl *requestLimitsConfig) SetSeriesLimit(value int64) *requestLimitsConfig {
-	rl.SeriesLimit = &value
-	return rl
-}
-
-func (rl *requestLimitsConfig) SetSamplesLimit(value int64) *requestLimitsConfig {
-	rl.SamplesLimit = &value
 	return rl
 }

--- a/pkg/receive/limiter_config_test.go
+++ b/pkg/receive/limiter_config_test.go
@@ -42,18 +42,20 @@ func TestParseLimiterConfig(t *testing.T) {
 						HeadSeriesLimit: 1000,
 					},
 					TenantsLimits: TenantsWriteLimitsConfig{
-						"acme": &WriteLimitConfig{
-							RequestLimits: newEmptyRequestLimitsConfig().
-								SetSizeBytesLimit(0).
-								SetSeriesLimit(0).
-								SetSamplesLimit(0),
-							HeadSeriesLimit: 2000,
-						},
-						"ajax": &WriteLimitConfig{
-							RequestLimits: newEmptyRequestLimitsConfig().
-								SetSeriesLimit(50000).
-								SetSamplesLimit(500),
-						},
+						"acme": NewEmptyWriteLimitConfig().
+							SetRequestLimits(
+								newEmptyRequestLimitsConfig().
+									SetSizeBytesLimit(0).
+									SetSeriesLimit(0).
+									SetSamplesLimit(0),
+							).
+							SetHeadSeriesLimit(2000),
+						"ajax": NewEmptyWriteLimitConfig().
+							SetRequestLimits(
+								newEmptyRequestLimitsConfig().
+									SetSeriesLimit(50000).
+									SetSamplesLimit(500),
+							),
 					},
 				},
 			},

--- a/pkg/receive/limiter_config_test.go
+++ b/pkg/receive/limiter_config_test.go
@@ -4,6 +4,7 @@
 package receive
 
 import (
+	"net/url"
 	"os"
 	"path"
 	"testing"
@@ -23,22 +24,32 @@ func TestParseLimiterConfig(t *testing.T) {
 			configFileName: "good_limits.yaml",
 			wantErr:        false,
 			want: &RootLimitsConfig{
-				WriteLimits: writeLimitsConfig{
-					GlobalLimits: globalLimitsConfig{MaxConcurrency: 30},
-					DefaultLimits: defaultLimitsConfig{
+				WriteLimits: WriteLimitsConfig{
+					GlobalLimits: GlobalLimitsConfig{
+						MaxConcurrency:           30,
+						MetaMonitoringURL:        "http://localhost:9090",
+						MetaMonitoringLimitQuery: "sum(prometheus_tsdb_head_series) by (tenant)",
+						metaMonitoringURL: &url.URL{
+							Scheme: "http",
+							Host:   "localhost:9090",
+						},
+					},
+					DefaultLimits: DefaultLimitsConfig{
 						RequestLimits: *newEmptyRequestLimitsConfig().
 							SetSizeBytesLimit(1024).
 							SetSeriesLimit(1000).
 							SetSamplesLimit(10),
+						HeadSeriesLimit: 1000,
 					},
-					TenantsLimits: tenantsWriteLimitsConfig{
-						"acme": &writeLimitConfig{
+					TenantsLimits: TenantsWriteLimitsConfig{
+						"acme": &WriteLimitConfig{
 							RequestLimits: newEmptyRequestLimitsConfig().
 								SetSizeBytesLimit(0).
 								SetSeriesLimit(0).
 								SetSamplesLimit(0),
+							HeadSeriesLimit: 2000,
 						},
-						"ajax": &writeLimitConfig{
+						"ajax": &WriteLimitConfig{
 							RequestLimits: newEmptyRequestLimitsConfig().
 								SetSeriesLimit(50000).
 								SetSamplesLimit(500),

--- a/pkg/receive/request_limiter.go
+++ b/pkg/receive/request_limiter.go
@@ -19,12 +19,7 @@ var unlimitedRequestLimitsConfig = newEmptyRequestLimitsConfig().
 	SetSeriesLimit(0).
 	SetSamplesLimit(0)
 
-type requestLimiter interface {
-	AllowSizeBytes(tenant string, contentLengthBytes int64) bool
-	AllowSeries(tenant string, amount int64) bool
-	AllowSamples(tenant string, amount int64) bool
-}
-
+// configRequestLimiter implements requestLimiter interface.
 type configRequestLimiter struct {
 	tenantLimits        map[string]*requestLimitsConfig
 	cachedDefaultLimits *requestLimitsConfig

--- a/pkg/receive/request_limiter.go
+++ b/pkg/receive/request_limiter.go
@@ -19,6 +19,12 @@ var unlimitedRequestLimitsConfig = newEmptyRequestLimitsConfig().
 	SetSeriesLimit(0).
 	SetSamplesLimit(0)
 
+type requestLimiter interface {
+	AllowSizeBytes(tenant string, contentLengthBytes int64) bool
+	AllowSeries(tenant string, amount int64) bool
+	AllowSamples(tenant string, amount int64) bool
+}
+
 type configRequestLimiter struct {
 	tenantLimits        map[string]*requestLimitsConfig
 	cachedDefaultLimits *requestLimitsConfig
@@ -26,7 +32,7 @@ type configRequestLimiter struct {
 	configuredLimits    *prometheus.GaugeVec
 }
 
-func newConfigRequestLimiter(reg prometheus.Registerer, writeLimits *writeLimitsConfig) *configRequestLimiter {
+func newConfigRequestLimiter(reg prometheus.Registerer, writeLimits *WriteLimitsConfig) *configRequestLimiter {
 	// Merge the default limits configuration with an unlimited configuration
 	// to ensure the nils are overwritten with zeroes.
 	defaultRequestLimits := writeLimits.DefaultLimits.RequestLimits.OverlayWith(unlimitedRequestLimitsConfig)
@@ -39,7 +45,9 @@ func newConfigRequestLimiter(reg prometheus.Registerer, writeLimits *writeLimits
 	tenantsLimits := writeLimits.TenantsLimits
 	tenantRequestLimits := make(map[string]*requestLimitsConfig)
 	for tenant, limitConfig := range tenantsLimits {
-		tenantRequestLimits[tenant] = limitConfig.RequestLimits.OverlayWith(defaultRequestLimits)
+		if limitConfig.RequestLimits != nil {
+			tenantRequestLimits[tenant] = limitConfig.RequestLimits.OverlayWith(defaultRequestLimits)
+		}
 	}
 
 	limiter := configRequestLimiter{

--- a/pkg/receive/request_limiter_test.go
+++ b/pkg/receive/request_limiter_test.go
@@ -13,13 +13,13 @@ func TestRequestLimiter_limitsFor(t *testing.T) {
 	tenantWithLimits := "limited-tenant"
 	tenantWithoutLimits := "unlimited-tenant"
 
-	limits := writeLimitsConfig{
-		DefaultLimits: defaultLimitsConfig{
+	limits := WriteLimitsConfig{
+		DefaultLimits: DefaultLimitsConfig{
 			RequestLimits: *newEmptyRequestLimitsConfig().
 				SetSeriesLimit(10),
 		},
-		TenantsLimits: tenantsWriteLimitsConfig{
-			tenantWithLimits: &writeLimitConfig{
+		TenantsLimits: TenantsWriteLimitsConfig{
+			tenantWithLimits: &WriteLimitConfig{
 				RequestLimits: newEmptyRequestLimitsConfig().
 					SetSeriesLimit(30),
 			},
@@ -100,12 +100,12 @@ func TestRequestLimiter_AllowRequestBodySizeBytes(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tenant := "tenant"
-			limits := writeLimitsConfig{
-				DefaultLimits: defaultLimitsConfig{
+			limits := WriteLimitsConfig{
+				DefaultLimits: DefaultLimitsConfig{
 					RequestLimits: *newEmptyRequestLimitsConfig().SetSeriesLimit(10),
 				},
-				TenantsLimits: tenantsWriteLimitsConfig{
-					tenant: &writeLimitConfig{
+				TenantsLimits: TenantsWriteLimitsConfig{
+					tenant: &WriteLimitConfig{
 						RequestLimits: newEmptyRequestLimitsConfig().SetSizeBytesLimit(tt.sizeByteLimit),
 					},
 				},
@@ -157,12 +157,12 @@ func TestRequestLimiter_AllowSeries(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tenant := "tenant"
-			limits := writeLimitsConfig{
-				DefaultLimits: defaultLimitsConfig{
+			limits := WriteLimitsConfig{
+				DefaultLimits: DefaultLimitsConfig{
 					RequestLimits: *newEmptyRequestLimitsConfig().SetSeriesLimit(10),
 				},
-				TenantsLimits: tenantsWriteLimitsConfig{
-					tenant: &writeLimitConfig{
+				TenantsLimits: TenantsWriteLimitsConfig{
+					tenant: &WriteLimitConfig{
 						RequestLimits: newEmptyRequestLimitsConfig().SetSeriesLimit(tt.seriesLimit),
 					},
 				},
@@ -215,12 +215,12 @@ func TestRequestLimiter_AllowSamples(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tenant := "tenant"
-			limits := writeLimitsConfig{
-				DefaultLimits: defaultLimitsConfig{
+			limits := WriteLimitsConfig{
+				DefaultLimits: DefaultLimitsConfig{
 					RequestLimits: *newEmptyRequestLimitsConfig().SetSeriesLimit(10),
 				},
-				TenantsLimits: tenantsWriteLimitsConfig{
-					tenant: &writeLimitConfig{
+				TenantsLimits: TenantsWriteLimitsConfig{
+					tenant: &WriteLimitConfig{
 						RequestLimits: newEmptyRequestLimitsConfig().SetSamplesLimit(tt.samplesLimit),
 					},
 				},

--- a/pkg/receive/testdata/limits_config/good_limits.yaml
+++ b/pkg/receive/testdata/limits_config/good_limits.yaml
@@ -1,17 +1,21 @@
 write:
   global:
     max_concurrency: 30
+    meta_monitoring_url: "http://localhost:9090"
+    meta_monitoring_limit_query: "sum(prometheus_tsdb_head_series) by (tenant)"
   default:
     request:
       size_bytes_limit: 1024
       series_limit: 1000
       samples_limit: 10
+    head_series_limit: 1000
   tenants:
     acme:
       request:
         size_bytes_limit: 0
         series_limit: 0
         samples_limit: 0
+      head_series_limit: 2000
     ajax:
       request:
         series_limit: 50000

--- a/test/e2e/e2ethanos/services.go
+++ b/test/e2e/e2ethanos/services.go
@@ -507,6 +507,17 @@ func (r *ReceiveBuilder) Init() *e2emon.InstrumentedRunnable {
 		if r.metaMonitoringQuery != "" {
 			args["--receive.tenant-limits.meta-monitoring-query"] = r.metaMonitoringQuery
 		}
+
+		b, err := yaml.Marshal(cfg)
+		if err != nil {
+			return e2e.NewErrInstrumentedRunnable(r.Name(), errors.Wrapf(err, "generate limiting file: %v", hashring))
+		}
+
+		if err := os.WriteFile(filepath.Join(r.Dir(), "limits.yaml"), b, 0600); err != nil {
+			return e2e.NewErrInstrumentedRunnable(r.Name(), errors.Wrap(err, "creating limits config"))
+		}
+
+		args["--receive.limits-config-file"] = filepath.Join(r.InternalDir(), "limits.yaml")
 	}
 
 	if err := os.MkdirAll(filepath.Join(r.Dir(), "data"), 0750); err != nil {

--- a/test/e2e/receive_test.go
+++ b/test/e2e/receive_test.go
@@ -729,7 +729,7 @@ func TestReceive(t *testing.T) {
 		ingestor1Name := e.Name() + "-" + ingestor1.Name()
 		// Here for exceed-tenant we go above limit by 10, which results in 0 value.
 		queryWaitAndAssert(t, ctx, meta.GetMonitoringRunnable().Endpoint(e2edb.AccessPortName), func() string {
-			return fmt.Sprintf("sum(prometheus_tsdb_head_series{tenant=\"exceed-tenant\"}) - on() thanos_receive_tenant_head_series_limit{instance=\"%s:8080\", job=\"receive-i1\"}", ingestor1Name)
+			return fmt.Sprintf("sum(prometheus_tsdb_head_series{tenant=\"exceed-tenant\"}) - on() thanos_receive_head_series_limit{instance=\"%s:8080\", job=\"receive-i1\"}", ingestor1Name)
 		}, time.Now, promclient.QueryOptions{
 			Deduplicate: true,
 		}, model.Vector{
@@ -741,7 +741,7 @@ func TestReceive(t *testing.T) {
 
 		// For under-tenant we stay at -5, as we have only pushed 5 series.
 		queryWaitAndAssert(t, ctx, meta.GetMonitoringRunnable().Endpoint(e2edb.AccessPortName), func() string {
-			return fmt.Sprintf("sum(prometheus_tsdb_head_series{tenant=\"under-tenant\"}) - on() thanos_receive_tenant_head_series_limit{instance=\"%s:8080\", job=\"receive-i1\"}", ingestor1Name)
+			return fmt.Sprintf("sum(prometheus_tsdb_head_series{tenant=\"under-tenant\"}) - on() thanos_receive_head_series_limit{instance=\"%s:8080\", job=\"receive-i1\"}", ingestor1Name)
 		}, time.Now, promclient.QueryOptions{
 			Deduplicate: true,
 		}, model.Vector{


### PR DESCRIPTION
This PR adds head/active series limiting configuration to the new per tenant limiting config added in #5565.
* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

- Remove flags and fields passed via receive Handler options
- Make naming of active series limiting interfaces/structs consistent to "head series" and move to a separate file
- Add options to limiting config file
- Update e2e test to use new config
- Update docs

## Verification

All receive e2e tests pass locally and have tested different config scenarios.