### PR TITLE
Exemplar OTel: Fix exemplar for otel to use traceId instead of spanId and sample only if trace is sampled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#6172](https://github.com/thanos-io/thanos/pull/6172) query-frontend: return JSON formatted errors for invalid PromQL expression in the split by interval middleware.
 - [#6171](https://github.com/thanos-io/thanos/pull/6171) Store: fix error handling on limits.
 - [#6183](https://github.com/thanos-io/thanos/pull/6183) Receiver: fix off by one in multitsdb flush that will result in empty blocks if the head only contains one sample
+- [#6197](https://github.com/thanos-io/thanos/pull/6197) Exemplar OTel: Fix exemplar for otel to use traceId instead of spanId and sample only if trace is sampled
 
 ### Changed
 - [#6168](https://github.com/thanos-io/thanos/pull/6168) Receiver: Make ketama hashring fail early when configured with number of nodes lower than the replication factor.

--- a/pkg/extprom/http/instrument_server.go
+++ b/pkg/extprom/http/instrument_server.go
@@ -97,8 +97,8 @@ func httpInstrumentationHandler(baseLabels prometheus.Labels, metrics *defaultMe
 						// If OpenTracing span not found, try OTEL.
 						if !OTfound {
 							span := trace.SpanFromContext(r.Context())
-							if span != nil {
-								traceID = span.SpanContext().SpanID().String()
+							if span != nil && span.SpanContext().IsSampled() {
+								traceID = span.SpanContext().TraceID().String()
 							}
 						}
 


### PR DESCRIPTION
….

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Fix the exemplar for otel to use correct traceId

## Verification

We identified this bug when we enabled the exemplar in Grafana, the tracedId value is by mistake to assigned with spanId which causes broken link to jaeger trace ui. After the fix, we verified everything works fine. 
