### PR TITLE
Fix error handling in gRPC query API

### DIFF
--- a/pkg/api/query/grpc_test.go
+++ b/pkg/api/query/grpc_test.go
@@ -1,63 +1,120 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
 package v1
 
 import (
 	"context"
-	"math"
 	"testing"
 	"time"
 
+	"github.com/efficientgo/core/errors"
 	"github.com/efficientgo/core/testutil"
 	"github.com/go-kit/log"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/promql"
+	"github.com/prometheus/prometheus/storage"
+	v1 "github.com/prometheus/prometheus/web/api/v1"
 
 	"github.com/thanos-io/thanos/pkg/api/query/querypb"
 	"github.com/thanos-io/thanos/pkg/component"
 	"github.com/thanos-io/thanos/pkg/query"
 	"github.com/thanos-io/thanos/pkg/store"
-	"github.com/thanos-io/thanos/pkg/store/storepb"
-	storetestutil "github.com/thanos-io/thanos/pkg/store/storepb/testutil"
 )
 
 func TestGRPCQueryAPIErrorHandling(t *testing.T) {
-	proxy := store.NewProxyStore(log.NewNopLogger(), prometheus.NewRegistry(), func() []store.Client {
-		client := storepb.ServerAsClient(&storepb.UnimplementedStoreServer{}, 1)
-		return []store.Client{storetestutil.TestClient{
-			StoreClient: client,
-			MinTime:     math.MinInt64,
-			MaxTime:     math.MaxInt64,
-		}}
-	}, component.Store, nil, 1*time.Minute, store.LazyRetrieval)
-
-	queryableCreator := query.NewQueryableCreator(log.NewNopLogger(), prometheus.NewRegistry(), proxy, 1, 1*time.Minute)
-	engine := promql.NewEngine(promql.EngineOpts{
-		Reg:           prometheus.NewRegistry(),
-		MaxSamples:    math.MaxInt64,
-		Timeout:       1 * time.Minute,
-		LookbackDelta: 5 * time.Minute,
-	})
+	logger := log.NewNopLogger()
+	reg := prometheus.NewRegistry()
+	proxy := store.NewProxyStore(logger, reg, func() []store.Client { return nil }, component.Store, nil, 1*time.Minute, store.LazyRetrieval)
+	queryableCreator := query.NewQueryableCreator(logger, reg, proxy, 1, 1*time.Minute)
 	lookbackDeltaFunc := func(i int64) time.Duration { return 5 * time.Minute }
-	api := NewGRPCAPI(time.Now, nil, queryableCreator, engine, lookbackDeltaFunc, 0)
+	tests := []struct {
+		name   string
+		engine *engineStub
+	}{
+		{
+			name: "error response",
+			engine: &engineStub{
+				err: errors.New("error stub"),
+			},
+		},
+		{
+			name: "error response",
+			engine: &engineStub{
+				warns: []error{errors.New("warn stub")},
+			},
+		},
+	}
 
-	t.Run("range_query", func(t *testing.T) {
-		rangeRequest := &querypb.QueryRangeRequest{
-			Query:            "metric",
-			StartTimeSeconds: 0,
-			IntervalSeconds:  10,
-			EndTimeSeconds:   300,
-		}
-		srv := newQueryRangeServer(context.Background())
-		testutil.NotOk(t, api.QueryRange(rangeRequest, srv))
-	})
+	for _, test := range tests {
+		api := NewGRPCAPI(time.Now, nil, queryableCreator, test.engine, lookbackDeltaFunc, 0)
+		t.Run("range_query", func(t *testing.T) {
+			rangeRequest := &querypb.QueryRangeRequest{
+				Query:            "metric",
+				StartTimeSeconds: 0,
+				IntervalSeconds:  10,
+				EndTimeSeconds:   300,
+			}
+			srv := newQueryRangeServer(context.Background())
+			err := api.QueryRange(rangeRequest, srv)
 
-	t.Run("instant_query", func(t *testing.T) {
-		instantRequest := &querypb.QueryRequest{
-			Query:          "metric",
-			TimeoutSeconds: 60,
-		}
-		srv := newQueryServer(context.Background())
-		testutil.NotOk(t, api.Query(instantRequest, srv))
-	})
+			if test.engine.err != nil {
+				testutil.NotOk(t, err)
+				return
+			}
+			if len(test.engine.warns) > 0 {
+				testutil.Ok(t, err)
+				for i, resp := range srv.responses {
+					testutil.Equals(t, test.engine.warns[i].Error(), resp.GetWarnings())
+				}
+			}
+		})
+
+		t.Run("instant_query", func(t *testing.T) {
+			instantRequest := &querypb.QueryRequest{
+				Query:          "metric",
+				TimeoutSeconds: 60,
+			}
+			srv := newQueryServer(context.Background())
+			err := api.Query(instantRequest, srv)
+			if test.engine.err != nil {
+				testutil.NotOk(t, err)
+				return
+			}
+			if len(test.engine.warns) > 0 {
+				testutil.Ok(t, err)
+				for i, resp := range srv.responses {
+					testutil.Equals(t, test.engine.warns[i].Error(), resp.GetWarnings())
+				}
+			}
+		})
+	}
+}
+
+type engineStub struct {
+	v1.QueryEngine
+	err   error
+	warns []error
+}
+
+func (e engineStub) NewInstantQuery(q storage.Queryable, opts *promql.QueryOpts, qs string, ts time.Time) (promql.Query, error) {
+	return &queryStub{err: e.err, warns: e.warns}, nil
+}
+
+func (e engineStub) NewRangeQuery(q storage.Queryable, opts *promql.QueryOpts, qs string, start, end time.Time, interval time.Duration) (promql.Query, error) {
+	return &queryStub{err: e.err, warns: e.warns}, nil
+}
+
+type queryStub struct {
+	promql.Query
+	err   error
+	warns []error
+}
+
+func (q queryStub) Close() {}
+
+func (q queryStub) Exec(context.Context) *promql.Result {
+	return &promql.Result{Err: q.err, Warnings: q.warns}
 }
 
 type queryServer struct {

--- a/pkg/api/query/grpc_test.go
+++ b/pkg/api/query/grpc_test.go
@@ -1,0 +1,101 @@
+package v1
+
+import (
+	"context"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/efficientgo/core/testutil"
+	"github.com/go-kit/log"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/prometheus/promql"
+
+	"github.com/thanos-io/thanos/pkg/api/query/querypb"
+	"github.com/thanos-io/thanos/pkg/component"
+	"github.com/thanos-io/thanos/pkg/query"
+	"github.com/thanos-io/thanos/pkg/store"
+	"github.com/thanos-io/thanos/pkg/store/storepb"
+	storetestutil "github.com/thanos-io/thanos/pkg/store/storepb/testutil"
+)
+
+func TestGRPCQueryAPIErrorHandling(t *testing.T) {
+	proxy := store.NewProxyStore(log.NewNopLogger(), prometheus.NewRegistry(), func() []store.Client {
+		client := storepb.ServerAsClient(&storepb.UnimplementedStoreServer{}, 1)
+		return []store.Client{storetestutil.TestClient{
+			StoreClient: client,
+			MinTime:     math.MinInt64,
+			MaxTime:     math.MaxInt64,
+		}}
+	}, component.Store, nil, 1*time.Minute, store.LazyRetrieval)
+
+	queryableCreator := query.NewQueryableCreator(log.NewNopLogger(), prometheus.NewRegistry(), proxy, 1, 1*time.Minute)
+	engine := promql.NewEngine(promql.EngineOpts{
+		Reg:           prometheus.NewRegistry(),
+		MaxSamples:    math.MaxInt64,
+		Timeout:       1 * time.Minute,
+		LookbackDelta: 5 * time.Minute,
+	})
+	lookbackDeltaFunc := func(i int64) time.Duration { return 5 * time.Minute }
+	api := NewGRPCAPI(time.Now, nil, queryableCreator, engine, lookbackDeltaFunc, 0)
+
+	t.Run("range_query", func(t *testing.T) {
+		rangeRequest := &querypb.QueryRangeRequest{
+			Query:            "metric",
+			StartTimeSeconds: 0,
+			IntervalSeconds:  10,
+			EndTimeSeconds:   300,
+		}
+		srv := newQueryRangeServer(context.Background())
+		testutil.NotOk(t, api.QueryRange(rangeRequest, srv))
+	})
+
+	t.Run("instant_query", func(t *testing.T) {
+		instantRequest := &querypb.QueryRequest{
+			Query:          "metric",
+			TimeoutSeconds: 60,
+		}
+		srv := newQueryServer(context.Background())
+		testutil.NotOk(t, api.Query(instantRequest, srv))
+	})
+}
+
+type queryServer struct {
+	querypb.Query_QueryServer
+
+	ctx       context.Context
+	responses []querypb.QueryResponse
+}
+
+func newQueryServer(ctx context.Context) *queryServer {
+	return &queryServer{ctx: ctx}
+}
+
+func (q *queryServer) Send(r *querypb.QueryResponse) error {
+	q.responses = append(q.responses, *r)
+	return nil
+}
+
+func (q *queryServer) Context() context.Context {
+	return q.ctx
+}
+
+type queryRangeServer struct {
+	querypb.Query_QueryRangeServer
+
+	ctx       context.Context
+	responses []querypb.QueryRangeResponse
+}
+
+func newQueryRangeServer(ctx context.Context) *queryRangeServer {
+	return &queryRangeServer{ctx: ctx}
+}
+
+func (q *queryRangeServer) Send(r *querypb.QueryRangeResponse) error {
+	q.responses = append(q.responses, *r)
+	return nil
+}
+
+func (q *queryRangeServer) Context() context.Context {
+	return q.ctx
+}

--- a/pkg/api/query/querypb/responses.go
+++ b/pkg/api/query/querypb/responses.go
@@ -17,8 +17,8 @@ func NewQueryResponse(series *prompb.TimeSeries) *QueryResponse {
 	}
 }
 
-func NewQueryWarningsResponse(errs []error) *QueryResponse {
-	warnings := make([]string, len(errs))
+func NewQueryWarningsResponse(errs ...error) *QueryResponse {
+	warnings := make([]string, 0, len(errs))
 	for _, err := range errs {
 		warnings = append(warnings, err.Error())
 	}
@@ -37,8 +37,8 @@ func NewQueryRangeResponse(series *prompb.TimeSeries) *QueryRangeResponse {
 	}
 }
 
-func NewQueryRangeWarningsResponse(errs []error) *QueryRangeResponse {
-	warnings := make([]string, len(errs))
+func NewQueryRangeWarningsResponse(errs ...error) *QueryRangeResponse {
+	warnings := make([]string, 0, len(errs))
 	for _, err := range errs {
 		warnings = append(warnings, err.Error())
 	}

--- a/pkg/query/remote_engine.go
+++ b/pkg/query/remote_engine.go
@@ -5,7 +5,6 @@ package query
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"time"
 
@@ -154,14 +153,12 @@ func (r *remoteQuery) Exec(ctx context.Context) *promql.Result {
 		IntervalSeconds:       int64(r.interval.Seconds()),
 		TimeoutSeconds:        int64(r.opts.Timeout.Seconds()),
 		EnablePartialResponse: r.opts.EnablePartialResponse,
-		LookbackDeltaSeconds:  300,
 		// TODO (fpetkovski): Allow specifying these parameters at query time.
 		// This will likely require a change in the remote engine interface.
 		ReplicaLabels:        r.opts.ReplicaLabels,
 		MaxResolutionSeconds: maxResolution,
 		EnableDedup:          true,
 	}
-
 	qry, err := r.client.QueryRange(qctx, request)
 	if err != nil {
 		return &promql.Result{Err: err}
@@ -170,7 +167,6 @@ func (r *remoteQuery) Exec(ctx context.Context) *promql.Result {
 	result := make(promql.Matrix, 0)
 	for {
 		msg, err := qry.Recv()
-		fmt.Println(msg)
 		if err == io.EOF {
 			break
 		}

--- a/pkg/query/remote_engine.go
+++ b/pkg/query/remote_engine.go
@@ -5,6 +5,7 @@ package query
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"time"
 
@@ -153,12 +154,14 @@ func (r *remoteQuery) Exec(ctx context.Context) *promql.Result {
 		IntervalSeconds:       int64(r.interval.Seconds()),
 		TimeoutSeconds:        int64(r.opts.Timeout.Seconds()),
 		EnablePartialResponse: r.opts.EnablePartialResponse,
+		LookbackDeltaSeconds:  300,
 		// TODO (fpetkovski): Allow specifying these parameters at query time.
 		// This will likely require a change in the remote engine interface.
 		ReplicaLabels:        r.opts.ReplicaLabels,
 		MaxResolutionSeconds: maxResolution,
 		EnableDedup:          true,
 	}
+
 	qry, err := r.client.QueryRange(qctx, request)
 	if err != nil {
 		return &promql.Result{Err: err}
@@ -167,6 +170,7 @@ func (r *remoteQuery) Exec(ctx context.Context) *promql.Result {
 	result := make(promql.Matrix, 0)
 	for {
 		msg, err := qry.Recv()
+		fmt.Println(msg)
 		if err == io.EOF {
 			break
 		}


### PR DESCRIPTION
The gRPC query api does not propagate errors from the promql engine to the upstream client. This causes calls against it to fail silently without any error messages. Noticed while testing the distributed query mode.

This commit changes the API to propagate errors and warnings as warn messages. The client can then decide whether to abort on each message type, or to proceed with execution and present a partial response message to the user.

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

* Fix error handling in gRPC query API.

## Verification

Added unit tests.
