### PR TITLE
Support native histograms in store-gateway

### DIFF
--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -1055,8 +1055,11 @@ func populateChunk(out *storepb.AggrChunk, in chunkenc.Chunk, aggrs []storepb.Ag
 		if err != nil {
 			return err
 		}
-		storeEnc := storepb.Chunk_Encoding(in.Encoding() - 1)
-		out.Raw = &storepb.Chunk{Type: storeEnc, Data: b, Hash: hashChunk(hasher, b, calculateChecksum)}
+		out.Raw = &storepb.Chunk{
+			Data: b,
+			Type: storepb.Chunk_Encoding(in.Encoding() - 1),
+			Hash: hashChunk(hasher, b, calculateChecksum),
+		}
 		return nil
 	}
 

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -1050,14 +1050,16 @@ func populateChunk(out *storepb.AggrChunk, in chunkenc.Chunk, aggrs []storepb.Ag
 	hasher := hashPool.Get().(hash.Hash64)
 	defer hashPool.Put(hasher)
 
-	if in.Encoding() == chunkenc.EncXOR {
+	if in.Encoding() == chunkenc.EncXOR || in.Encoding() == chunkenc.EncHistogram {
 		b, err := save(in.Bytes())
 		if err != nil {
 			return err
 		}
-		out.Raw = &storepb.Chunk{Type: storepb.Chunk_XOR, Data: b, Hash: hashChunk(hasher, b, calculateChecksum)}
+		storeEnc := storepb.Chunk_Encoding(in.Encoding() - 1)
+		out.Raw = &storepb.Chunk{Type: storeEnc, Data: b, Hash: hashChunk(hasher, b, calculateChecksum)}
 		return nil
 	}
+
 	if in.Encoding() != downsample.ChunkEncAggr {
 		return errors.Errorf("unsupported chunk encoding %d", in.Encoding())
 	}

--- a/pkg/store/storepb/testutil/series.go
+++ b/pkg/store/storepb/testutil/series.go
@@ -16,20 +16,18 @@ import (
 	"time"
 
 	"github.com/cespare/xxhash"
-	"github.com/prometheus/prometheus/model/histogram"
-	"github.com/prometheus/prometheus/storage"
-	"github.com/prometheus/prometheus/tsdb/chunkenc"
-	"github.com/stretchr/testify/require"
-	"go.uber.org/atomic"
-
+	"github.com/efficientgo/core/testutil"
 	"github.com/gogo/protobuf/types"
+	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb"
+	"github.com/prometheus/prometheus/tsdb/chunkenc"
 	"github.com/prometheus/prometheus/tsdb/chunks"
 	"github.com/prometheus/prometheus/tsdb/index"
 	"github.com/prometheus/prometheus/tsdb/wlog"
-
-	"github.com/efficientgo/core/testutil"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
 
 	"github.com/thanos-io/thanos/pkg/store/hintspb"
 	"github.com/thanos-io/thanos/pkg/store/labelpb"
@@ -71,6 +69,10 @@ func CreateHeadWithSeries(t testing.TB, j int, opts HeadGenOptions) (*tsdb.Head,
 	}
 	if opts.ScrapeInterval == 0 {
 		opts.ScrapeInterval = 1 * time.Millisecond
+	}
+	// Use float type if sample type is not set.
+	if opts.SampleType == chunkenc.ValNone {
+		opts.SampleType = chunkenc.ValFloat
 	}
 
 	fmt.Printf(

--- a/pkg/store/storepb/testutil/series.go
+++ b/pkg/store/storepb/testutil/series.go
@@ -16,6 +16,11 @@ import (
 	"time"
 
 	"github.com/cespare/xxhash"
+	"github.com/prometheus/prometheus/model/histogram"
+	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/tsdb/chunkenc"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
 
 	"github.com/gogo/protobuf/types"
 	"github.com/prometheus/prometheus/model/labels"
@@ -51,6 +56,7 @@ type HeadGenOptions struct {
 	WithWAL       bool
 	PrependLabels labels.Labels
 	SkipChunks    bool // Skips chunks in returned slice (not in generated head!).
+	SampleType    chunkenc.ValueType
 
 	Random *rand.Rand
 }
@@ -86,27 +92,26 @@ func CreateHeadWithSeries(t testing.TB, j int, opts HeadGenOptions) (*tsdb.Head,
 
 	headOpts := tsdb.DefaultHeadOptions()
 	headOpts.ChunkDirRoot = opts.TSDBDir
+	headOpts.EnableNativeHistograms = *atomic.NewBool(true)
 	h, err := tsdb.NewHead(nil, nil, w, nil, headOpts, nil)
 	testutil.Ok(t, err)
 
 	app := h.Appender(context.Background())
 	for i := 0; i < opts.Series; i++ {
 		tsLabel := j*opts.Series*opts.SamplesPerSeries + i*opts.SamplesPerSeries
-		ref, err := app.Append(
-			0,
-			labels.FromStrings("foo", "bar", "i", fmt.Sprintf("%07d%s", tsLabel, LabelLongSuffix)),
-			int64(tsLabel)*opts.ScrapeInterval.Milliseconds(),
-			opts.Random.Float64(),
-		)
-		testutil.Ok(t, err)
-
-		for is := 1; is < opts.SamplesPerSeries; is++ {
-			_, err := app.Append(ref, nil, int64(tsLabel+is)*opts.ScrapeInterval.Milliseconds(), opts.Random.Float64())
-			testutil.Ok(t, err)
+		switch opts.SampleType {
+		case chunkenc.ValFloat:
+			appendFloatSamples(t, app, tsLabel, opts)
+		case chunkenc.ValHistogram:
+			appendHistogramSamples(t, app, tsLabel, opts)
 		}
 	}
 	testutil.Ok(t, app.Commit())
 
+	return h, ReadSeriesFromBlock(t, h, opts.PrependLabels, opts.SkipChunks)
+}
+
+func ReadSeriesFromBlock(t testing.TB, h tsdb.BlockReader, extLabels labels.Labels, skipChunks bool) []*storepb.Series {
 	// Use TSDB and get all series for assertion.
 	chks, err := h.Chunks()
 	testutil.Ok(t, err)
@@ -119,7 +124,7 @@ func CreateHeadWithSeries(t testing.TB, j int, opts HeadGenOptions) (*tsdb.Head,
 	var (
 		lset       labels.Labels
 		chunkMetas []chunks.Meta
-		expected   = make([]*storepb.Series, 0, opts.Series)
+		expected   = make([]*storepb.Series, 0)
 	)
 
 	var builder labels.ScratchBuilder
@@ -128,9 +133,9 @@ func CreateHeadWithSeries(t testing.TB, j int, opts HeadGenOptions) (*tsdb.Head,
 	for all.Next() {
 		testutil.Ok(t, ir.Series(all.At(), &builder, &chunkMetas))
 		lset = builder.Labels()
-		expected = append(expected, &storepb.Series{Labels: labelpb.ZLabelsFromPromLabels(append(opts.PrependLabels.Copy(), lset...))})
+		expected = append(expected, &storepb.Series{Labels: labelpb.ZLabelsFromPromLabels(append(extLabels.Copy(), lset...))})
 
-		if opts.SkipChunks {
+		if skipChunks {
 			continue
 		}
 
@@ -143,15 +148,60 @@ func CreateHeadWithSeries(t testing.TB, j int, opts HeadGenOptions) (*tsdb.Head,
 				c.MaxTime = c.MinTime + int64(chEnc.NumSamples()) - 1
 			}
 
+			storeChunkEnc := storepb.Chunk_Encoding(chEnc.Encoding() - 1)
 			expected[len(expected)-1].Chunks = append(expected[len(expected)-1].Chunks, storepb.AggrChunk{
 				MinTime: c.MinTime,
 				MaxTime: c.MaxTime,
-				Raw:     &storepb.Chunk{Type: storepb.Chunk_XOR, Data: chEnc.Bytes(), Hash: xxhash.Sum64(chEnc.Bytes())},
+				Raw:     &storepb.Chunk{Type: storeChunkEnc, Data: chEnc.Bytes(), Hash: xxhash.Sum64(chEnc.Bytes())},
 			})
 		}
 	}
 	testutil.Ok(t, all.Err())
-	return h, expected
+	return expected
+}
+
+func appendFloatSamples(t testing.TB, app storage.Appender, tsLabel int, opts HeadGenOptions) {
+	ref, err := app.Append(
+		0,
+		labels.FromStrings("foo", "bar", "i", fmt.Sprintf("%07d%s", tsLabel, LabelLongSuffix)),
+		int64(tsLabel)*opts.ScrapeInterval.Milliseconds(),
+		opts.Random.Float64(),
+	)
+	testutil.Ok(t, err)
+
+	for is := 1; is < opts.SamplesPerSeries; is++ {
+		_, err := app.Append(ref, nil, int64(tsLabel+is)*opts.ScrapeInterval.Milliseconds(), opts.Random.Float64())
+		testutil.Ok(t, err)
+	}
+}
+
+func appendHistogramSamples(t testing.TB, app storage.Appender, tsLabel int, opts HeadGenOptions) {
+	sample := &histogram.Histogram{
+		Schema:        0,
+		Count:         9,
+		Sum:           -3.1415,
+		ZeroCount:     12,
+		ZeroThreshold: 0.001,
+		NegativeSpans: []histogram.Span{
+			{Offset: 0, Length: 4},
+			{Offset: 1, Length: 1},
+		},
+		NegativeBuckets: []int64{1, 2, -2, 1, -1},
+	}
+
+	ref, err := app.AppendHistogram(
+		0,
+		labels.FromStrings("foo", "bar", "i", fmt.Sprintf("%07d%s", tsLabel, LabelLongSuffix)),
+		int64(tsLabel)*opts.ScrapeInterval.Milliseconds(),
+		sample,
+		nil,
+	)
+	testutil.Ok(t, err)
+
+	for is := 1; is < opts.SamplesPerSeries; is++ {
+		_, err := app.AppendHistogram(ref, nil, int64(tsLabel+is)*opts.ScrapeInterval.Milliseconds(), sample, nil)
+		testutil.Ok(t, err)
+	}
 }
 
 // SeriesServer is test gRPC storeAPI series server.
@@ -256,20 +306,22 @@ func TestServerSeries(t testutil.TB, store storepb.StoreServer, cases ...*Series
 					}
 
 					// Huge responses can produce unreadable diffs - make it more human readable.
-					if len(c.ExpectedSeries) > 4 {
+					if len(c.ExpectedSeries) > 1 {
 						for j := range c.ExpectedSeries {
 							testutil.Equals(t, c.ExpectedSeries[j].Labels, srv.SeriesSet[j].Labels, "%v series chunks mismatch", j)
 
 							// Check chunks when it is not a skip chunk query
 							if !c.Req.SkipChunks {
 								if len(c.ExpectedSeries[j].Chunks) > 20 {
-									testutil.Equals(t, len(c.ExpectedSeries[j].Chunks), len(srv.SeriesSet[j].Chunks), "%v series chunks number mismatch", j)
+									require.Equal(t, len(c.ExpectedSeries[j].Chunks), len(srv.SeriesSet[j].Chunks), "%v series chunks number mismatch", j)
 								}
-								testutil.Equals(t, c.ExpectedSeries[j].Chunks, srv.SeriesSet[j].Chunks, "%v series chunks mismatch", j)
+								for ci := range c.ExpectedSeries[j].Chunks {
+									testutil.Equals(t, c.ExpectedSeries[j].Chunks[ci], srv.SeriesSet[j].Chunks[ci], "%v series chunks mismatch %v", j, ci)
+								}
 							}
 						}
 					} else {
-						testutil.Equals(t, c.ExpectedSeries, srv.SeriesSet)
+						require.Equal(t, c.ExpectedSeries, srv.SeriesSet)
 					}
 
 					var actualHints []hintspb.SeriesResponseHints

--- a/pkg/testutil/e2eutil/prometheus.go
+++ b/pkg/testutil/e2eutil/prometheus.go
@@ -25,6 +25,7 @@ import (
 	"github.com/go-kit/log"
 	"github.com/oklog/ulid"
 	"github.com/pkg/errors"
+	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/timestamp"
 	"github.com/prometheus/prometheus/storage"
@@ -32,9 +33,11 @@ import (
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
 	"github.com/prometheus/prometheus/tsdb/chunks"
 	"github.com/prometheus/prometheus/tsdb/index"
+	"go.uber.org/atomic"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/efficientgo/core/testutil"
+
 	"github.com/thanos-io/thanos/pkg/block/metadata"
 	"github.com/thanos-io/thanos/pkg/runutil"
 )
@@ -52,6 +55,19 @@ const (
 	// A placeholder for actual Prometheus instance address in the scrape config.
 	PromAddrPlaceHolder = "PROMETHEUS_ADDRESS"
 )
+
+var histogramSample = histogram.Histogram{
+	Schema:        0,
+	Count:         9,
+	Sum:           -3.1415,
+	ZeroCount:     12,
+	ZeroThreshold: 0.001,
+	NegativeSpans: []histogram.Span{
+		{Offset: 0, Length: 4},
+		{Offset: 1, Length: 1},
+	},
+	NegativeBuckets: []int64{1, 2, -2, 1, -1},
+}
 
 func PrometheusBinary() string {
 	return "prometheus-" + defaultPrometheusVersion
@@ -362,7 +378,7 @@ func CreateBlock(
 	resolution int64,
 	hashFunc metadata.HashFunc,
 ) (id ulid.ULID, err error) {
-	return createBlock(ctx, dir, series, numSamples, mint, maxt, extLset, resolution, false, hashFunc)
+	return createBlock(ctx, dir, series, numSamples, mint, maxt, extLset, resolution, false, hashFunc, chunkenc.ValFloat)
 }
 
 // CreateBlockWithTombstone is same as CreateBlock but leaves tombstones which mimics the Prometheus local block.
@@ -376,7 +392,7 @@ func CreateBlockWithTombstone(
 	resolution int64,
 	hashFunc metadata.HashFunc,
 ) (id ulid.ULID, err error) {
-	return createBlock(ctx, dir, series, numSamples, mint, maxt, extLset, resolution, true, hashFunc)
+	return createBlock(ctx, dir, series, numSamples, mint, maxt, extLset, resolution, true, hashFunc, chunkenc.ValFloat)
 }
 
 // CreateBlockWithBlockDelay writes a block with the given series and numSamples samples each.
@@ -393,7 +409,27 @@ func CreateBlockWithBlockDelay(
 	resolution int64,
 	hashFunc metadata.HashFunc,
 ) (ulid.ULID, error) {
-	blockID, err := createBlock(ctx, dir, series, numSamples, mint, maxt, extLset, resolution, false, hashFunc)
+	return createBlockWithDelay(ctx, dir, series, numSamples, mint, maxt, blockDelay, extLset, resolution, hashFunc, chunkenc.ValFloat)
+}
+
+// CreateHistogramBlockWithDelay writes a block with the given native histogram series and numSamples samples each.
+// Samples will be in the time range [mint, maxt).
+func CreateHistogramBlockWithDelay(
+	ctx context.Context,
+	dir string,
+	series []labels.Labels,
+	numSamples int,
+	mint, maxt int64,
+	blockDelay time.Duration,
+	extLset labels.Labels,
+	resolution int64,
+	hashFunc metadata.HashFunc,
+) (id ulid.ULID, err error) {
+	return createBlockWithDelay(ctx, dir, series, numSamples, mint, maxt, blockDelay, extLset, resolution, hashFunc, chunkenc.ValHistogram)
+}
+
+func createBlockWithDelay(ctx context.Context, dir string, series []labels.Labels, numSamples int, mint int64, maxt int64, blockDelay time.Duration, extLset labels.Labels, resolution int64, hashFunc metadata.HashFunc, samplesType chunkenc.ValueType) (ulid.ULID, error) {
+	blockID, err := createBlock(ctx, dir, series, numSamples, mint, maxt, extLset, resolution, false, hashFunc, samplesType)
 	if err != nil {
 		return ulid.ULID{}, errors.Wrap(err, "block creation")
 	}
@@ -428,10 +464,12 @@ func createBlock(
 	resolution int64,
 	tombstones bool,
 	hashFunc metadata.HashFunc,
+	sampleType chunkenc.ValueType,
 ) (id ulid.ULID, err error) {
 	headOpts := tsdb.DefaultHeadOptions()
 	headOpts.ChunkDirRoot = filepath.Join(dir, "chunks")
 	headOpts.ChunkRange = 10000000000
+	headOpts.EnableNativeHistograms = *atomic.NewBool(true)
 	h, err := tsdb.NewHead(nil, nil, nil, nil, headOpts, nil)
 	if err != nil {
 		return id, errors.Wrap(err, "create head block")
@@ -462,7 +500,16 @@ func createBlock(
 				app := h.Appender(ctx)
 
 				for _, lset := range batch {
-					_, err := app.Append(0, lset, t, rand.Float64())
+					sort.Slice(lset, func(i, j int) bool {
+						return lset[i].Name < lset[j].Name
+					})
+
+					var err error
+					if sampleType == chunkenc.ValFloat {
+						_, err = app.Append(0, lset, t, rand.Float64())
+					} else if sampleType == chunkenc.ValHistogram {
+						_, err = app.AppendHistogram(0, lset, t, &histogramSample)
+					}
 					if err != nil {
 						if rerr := app.Rollback(); rerr != nil {
 							err = errors.Wrapf(err, "rollback failed: %v", rerr)

--- a/pkg/testutil/e2eutil/prometheus.go
+++ b/pkg/testutil/e2eutil/prometheus.go
@@ -508,7 +508,7 @@ func createBlock(
 					if sampleType == chunkenc.ValFloat {
 						_, err = app.Append(0, lset, t, rand.Float64())
 					} else if sampleType == chunkenc.ValHistogram {
-						_, err = app.AppendHistogram(0, lset, t, &histogramSample)
+						_, err = app.AppendHistogram(0, lset, t, &histogramSample, nil)
 					}
 					if err != nil {
 						if rerr := app.Rollback(); rerr != nil {


### PR DESCRIPTION
This commit adds support for retrieving native histogram chunks
in Store Gateway.

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
