### PR TITLE
*:Fix stateless ruler config in quickstart

### DIFF
--- a/scripts/quickstart.sh
+++ b/scripts/quickstart.sh
@@ -260,14 +260,13 @@ QUERIER_JAEGER_CONFIG=$(
 
 REMOTE_WRITE_FLAGS=""
 if [ -n "${STATELESS_RULER_ENABLED}" ]; then
-  cat >/data/rule-remote-write.yaml <<-EOF
-  name: "thanos-receivers"
+  cat > data/rule-remote-write.yaml <<-EOF
   remote_write:
-    url: "http://127.0.0.1:10908/api/v1/receive"
+  - url: "http://localhost:10908/api/v1/receive"
     name: "receive-0"
 EOF
 
-  REMOTE_WRITE_FLAGS="--remote-write.config-file data/rule-remote-write.yaml"
+  REMOTE_WRITE_FLAGS="--remote-write.config-file=data/rule-remote-write.yaml"
 fi
 
 # Start Thanos Ruler.


### PR DESCRIPTION
Signed-off-by: Matej Gera <matejgera@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Small fix for stateless ruler config in the quickstart, as presently it does not seem to work.

## Verification

<!-- How you tested it? How do you know it works? -->
