### PR TITLE
Store: Fix panic on `nil` resp from response heap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#5642](https://github.com/thanos-io/thanos/pull/5642) Receive: Log labels correctly in writer debug messages.
 - [#5655](https://github.com/thanos-io/thanos/pull/5655) Receive: Fix recreating already pruned tenants.
 - [#5702](https://github.com/thanos-io/thanos/pull/5702) Store: Upgrade minio-go/v7 to fix panic caused by leaked goroutines.
+- [#8711] (https://github.com/thanos-io/thanos/pull/5702) Store: Fix panic on `nil` resp from response heap in proxy.
 
 ### Added
 * [#5654](https://github.com/thanos-io/thanos/pull/5654) Query: add `--grpc-compression` flag that controls the compression used in gRPC client. With the flag it is now possible to compress the traffic between Query and StoreAPI nodes - you get lower network usage in exchange for a bit higher CPU/RAM usage.

--- a/pkg/store/proxy.go
+++ b/pkg/store/proxy.go
@@ -332,6 +332,9 @@ func (s *ProxyStore) Series(originalRequest *storepb.SeriesRequest, srv storepb.
 	respHeap := NewDedupResponseHeap(NewProxyResponseHeap(storeResponses...))
 	for respHeap.Next() {
 		resp := respHeap.At()
+		if resp == nil {
+			continue
+		}
 
 		if resp.GetWarning() != "" && (r.PartialResponseDisabled || r.PartialResponseStrategy == storepb.PartialResponseStrategy_ABORT) {
 			return status.Error(codes.Aborted, resp.GetWarning())


### PR DESCRIPTION
Signed-off-by: Matej Gera <matejgera@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [X] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

As part of refactoring MultiTSDB to use proxy methods (https://github.com/thanos-io/thanos/pull/5552), I noticed that lazy evaluation strategy is causing the receiver to panic in some cases. Upon closer looker, I realized this is happening when the resp from heap is `nil` (which can happen if there are no responses, seems like this can happen if e.g. I query for non-existing metric). We still send the `nil` `resp` [further down](https://github.com/thanos-io/thanos/blob/main/pkg/store/proxy.go#L340) the line, causing a panic. This fix checks for `nil` and skips a `resp` if this is true.

## Verification
- Manual test with receiver from https://github.com/thanos-io/thanos/pull/5552
- Some E2E tests with receiver also depend on querying for non-existing metrics so after https://github.com/thanos-io/thanos/pull/5552 is using lazy eval, this will be implicitly tested as well
