### PR TITLE
chore: Bump objstore package to latest main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#5674](https://github.com/thanos-io/thanos/pull/5674) Query Frontend/Store: Add support connecting to redis using TLS.
 - [#5734](https://github.com/thanos-io/thanos/pull/5734) Store: Support disable block viewer UI.
 - [#5411](https://github.com/thanos-io/thanos/pull/5411) Tracing: Add OpenTelemetry Protocol exporter.
-- [#5779](https://github.com/thanos-io/thanos/pull/5779) Objstore: Support specifying S3 storage class. 
+- [#5779](https://github.com/thanos-io/thanos/pull/5779) Objstore: Support specifying S3 storage class.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#5674](https://github.com/thanos-io/thanos/pull/5674) Query Frontend/Store: Add support connecting to redis using TLS.
 - [#5734](https://github.com/thanos-io/thanos/pull/5734) Store: Support disable block viewer UI.
 - [#5411](https://github.com/thanos-io/thanos/pull/5411) Tracing: Add OpenTelemetry Protocol exporter.
+- [#5779](https://github.com/thanos-io/thanos/pull/5779) Objstore: Support specifying S3 storage class. 
 
 ### Changed
 

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -257,7 +257,7 @@ By default, the `STANDARD` S3 storage class will be used. To specify a storage c
 
 For example, the config file below specifies storage class of `STANDARD_IA`.
 
-``` yaml
+```yaml
 type: S3
 prefix: thanos-test-standard-ia
 config:

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -251,6 +251,25 @@ If you want to use IAM credential retrieved from an instance profile, Thanos nee
 
 By default Thanos will use endpoint: https://sts.amazonaws.com and AWS region corresponding endpoints.
 
+##### S3 Storage Class
+
+By default, the `STANDARD` S3 storage class will be used. To specify a storage class, add it to the `put_user_metadata` section of the config file.
+
+For example, the config file below specifies storage class of `STANDARD_IA`.
+
+``` yaml
+type: S3
+prefix: thanos-test-standard-ia
+config:
+  endpoint: s3.us-east-1.amazonaws.com
+  region: us-east-1
+  bucket: MY_BUCKET
+  put_user_metadata:
+    X-Amz-Storage-Class: STANDARD_IA
+  trace:
+    enable: true
+```
+
 #### GCS
 
 To configure Google Cloud Storage bucket as an object store you need to set `bucket` with GCS bucket name and configure Google Application credentials.

--- a/go.mod
+++ b/go.mod
@@ -73,7 +73,7 @@ require (
 	github.com/sony/gobreaker v0.5.0
 	github.com/stretchr/testify v1.8.0
 	github.com/thanos-community/promql-engine v0.0.0-20221004075442-da92170150df
-	github.com/thanos-io/objstore v0.0.0-20220923084403-cec51c61948b
+	github.com/thanos-io/objstore v0.0.0-20221006135717-79dcec7fe604
 	github.com/uber/jaeger-client-go v2.30.0+incompatible
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	github.com/vimeo/galaxycache v0.0.0-20210323154928-b7e5d71c067a

--- a/go.sum
+++ b/go.sum
@@ -954,8 +954,8 @@ github.com/thanos-community/galaxycache v0.0.0-20211122094458-3a32041a1f1e h1:f1
 github.com/thanos-community/galaxycache v0.0.0-20211122094458-3a32041a1f1e/go.mod h1:jXcofnrSln/cLI6/dhlBxPQZEEQHVPCcFaH75M+nSzM=
 github.com/thanos-community/promql-engine v0.0.0-20221004075442-da92170150df h1:vrevr7p2FtiqD48UiuuPyFvu2t8WdHEENDD+6jMyFyU=
 github.com/thanos-community/promql-engine v0.0.0-20221004075442-da92170150df/go.mod h1:xPhabVMItFWDcYsyOJ1QBZtjl0zBytHdgv8P+6dPtPM=
-github.com/thanos-io/objstore v0.0.0-20220923084403-cec51c61948b h1:P+MnJn+NoU6N2v7wLexTVRCu6ZvcOdPU4L8f2dgEfiY=
-github.com/thanos-io/objstore v0.0.0-20220923084403-cec51c61948b/go.mod h1:Vx5dZs9ElxEhNLnum/OgB0pNTqNdI2zdXL82BeJr3T4=
+github.com/thanos-io/objstore v0.0.0-20221006135717-79dcec7fe604 h1:9dceDSKKsLWNHjrMpyzK1t7eVcAZv9Dp3FX+uokUS2Y=
+github.com/thanos-io/objstore v0.0.0-20221006135717-79dcec7fe604/go.mod h1:Vx5dZs9ElxEhNLnum/OgB0pNTqNdI2zdXL82BeJr3T4=
 github.com/themihai/gomemcache v0.0.0-20180902122335-24332e2d58ab h1:7ZR3hmisBWw77ZpO1/o86g+JV3VKlk3d48jopJxzTjU=
 github.com/themihai/gomemcache v0.0.0-20180902122335-24332e2d58ab/go.mod h1:eheTFp954zcWZXCU8d0AT76ftsQOTo4DTqkN/h3k1MY=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=


### PR DESCRIPTION
Signed-off-by: Ben Ye <benye@amazon.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

Fixes https://github.com/thanos-io/thanos/issues/5663

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Brings in support for S3 storage class.

## Verification

<!-- How you tested it? How do you know it works? -->
