### PR TITLE
store/bucket: snappy-encoded postings reading improvements

### DIFF
--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -2163,14 +2163,14 @@ func (r *bucketIndexReader) ExpandedPostings(ctx context.Context, ms []*labels.M
 	}
 
 	fetchedPostings, closeFns, err := r.fetchPostings(ctx, keys, bytesLimiter)
-	if err != nil {
-		return nil, errors.Wrap(err, "get postings")
-	}
 	defer func() {
 		for _, closeFn := range closeFns {
 			closeFn()
 		}
 	}()
+	if err != nil {
+		return nil, errors.Wrap(err, "get postings")
+	}
 
 	// Get "add" and "remove" postings from groups. We iterate over postingGroups and their keys
 	// again, and this is exactly the same order as before (when building the groups), so we can simply

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -2372,7 +2372,7 @@ func (r *bucketIndexReader) fetchPostings(ctx context.Context, keys []labels.Lab
 		}
 
 		if err != nil {
-			return nil, nil, errors.Wrap(err, "index header PostingsOffset")
+			return nil, closeFns, errors.Wrap(err, "index header PostingsOffset")
 		}
 
 		r.stats.postingsToFetch++
@@ -2394,7 +2394,7 @@ func (r *bucketIndexReader) fetchPostings(ctx context.Context, keys []labels.Lab
 		length := int64(part.End) - start
 
 		if err := bytesLimiter.Reserve(uint64(length)); err != nil {
-			return nil, nil, errors.Wrap(err, "bytes limit exceeded while fetching postings")
+			return nil, closeFns, errors.Wrap(err, "bytes limit exceeded while fetching postings")
 		}
 	}
 

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -2309,6 +2309,7 @@ type postingPtr struct {
 // If postings for given key is not fetched, entry at given index will be nil.
 func (r *bucketIndexReader) fetchPostings(ctx context.Context, keys []labels.Label, bytesLimiter BytesLimiter) ([]index.Postings, []func(), error) {
 	var closeFns []func()
+
 	timer := prometheus.NewTimer(r.block.metrics.postingsFetchDuration)
 	defer timer.ObserveDuration()
 

--- a/pkg/store/postings_codec.go
+++ b/pkg/store/postings_codec.go
@@ -5,6 +5,7 @@ package store
 
 import (
 	"bytes"
+	"sync"
 
 	"github.com/golang/snappy"
 	"github.com/pkg/errors"
@@ -82,27 +83,53 @@ func diffVarintEncodeNoHeader(p index.Postings, length int) ([]byte, error) {
 	return buf.B, nil
 }
 
-func diffVarintSnappyDecode(input []byte) (index.Postings, error) {
+var snappyDecodePool sync.Pool
+
+type closeablePostings interface {
+	index.Postings
+	close()
+}
+
+func diffVarintSnappyDecode(input []byte) (closeablePostings, error) {
 	if !isDiffVarintSnappyEncodedPostings(input) {
 		return nil, errors.New("header not found")
 	}
 
-	raw, err := snappy.Decode(nil, input[len(codecHeaderSnappy):])
+	var dstBuf []byte
+	decodeBuf := snappyDecodePool.Get()
+	if decodeBuf != nil {
+		dstBuf = *(decodeBuf.(*[]byte))
+	}
+
+	raw, err := snappy.Decode(dstBuf, input[len(codecHeaderSnappy):])
 	if err != nil {
 		return nil, errors.Wrap(err, "snappy decode")
 	}
 
-	return newDiffVarintPostings(raw), nil
+	biggerSlice := raw
+	if cap(dstBuf) > cap(biggerSlice) {
+		biggerSlice = dstBuf
+	}
+
+	return newDiffVarintPostings(raw, biggerSlice), nil
 }
 
-func newDiffVarintPostings(input []byte) *diffVarintPostings {
-	return &diffVarintPostings{buf: &encoding.Decbuf{B: input}}
+func newDiffVarintPostings(input, freeSlice []byte) *diffVarintPostings {
+	return &diffVarintPostings{freeSlice: freeSlice, buf: &encoding.Decbuf{B: input}}
 }
 
 // diffVarintPostings is an implementation of index.Postings based on diff+varint encoded data.
 type diffVarintPostings struct {
-	buf *encoding.Decbuf
-	cur storage.SeriesRef
+	buf       *encoding.Decbuf
+	cur       storage.SeriesRef
+	freeSlice []byte
+}
+
+func (it *diffVarintPostings) close() {
+	if it.freeSlice == nil {
+		return
+	}
+	snappyDecodePool.Put(&it.freeSlice)
 }
 
 func (it *diffVarintPostings) At() storage.SeriesRef {

--- a/pkg/store/postings_codec.go
+++ b/pkg/store/postings_codec.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 
 	"github.com/golang/snappy"
+	"github.com/klauspost/compress/s2"
 	"github.com/pkg/errors"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb/encoding"
@@ -101,7 +102,7 @@ func diffVarintSnappyDecode(input []byte) (closeablePostings, error) {
 		dstBuf = *(decodeBuf.(*[]byte))
 	}
 
-	raw, err := snappy.Decode(dstBuf, input[len(codecHeaderSnappy):])
+	raw, err := s2.Decode(dstBuf, input[len(codecHeaderSnappy):])
 	if err != nil {
 		return nil, errors.Wrap(err, "snappy decode")
 	}

--- a/pkg/store/postings_codec_test.go
+++ b/pkg/store/postings_codec_test.go
@@ -55,9 +55,9 @@ func TestDiffVarintCodec(t *testing.T) {
 
 	codecs := map[string]struct {
 		codingFunction   func(index.Postings, int) ([]byte, error)
-		decodingFunction func([]byte) (index.Postings, error)
+		decodingFunction func([]byte) (closeablePostings, error)
 	}{
-		"raw":    {codingFunction: diffVarintEncodeNoHeader, decodingFunction: func(bytes []byte) (index.Postings, error) { return newDiffVarintPostings(bytes), nil }},
+		"raw":    {codingFunction: diffVarintEncodeNoHeader, decodingFunction: func(bytes []byte) (closeablePostings, error) { return newDiffVarintPostings(bytes, nil), nil }},
 		"snappy": {codingFunction: diffVarintSnappyEncode, decodingFunction: diffVarintSnappyDecode},
 	}
 


### PR DESCRIPTION
* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

- Pool input to the decoding function so that it would avoid needless allocations with client-side caching enabled
- Use `s2.Decode` because it works faster

## Verification

Ad-hoc testing