### PR TITLE
*: Add grpc error wrapping in the limitedStoreServer

### DIFF
--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -20,8 +20,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/weaveworks/common/httpgrpc"
-
 	"github.com/cespare/xxhash"
 
 	"github.com/alecthomas/units"

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -934,7 +934,7 @@ func (b *blockSeriesClient) ExpandPostings(
 	}
 
 	if err := seriesLimiter.Reserve(uint64(len(ps))); err != nil {
-		return httpgrpc.Errorf(int(codes.ResourceExhausted), "exceeded series limit: %s", err)
+		return status.Errorf(codes.ResourceExhausted, "exceeded series limit: %s", err)
 	}
 
 	b.postings = ps
@@ -1033,7 +1033,7 @@ func (b *blockSeriesClient) nextBatch() error {
 
 		// Ensure sample limit through chunksLimiter if we return chunks.
 		if err := b.chunksLimiter.Reserve(uint64(len(b.chkMetas))); err != nil {
-			return httpgrpc.Errorf(int(codes.ResourceExhausted), "exceeded chunks limit: %s", err)
+			return status.Errorf(codes.ResourceExhausted, "exceeded chunks limit: %s", err)
 		}
 
 		b.entries = append(b.entries, s)

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -1407,7 +1407,7 @@ func (s *BucketStore) Series(req *storepb.SeriesRequest, srv storepb.Store_Serie
 		}
 
 		if err = srv.Send(storepb.NewHintsSeriesResponse(anyHints)); err != nil {
-			err = status.Error(codes.Unknown, errors.Wrap(err, "send series response hints").Error())
+			err = status.Error(status.Code(err), errors.Wrap(err, "send series response hints").Error())
 			return
 		}
 	}

--- a/pkg/store/limiter.go
+++ b/pkg/store/limiter.go
@@ -4,9 +4,9 @@
 package store
 
 import (
+	"google.golang.org/grpc/status"
 	"sync"
 
-	"github.com/weaveworks/common/httpgrpc"
 	"google.golang.org/grpc/codes"
 
 	"github.com/alecthomas/units"
@@ -172,10 +172,10 @@ func (i *limitedServer) Send(response *storepb.SeriesResponse) error {
 	}
 
 	if err := i.seriesLimiter.Reserve(1); err != nil {
-		return httpgrpc.Errorf(int(codes.ResourceExhausted), "exceeded series limit: %s", err)
+		return status.Errorf(codes.ResourceExhausted, "exceeded series limit: %s", err)
 	}
 	if err := i.samplesLimiter.Reserve(uint64(len(series.Chunks) * MaxSamplesPerChunk)); err != nil {
-		return httpgrpc.Errorf(int(codes.ResourceExhausted), "exceeded samples limit: %s", err)
+		return status.Errorf(codes.ResourceExhausted, "exceeded samples limit: %s", err)
 	}
 
 	return i.Store_SeriesServer.Send(response)

--- a/pkg/store/limiter.go
+++ b/pkg/store/limiter.go
@@ -4,8 +4,9 @@
 package store
 
 import (
-	"google.golang.org/grpc/status"
 	"sync"
+
+	"google.golang.org/grpc/status"
 
 	"google.golang.org/grpc/codes"
 


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->
* Wraps the possible errors from the `limitedStoreServer` with grpc error codes.
* Align the messages around limits hit between the `limitedStoreServer` and the limits in the Thanos Store.

## Verification

<!-- How you tested it? How do you know it works? -->
