### PR TITLE
Reduce usage of fmt.Sprintf in cachekey string

### DIFF
--- a/pkg/store/cache/cachekey/cachekey.go
+++ b/pkg/store/cache/cachekey/cachekey.go
@@ -4,7 +4,6 @@
 package cachekey
 
 import (
-	"fmt"
 	"strconv"
 	"strings"
 
@@ -38,10 +37,10 @@ type BucketCacheKey struct {
 // String returns the string representation of BucketCacheKey.
 func (ck BucketCacheKey) String() string {
 	if ck.Start == 0 && ck.End == 0 {
-		return fmt.Sprintf("%s:%s", ck.Verb, ck.Name)
+		return string(ck.Verb) + ":" + ck.Name
 	}
 
-	return fmt.Sprintf("%s:%s:%d:%d", ck.Verb, ck.Name, ck.Start, ck.End)
+	return strings.Join([]string{string(ck.Verb), ck.Name, strconv.FormatInt(ck.Start, 10), strconv.FormatInt(ck.End, 10)}, ":")
 }
 
 // IsValidVerb checks if the VerbType matches the predefined verbs.


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

<img width="1007" alt="image" src="https://user-images.githubusercontent.com/25150124/225080208-dce156e1-a962-4b4a-a441-f44309b3cac6.png">

I am seeing `fmt.Sprintf` showing up in the store gateway CPU profile so want to reduce it if possible.

Move to `+` and `strings.Join` as they provide better performance than Sprintf

## Verification

<!-- How you tested it? How do you know it works? -->
