### PR TITLE
Fixes .gitignore to only ignore data folder on root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@ kube/.minikube
 .mdoxcache
 
 # Ignore e2e working dirs.
-data/
+/data/
 test/e2e/e2e_*
 
 # Ignore benchmarks dir.


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

Problem: Recently the go package`golang.org/x/net` was changed to start using go embed, in this change a folder called "data" was added to the subfolder "publicsuffix" and it's embedded by the file `golang.org/x/net/publicsuffix/table.go`. Because the gitignore was ignoring all "data/" folder if we tried to vendor the project then this folder would be ignored which would break the compilation of Thanos

Solution: only ignore "data" folders at root

## Verification

https://github.com/openshift/thanos/pull/102
