### PR TITLE
Fix: Large number of spans in thanos traces.

### DIFF
--- a/pkg/store/proxy.go
+++ b/pkg/store/proxy.go
@@ -330,11 +330,7 @@ func (s *ProxyStore) Series(originalRequest *storepb.SeriesRequest, srv storepb.
 }
 
 // storeMatches returns boolean if the given store may hold data for the given label matchers, time ranges and debug store matches gathered from context.
-// It also produces tracing span.
 func storeMatches(ctx context.Context, s Client, mint, maxt int64, matchers ...*labels.Matcher) (ok bool, reason string) {
-	span, ctx := tracing.StartSpan(ctx, "store_matches")
-	defer span.Finish()
-
 	var storeDebugMatcher [][]*labels.Matcher
 	if ctxVal := ctx.Value(StoreMatcherKey); ctxVal != nil {
 		if value, ok := ctxVal.([][]*labels.Matcher); ok {


### PR DESCRIPTION
Signed-off-by: Jatin <jatin_a@ch.iitr.ac.in>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes
Removed `store_matches` span  to reduce number of spans.
Fixes #6099 

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
