### PR TITLE
Fix: Failure to close BlockSeriesClient cause store-gateway deadlock

### DIFF
--- a/pkg/store/bucket_e2e_test.go
+++ b/pkg/store/bucket_e2e_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -765,6 +766,10 @@ func TestBucketStore_LabelNames_e2e(t *testing.T) {
 		} {
 			t.Run(name, func(t *testing.T) {
 				vals, err := s.store.LabelNames(ctx, tc.req)
+				for _, b := range s.store.blocks {
+					waitTimeout(t, b.pendingReaders, 5*time.Second)
+				}
+
 				testutil.Ok(t, err)
 
 				testutil.Equals(t, tc.expected, vals.Names)
@@ -868,6 +873,10 @@ func TestBucketStore_LabelValues_e2e(t *testing.T) {
 		} {
 			t.Run(name, func(t *testing.T) {
 				vals, err := s.store.LabelValues(ctx, tc.req)
+				for _, b := range s.store.blocks {
+					waitTimeout(t, b.pendingReaders, 5*time.Second)
+				}
+
 				testutil.Ok(t, err)
 
 				testutil.Equals(t, tc.expected, emptyToNil(vals.Values))
@@ -881,4 +890,18 @@ func emptyToNil(values []string) []string {
 		return nil
 	}
 	return values
+}
+
+func waitTimeout(t *testing.T, wg sync.WaitGroup, timeout time.Duration) {
+	c := make(chan struct{})
+	go func() {
+		defer close(c)
+		wg.Wait()
+	}()
+	select {
+	case <-c:
+		return
+	case <-time.After(timeout):
+		t.Fatalf("timeout waiting wg for %v", timeout)
+	}
 }

--- a/pkg/store/bucket_e2e_test.go
+++ b/pkg/store/bucket_e2e_test.go
@@ -767,7 +767,7 @@ func TestBucketStore_LabelNames_e2e(t *testing.T) {
 			t.Run(name, func(t *testing.T) {
 				vals, err := s.store.LabelNames(ctx, tc.req)
 				for _, b := range s.store.blocks {
-					waitTimeout(t, b.pendingReaders, 5*time.Second)
+					waitTimeout(t, &b.pendingReaders, 5*time.Second)
 				}
 
 				testutil.Ok(t, err)
@@ -874,7 +874,7 @@ func TestBucketStore_LabelValues_e2e(t *testing.T) {
 			t.Run(name, func(t *testing.T) {
 				vals, err := s.store.LabelValues(ctx, tc.req)
 				for _, b := range s.store.blocks {
-					waitTimeout(t, b.pendingReaders, 5*time.Second)
+					waitTimeout(t, &b.pendingReaders, 5*time.Second)
 				}
 
 				testutil.Ok(t, err)
@@ -892,7 +892,7 @@ func emptyToNil(values []string) []string {
 	return values
 }
 
-func waitTimeout(t *testing.T, wg sync.WaitGroup, timeout time.Duration) {
+func waitTimeout(t *testing.T, wg *sync.WaitGroup, timeout time.Duration) {
 	c := make(chan struct{})
 	go func() {
 		defer close(c)


### PR DESCRIPTION
Fix: https://github.com/thanos-io/thanos/issues/6085
## Changes

* Calling `blockSeriesClient#close` on the `LabelNames` and `LabelValues` methods.
* ~~Instantiating  `blockSeriesClient` inside the `go func`  on the `Series` method so we can release the resources as soon as possible.~~
