### PR TITLE
Fix Receiver panic when querying uninitialized TSDBs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#5995](https://github.com/thanos-io/thanos/pull/5995) Sidecar: Loads the TLS certificate during startup.
 - [#6044](https://github.com/thanos-io/thanos/pull/6044) Receive: mark ouf of window errors as conflict, if out-of-window samples ingestion is activated
 - [#6066](https://github.com/thanos-io/thanos/pull/6066) Tracing: fixed panic because of nil sampler
+- [#6067](https://github.com/thanos-io/thanos/pull/6067) Receive: fixed panic when querying uninitialized TSDBs.
 
 ### Changed
 

--- a/pkg/receive/multitsdb.go
+++ b/pkg/receive/multitsdb.go
@@ -164,6 +164,9 @@ func (t *tenant) client() store.Client {
 	defer t.mtx.RUnlock()
 
 	store := t.store()
+	if store == nil {
+		return nil
+	}
 	client := storepb.ServerAsClient(store, 0)
 	return newLocalClient(client, store.LabelSet, store.TimeRange)
 }
@@ -429,7 +432,10 @@ func (t *MultiTSDB) TSDBLocalClients() []store.Client {
 
 	res := make([]store.Client, 0, len(t.tenants))
 	for _, tenant := range t.tenants {
-		res = append(res, tenant.client())
+		client := tenant.client()
+		if client != nil {
+			res = append(res, client)
+		}
 	}
 
 	return res


### PR DESCRIPTION
Receivers currently panic when retrieving labels for a TSDB that is being initialized. The reason for this is that the tenant is added to the tenants map and the TSDB is started in the background. When retrieving labels, the MultiTSDB creates Clients for each TSDB, even if a TSDB is not yet ready.

Adding a tenant to the tenants map: https://github.com/thanos-io/thanos/blob/main/pkg/receive/multitsdb.go#L562
Setting the underlying TSDB: https://github.com/thanos-io/thanos/blob/main/pkg/receive/multitsdb.go#L533
Retrieving the TSDB: https://github.com/thanos-io/thanos/blob/main/pkg/receive/multitsdb.go#L166

Fixes https://github.com/thanos-io/thanos/issues/6047

Signed-off-by: Filip Petkovski <filip.petkovsky@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
