### PR TITLE
store: add flag to select the label to use as timeline title in web UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 ### Added
 
 - [#6185](https://github.com/thanos-io/thanos/pull/6185) Tracing: tracing in OTLP support configuring service_name.
+- [#6192](https://github.com/thanos-io/thanos/pull/6192) Store: add flag `bucket-web-label` to select the label to use as timeline title in web UI
 
 ### Fixed
 

--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -781,5 +781,5 @@ func (cc *compactConfig) registerFlag(cmd extkingpin.FlagClause) {
 
 	cc.webConf.registerFlag(cmd)
 
-	cmd.Flag("bucket-web-label", "Prometheus label to use as timeline title in the bucket web UI").StringVar(&cc.label)
+	cmd.Flag("bucket-web-label", "External block label to use as group title in the bucket web UI").StringVar(&cc.label)
 }

--- a/cmd/thanos/tools_bucket.go
+++ b/cmd/thanos/tools_bucket.go
@@ -198,7 +198,7 @@ func (tbc *bucketWebConfig) registerBucketWebFlag(cmd extkingpin.FlagClause) *bu
 
 	cmd.Flag("timeout", "Timeout to download metadata from remote storage").Default("5m").DurationVar(&tbc.timeout)
 
-	cmd.Flag("label", "Prometheus label to use as timeline title").StringVar(&tbc.label)
+	cmd.Flag("label", "External block label to use as group title").StringVar(&tbc.label)
 	return tbc
 }
 

--- a/docs/components/compact.md
+++ b/docs/components/compact.md
@@ -295,8 +295,8 @@ Flags:
                                 local and remote view for /global Block Viewer
                                 UI.
       --bucket-web-label=BUCKET-WEB-LABEL
-                                Prometheus label to use as timeline title in the
-                                bucket web UI
+                                External block label to use as group title in
+                                the bucket web UI
       --compact.blocks-fetch-concurrency=1
                                 Number of goroutines to use when download block
                                 during compaction.

--- a/docs/components/store.md
+++ b/docs/components/store.md
@@ -36,6 +36,9 @@ Flags:
                                  Number of goroutines to use when constructing
                                  index-cache.json blocks from object storage.
                                  Must be equal or greater than 1.
+      --bucket-web-label=BUCKET-WEB-LABEL
+                                 External block label to use as group title in
+                                 the bucket web UI
       --cache-index-header       Cache TSDB index-headers on disk to reduce
                                  startup time. When set to true, Thanos Store
                                  will download index headers from remote object

--- a/docs/components/tools.md
+++ b/docs/components/tools.md
@@ -219,7 +219,7 @@ Flags:
       --http.config=""          [EXPERIMENTAL] Path to the configuration file
                                 that can enable TLS or authentication for all
                                 HTTP endpoints.
-      --label=LABEL             Prometheus label to use as timeline title
+      --label=LABEL             External block label to use as group title
       --log.format=logfmt       Log format to use. Possible options: logfmt or
                                 json.
       --log.level=info          Log filtering level.


### PR DESCRIPTION
Hello,

`Compactor` has this nice flag `--bucket-web-label` to select the label to use as timeline title in the 'block' web UI (i.e. replace the `1` value in the following screenshot with a comprehensible value) :

![Capture d’écran 2023-03-07 à 10 36 58](https://user-images.githubusercontent.com/6303650/223383987-e82abbe8-f8ee-47c0-8c1d-5024c892ae36.png)

However, `Store` is missing this flag, so I added it, using the same name/description to stay consistent.

<!--
    Don't forget about CHANGELOG!



    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

- added flag `--bucket-web-label` to `store` command

## Verification

<!-- How you tested it? How do you know it works? -->
