### PR TITLE
mixin(Receive): Fix series/samples written rate

### DIFF
--- a/examples/dashboards/receive.json
+++ b/examples/dashboards/receive.json
@@ -982,7 +982,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "sum(rate(thanos_receive_write_samples_bucket{job=~\"$job\", tenant=~\"$tenant\", code=~\"2..\"}[$interval])) by (job, tenant) ",
+                     "expr": "sum(rate(thanos_receive_write_samples_sum{job=~\"$job\", tenant=~\"$tenant\", code=~\"2..\"}[$interval])) by (job, tenant) ",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{tenant}}",
@@ -1058,7 +1058,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "sum(rate(thanos_receive_write_samples_bucket{job=~\"$job\", tenant=~\"$tenant\", code!~\"2..\"}[$interval])) by (tenant, code) ",
+                     "expr": "sum(rate(thanos_receive_write_samples_sum{job=~\"$job\", tenant=~\"$tenant\", code!~\"2..\"}[$interval])) by (tenant, code) ",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{code}} - {{tenant}}",

--- a/mixin/dashboards/receive.libsonnet
+++ b/mixin/dashboards/receive.libsonnet
@@ -154,7 +154,7 @@ local utils = import '../lib/utils.libsonnet';
         .addPanel(
           g.panel('Rate of samples received (per tenant, only 2XX)') +
           g.queryPanel(
-            'sum(rate(thanos_receive_write_samples_bucket{%s}[$interval])) by (%s) ' % [
+            'sum(rate(thanos_receive_write_samples_sum{%s}[$interval])) by (%s) ' % [
               utils.joinLabels([thanos.receive.dashboard.tenantSelector, 'code=~"2.."']),
               thanos.receive.dashboard.tenantDimensions,
             ],
@@ -164,7 +164,7 @@ local utils = import '../lib/utils.libsonnet';
         .addPanel(
           g.panel('Rate of samples not written (per tenant and code, non 2XX)') +
           g.queryPanel(
-            'sum(rate(thanos_receive_write_samples_bucket{%s}[$interval])) by (%s) ' % [
+            'sum(rate(thanos_receive_write_samples_sum{%s}[$interval])) by (%s) ' % [
               utils.joinLabels([thanos.receive.dashboard.tenantSelector, 'code!~"2.."']),
               tenantWithHttpCodeDimensions,
             ],


### PR DESCRIPTION
Signed-off-by: Douglas Camata <159076+douglascamata@users.noreply.github.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->
- Fixed rates that were being applied to the `_bucket` histogram metrics instead of `_sum`.

## Verification

<!-- How you tested it? How do you know it works? -->

Tested in my dev Grafana receiving real data.