### PR TITLE
ui: Added back support for warnings printed in info level.

### DIFF
--- a/pkg/ui/react-app/src/pages/graph/Panel.tsx
+++ b/pkg/ui/react-app/src/pages/graph/Panel.tsx
@@ -38,6 +38,7 @@ interface PanelState {
   lastQueryParams: QueryParams | null;
   loading: boolean;
   error: string | null;
+  warnings: string[] | null;
   stats: QueryStats | null;
   exprInputValue: string;
 }
@@ -83,6 +84,7 @@ class Panel extends Component<PanelProps & PathPrefixProps, PanelState> {
       data: null,
       lastQueryParams: null,
       loading: false,
+      warnings: null,
       error: null,
       stats: null,
       exprInputValue: props.options.expr,
@@ -206,6 +208,7 @@ class Panel extends Component<PanelProps & PathPrefixProps, PanelState> {
             endTime,
             resolution,
           },
+          warnings: json.warnings,
           stats: {
             loadTime: Date.now() - queryStart,
             resolution,
@@ -284,6 +287,10 @@ class Panel extends Component<PanelProps & PathPrefixProps, PanelState> {
     this.setState({ error: null });
   };
 
+  handleToggleWarn = (): void => {
+    this.setState({ warnings: null });
+  };
+
   render(): JSX.Element {
     const { pastQueries, metricNames, options, id, stores } = this.props;
     return (
@@ -308,6 +315,18 @@ class Panel extends Component<PanelProps & PathPrefixProps, PanelState> {
           <Col>
             <UncontrolledAlert isOpen={this.state.error || false} toggle={this.handleToggleAlert} color="danger">
               {this.state.error}
+            </UncontrolledAlert>
+          </Col>
+        </Row>
+        <Row>
+          <Col>
+            <UncontrolledAlert
+              isOpen={this.state.warnings || false}
+              toggle={this.handleToggleWarn}
+              color="info"
+              style={{ whiteSpace: 'break-spaces' }}
+            >
+              {this.state.warnings}
             </UncontrolledAlert>
           </Col>
         </Row>


### PR DESCRIPTION
I thought we had printed warnings on UI, somehow it got forgotten when switching to new UI?

Adding back on info level. The reason why it's info CSS (so blue color), not yellow (warning), is because I want to reuse this for "explain" command in future.

Signed-off-by: bwplotka <bwplotka@gmail.com>

@saswatamcode 