### PR TITLE
.*: fix: re-enable some golang runtime metrics

### DIFF
--- a/cmd/thanos/main.go
+++ b/cmd/thanos/main.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"runtime/debug"
 	"syscall"
@@ -73,7 +74,9 @@ func main() {
 	metrics := prometheus.NewRegistry()
 	metrics.MustRegister(
 		version.NewCollector("thanos"),
-		collectors.NewGoCollector(),
+		collectors.NewGoCollector(
+			collectors.WithGoCollectorRuntimeMetrics(collectors.GoRuntimeMetricsRule{Matcher: regexp.MustCompile("/.*")}),
+		),
 		collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}),
 	)
 


### PR DESCRIPTION
We are experiencing some high gc times and during debugging sessions, we figured out that the go_gc_pause.* metrics were accidentally disabled on an earlier upgrade of the Prometheus client, this PR re-enables it.

Signed-off-by: Victor Fernandes <victorhbfernandes@gmail.com>

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

- During the upgrade of the Prometheus client (done here https://github.com/thanos-io/thanos/pull/5484) some metrics were disabled by default (https://github.com/prometheus/client_golang/releases/tag/v1.12.2),
- I re-enabled them as per suggestion on the author's pull request https://github.com/prometheus/client_golang/pull/1102

## Verification

Manually ran the docker container and ensure the `go_gc_pauses_seconds_total_bucket` was present