### PR TITLE
Copy chunk bytes in TSDB store before sending to client

### DIFF
--- a/pkg/store/tsdb.go
+++ b/pkg/store/tsdb.go
@@ -202,13 +202,15 @@ func (s *TSDBStore) Series(r *storepb.SeriesRequest, srv storepb.Store_SeriesSer
 				return status.Errorf(codes.Internal, "TSDBStore: found not populated chunk returned by SeriesSet at ref: %v", chk.Ref)
 			}
 
+			chunkBytes := make([]byte, len(chk.Chunk.Bytes()))
+			copy(chunkBytes, chk.Chunk.Bytes())
 			c := storepb.AggrChunk{
 				MinTime: chk.MinTime,
 				MaxTime: chk.MaxTime,
 				Raw: &storepb.Chunk{
 					Type: storepb.Chunk_Encoding(chk.Chunk.Encoding() - 1), // Proto chunk encoding is one off to TSDB one.
-					Data: chk.Chunk.Bytes(),
-					Hash: hashChunk(hasher, chk.Chunk.Bytes(), enableChunkHashCalculation),
+					Data: chunkBytes,
+					Hash: hashChunk(hasher, chunkBytes, enableChunkHashCalculation),
 				},
 			}
 			frameBytesLeft -= c.Size()


### PR DESCRIPTION
During head compaction mmaped memory gets released while gRPC is marshaling bytes from that same memory region. This leads to a fatal segfault and crashes the receiver. The segfault happens when marshaling chunks specifically.

This commit modifies the TSDB store server to copy chunk bytes before sending them to the client. I tried running this for a while and saw no significant increase in memory usage.

Fixes https://github.com/thanos-io/thanos/issues/6196.

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
