### PR TITLE
Add pooling for remote-write requests

### DIFF
--- a/pkg/receive/handler.go
+++ b/pkg/receive/handler.go
@@ -17,10 +17,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/thanos-io/thanos/pkg/api"
-	statusapi "github.com/thanos-io/thanos/pkg/api/status"
-	"github.com/thanos-io/thanos/pkg/logging"
-
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/gogo/protobuf/proto"
@@ -38,6 +34,10 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	"github.com/thanos-io/thanos/pkg/api"
+	statusapi "github.com/thanos-io/thanos/pkg/api/status"
+	"github.com/thanos-io/thanos/pkg/logging"
 
 	"github.com/thanos-io/thanos/pkg/errutil"
 	extpromhttp "github.com/thanos-io/thanos/pkg/extprom/http"
@@ -125,6 +125,8 @@ type Handler struct {
 	writeTimeseriesTotal *prometheus.HistogramVec
 
 	limiter *limiter
+	reqPool *requestPool
+	pool    *bytesPool
 }
 
 func NewHandler(logger log.Logger, o *Options) *Handler {
@@ -144,6 +146,8 @@ func NewHandler(logger log.Logger, o *Options) *Handler {
 		options:      o,
 		peers:        newPeerGroup(o.DialOpts...),
 		receiverMode: o.ReceiverMode,
+		reqPool:      newRequestPool(),
+		pool:         newBytesPool(),
 		expBackoff: backoff.Backoff{
 			Factor: 2,
 			Min:    100 * time.Millisecond,
@@ -431,7 +435,8 @@ func (h *Handler) receiveHTTP(w http.ResponseWriter, r *http.Request) {
 	requestLimiter := h.limiter.requestLimiter
 	// io.ReadAll dynamically adjust the byte slice for read data, starting from 512B.
 	// Since this is receive hot path, grow upfront saving allocations and CPU time.
-	compressed := bytes.Buffer{}
+	bodyBuf := h.pool.get()
+	compressed := bytes.NewBuffer(*bodyBuf)
 	if r.ContentLength >= 0 {
 		if !requestLimiter.AllowSizeBytes(tenant, r.ContentLength) {
 			http.Error(w, "write request too large", http.StatusRequestEntityTooLarge)
@@ -441,17 +446,20 @@ func (h *Handler) receiveHTTP(w http.ResponseWriter, r *http.Request) {
 	} else {
 		compressed.Grow(512)
 	}
-	_, err = io.Copy(&compressed, r.Body)
+	_, err = io.Copy(compressed, r.Body)
 	if err != nil {
 		http.Error(w, errors.Wrap(err, "read compressed request body").Error(), http.StatusInternalServerError)
 		return
 	}
-	reqBuf, err := s2.Decode(nil, compressed.Bytes())
+
+	decodeBuf := h.pool.get()
+	reqBuf, err := s2.Decode(*decodeBuf, compressed.Bytes())
 	if err != nil {
 		level.Error(tLogger).Log("msg", "snappy decode error", "err", err)
 		http.Error(w, errors.Wrap(err, "snappy decode error").Error(), http.StatusBadRequest)
 		return
 	}
+	h.pool.put(bodyBuf)
 
 	if !requestLimiter.AllowSizeBytes(tenant, int64(len(reqBuf))) {
 		http.Error(w, "write request too large", http.StatusRequestEntityTooLarge)
@@ -461,11 +469,12 @@ func (h *Handler) receiveHTTP(w http.ResponseWriter, r *http.Request) {
 	// NOTE: Due to zero copy ZLabels, Labels used from WriteRequests keeps memory
 	// from the whole request. Ensure that we always copy those when we want to
 	// store them for longer time.
-	var wreq prompb.WriteRequest
-	if err := proto.Unmarshal(reqBuf, &wreq); err != nil {
+	wreq := h.reqPool.get()
+	if err := proto.Unmarshal(reqBuf, wreq); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
+	h.pool.put(decodeBuf)
 
 	rep := uint64(0)
 	// If the header is empty, we assume the request is not yet replicated.
@@ -504,14 +513,14 @@ func (h *Handler) receiveHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Apply relabeling configs.
-	h.relabel(&wreq)
+	h.relabel(wreq)
 	if len(wreq.Timeseries) == 0 {
 		level.Debug(tLogger).Log("msg", "remote write request dropped due to relabeling.")
 		return
 	}
 
 	responseStatusCode := http.StatusOK
-	if err = h.handleRequest(ctx, rep, tenant, &wreq); err != nil {
+	if err = h.handleRequest(ctx, rep, tenant, wreq); err != nil {
 		level.Debug(tLogger).Log("msg", "failed to handle request", "err", err)
 		switch determineWriteErrorCause(err, 1) {
 		case errNotReady:
@@ -543,6 +552,7 @@ func (h *Handler) receiveHTTP(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) forward(ctx context.Context, tenant string, r replica, wreq *prompb.WriteRequest) error {
 	span, ctx := tracing.StartSpan(ctx, "receive_fanout_forward")
 	defer span.Finish()
+	defer h.reqPool.put(wreq)
 
 	// It is possible that hashring is ready in testReady() but unready now,
 	// so need to lock here.
@@ -568,7 +578,7 @@ func (h *Handler) forward(ctx context.Context, tenant string, r replica, wreq *p
 		}
 		key := endpointReplica{endpoint: endpoint, replica: r}
 		if _, ok := wreqs[key]; !ok {
-			wreqs[key] = &prompb.WriteRequest{}
+			wreqs[key] = h.reqPool.get()
 		}
 		wr := wreqs[key]
 		wr.Timeseries = append(wr.Timeseries, wreq.Timeseries[i])
@@ -590,6 +600,10 @@ func (h *Handler) fanoutForward(pctx context.Context, tenant string, wreqs map[e
 
 	fctx, cancel := context.WithTimeout(tracing.CopyTraceContext(context.Background(), pctx), h.options.ForwardTimeout)
 	defer func() {
+		for _, w := range wreqs {
+			h.reqPool.put(w)
+		}
+
 		if errs.Err() != nil {
 			// NOTICE: The cancel function is not used on all paths intentionally,
 			// if there is no error when quorum successThreshold is reached,
@@ -807,9 +821,7 @@ func (h *Handler) replicate(ctx context.Context, tenant string, wreq *prompb.Wri
 			}
 			replicatedRequest, ok := replicatedRequests[er]
 			if !ok {
-				replicatedRequest = &prompb.WriteRequest{
-					Timeseries: make([]prompb.TimeSeries, 0),
-				}
+				replicatedRequest = h.reqPool.get()
 				replicatedRequests[er] = replicatedRequest
 			}
 			replicatedRequest.Timeseries = append(replicatedRequest.Timeseries, ts)

--- a/pkg/receive/pool.go
+++ b/pkg/receive/pool.go
@@ -1,0 +1,58 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package receive
+
+import (
+	"sync"
+
+	"github.com/thanos-io/thanos/pkg/store/storepb/prompb"
+)
+
+type requestPool struct {
+	pool *sync.Pool
+}
+
+func newRequestPool() *requestPool {
+	return &requestPool{
+		pool: &sync.Pool{
+			New: func() interface{} {
+				return &prompb.WriteRequest{}
+			},
+		},
+	}
+}
+
+func (p *requestPool) get() *prompb.WriteRequest {
+	return p.pool.Get().(*prompb.WriteRequest)
+}
+
+func (p *requestPool) put(request *prompb.WriteRequest) {
+	request.Timeseries = request.Timeseries[:0]
+	request.Metadata = request.Metadata[:0]
+	p.pool.Put(request)
+}
+
+type bytesPool struct {
+	pool *sync.Pool
+}
+
+func newBytesPool() *bytesPool {
+	return &bytesPool{
+		pool: &sync.Pool{
+			New: func() interface{} {
+				buf := make([]byte, 0, 1024)
+				return &buf
+			},
+		},
+	}
+}
+
+func (p *bytesPool) get() *[]byte {
+	return p.pool.Get().(*[]byte)
+}
+
+func (p *bytesPool) put(b *[]byte) {
+	*b = (*b)[:0]
+	p.pool.Put(b)
+}


### PR DESCRIPTION
This commit adds a pool for reusing bytes and request objects
in the Receiver component in order to reduce overall memory usage.


```
name                                                                               old time/op    new time/op    delta
HandlerReceiveHTTP/typical_labels_under_1KB,_500_of_them/OK-8                         590µs ± 1%     564µs ± 5%     ~     (p=0.095 n=5+5)
HandlerReceiveHTTP/typical_labels_under_1KB,_500_of_them/conflict_errors-8            679µs ± 2%     636µs ± 2%   -6.36%  (p=0.008 n=5+5)
HandlerReceiveHTTP/typical_labels_under_1KB,_5000_of_them/OK-8                       5.84ms ± 1%    5.47ms ± 1%   -6.39%  (p=0.016 n=4+5)
HandlerReceiveHTTP/typical_labels_under_1KB,_5000_of_them/conflict_errors-8          6.51ms ± 1%    6.25ms ± 1%   -3.88%  (p=0.008 n=5+5)
HandlerReceiveHTTP/typical_labels_under_1KB,_20000_of_them/OK-8                      23.2ms ± 1%    22.1ms ± 2%   -4.80%  (p=0.008 n=5+5)
HandlerReceiveHTTP/typical_labels_under_1KB,_20000_of_them/conflict_errors-8         27.0ms ± 2%    25.7ms ± 2%   -4.86%  (p=0.008 n=5+5)
HandlerReceiveHTTP/extremely_large_label_value_10MB,_10_of_them/OK-8                 52.3ms ± 2%    51.6ms ± 2%     ~     (p=0.151 n=5+5)
HandlerReceiveHTTP/extremely_large_label_value_10MB,_10_of_them/conflict_errors-8    53.1ms ± 4%    50.9ms ± 0%   -4.13%  (p=0.008 n=5+5)

name                                                                               old alloc/op   new alloc/op   delta
HandlerReceiveHTTP/typical_labels_under_1KB,_500_of_them/OK-8                        1.20MB ± 0%    1.07MB ± 0%  -10.78%  (p=0.008 n=5+5)
HandlerReceiveHTTP/typical_labels_under_1KB,_500_of_them/conflict_errors-8           1.46MB ± 0%    1.33MB ± 0%   -8.91%  (p=0.008 n=5+5)
HandlerReceiveHTTP/typical_labels_under_1KB,_5000_of_them/OK-8                       13.5MB ± 0%    11.4MB ± 0%  -15.15%  (p=0.008 n=5+5)
HandlerReceiveHTTP/typical_labels_under_1KB,_5000_of_them/conflict_errors-8          16.0MB ± 0%    13.9MB ± 0%  -12.64%  (p=0.008 n=5+5)
HandlerReceiveHTTP/typical_labels_under_1KB,_20000_of_them/OK-8                      54.3MB ± 1%    46.4MB ± 1%  -14.54%  (p=0.008 n=5+5)
HandlerReceiveHTTP/typical_labels_under_1KB,_20000_of_them/conflict_errors-8         63.8MB ± 0%    56.0MB ± 0%  -12.15%  (p=0.008 n=5+5)
HandlerReceiveHTTP/extremely_large_label_value_10MB,_10_of_them/OK-8                  120MB ± 0%     110MB ± 0%   -8.25%  (p=0.008 n=5+5)
HandlerReceiveHTTP/extremely_large_label_value_10MB,_10_of_them/conflict_errors-8     120MB ± 0%     110MB ± 0%   -8.25%  (p=0.008 n=5+5)

name                                                                               old allocs/op  new allocs/op  delta
HandlerReceiveHTTP/typical_labels_under_1KB,_500_of_them/OK-8                         3.10k ± 0%     3.08k ± 0%   -0.42%  (p=0.008 n=5+5)
HandlerReceiveHTTP/typical_labels_under_1KB,_500_of_them/conflict_errors-8            6.64k ± 0%     6.62k ± 0%   -0.20%  (p=0.008 n=5+5)
HandlerReceiveHTTP/typical_labels_under_1KB,_5000_of_them/OK-8                        30.3k ± 0%     30.3k ± 0%   -0.07%  (p=0.008 n=5+5)
HandlerReceiveHTTP/typical_labels_under_1KB,_5000_of_them/conflict_errors-8           65.2k ± 0%     65.1k ± 0%   -0.03%  (p=0.008 n=5+5)
HandlerReceiveHTTP/typical_labels_under_1KB,_20000_of_them/OK-8                        121k ± 0%      121k ± 0%   -0.02%  (p=0.008 n=5+5)
HandlerReceiveHTTP/typical_labels_under_1KB,_20000_of_them/conflict_errors-8           260k ± 0%      260k ± 0%   -0.01%  (p=0.016 n=4+5)
HandlerReceiveHTTP/extremely_large_label_value_10MB,_10_of_them/OK-8                   88.4 ± 1%      81.8 ± 1%   -7.47%  (p=0.008 n=5+5)
HandlerReceiveHTTP/extremely_large_label_value_10MB,_10_of_them/conflict_errors-8       220 ± 1%       212 ± 0%   -3.55%  (p=0.000 n=5+4)
```

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
