### PR TITLE
Receive: reduce disruption when changing hashring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 
 - [#5716](https://github.com/thanos-io/thanos/pull/5716) DNS: Fix miekgdns resolver LookupSRV to work with CNAME records.
 - [#5846](https://github.com/thanos-io/thanos/pull/5846) Query Frontend: vertical query sharding supports subqueries.
-- [#5905](https://github.com/thanos-io/thanos/pull/5905) Receive: reduce occurrences of forced head compaction. 
+- [#5905](https://github.com/thanos-io/thanos/pull/5905) Receive: reduce occurrences of forced head compaction.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 
 - [#5716](https://github.com/thanos-io/thanos/pull/5716) DNS: Fix miekgdns resolver LookupSRV to work with CNAME records.
 - [#5846](https://github.com/thanos-io/thanos/pull/5846) Query Frontend: vertical query sharding supports subqueries.
+- [#5905](https://github.com/thanos-io/thanos/pull/5905) Receive: reduce occurrences of forced head compaction. 
 
 ### Removed
 

--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -5,7 +5,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"path"
 	"strings"
@@ -513,7 +512,6 @@ func setupHashring(g *run.Group,
 
 				// If ingestion is enabled, send a signal to TSDB to flush.
 				if enableIngestion && update.IsUpdatedForEndpoint(ownEndpoint) {
-					fmt.Println("Triggering update")
 					hashringChangedChan <- struct{}{}
 				} else {
 					// If not, just signal we are ready (this is important during first hashring load)

--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -511,7 +511,7 @@ func setupHashring(g *run.Group,
 				webHandler.Hashring(update.Hashring)
 
 				// If ingestion is enabled, send a signal to TSDB to flush.
-				if enableIngestion && update.IsUpdatedForEndpoint(ownEndpoint) {
+				if enableIngestion && update.HasUpdateForEndpoint(ownEndpoint) {
 					hashringChangedChan <- struct{}{}
 				} else {
 					// If not, just signal we are ready (this is important during first hashring load)

--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -274,7 +274,7 @@ func runReceive(
 
 	level.Debug(logger).Log("msg", "setting up hashring")
 	{
-		if err := setupHashring(g, logger, reg, conf, hashringChangedChan, webHandler, statusProber, enableIngestion, conf.endpoint); err != nil {
+		if err := setupHashring(g, logger, reg, conf, hashringChangedChan, webHandler, statusProber, enableIngestion); err != nil {
 			return err
 		}
 	}
@@ -436,7 +436,6 @@ func setupHashring(g *run.Group,
 	webHandler *receive.Handler,
 	statusProber prober.Probe,
 	enableIngestion bool,
-	ownEndpoint string,
 ) error {
 	// Note: the hashring configuration watcher
 	// is the sender and thus closes the chan.
@@ -511,7 +510,7 @@ func setupHashring(g *run.Group,
 				webHandler.Hashring(update.Hashring)
 
 				// If ingestion is enabled, send a signal to TSDB to flush.
-				if enableIngestion && update.HasUpdateForEndpoint(ownEndpoint) {
+				if enableIngestion && update.HasUpdateForEndpoint(conf.endpoint) {
 					hashringChangedChan <- struct{}{}
 				} else {
 					// If not, just signal we are ready (this is important during first hashring load)

--- a/go.mod
+++ b/go.mod
@@ -128,7 +128,10 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.10.0
 )
 
-require go.opentelemetry.io/contrib/propagators/autoprop v0.34.0
+require (
+	go.opentelemetry.io/contrib/propagators/autoprop v0.34.0
+	k8s.io/utils v0.0.0-20220728103510-ee6ede2d64ed
+)
 
 require (
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.32.3 // indirect

--- a/go.mod
+++ b/go.mod
@@ -130,7 +130,7 @@ require (
 
 require (
 	go.opentelemetry.io/contrib/propagators/autoprop v0.34.0
-	k8s.io/utils v0.0.0-20220728103510-ee6ede2d64ed
+	golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e
 )
 
 require (
@@ -258,7 +258,6 @@ require (
 	go.opentelemetry.io/proto/otlp v0.19.0 // indirect
 	go.uber.org/multierr v1.8.0 // indirect
 	go.uber.org/zap v1.21.0 // indirect
-	golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e // indirect
 	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 // indirect
 	golang.org/x/oauth2 v0.0.0-20220909003341-f21342109be1 // indirect
 	golang.org/x/sys v0.0.0-20220919091848-fb04ddd9f9c8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -910,6 +910,7 @@ github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeV
 github.com/shurcooL/vfsgen v0.0.0-20200824052919-0d455de96546/go.mod h1:TrYk7fJVaAttu97ZZKrO9UbRa8izdowaMIZcxYMbVaw=
 github.com/simonpasquier/klog-gokit v0.3.0 h1:TkFK21cbwDRS+CiystjqbAiq5ubJcVTk9hLUck5Ntcs=
 github.com/simonpasquier/klog-gokit/v3 v3.0.0 h1:J0QrVhAULISHWN05PeXX/xMqJBjnpl2fAuO8uHdQGsA=
+github.com/simonpasquier/klog-gokit/v3 v3.0.0/go.mod h1:+WRhGy707Lp2Q4r727m9Oc7FxazOHgW76FIyCr23nus=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
@@ -926,6 +927,7 @@ github.com/sony/gobreaker v0.5.0/go.mod h1:ZKptC7FHNvhBz7dN2LGjPVBz2sZJmc0/PkyDJ
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
+github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
 github.com/spf13/cast v1.3.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/pflag v1.0.1/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
@@ -1652,6 +1654,7 @@ k8s.io/apimachinery v0.25.1 h1:t0XrnmCEHVgJlR2arwO8Awp9ylluDic706WePaYCBTI=
 k8s.io/client-go v0.25.1 h1:uFj4AJKtE1/ckcSKz8IhgAuZTdRXZDKev8g387ndD58=
 k8s.io/kube-openapi v0.0.0-20220803162953-67bda5d908f1 h1:MQ8BAZPZlWk3S9K4a9NCkIFQtZShWqoha7snGixVgEA=
 k8s.io/utils v0.0.0-20220728103510-ee6ede2d64ed h1:jAne/RjBTyawwAy0utX5eqigAwz/lQhTmy+Hr/Cpue4=
+k8s.io/utils v0.0.0-20220728103510-ee6ede2d64ed/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=

--- a/go.sum
+++ b/go.sum
@@ -910,7 +910,6 @@ github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeV
 github.com/shurcooL/vfsgen v0.0.0-20200824052919-0d455de96546/go.mod h1:TrYk7fJVaAttu97ZZKrO9UbRa8izdowaMIZcxYMbVaw=
 github.com/simonpasquier/klog-gokit v0.3.0 h1:TkFK21cbwDRS+CiystjqbAiq5ubJcVTk9hLUck5Ntcs=
 github.com/simonpasquier/klog-gokit/v3 v3.0.0 h1:J0QrVhAULISHWN05PeXX/xMqJBjnpl2fAuO8uHdQGsA=
-github.com/simonpasquier/klog-gokit/v3 v3.0.0/go.mod h1:+WRhGy707Lp2Q4r727m9Oc7FxazOHgW76FIyCr23nus=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
@@ -927,7 +926,6 @@ github.com/sony/gobreaker v0.5.0/go.mod h1:ZKptC7FHNvhBz7dN2LGjPVBz2sZJmc0/PkyDJ
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
-github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
 github.com/spf13/cast v1.3.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/pflag v1.0.1/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
@@ -1654,7 +1652,6 @@ k8s.io/apimachinery v0.25.1 h1:t0XrnmCEHVgJlR2arwO8Awp9ylluDic706WePaYCBTI=
 k8s.io/client-go v0.25.1 h1:uFj4AJKtE1/ckcSKz8IhgAuZTdRXZDKev8g387ndD58=
 k8s.io/kube-openapi v0.0.0-20220803162953-67bda5d908f1 h1:MQ8BAZPZlWk3S9K4a9NCkIFQtZShWqoha7snGixVgEA=
 k8s.io/utils v0.0.0-20220728103510-ee6ede2d64ed h1:jAne/RjBTyawwAy0utX5eqigAwz/lQhTmy+Hr/Cpue4=
-k8s.io/utils v0.0.0-20220728103510-ee6ede2d64ed/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=

--- a/pkg/receive/hashring.go
+++ b/pkg/receive/hashring.go
@@ -11,12 +11,10 @@ import (
 	"sync"
 
 	"github.com/cespare/xxhash"
-	"k8s.io/utils/strings/slices"
-
 	"github.com/pkg/errors"
+	"golang.org/x/exp/slices"
 
 	"github.com/thanos-io/thanos/pkg/store/labelpb"
-
 	"github.com/thanos-io/thanos/pkg/store/storepb/prompb"
 )
 

--- a/pkg/receive/hashring.go
+++ b/pkg/receive/hashring.go
@@ -266,9 +266,9 @@ type HashringUpdate struct {
 	Hashring       Hashring
 }
 
-// IsUpdatedForEndpoint returns true if any of the hashrings where
+// HasUpdateForEndpoint returns true if any of the hashrings where
 // the given endpoint is present has been updated.
-func (h HashringUpdate) IsUpdatedForEndpoint(endpoint string) bool {
+func (h HashringUpdate) HasUpdateForEndpoint(endpoint string) bool {
 	newHashrings := hashringsByTenant(h.NewConfig)
 	oldHashrings := hashringsByTenant(h.PreviousConfig)
 

--- a/pkg/receive/hashring_test.go
+++ b/pkg/receive/hashring_test.go
@@ -18,10 +18,10 @@ import (
 
 func TestHashringUpdated(t *testing.T) {
 	tests := []struct {
-		name       string
-		update     HashringUpdate
-		endpoint   string
-		hasUpdates bool
+		name           string
+		update         HashringUpdate
+		endpoint       string
+		updatedTenants []string
 	}{
 		{
 			name: "hashring added",
@@ -34,8 +34,8 @@ func TestHashringUpdated(t *testing.T) {
 					},
 				},
 			},
-			endpoint:   "endpoint-1",
-			hasUpdates: false,
+			endpoint:       "endpoint-1",
+			updatedTenants: nil,
 		},
 		{
 			name: "hashring removed",
@@ -48,8 +48,8 @@ func TestHashringUpdated(t *testing.T) {
 				},
 				NewConfig: nil,
 			},
-			endpoint:   "endpoint-1",
-			hasUpdates: true,
+			endpoint:       "endpoint-1",
+			updatedTenants: []string{"tenant-1"},
 		},
 		{
 			name: "hashring removed, endpoint not part of it",
@@ -62,8 +62,8 @@ func TestHashringUpdated(t *testing.T) {
 				},
 				NewConfig: nil,
 			},
-			endpoint:   "endpoint-3",
-			hasUpdates: false,
+			endpoint:       "endpoint-3",
+			updatedTenants: nil,
 		},
 		{
 			name: "hashring with endpoint updated",
@@ -73,16 +73,24 @@ func TestHashringUpdated(t *testing.T) {
 						Tenants:   []string{"tenant-1"},
 						Endpoints: []string{"endpoint-1", "endpoint-2"},
 					},
+					{
+						Tenants:   []string{"tenant-2"},
+						Endpoints: []string{"endpoint-3", "endpoint-4"},
+					},
 				},
 				NewConfig: []HashringConfig{
 					{
 						Tenants:   []string{"tenant-1"},
 						Endpoints: []string{"endpoint-1", "endpoint-3"},
 					},
+					{
+						Tenants:   []string{"tenant-2"},
+						Endpoints: []string{"endpoint-3", "endpoint-5"},
+					},
 				},
 			},
-			endpoint:   "endpoint-1",
-			hasUpdates: true,
+			endpoint:       "endpoint-1",
+			updatedTenants: []string{"tenant-1"},
 		},
 		{
 			name: "hashring without endpoint updated",
@@ -100,14 +108,14 @@ func TestHashringUpdated(t *testing.T) {
 					},
 				},
 			},
-			endpoint:   "endpoint-4",
-			hasUpdates: false,
+			endpoint:       "endpoint-4",
+			updatedTenants: nil,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			testutil.Equals(t, tc.hasUpdates, tc.update.HasUpdateForEndpoint(tc.endpoint))
+			testutil.Equals(t, tc.updatedTenants, tc.update.UpdatedTenants(tc.endpoint))
 		})
 	}
 }

--- a/pkg/receive/hashring_test.go
+++ b/pkg/receive/hashring_test.go
@@ -107,7 +107,7 @@ func TestHashringUpdated(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			testutil.Equals(t, tc.hasUpdates, tc.update.IsUpdatedForEndpoint(tc.endpoint))
+			testutil.Equals(t, tc.hasUpdates, tc.update.HasUpdateForEndpoint(tc.endpoint))
 		})
 	}
 }


### PR DESCRIPTION
With the current implementation, whenever the hashrings config file changes all receivers that detect any change will flush their TSDBs and stop ingestion for a short period of time. This also leads to out of bounds samples since a new head block will be created, and samples with the previous timestamp will be rejected.

This commit reduces the need to flush TSDBs by comparing old hashrings to new hashrings. If an endpoint was not part of a hashring that was modified, it will not flush its TSDBs.

Signed-off-by: Filip Petkovski <filip.petkovsky@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Reduce forced head compactions in Receiver.

## Verification

With unit tests and local testing.