### PR TITLE
docs: Fix the missed parenthesis after defer func

### DIFF
--- a/docs/contributing/coding-style-guide.md
+++ b/docs/contributing/coding-style-guide.md
@@ -523,26 +523,26 @@ func OpenSomeFileAndDoSomeStuff() (*os.File, error) {
 
 ```go
 func OpenSomeFileAndDoSomeStuff() (f *os.File, err error) {
-    f, err = os.OpenFile("file.txt", os.O_RDONLY, 0)
-    if err != nil {
-        return nil, err
-    }
-    defer func() {
-        if err != nil {
-             runutil.CloseWithErrCapture(&err, f, "close file")
-        }
-    }()
+	f, err = os.OpenFile("file.txt", os.O_RDONLY, 0)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err != nil {
+			runutil.CloseWithErrCapture(&err, f, "close file")
+		}
+	}()
 
-    if err := doStuff1(); err != nil {
-        return nil, err
-    }
-    if err := doStuff2(); err != nil {
-        return nil, err
-    }
-    if err := doStuff232241(); err != nil {
-        return nil, err
-    }
-    return f, nil
+	if err := doStuff1(); err != nil {
+		return nil, err
+	}
+	if err := doStuff2(); err != nil {
+		return nil, err
+	}
+	if err := doStuff232241(); err != nil {
+		return nil, err
+	}
+	return f, nil
 }
 ```
 

--- a/docs/contributing/coding-style-guide.md
+++ b/docs/contributing/coding-style-guide.md
@@ -531,7 +531,7 @@ func OpenSomeFileAndDoSomeStuff() (f *os.File, err error) {
         if err != nil {
              runutil.CloseWithErrCapture(&err, f, "close file")
         }
-    }
+    }()
 
     if err := doStuff1(); err != nil {
         return nil, err


### PR DESCRIPTION
The defer statement expression must be a function or method call that is invoked directly.
Fixes the error `expression in defer must be function call`.

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
https://go.dev/play/p/sh2MVeQ9s-m
`make format`