### PR TITLE
Tools: Support downsampled blocks in bucket rewrite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#5642](https://github.com/thanos-io/thanos/pull/5642) Receive: Log labels correctly in writer debug messages.
 - [#5655](https://github.com/thanos-io/thanos/pull/5655) Receive: Fix recreating already pruned tenants.
 - [#5702](https://github.com/thanos-io/thanos/pull/5702) Store: Upgrade minio-go/v7 to fix panic caused by leaked goroutines.
+- [#5725](https://github.com/thanos-io/thanos/pull/5725) Tools: Support downsampled blocks in bucket rewrite.
 
 ### Added
 * [#5654](https://github.com/thanos-io/thanos/pull/5654) Query: add `--grpc-compression` flag that controls the compression used in gRPC client. With the flag it is now possible to compress the traffic between Query and StoreAPI nodes - you get lower network usage in exchange for a bit higher CPU/RAM usage.


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

## Summary

`thanos tools bucket rewrite` currently fails on downsampled blocks. This happens because it tries to use a prometheus `chunkenc.Pool` which does not support `AggrChunk`.

This patch fixes that by using a thanos `downsample.pool` for downsampled blocks.

## Background

When rewriting (uses compaction under the hood) a downsampled block, we get this segfault:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x20 pc=0x1060838b4]
```

<details>

```
goroutine 146 [running]:
github.com/thanos-io/thanos/pkg/compactv2.(*lazyPopulatableChunk).Bytes(0x1400074a180?)
	/Users/igor/code/thanos/pkg/compactv2/chunk_series_set.go:120 +0x34
github.com/prometheus/prometheus/tsdb/chunks.(*Writer).WriteChunks(0x1400031e460, {0x1400074a240, 0x1, 0x1})
	/Users/igor/go/pkg/mod/github.com/prometheus/prometheus@v0.38.0/tsdb/chunks/chunks.go:365 +0x1b8
github.com/thanos-io/thanos/pkg/block.(*statsGatheringSeriesWriter).WriteChunks(0x14000495b00, {0x1400074a240?, 0x1, 0x1060845c0?})
	/Users/igor/code/thanos/pkg/block/writer.go:173 +0x3c
github.com/thanos-io/thanos/pkg/compactv2.(*Compactor).write(0x14000c99d00, {0x106b1b408, 0x14000a2fcc0}, {0x106b14500, 0x1400031e0f0}, {0x106b1c198, 0x1400031e410}, {0x12fed1940, 0x14000495b00}, {0x106b032e0, ...})
	/Users/igor/code/thanos/pkg/compactv2/chunk_series_set.go:201 +0x1cc
github.com/thanos-io/thanos/pkg/compactv2.(*Compactor).WriteSeries(0x14000c99d00, {0x106b1b408, 0x14000a2fcc0}, {0x14000c99b60?, 0x1, 0x1}, {0x106b1f580?, 0x14000495b00}, {0x106b032e0, 0x1400092bcc0?}, ...)
	/Users/igor/code/thanos/pkg/compactv2/compactor.go:148 +0x5d4
main.registerBucketRewrite.func1.1()
	/Users/igor/code/thanos/cmd/thanos/tools_bucket.go:1212 +0x1378
github.com/oklog/run.(*Group).Run.func1({0x14000939ba0?, 0x14000a39170?})
	/Users/igor/go/pkg/mod/github.com/oklog/run@v1.1.0/group.go:38 +0x34
created by github.com/oklog/run.(*Group).Run
	/Users/igor/go/pkg/mod/github.com/oklog/run@v1.1.0/group.go:37 +0x21c
```

</details>

With some strategically inserted `panic` calls, we find that a previous error was:

```
panic: invalid chunk encoding "<unknown>" 255
```

<details>

```
goroutine 111 [running]:
github.com/prometheus/prometheus/tsdb/chunkenc.(*pool).Get(0x1049d3dc0?, 0x18?, {0x14b5aeceb?, 0x2?, 0x2?})
	/Users/igor/go/pkg/mod/github.com/prometheus/prometheus@v0.38.0/tsdb/chunkenc/chunk.go:164 +0x10c
github.com/prometheus/prometheus/tsdb/chunks.(*Reader).Chunk(0x1400085a050, 0x1d6b6ce8)
	/Users/igor/go/pkg/mod/github.com/prometheus/prometheus@v0.38.0/tsdb/chunks/chunks.go:607 +0x678
github.com/thanos-io/thanos/pkg/compactv2.(*lazyPopulatableChunk).populate(0x14002e4c5d0)
	/Users/igor/code/thanos/pkg/compactv2/chunk_series_set.go:110 +0x3c
github.com/thanos-io/thanos/pkg/compactv2.(*lazyPopulatableChunk).Iterator(0x14002e4c5d0, {0x0, 0x0})
	/Users/igor/code/thanos/pkg/compactv2/chunk_series_set.go:143 +0x38
github.com/thanos-io/thanos/pkg/compactv2.(*delGenericSeriesIterator).next(0x14002e4adc0)
	/Users/igor/code/thanos/pkg/compactv2/modifiers.go:206 +0x208
github.com/thanos-io/thanos/pkg/compactv2.(*delChunkSeriesIterator).Next(0x14002e4c6c0)
	/Users/igor/code/thanos/pkg/compactv2/modifiers.go:286 +0x28
github.com/thanos-io/thanos/pkg/compactv2.(*Compactor).WriteSeries(0x14000c15d48, {0x1049e7448, 0x14000b01540}, {0x14000c15b60?, 0x1, 0x1}, {0x1049eb5c0?, 0x1400025c090}, {0x1049cf320, 0x14000afd940?}, ...)
	/Users/igor/code/thanos/pkg/compactv2/compactor.go:135 +0xa0c
main.registerBucketRewrite.func1.1()
	/Users/igor/code/thanos/cmd/thanos/tools_bucket.go:1212 +0x124c
github.com/oklog/run.(*Group).Run.func1({0x14000ae94a0?, 0x14000b05ad0?})
	/Users/igor/go/pkg/mod/github.com/oklog/run@v1.1.0/group.go:38 +0x34
created by github.com/oklog/run.(*Group).Run
	/Users/igor/go/pkg/mod/github.com/oklog/run@v1.1.0/group.go:37 +0x21c
```

</details>

That `0xff` chunk encoding is for `AggrChunk` ([source](https://github.com/thanos-io/thanos/blob/deb599814af8c93fb29efb80d3c42ec88e530938/pkg/compact/downsample/aggr.go#L15)), which is thanos specific. We can see from the stack trace that `tsdb.Reader` is calling `chunkenc.pool.Get` -- which is the prometheus one, that lacks `AggrChunk` support.

It turns out that in the downsampler, we already conditionally create a `downsample.pool` if the input block is already downsampled ([source](https://github.com/thanos-io/thanos/blob/2fd75cd6237718e84cb6ebf87b8787156c2c419f/cmd/thanos/downsample.go#L362-L367)).

All we need to do is apply the same check in the `thanos tools bucket rewrite` path.

See [our downstream issue](https://gitlab.com/gitlab-com/gl-infra/production/-/issues/7782#note_1110918053) for more research.

## Tasks

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

- `thanos tools bucket rewrite` now supports downsampled blocks.

## Verification

<!-- How you tested it? How do you know it works? -->

I ran `thanos tools bucket rewrite` on a downsampled block.