### PR TITLE
e2e/store: fix flaky limits test

### DIFF
--- a/test/e2e/store_gateway_test.go
+++ b/test/e2e/store_gateway_test.go
@@ -774,6 +774,11 @@ metafile_content_ttl: 0s`
 func TestStoreGatewayBytesLimit(t *testing.T) {
 	t.Parallel()
 
+	const cacheCfg = `type: IN-MEMORY
+config:
+  max_size: 2B
+  max_item_size: 1B`
+
 	e, err := e2e.NewDockerEnvironment("store-limit")
 	testutil.Ok(t, err)
 	t.Cleanup(e2ethanos.CleanScenario(t, e))
@@ -789,7 +794,7 @@ func TestStoreGatewayBytesLimit(t *testing.T) {
 			Type:   client.S3,
 			Config: e2ethanos.NewS3Config(bucket, m.InternalEndpoint("http"), m.InternalDir()),
 		},
-		"",
+		string(cacheCfg),
 		[]string{"--store.grpc.downloaded-bytes-limit=1B"},
 	)
 
@@ -800,7 +805,7 @@ func TestStoreGatewayBytesLimit(t *testing.T) {
 			Type:   client.S3,
 			Config: e2ethanos.NewS3Config(bucket, m.InternalEndpoint("http"), m.InternalDir()),
 		},
-		"",
+		string(cacheCfg),
 		[]string{"--store.grpc.downloaded-bytes-limit=100B"},
 	)
 	store3 := e2ethanos.NewStoreGW(
@@ -810,7 +815,7 @@ func TestStoreGatewayBytesLimit(t *testing.T) {
 			Type:   client.S3,
 			Config: e2ethanos.NewS3Config(bucket, m.InternalEndpoint("http"), m.InternalDir()),
 		},
-		"",
+		string(cacheCfg),
 		[]string{"--store.grpc.downloaded-bytes-limit=196627B"},
 	)
 


### PR DESCRIPTION
Intentionally disable the default in-memory cache to get consistent values during the test.

I have identified this originally in https://github.com/thanos-io/thanos/pull/5906. Since that PR is stuck a bit now, I've moved out the fix into this PR.
