### PR TITLE
Sidecar: add external_label parameter on prometheus config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#6104](https://github.com/thanos-io/thanos/pull/6104) Objstore: Support S3 session token.
 - [#5548](https://github.com/thanos-io/thanos/pull/5548) Query: Added experimental support for load balancing across multiple Store endpoints.
 - [#6148](https://github.com/thanos-io/thanos/pull/6148) Query-frontend: add traceID to slow query detected log line
+- [#6150](https://github.com/thanos-io/thanos/pull/6150) Sidecar: add external_label parameter on prometheus config
 
 ### Fixed
 

--- a/cmd/thanos/config.go
+++ b/cmd/thanos/config.go
@@ -69,6 +69,7 @@ type prometheusConfig struct {
 	getConfigInterval time.Duration
 	getConfigTimeout  time.Duration
 	httpClient        *extflag.PathOrContent
+	externalLabels    []string
 }
 
 func (pc *prometheusConfig) registerFlag(cmd extkingpin.FlagClause) *prometheusConfig {
@@ -84,6 +85,8 @@ func (pc *prometheusConfig) registerFlag(cmd extkingpin.FlagClause) *prometheusC
 	cmd.Flag("prometheus.get_config_timeout",
 		"Timeout for getting Prometheus config").
 		Default("5s").DurationVar(&pc.getConfigTimeout)
+	cmd.Flag("prometheus.external_label", "Override prometheus external labels (repeated).").
+		PlaceHolder("<name>=\"<value>\"").StringsVar(&pc.externalLabels)
 	pc.httpClient = extflag.RegisterPathOrContent(
 		cmd,
 		"prometheus.http-client",

--- a/docs/components/sidecar.md
+++ b/docs/components/sidecar.md
@@ -125,6 +125,8 @@ Flags:
                                  Path to YAML file that contains object
                                  store configuration. See format details:
                                  https://thanos.io/tip/thanos/storage.md/#configuration
+      --prometheus.external_label=<name>="<value>" ...
+                                 Override prometheus external labels (repeated).
       --prometheus.get_config_interval=30s
                                  How often to get Prometheus config
       --prometheus.get_config_timeout=5s


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->
Add an optional parameter on Thanos sidecar component: `external_label` that it take `key=value`, it can be used multiple time as:

```
thanos sidecar --prometheus.external_label=<key1>=<value1> --prometheus.external_label=<key2>=<value2> ...
```

that overrides fetching external labels from prometheus and use custom labels instead. This makes sidecar compatible with backends that don't expose external labels (as mimir).

## Verification

<!-- How you tested it? How do you know it works? -->
test with one query configured to scrape metrics from mutiple prometheus and some mimir tenants and it works as expected.