### PR TITLE
Implement distributed query mode

### DIFF
--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -8,15 +8,17 @@ import (
 	"fmt"
 	"math"
 	"net/http"
+	"os"
 	"strings"
 	"time"
+
+	"google.golang.org/grpc"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	grpc_logging "github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/logging"
 	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/tags"
 	"github.com/oklog/run"
-	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -25,9 +27,8 @@ import (
 	"github.com/prometheus/prometheus/discovery/targetgroup"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql"
-	"google.golang.org/grpc"
-
 	v1 "github.com/prometheus/prometheus/web/api/v1"
+
 	"github.com/thanos-community/promql-engine/engine"
 
 	apiv1 "github.com/thanos-io/thanos/pkg/api/query"
@@ -72,6 +73,13 @@ const (
 	promqlEngineThanos     promqlEngineType = "thanos"
 )
 
+type queryMode string
+
+const (
+	queryModeLocal       queryMode = "local"
+	queryModeDistributed queryMode = "distributed"
+)
+
 // registerQuery registers a query command.
 func registerQuery(app *extkingpin.App) {
 	comp := component.Query
@@ -101,6 +109,11 @@ func registerQuery(app *extkingpin.App) {
 
 	promqlEngine := cmd.Flag("query.promql-engine", "PromQL engine to use.").Default(string(promqlEnginePrometheus)).
 		Enum(string(promqlEnginePrometheus), string(promqlEngineThanos))
+
+	promqlQueryMode := cmd.Flag("query.mode", "PromQL query mode. One of: local, distributed.").
+		Hidden().
+		Default(string(queryModeLocal)).
+		Enum(string(queryModeLocal), string(queryModeDistributed))
 
 	maxConcurrentQueries := cmd.Flag("query.max-concurrent", "Maximum number of queries processed concurrently by query node.").
 		Default("20").Int()
@@ -333,6 +346,7 @@ func registerQuery(app *extkingpin.App) {
 			*queryTelemetrySeriesQuantiles,
 			promqlEngineType(*promqlEngine),
 			storeRateLimits,
+			queryMode(*promqlQueryMode),
 		)
 	})
 }
@@ -412,6 +426,7 @@ func runQuery(
 	queryTelemetrySeriesQuantiles []int64,
 	promqlEngine promqlEngineType,
 	storeRateLimits store.SeriesSelectLimits,
+	queryMode queryMode,
 ) error {
 	if alertQueryURL == "" {
 		lastColon := strings.LastIndex(httpBindAddr, ":")
@@ -667,7 +682,20 @@ func runQuery(
 	case promqlEnginePrometheus:
 		queryEngine = promql.NewEngine(engineOpts)
 	case promqlEngineThanos:
-		queryEngine = engine.New(engine.Opts{EngineOpts: engineOpts})
+		if queryMode == queryModeLocal {
+			queryEngine = engine.New(engine.Opts{EngineOpts: engineOpts})
+		} else {
+			opts := engine.Opts{
+				DebugWriter: os.Stdout,
+				EngineOpts:  engineOpts,
+			}
+			remoteEngineEndpoints := query.NewRemoteEndpoints(logger, endpoints.GetQueryAPIClients, query.Opts{
+				AutoDownSample: enableAutodownsampling,
+				ReplicaLabels:  queryReplicaLabels,
+				Timeout:        queryTimeout,
+			})
+			queryEngine = engine.NewDistributedEngine(opts, remoteEngineEndpoints)
+		}
 	default:
 		return errors.Errorf("unknown query.promql-engine type %v", promqlEngine)
 	}

--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -691,7 +691,7 @@ func runQuery(
 				EngineOpts:  engineOpts,
 			}
 			remoteEngineEndpoints := query.NewRemoteEndpoints(logger, endpoints.GetQueryAPIClients, query.Opts{
-				AutoDownSample:        enableAutodownsampling,
+				AutoDownsample:        enableAutodownsampling,
 				ReplicaLabels:         queryReplicaLabels,
 				Timeout:               queryTimeout,
 				EnablePartialResponse: enableQueryPartialResponse,

--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"math"
 	"net/http"
-	"os"
 	"strings"
 	"time"
 
@@ -686,17 +685,13 @@ func runQuery(
 		if queryMode == queryModeLocal {
 			queryEngine = engine.New(engine.Opts{EngineOpts: engineOpts})
 		} else {
-			opts := engine.Opts{
-				DebugWriter: os.Stdout,
-				EngineOpts:  engineOpts,
-			}
 			remoteEngineEndpoints := query.NewRemoteEndpoints(logger, endpoints.GetQueryAPIClients, query.Opts{
 				AutoDownsample:        enableAutodownsampling,
 				ReplicaLabels:         queryReplicaLabels,
 				Timeout:               queryTimeout,
 				EnablePartialResponse: enableQueryPartialResponse,
 			})
-			queryEngine = engine.NewDistributedEngine(opts, remoteEngineEndpoints)
+			queryEngine = engine.NewDistributedEngine(engine.Opts{EngineOpts: engineOpts}, remoteEngineEndpoints)
 		}
 	default:
 		return errors.Errorf("unknown query.promql-engine type %v", promqlEngine)

--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -19,6 +19,7 @@ import (
 	grpc_logging "github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/logging"
 	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/tags"
 	"github.com/oklog/run"
+	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -690,9 +691,10 @@ func runQuery(
 				EngineOpts:  engineOpts,
 			}
 			remoteEngineEndpoints := query.NewRemoteEndpoints(logger, endpoints.GetQueryAPIClients, query.Opts{
-				AutoDownSample: enableAutodownsampling,
-				ReplicaLabels:  queryReplicaLabels,
-				Timeout:        queryTimeout,
+				AutoDownSample:        enableAutodownsampling,
+				ReplicaLabels:         queryReplicaLabels,
+				Timeout:               queryTimeout,
+				EnablePartialResponse: enableQueryPartialResponse,
 			})
 			queryEngine = engine.NewDistributedEngine(opts, remoteEngineEndpoints)
 		}

--- a/pkg/query/endpointset.go
+++ b/pkg/query/endpointset.go
@@ -514,16 +514,18 @@ func (e *EndpointSet) GetStoreClients() []store.Client {
 }
 
 // GetQueryAPIClients returns a list of all active query API clients.
-func (e *EndpointSet) GetQueryAPIClients() []querypb.QueryClient {
+func (e *EndpointSet) GetQueryAPIClients() []Client {
 	endpoints := e.getQueryableRefs()
 
-	stores := make([]querypb.QueryClient, 0, len(endpoints))
+	queryClients := make([]Client, 0, len(endpoints))
 	for _, er := range endpoints {
 		if er.HasQueryAPI() {
-			stores = append(stores, querypb.NewQueryClient(er.cc))
+			_, maxt := er.timeRange()
+			client := querypb.NewQueryClient(er.cc)
+			queryClients = append(queryClients, NewClient(client, er.addr, maxt, er.labelSets()))
 		}
 	}
-	return stores
+	return queryClients
 }
 
 // GetRulesClients returns a list of all active rules clients.

--- a/pkg/query/remote_engine.go
+++ b/pkg/query/remote_engine.go
@@ -1,0 +1,223 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package query
+
+import (
+	"context"
+	"io"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/pkg/errors"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/promql"
+	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/prometheus/prometheus/util/stats"
+	"github.com/thanos-community/promql-engine/api"
+
+	"github.com/thanos-io/thanos/pkg/api/query/querypb"
+	"github.com/thanos-io/thanos/pkg/store/labelpb"
+)
+
+// Opts are the options for a PromQL query.
+type Opts struct {
+	AutoDownSample bool
+	ReplicaLabels  []string
+	Timeout        time.Duration
+}
+
+// Client is a query client that executes PromQL queries.
+type Client struct {
+	querypb.QueryClient
+	address   string
+	maxt      int64
+	labelSets []labels.Labels
+}
+
+// NewClient creates a new Client.
+func NewClient(queryClient querypb.QueryClient, address string, maxt int64, labelSets []labels.Labels) Client {
+	return Client{QueryClient: queryClient, address: address, maxt: maxt, labelSets: labelSets}
+}
+
+func (q Client) MaxT() int64 { return q.maxt }
+
+func (q Client) LabelSets() []labels.Labels { return q.labelSets }
+
+func (q Client) GetAddress() string { return q.address }
+
+type remoteEndpoints struct {
+	logger     log.Logger
+	getClients func() []Client
+	opts       Opts
+}
+
+func NewRemoteEndpoints(logger log.Logger, getClients func() []Client, opts Opts) api.RemoteEndpoints {
+	return remoteEndpoints{
+		logger:     logger,
+		getClients: getClients,
+		opts:       opts,
+	}
+}
+
+func (r remoteEndpoints) Engines() []api.RemoteEngine {
+	clients := r.getClients()
+	engines := make([]api.RemoteEngine, len(clients))
+	for i := range clients {
+		engines[i] = newRemoteEngine(r.logger, clients[i], r.opts)
+	}
+	return engines
+}
+
+type remoteEngine struct {
+	Client
+	opts   Opts
+	logger log.Logger
+}
+
+func newRemoteEngine(logger log.Logger, queryClient Client, opts Opts) api.RemoteEngine {
+	return &remoteEngine{
+		logger: logger,
+		Client: queryClient,
+		opts:   opts,
+	}
+}
+
+func (r remoteEngine) LabelSets() []labels.Labels {
+	replicaLabelSet := make(map[string]struct{})
+	for _, lbl := range r.opts.ReplicaLabels {
+		replicaLabelSet[lbl] = struct{}{}
+	}
+
+	// Strip replica labels from the result.
+	labelSets := r.Client.LabelSets()
+	result := make([]labels.Labels, len(labelSets))
+	for i := range labelSets {
+		numLabels := len(labelSets[i]) - len(r.opts.ReplicaLabels)
+		if numLabels < 0 {
+			continue
+		}
+		result[i] = make(labels.Labels, 0, numLabels)
+		for _, lbl := range labelSets[i] {
+			if _, ok := replicaLabelSet[lbl.Name]; ok {
+				continue
+			}
+			result[i] = append(result[i], lbl)
+		}
+	}
+
+	return result
+}
+
+func (r remoteEngine) NewRangeQuery(opts *promql.QueryOpts, qs string, start, end time.Time, interval time.Duration) (promql.Query, error) {
+	return &remoteQuery{
+		logger: r.logger,
+		client: r.Client,
+		opts:   r.opts,
+
+		qs:       qs,
+		start:    start,
+		end:      end,
+		interval: interval,
+	}, nil
+}
+
+type remoteQuery struct {
+	logger log.Logger
+	client Client
+	opts   Opts
+
+	qs       string
+	start    time.Time
+	end      time.Time
+	interval time.Duration
+
+	cancel context.CancelFunc
+}
+
+func (r *remoteQuery) Exec(ctx context.Context) *promql.Result {
+	start := time.Now()
+
+	qctx, cancel := context.WithCancel(ctx)
+	r.cancel = cancel
+	defer cancel()
+
+	var maxResolution int64
+	if r.opts.AutoDownSample {
+		maxResolution = int64(r.interval / 5)
+	}
+
+	request := &querypb.QueryRangeRequest{
+		Query:            r.qs,
+		StartTimeSeconds: r.start.Unix(),
+		EndTimeSeconds:   r.end.Unix(),
+		IntervalSeconds:  int64(r.interval.Seconds()),
+		TimeoutSeconds:   int64(r.opts.Timeout.Seconds()),
+		// TODO (fpetkovski): Allow specifying these parameters at query time.
+		// This will likely require a change in the remote engine interface.
+		ReplicaLabels:        r.opts.ReplicaLabels,
+		MaxResolutionSeconds: maxResolution,
+		EnableDedup:          true,
+	}
+	qry, err := r.client.QueryRange(qctx, request)
+	if err != nil {
+		return &promql.Result{Err: err}
+	}
+
+	result := make(promql.Matrix, 0)
+	for {
+		msg, err := qry.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return &promql.Result{Err: err}
+		}
+
+		if warn := msg.GetWarnings(); warn != "" {
+			return &promql.Result{Err: errors.New(warn)}
+		}
+
+		ts := msg.GetTimeseries()
+		if ts == nil {
+			continue
+		}
+		series := promql.Series{
+			Metric: labelpb.ZLabelsToPromLabels(ts.Labels),
+			Points: make([]promql.Point, 0, len(ts.Samples)),
+		}
+		for _, s := range ts.Samples {
+			series.Points = append(series.Points, promql.Point{
+				T: s.Timestamp,
+				V: s.Value,
+			})
+		}
+		result = append(result, series)
+	}
+	level.Debug(r.logger).Log("Executed query", "query", r.qs, "time", time.Since(start))
+
+	return &promql.Result{Value: result}
+}
+
+func (r *remoteQuery) Close() {
+	r.Cancel()
+}
+
+func (r *remoteQuery) Statement() parser.Statement {
+	return nil
+}
+
+func (r *remoteQuery) Stats() *stats.Statistics {
+	return nil
+}
+
+func (r *remoteQuery) Cancel() {
+	if r.cancel != nil {
+		r.cancel()
+	}
+}
+
+func (r *remoteQuery) String() string {
+	return r.qs
+}

--- a/pkg/query/remote_engine.go
+++ b/pkg/query/remote_engine.go
@@ -95,7 +95,7 @@ func (r remoteEngine) LabelSets() []labels.Labels {
 	result := make([]labels.Labels, len(labelSets))
 	for i := range labelSets {
 		numLabels := len(labelSets[i]) - len(r.opts.ReplicaLabels)
-		if numLabels < 0 {
+		if numLabels <= 0 {
 			continue
 		}
 		result[i] = make(labels.Labels, 0, numLabels)

--- a/pkg/query/remote_engine.go
+++ b/pkg/query/remote_engine.go
@@ -146,7 +146,7 @@ func (r *remoteQuery) Exec(ctx context.Context) *promql.Result {
 
 	var maxResolution int64
 	if r.opts.AutoDownSample {
-		maxResolution = int64(r.interval / 5)
+		maxResolution = int64(r.interval.Seconds() / 5)
 	}
 
 	request := &querypb.QueryRangeRequest{

--- a/pkg/query/remote_engine.go
+++ b/pkg/query/remote_engine.go
@@ -93,19 +93,16 @@ func (r remoteEngine) LabelSets() []labels.Labels {
 
 	// Strip replica labels from the result.
 	labelSets := r.Client.LabelSets()
-	result := make([]labels.Labels, len(labelSets))
-	for i := range labelSets {
-		numLabels := len(labelSets[i]) - len(r.opts.ReplicaLabels)
-		if numLabels <= 0 {
-			continue
-		}
-		result[i] = make(labels.Labels, 0, numLabels)
-		for _, lbl := range labelSets[i] {
+	result := make([]labels.Labels, 0, len(labelSets))
+	for _, labelSet := range labelSets {
+		var builder labels.ScratchBuilder
+		for _, lbl := range labelSet {
 			if _, ok := replicaLabelSet[lbl.Name]; ok {
 				continue
 			}
-			result[i] = append(result[i], lbl)
+			builder.Add(lbl.Name, lbl.Value)
 		}
+		result = append(result, builder.Labels())
 	}
 
 	return result

--- a/pkg/query/remote_engine.go
+++ b/pkg/query/remote_engine.go
@@ -23,7 +23,7 @@ import (
 
 // Opts are the options for a PromQL query.
 type Opts struct {
-	AutoDownSample        bool
+	AutoDownsample        bool
 	ReplicaLabels         []string
 	Timeout               time.Duration
 	EnablePartialResponse bool
@@ -142,7 +142,7 @@ func (r *remoteQuery) Exec(ctx context.Context) *promql.Result {
 	defer cancel()
 
 	var maxResolution int64
-	if r.opts.AutoDownSample {
+	if r.opts.AutoDownsample {
 		maxResolution = int64(r.interval.Seconds() / 5)
 	}
 

--- a/pkg/query/remote_engine.go
+++ b/pkg/query/remote_engine.go
@@ -23,9 +23,10 @@ import (
 
 // Opts are the options for a PromQL query.
 type Opts struct {
-	AutoDownSample bool
-	ReplicaLabels  []string
-	Timeout        time.Duration
+	AutoDownSample        bool
+	ReplicaLabels         []string
+	Timeout               time.Duration
+	EnablePartialResponse bool
 }
 
 // Client is a query client that executes PromQL queries.
@@ -149,11 +150,12 @@ func (r *remoteQuery) Exec(ctx context.Context) *promql.Result {
 	}
 
 	request := &querypb.QueryRangeRequest{
-		Query:            r.qs,
-		StartTimeSeconds: r.start.Unix(),
-		EndTimeSeconds:   r.end.Unix(),
-		IntervalSeconds:  int64(r.interval.Seconds()),
-		TimeoutSeconds:   int64(r.opts.Timeout.Seconds()),
+		Query:                 r.qs,
+		StartTimeSeconds:      r.start.Unix(),
+		EndTimeSeconds:        r.end.Unix(),
+		IntervalSeconds:       int64(r.interval.Seconds()),
+		TimeoutSeconds:        int64(r.opts.Timeout.Seconds()),
+		EnablePartialResponse: r.opts.EnablePartialResponse,
 		// TODO (fpetkovski): Allow specifying these parameters at query time.
 		// This will likely require a change in the remote engine interface.
 		ReplicaLabels:        r.opts.ReplicaLabels,

--- a/pkg/query/remote_engine_test.go
+++ b/pkg/query/remote_engine_test.go
@@ -1,0 +1,59 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package query
+
+import (
+	"testing"
+
+	"github.com/efficientgo/core/testutil"
+	"github.com/go-kit/log"
+	"github.com/prometheus/prometheus/model/labels"
+)
+
+func TestRemoteEngine_LabelSets(t *testing.T) {
+	tests := []struct {
+		name          string
+		labelSets     []labels.Labels
+		replicaLabels []string
+		expected      []labels.Labels
+	}{
+		{
+			name:      "empty label sets",
+			labelSets: []labels.Labels{},
+			expected:  []labels.Labels{},
+		},
+		{
+			name:          "empty label sets with replica labels",
+			labelSets:     []labels.Labels{},
+			replicaLabels: []string{"replica"},
+			expected:      []labels.Labels{},
+		},
+		{
+			name:      "non-empty label sets",
+			labelSets: []labels.Labels{labels.FromStrings("a", "1")},
+			expected:  []labels.Labels{labels.FromStrings("a", "1")},
+		},
+		{
+			name:          "non-empty label sets with replica labels",
+			labelSets:     []labels.Labels{labels.FromStrings("a", "1", "b", "2")},
+			replicaLabels: []string{"a"},
+			expected:      []labels.Labels{labels.FromStrings("b", "2")},
+		},
+		{
+			name:          "replica labels not in label sets",
+			labelSets:     []labels.Labels{labels.FromStrings("a", "1", "c", "2")},
+			replicaLabels: []string{"a", "b"},
+			expected:      []labels.Labels{labels.FromStrings("c", "2")},
+		},
+	}
+
+	for _, test := range tests {
+		client := Client{labelSets: test.labelSets}
+		engine := newRemoteEngine(log.NewNopLogger(), client, Opts{
+			ReplicaLabels: test.replicaLabels,
+		})
+
+		testutil.Equals(t, test.expected, engine.LabelSets())
+	}
+}

--- a/test/e2e/distributed_query_test.go
+++ b/test/e2e/distributed_query_test.go
@@ -69,6 +69,8 @@ func TestDistributedQueryExecution(t *testing.T) {
 		distQryRangeResult = res
 		return nil
 	})
+	testutil.Assert(t, len(fanoutQryRangeResult) != 0)
+	testutil.Assert(t, len(distQryRangeResult) != 0)
 	testutil.Equals(t, fanoutQryRangeResult, distQryRangeResult)
 
 	// Test instant query.

--- a/test/e2e/distributed_query_test.go
+++ b/test/e2e/distributed_query_test.go
@@ -1,0 +1,82 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package e2e_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/efficientgo/core/testutil"
+	"github.com/efficientgo/e2e"
+	"github.com/prometheus/common/model"
+
+	"github.com/thanos-io/thanos/pkg/promclient"
+	"github.com/thanos-io/thanos/test/e2e/e2ethanos"
+)
+
+func TestDistributedQueryExecution(t *testing.T) {
+	t.Parallel()
+
+	// Build up.
+	e, err := e2e.New(e2e.WithName("dist-query"))
+	testutil.Ok(t, err)
+	t.Cleanup(e2ethanos.CleanScenario(t, e))
+
+	prom1, sidecar1 := e2ethanos.NewPrometheusWithSidecar(e, "prom1", e2ethanos.DefaultPromConfig("prom1", 0, "", ""), "", e2ethanos.DefaultPrometheusImage(), "", "remote-write-receiver")
+	prom2, sidecar2 := e2ethanos.NewPrometheusWithSidecar(e, "prom2", e2ethanos.DefaultPromConfig("prom2", 0, "", ""), "", e2ethanos.DefaultPrometheusImage(), "", "remote-write-receiver")
+	testutil.Ok(t, e2e.StartAndWaitReady(prom1, prom2, sidecar1, sidecar2))
+
+	qry1 := e2ethanos.NewQuerierBuilder(e, "1", sidecar1.InternalEndpoint("grpc")).Init()
+	qry2 := e2ethanos.NewQuerierBuilder(e, "2", sidecar2.InternalEndpoint("grpc")).Init()
+	testutil.Ok(t, e2e.StartAndWaitReady(qry1, qry2))
+
+	qryEndpoints := []string{qry1.InternalEndpoint("grpc"), qry2.InternalEndpoint("grpc")}
+	fanoutQry := e2ethanos.NewQuerierBuilder(e, "3", qryEndpoints...).Init()
+	distQry := e2ethanos.NewQuerierBuilder(e, "4", qryEndpoints...).
+		WithEngine("thanos").
+		WithQueryMode("distributed").
+		Init()
+	testutil.Ok(t, e2e.StartAndWaitReady(fanoutQry))
+	testutil.Ok(t, e2e.StartAndWaitReady(distQry))
+
+	// Use current time to make debugging through UI easier.
+	now := time.Now()
+	nowFunc := func() time.Time { return now }
+	timeOffset := nowFunc().UnixNano()
+	samples := []fakeMetricSample{
+		{"i1", 1, timeOffset + 30*1000*1000}, {"i1", 2, timeOffset + 60*1000*1000}, {"i1", 3, timeOffset + 90*1000*1000},
+		{"i2", 5, timeOffset + 30*1000*1000}, {"i2", 6, timeOffset + 60*1000*1000}, {"i2", 7, timeOffset + 90*1000*1000},
+		{"i3", 9, timeOffset + 30*1000*1000}, {"i3", 10, timeOffset + 60*1000*1000}, {"i3", 11, timeOffset + 90*1000*1000},
+	}
+	ctx := context.Background()
+	testutil.Ok(t, synthesizeFakeMetricSamples(ctx, prom1, samples))
+	testutil.Ok(t, synthesizeFakeMetricSamples(ctx, prom2, samples))
+
+	queryFunc := func() string { return "sum(sum_over_time(my_fake_metric[2m]))" }
+	queryOpts := promclient.QueryOptions{
+		Deduplicate: true,
+	}
+
+	// Test range query.
+	var fanoutQryRangeResult, distQryRangeResult model.Matrix
+	rangeQuery(t, ctx, fanoutQry.Endpoint("http"), queryFunc, nowFunc().UnixMilli(), nowFunc().Add(5*time.Minute).UnixMilli(), 30, queryOpts, func(res model.Matrix) error {
+		fanoutQryRangeResult = res
+		return nil
+	})
+	rangeQuery(t, ctx, fanoutQry.Endpoint("http"), queryFunc, nowFunc().UnixMilli(), nowFunc().Add(5*time.Minute).UnixMilli(), 30, queryOpts, func(res model.Matrix) error {
+		distQryRangeResult = res
+		return nil
+	})
+	testutil.Equals(t, fanoutQryRangeResult, distQryRangeResult)
+
+	// Test instant query.
+	queryAndAssert(t, ctx, distQry.Endpoint("http"), queryFunc, nowFunc, queryOpts, model.Vector{
+		{
+			Metric:    map[model.LabelName]model.LabelValue{},
+			Value:     30,
+			Timestamp: 0,
+		},
+	})
+}

--- a/test/e2e/e2ethanos/services.go
+++ b/test/e2e/e2ethanos/services.go
@@ -28,6 +28,7 @@ import (
 	"github.com/thanos-io/objstore/providers/s3"
 
 	"github.com/thanos-io/objstore/exthttp"
+
 	"github.com/thanos-io/thanos/pkg/alert"
 	"github.com/thanos-io/thanos/pkg/httpconfig"
 
@@ -252,6 +253,9 @@ type QuerierBuilder struct {
 	enableFeatures          []string
 	endpoints               []string
 
+	engine    string
+	queryMode string
+
 	replicaLabels []string
 	tracingConfig string
 
@@ -346,6 +350,16 @@ func (q *QuerierBuilder) WithReplicaLabels(labels ...string) *QuerierBuilder {
 
 func (q *QuerierBuilder) WithDisablePartialResponses(disable bool) *QuerierBuilder {
 	q.disablePartialResponses = disable
+	return q
+}
+
+func (q *QuerierBuilder) WithEngine(engine string) *QuerierBuilder {
+	q.engine = engine
+	return q
+}
+
+func (q *QuerierBuilder) WithQueryMode(mode string) *QuerierBuilder {
+	q.queryMode = mode
 	return q
 }
 


### PR DESCRIPTION
This commit adds support for distributed query execution based on the distributed mode of the Thanos PromQL engine.

Currently the mode is enabled through a hidden flag which will allow us to run it in a test environment before releasing it as an experimental feature. Another reason for having the flag hidden is that it allows us to implement auto-detection of the mode before the feature is released, instead of having the user configure it explicitly.

The current version still lacks support for overriding query parameters, such as resolution, store filtering etc. through the UI. Adding support for those features will likely require an interface change in the distributed engine.


Signed-off-by: Filip Petkovski <filip.petkovsky@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
