### PR TITLE
Store: Don't error when no stores are matched

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#6050](https://github.com/thanos-io/thanos/pull/6050) Store: Re-try bucket store initial sync upon failure.
 - [#6066](https://github.com/thanos-io/thanos/pull/6066) Tracing: fixed panic because of nil sampler
 - [#6067](https://github.com/thanos-io/thanos/pull/6067) Receive: fixed panic when querying uninitialized TSDBs.
+- [#6082](https://github.com/thanos-io/thanos/pull/6082) Store: Don't error when no stores are matched.
 
 ### Changed
 

--- a/pkg/store/proxy_test.go
+++ b/pkg/store/proxy_test.go
@@ -133,7 +133,7 @@ func TestProxyStore_Series(t *testing.T) {
 				MaxTime:  300,
 				Matchers: []storepb.LabelMatcher{{Name: "a", Value: "a", Type: storepb.LabelMatcher_EQ}},
 			},
-			expectedWarningsLen: 1, // No store matched for this query.
+			expectedWarningsLen: 0, // No store matched for this query.
 		},
 		{
 			title: "no storeAPI available for 301-302 time range",
@@ -153,7 +153,7 @@ func TestProxyStore_Series(t *testing.T) {
 				MaxTime:  400,
 				Matchers: []storepb.LabelMatcher{{Name: "a", Value: "a", Type: storepb.LabelMatcher_EQ}},
 			},
-			expectedWarningsLen: 1, // No store matched for this query.
+			expectedWarningsLen: 0, // No store matched for this query.
 		},
 		{
 			title: "storeAPI available for time range; no series for ext=2 external label matcher",
@@ -174,7 +174,7 @@ func TestProxyStore_Series(t *testing.T) {
 				MaxTime:  300,
 				Matchers: []storepb.LabelMatcher{{Name: "ext", Value: "2", Type: storepb.LabelMatcher_EQ}},
 			},
-			expectedWarningsLen: 1, // No store matched for this query.
+			expectedWarningsLen: 0, // No store matched for this query.
 		},
 		{
 			title: "storeAPI available for time range; available series for ext=1 external label matcher",
@@ -499,7 +499,7 @@ func TestProxyStore_Series(t *testing.T) {
 				Matchers: []storepb.LabelMatcher{{Name: "ext", Value: "1", Type: storepb.LabelMatcher_EQ}},
 			},
 			storeDebugMatchers:  [][]*labels.Matcher{{labels.MustNewMatcher(labels.MatchEqual, "__address__", "foo")}},
-			expectedWarningsLen: 1, // No stores match.
+			expectedWarningsLen: 0, // No stores match.
 		},
 		{
 			title: "sharded series response",


### PR DESCRIPTION
* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

It's normal and not an error if a query does not match due to no downstream stores. This is common when querying with external labels and tiered query servers.

This bug was introduced in https://github.com/thanos-io/thanos/pull/5296

Fixes: https://github.com/thanos-io/thanos/issues/5862

## Verification

<!-- How you tested it? How do you know it works? -->
