### PR TITLE
tools: Added remove flag on bucket mark command to remove deletion, no-downsample or no-compact markers on the block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#5889](https://github.com/thanos-io/thanos/pull/5889) Query Frontend: Support sharding vertical sharding `label_replace` and `label_join` functions.
 - [#5819](https://github.com/thanos-io/thanos/pull/5819) Store: Add a few objectives for Store's data touched/fetched amount and sizes. They are: 50, 95, and 99 quantiles.
 - [#5940](https://github.com/thanos-io/thanos/pull/5940) Objstore: Support for authenticating to Swift using application credentials.
+- [#5977](https://github.com/thanos-io/thanos/pull/5977) Tools: Added remove flag on bucket mark command to remove deletion, no-downsample or no-compact markers on the block.
 
 ### Changed
 

--- a/docs/components/tools.md
+++ b/docs/components/tools.md
@@ -52,7 +52,7 @@ Subcommands:
   tools bucket cleanup [<flags>]
     Cleans up all blocks marked for deletion.
 
-  tools bucket mark --id=ID --marker=MARKER --details=DETAILS
+  tools bucket mark --id=ID --marker=MARKER [<flags>]
     Mark block for deletion or no-compact in a safe way. NOTE: If the compactor
     is currently running compacting same block, this operation would be
     potentially a noop.
@@ -161,7 +161,7 @@ Subcommands:
   tools bucket cleanup [<flags>]
     Cleans up all blocks marked for deletion.
 
-  tools bucket mark --id=ID --marker=MARKER --details=DETAILS
+  tools bucket mark --id=ID --marker=MARKER [<flags>]
     Mark block for deletion or no-compact in a safe way. NOTE: If the compactor
     is currently running compacting same block, this operation would be
     potentially a noop.
@@ -681,7 +681,7 @@ prefix: ""
 ```
 
 ```$ mdox-exec="thanos tools bucket mark --help"
-usage: thanos tools bucket mark --id=ID --marker=MARKER --details=DETAILS
+usage: thanos tools bucket mark --id=ID --marker=MARKER [<flags>]
 
 Mark block for deletion or no-compact in a safe way. NOTE: If the compactor is
 currently running compacting same block, this operation would be potentially a
@@ -705,6 +705,7 @@ Flags:
                            Path to YAML file that contains object
                            store configuration. See format details:
                            https://thanos.io/tip/thanos/storage.md/#configuration
+      --remove             Remove the marker.
       --tracing.config=<content>
                            Alternative to 'tracing.config-file' flag
                            (mutually exclusive). Content of YAML file


### PR DESCRIPTION
Closes #5946 

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Added `remove` flag on `thanos tools bucket mark` command to remove the deletion, no-downsample and no-compact markers that were added on the block.

## Verification

Tested the changes by building the CLI and running the new command to check if the marker files were deleted. Also, added unit tests for the new functionality.
