### PR TITLE
Compactor: Support disable block viewer UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#5650](https://github.com/thanos-io/thanos/pull/5650) Query Frontend: Add sharded queries metrics.
 - [#5658](https://github.com/thanos-io/thanos/pull/5658) Query Frontend: Introduce new optional parameters (`query-range.min-split-interval`, `query-range.max-split-interval`, `query-range.horizontal-shards`) to implement more dynamic horizontal query splitting.
 - [#5721](https://github.com/thanos-io/thanos/pull/5721) Store: Add metric `thanos_bucket_store_empty_postings_total` for number of empty postings when fetching series.
+- [#5723](https://github.com/thanos-io/thanos/pull/5723) Compactor: Support disable block viewer UI.
 
 ### Changed
 

--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -509,28 +509,49 @@ func runCompact(
 	})
 
 	if conf.wait {
-		r := route.New()
+		if !conf.disableWeb {
+			r := route.New()
 
-		ins := extpromhttp.NewInstrumentationMiddleware(reg, nil)
+			ins := extpromhttp.NewInstrumentationMiddleware(reg, nil)
 
-		global := ui.NewBucketUI(logger, conf.webConf.externalPrefix, conf.webConf.prefixHeaderName, component)
-		global.Register(r, ins)
+			global := ui.NewBucketUI(logger, conf.webConf.externalPrefix, conf.webConf.prefixHeaderName, component)
+			global.Register(r, ins)
 
-		// Configure Request Logging for HTTP calls.
-		opts := []logging.Option{logging.WithDecider(func(_ string, _ error) logging.Decision {
-			return logging.NoLogCall
-		})}
-		logMiddleware := logging.NewHTTPServerMiddleware(logger, opts...)
-		api.Register(r.WithPrefix("/api/v1"), tracer, logger, ins, logMiddleware)
+			// Configure Request Logging for HTTP calls.
+			opts := []logging.Option{logging.WithDecider(func(_ string, _ error) logging.Decision {
+				return logging.NoLogCall
+			})}
+			logMiddleware := logging.NewHTTPServerMiddleware(logger, opts...)
+			api.Register(r.WithPrefix("/api/v1"), tracer, logger, ins, logMiddleware)
 
-		// Separate fetcher for global view.
-		// TODO(bwplotka): Allow Bucket UI to visualize the state of the block as well.
-		f := baseMetaFetcher.NewMetaFetcher(extprom.WrapRegistererWithPrefix("thanos_bucket_ui", reg), nil, "component", "globalBucketUI")
-		f.UpdateOnChange(func(blocks []metadata.Meta, err error) {
-			api.SetGlobal(blocks, err)
-		})
+			// Separate fetcher for global view.
+			// TODO(bwplotka): Allow Bucket UI to visualize the state of the block as well.
+			f := baseMetaFetcher.NewMetaFetcher(extprom.WrapRegistererWithPrefix("thanos_bucket_ui", reg), nil, "component", "globalBucketUI")
+			f.UpdateOnChange(func(blocks []metadata.Meta, err error) {
+				api.SetGlobal(blocks, err)
+			})
 
-		srv.Handle("/", r)
+			srv.Handle("/", r)
+
+			g.Add(func() error {
+				iterCtx, iterCancel := context.WithTimeout(ctx, conf.blockViewerSyncBlockTimeout)
+				_, _, _ = f.Fetch(iterCtx)
+				iterCancel()
+
+				// For /global state make sure to fetch periodically.
+				return runutil.Repeat(conf.blockViewerSyncBlockInterval, ctx.Done(), func() error {
+					return runutil.RetryWithLog(logger, time.Minute, ctx.Done(), func() error {
+						iterCtx, iterCancel := context.WithTimeout(ctx, conf.blockViewerSyncBlockTimeout)
+						defer iterCancel()
+
+						_, _, err := f.Fetch(iterCtx)
+						return err
+					})
+				})
+			}, func(error) {
+				cancel()
+			})
+		}
 
 		// Periodically remove partial blocks and blocks marked for deletion
 		// since one iteration potentially could take a long time.
@@ -593,25 +614,6 @@ func runCompact(
 				cancel()
 			})
 		}
-
-		g.Add(func() error {
-			iterCtx, iterCancel := context.WithTimeout(ctx, conf.blockViewerSyncBlockTimeout)
-			_, _, _ = f.Fetch(iterCtx)
-			iterCancel()
-
-			// For /global state make sure to fetch periodically.
-			return runutil.Repeat(conf.blockViewerSyncBlockInterval, ctx.Done(), func() error {
-				return runutil.RetryWithLog(logger, time.Minute, ctx.Done(), func() error {
-					iterCtx, iterCancel := context.WithTimeout(ctx, conf.blockViewerSyncBlockTimeout)
-					defer iterCancel()
-
-					_, _, err := f.Fetch(iterCtx)
-					return err
-				})
-			})
-		}, func(error) {
-			cancel()
-		})
 	}
 
 	level.Info(logger).Log("msg", "starting compact node")
@@ -642,6 +644,7 @@ type compactConfig struct {
 	deleteDelay                                    model.Duration
 	dedupReplicaLabels                             []string
 	selectorRelabelConf                            extflag.PathOrContent
+	disableWeb                                     bool
 	webConf                                        webConfig
 	label                                          string
 	maxBlockIndexSize                              units.Base2Bytes
@@ -751,6 +754,8 @@ func (cc *compactConfig) registerFlag(cmd extkingpin.FlagClause) {
 		Default("0000-01-01T00:00:00Z").SetValue(&cc.filterConf.MinTime)
 	cmd.Flag("max-time", "End of time range limit to compact. Thanos Compactor will compact only blocks, which happened earlier than this value. Option can be a constant time in RFC3339 format or time duration relative to current time, such as -1d or 2h45m. Valid duration units are ms, s, m, h, d, w, y.").
 		Default("9999-12-31T23:59:59Z").SetValue(&cc.filterConf.MaxTime)
+
+	cmd.Flag("web.disable", "Disable Block Viewer UI.").Default("false").BoolVar(&cc.disableWeb)
 
 	cc.selectorRelabelConf = *extkingpin.RegisterSelectorRelabelFlags(cmd)
 

--- a/docs/components/compact.md
+++ b/docs/components/compact.md
@@ -447,6 +447,7 @@ Flags:
       --wait-interval=5m        Wait interval between consecutive compaction
                                 runs and bucket refreshes. Only works when
                                 --wait flag specified.
+      --web.disable             Disable Block Viewer UI.
       --web.disable-cors        Whether to disable CORS headers to be set by
                                 Thanos. By default Thanos sets CORS headers to
                                 be allowed by all.


### PR DESCRIPTION
Signed-off-by: wanjunlei <wanjunlei@kubesphere.io>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

Add a new flag `--web.disable` for compactor, users can disable the block viewer UI of compactor using this flag

## Verification

<!-- How you tested it? How do you know it works? -->

Run the compactor without `--web.disable` and access the URL `localhost:19092`, the bucket UI works.
Run the compactor with `--web.disable` and access the URL `localhost:19092`, it returns `404 page not found`.