### PR TITLE
Mixins(Rule): Fix query for long rule evaluations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#6050](https://github.com/thanos-io/thanos/pull/6050) Store: Re-try bucket store initial sync upon failure.
 - [#6067](https://github.com/thanos-io/thanos/pull/6067) Receive: fixed panic when querying uninitialized TSDBs.
 - [#6082](https://github.com/thanos-io/thanos/pull/6082) Store: Don't error when no stores are matched.
+- [#6103](https://github.com/thanos-io/thanos/pull/6103) Mixins(Rule): Fix query for long rule evaluations.
 
 ### Changed
 

--- a/examples/dashboards/rule.json
+++ b/examples/dashboards/rule.json
@@ -197,7 +197,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "(\n  max by(job, rule_group) (prometheus_rule_group_last_duration_seconds{job=~\"$job\"})\n  >\n  sum by(job, rule_group) (prometheus_rule_group_interval_seconds{job=~\"$job\"})\n)\n",
+                     "expr": "(\n  sum by(job, rule_group) (prometheus_rule_group_last_duration_seconds{job=~\"$job\"})\n  >\n  sum by(job, rule_group) (prometheus_rule_group_interval_seconds{job=~\"$job\"})\n)\n",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{ rule_group }}",

--- a/mixin/dashboards/rule.libsonnet
+++ b/mixin/dashboards/rule.libsonnet
@@ -38,7 +38,7 @@ local utils = import '../lib/utils.libsonnet';
           g.queryPanel(
             |||
               (
-                max by(%(dimensions)s, rule_group) (prometheus_rule_group_last_duration_seconds{%(selector)s})
+                sum by(%(dimensions)s, rule_group) (prometheus_rule_group_last_duration_seconds{%(selector)s})
                 >
                 sum by(%(dimensions)s, rule_group) (prometheus_rule_group_interval_seconds{%(selector)s})
               )


### PR DESCRIPTION
Signed-off-by: Douglas Camata <159076+douglascamata@users.noreply.github.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

* Fixed Thanos Rule dashboard widget that's supposed to show rules that are taking too long to evaluate.

## Verification

Now it properly matches the PromQL used for the alert `ThanosRuleRuleEvaluationLatencyHigh`.
