### PR TITLE
Query Frontend: Split interval middleware sends query when start equals false

### DIFF
--- a/internal/cortex/querier/queryrange/split_by_interval.go
+++ b/internal/cortex/querier/queryrange/split_by_interval.go
@@ -70,6 +70,11 @@ func (s splitByInterval) Do(ctx context.Context, r Request) (Response, error) {
 }
 
 func splitQuery(r Request, interval time.Duration) ([]Request, error) {
+	// If Start == end we should just run the original request.
+	if r.GetStart() == r.GetEnd() {
+		return []Request{r}, nil
+	}
+
 	// Replace @ modifier function to their respective constant values in the query.
 	// This way subqueries will be evaluated at the same time as the parent query.
 	query, err := evaluateAtModifierFunction(r.GetQuery(), r.GetStart(), r.GetEnd())

--- a/internal/cortex/querier/queryrange/split_by_interval_test.go
+++ b/internal/cortex/querier/queryrange/split_by_interval_test.go
@@ -87,6 +87,23 @@ func TestSplitQuery(t *testing.T) {
 		},
 		{
 			input: &PrometheusRequest{
+				Start: 60 * 60 * seconds,
+				End:   60 * 60 * seconds,
+				Step:  15 * seconds,
+				Query: "foo",
+			},
+			expected: []Request{
+				&PrometheusRequest{
+					Start: 60 * 60 * seconds,
+					End:   60 * 60 * seconds,
+					Step:  15 * seconds,
+					Query: "foo",
+				},
+			},
+			interval: day,
+		},
+		{
+			input: &PrometheusRequest{
 				Start: 0,
 				End:   60 * 60 * seconds,
 				Step:  15 * seconds,


### PR DESCRIPTION
Signed-off-by: Ben Ye <benye@amazon.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Same as https://github.com/cortexproject/cortex/pull/4877.

Query frontend should send the request to downstream when start == end.

## Verification

<!-- How you tested it? How do you know it works? -->
