### PR TITLE
fix duplicate metrics registration in redis client

### DIFF
--- a/pkg/cacheutil/cacheutil_test.go
+++ b/pkg/cacheutil/cacheutil_test.go
@@ -16,7 +16,11 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(
+		m,
+		// https://github.com/rueian/rueidis/blob/v0.0.90/pipe.go#L204.
+		goleak.IgnoreTopFunction("github.com/rueian/rueidis.(*pipe).backgroundPing"),
+	)
 }
 
 func TestDoWithBatch(t *testing.T) {

--- a/pkg/cacheutil/redis_client.go
+++ b/pkg/cacheutil/redis_client.go
@@ -175,6 +175,10 @@ func NewRedisClientWithConfig(logger log.Logger, name string, config RedisClient
 		return nil, err
 	}
 
+	if reg != nil {
+		reg = prometheus.WrapRegistererWith(prometheus.Labels{"name": name}, reg)
+	}
+
 	var tlsConfig *tls.Config
 	if config.TLSEnabled {
 		userTLSConfig := config.TLSConfig

--- a/pkg/cacheutil/redis_client_test.go
+++ b/pkg/cacheutil/redis_client_test.go
@@ -212,3 +212,19 @@ func TestValidateRedisConfig(t *testing.T) {
 	}
 
 }
+
+func TestMultipleRedisClient(t *testing.T) {
+	s, err := miniredis.Run()
+	if err != nil {
+		testutil.Ok(t, err)
+	}
+	defer s.Close()
+	cfg := DefaultRedisClientConfig
+	cfg.Addr = s.Addr()
+	logger := log.NewLogfmtLogger(os.Stderr)
+	reg := prometheus.NewRegistry()
+	_, err = NewRedisClientWithConfig(logger, "test1", cfg, reg)
+	testutil.Ok(t, err)
+	_, err = NewRedisClientWithConfig(logger, "test2", cfg, reg)
+	testutil.Ok(t, err)
+}


### PR DESCRIPTION
Signed-off-by: Kama Huang <kamatogo13@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

fixes #6006 
<!-- Enumerate changes you made -->

## Verification
added test and it's working
<!-- How you tested it? How do you know it works? -->
