### PR TITLE
Add counter metric to gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#5819](https://github.com/thanos-io/thanos/pull/5819) Store: Add a few objectives for Store's data touched/fetched amount and sizes. They are: 50, 95, and 99 quantiles.
 - [#5940](https://github.com/thanos-io/thanos/pull/5940) Objstore: Support for authenticating to Swift using application credentials.
 - [#5977](https://github.com/thanos-io/thanos/pull/5977) Tools: Added remove flag on bucket mark command to remove deletion, no-downsample or no-compact markers on the block.
-- [#5977](https://github.com/thanos-io/thanos/pull/6008) *: Add counter metric to gate. 
+- [#6008](https://github.com/thanos-io/thanos/pull/6008) *: Add counter metric to gate.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 ### Added
 
 - [#5990](https://github.com/thanos-io/thanos/pull/5990) Cache/Redis: add support for Redis Sentinel via new option `master_name`.
+- [#6008](https://github.com/thanos-io/thanos/pull/6008) *: Add counter metric `gate_queries_total` to gate.
 
 ## [v0.30.0](https://github.com/thanos-io/thanos/tree/release-0.30) - in progress.
 
@@ -37,7 +38,6 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#5819](https://github.com/thanos-io/thanos/pull/5819) Store: Add a few objectives for Store's data touched/fetched amount and sizes. They are: 50, 95, and 99 quantiles.
 - [#5940](https://github.com/thanos-io/thanos/pull/5940) Objstore: Support for authenticating to Swift using application credentials.
 - [#5977](https://github.com/thanos-io/thanos/pull/5977) Tools: Added remove flag on bucket mark command to remove deletion, no-downsample or no-compact markers on the block.
-- [#6008](https://github.com/thanos-io/thanos/pull/6008) *: Add counter metric to gate.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#5819](https://github.com/thanos-io/thanos/pull/5819) Store: Add a few objectives for Store's data touched/fetched amount and sizes. They are: 50, 95, and 99 quantiles.
 - [#5940](https://github.com/thanos-io/thanos/pull/5940) Objstore: Support for authenticating to Swift using application credentials.
 - [#5977](https://github.com/thanos-io/thanos/pull/5977) Tools: Added remove flag on bucket mark command to remove deletion, no-downsample or no-compact markers on the block.
+- [#5977](https://github.com/thanos-io/thanos/pull/6008) *: Add counter metric to gate. 
 
 ### Changed
 

--- a/pkg/gate/gate.go
+++ b/pkg/gate/gate.go
@@ -21,6 +21,10 @@ var (
 		Name: "gate_queries_in_flight",
 		Help: "Number of queries that are currently in flight.",
 	}
+	TotalCounterOpts = prometheus.CounterOpts{
+		Name: "gate_queries_total",
+		Help: "Total number of queries.",
+	}
 	DurationHistogramOpts = prometheus.HistogramOpts{
 		Name:    "gate_duration_seconds",
 		Help:    "How many seconds it took for queries to wait at the gate.",
@@ -87,9 +91,12 @@ func New(reg prometheus.Registerer, maxConcurrent int) Gate {
 
 	return InstrumentGateDuration(
 		promauto.With(reg).NewHistogram(DurationHistogramOpts),
-		InstrumentGateInFlight(
-			promauto.With(reg).NewGauge(InFlightGaugeOpts),
-			promgate.New(maxConcurrent),
+		InstrumentGateTotal(
+			promauto.With(reg).NewCounter(TotalCounterOpts),
+			InstrumentGateInFlight(
+				promauto.With(reg).NewGauge(InFlightGaugeOpts),
+				promgate.New(maxConcurrent),
+			),
 		),
 	)
 }
@@ -157,5 +164,33 @@ func (g *instrumentedInFlightGate) Start(ctx context.Context) error {
 // Done implements the Gate interface.
 func (g *instrumentedInFlightGate) Done() {
 	g.inflight.Dec()
+	g.g.Done()
+}
+
+type instrumentedTotalGate struct {
+	g     Gate
+	total prometheus.Counter
+}
+
+// InstrumentGateTotal instruments the provided Gate to track total requests.
+func InstrumentGateTotal(total prometheus.Counter, g Gate) Gate {
+	return &instrumentedTotalGate{
+		g:     g,
+		total: total,
+	}
+}
+
+// Start implements the Gate interface.
+func (g *instrumentedTotalGate) Start(ctx context.Context) error {
+	g.total.Inc()
+	if err := g.g.Start(ctx); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Done implements the Gate interface.
+func (g *instrumentedTotalGate) Done() {
 	g.g.Done()
 }


### PR DESCRIPTION
Signed-off-by: Ben Ye <benye@amazon.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Added a new `*_gate_queries_total` counter metric to gate package. This is useful because the current gate metric only tracks inflight queries and it is a gauge. Having a counter can help with calculating the rate.

## Verification

<!-- How you tested it? How do you know it works? -->
