### PR TITLE
*: fix problems with pkg/gate

### DIFF
--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -699,6 +699,7 @@ func runQuery(
 			gate.New(
 				extprom.WrapRegistererWithPrefix("thanos_query_concurrent_", reg),
 				maxConcurrentQueries,
+				gate.Queries,
 			),
 			store.NewSeriesStatsAggregator(
 				reg,

--- a/cmd/thanos/store.go
+++ b/cmd/thanos/store.go
@@ -344,7 +344,7 @@ func runStore(
 		return errors.Errorf("max concurrency value cannot be lower than 0 (got %v)", conf.maxConcurrency)
 	}
 
-	queriesGate := gate.New(extprom.WrapRegistererWithPrefix("thanos_bucket_store_series_", reg), int(conf.maxConcurrency))
+	queriesGate := gate.New(extprom.WrapRegistererWithPrefix("thanos_bucket_store_series_", reg), int(conf.maxConcurrency), gate.Queries)
 
 	chunkPool, err := store.NewDefaultChunkBytesPool(uint64(conf.chunkPoolSize))
 	if err != nil {

--- a/pkg/api/query/v1_test.go
+++ b/pkg/api/query/v1_test.go
@@ -195,7 +195,7 @@ func TestQueryEndpoints(t *testing.T) {
 		queryableCreate:       query.NewQueryableCreator(nil, nil, store.NewTSDBStore(nil, db, component.Query, nil), 2, timeout),
 		queryEngine:           qe,
 		lookbackDeltaCreate:   func(m int64) time.Duration { return time.Duration(0) },
-		gate:                  gate.New(nil, 4),
+		gate:                  gate.New(nil, 4, gate.Queries),
 		defaultRangeQueryStep: time.Second,
 		queryRangeHist: promauto.With(prometheus.NewRegistry()).NewHistogram(prometheus.HistogramOpts{
 			Name: "query_range_hist",
@@ -736,7 +736,7 @@ func TestMetadataEndpoints(t *testing.T) {
 		queryableCreate:     query.NewQueryableCreator(nil, nil, store.NewTSDBStore(nil, db, component.Query, nil), 2, timeout),
 		queryEngine:         qe,
 		lookbackDeltaCreate: func(m int64) time.Duration { return time.Duration(0) },
-		gate:                gate.New(nil, 4),
+		gate:                gate.New(nil, 4, gate.Queries),
 		queryRangeHist: promauto.With(prometheus.NewRegistry()).NewHistogram(prometheus.HistogramOpts{
 			Name: "query_range_hist",
 		}),
@@ -749,7 +749,7 @@ func TestMetadataEndpoints(t *testing.T) {
 		queryableCreate:          query.NewQueryableCreator(nil, nil, store.NewTSDBStore(nil, db, component.Query, nil), 2, timeout),
 		queryEngine:              qe,
 		lookbackDeltaCreate:      func(m int64) time.Duration { return time.Duration(0) },
-		gate:                     gate.New(nil, 4),
+		gate:                     gate.New(nil, 4, gate.Queries),
 		defaultMetadataTimeRange: apiLookbackDelta,
 		queryRangeHist: promauto.With(prometheus.NewRegistry()).NewHistogram(prometheus.HistogramOpts{
 			Name: "query_range_hist",
@@ -1461,7 +1461,7 @@ func TestParseDownsamplingParamMillis(t *testing.T) {
 	for i, test := range tests {
 		api := QueryAPI{
 			enableAutodownsampling: test.enableAutodownsampling,
-			gate:                   gate.New(nil, 4),
+			gate:                   gate.New(nil, 4, gate.Queries),
 			queryRangeHist: promauto.With(prometheus.NewRegistry()).NewHistogram(prometheus.HistogramOpts{
 				Name: "query_range_hist",
 			}),

--- a/pkg/cacheutil/cacheutil_test.go
+++ b/pkg/cacheutil/cacheutil_test.go
@@ -62,7 +62,7 @@ func TestDoWithBatch(t *testing.T) {
 			items:           []string{"key1", "key2", "key3", "key4", "key5"},
 			batchSize:       2,
 			expectedBatches: 3,
-			concurrency:     gate.New(prometheus.NewPedanticRegistry(), 1),
+			concurrency:     gate.New(prometheus.NewPedanticRegistry(), 1, gate.Queries),
 		},
 	}
 

--- a/pkg/cacheutil/memcached_client.go
+++ b/pkg/cacheutil/memcached_client.go
@@ -286,6 +286,7 @@ func newMemcachedClient(
 		getMultiGate: gate.New(
 			extprom.WrapRegistererWithPrefix("thanos_memcached_getmulti_", reg),
 			config.MaxGetMultiConcurrency,
+			gate.Gets,
 		),
 	}
 

--- a/pkg/cacheutil/redis_client.go
+++ b/pkg/cacheutil/redis_client.go
@@ -233,10 +233,12 @@ func NewRedisClientWithConfig(logger log.Logger, name string, config RedisClient
 		getMultiGate: gate.New(
 			extprom.WrapRegistererWithPrefix("thanos_redis_getmulti_", reg),
 			config.MaxGetMultiConcurrency,
+			gate.Gets,
 		),
 		setMultiGate: gate.New(
 			extprom.WrapRegistererWithPrefix("thanos_redis_setmulti_", reg),
 			config.MaxSetMultiConcurrency,
+			gate.Sets,
 		),
 	}
 	duration := promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{

--- a/pkg/gate/gate_test.go
+++ b/pkg/gate/gate_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestGateAllowsDisablingLimits(t *testing.T) {
 	reg := prometheus.NewRegistry()
-	g := New(reg, 0)
+	g := New(reg, 0, Queries)
 
 	require.NoError(t, g.Start(context.Background()))
 }

--- a/pkg/query/querier.go
+++ b/pkg/query/querier.go
@@ -66,7 +66,7 @@ func NewQueryableCreator(
 	maxConcurrentSelects int,
 	selectTimeout time.Duration,
 ) QueryableCreator {
-	g := gate.New(extprom.WrapRegistererWithPrefix("concurrent_selects_", reg), maxConcurrentSelects, gate.Selects)
+	gf := gate.NewGateFactory(extprom.WrapRegistererWithPrefix("concurrent_selects_", reg), maxConcurrentSelects, gate.Selects)
 
 	return func(
 		deduplicate bool,
@@ -89,7 +89,7 @@ func NewQueryableCreator(
 			partialResponse:     partialResponse,
 			skipChunks:          skipChunks,
 			gateProviderFn: func() gate.Gate {
-				return g
+				return gf.New()
 			},
 			maxConcurrentSelects: maxConcurrentSelects,
 			selectTimeout:        selectTimeout,

--- a/pkg/query/querier.go
+++ b/pkg/query/querier.go
@@ -66,6 +66,8 @@ func NewQueryableCreator(
 	maxConcurrentSelects int,
 	selectTimeout time.Duration,
 ) QueryableCreator {
+	g := gate.New(extprom.WrapRegistererWithPrefix("concurrent_selects_", reg), maxConcurrentSelects)
+
 	return func(
 		deduplicate bool,
 		replicaLabels []string,
@@ -77,7 +79,6 @@ func NewQueryableCreator(
 		shardInfo *storepb.ShardInfo,
 		seriesStatsReporter seriesStatsReporter,
 	) storage.Queryable {
-		reg = extprom.WrapRegistererWithPrefix("concurrent_selects_", reg)
 		return &queryable{
 			logger:              logger,
 			replicaLabels:       replicaLabels,
@@ -88,7 +89,7 @@ func NewQueryableCreator(
 			partialResponse:     partialResponse,
 			skipChunks:          skipChunks,
 			gateProviderFn: func() gate.Gate {
-				return gate.New(reg, maxConcurrentSelects)
+				return g
 			},
 			maxConcurrentSelects: maxConcurrentSelects,
 			selectTimeout:        selectTimeout,

--- a/pkg/query/querier.go
+++ b/pkg/query/querier.go
@@ -66,7 +66,7 @@ func NewQueryableCreator(
 	maxConcurrentSelects int,
 	selectTimeout time.Duration,
 ) QueryableCreator {
-	g := gate.New(extprom.WrapRegistererWithPrefix("concurrent_selects_", reg), maxConcurrentSelects)
+	g := gate.New(extprom.WrapRegistererWithPrefix("concurrent_selects_", reg), maxConcurrentSelects, gate.Selects)
 
 	return func(
 		deduplicate bool,

--- a/pkg/receive/limiter.go
+++ b/pkg/receive/limiter.go
@@ -144,7 +144,7 @@ func (l *Limiter) loadConfig() error {
 				l.registerer,
 			),
 			int(maxWriteConcurrency),
-			gate.Writes,
+			gate.WriteRequests,
 		)
 	}
 	l.requestLimiter = newConfigRequestLimiter(

--- a/pkg/receive/limiter.go
+++ b/pkg/receive/limiter.go
@@ -144,6 +144,7 @@ func (l *Limiter) loadConfig() error {
 				l.registerer,
 			),
 			int(maxWriteConcurrency),
+			gate.Writes,
 		)
 	}
 	l.requestLimiter = newConfigRequestLimiter(


### PR DESCRIPTION
- Fix bug with duplicate metric registration (https://github.com/thanos-io/thanos/issues/6102)
- Create a gate factory that reuses the same metrics but individually they have separate max limits;
- Fix metric names so that they would reflect what is being limited; previously the word `queries` was hardcoded everywhere. I checked dashboards/alerts and it seems like those metrics are not used anywhere.