### PR TITLE
[tracing] tracing in OTLP support configuring service_name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 
 ### Added
 
+- [#6185](https://github.com/thanos-io/thanos/pull/6185) Tracing: tracing in OTLP support configuring service_name.
+
 ### Fixed
 
 - [#6172](https://github.com/thanos-io/thanos/pull/6172) query-frontend: return JSON formatted errors for invalid PromQL expression in the split by interval middleware.

--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -78,6 +78,7 @@ Thanos supports exporting traces in the OpenTelemetry Protocol (OTLP). Both gRPC
 type: OTLP
 config:
   client_type: ""
+  service_name: ""
   reconnection_period: 0s
   compression: ""
   insecure: false

--- a/pkg/tracing/otlp/config_yaml.go
+++ b/pkg/tracing/otlp/config_yaml.go
@@ -21,6 +21,7 @@ type retryConfig struct {
 
 type Config struct {
 	ClientType         string            `yaml:"client_type"`
+	ServiceName        string            `yaml:"service_name"`
 	ReconnectionPeriod time.Duration     `yaml:"reconnection_period"`
 	Compression        string            `yaml:"compression"`
 	Insecure           bool              `yaml:"insecure"`

--- a/pkg/tracing/otlp/otlp_test.go
+++ b/pkg/tracing/otlp/otlp_test.go
@@ -23,7 +23,8 @@ func TestContextTracing_ClientEnablesTracing(t *testing.T) {
 	tracerOtel := newTraceProvider(
 		context.Background(),
 		tracesdk.NewSimpleSpanProcessor(exp),
-		log.NewNopLogger())
+		log.NewNopLogger(),
+		"thanos")
 	tracer, _ := migration.Bridge(tracerOtel, log.NewNopLogger())
 	clientRoot, _ := tracing.StartSpan(tracing.ContextWithTracer(context.Background(), tracer), "a")
 


### PR DESCRIPTION
* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

fix #6184

add `service_name` to OTLP tracing config to improve the readiness of the trace data.

![image](https://user-images.githubusercontent.com/11855957/223021738-f7c43480-61ea-4be2-9e1d-26b62d8eab39.png)
