### PR TITLE
Handle query parsing errors on QFE range split middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 
 ### Fixed
 
+- [#6172](https://github.com/thanos-io/thanos/pull/6172) query-frontend: return JSON formatted errors for invalid PromQL expression in the split by interval middleware.
 - [#6171](https://github.com/thanos-io/thanos/pull/6171) Store: fix error handling on limits.
 
 ### Changed

--- a/internal/cortex/querier/queryrange/split_by_interval.go
+++ b/internal/cortex/querier/queryrange/split_by_interval.go
@@ -99,7 +99,7 @@ func splitQuery(r Request, interval time.Duration) ([]Request, error) {
 func EvaluateAtModifierFunction(query string, start, end int64) (string, error) {
 	expr, err := parser.ParseExpr(query)
 	if err != nil {
-		return "", httpgrpc.Errorf(http.StatusBadRequest, "%s", err)
+		return "", httpgrpc.Errorf(http.StatusBadRequest, `{"status": "error", "error": "%s"}`, err)
 	}
 	parser.Inspect(expr, func(n parser.Node, _ []parser.Node) error {
 		if selector, ok := n.(*parser.VectorSelector); ok {


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

Related/fixes: https://github.com/thanos-io/thanos/issues/6075

## Changes

* Return JSON error message from query range split middleware when parsing PromQL expression.

## Verification

I have tested it by running QFE with query split enabled.
