### PR TITLE
Potential fix for e2e flake from 6114

### DIFF
--- a/test/e2e/distributed_query_test.go
+++ b/test/e2e/distributed_query_test.go
@@ -28,13 +28,13 @@ func TestDistributedQueryExecution(t *testing.T) {
 	prom2, sidecar2 := e2ethanos.NewPrometheusWithSidecar(e, "prom2", e2ethanos.DefaultPromConfig("prom2", 0, "", ""), "", e2ethanos.DefaultPrometheusImage(), "", "remote-write-receiver")
 	testutil.Ok(t, e2e.StartAndWaitReady(prom1, prom2, sidecar1, sidecar2))
 
-	qry1 := e2ethanos.NewQuerierBuilder(e, "1", sidecar1.InternalEndpoint("grpc")).Init()
-	qry2 := e2ethanos.NewQuerierBuilder(e, "2", sidecar2.InternalEndpoint("grpc")).Init()
+	qry1 := e2ethanos.NewQuerierBuilder(e, "1").WithStrictEndpoints(sidecar1.InternalEndpoint("grpc")).Init()
+	qry2 := e2ethanos.NewQuerierBuilder(e, "2").WithStrictEndpoints(sidecar2.InternalEndpoint("grpc")).Init()
 	testutil.Ok(t, e2e.StartAndWaitReady(qry1, qry2))
 
 	qryEndpoints := []string{qry1.InternalEndpoint("grpc"), qry2.InternalEndpoint("grpc")}
-	fanoutQry := e2ethanos.NewQuerierBuilder(e, "3", qryEndpoints...).Init()
-	distQry := e2ethanos.NewQuerierBuilder(e, "4", qryEndpoints...).
+	fanoutQry := e2ethanos.NewQuerierBuilder(e, "3").WithStrictEndpoints(qryEndpoints...).Init()
+	distQry := e2ethanos.NewQuerierBuilder(e, "4").WithStrictEndpoints(qryEndpoints...).
 		WithEngine("thanos").
 		WithQueryMode("distributed").
 		Init()

--- a/test/e2e/e2ethanos/services.go
+++ b/test/e2e/e2ethanos/services.go
@@ -252,6 +252,7 @@ type QuerierBuilder struct {
 	exemplarAddresses       []string
 	enableFeatures          []string
 	endpoints               []string
+	strictEndpoints         []string
 
 	engine    string
 	queryMode string
@@ -324,6 +325,11 @@ func (q *QuerierBuilder) WithMetadataAddresses(metadataAddresses ...string) *Que
 
 func (q *QuerierBuilder) WithEndpoints(endpoints ...string) *QuerierBuilder {
 	q.endpoints = endpoints
+	return q
+}
+
+func (q *QuerierBuilder) WithStrictEndpoints(strictEndpoints ...string) *QuerierBuilder {
+	q.strictEndpoints = strictEndpoints
 	return q
 }
 
@@ -419,6 +425,9 @@ func (q *QuerierBuilder) collectArgs() ([]string, error) {
 	}
 	for _, addr := range q.endpoints {
 		args = append(args, "--endpoint="+addr)
+	}
+	for _, addr := range q.strictEndpoints {
+		args = append(args, "--endpoint-strict="+addr)
 	}
 	if len(q.fileSDStoreAddresses) > 0 {
 		if err := os.MkdirAll(q.Dir(), 0750); err != nil {


### PR DESCRIPTION
This commit is a potential fix for the flake e2e test intruduced in #6114. The commit uses strict endpoints in queriers to make sure all stores are ready in order for the query to be considered successful.

I verified the fix by running the test locally using `go test ./test/e2e/... -run TestDistributedQueryExecution -count 20`.

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
