### PR TITLE
Update promql engine

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -72,7 +72,7 @@ require (
 	github.com/prometheus/prometheus v0.39.1
 	github.com/sony/gobreaker v0.5.0
 	github.com/stretchr/testify v1.8.0
-	github.com/thanos-community/promql-engine v0.0.0-20221025072844-52d728e59fa0
+	github.com/thanos-community/promql-engine v0.0.0-20221101075408-6d5b22b2cd4d
 	github.com/thanos-io/objstore v0.0.0-20221006135717-79dcec7fe604
 	github.com/uber/jaeger-client-go v2.30.0+incompatible
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -952,8 +952,8 @@ github.com/tencentyun/cos-go-sdk-v5 v0.7.34 h1:xm+Pg+6m486y4eugRI7/E4WasbVmpY1hp
 github.com/tencentyun/cos-go-sdk-v5 v0.7.34/go.mod h1:4dCEtLHGh8QPxHEkgq+nFaky7yZxQuYwgSJM87icDaw=
 github.com/thanos-community/galaxycache v0.0.0-20211122094458-3a32041a1f1e h1:f1Zsv7OAU9iQhZwigp50Yl38W10g/vd5NC8Rdk1Jzng=
 github.com/thanos-community/galaxycache v0.0.0-20211122094458-3a32041a1f1e/go.mod h1:jXcofnrSln/cLI6/dhlBxPQZEEQHVPCcFaH75M+nSzM=
-github.com/thanos-community/promql-engine v0.0.0-20221025072844-52d728e59fa0 h1:zk6SEHgZ1BkUAerSeD4KzcgL8a7BlMC/niI0S5dGII8=
-github.com/thanos-community/promql-engine v0.0.0-20221025072844-52d728e59fa0/go.mod h1:e3BzS0UVlHOKQa5STt/C0elYAa4Qp/7jyzp/Xf+e0C0=
+github.com/thanos-community/promql-engine v0.0.0-20221101075408-6d5b22b2cd4d h1:UIqUy9mHwI1ZqAtxYiYmRhSlGCgRtfS9rFy2usHcA30=
+github.com/thanos-community/promql-engine v0.0.0-20221101075408-6d5b22b2cd4d/go.mod h1:e3BzS0UVlHOKQa5STt/C0elYAa4Qp/7jyzp/Xf+e0C0=
 github.com/thanos-io/objstore v0.0.0-20221006135717-79dcec7fe604 h1:9dceDSKKsLWNHjrMpyzK1t7eVcAZv9Dp3FX+uokUS2Y=
 github.com/thanos-io/objstore v0.0.0-20221006135717-79dcec7fe604/go.mod h1:Vx5dZs9ElxEhNLnum/OgB0pNTqNdI2zdXL82BeJr3T4=
 github.com/themihai/gomemcache v0.0.0-20180902122335-24332e2d58ab h1:7ZR3hmisBWw77ZpO1/o86g+JV3VKlk3d48jopJxzTjU=


### PR DESCRIPTION
This commit updates the thanos-communty PromQL engine to the latest version, containing support for the histogram_quantile function.

Signed-off-by: Filip Petkovski <filip.petkovsky@gmail.com>

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

Update the community PromQL engine to the latest version.

## Verification

<!-- How you tested it? How do you know it works? -->
