### PR TITLE
Receive: Reuse strings in writer, scoped to a request

### DIFF
--- a/pkg/receive/writer.go
+++ b/pkg/receive/writer.go
@@ -72,8 +72,9 @@ func (r *Writer) Write(ctx context.Context, tenantID string, wreq *prompb.WriteR
 	getRef := app.(storage.GetRef)
 
 	var (
-		ref  storage.SeriesRef
-		errs errutil.MultiError
+		ref       storage.SeriesRef
+		errs      errutil.MultiError
+		internMap = make(map[string]string)
 	)
 	for _, t := range wreq.Timeseries {
 		// Check if time series labels are valid. If not, skip the time series
@@ -104,7 +105,7 @@ func (r *Writer) Write(ctx context.Context, tenantID string, wreq *prompb.WriteR
 		if ref == 0 {
 			// If not, copy labels, as TSDB will hold those strings long term. Given no
 			// copy unmarshal we don't want to keep memory for whole protobuf, only for labels.
-			labelpb.ReAllocZLabelsStrings(&t.Labels)
+			labelpb.ReAllocZLabelsStrings(&t.Labels, internMap)
 			lset = labelpb.ZLabelsToPromLabels(t.Labels)
 		}
 

--- a/pkg/store/labelpb/label_test.go
+++ b/pkg/store/labelpb/label_test.go
@@ -380,7 +380,7 @@ func BenchmarkTransformWithAndWithoutCopy(b *testing.B) {
 		b.ResetTimer()
 
 		for i := 0; i < b.N; i++ {
-			ReAllocZLabelsStrings(&lbls)
+			ReAllocZLabelsStrings(&lbls, make(map[string]string))
 			ret = ZLabelsToPromLabels(lbls)
 		}
 	})


### PR DESCRIPTION
Signed-off-by: Matej Gera <matejgera@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

This is a quick idea inspired by some recent discussions on label optimizations and [string interning](https://en.wikipedia.org/wiki/String_interning).

It comes from assumption that even in a single write request, on average, there ought to be at least some label names and / or values that will be repeated. I good example is the label name `__name__` which every series is guaranteed to have. Other good candidates can be label names `job`, `instance` etc. which will repeat in multiple series with high probability.

The idea is to intern these strings, but only on the level of a single write request. We already do reallocation of these strings to detach them from the larger gRPC request, so we might reuse strings that repeat themselves in either label name or value. Doing this on a per request level also means we do not need to track string usage globally, which although would be even more efficient, is more tricky to implement (see the Prometheus issue ref below).

While this does not give us 100% string interning when it comes to TSDB as a whole, it could already save us some long-term string allocations which are held in TSDB's memory.  Summing up all smaller allocation savings on each request could still translate into overall lower memory usage on receiver, at least until Prometheus has figured string interning on their side (reference: https://github.com/prometheus/prometheus/issues/11133) when such mechanism would be part of the TSDB itself. Although this introduces some overhead at the time of string reallocation, this trade off might be acceptable from the point of long-term memory usage of receiver.

## Verification
Test are still passing. I also have tried running this locally on a `kind` cluster and all seem working fine. If this idea is deemed valid, I'll try few more longer term test runs / benchmarks, to see how it fairs in comparison to latest Thanos release.

On benchmarks, with an extreme test case (100 series, each with a single label, where label name == label value  - meaning we'll always intern this to single string), the allocations have decreased as expected, but the overhead of interning is more pronounced:

```
name                                                           old time/op    new time/op    delta
TransformWithAndWithoutCopy/ZLabelsToPromLabels-12               12.8ns ± 0%    10.1ns ± 0%   ~     (p=1.000 n=1+1)
TransformWithAndWithoutCopy/ZLabelsToPromLabelsWithRealloc-12    6.58µs ± 0%   19.84µs ± 0%   ~     (p=1.000 n=1+1)

name                                                           old alloc/op   new alloc/op   delta
TransformWithAndWithoutCopy/ZLabelsToPromLabels-12                0.00B          0.00B        ~     (all equal)
TransformWithAndWithoutCopy/ZLabelsToPromLabelsWithRealloc-12    9.60kB ± 0%   14.76kB ± 0%   ~     (p=1.000 n=1+1)

name                                                           old allocs/op  new allocs/op  delta
TransformWithAndWithoutCopy/ZLabelsToPromLabels-12                 0.00           0.00        ~     (all equal)
TransformWithAndWithoutCopy/ZLabelsToPromLabelsWithRealloc-12       200 ± 0%       108 ± 0%   ~     (p=1.000 n=1+1)
```

<!-- How you tested it? How do you know it works? -->
