### PR TITLE
Fix sharding behavior for vector matches

### DIFF
--- a/pkg/querysharding/analyzer.go
+++ b/pkg/querysharding/analyzer.go
@@ -99,6 +99,9 @@ func (a *QueryAnalyzer) Analyze(query string) (QueryAnalysis, error) {
 		case *parser.BinaryExpr:
 			if n.VectorMatching != nil {
 				shardingLabels := without(n.VectorMatching.MatchingLabels, []string{"le"})
+				if !n.VectorMatching.On && len(shardingLabels) > 0 {
+					shardingLabels = append(shardingLabels, "__name__")
+				}
 				analysis = analysis.scopeToLabels(shardingLabels, n.VectorMatching.On)
 			}
 		case *parser.AggregateExpr:

--- a/pkg/querysharding/analyzer.go
+++ b/pkg/querysharding/analyzer.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	lru "github.com/hashicorp/golang-lru"
+	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/promql/parser"
 )
 
@@ -100,7 +101,7 @@ func (a *QueryAnalyzer) Analyze(query string) (QueryAnalysis, error) {
 			if n.VectorMatching != nil {
 				shardingLabels := without(n.VectorMatching.MatchingLabels, []string{"le"})
 				if !n.VectorMatching.On && len(shardingLabels) > 0 {
-					shardingLabels = append(shardingLabels, "__name__")
+					shardingLabels = append(shardingLabels, model.MetricNameLabel)
 				}
 				analysis = analysis.scopeToLabels(shardingLabels, n.VectorMatching.On)
 			}

--- a/pkg/querysharding/analyzer_test.go
+++ b/pkg/querysharding/analyzer_test.go
@@ -142,12 +142,12 @@ sum by (container) (
 		{
 			name:           "binary expression with without vector matching and grouping",
 			expression:     `sum without (cluster, pod) (http_requests_total{code="400"}) / ignoring (pod) sum without (cluster, pod) (http_requests_total)`,
-			shardingLabels: []string{"pod", "cluster"},
+			shardingLabels: []string{"pod", "cluster", "__name__"},
 		},
 		{
 			name:           "multiple binary expressions with without grouping",
 			expression:     `(http_requests_total{code="400"} + ignoring (pod) http_requests_total{code="500"}) / ignoring (cluster, pod) http_requests_total`,
-			shardingLabels: []string{"cluster", "pod"},
+			shardingLabels: []string{"cluster", "pod", "__name__"},
 		},
 		{
 			name: "multiple binary expressions with without vector matchers",
@@ -155,7 +155,7 @@ sum by (container) (
 (http_requests_total{code="400"} + ignoring (cluster, pod) http_requests_total{code="500"})
 / ignoring (pod)
 http_requests_total`,
-			shardingLabels: []string{"cluster", "pod"},
+			shardingLabels: []string{"cluster", "pod", "__name__"},
 		},
 		{
 			name:           "histogram quantile",

--- a/pkg/querysharding/analyzer_test.go
+++ b/pkg/querysharding/analyzer_test.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 )
 
@@ -142,12 +143,12 @@ sum by (container) (
 		{
 			name:           "binary expression with without vector matching and grouping",
 			expression:     `sum without (cluster, pod) (http_requests_total{code="400"}) / ignoring (pod) sum without (cluster, pod) (http_requests_total)`,
-			shardingLabels: []string{"pod", "cluster", "__name__"},
+			shardingLabels: []string{"pod", "cluster", model.MetricNameLabel},
 		},
 		{
 			name:           "multiple binary expressions with without grouping",
 			expression:     `(http_requests_total{code="400"} + ignoring (pod) http_requests_total{code="500"}) / ignoring (cluster, pod) http_requests_total`,
-			shardingLabels: []string{"cluster", "pod", "__name__"},
+			shardingLabels: []string{"cluster", "pod", model.MetricNameLabel},
 		},
 		{
 			name: "multiple binary expressions with without vector matchers",
@@ -155,7 +156,7 @@ sum by (container) (
 (http_requests_total{code="400"} + ignoring (cluster, pod) http_requests_total{code="500"})
 / ignoring (pod)
 http_requests_total`,
-			shardingLabels: []string{"cluster", "pod", "__name__"},
+			shardingLabels: []string{"cluster", "pod", model.MetricNameLabel},
 		},
 		{
 			name:           "histogram quantile",


### PR DESCRIPTION
Fixes #5798

When analyzing a query composed of boolean expression with a non-"on" vector match, the current vertical sharding logic is incorrectly scoping to labels in the vector match and changing the semantics of the query.

Example:
```
foo and without (lbl) bar
```

## Changes
- Prevents the vertical sharding query analyzer from using labels in a vector match to shard on if the match is done with the `ignoring` keyword (match On == false)

## Verification
- Manual verification of queries with and without the change; after this modification, queries worked as expected.

I am not clear on if it's actually possible to shard `without` labels without breaking queries; it's possible that a more appropriate change would be to the shard matcher code in the querier. 
