### PR TITLE
Announce sorted series from Ruler

### DIFF
--- a/cmd/thanos/rule.go
+++ b/cmd/thanos/rule.go
@@ -607,9 +607,10 @@ func runRule(
 				if httpProbe.IsReady() {
 					mint, maxt := tsdbStore.TimeRange()
 					return &infopb.StoreInfo{
-						MinTime:          mint,
-						MaxTime:          maxt,
-						SupportsSharding: true,
+						MinTime:           mint,
+						MaxTime:           maxt,
+						SupportsSharding:  true,
+						SendsSortedSeries: true,
 					}
 				}
 				return nil


### PR DESCRIPTION
The TSDB module now does a sorted series select when querying series. Since the ruler uses that module, we can indicate that it will send series in sorted order.

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

Announce that series coming from the Ruler will be sorted.

## Verification

Relying on the fact that Ruler uses the TSDB module.
