### PR TITLE
Fix ketama quorum

### DIFF
--- a/pkg/receive/handler.go
+++ b/pkg/receive/handler.go
@@ -689,9 +689,15 @@ func (h *Handler) fanoutForward(pctx context.Context, tenant string, wreqs map[e
 				// This is an actual remote forward request so report metric here.
 				if err != nil {
 					h.forwardRequests.WithLabelValues(labelError).Inc()
+					if !seriesReplicated {
+						h.replications.WithLabelValues(labelError).Inc()
+					}
 					return
 				}
 				h.forwardRequests.WithLabelValues(labelSuccess).Inc()
+				if !seriesReplicated {
+					h.replications.WithLabelValues(labelSuccess).Inc()
+				}
 			}()
 
 			cl, err = h.peers.get(fctx, er.endpoint)

--- a/pkg/receive/handler_test.go
+++ b/pkg/receive/handler_test.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"io"
 	"math"
-	"math/rand"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -53,10 +52,11 @@ import (
 
 func TestDetermineWriteErrorCause(t *testing.T) {
 	for _, tc := range []struct {
-		name      string
-		err       error
-		threshold int
-		exp       error
+		name           string
+		err            error
+		threshold      int
+		forReplication bool
+		exp            error
 	}{
 		{
 			name: "nil",
@@ -231,13 +231,15 @@ func TestDetermineWriteErrorCause(t *testing.T) {
 			exp:       errors.New("baz: 3 errors: 3 errors: qux; rpc error: code = AlreadyExists desc = conflict; rpc error: code = AlreadyExists desc = conflict; foo; bar"),
 		},
 	} {
-		err := determineWriteErrorCause(tc.err, tc.threshold)
-		if tc.exp != nil {
-			testutil.NotOk(t, err)
-			testutil.Equals(t, tc.exp.Error(), err.Error())
-			continue
-		}
-		testutil.Ok(t, err)
+		t.Run(tc.name, func(t *testing.T) {
+			err := determineWriteErrorCause(tc.err, tc.threshold)
+			if tc.exp != nil {
+				testutil.NotOk(t, err)
+				testutil.Equals(t, tc.exp.Error(), err.Error())
+				return
+			}
+			testutil.Ok(t, err)
+		})
 	}
 }
 
@@ -347,7 +349,7 @@ func (f *fakeAppender) Rollback() error {
 	return f.rollbackErr()
 }
 
-func newTestHandlerHashring(appendables []*fakeAppendable, replicationFactor uint64) ([]*Handler, Hashring) {
+func newTestHandlerHashring(appendables []*fakeAppendable, replicationFactor uint64, hashringAlgo HashringAlgorithm) ([]*Handler, Hashring) {
 	var (
 		cfg      = []HashringConfig{{Hashring: "test"}}
 		handlers []*Handler
@@ -366,6 +368,7 @@ func newTestHandlerHashring(appendables []*fakeAppendable, replicationFactor uin
 		},
 	}
 
+	ag := addrGen{}
 	limiter, _ := NewLimiter(NewNopConfig(), nil, RouterIngestor, log.NewNopLogger())
 	for i := range appendables {
 		h := NewHandler(nil, &Options{
@@ -378,48 +381,31 @@ func newTestHandlerHashring(appendables []*fakeAppendable, replicationFactor uin
 		})
 		handlers = append(handlers, h)
 		h.peers = peers
-		addr := randomAddr()
+		addr := ag.newAddr()
 		h.options.Endpoint = addr
 		cfg[0].Endpoints = append(cfg[0].Endpoints, h.options.Endpoint)
 		peers.cache[addr] = &fakeRemoteWriteGRPCServer{h: h}
 	}
-	hashring := newMultiHashring(AlgorithmHashmod, replicationFactor, cfg)
+	// Use hashmod as default.
+	if hashringAlgo == "" {
+		hashringAlgo = AlgorithmHashmod
+	}
+
+	hashring := newMultiHashring(hashringAlgo, replicationFactor, cfg)
 	for _, h := range handlers {
 		h.Hashring(hashring)
 	}
 	return handlers, hashring
 }
 
-func TestReceiveQuorum(t *testing.T) {
+func testReceiveQuorum(t *testing.T, hashringAlgo HashringAlgorithm, withConsistencyDelay bool) {
 	appenderErrFn := func() error { return errors.New("failed to get appender") }
 	conflictErrFn := func() error { return storage.ErrOutOfBounds }
 	commitErrFn := func() error { return errors.New("failed to commit") }
-	wreq1 := &prompb.WriteRequest{
-		Timeseries: []prompb.TimeSeries{
-			{
-				Labels: []labelpb.ZLabel{
-					{
-						Name:  "foo",
-						Value: "bar",
-					},
-				},
-				Samples: []prompb.Sample{
-					{
-						Value:     1,
-						Timestamp: 1,
-					},
-					{
-						Value:     2,
-						Timestamp: 2,
-					},
-					{
-						Value:     3,
-						Timestamp: 3,
-					},
-				},
-			},
-		},
+	wreq := &prompb.WriteRequest{
+		Timeseries: makeSeriesWithValues(50),
 	}
+
 	for _, tc := range []struct {
 		name              string
 		status            int
@@ -431,7 +417,7 @@ func TestReceiveQuorum(t *testing.T) {
 			name:              "size 1 success",
 			status:            http.StatusOK,
 			replicationFactor: 1,
-			wreq:              wreq1,
+			wreq:              wreq,
 			appendables: []*fakeAppendable{
 				{
 					appender: newFakeAppender(nil, nil, nil),
@@ -442,7 +428,7 @@ func TestReceiveQuorum(t *testing.T) {
 			name:              "size 1 commit error",
 			status:            http.StatusInternalServerError,
 			replicationFactor: 1,
-			wreq:              wreq1,
+			wreq:              wreq,
 			appendables: []*fakeAppendable{
 				{
 					appender: newFakeAppender(nil, commitErrFn, nil),
@@ -453,7 +439,7 @@ func TestReceiveQuorum(t *testing.T) {
 			name:              "size 1 conflict",
 			status:            http.StatusConflict,
 			replicationFactor: 1,
-			wreq:              wreq1,
+			wreq:              wreq,
 			appendables: []*fakeAppendable{
 				{
 					appender: newFakeAppender(conflictErrFn, nil, nil),
@@ -464,7 +450,7 @@ func TestReceiveQuorum(t *testing.T) {
 			name:              "size 2 success",
 			status:            http.StatusOK,
 			replicationFactor: 1,
-			wreq:              wreq1,
+			wreq:              wreq,
 			appendables: []*fakeAppendable{
 				{
 					appender: newFakeAppender(nil, nil, nil),
@@ -478,7 +464,7 @@ func TestReceiveQuorum(t *testing.T) {
 			name:              "size 3 success",
 			status:            http.StatusOK,
 			replicationFactor: 1,
-			wreq:              wreq1,
+			wreq:              wreq,
 			appendables: []*fakeAppendable{
 				{
 					appender: newFakeAppender(nil, nil, nil),
@@ -495,7 +481,7 @@ func TestReceiveQuorum(t *testing.T) {
 			name:              "size 3 success with replication",
 			status:            http.StatusOK,
 			replicationFactor: 3,
-			wreq:              wreq1,
+			wreq:              wreq,
 			appendables: []*fakeAppendable{
 				{
 					appender: newFakeAppender(nil, nil, nil),
@@ -512,7 +498,7 @@ func TestReceiveQuorum(t *testing.T) {
 			name:              "size 3 commit error",
 			status:            http.StatusInternalServerError,
 			replicationFactor: 1,
-			wreq:              wreq1,
+			wreq:              wreq,
 			appendables: []*fakeAppendable{
 				{
 					appender: newFakeAppender(nil, commitErrFn, nil),
@@ -529,7 +515,7 @@ func TestReceiveQuorum(t *testing.T) {
 			name:              "size 3 commit error with replication",
 			status:            http.StatusInternalServerError,
 			replicationFactor: 3,
-			wreq:              wreq1,
+			wreq:              wreq,
 			appendables: []*fakeAppendable{
 				{
 					appender: newFakeAppender(nil, commitErrFn, nil),
@@ -546,7 +532,7 @@ func TestReceiveQuorum(t *testing.T) {
 			name:              "size 3 appender error with replication",
 			status:            http.StatusInternalServerError,
 			replicationFactor: 3,
-			wreq:              wreq1,
+			wreq:              wreq,
 			appendables: []*fakeAppendable{
 				{
 					appender:    newFakeAppender(nil, nil, nil),
@@ -566,7 +552,7 @@ func TestReceiveQuorum(t *testing.T) {
 			name:              "size 3 conflict with replication",
 			status:            http.StatusConflict,
 			replicationFactor: 3,
-			wreq:              wreq1,
+			wreq:              wreq,
 			appendables: []*fakeAppendable{
 				{
 					appender: newFakeAppender(conflictErrFn, nil, nil),
@@ -583,7 +569,7 @@ func TestReceiveQuorum(t *testing.T) {
 			name:              "size 3 conflict and commit error with replication",
 			status:            http.StatusConflict,
 			replicationFactor: 3,
-			wreq:              wreq1,
+			wreq:              wreq,
 			appendables: []*fakeAppendable{
 				{
 					appender: newFakeAppender(conflictErrFn, commitErrFn, nil),
@@ -600,7 +586,7 @@ func TestReceiveQuorum(t *testing.T) {
 			name:              "size 3 with replication and one faulty",
 			status:            http.StatusOK,
 			replicationFactor: 3,
-			wreq:              wreq1,
+			wreq:              wreq,
 			appendables: []*fakeAppendable{
 				{
 					appender: newFakeAppender(cycleErrors([]error{storage.ErrOutOfBounds, storage.ErrOutOfOrderSample, storage.ErrDuplicateSampleForTimestamp}), nil, nil),
@@ -617,7 +603,7 @@ func TestReceiveQuorum(t *testing.T) {
 			name:              "size 3 with replication and one commit error",
 			status:            http.StatusOK,
 			replicationFactor: 3,
-			wreq:              wreq1,
+			wreq:              wreq,
 			appendables: []*fakeAppendable{
 				{
 					appender: newFakeAppender(nil, commitErrFn, nil),
@@ -634,7 +620,7 @@ func TestReceiveQuorum(t *testing.T) {
 			name:              "size 3 with replication and two conflicts",
 			status:            http.StatusConflict,
 			replicationFactor: 3,
-			wreq:              wreq1,
+			wreq:              wreq,
 			appendables: []*fakeAppendable{
 				{
 					appender: newFakeAppender(cycleErrors([]error{storage.ErrOutOfBounds, storage.ErrOutOfOrderSample, storage.ErrDuplicateSampleForTimestamp}), nil, nil),
@@ -651,10 +637,27 @@ func TestReceiveQuorum(t *testing.T) {
 			name:              "size 3 with replication one conflict and one commit error",
 			status:            http.StatusInternalServerError,
 			replicationFactor: 3,
-			wreq:              wreq1,
+			wreq:              wreq,
 			appendables: []*fakeAppendable{
 				{
+					appender: newFakeAppender(nil, commitErrFn, nil),
+				},
+				{
+					appender: newFakeAppender(nil, nil, nil),
+				},
+				{
 					appender: newFakeAppender(cycleErrors([]error{storage.ErrOutOfBounds, storage.ErrOutOfOrderSample, storage.ErrDuplicateSampleForTimestamp}), nil, nil),
+				},
+			},
+		},
+		{
+			name:              "size 3 with replication two commit errors",
+			status:            http.StatusInternalServerError,
+			replicationFactor: 3,
+			wreq:              wreq,
+			appendables: []*fakeAppendable{
+				{
+					appender: newFakeAppender(nil, commitErrFn, nil),
 				},
 				{
 					appender: newFakeAppender(nil, commitErrFn, nil),
@@ -665,10 +668,62 @@ func TestReceiveQuorum(t *testing.T) {
 			},
 		},
 		{
-			name:              "size 3 with replication two commit errors",
-			status:            http.StatusInternalServerError,
+			name:              "size 6 with replication 3",
+			status:            http.StatusOK,
 			replicationFactor: 3,
-			wreq:              wreq1,
+			wreq:              wreq,
+			appendables: []*fakeAppendable{
+				{
+					appender: newFakeAppender(nil, nil, nil),
+				},
+				{
+					appender: newFakeAppender(nil, nil, nil),
+				},
+				{
+					appender: newFakeAppender(nil, nil, nil),
+				},
+				{
+					appender: newFakeAppender(nil, nil, nil),
+				},
+				{
+					appender: newFakeAppender(nil, nil, nil),
+				},
+				{
+					appender: newFakeAppender(nil, nil, nil),
+				},
+			},
+		},
+		{
+			name:              "size 6 with replication 3 one commit and two conflict error",
+			status:            http.StatusConflict,
+			replicationFactor: 3,
+			wreq:              wreq,
+			appendables: []*fakeAppendable{
+				{
+					appender: newFakeAppender(nil, commitErrFn, nil),
+				},
+				{
+					appender: newFakeAppender(nil, conflictErrFn, nil),
+				},
+				{
+					appender: newFakeAppender(nil, conflictErrFn, nil),
+				},
+				{
+					appender: newFakeAppender(nil, nil, nil),
+				},
+				{
+					appender: newFakeAppender(nil, nil, nil),
+				},
+				{
+					appender: newFakeAppender(nil, nil, nil),
+				},
+			},
+		},
+		{
+			name:              "size 6 with replication 5 two commit errors",
+			status:            http.StatusOK,
+			replicationFactor: 5,
+			wreq:              wreq,
 			appendables: []*fakeAppendable{
 				{
 					appender: newFakeAppender(nil, commitErrFn, nil),
@@ -679,11 +734,20 @@ func TestReceiveQuorum(t *testing.T) {
 				{
 					appender: newFakeAppender(nil, nil, nil),
 				},
+				{
+					appender: newFakeAppender(nil, nil, nil),
+				},
+				{
+					appender: newFakeAppender(nil, nil, nil),
+				},
+				{
+					appender: newFakeAppender(nil, nil, nil),
+				},
 			},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			handlers, hashring := newTestHandlerHashring(tc.appendables, tc.replicationFactor)
+			handlers, hashring := newTestHandlerHashring(tc.appendables, tc.replicationFactor, hashringAlgo)
 			tenant := "test"
 			// Test from the point of view of every node
 			// so that we know status code does not depend
@@ -692,12 +756,17 @@ func TestReceiveQuorum(t *testing.T) {
 				// Test that the correct status is returned.
 				rec, err := makeRequest(handler, tenant, tc.wreq)
 				if err != nil {
-					t.Fatalf("handler %d: unexpectedly failed making HTTP request: %v", tc.status, err)
+					t.Fatalf("handler %d: unexpectedly failed making HTTP request: %v", i+1, err)
 				}
 				if rec.Code != tc.status {
-					t.Errorf("handler %d: got unexpected HTTP status code: expected %d, got %d; body: %s", i, tc.status, rec.Code, rec.Body.String())
+					t.Errorf("handler %d: got unexpected HTTP status code: expected %d, got %d; body: %s", i+1, tc.status, rec.Code, rec.Body.String())
 				}
 			}
+
+			if withConsistencyDelay {
+				time.Sleep(50 * time.Millisecond)
+			}
+
 			// Test that each time series is stored
 			// the correct amount of times in each fake DB.
 			for _, ts := range tc.wreq.Timeseries {
@@ -709,21 +778,51 @@ func TestReceiveQuorum(t *testing.T) {
 					}
 				}
 				for j, a := range tc.appendables {
-					var expectedMin int
-					n := a.appender.(*fakeAppender).Get(lset)
-					got := uint64(len(n))
-					if a.appenderErr == nil && endpointHit(t, hashring, tc.replicationFactor, handlers[j].options.Endpoint, tenant, &ts) {
-						// We have len(handlers) copies of each sample because the test case
-						// is run once for each handler and they all use the same appender.
-						expectedMin = int((tc.replicationFactor/2)+1) * len(ts.Samples)
-					}
-					if uint64(expectedMin) > got {
-						t.Errorf("handler: %d, labels %q: expected minimum of %d samples, got %d", j, lset.String(), expectedMin, got)
+					if withConsistencyDelay {
+						var expected int
+						n := a.appender.(*fakeAppender).Get(lset)
+						got := uint64(len(n))
+						if a.appenderErr == nil && endpointHit(t, hashring, tc.replicationFactor, handlers[j].options.Endpoint, tenant, &ts) {
+							// We have len(handlers) copies of each sample because the test case
+							// is run once for each handler and they all use the same appender.
+							expected = len(handlers) * len(ts.Samples)
+						}
+						if uint64(expected) != got {
+							t.Errorf("handler: %d, labels %q: expected %d samples, got %d", j, lset.String(), expected, got)
+						}
+					} else {
+						var expectedMin int
+						n := a.appender.(*fakeAppender).Get(lset)
+						got := uint64(len(n))
+						if a.appenderErr == nil && endpointHit(t, hashring, tc.replicationFactor, handlers[j].options.Endpoint, tenant, &ts) {
+							// We have len(handlers) copies of each sample because the test case
+							// is run once for each handler and they all use the same appender.
+							expectedMin = int((tc.replicationFactor/2)+1) * len(ts.Samples)
+						}
+						if uint64(expectedMin) > got {
+							t.Errorf("handler: %d, labels %q: expected minimum of %d samples, got %d", j, lset.String(), expectedMin, got)
+						}
 					}
 				}
 			}
 		})
 	}
+}
+
+func TestReceiveQuorumHashmod(t *testing.T) {
+	testReceiveQuorum(t, AlgorithmHashmod, false)
+}
+
+func TestReceiveQuorumKetama(t *testing.T) {
+	testReceiveQuorum(t, AlgorithmKetama, false)
+}
+
+func TestReceiveWithConsistencyDelayHashmod(t *testing.T) {
+	testReceiveQuorum(t, AlgorithmHashmod, true)
+}
+
+func TestReceiveWithConsistencyDelayKetama(t *testing.T) {
+	testReceiveQuorum(t, AlgorithmKetama, true)
 }
 
 func TestReceiveWriteRequestLimits(t *testing.T) {
@@ -778,7 +877,7 @@ func TestReceiveWriteRequestLimits(t *testing.T) {
 					appender: newFakeAppender(nil, nil, nil),
 				},
 			}
-			handlers, _ := newTestHandlerHashring(appendables, 3)
+			handlers, _ := newTestHandlerHashring(appendables, 3, AlgorithmHashmod)
 			handler := handlers[0]
 
 			tenant := "test"
@@ -827,348 +926,6 @@ func TestReceiveWriteRequestLimits(t *testing.T) {
 			}
 			if rec.Code != tc.status {
 				t.Errorf("handler: got unexpected HTTP status code: expected %d, got %d; body: %s", tc.status, rec.Code, rec.Body.String())
-			}
-		})
-	}
-}
-
-func TestReceiveWithConsistencyDelay(t *testing.T) {
-	appenderErrFn := func() error { return errors.New("failed to get appender") }
-	conflictErrFn := func() error { return storage.ErrOutOfBounds }
-	commitErrFn := func() error { return errors.New("failed to commit") }
-	wreq1 := &prompb.WriteRequest{
-		Timeseries: []prompb.TimeSeries{
-			{
-				Labels: []labelpb.ZLabel{
-					{
-						Name:  "foo",
-						Value: "bar",
-					},
-				},
-				Samples: []prompb.Sample{
-					{
-						Value:     1,
-						Timestamp: 1,
-					},
-					{
-						Value:     2,
-						Timestamp: 2,
-					},
-					{
-						Value:     3,
-						Timestamp: 3,
-					},
-				},
-			},
-		},
-	}
-	for _, tc := range []struct {
-		name              string
-		status            int
-		replicationFactor uint64
-		wreq              *prompb.WriteRequest
-		appendables       []*fakeAppendable
-	}{
-		{
-			name:              "size 1 success",
-			status:            http.StatusOK,
-			replicationFactor: 1,
-			wreq:              wreq1,
-			appendables: []*fakeAppendable{
-				{
-					appender: newFakeAppender(nil, nil, nil),
-				},
-			},
-		},
-		{
-			name:              "size 1 commit error",
-			status:            http.StatusInternalServerError,
-			replicationFactor: 1,
-			wreq:              wreq1,
-			appendables: []*fakeAppendable{
-				{
-					appender: newFakeAppender(nil, commitErrFn, nil),
-				},
-			},
-		},
-		{
-			name:              "size 1 conflict",
-			status:            http.StatusConflict,
-			replicationFactor: 1,
-			wreq:              wreq1,
-			appendables: []*fakeAppendable{
-				{
-					appender: newFakeAppender(conflictErrFn, nil, nil),
-				},
-			},
-		},
-		{
-			name:              "size 2 success",
-			status:            http.StatusOK,
-			replicationFactor: 1,
-			wreq:              wreq1,
-			appendables: []*fakeAppendable{
-				{
-					appender: newFakeAppender(nil, nil, nil),
-				},
-				{
-					appender: newFakeAppender(nil, nil, nil),
-				},
-			},
-		},
-		{
-			name:              "size 3 success",
-			status:            http.StatusOK,
-			replicationFactor: 1,
-			wreq:              wreq1,
-			appendables: []*fakeAppendable{
-				{
-					appender: newFakeAppender(nil, nil, nil),
-				},
-				{
-					appender: newFakeAppender(nil, nil, nil),
-				},
-				{
-					appender: newFakeAppender(nil, nil, nil),
-				},
-			},
-		},
-		{
-			name:              "size 3 success with replication",
-			status:            http.StatusOK,
-			replicationFactor: 3,
-			wreq:              wreq1,
-			appendables: []*fakeAppendable{
-				{
-					appender: newFakeAppender(nil, nil, nil),
-				},
-				{
-					appender: newFakeAppender(nil, nil, nil),
-				},
-				{
-					appender: newFakeAppender(nil, nil, nil),
-				},
-			},
-		},
-		{
-			name:              "size 3 commit error",
-			status:            http.StatusInternalServerError,
-			replicationFactor: 1,
-			wreq:              wreq1,
-			appendables: []*fakeAppendable{
-				{
-					appender: newFakeAppender(nil, commitErrFn, nil),
-				},
-				{
-					appender: newFakeAppender(nil, commitErrFn, nil),
-				},
-				{
-					appender: newFakeAppender(nil, commitErrFn, nil),
-				},
-			},
-		},
-		{
-			name:              "size 3 commit error with replication",
-			status:            http.StatusInternalServerError,
-			replicationFactor: 3,
-			wreq:              wreq1,
-			appendables: []*fakeAppendable{
-				{
-					appender: newFakeAppender(nil, commitErrFn, nil),
-				},
-				{
-					appender: newFakeAppender(nil, commitErrFn, nil),
-				},
-				{
-					appender: newFakeAppender(nil, commitErrFn, nil),
-				},
-			},
-		},
-		{
-			name:              "size 3 appender error with replication",
-			status:            http.StatusInternalServerError,
-			replicationFactor: 3,
-			wreq:              wreq1,
-			appendables: []*fakeAppendable{
-				{
-					appender:    newFakeAppender(nil, nil, nil),
-					appenderErr: appenderErrFn,
-				},
-				{
-					appender:    newFakeAppender(nil, nil, nil),
-					appenderErr: appenderErrFn,
-				},
-				{
-					appender:    newFakeAppender(nil, nil, nil),
-					appenderErr: appenderErrFn,
-				},
-			},
-		},
-		{
-			name:              "size 3 conflict with replication",
-			status:            http.StatusConflict,
-			replicationFactor: 3,
-			wreq:              wreq1,
-			appendables: []*fakeAppendable{
-				{
-					appender: newFakeAppender(conflictErrFn, nil, nil),
-				},
-				{
-					appender: newFakeAppender(conflictErrFn, nil, nil),
-				},
-				{
-					appender: newFakeAppender(conflictErrFn, nil, nil),
-				},
-			},
-		},
-		{
-			name:              "size 3 conflict and commit error with replication",
-			status:            http.StatusConflict,
-			replicationFactor: 3,
-			wreq:              wreq1,
-			appendables: []*fakeAppendable{
-				{
-					appender: newFakeAppender(conflictErrFn, commitErrFn, nil),
-				},
-				{
-					appender: newFakeAppender(conflictErrFn, commitErrFn, nil),
-				},
-				{
-					appender: newFakeAppender(conflictErrFn, commitErrFn, nil),
-				},
-			},
-		},
-		{
-			name:              "size 3 with replication and one faulty",
-			status:            http.StatusOK,
-			replicationFactor: 3,
-			wreq:              wreq1,
-			appendables: []*fakeAppendable{
-				{
-					appender: newFakeAppender(cycleErrors([]error{storage.ErrOutOfBounds, storage.ErrOutOfOrderSample, storage.ErrDuplicateSampleForTimestamp}), nil, nil),
-				},
-				{
-					appender: newFakeAppender(nil, nil, nil),
-				},
-				{
-					appender: newFakeAppender(nil, nil, nil),
-				},
-			},
-		},
-		{
-			name:              "size 3 with replication and one commit error",
-			status:            http.StatusOK,
-			replicationFactor: 3,
-			wreq:              wreq1,
-			appendables: []*fakeAppendable{
-				{
-					appender: newFakeAppender(nil, commitErrFn, nil),
-				},
-				{
-					appender: newFakeAppender(nil, nil, nil),
-				},
-				{
-					appender: newFakeAppender(nil, nil, nil),
-				},
-			},
-		},
-		{
-			name:              "size 3 with replication and two conflicts",
-			status:            http.StatusConflict,
-			replicationFactor: 3,
-			wreq:              wreq1,
-			appendables: []*fakeAppendable{
-				{
-					appender: newFakeAppender(cycleErrors([]error{storage.ErrOutOfBounds, storage.ErrOutOfOrderSample, storage.ErrDuplicateSampleForTimestamp}), nil, nil),
-				},
-				{
-					appender: newFakeAppender(conflictErrFn, nil, nil),
-				},
-				{
-					appender: newFakeAppender(nil, nil, nil),
-				},
-			},
-		},
-		{
-			name:              "size 3 with replication one conflict and one commit error",
-			status:            http.StatusInternalServerError,
-			replicationFactor: 3,
-			wreq:              wreq1,
-			appendables: []*fakeAppendable{
-				{
-					appender: newFakeAppender(cycleErrors([]error{storage.ErrOutOfBounds, storage.ErrOutOfOrderSample, storage.ErrDuplicateSampleForTimestamp}), nil, nil),
-				},
-				{
-					appender: newFakeAppender(nil, commitErrFn, nil),
-				},
-				{
-					appender: newFakeAppender(nil, nil, nil),
-				},
-			},
-		},
-		{
-			name:              "size 3 with replication two commit errors",
-			status:            http.StatusInternalServerError,
-			replicationFactor: 3,
-			wreq:              wreq1,
-			appendables: []*fakeAppendable{
-				{
-					appender: newFakeAppender(nil, commitErrFn, nil),
-				},
-				{
-					appender: newFakeAppender(nil, commitErrFn, nil),
-				},
-				{
-					appender: newFakeAppender(nil, nil, nil),
-				},
-			},
-		},
-	} {
-		// Run the quorum tests with consistency delay, which should allow us
-		// to see all requests completing all the time, since we're using local
-		// network we are not expecting anything to go wrong with these.
-		t.Run(tc.name, func(t *testing.T) {
-			handlers, hashring := newTestHandlerHashring(tc.appendables, tc.replicationFactor)
-			tenant := "test"
-			// Test from the point of view of every node
-			// so that we know status code does not depend
-			// on which node is erroring and which node is receiving.
-			for i, handler := range handlers {
-				// Test that the correct status is returned.
-				rec, err := makeRequest(handler, tenant, tc.wreq)
-				if err != nil {
-					t.Fatalf("handler %d: unexpectedly failed making HTTP request: %v", tc.status, err)
-				}
-				if rec.Code != tc.status {
-					t.Errorf("handler %d: got unexpected HTTP status code: expected %d, got %d; body: %s", i, tc.status, rec.Code, rec.Body.String())
-				}
-			}
-
-			time.Sleep(50 * time.Millisecond)
-
-			// Test that each time series is stored
-			// the correct amount of times in each fake DB.
-			for _, ts := range tc.wreq.Timeseries {
-				lset := make(labels.Labels, len(ts.Labels))
-				for j := range ts.Labels {
-					lset[j] = labels.Label{
-						Name:  ts.Labels[j].Name,
-						Value: ts.Labels[j].Value,
-					}
-				}
-				for j, a := range tc.appendables {
-					var expected int
-					n := a.appender.(*fakeAppender).Get(lset)
-					got := uint64(len(n))
-					if a.appenderErr == nil && endpointHit(t, hashring, tc.replicationFactor, handlers[j].options.Endpoint, tenant, &ts) {
-						// We have len(handlers) copies of each sample because the test case
-						// is run once for each handler and they all use the same appender.
-						expected = len(handlers) * len(ts.Samples)
-					}
-					if uint64(expected) != got {
-						t.Errorf("handler: %d, labels %q: expected %d samples, got %d", j, lset.String(), expected, got)
-					}
-				}
 			}
 		})
 	}
@@ -1224,8 +981,11 @@ func makeRequest(h *Handler, tenant string, wreq *prompb.WriteRequest) (*httptes
 	return rec, nil
 }
 
-func randomAddr() string {
-	return fmt.Sprintf("http://%d.%d.%d.%d:%d", rand.Intn(256), rand.Intn(256), rand.Intn(256), rand.Intn(256), rand.Intn(35000)+30000)
+type addrGen struct{ n int }
+
+func (a *addrGen) newAddr() string {
+	a.n++
+	return fmt.Sprintf("http://node-%d:%d", a.n, 12345+a.n)
 }
 
 type fakeRemoteWriteGRPCServer struct {
@@ -1302,10 +1062,31 @@ func serializeSeriesWithOneSample(t testing.TB, series [][]labelpb.ZLabel) []byt
 	return snappy.Encode(nil, body)
 }
 
+func makeSeriesWithValues(numSeries int) []prompb.TimeSeries {
+	series := make([]prompb.TimeSeries, numSeries)
+	for i := 0; i < numSeries; i++ {
+		series[i] = prompb.TimeSeries{
+			Labels: []labelpb.ZLabel{
+				{
+					Name:  fmt.Sprintf("pod-%d", i),
+					Value: fmt.Sprintf("nginx-%d", i),
+				},
+			},
+			Samples: []prompb.Sample{
+				{
+					Value:     float64(i),
+					Timestamp: 10,
+				},
+			},
+		}
+	}
+	return series
+}
+
 func benchmarkHandlerMultiTSDBReceiveRemoteWrite(b testutil.TB) {
 	dir := b.TempDir()
 
-	handlers, _ := newTestHandlerHashring([]*fakeAppendable{nil}, 1)
+	handlers, _ := newTestHandlerHashring([]*fakeAppendable{nil}, 1, AlgorithmHashmod)
 	handler := handlers[0]
 
 	reg := prometheus.NewRegistry()

--- a/pkg/receive/handler_test.go
+++ b/pkg/receive/handler_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"google.golang.org/grpc"
 	"gopkg.in/yaml.v3"
 
 	"github.com/alecthomas/units"
@@ -36,6 +37,7 @@ import (
 	"github.com/prometheus/prometheus/model/relabel"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb"
+
 	"github.com/thanos-io/thanos/pkg/block/metadata"
 	"github.com/thanos-io/thanos/pkg/extkingpin"
 	"github.com/thanos-io/thanos/pkg/runutil"
@@ -43,7 +45,6 @@ import (
 	"github.com/thanos-io/thanos/pkg/store/storepb"
 	"github.com/thanos-io/thanos/pkg/store/storepb/prompb"
 	"github.com/thanos-io/thanos/pkg/testutil"
-	"google.golang.org/grpc"
 )
 
 type fakeTenantAppendable struct {
@@ -370,7 +371,7 @@ func testReceiveQuorum(t *testing.T, hashringAlgo HashringAlgorithm, withConsist
 		},
 		{
 			name:              "size 3 conflict and commit error with replication",
-			status:            http.StatusInternalServerError,
+			status:            http.StatusConflict,
 			replicationFactor: 3,
 			wreq:              wreq,
 			appendables: []*fakeAppendable{
@@ -498,7 +499,7 @@ func testReceiveQuorum(t *testing.T, hashringAlgo HashringAlgorithm, withConsist
 		},
 		{
 			name:              "size 6 with replication 3 one commit and two conflict error",
-			status:            http.StatusInternalServerError,
+			status:            http.StatusConflict,
 			replicationFactor: 3,
 			wreq:              wreq,
 			appendables: []*fakeAppendable{

--- a/pkg/receive/writer.go
+++ b/pkg/receive/writer.go
@@ -13,7 +13,6 @@ import (
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb"
 
-	"github.com/thanos-io/thanos/pkg/errutil"
 	"github.com/thanos-io/thanos/pkg/store/labelpb"
 	"github.com/thanos-io/thanos/pkg/store/storepb/prompb"
 )
@@ -73,7 +72,7 @@ func (r *Writer) Write(ctx context.Context, tenantID string, wreq *prompb.WriteR
 
 	var (
 		ref  storage.SeriesRef
-		errs errutil.MultiError
+		errs writeErrors
 	)
 	for _, t := range wreq.Timeseries {
 		// Check if time series labels are valid. If not, skip the time series
@@ -210,5 +209,5 @@ func (r *Writer) Write(ctx context.Context, tenantID string, wreq *prompb.WriteR
 	if err := app.Commit(); err != nil {
 		errs.Add(errors.Wrap(err, "commit samples"))
 	}
-	return errs.Err()
+	return errs.Cause()
 }

--- a/pkg/receive/writer.go
+++ b/pkg/receive/writer.go
@@ -209,5 +209,5 @@ func (r *Writer) Write(ctx context.Context, tenantID string, wreq *prompb.WriteR
 	if err := app.Commit(); err != nil {
 		errs.Add(errors.Wrap(err, "commit samples"))
 	}
-	return errs.Cause()
+	return errs.ErrOrNil()
 }


### PR DESCRIPTION
The quorum calculation is currently broken when using the Ketama
hashring. The reasons are explained in detail in issue https://github.com/thanos-io/thanos/issues/5784.

This commit fixes quorum calculation by tracking successfull writes
for each individual time-series inside a remote-write request.

The commit also removes the replicate() method inside the Handler
and moves the entire logic of fanning out and calculating success
into the fanoutForward() method.

Signed-off-by: Filip Petkovski <filip.petkovsky@gmail.com>

Fixes https://github.com/thanos-io/thanos/issues/5784