### PR TITLE
compact: remove cancel on SyncMetas errors

### DIFF
--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -406,7 +406,6 @@ func runCompact(
 		defer cleanMtx.Unlock()
 
 		if err := sy.SyncMetas(ctx); err != nil {
-			cancel()
 			return errors.Wrap(err, "syncing metas")
 		}
 


### PR DESCRIPTION
## Changes

A follow-up on #5922
In a favour of 86b4039948b0918ca2ba121637d1d0d5b3f768c0 SyncMetas will retry if it's retriable.
Also, the cleanPartialMarked calls are surrounded by runutil.Repeat() will be repeated,
the ones not and are not retriable will throw an interrupt to run.Group() by returning err
and Group will call cancel() as it's configured for its interrupt func.

Signed-off-by: Seena Fallah <seenafallah@gmail.com>