### PR TITLE
cacheutil: add support for Redis Sentinel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 
 ## Unreleased
 
+### Added
+
+- [#5990](https://github.com/thanos-io/thanos/pull/5990) Cache/Redis: add support for Redis Sentinel via new option `master_name`.
+
 ## [v0.30.0](https://github.com/thanos-io/thanos/tree/release-0.30) - in progress.
 
 ### Fixed

--- a/docs/components/query-frontend.md
+++ b/docs/components/query-frontend.md
@@ -133,6 +133,7 @@ config:
     server_name: ""
     insecure_skip_verify: false
   cache_size: 0
+  master_name: ""
   expiration: 24h0m0s
 ```
 

--- a/docs/components/store.md
+++ b/docs/components/store.md
@@ -343,6 +343,7 @@ config:
     server_name: ""
     insecure_skip_verify: false
   cache_size: 0
+  master_name: ""
 ```
 
 The **required** settings are:

--- a/pkg/cacheutil/redis_client.go
+++ b/pkg/cacheutil/redis_client.go
@@ -125,6 +125,10 @@ type RedisClientConfig struct {
 	// instead of fetching data each time.
 	// See https://redis.io/docs/manual/client-side-caching/ for info.
 	CacheSize model.Bytes `yaml:"cache_size"`
+
+	// MasterName specifies the master's name. Must be not empty
+	// for Redis Sentinel.
+	MasterName string `yaml:"master_name"`
 }
 
 func (c *RedisClientConfig) validate() error {
@@ -194,7 +198,7 @@ func NewRedisClientWithConfig(logger log.Logger, name string, config RedisClient
 		clientSideCacheDisabled = true
 	}
 
-	client, err := rueidis.NewClient(rueidis.ClientOption{
+	clientOpts := rueidis.ClientOption{
 		InitAddress:       strings.Split(config.Addr, ","),
 		ShuffleInit:       true,
 		Username:          config.Username,
@@ -205,7 +209,15 @@ func NewRedisClientWithConfig(logger log.Logger, name string, config RedisClient
 		ConnWriteTimeout:  config.WriteTimeout,
 		DisableCache:      clientSideCacheDisabled,
 		TLSConfig:         tlsConfig,
-	})
+	}
+
+	if config.MasterName != "" {
+		clientOpts.Sentinel = rueidis.SentinelOption{
+			MasterSet: config.MasterName,
+		}
+	}
+
+	client, err := rueidis.NewClient(clientOpts)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/queryfrontend/config.go
+++ b/pkg/queryfrontend/config.go
@@ -162,6 +162,7 @@ func NewCacheConfig(logger log.Logger, confContentYaml []byte) (*cortexcache.Con
 			Redis: cortexcache.RedisConfig{
 				Endpoint:    config.Redis.Addr,
 				Timeout:     config.Redis.ReadTimeout,
+				MasterName:  config.Redis.MasterName,
 				Expiration:  config.Expiration,
 				DB:          config.Redis.DB,
 				PoolSize:    config.Redis.PoolSize,


### PR DESCRIPTION
Add a new option `master_name` that if not empty chooses the appropriate master. Reusing terminology used by Cortex and official Redis documentation (https://redis.io/docs/management/sentinel/).

Signed-off-by: Giedrius Statkevičius <giedrius.statkevicius@vinted.com>
