### PR TITLE
store: add missing debugLogging set

### DIFF
--- a/cmd/thanos/store.go
+++ b/cmd/thanos/store.go
@@ -200,6 +200,8 @@ func registerStore(app *extkingpin.App) {
 			return errors.Wrap(err, "error while parsing config for request logging")
 		}
 
+		conf.debugLogging = debugLogging
+
 		return runStore(g,
 			logger,
 			reg,


### PR DESCRIPTION
Signed-off-by: Seena Fallah <seenafallah@gmail.com>

## Changes

add missing `debugLogging` set in store config

## Verification

run store with `--log.level=debug` and bucket in back and check for the `debugFoundBlockSetOverview` function output
