### PR TITLE
Tracing: Fix sampler defaults

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,7 @@ version: 2.1
 
 orbs:
   go: circleci/go@1.7.1
+  git-shallow-clone: guitarrapc/git-shallow-clone@2.4.0
 
 executors:
   golang:
@@ -19,7 +20,7 @@ jobs:
     environment:
       GO111MODULE: 'on'
     steps:
-      - checkout
+      - git-shallow-clone/checkout
       - go/mod-download-cached
       - setup_remote_docker:
           version: 20.10.12
@@ -58,7 +59,7 @@ jobs:
       GOBIN: "/home/circleci/.go_workspace/go/bin"
       PROMU_VERSION: "0.5.0"
     steps:
-      - checkout
+      - git-shallow-clone/checkout
       - run: mkdir -p ${GOBIN}
       - run: curl -L "https://github.com/prometheus/promu/releases/download/v${PROMU_VERSION}/promu-${PROMU_VERSION}.$(go env GOOS)-$(go env GOARCH).tar.gz" | tar --strip-components=1 -xzf - -C ${GOBIN}
       - run: mv -f ${GOBIN}/promu "${GOBIN}/promu-v${PROMU_VERSION}"
@@ -71,7 +72,7 @@ jobs:
   publish_main:
     executor: golang
     steps:
-      - checkout
+      - git-shallow-clone/checkout
       - go/mod-download-cached
       - setup_remote_docker:
           version: 20.10.12
@@ -93,7 +94,7 @@ jobs:
   publish_release:
     executor: golang
     steps:
-      - checkout
+      - git-shallow-clone/checkout
       - go/mod-download-cached
       - setup_remote_docker:
           version: 20.10.12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 
 We use *breaking :warning:* to mark changes that are not backward compatible (relates only to v0.y.z releases.)
 
+## Unreleased
+
+## [v0.29.1](https://github.com/thanos-io/thanos/tree/release-0.29) - In progress
+
+### Fixed
+
+- [#5887](https://github.com/thanos-io/thanos/pull/5887) Tracing: Make sure rate limiting sampler is the default, as was the case in version pre-0.29.0.
+
+### Added
+
+### Changed
+
 ## [v0.29.0](https://github.com/thanos-io/thanos/tree/release-0.29) - 2022.11.03
 
 ### Fixed

--- a/pkg/tracing/jaeger/config_yaml.go
+++ b/pkg/tracing/jaeger/config_yaml.go
@@ -19,6 +19,13 @@ import (
 	tracesdk "go.opentelemetry.io/otel/sdk/trace"
 )
 
+const (
+	SamplerTypeRemote        = "remote"
+	SamplerTypeProbabilistic = "probabilistic"
+	SamplerTypeConstant      = "const"
+	SamplerTypeRateLimiting  = "ratelimiting"
+)
+
 type ParentBasedSamplerConfig struct {
 	LocalParentSampled  bool `yaml:"local_parent_sampled"`
 	RemoteParentSampled bool `yaml:"remote_parent_sampled"`
@@ -114,22 +121,27 @@ func getSamplingFraction(samplerType string, samplingFactor float64) float64 {
 
 func getSampler(config Config) tracesdk.Sampler {
 	samplerType := config.SamplerType
+	if samplerType == "" {
+		samplerType = SamplerTypeRateLimiting
+	}
 	samplingFraction := getSamplingFraction(samplerType, config.SamplerParam)
 
 	var sampler tracesdk.Sampler
 	switch samplerType {
-	case "probabilistic":
-		sampler = tracesdk.ParentBased(tracesdk.TraceIDRatioBased(samplingFraction))
-	case "const":
+	case SamplerTypeProbabilistic:
+		sampler = tracesdk.TraceIDRatioBased(samplingFraction)
+	case SamplerTypeConstant:
 		if samplingFraction == 1.0 {
 			sampler = tracesdk.AlwaysSample()
 		} else {
 			sampler = tracesdk.NeverSample()
 		}
-	case "remote":
+	case SamplerTypeRemote:
 		remoteOptions := getRemoteOptions(config)
 		sampler = jaegerremote.New(config.ServiceName, remoteOptions...)
-	case "ratelimiting":
+	// Fallback always to default (rate limiting).
+	case SamplerTypeRateLimiting:
+	default:
 		// The same config options are applicable to both remote and rate-limiting samplers.
 		remoteOptions := getRemoteOptions(config)
 		sampler = jaegerremote.New(config.ServiceName, remoteOptions...)
@@ -137,17 +149,20 @@ func getSampler(config Config) tracesdk.Sampler {
 		if ok {
 			sampler.Update(config.SamplerParam)
 		}
-	default:
-		var root tracesdk.Sampler
-		var parentOptions []tracesdk.ParentBasedSamplerOption
-		if config.SamplerParentConfig.LocalParentSampled {
-			parentOptions = append(parentOptions, tracesdk.WithLocalParentSampled(root))
-		}
-		if config.SamplerParentConfig.RemoteParentSampled {
-			parentOptions = append(parentOptions, tracesdk.WithRemoteParentSampled(root))
-		}
-		sampler = tracesdk.ParentBased(root, parentOptions...)
 	}
+
+	// Use parent-based to make sure we respect the span parent, if
+	// it is sampled. Optionally, allow user to specify the
+	// parent-based options.
+	var parentOptions []tracesdk.ParentBasedSamplerOption
+	if config.SamplerParentConfig.LocalParentSampled {
+		parentOptions = append(parentOptions, tracesdk.WithLocalParentSampled(sampler))
+	}
+	if config.SamplerParentConfig.RemoteParentSampled {
+		parentOptions = append(parentOptions, tracesdk.WithRemoteParentSampled(sampler))
+	}
+	sampler = tracesdk.ParentBased(sampler, parentOptions...)
+
 	return sampler
 }
 


### PR DESCRIPTION
Signed-off-by: Matej Gera <matejgera@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Fixes #5872

- Makes sure we use rate limiting sampler as default, as was the case pre-migration
- Correct the of parent-based sampler and option - we should always use parent based sampler to respect the span parent, if it is being sampled. Optionally let user configure parent based sampler.

## Verification
- Added unit test
