### PR TITLE
Reduce label values hash op

### DIFF
--- a/pkg/store/cache/memcached_test.go
+++ b/pkg/store/cache/memcached_test.go
@@ -101,10 +101,10 @@ func TestMemcachedIndexCache_FetchMultiPostings(t *testing.T) {
 			testutil.Equals(t, testData.expectedMisses, misses)
 
 			// Assert on metrics.
-			testutil.Equals(t, float64(len(testData.fetchLabels)), prom_testutil.ToFloat64(c.requests.WithLabelValues(cacheTypePostings)))
-			testutil.Equals(t, float64(len(testData.expectedHits)), prom_testutil.ToFloat64(c.hits.WithLabelValues(cacheTypePostings)))
-			testutil.Equals(t, 0.0, prom_testutil.ToFloat64(c.requests.WithLabelValues(cacheTypeSeries)))
-			testutil.Equals(t, 0.0, prom_testutil.ToFloat64(c.hits.WithLabelValues(cacheTypeSeries)))
+			testutil.Equals(t, float64(len(testData.fetchLabels)), prom_testutil.ToFloat64(c.postingRequests))
+			testutil.Equals(t, float64(len(testData.expectedHits)), prom_testutil.ToFloat64(c.postingHits))
+			testutil.Equals(t, 0.0, prom_testutil.ToFloat64(c.seriesRequests))
+			testutil.Equals(t, 0.0, prom_testutil.ToFloat64(c.seriesHits))
 		})
 	}
 }
@@ -190,10 +190,10 @@ func TestMemcachedIndexCache_FetchMultiSeries(t *testing.T) {
 			testutil.Equals(t, testData.expectedMisses, misses)
 
 			// Assert on metrics.
-			testutil.Equals(t, float64(len(testData.fetchIds)), prom_testutil.ToFloat64(c.requests.WithLabelValues(cacheTypeSeries)))
-			testutil.Equals(t, float64(len(testData.expectedHits)), prom_testutil.ToFloat64(c.hits.WithLabelValues(cacheTypeSeries)))
-			testutil.Equals(t, 0.0, prom_testutil.ToFloat64(c.requests.WithLabelValues(cacheTypePostings)))
-			testutil.Equals(t, 0.0, prom_testutil.ToFloat64(c.hits.WithLabelValues(cacheTypePostings)))
+			testutil.Equals(t, float64(len(testData.fetchIds)), prom_testutil.ToFloat64(c.seriesRequests))
+			testutil.Equals(t, float64(len(testData.expectedHits)), prom_testutil.ToFloat64(c.seriesHits))
+			testutil.Equals(t, 0.0, prom_testutil.ToFloat64(c.postingRequests))
+			testutil.Equals(t, 0.0, prom_testutil.ToFloat64(c.postingHits))
 		})
 	}
 }


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

We are calling `WithLabelValues(operation)` every time to increment the counter. `operation` is set as a constant and only contains 2 values, postings or series.

`WithLabelValues(operation)` will try to hash the given label values and find the corresponding counter. In this case, we can just store the counter itself to reduce the CPU time on hashing.

This issue is identified in the store gateway CPU profile.

## Verification

<!-- How you tested it? How do you know it works? -->
