### PR TITLE
Support matrix type response merge for instant query sharding

### DIFF
--- a/internal/cortex/querier/queryrange/query_range.go
+++ b/internal/cortex/querier/queryrange/query_range.go
@@ -654,7 +654,7 @@ func matrixMerge(resps []*PrometheusResponse) []SampleStream {
 					stream.Samples = stream.Samples[1:]
 				} else if existingEndTs > stream.Samples[0].TimestampMs {
 					// Overlap might be big, use heavier algorithm to remove overlap.
-					stream.Samples = sliceSamples(stream.Samples, existingEndTs)
+					stream.Samples = SliceSamples(stream.Samples, existingEndTs)
 				} // else there is no overlap, yay!
 			}
 			existing.Samples = append(existing.Samples, stream.Samples...)
@@ -676,11 +676,11 @@ func matrixMerge(resps []*PrometheusResponse) []SampleStream {
 	return result
 }
 
-// sliceSamples assumes given samples are sorted by timestamp in ascending order and
+// SliceSamples assumes given samples are sorted by timestamp in ascending order and
 // return a sub slice whose first element's is the smallest timestamp that is strictly
 // bigger than the given minTs. Empty slice is returned if minTs is bigger than all the
 // timestamps in samples.
-func sliceSamples(samples []cortexpb.Sample, minTs int64) []cortexpb.Sample {
+func SliceSamples(samples []cortexpb.Sample, minTs int64) []cortexpb.Sample {
 	if len(samples) <= 0 || minTs < samples[0].TimestampMs {
 		return samples
 	}

--- a/pkg/queryfrontend/queryinstant_codec.go
+++ b/pkg/queryfrontend/queryinstant_codec.go
@@ -38,8 +38,8 @@ func NewThanosQueryInstantCodec(partialResponse bool) *queryInstantCodec {
 	}
 }
 
-// MergeResponse merges multiple responses into a single response.
-// For instant query only vector responses will be merged because other types of queries
+// MergeResponse merges multiple responses into a single response. For instant query
+// only vector and matrix responses will be merged because other types of queries
 // are not shardable like number literal, string literal, scalar, etc.
 func (c queryInstantCodec) MergeResponse(responses ...queryrange.Response) (queryrange.Response, error) {
 	if len(responses) == 0 {
@@ -52,18 +52,36 @@ func (c queryInstantCodec) MergeResponse(responses ...queryrange.Response) (quer
 	for _, resp := range responses {
 		promResponses = append(promResponses, resp.(*queryrange.PrometheusInstantQueryResponse))
 	}
-	res := &queryrange.PrometheusInstantQueryResponse{
-		Status: queryrange.StatusSuccess,
-		Data: queryrange.PrometheusInstantQueryData{
-			ResultType: model.ValVector.String(),
-			Result: queryrange.PrometheusInstantQueryResult{
-				Result: &queryrange.PrometheusInstantQueryResult_Vector{
-					Vector: vectorMerge(promResponses),
+	var res queryrange.Response
+	switch promResponses[0].Data.ResultType {
+	case model.ValMatrix.String():
+		res = &queryrange.PrometheusInstantQueryResponse{
+			Status: queryrange.StatusSuccess,
+			Data: queryrange.PrometheusInstantQueryData{
+				ResultType: model.ValMatrix.String(),
+				Result: queryrange.PrometheusInstantQueryResult{
+					Result: &queryrange.PrometheusInstantQueryResult_Matrix{
+						Matrix: matrixMerge(promResponses),
+					},
 				},
+				Stats: queryrange.StatsMerge(responses),
 			},
-			Stats: queryrange.StatsMerge(responses),
-		},
+		}
+	default:
+		res = &queryrange.PrometheusInstantQueryResponse{
+			Status: queryrange.StatusSuccess,
+			Data: queryrange.PrometheusInstantQueryData{
+				ResultType: model.ValVector.String(),
+				Result: queryrange.PrometheusInstantQueryResult{
+					Result: &queryrange.PrometheusInstantQueryResult_Vector{
+						Vector: vectorMerge(promResponses),
+					},
+				},
+				Stats: queryrange.StatsMerge(responses),
+			},
+		}
 	}
+
 	return res, nil
 }
 
@@ -281,4 +299,77 @@ func vectorMerge(resps []*queryrange.PrometheusInstantQueryResponse) *queryrange
 		result.Samples = append(result.Samples, output[key])
 	}
 	return result
+}
+
+func matrixMerge(resps []*queryrange.PrometheusInstantQueryResponse) *queryrange.Matrix {
+	output := map[string]*queryrange.SampleStream{}
+	for _, resp := range resps {
+		if resp == nil {
+			continue
+		}
+		// Merge matrix result samples only. Skip other types such as
+		// string, scalar as those are not sharable.
+		if resp.Data.Result.GetMatrix() == nil {
+			continue
+		}
+		for _, stream := range resp.Data.Result.GetMatrix().SampleStreams {
+			metric := cortexpb.FromLabelAdaptersToLabels(stream.Labels).String()
+			existing, ok := output[metric]
+			if !ok {
+				existing = &queryrange.SampleStream{
+					Labels: stream.Labels,
+				}
+			}
+			// We need to make sure we don't repeat samples. This causes some visualizations to be broken in Grafana.
+			// The prometheus API is inclusive of start and end timestamps.
+			if len(existing.Samples) > 0 && len(stream.Samples) > 0 {
+				existingEndTs := existing.Samples[len(existing.Samples)-1].TimestampMs
+				if existingEndTs == stream.Samples[0].TimestampMs {
+					// Typically this the cases where only 1 sample point overlap,
+					// so optimize with simple code.
+					stream.Samples = stream.Samples[1:]
+				} else if existingEndTs > stream.Samples[0].TimestampMs {
+					// Overlap might be big, use heavier algorithm to remove overlap.
+					stream.Samples = sliceSamples(stream.Samples, existingEndTs)
+				} // else there is no overlap, yay!
+			}
+			existing.Samples = append(existing.Samples, stream.Samples...)
+			output[metric] = existing
+		}
+	}
+
+	keys := make([]string, 0, len(output))
+	for key := range output {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	result := &queryrange.Matrix{
+		SampleStreams: make([]*queryrange.SampleStream, 0, len(output)),
+	}
+	for _, key := range keys {
+		result.SampleStreams = append(result.SampleStreams, output[key])
+	}
+
+	return result
+}
+
+// sliceSamples assumes given samples are sorted by timestamp in ascending order and
+// return a sub slice whose first element's is the smallest timestamp that is strictly
+// bigger than the given minTs. Empty slice is returned if minTs is bigger than all the
+// timestamps in samples.
+func sliceSamples(samples []cortexpb.Sample, minTs int64) []cortexpb.Sample {
+	if len(samples) <= 0 || minTs < samples[0].TimestampMs {
+		return samples
+	}
+
+	if len(samples) > 0 && minTs > samples[len(samples)-1].TimestampMs {
+		return samples[len(samples):]
+	}
+
+	searchResult := sort.Search(len(samples), func(i int) bool {
+		return samples[i].TimestampMs > minTs
+	})
+
+	return samples[searchResult:]
 }

--- a/pkg/queryfrontend/queryinstant_codec.go
+++ b/pkg/queryfrontend/queryinstant_codec.go
@@ -330,7 +330,7 @@ func matrixMerge(resps []*queryrange.PrometheusInstantQueryResponse) *queryrange
 					stream.Samples = stream.Samples[1:]
 				} else if existingEndTs > stream.Samples[0].TimestampMs {
 					// Overlap might be big, use heavier algorithm to remove overlap.
-					stream.Samples = sliceSamples(stream.Samples, existingEndTs)
+					stream.Samples = queryrange.SliceSamples(stream.Samples, existingEndTs)
 				} // else there is no overlap, yay!
 			}
 			existing.Samples = append(existing.Samples, stream.Samples...)
@@ -352,24 +352,4 @@ func matrixMerge(resps []*queryrange.PrometheusInstantQueryResponse) *queryrange
 	}
 
 	return result
-}
-
-// sliceSamples assumes given samples are sorted by timestamp in ascending order and
-// return a sub slice whose first element's is the smallest timestamp that is strictly
-// bigger than the given minTs. Empty slice is returned if minTs is bigger than all the
-// timestamps in samples.
-func sliceSamples(samples []cortexpb.Sample, minTs int64) []cortexpb.Sample {
-	if len(samples) <= 0 || minTs < samples[0].TimestampMs {
-		return samples
-	}
-
-	if len(samples) > 0 && minTs > samples[len(samples)-1].TimestampMs {
-		return samples[len(samples):]
-	}
-
-	searchResult := sort.Search(len(samples), func(i int) bool {
-		return samples[i].TimestampMs > minTs
-	})
-
-	return samples[searchResult:]
 }

--- a/pkg/queryfrontend/queryinstant_codec_test.go
+++ b/pkg/queryfrontend/queryinstant_codec_test.go
@@ -514,6 +514,184 @@ func TestMergeResponse(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "merge two matrix responses with non-duplicate samples",
+			resps: []queryrange.Response{
+				&queryrange.PrometheusInstantQueryResponse{
+					Status: queryrange.StatusSuccess,
+					Data: queryrange.PrometheusInstantQueryData{
+						ResultType: model.ValMatrix.String(),
+						Result: queryrange.PrometheusInstantQueryResult{
+							Result: &queryrange.PrometheusInstantQueryResult_Matrix{
+								Matrix: &queryrange.Matrix{
+									SampleStreams: []*queryrange.SampleStream{
+										{
+											Samples: []cortexpb.Sample{{TimestampMs: 1, Value: 2}},
+											Labels: cortexpb.FromLabelsToLabelAdapters(labels.FromMap(map[string]string{
+												"__name__": "up",
+												"job":      "bar",
+											})),
+										},
+										{
+											Samples: []cortexpb.Sample{{TimestampMs: 1, Value: 2}},
+											Labels: cortexpb.FromLabelsToLabelAdapters(labels.FromMap(map[string]string{
+												"__name__": "up",
+												"job":      "foo",
+											})),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				&queryrange.PrometheusInstantQueryResponse{
+					Status: queryrange.StatusSuccess,
+					Data: queryrange.PrometheusInstantQueryData{
+						ResultType: model.ValMatrix.String(),
+						Result: queryrange.PrometheusInstantQueryResult{
+							Result: &queryrange.PrometheusInstantQueryResult_Matrix{
+								Matrix: &queryrange.Matrix{
+									SampleStreams: []*queryrange.SampleStream{
+										{
+											Samples: []cortexpb.Sample{{TimestampMs: 2, Value: 3}},
+											Labels: cortexpb.FromLabelsToLabelAdapters(labels.FromMap(map[string]string{
+												"__name__": "up",
+												"job":      "bar",
+											})),
+										},
+										{
+											Samples: []cortexpb.Sample{{TimestampMs: 2, Value: 3}},
+											Labels: cortexpb.FromLabelsToLabelAdapters(labels.FromMap(map[string]string{
+												"__name__": "up",
+												"job":      "foo",
+											})),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedResp: &queryrange.PrometheusInstantQueryResponse{
+				Status: queryrange.StatusSuccess,
+				Data: queryrange.PrometheusInstantQueryData{
+					ResultType: model.ValMatrix.String(),
+					Result: queryrange.PrometheusInstantQueryResult{
+						Result: &queryrange.PrometheusInstantQueryResult_Matrix{
+							Matrix: &queryrange.Matrix{
+								SampleStreams: []*queryrange.SampleStream{
+									{
+										Samples: []cortexpb.Sample{{TimestampMs: 1, Value: 2}, {TimestampMs: 2, Value: 3}},
+										Labels: cortexpb.FromLabelsToLabelAdapters(labels.FromMap(map[string]string{
+											"__name__": "up",
+											"job":      "bar",
+										})),
+									},
+									{
+										Samples: []cortexpb.Sample{{TimestampMs: 1, Value: 2}, {TimestampMs: 2, Value: 3}},
+										Labels: cortexpb.FromLabelsToLabelAdapters(labels.FromMap(map[string]string{
+											"__name__": "up",
+											"job":      "foo",
+										})),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "merge two matrix responses with duplicate samples",
+			resps: []queryrange.Response{
+				&queryrange.PrometheusInstantQueryResponse{
+					Status: queryrange.StatusSuccess,
+					Data: queryrange.PrometheusInstantQueryData{
+						ResultType: model.ValMatrix.String(),
+						Result: queryrange.PrometheusInstantQueryResult{
+							Result: &queryrange.PrometheusInstantQueryResult_Matrix{
+								Matrix: &queryrange.Matrix{
+									SampleStreams: []*queryrange.SampleStream{
+										{
+											Samples: []cortexpb.Sample{{TimestampMs: 1, Value: 2}},
+											Labels: cortexpb.FromLabelsToLabelAdapters(labels.FromMap(map[string]string{
+												"__name__": "up",
+												"job":      "bar",
+											})),
+										},
+										{
+											Samples: []cortexpb.Sample{{TimestampMs: 1, Value: 2}},
+											Labels: cortexpb.FromLabelsToLabelAdapters(labels.FromMap(map[string]string{
+												"__name__": "up",
+												"job":      "foo",
+											})),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				&queryrange.PrometheusInstantQueryResponse{
+					Status: queryrange.StatusSuccess,
+					Data: queryrange.PrometheusInstantQueryData{
+						ResultType: model.ValMatrix.String(),
+						Result: queryrange.PrometheusInstantQueryResult{
+							Result: &queryrange.PrometheusInstantQueryResult_Matrix{
+								Matrix: &queryrange.Matrix{
+									SampleStreams: []*queryrange.SampleStream{
+										{
+											Samples: []cortexpb.Sample{{TimestampMs: 1, Value: 2}},
+											Labels: cortexpb.FromLabelsToLabelAdapters(labels.FromMap(map[string]string{
+												"__name__": "up",
+												"job":      "bar",
+											})),
+										},
+										{
+											Samples: []cortexpb.Sample{{TimestampMs: 1, Value: 2}},
+											Labels: cortexpb.FromLabelsToLabelAdapters(labels.FromMap(map[string]string{
+												"__name__": "up",
+												"job":      "foo",
+											})),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedResp: &queryrange.PrometheusInstantQueryResponse{
+				Status: queryrange.StatusSuccess,
+				Data: queryrange.PrometheusInstantQueryData{
+					ResultType: model.ValMatrix.String(),
+					Result: queryrange.PrometheusInstantQueryResult{
+						Result: &queryrange.PrometheusInstantQueryResult_Matrix{
+							Matrix: &queryrange.Matrix{
+								SampleStreams: []*queryrange.SampleStream{
+									{
+										Samples: []cortexpb.Sample{{TimestampMs: 1, Value: 2}},
+										Labels: cortexpb.FromLabelsToLabelAdapters(labels.FromMap(map[string]string{
+											"__name__": "up",
+											"job":      "bar",
+										})),
+									},
+									{
+										Samples: []cortexpb.Sample{{TimestampMs: 1, Value: 2}},
+										Labels: cortexpb.FromLabelsToLabelAdapters(labels.FromMap(map[string]string{
+											"__name__": "up",
+											"job":      "foo",
+										})),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			resp, err := codec.MergeResponse(tc.resps...)

--- a/pkg/querysharding/analyzer.go
+++ b/pkg/querysharding/analyzer.go
@@ -66,8 +66,8 @@ func (a *CachedQueryAnalyzer) Analyze(query string) (QueryAnalysis, error) {
 // Analyze analyzes a query and returns a QueryAnalysis.
 
 // Analyze uses the following algorithm:
-//   - if a query has subqueries, such as label_join or label_replace,
-//     or has functions which cannot be sharded, then treat the query as non shardable.
+//   - if a query has functions which cannot be sharded such as
+//     label_join or label_replace, then treat the query as non shardable.
 //   - Walk the query and find the least common labelset
 //     used in grouping expressions. If non-empty, treat the query
 //     as shardable by those labels.


### PR DESCRIPTION
Signed-off-by: Ben Ye <benye@amazon.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

Fix the leftover issue mentioned in https://github.com/thanos-io/thanos/pull/5846#issuecomment-1300953809

## Changes

Instant query sharding support merging matrix response

## Verification

Added unit test and tested manually.
