### PR TITLE
Sidecar: Loads the TLS certificate during startup.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 
 - [#5990](https://github.com/thanos-io/thanos/pull/5990) Cache/Redis: add support for Redis Sentinel via new option `master_name`.
 
+### Fixed
+- [#5995] (https://github.com/thanos-io/thanos/pull/5993) Sidecar: Loads the TLS certificate during startup.
+
 ## [v0.30.0](https://github.com/thanos-io/thanos/tree/release-0.30) - in progress.
 
 ### Fixed

--- a/test/e2e/tls_test.go
+++ b/test/e2e/tls_test.go
@@ -179,3 +179,15 @@ type ecServer struct {
 func (s *ecServer) UnaryEcho(ctx context.Context, req *pb.EchoRequest) (*pb.EchoResponse, error) {
 	return &pb.EchoResponse{Message: req.Message}, nil
 }
+
+func TestInvalidCertAndKey(t *testing.T) {
+	defer leaktest.CheckTimeout(t, 10*time.Second)()
+	logger := log.NewLogfmtLogger(os.Stderr)
+	tmpDirSrv := t.TempDir()
+	caSrv := filepath.Join(tmpDirSrv, "ca")
+	certSrv := filepath.Join(tmpDirSrv, "cert")
+	keySrv := filepath.Join(tmpDirSrv, "key")
+	// Certificate and key are not present in the above path
+	_, err := thTLS.NewServerConfig(logger, certSrv, keySrv, caSrv)
+	testutil.NotOk(t, err)
+}


### PR DESCRIPTION
Closes [#5223] [#4923]

* [X] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

The sidecar did not validate the certificate and key while starting; Reading and parsing of the certificate were done only when the client initiated the TLS handshake with the sidecar. This is when the certificate related issues surfaced.

With this code change, these files are now loaded and checked by the sidecar when it starts.

## Verification

Tested the fix by adding unit tests. Also, by running the sidecar and query components with TLS configurations.
