### PR TITLE
Compact: Remove spam of replica label removed log

### DIFF
--- a/pkg/block/fetcher.go
+++ b/pkg/block/fetcher.go
@@ -717,7 +717,6 @@ func (r *ReplicaLabelRemover) Filter(_ context.Context, metas map[ulid.ULID]*met
 
 		for _, replicaLabel := range r.replicaLabels {
 			if _, exists := l[replicaLabel]; exists {
-				level.Debug(r.logger).Log("msg", "replica label removed", "label", replicaLabel)
 				delete(l, replicaLabel)
 				modified.WithLabelValues(replicaRemovedMeta).Inc()
 			}

--- a/pkg/block/fetcher.go
+++ b/pkg/block/fetcher.go
@@ -709,7 +709,7 @@ func (r *ReplicaLabelRemover) Filter(_ context.Context, metas map[ulid.ULID]*met
 		return nil
 	}
 
-  countReplicaLabelRemoved := make(map[string]int, len(metas))
+	countReplicaLabelRemoved := make(map[string]int, len(metas))
 	for u, meta := range metas {
 		l := make(map[string]string)
 		for n, v := range meta.Thanos.Labels {
@@ -719,7 +719,7 @@ func (r *ReplicaLabelRemover) Filter(_ context.Context, metas map[ulid.ULID]*met
 		for _, replicaLabel := range r.replicaLabels {
 			if _, exists := l[replicaLabel]; exists {
 				delete(l, replicaLabel)
-        countReplicaLabelRemoved[replicaLabel] += 1
+				countReplicaLabelRemoved[replicaLabel] += 1
 				modified.WithLabelValues(replicaRemovedMeta).Inc()
 			}
 		}
@@ -732,9 +732,9 @@ func (r *ReplicaLabelRemover) Filter(_ context.Context, metas map[ulid.ULID]*met
 		nm.Thanos.Labels = l
 		metas[u] = &nm
 	}
-  for replicaLabelRemoved, count := range countReplicaLabelRemoved {
-    level.Debug(r.logger).Log("msg", "removed replica label", "label", replicaLabelRemoved, "count", count)
-  }
+	for replicaLabelRemoved, count := range countReplicaLabelRemoved {
+		level.Debug(r.logger).Log("msg", "removed replica label", "label", replicaLabelRemoved, "count", count)
+	}
 	return nil
 }
 

--- a/pkg/block/fetcher.go
+++ b/pkg/block/fetcher.go
@@ -709,6 +709,7 @@ func (r *ReplicaLabelRemover) Filter(_ context.Context, metas map[ulid.ULID]*met
 		return nil
 	}
 
+  countReplicaLabelRemoved := make(map[string]int, len(metas))
 	for u, meta := range metas {
 		l := make(map[string]string)
 		for n, v := range meta.Thanos.Labels {
@@ -718,6 +719,7 @@ func (r *ReplicaLabelRemover) Filter(_ context.Context, metas map[ulid.ULID]*met
 		for _, replicaLabel := range r.replicaLabels {
 			if _, exists := l[replicaLabel]; exists {
 				delete(l, replicaLabel)
+        countReplicaLabelRemoved[replicaLabel] += 1
 				modified.WithLabelValues(replicaRemovedMeta).Inc()
 			}
 		}
@@ -730,6 +732,9 @@ func (r *ReplicaLabelRemover) Filter(_ context.Context, metas map[ulid.ULID]*met
 		nm.Thanos.Labels = l
 		metas[u] = &nm
 	}
+  for replicaLabelRemoved, count := range countReplicaLabelRemoved {
+    level.Debug(r.logger).Log("msg", "removed replica label", "label", replicaLabelRemoved, "count", count)
+  }
 	return nil
 }
 


### PR DESCRIPTION
Signed-off-by: Douglas Camata <159076+douglascamata@users.noreply.github.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

* Grouped the logging about removed replica labels to avoid spamming the logs too much when debug mode is enabled.

This is what the Compact's debug logs look like in a low-load instance:

```
level=info ts=2023-01-29T03:29:24.893860294Z caller=compact.go:1291 msg="start sync of metas"
level=debug ts=2023-01-29T03:29:24.893956263Z caller=fetcher.go:327 component=block.BaseFetcher msg="fetching meta data" concurrency=32
level=debug ts=2023-01-29T03:29:25.3041953Z caller=fetcher.go:720 msg="replica label removed" label=replica
level=debug ts=2023-01-29T03:29:25.304232008Z caller=fetcher.go:720 msg="replica label removed" label=replica
level=debug ts=2023-01-29T03:29:25.304241189Z caller=fetcher.go:720 msg="replica label removed" label=replica
level=debug ts=2023-01-29T03:29:25.304247631Z caller=fetcher.go:720 msg="replica label removed" label=replica
level=debug ts=2023-01-29T03:29:25.304260272Z caller=fetcher.go:720 msg="replica label removed" label=replica
level=debug ts=2023-01-29T03:29:25.304266406Z caller=fetcher.go:720 msg="replica label removed" label=replica
level=debug ts=2023-01-29T03:29:25.304276962Z caller=fetcher.go:720 msg="replica label removed" label=replica
level=debug ts=2023-01-29T03:29:25.30428612Z caller=fetcher.go:720 msg="replica label removed" label=replica
level=debug ts=2023-01-29T03:29:25.304297998Z caller=fetcher.go:720 msg="replica label removed" label=replica
level=debug ts=2023-01-29T03:29:25.304309036Z caller=fetcher.go:720 msg="replica label removed" label=replica
level=debug ts=2023-01-29T03:29:25.304331501Z caller=fetcher.go:720 msg="replica label removed" label=replica
level=debug ts=2023-01-29T03:29:25.304342472Z caller=fetcher.go:720 msg="replica label removed" label=replica
level=debug ts=2023-01-29T03:29:25.304352428Z caller=fetcher.go:720 msg="replica label removed" label=replica
level=debug ts=2023-01-29T03:29:25.304362091Z caller=fetcher.go:720 msg="replica label removed" label=replica
level=debug ts=2023-01-29T03:29:25.304381289Z caller=fetcher.go:720 msg="replica label removed" label=replica
level=debug ts=2023-01-29T03:29:25.304404192Z caller=fetcher.go:720 msg="replica label removed" label=replica
level=debug ts=2023-01-29T03:29:25.304414971Z caller=fetcher.go:720 msg="replica label removed" label=replica
level=debug ts=2023-01-29T03:29:25.304425322Z caller=fetcher.go:720 msg="replica label removed" label=replica
level=debug ts=2023-01-29T03:29:25.304446152Z caller=fetcher.go:720 msg="replica label removed" label=replica
level=debug ts=2023-01-29T03:29:25.304467Z caller=fetcher.go:720 msg="replica label removed" label=replica
level=debug ts=2023-01-29T03:29:25.30448368Z caller=fetcher.go:720 msg="replica label removed" label=replica
level=debug ts=2023-01-29T03:29:25.304493964Z caller=fetcher.go:720 msg="replica label removed" label=replica
level=debug ts=2023-01-29T03:29:25.304505931Z caller=fetcher.go:720 msg="replica label removed" label=replica
level=debug ts=2023-01-29T03:29:25.304516467Z caller=fetcher.go:720 msg="replica label removed" label=replica
level=debug ts=2023-01-29T03:29:25.304527957Z caller=fetcher.go:720 msg="replica label removed" label=replica
level=debug ts=2023-01-29T03:29:25.304542469Z caller=fetcher.go:720 msg="replica label removed" label=replica
level=debug ts=2023-01-29T03:29:25.304556674Z caller=fetcher.go:720 msg="replica label removed" label=replica
level=debug ts=2023-01-29T03:29:25.304567871Z caller=fetcher.go:720 msg="replica label removed" label=replica
level=debug ts=2023-01-29T03:29:25.304581458Z caller=fetcher.go:720 msg="replica label removed" label=replica
level=debug ts=2023-01-29T03:29:25.304601503Z caller=fetcher.go:720 msg="replica label removed" label=replica
level=debug ts=2023-01-29T03:29:25.304613191Z caller=fetcher.go:720 msg="replica label removed" label=replica
level=debug ts=2023-01-29T03:29:25.304626476Z caller=fetcher.go:720 msg="replica label removed" label=replica
level=debug ts=2023-01-29T03:29:25.304636702Z caller=fetcher.go:720 msg="replica label removed" label=replica
level=debug ts=2023-01-29T03:29:25.304651358Z caller=fetcher.go:720 msg="replica label removed" label=replica
level=debug ts=2023-01-29T03:29:25.304666153Z caller=fetcher.go:720 msg="replica label removed" label=replica
level=debug ts=2023-01-29T03:29:25.304699917Z caller=fetcher.go:720 msg="replica label removed" label=replica
level=debug ts=2023-01-29T03:29:25.304712046Z caller=fetcher.go:720 msg="replica label removed" label=replica
level=debug ts=2023-01-29T03:29:25.304728799Z caller=fetcher.go:720 msg="replica label removed" label=replica
level=debug ts=2023-01-29T03:29:25.304739013Z caller=fetcher.go:720 msg="replica label removed" label=replica
level=debug ts=2023-01-29T03:29:25.304750357Z caller=fetcher.go:720 msg="replica label removed" label=replica
level=debug ts=2023-01-29T03:29:25.304761251Z caller=fetcher.go:720 msg="replica label removed" label=replica
level=debug ts=2023-01-29T03:29:25.304778166Z caller=fetcher.go:720 msg="replica label removed" label=replica
level=debug ts=2023-01-29T03:29:25.304792187Z caller=fetcher.go:720 msg="replica label removed" label=replica
level=debug ts=2023-01-29T03:29:25.304802597Z caller=fetcher.go:720 msg="replica label removed" label=replica
level=debug ts=2023-01-29T03:29:25.304820999Z caller=fetcher.go:720 msg="replica label removed" label=replica
level=debug ts=2023-01-29T03:29:25.304835765Z caller=fetcher.go:720 msg="replica label removed" label=replica
level=debug ts=2023-01-29T03:29:25.304851857Z caller=fetcher.go:720 msg="replica label removed" label=replica
level=debug ts=2023-01-29T03:29:25.304868054Z caller=fetcher.go:720 msg="replica label removed" label=replica
level=debug ts=2023-01-29T03:29:25.30488155Z caller=fetcher.go:720 msg="replica label removed" label=replica
level=debug ts=2023-01-29T03:29:25.304893883Z caller=fetcher.go:720 msg="replica label removed" label=replica
level=debug ts=2023-01-29T03:29:25.304907282Z caller=fetcher.go:720 msg="replica label removed" label=replica
level=debug ts=2023-01-29T03:29:25.304920669Z caller=fetcher.go:720 msg="replica label removed" label=replica
level=debug ts=2023-01-29T03:29:25.304930795Z caller=fetcher.go:720 msg="replica label removed" label=replica
level=debug ts=2023-01-29T03:29:25.304946865Z caller=fetcher.go:720 msg="replica label removed" label=replica
level=debug ts=2023-01-29T03:29:25.304956475Z caller=fetcher.go:720 msg="replica label removed" label=replica
level=debug ts=2023-01-29T03:29:25.304966641Z caller=fetcher.go:720 msg="replica label removed" label=replica
level=debug ts=2023-01-29T03:29:25.304979558Z caller=fetcher.go:720 msg="replica label removed" label=replica
level=debug ts=2023-01-29T03:29:25.305003916Z caller=fetcher.go:720 msg="replica label removed" label=replica
level=debug ts=2023-01-29T03:29:25.305031275Z caller=fetcher.go:720 msg="replica label removed" label=replica
level=debug ts=2023-01-29T03:29:25.305044551Z caller=fetcher.go:720 msg="replica label removed" label=replica
level=debug ts=2023-01-29T03:29:25.305061988Z caller=fetcher.go:720 msg="replica label removed" label=replica
level=debug ts=2023-01-29T03:29:25.305072176Z caller=fetcher.go:720 msg="replica label removed" label=replica
level=debug ts=2023-01-29T03:29:25.305084248Z caller=fetcher.go:720 msg="replica label removed" label=replica
level=debug ts=2023-01-29T03:29:25.305098589Z caller=fetcher.go:720 msg="replica label removed" label=replica
level=debug ts=2023-01-29T03:29:25.305108541Z caller=fetcher.go:720 msg="replica label removed" label=replica
level=debug ts=2023-01-29T03:29:25.305121397Z caller=fetcher.go:720 msg="replica label removed" label=replica
level=debug ts=2023-01-29T03:29:25.305137376Z caller=fetcher.go:720 msg="replica label removed" label=replica
level=debug ts=2023-01-29T03:29:25.305152262Z caller=fetcher.go:720 msg="replica label removed" label=replica
level=debug ts=2023-01-29T03:29:25.30516293Z caller=fetcher.go:720 msg="replica label removed" label=replica
level=debug ts=2023-01-29T03:29:25.305172742Z caller=fetcher.go:720 msg="replica label removed" label=replica
level=debug ts=2023-01-29T03:29:25.305182315Z caller=fetcher.go:720 msg="replica label removed" label=replica
level=debug ts=2023-01-29T03:29:25.305193599Z caller=fetcher.go:720 msg="replica label removed" label=replica
level=info ts=2023-01-29T03:29:25.346139351Z caller=fetcher.go:478 component=block.BaseFetcher msg="successfully synchronized block metadata" duration=452.21107ms duration_ms=452 cached=430 returned=96 partial=0
```

And this is how they will look like now:

```
level=info ts=2023-01-29T03:29:24.893860294Z caller=compact.go:1291 msg="start sync of metas"
level=debug ts=2023-01-29T03:29:24.893956263Z caller=fetcher.go:327 component=block.BaseFetcher msg="fetching meta data" concurrency=32
level=debug ts=2023-01-29T03:29:25.3041953Z caller=fetcher.go:720 msg="removed replica label" label="replica" count="72"
level=info ts=2023-01-29T03:29:25.346139351Z caller=fetcher.go:478 component=block.BaseFetcher msg="successfully synchronized block metadata" duration=452.21107ms duration_ms=452 cached=430 returned=96 partial=0
```

## Verification

<!-- How you tested it? How do you know it works? -->
