### PR TITLE
Cache: Fixed redis cache to use multi batch size config value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,11 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 ## Unreleased
 
 ### Fixed
-
 - [#5844](https://github.com/thanos-io/thanos/pull/5844) Query Frontend: Fixes @ modifier time range when splitting queries by interval.
 - [#5854](https://github.com/thanos-io/thanos/pull/5854) Query Frontend: Handles `lookback_delta` param in query frontend.
 - [#5230](https://github.com/thanos-io/thanos/pull/5230) Rule: Stateless ruler support restoring `for` state from query API servers. The query API servers should be able to access the remote write storage.
 - [#5880](https://github.com/thanos-io/thanos/pull/5880) Query Frontend: Fixes some edge cases of query sharding analysis.
+- [#5893](https://github.com/thanos-io/thanos/pull/5893) Cache: fixed redis client not respecting `SetMultiBatchSize` config value.
 
 ### Added
 

--- a/pkg/cacheutil/redis_client.go
+++ b/pkg/cacheutil/redis_client.go
@@ -239,8 +239,9 @@ func (c *RedisClient) SetMulti(ctx context.Context, data map[string][]byte, ttl 
 		keys = append(keys, k)
 	}
 	err := doWithBatch(ctx, len(data), c.config.SetMultiBatchSize, c.setMultiGate, func(startIndex, endIndex int) error {
+		currentKeys := keys[startIndex:endIndex]
 		_, err := c.Pipelined(ctx, func(p redis.Pipeliner) error {
-			for _, key := range keys {
+			for _, key := range currentKeys {
 				p.SetEX(ctx, key, data[key], ttl)
 			}
 			return nil


### PR DESCRIPTION
Signed-off-by: Ivan Ryabov <abbyssoul@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->
Cache: fixed redis client not respecting `SetMultiBatchSize` config value.

## Verification

<!-- How you tested it? How do you know it works? -->
