### PR TITLE
feat: Use non root user as default user in container image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#6168](https://github.com/thanos-io/thanos/pull/6168) Receiver: Make ketama hashring fail early when configured with number of nodes lower than the replication factor.
 - [#6201](https://github.com/thanos-io/thanos/pull/6201) Query-Frontend: Disable absent and absent_over_time for vertical sharding.
 - [#6212](https://github.com/thanos-io/thanos/pull/6212) Query-Frontend: Disable scalar for vertical sharding.
+- [#6107](https://github.com/thanos-io/thanos/pull/6082) Change default user id in container image from 0(root) to 1001
 
 ### Removed
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,11 @@ LABEL maintainer="The Thanos Authors"
 
 COPY /thanos_tmp_for_docker /bin/thanos
 
+RUN adduser \
+    -D `#Dont assign a password` \
+    -H `#Dont create home directory` \
+    -u 1001 `#User id`\
+    thanos && \
+    chown thanos /bin/thanos
+USER 1001
 ENTRYPOINT [ "/bin/thanos" ]

--- a/Dockerfile.multi-arch
+++ b/Dockerfile.multi-arch
@@ -9,4 +9,11 @@ ARG OS="linux"
 
 COPY .build/${OS}-${ARCH}/thanos /bin/thanos
 
+RUN adduser \
+    -D `#Dont assign a password` \
+    -H `#Dont create home directory` \
+    -u 1001 `#User id`\
+    thanos && \
+    chown thanos /bin/thanos
+USER 1001
 ENTRYPOINT [ "/bin/thanos" ]

--- a/Dockerfile.multi-stage
+++ b/Dockerfile.multi-stage
@@ -21,4 +21,11 @@ LABEL maintainer="The Thanos Authors"
 
 COPY --from=builder /go/bin/thanos /bin/thanos
 
+RUN adduser \
+    -D `#Dont assign a password` \
+    -H `#Dont create home directory` \
+    -u 1001 `#User id`\
+    thanos && \
+    chown thanos /bin/thanos
+USER 1001
 ENTRYPOINT [ "/bin/thanos" ]


### PR DESCRIPTION
Signed-off-by: Timo Haas <haastimo@gmx.de>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Changed default user in container images from 0 to 1001

## Verification

<!-- How you tested it? How do you know it works? -->
Tested thanos-query in k8s cluster
