### PR TITLE
Fix segfault in LabelValues during head compaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#6216](https://github.com/thanos-io/thanos/pull/6216) Receiver: removed hard-coded value of EnableExemplarStorage flag and set it according to max-exemplar value.
 - [#6222](https://github.com/thanos-io/thanos/pull/6222) mixin(Receive): Fix tenant series received charts.
 - [#6218](https://github.com/thanos-io/thanos/pull/6218) mixin(Store): handle ResourceExhausted as a non-server error. As a consequence, this error won't contribute to Store's grpc errors alerts.
+- [#6271](https://github.com/thanos-io/thanos/pull/6271) Receive: Fix segfault in `LabelValues` during head compaction.
 
 ### Changed
 - [#6168](https://github.com/thanos-io/thanos/pull/6168) Receiver: Make ketama hashring fail early when configured with number of nodes lower than the replication factor.

--- a/pkg/receive/multitsdb_test.go
+++ b/pkg/receive/multitsdb_test.go
@@ -6,24 +6,25 @@ package receive
 import (
 	"context"
 	"io"
+	"math"
 	"os"
 	"strings"
 	"testing"
 	"time"
 
-	"github.com/thanos-io/objstore"
-
+	"github.com/efficientgo/core/testutil"
 	"github.com/go-kit/log"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/model/exemplar"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb"
+	"github.com/thanos-io/objstore"
 	"golang.org/x/sync/errgroup"
-
-	"github.com/efficientgo/core/testutil"
+	"google.golang.org/grpc"
 
 	"github.com/thanos-io/thanos/pkg/block/metadata"
+	"github.com/thanos-io/thanos/pkg/component"
 	"github.com/thanos-io/thanos/pkg/exemplars/exemplarspb"
 	"github.com/thanos-io/thanos/pkg/runutil"
 	"github.com/thanos-io/thanos/pkg/store"
@@ -606,7 +607,61 @@ func TestMultiTSDBWithNilStore(t *testing.T) {
 	testutil.Ok(t, appendSample(m, tenantID, time.Now()))
 }
 
+type slowClient struct {
+	store.Client
+}
+
+func (s *slowClient) LabelValues(ctx context.Context, r *storepb.LabelValuesRequest, _ ...grpc.CallOption) (*storepb.LabelValuesResponse, error) {
+	<-time.After(10 * time.Millisecond)
+	return s.Client.LabelValues(ctx, r)
+}
+
+func TestProxyLabelValues(t *testing.T) {
+	dir := t.TempDir()
+	m := NewMultiTSDB(
+		dir, nil, prometheus.NewRegistry(), &tsdb.Options{
+			RetentionDuration: 10 * time.Minute.Milliseconds(),
+			MinBlockDuration:  5 * time.Minute.Milliseconds(),
+			MaxBlockDuration:  5 * time.Minute.Milliseconds(),
+			NoLockfile:        true,
+		},
+		labels.FromStrings("replica", "01"),
+		"tenant_id",
+		nil,
+		false,
+		metadata.NoneFunc,
+	)
+	defer func() { testutil.Ok(t, m.Close()) }()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+				queryLabelValues(ctx, m)
+			}
+		}
+	}()
+
+	// Append several samples to a TSDB outside the retention period.
+	testutil.Ok(t, appendSampleWithLabels(m, "tenant-a", labels.FromStrings(labels.MetricName, "metric-a"), time.Now().Add(-5*time.Hour)))
+	testutil.Ok(t, appendSampleWithLabels(m, "tenant-a", labels.FromStrings(labels.MetricName, "metric-b"), time.Now().Add(-3*time.Hour)))
+	testutil.Ok(t, appendSampleWithLabels(m, "tenant-b", labels.FromStrings(labels.MetricName, "metric-c"), time.Now().Add(-1*time.Hour)))
+
+	// Append a sample within the retention period and flush all tenants.
+	// This will lead deletion of blocks that fall out of the retention period.
+	testutil.Ok(t, appendSampleWithLabels(m, "tenant-b", labels.FromStrings(labels.MetricName, "metric-d"), time.Now()))
+	testutil.Ok(t, m.Flush())
+}
+
 func appendSample(m *MultiTSDB, tenant string, timestamp time.Time) error {
+	return appendSampleWithLabels(m, tenant, labels.FromStrings("foo", "bar"), timestamp)
+}
+
+func appendSampleWithLabels(m *MultiTSDB, tenant string, lbls labels.Labels, timestamp time.Time) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
@@ -623,12 +678,33 @@ func appendSample(m *MultiTSDB, tenant string, timestamp time.Time) error {
 		return err
 	}
 
-	_, err = a.Append(0, labels.FromStrings("foo", "bar"), timestamp.UnixMilli(), 10)
+	_, err = a.Append(0, lbls, timestamp.UnixMilli(), 10)
 	if err != nil {
 		return err
 	}
 
 	return a.Commit()
+}
+
+func queryLabelValues(ctx context.Context, m *MultiTSDB) error {
+	proxy := store.NewProxyStore(nil, nil, func() []store.Client {
+		clients := m.TSDBLocalClients()
+		if len(clients) > 0 {
+			clients[0] = &slowClient{clients[0]}
+		}
+		return clients
+	}, component.Store, nil, 1*time.Minute, store.LazyRetrieval, nil)
+
+	req := &storepb.LabelValuesRequest{
+		Label: labels.MetricName,
+		Start: math.MinInt64,
+		End:   math.MaxInt64,
+	}
+	_, err := proxy.LabelValues(ctx, req)
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 func BenchmarkMultiTSDB(b *testing.B) {

--- a/pkg/receive/multitsdb_test.go
+++ b/pkg/receive/multitsdb_test.go
@@ -641,7 +641,7 @@ func TestProxyLabelValues(t *testing.T) {
 			case <-ctx.Done():
 				return
 			default:
-				queryLabelValues(ctx, m)
+				testutil.Ok(t, queryLabelValues(ctx, m))
 			}
 		}
 	}()
@@ -693,7 +693,7 @@ func queryLabelValues(ctx context.Context, m *MultiTSDB) error {
 			clients[0] = &slowClient{clients[0]}
 		}
 		return clients
-	}, component.Store, nil, 1*time.Minute, store.LazyRetrieval, nil)
+	}, component.Store, nil, 1*time.Minute, store.LazyRetrieval)
 
 	req := &storepb.LabelValuesRequest{
 		Label: labels.MetricName,


### PR DESCRIPTION
Head compaction causes blocks outside the retention period to get deleted. If there is an in-flight LabelValues request at the same time, deleting the block can cause the store proxy to panic since it loses access to the data.

This commit fixes the issue by copying label values from TSDB stores before returning them to the store proxy. I thought about exposing a Close method on the TSDB store which the Proxy can call, but this will not eliminate cases where gRPC defers sending data over a channel using its queueing mechanism.

Fixes https://github.com/thanos-io/thanos/issues/6190.

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

* Fix segfault in `LabelValues` during head compaction.

## Verification

I managed to reproduce the issue with a unit test. After the fix I no longer see a panic in the store proxy.
