### PR TITLE
Bump promql engine version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -69,7 +69,7 @@ require (
 	github.com/prometheus/prometheus v0.38.0
 	github.com/sony/gobreaker v0.5.0
 	github.com/stretchr/testify v1.8.0
-	github.com/thanos-community/promql-engine v0.0.0-20220926123320-18a0a4b4be8f
+	github.com/thanos-community/promql-engine v0.0.0-20220929065849-dbc95397ccf3
 	github.com/thanos-io/objstore v0.0.0-20220923084403-cec51c61948b
 	github.com/uber/jaeger-client-go v2.30.0+incompatible
 	github.com/uber/jaeger-lib v2.4.1+incompatible

--- a/go.sum
+++ b/go.sum
@@ -937,8 +937,8 @@ github.com/tencentyun/cos-go-sdk-v5 v0.7.34 h1:xm+Pg+6m486y4eugRI7/E4WasbVmpY1hp
 github.com/tencentyun/cos-go-sdk-v5 v0.7.34/go.mod h1:4dCEtLHGh8QPxHEkgq+nFaky7yZxQuYwgSJM87icDaw=
 github.com/thanos-community/galaxycache v0.0.0-20211122094458-3a32041a1f1e h1:f1Zsv7OAU9iQhZwigp50Yl38W10g/vd5NC8Rdk1Jzng=
 github.com/thanos-community/galaxycache v0.0.0-20211122094458-3a32041a1f1e/go.mod h1:jXcofnrSln/cLI6/dhlBxPQZEEQHVPCcFaH75M+nSzM=
-github.com/thanos-community/promql-engine v0.0.0-20220926123320-18a0a4b4be8f h1:S+IFfNs2XA2pbd0cRtk8aOpLH8D/Q7Ipess3WRfcgPw=
-github.com/thanos-community/promql-engine v0.0.0-20220926123320-18a0a4b4be8f/go.mod h1:IEJ3g2fmXAun4Rj39T4Anfm1AYvcDmxqWWSuYdn2TRM=
+github.com/thanos-community/promql-engine v0.0.0-20220929065849-dbc95397ccf3 h1:p83vy5PKgJmYi/niwZes3oA3/jINnMwPvzUDNi1AODM=
+github.com/thanos-community/promql-engine v0.0.0-20220929065849-dbc95397ccf3/go.mod h1:IEJ3g2fmXAun4Rj39T4Anfm1AYvcDmxqWWSuYdn2TRM=
 github.com/thanos-io/objstore v0.0.0-20220923084403-cec51c61948b h1:P+MnJn+NoU6N2v7wLexTVRCu6ZvcOdPU4L8f2dgEfiY=
 github.com/thanos-io/objstore v0.0.0-20220923084403-cec51c61948b/go.mod h1:Vx5dZs9ElxEhNLnum/OgB0pNTqNdI2zdXL82BeJr3T4=
 github.com/themihai/gomemcache v0.0.0-20180902122335-24332e2d58ab h1:7ZR3hmisBWw77ZpO1/o86g+JV3VKlk3d48jopJxzTjU=


### PR DESCRIPTION
This commit bumps the promql engine to the latest version, which has better fallback for unsupported expressions.

Signed-off-by: Filip Petkovski <filip.petkovsky@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

Bump promql-engine version.

## Verification

