### PR TITLE
query: Add flag for specifying engine optimizers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 
 ### Added
 
+- [#6186](https://github.com/thanos-io/thanos/pull/6186) query: Add `--query.promql-engine.optimizers` flag to allow selecting specific query plan optimizers
+
 ### Fixed
 
 - [#6172](https://github.com/thanos-io/thanos/pull/6172) query-frontend: return JSON formatted errors for invalid PromQL expression in the split by interval middleware.

--- a/docs/components/query.md
+++ b/docs/components/query.md
@@ -398,6 +398,10 @@ Flags:
                                  --no-query.partial-response for disabling.
       --query.promql-engine=prometheus
                                  PromQL engine to use.
+      --query.promql-engine.optimizers=QUERY.PROMQL-ENGINE.OPTIMIZERS ...
+                                 Specifies the PromQL engine query plan
+                                 optimizers to use. Only used with thanos
+                                 engine.
       --query.replica-label=QUERY.REPLICA-LABEL ...
                                  Labels to treat as a replica indicator along
                                  which data is deduplicated. Still you will

--- a/go.mod
+++ b/go.mod
@@ -68,7 +68,7 @@ require (
 	github.com/prometheus/prometheus v0.42.0
 	github.com/sony/gobreaker v0.5.0
 	github.com/stretchr/testify v1.8.1
-	github.com/thanos-community/promql-engine v0.0.0-20230213101639-ab3d8dcea3f3
+	github.com/thanos-community/promql-engine v0.0.0-20230303073140-8fe603c6d1d9
 	github.com/thanos-io/objstore v0.0.0-20230201072718-11ffbc490204
 	github.com/uber/jaeger-client-go v2.30.0+incompatible
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -895,8 +895,8 @@ github.com/tencentyun/cos-go-sdk-v5 v0.7.40 h1:W6vDGKCHe4wBACI1d2UgE6+50sJFhRWU4
 github.com/tencentyun/cos-go-sdk-v5 v0.7.40/go.mod h1:4dCEtLHGh8QPxHEkgq+nFaky7yZxQuYwgSJM87icDaw=
 github.com/thanos-community/galaxycache v0.0.0-20211122094458-3a32041a1f1e h1:f1Zsv7OAU9iQhZwigp50Yl38W10g/vd5NC8Rdk1Jzng=
 github.com/thanos-community/galaxycache v0.0.0-20211122094458-3a32041a1f1e/go.mod h1:jXcofnrSln/cLI6/dhlBxPQZEEQHVPCcFaH75M+nSzM=
-github.com/thanos-community/promql-engine v0.0.0-20230213101639-ab3d8dcea3f3 h1:Uu7UEw9o3DbZRZwonnCa3LhXCUgGOmY94/Z7+uGa2Ok=
-github.com/thanos-community/promql-engine v0.0.0-20230213101639-ab3d8dcea3f3/go.mod h1:gREn4JarQ2DZdWirOtqZQd3p+c1xH+UVpGRjGKVoWx8=
+github.com/thanos-community/promql-engine v0.0.0-20230303073140-8fe603c6d1d9 h1:Qo8LriIVG3+86aahSoYNnU/nPEBKTTztt7LuPdkd6/0=
+github.com/thanos-community/promql-engine v0.0.0-20230303073140-8fe603c6d1d9/go.mod h1:gREn4JarQ2DZdWirOtqZQd3p+c1xH+UVpGRjGKVoWx8=
 github.com/thanos-io/objstore v0.0.0-20230201072718-11ffbc490204 h1:W4w5Iph7j32Sf1QFWLJDCqvO0WgZS0jHGID+qnq3wV0=
 github.com/thanos-io/objstore v0.0.0-20230201072718-11ffbc490204/go.mod h1:STSgpY8M6EKF2G/raUFdbIMf2U9GgYlEjAEHJxjvpAo=
 github.com/themihai/gomemcache v0.0.0-20180902122335-24332e2d58ab h1:7ZR3hmisBWw77ZpO1/o86g+JV3VKlk3d48jopJxzTjU=


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

This PR adds a repeatable `--query.promql-engine.optimizers` flag which allows selecting the exact query plan optimizers to pass to new promql engine options. 

Also, bumps github.com/thanos-community/promql-engine to latest.

## Verification

Built/ran locally.