### PR TITLE
store: don't ignore prometheus announced labels (fixes #5630)

### DIFF
--- a/test/e2e/query_test.go
+++ b/test/e2e/query_test.go
@@ -719,6 +719,17 @@ func TestSidecarQueryEvaluation(t *testing.T) {
 				},
 			},
 		},
+		{ // Testing pushdown feature with a prometheus announced label (here prometheus)
+			query:        "max (my_fake_metric{prometheus='p1'})",
+			prom1Samples: []fakeMetricSample{{"i1", 1, timeNow}, {"i2", 5, timeNow}, {"i3", 9, timeNow}},
+			prom2Samples: []fakeMetricSample{{"i1", 3, timeNow}, {"i2", 4, timeNow}, {"i3", 10, timeNow}},
+			result: []*model.Sample{
+				{
+					Metric: map[model.LabelName]model.LabelValue{},
+					Value:  9,
+				},
+			},
+		},
 		{
 			query:        "max by (instance) (my_fake_metric)",
 			prom1Samples: []fakeMetricSample{{"i1", 1, timeNow}, {"i2", 5, timeNow}, {"i3", 9, timeNow}},


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->
store: Add prometheus announced label to selector labels (fixes  #5630)

## Verification

<!-- How you tested it? How do you know it works? -->
Tested with:

- Architecture: query (with query-pushdown and no selector-label flags) --> a sidecar connected to a prometheus with external labels (and so announced labelset by sidecar).
- Query: `max by (extlabel,version) (prometheus_build_info{extlabel="extvalue"})` and `max by (extlabel,version) (prometheus_build_info)`