### PR TITLE
Tools: add cleanup API for bucket web

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#5674](https://github.com/thanos-io/thanos/pull/5674) Query Frontend/Store: Add support connecting to redis using TLS.
 - [#5734](https://github.com/thanos-io/thanos/pull/5734) Store: Support disable block viewer UI.
 - [#5411](https://github.com/thanos-io/thanos/pull/5411) Tracing: Add OpenTelemetry Protocol exporter.
+- [#5780](https://github.com/thanos-io/thanos/pull/5780) Tools: Add cleanup API for bucket web.
 
 ### Changed
 

--- a/cmd/thanos/tools_bucket.go
+++ b/cmd/thanos/tools_bucket.go
@@ -631,6 +631,7 @@ func registerBucketWeb(app extkingpin.AppClause, objStoreConfig *extflag.PathOrC
 		if err != nil {
 			return err
 		}
+		api.SetRelabelConfig(relabelConfig)
 		// TODO(bwplotka): Allow Bucket UI to visualize the state of block as well.
 		fetcher, err := block.NewMetaFetcher(logger, block.FetcherConcurrency, bkt, "", extprom.WrapRegistererWithPrefix(extpromPrefix, reg),
 			[]block.MetadataFilter{


### PR DESCRIPTION
Signed-off-by: wanjunlei <wanjunlei@kubesphere.io>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

Add a new API `/blocks/cleanup` for the tools bucket web, users can execute a cleanup command by calling this API.

### URL 
Post /blocks/cleanup

### Query parameter

- consistencyDelay - Minimum age of fresh (non-compacted) blocks before they are being processed. Malformed blocks older than the maximum of consistency-delay and 48h will be removed.
- blockSyncConcurrency - Number of goroutines to use when syncing block metadata from object storage.
- deleteDelay - Time before a block marked for deletion is deleted from bucket.
- sync - If true, server will wait the cleanup finished then return the result to client.

## Verification

<!-- How you tested it? How do you know it works? -->
