### PR TITLE
store: add histogram for postings size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 
 ### Added
 
+- [#5814](https://github.com/thanos-io/thanos/pull/5814) - Add metric `thanos_bucket_store_postings_size_bytes` that shows the distribution of how many postings (in bytes) were needed for each Series() call in Thanos Store. Useful for determining limits.
+
 ### Changed
 
 ## [v0.29.0](https://github.com/thanos-io/thanos/tree/release-0.29) - Release in progress


### PR DESCRIPTION
Add a metric that shows the distribution of how many postings (in bytes) were needed for each Series() call. Useful for determining limits.

Signed-off-by: Giedrius Statkevičius <giedrius.statkevicius@vinted.com>
