### PR TITLE
Store: Support disable block viewer UI.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#5721](https://github.com/thanos-io/thanos/pull/5721) Store: Add metric `thanos_bucket_store_empty_postings_total` for number of empty postings when fetching series.
 - [#5723](https://github.com/thanos-io/thanos/pull/5723) Compactor: Support disable block viewer UI.
 - [#5674](https://github.com/thanos-io/thanos/pull/5674) Query Frontend/Store: Add support connecting to redis using TLS.
+- [#5734](https://github.com/thanos-io/thanos/pull/5734) Store: Support disable block viewer UI.
 
 ### Changed
 

--- a/cmd/thanos/store.go
+++ b/cmd/thanos/store.go
@@ -69,6 +69,7 @@ type storeConfig struct {
 	advertiseCompatibilityLabel bool
 	consistencyDelay            commonmodel.Duration
 	ignoreDeletionMarksDelay    commonmodel.Duration
+	disableWeb                  bool
 	webConfig                   webConfig
 	postingOffsetsInMemSampling int
 	cachingBucketConfig         extflag.PathOrContent
@@ -156,6 +157,8 @@ func (sc *storeConfig) registerFlag(cmd extkingpin.FlagClause) {
 
 	cmd.Flag("store.index-header-lazy-reader-idle-timeout", "If index-header lazy reader is enabled and this idle timeout setting is > 0, memory map-ed index-headers will be automatically released after 'idle timeout' inactivity.").
 		Hidden().Default("5m").DurationVar(&sc.lazyIndexReaderIdleTimeout)
+
+	cmd.Flag("web.disable", "Disable Block Viewer UI.").Default("false").BoolVar(&sc.disableWeb)
 
 	cmd.Flag("web.external-prefix", "Static prefix for all HTML links and redirect URLs in the bucket web UI interface. Actual endpoints are still served on / or the web.route-prefix. This allows thanos bucket web UI to be served behind a reverse proxy that strips a URL sub-path.").
 		Default("").StringVar(&sc.webConfig.externalPrefix)
@@ -431,17 +434,20 @@ func runStore(
 	{
 		ins := extpromhttp.NewInstrumentationMiddleware(reg, nil)
 
-		compactorView := ui.NewBucketUI(logger, conf.webConfig.externalPrefix, conf.webConfig.prefixHeaderName, conf.component)
-		compactorView.Register(r, ins)
+		if !conf.disableWeb {
+			compactorView := ui.NewBucketUI(logger, conf.webConfig.externalPrefix, conf.webConfig.prefixHeaderName, conf.component)
+			compactorView.Register(r, ins)
 
-		// Configure Request Logging for HTTP calls.
-		logMiddleware := logging.NewHTTPServerMiddleware(logger, httpLogOpts...)
-		api := blocksAPI.NewBlocksAPI(logger, conf.webConfig.disableCORS, "", flagsMap, bkt)
-		api.Register(r.WithPrefix("/api/v1"), tracer, logger, ins, logMiddleware)
+			// Configure Request Logging for HTTP calls.
+			logMiddleware := logging.NewHTTPServerMiddleware(logger, httpLogOpts...)
+			api := blocksAPI.NewBlocksAPI(logger, conf.webConfig.disableCORS, "", flagsMap, bkt)
+			api.Register(r.WithPrefix("/api/v1"), tracer, logger, ins, logMiddleware)
 
-		metaFetcher.UpdateOnChange(func(blocks []metadata.Meta, err error) {
-			api.SetLoaded(blocks, err)
-		})
+			metaFetcher.UpdateOnChange(func(blocks []metadata.Meta, err error) {
+				api.SetLoaded(blocks, err)
+			})
+		}
+
 		srv.Handle("/", r)
 	}
 

--- a/docs/components/store.md
+++ b/docs/components/store.md
@@ -190,6 +190,7 @@ Flags:
                                  See format details:
                                  https://thanos.io/tip/thanos/tracing.md/#configuration
       --version                  Show application version.
+      --web.disable              Disable Block Viewer UI.
       --web.disable-cors         Whether to disable CORS headers to be set by
                                  Thanos. By default Thanos sets CORS headers to
                                  be allowed by all.


### PR DESCRIPTION
Signed-off-by: wanjunlei <wanjunlei@kubesphere.io>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

Add a new flag --web.disable for store, users can disable the block viewer UI of store using this flag.

This pr is similar #5723 , but there are still some differences. 
If the compactor running with `--web.disable`, the block viewer UI and the bucket APIS will be disabled.
If the store running with `--web.disable`, only the block viewer UI  will be disabled.

The reason for this difference is the compactor bucket API uses a separate meta fetcher to sync the block meta, disable the bucket APIS can Reduce resource consumption. The store bucket APIS reuses the mete fetcher of buckets store, no additional resource consumption.

## Verification

<!-- How you tested it? How do you know it works? -->
