### PR TITLE
Query-frontend: add traceID to `slow query detected` log line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,8 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#6074](https://github.com/thanos-io/thanos/pull/6074) *: Add histogram metrics `thanos_store_server_series_requested` and `thanos_store_server_chunks_requested` to all Stores.
 - [#6074](https://github.com/thanos-io/thanos/pull/6074) *: Allow configuring series and sample limits per `Series` request for all Stores.
 - [#6104](https://github.com/thanos-io/thanos/pull/6104) Objstore: Support S3 session token.
-- [#5548](https://github.com/thanos-io/thanos/pull/5548) Query: Added experimental support for load balancing across multiple Store endpoints.
+
+- [#6148](https://github.com/thanos-io/thanos/pull/6148) Query-frontend: add traceID to slow query detected log line
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#6074](https://github.com/thanos-io/thanos/pull/6074) *: Add histogram metrics `thanos_store_server_series_requested` and `thanos_store_server_chunks_requested` to all Stores.
 - [#6074](https://github.com/thanos-io/thanos/pull/6074) *: Allow configuring series and sample limits per `Series` request for all Stores.
 - [#6104](https://github.com/thanos-io/thanos/pull/6104) Objstore: Support S3 session token.
+- [#5548](https://github.com/thanos-io/thanos/pull/5548) Query: Added experimental support for load balancing across multiple Store endpoints.
 - [#6148](https://github.com/thanos-io/thanos/pull/6148) Query-frontend: add traceID to slow query detected log line
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,6 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#6074](https://github.com/thanos-io/thanos/pull/6074) *: Add histogram metrics `thanos_store_server_series_requested` and `thanos_store_server_chunks_requested` to all Stores.
 - [#6074](https://github.com/thanos-io/thanos/pull/6074) *: Allow configuring series and sample limits per `Series` request for all Stores.
 - [#6104](https://github.com/thanos-io/thanos/pull/6104) Objstore: Support S3 session token.
-
 - [#6148](https://github.com/thanos-io/thanos/pull/6148) Query-frontend: add traceID to slow query detected log line
 
 ### Fixed

--- a/internal/cortex/frontend/transport/handler.go
+++ b/internal/cortex/frontend/transport/handler.go
@@ -177,8 +177,6 @@ func (f *Handler) reportSlowQuery(r *http.Request, responseHeaders http.Header, 
 		thanosTraceID = traceID
 	}
 
-	level.Info(util_log.WithContext(r.Context(), f.log)).Log("aba trace id", thanosTraceID)
-
 	logMessage := append([]interface{}{
 		"msg", "slow query detected",
 		"method", r.Method,


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Add traceID to `slow query detected` log line. The traceID is extracted from the `X-Thanos-Trace-Id` header, which is send in the request.
If there is no trace id the value will be empty. This behaviour is similar to the already existing log fields `grafana_dashboard_uid` and `grafana_panel_id`.

This will greatly facilitate debugging as we are often interested in analyzing the traces of the slowest queries

## Verification

<!-- How you tested it? How do you know it works? -->

Built the binary, deployed it as query frontend and checked its logs: 
```
level=info ts=2023-02-21T11:15:28.920622293Z caller=handler.go:194 org_id=anonymous msg="slow query detected" method=POST host=thanos-query-frontend-grafana.thanos.svc:9090 path=/api/v1/query time_taken=192.624733ms grafana_dashboard_uid=- grafana_panel_id=- trace_id=c33ad57d9ed443895223d5fa01499ead param_query="avg(kube_persistentvolume_capacity_bytes) by (cluster_id, persistentvolume)[1h:1m]" param_time=1676980800
```