### PR TITLE
Store: fix error handling on limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 
 ### Fixed
 
+- [#6171](https://github.com/thanos-io/thanos/pull/6171) Store: fix error handling on limits.
+
 ### Changed
 
 ### Removed

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
+	"github.com/weaveworks/common/httpgrpc"
 	"hash"
 	"io"
 	"math"
@@ -932,7 +933,7 @@ func (b *blockSeriesClient) ExpandPostings(
 	}
 
 	if err := seriesLimiter.Reserve(uint64(len(ps))); err != nil {
-		return errors.Wrap(err, "exceeded series limit")
+		return httpgrpc.Errorf(int(codes.ResourceExhausted), "exceeded series limit: %s", err)
 	}
 
 	b.postings = ps
@@ -1031,7 +1032,7 @@ func (b *blockSeriesClient) nextBatch() error {
 
 		// Ensure sample limit through chunksLimiter if we return chunks.
 		if err := b.chunksLimiter.Reserve(uint64(len(b.chkMetas))); err != nil {
-			return errors.Wrap(err, "exceeded chunks limit")
+			return httpgrpc.Errorf(int(codes.ResourceExhausted), "exceeded chunks limit: %s", err)
 		}
 
 		b.entries = append(b.entries, s)

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
-	"github.com/weaveworks/common/httpgrpc"
 	"hash"
 	"io"
 	"math"
@@ -20,6 +19,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/weaveworks/common/httpgrpc"
 
 	"github.com/cespare/xxhash"
 


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

I noticed from running Thanos Store in production that limits were being hit quite often and this triggered an alert based on percentage of failed requests. A deep investigation allowed me to identify that the grpc codes for requests hitting limits made no sense: they were mostly "Unknown" and "Aborted". This motivated me to fix such logic.

* Removed a test implementation of the series and samples limiter factories used in a test to test its own behavior. 
* Now such test uses the real implementation of such limiters.
* Fixed the error handling from the limiters, allowing a proper gRPC status code to be returned when limits are hit: `ResourceExhausted`.

## Verification

E2E tests changed and passing.
