### PR TITLE
Bump thanos-community/promql-engine to latest version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -69,7 +69,7 @@ require (
 	github.com/prometheus/prometheus v0.38.0
 	github.com/sony/gobreaker v0.5.0
 	github.com/stretchr/testify v1.8.0
-	github.com/thanos-community/promql-engine v0.0.0-20220920130216-1ec1401acc2c
+	github.com/thanos-community/promql-engine v0.0.0-20220926123320-18a0a4b4be8f
 	github.com/thanos-io/objstore v0.0.0-20220923084403-cec51c61948b
 	github.com/uber/jaeger-client-go v2.30.0+incompatible
 	github.com/uber/jaeger-lib v2.4.1+incompatible

--- a/go.sum
+++ b/go.sum
@@ -937,8 +937,8 @@ github.com/tencentyun/cos-go-sdk-v5 v0.7.34 h1:xm+Pg+6m486y4eugRI7/E4WasbVmpY1hp
 github.com/tencentyun/cos-go-sdk-v5 v0.7.34/go.mod h1:4dCEtLHGh8QPxHEkgq+nFaky7yZxQuYwgSJM87icDaw=
 github.com/thanos-community/galaxycache v0.0.0-20211122094458-3a32041a1f1e h1:f1Zsv7OAU9iQhZwigp50Yl38W10g/vd5NC8Rdk1Jzng=
 github.com/thanos-community/galaxycache v0.0.0-20211122094458-3a32041a1f1e/go.mod h1:jXcofnrSln/cLI6/dhlBxPQZEEQHVPCcFaH75M+nSzM=
-github.com/thanos-community/promql-engine v0.0.0-20220920130216-1ec1401acc2c h1:/ZcQbCSj+ut2d7Ut5+/GYctfh6ZlIdiTtWY3H/ciSBc=
-github.com/thanos-community/promql-engine v0.0.0-20220920130216-1ec1401acc2c/go.mod h1:IEJ3g2fmXAun4Rj39T4Anfm1AYvcDmxqWWSuYdn2TRM=
+github.com/thanos-community/promql-engine v0.0.0-20220926123320-18a0a4b4be8f h1:S+IFfNs2XA2pbd0cRtk8aOpLH8D/Q7Ipess3WRfcgPw=
+github.com/thanos-community/promql-engine v0.0.0-20220926123320-18a0a4b4be8f/go.mod h1:IEJ3g2fmXAun4Rj39T4Anfm1AYvcDmxqWWSuYdn2TRM=
 github.com/thanos-io/objstore v0.0.0-20220923084403-cec51c61948b h1:P+MnJn+NoU6N2v7wLexTVRCu6ZvcOdPU4L8f2dgEfiY=
 github.com/thanos-io/objstore v0.0.0-20220923084403-cec51c61948b/go.mod h1:Vx5dZs9ElxEhNLnum/OgB0pNTqNdI2zdXL82BeJr3T4=
 github.com/themihai/gomemcache v0.0.0-20180902122335-24332e2d58ab h1:7ZR3hmisBWw77ZpO1/o86g+JV3VKlk3d48jopJxzTjU=


### PR DESCRIPTION
The latest version adds support for number literals and binary expressions.

It also fixe bugs with instant queries against empty series sets, and add with fallbacks to the old engine for unsupported expressions.

Issues unrelated to compatibility are still present, looking into those now.

Signed-off-by: Filip Petkovski <filip.petkovsky@gmail.com>

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

Updates the Thanos PromQL engine to the latest commit from main.

## Verification

I did manual tests in one of our environments. We are now properly fall back to the old engine for all unsupported operations.
