### PR TITLE
Remove tenant shipper after prunning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,6 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#6197](https://github.com/thanos-io/thanos/pull/6197) Exemplar OTel: Fix exemplar for otel to use traceId instead of spanId and sample only if trace is sampled
 - [#6207](https://github.com/thanos-io/thanos/pull/6207) Receive: Remove the shipper once a tenant has been pruned.
 
-
 ### Changed
 - [#6168](https://github.com/thanos-io/thanos/pull/6168) Receiver: Make ketama hashring fail early when configured with number of nodes lower than the replication factor.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#6171](https://github.com/thanos-io/thanos/pull/6171) Store: fix error handling on limits.
 - [#6183](https://github.com/thanos-io/thanos/pull/6183) Receiver: fix off by one in multitsdb flush that will result in empty blocks if the head only contains one sample
 - [#6197](https://github.com/thanos-io/thanos/pull/6197) Exemplar OTel: Fix exemplar for otel to use traceId instead of spanId and sample only if trace is sampled
+- [#6207](https://github.com/thanos-io/thanos/pull/6207) Receive: Remove the shipper once a tenant has been pruned.
+
 
 ### Changed
 - [#6168](https://github.com/thanos-io/thanos/pull/6168) Receiver: Make ketama hashring fail early when configured with number of nodes lower than the replication factor.

--- a/pkg/receive/multitsdb_test.go
+++ b/pkg/receive/multitsdb_test.go
@@ -425,7 +425,7 @@ func TestMultiTSDBPrune(t *testing.T) {
 			name:            "prune tsdbs with object storage",
 			bucket:          objstore.NewInMemBucket(),
 			expectedTenants: 2,
-			expectedUploads: 1,
+			expectedUploads: 2,
 		},
 	}
 
@@ -454,9 +454,17 @@ func TestMultiTSDBPrune(t *testing.T) {
 			}
 			testutil.Equals(t, 3, len(m.TSDBLocalClients()))
 
-			testutil.Ok(t, m.Prune(context.Background()))
-			testutil.Equals(t, test.expectedTenants, len(m.TSDBLocalClients()))
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
 
+			if test.bucket != nil {
+				go func() {
+					testutil.Ok(t, syncTSDBs(ctx, m, 10*time.Millisecond))
+				}()
+			}
+
+			testutil.Ok(t, m.Prune(ctx))
+			testutil.Equals(t, test.expectedTenants, len(m.TSDBLocalClients()))
 			var shippedBlocks int
 			if test.bucket != nil {
 				testutil.Ok(t, test.bucket.Iter(context.Background(), "", func(s string) error {
@@ -466,6 +474,20 @@ func TestMultiTSDBPrune(t *testing.T) {
 			}
 			testutil.Equals(t, test.expectedUploads, shippedBlocks)
 		})
+	}
+}
+
+func syncTSDBs(ctx context.Context, m *MultiTSDB, interval time.Duration) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-time.After(interval):
+			_, err := m.Sync(ctx)
+			if err != nil {
+				return err
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
We noticed another edge case with tenant prunning where the shipper would keep syncing blocks even after the tenant TSDB was removed. The reason for this is because the shipper runs in parallel in a different goroutine and is not stopped when the TSDB is gone.

This leads to empty shipper files being created on disk once a tenant is pruned, and the orphaned TSDBs alert from the mixing starts to fire.

This commit modifies the pruning logic to remove all components from a tenant once eviction conditions have been met.

![image](https://user-images.githubusercontent.com/1286231/224339165-9a926a04-7f13-43fe-bf43-0b983510910b.png)


<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

* Remove all tenant components after pruning.

## Verification

* I extended the existing test and run it locally with 

```
go test -race ./pkg/receive/... -count 10 -run TestMultiTSDBPrune
```