### PR TITLE
Changing store to match debug level

### DIFF
--- a/pkg/store/proxy.go
+++ b/pkg/store/proxy.go
@@ -279,7 +279,7 @@ func (s *ProxyStore) Series(originalRequest *storepb.SeriesRequest, srv storepb.
 
 	if len(stores) == 0 {
 		err := errors.New("No StoreAPIs matched for this query")
-		level.Warn(reqLogger).Log("err", err, "stores", strings.Join(storeDebugMsgs, ";"))
+		level.Debug(reqLogger).Log("err", err, "stores", strings.Join(storeDebugMsgs, ";"))
 		if sendErr := srv.Send(storepb.NewWarnSeriesResponse(err)); sendErr != nil {
 			level.Error(reqLogger).Log("err", sendErr)
 			return status.Error(codes.Unknown, errors.Wrap(sendErr, "send series response").Error())


### PR DESCRIPTION
Signed-off-by: Kama Huang <kamatogo13@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes
Fixes https://github.com/thanos-io/thanos/issues/5825

## Verification

<!-- How you tested it? How do you know it works? -->
