### PR TITLE
Fix stores filtering resets on reload

### DIFF
--- a/pkg/ui/react-app/src/pages/graph/PanelList.test.tsx
+++ b/pkg/ui/react-app/src/pages/graph/PanelList.test.tsx
@@ -10,7 +10,7 @@ describe('PanelList', () => {
     [
       { id: 'use-local-time-checkbox', label: 'Use local time', default: false },
       { id: 'query-history-checkbox', label: 'Enable query history', default: false },
-      { id: 'debug-mode-checkbox', label: 'Enable Store Filtering', default: false },
+      { id: 'store-filtering-checkbox', label: 'Enable Store Filtering', default: false },
       { id: 'autocomplete-checkbox', label: 'Enable autocomplete', default: true },
       { id: 'highlighting-checkbox', label: 'Enable highlighting', default: true },
       { id: 'linter-checkbox', label: 'Enable linter', default: true },

--- a/pkg/ui/react-app/src/pages/graph/PanelList.tsx
+++ b/pkg/ui/react-app/src/pages/graph/PanelList.tsx
@@ -55,8 +55,6 @@ export const PanelListContent: FC<PanelListProps> = ({
       storeList.push(...stores[type]);
     }
     setStoreData(storeList);
-    // Clear selected stores for each panel.
-    panels.forEach((panel: PanelMeta) => (panel.options.storeMatches = []));
     !panels.length && addPanel();
     window.onpopstate = () => {
       const panels = decodePanelOptionsFromQueryString(window.location.search);
@@ -142,7 +140,7 @@ const PanelList: FC<RouteComponentProps & PathPrefixProps> = ({ pathPrefix = '' 
   const [delta, setDelta] = useState(0);
   const [useLocalTime, setUseLocalTime] = useLocalStorage('use-local-time', false);
   const [enableQueryHistory, setEnableQueryHistory] = useLocalStorage('enable-query-history', false);
-  const [debugMode, setDebugMode] = useState(false);
+  const [enableStoreFiltering, setEnableStoreFiltering] = useLocalStorage('enable-store-filtering', false);
   const [enableAutocomplete, setEnableAutocomplete] = useLocalStorage('enable-autocomplete', true);
   const [enableHighlighting, setEnableHighlighting] = useLocalStorage('enable-syntax-highlighting', true);
   const [enableLinter, setEnableLinter] = useLocalStorage('enable-linter', true);
@@ -198,9 +196,9 @@ const PanelList: FC<RouteComponentProps & PathPrefixProps> = ({ pathPrefix = '' 
           </Checkbox>
           <Checkbox
             wrapperStyles={{ marginLeft: 20, display: 'inline-block' }}
-            id="debug-mode-checkbox"
-            defaultChecked={debugMode}
-            onChange={({ target }) => setDebugMode(target.checked)}
+            id="store-filtering-checkbox"
+            defaultChecked={enableStoreFiltering}
+            onChange={({ target }) => setEnableStoreFiltering(target.checked)}
           >
             Enable Store Filtering
           </Checkbox>
@@ -263,7 +261,7 @@ const PanelList: FC<RouteComponentProps & PathPrefixProps> = ({ pathPrefix = '' 
         pathPrefix={pathPrefix}
         useLocalTime={useLocalTime}
         metrics={metricsRes.data}
-        stores={debugMode ? storesRes.data : {}}
+        stores={enableStoreFiltering ? storesRes.data : {}}
         enableAutocomplete={enableAutocomplete}
         enableHighlighting={enableHighlighting}
         enableLinter={enableLinter}


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

Fixes #5951

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

`g0.store_matches` parameter appears in the url but doesn't applies in the frontend. Looks like it has been done on purpose and by removing a small piece of code fixes this issue.

variable named `debugMode` is used for the store filtering checkbox which is an unappropriate name. Using `enableStoreFiltering` variable to represent the state of checkbox.


## Verification

I have tested this and the store filtering remains after window reload.
