### PR TITLE
Add remoteUser (from http basic auth) and remoteAddr to Thanos slow query logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#6104](https://github.com/thanos-io/thanos/pull/6104) Objstore: Support S3 session token.
 - [#5548](https://github.com/thanos-io/thanos/pull/5548) Query: Added experimental support for load balancing across multiple Store endpoints.
 - [#6148](https://github.com/thanos-io/thanos/pull/6148) Query-frontend: add traceID to slow query detected log line
+- [#6153](https://github.com/thanos-io/thanos/pull/6153) Query-frontend: add remote_user (from http basic auth) and remote_addr to slow query detected log line
 
 ### Fixed
 

--- a/internal/cortex/frontend/transport/handler.go
+++ b/internal/cortex/frontend/transport/handler.go
@@ -177,11 +177,15 @@ func (f *Handler) reportSlowQuery(r *http.Request, responseHeaders http.Header, 
 		thanosTraceID = traceID
 	}
 
+	remoteUser, _, _ := r.BasicAuth()
+
 	logMessage := append([]interface{}{
 		"msg", "slow query detected",
 		"method", r.Method,
 		"host", r.Host,
 		"path", r.URL.Path,
+		"remote_user", remoteUser,
+		"remote_addr", r.RemoteAddr,
 		"time_taken", queryResponseTime.String(),
 		"grafana_dashboard_uid", grafanaDashboardUID,
 		"grafana_panel_id", grafanaPanelID,
@@ -200,6 +204,7 @@ func (f *Handler) reportQueryStats(r *http.Request, queryString url.Values, quer
 	wallTime := stats.LoadWallTime()
 	numSeries := stats.LoadFetchedSeries()
 	numBytes := stats.LoadFetchedChunkBytes()
+	remoteUser, _, _ := r.BasicAuth()
 
 	// Track stats.
 	f.querySeconds.WithLabelValues(userID).Add(wallTime.Seconds())
@@ -213,6 +218,8 @@ func (f *Handler) reportQueryStats(r *http.Request, queryString url.Values, quer
 		"component", "query-frontend",
 		"method", r.Method,
 		"path", r.URL.Path,
+		"remote_user", remoteUser,
+		"remote_addr", r.RemoteAddr,
 		"response_time", queryResponseTime,
 		"query_wall_time_seconds", wallTime.Seconds(),
 		"fetched_series_count", numSeries,


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

When tracking where a suspicious query came from, one often needs to know the remote address or remote user that made the request. Adding these should help with debugging.

## Verification

Built locally and ran locally then queried with http client.

```
http 'http://localhost:10902/api/v1/query?query=count(up)' --auth foo:bar
```

```
level=info ts=2023-02-22T00:29:36.712614Z caller=handler.go:195 org_id=anonymous msg="slow query detected" method=GET host=localhost:10902 path=/api/v1/query remote_user=foo remote_addr=[::1]:54112 time_taken=2.956678125s grafana_dashboard_uid=- grafana_panel_id=- trace_id=- param_query=count(up)
```



## Notes

So this is posted slightly early as a proof of concept to see if the basic idea makes sense to the Thanos team.

It seems like `reportQueryStats` is not actually called from anywhere, only `reportSlowQuery` but I've updated both in the interest of keeping things in sync.
