### PR TITLE
Store: Make bucket store initial sync more robust

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 
 - [#5995](https://github.com/thanos-io/thanos/pull/5995) Sidecar: Loads the TLS certificate during startup.
 - [#6044](https://github.com/thanos-io/thanos/pull/6044) Receive: mark ouf of window errors as conflict, if out-of-window samples ingestion is activated
+- [#6050](https://github.com/thanos-io/thanos/pull/6050) Store: Re-try bucket store initial sync upon failure.
 - [#6066](https://github.com/thanos-io/thanos/pull/6066) Tracing: fixed panic because of nil sampler
 - [#6067](https://github.com/thanos-io/thanos/pull/6067) Receive: fixed panic when querying uninitialized TSDBs.
 


### PR DESCRIPTION
This PR fixes issue: #4810 

Signed-off-by: Kartik-Garg <kartik.garg@infracloud.io>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes
This PR implements the change: If the initial sync fails for the store, it will retry the initialization using runutil.retry with default values, it retries to initialize the store every 10 seconds for 30 duration of seconds, i.e., total of three times
<!-- Enumerate changes you made -->

## Verification
After starting the local minio server, started store component ([quickstart gist](https://gist.github.com/Kartik-Garg/b4fbdfe37023f5db5dda6b9318a310af), edited from [quickstart.sh](https://github.com/thanos-io/thanos/blob/b08c0ea62abfe4dcf1400da0e37598f0cd8fa8cf/scripts/quickstart.sh))
Store retried sync and succeeded with initial sync
<!-- How you tested it? How do you know it works? -->
