### PR TITLE
[react-app] Add TraceID to QueryStatsViewer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#6192](https://github.com/thanos-io/thanos/pull/6192) Store: add flag `bucket-web-label` to select the label to use as timeline title in web UI
 - [#6167](https://github.com/thanos-io/thanos/pull/6195) Receive: add flag `tsdb.too-far-in-future.time-window` to prevent clock skewed samples to pollute TSDB head and block all valid incoming samples.
 - [#6273](https://github.com/thanos-io/thanos/pull/6273) Mixin: Allow specifying an instance name filter in dashboards
+- [#6305](https://github.com/thanos-io/thanos/pull/6305) UI: Added TraceID to query stats
 
 ### Fixed
 

--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -59,6 +59,7 @@ When using tracing with Thanos, you can obtain trace ID in multiple ways:
 * Search by labels/attributes/tags/time/component/latency e.g. using Jaeger indexing.
 * [Exemplars](https://www.bwplotka.dev/2021/correlations-exemplars/)
 * If request was sampled, response will have `X-Thanos-Trace-Id` response header with trace ID of this request as value.
+* If `X-Thanos-Trace-Id` header is present in the response, it will be shown in the query UI
 
 ![view](img/tracing.png)
 

--- a/pkg/ui/react-app/src/pages/graph/Panel.tsx
+++ b/pkg/ui/react-app/src/pages/graph/Panel.tsx
@@ -196,8 +196,18 @@ class Panel extends Component<PanelProps & PathPrefixProps, PanelState> {
       credentials: 'same-origin',
       signal: abortController.signal,
     })
-      .then((resp) => resp.json())
-      .then((json) => {
+      .then((resp) => {
+        return {
+          json: resp.json(),
+          headers: resp.headers,
+        };
+      })
+      .then(({json, headers}) => {
+        const traceID = headers.get('X-Thanos-Trace-ID');
+
+        (json) => { // need to resolve the promise
+          json.then()
+        }
         if (json.status !== 'success') {
           throw new Error(json.error || 'invalid response JSON');
         }
@@ -225,6 +235,7 @@ class Panel extends Component<PanelProps & PathPrefixProps, PanelState> {
             loadTime: Date.now() - queryStart,
             resolution,
             resultSeries,
+            traceID,
           },
           loading: false,
         });

--- a/pkg/ui/react-app/src/pages/graph/Panel.tsx
+++ b/pkg/ui/react-app/src/pages/graph/Panel.tsx
@@ -197,17 +197,10 @@ class Panel extends Component<PanelProps & PathPrefixProps, PanelState> {
       signal: abortController.signal,
     })
       .then((resp) => {
-        return {
-          json: resp.json(),
-          headers: resp.headers,
-        };
+        const traceID = resp.headers.get('X-Thanos-Trace-ID');
+        return resp.json()
       })
-      .then(({json, headers}) => {
-        const traceID = headers.get('X-Thanos-Trace-ID');
-
-        (json) => { // need to resolve the promise
-          json.then()
-        }
+      .then((json) => {
         if (json.status !== 'success') {
           throw new Error(json.error || 'invalid response JSON');
         }

--- a/pkg/ui/react-app/src/pages/graph/Panel.tsx
+++ b/pkg/ui/react-app/src/pages/graph/Panel.tsx
@@ -197,10 +197,15 @@ class Panel extends Component<PanelProps & PathPrefixProps, PanelState> {
       signal: abortController.signal,
     })
       .then((resp) => {
-        const traceID = resp.headers.get('X-Thanos-Trace-ID');
-        return resp.json()
+        return resp.json().then((json) => {
+          return {
+            json,
+            headers: resp.headers,
+          };
+        });
       })
-      .then((json) => {
+      .then(({ json, headers }) => {
+        const traceID = headers.get('X-Thanos-Trace-ID');
         if (json.status !== 'success') {
           throw new Error(json.error || 'invalid response JSON');
         }
@@ -228,7 +233,7 @@ class Panel extends Component<PanelProps & PathPrefixProps, PanelState> {
             loadTime: Date.now() - queryStart,
             resolution,
             resultSeries,
-            traceID,
+            traceID: traceID ? traceID : '',
           },
           loading: false,
         });

--- a/pkg/ui/react-app/src/pages/graph/Panel.tsx
+++ b/pkg/ui/react-app/src/pages/graph/Panel.tsx
@@ -205,7 +205,6 @@ class Panel extends Component<PanelProps & PathPrefixProps, PanelState> {
         });
       })
       .then(({ json, headers }) => {
-        const traceID = headers.get('X-Thanos-Trace-ID');
         if (json.status !== 'success') {
           throw new Error(json.error || 'invalid response JSON');
         }
@@ -219,6 +218,8 @@ class Panel extends Component<PanelProps & PathPrefixProps, PanelState> {
             resultSeries = result.length;
           }
         }
+
+        const traceID = headers.get('X-Thanos-Trace-ID');
 
         this.setState({
           error: null,

--- a/pkg/ui/react-app/src/pages/graph/QueryStatsView.test.tsx
+++ b/pkg/ui/react-app/src/pages/graph/QueryStatsView.test.tsx
@@ -30,8 +30,6 @@ describe('QueryStatsView', () => {
     const queryStatsView = shallow(<QueryStatsView {...queryStatsProps} />);
     expect(queryStatsView.prop('className')).toEqual('query-stats');
     expect(queryStatsView.children().prop('className')).toEqual('float-right');
-    expect(queryStatsView.children().text()).toEqual(
-      'Load time: 100ms   Resolution: 5s   Result series: 10000'
-    );
+    expect(queryStatsView.children().text()).toEqual('Load time: 100ms   Resolution: 5s   Result series: 10000');
   });
 });

--- a/pkg/ui/react-app/src/pages/graph/QueryStatsView.test.tsx
+++ b/pkg/ui/react-app/src/pages/graph/QueryStatsView.test.tsx
@@ -8,11 +8,13 @@ describe('QueryStatsView', () => {
       loadTime: 100,
       resolution: 5,
       resultSeries: 10000,
-      traceID: "300277e5ef87c55f0d723965fbd8b7fd"
+      traceID: '300277e5ef87c55f0d723965fbd8b7fd',
     };
     const queryStatsView = shallow(<QueryStatsView {...queryStatsProps} />);
     expect(queryStatsView.prop('className')).toEqual('query-stats');
     expect(queryStatsView.children().prop('className')).toEqual('float-right');
-    expect(queryStatsView.children().text()).toEqual('Load time: 100ms   Resolution: 5s   Result series: 10000');
+    expect(queryStatsView.children().text()).toEqual(
+      'Load time: 100ms   Resolution: 5s   Result series: 10000   Trace ID: 300277e5ef87c55f0d723965fbd8b7fd'
+    );
   });
 });

--- a/pkg/ui/react-app/src/pages/graph/QueryStatsView.test.tsx
+++ b/pkg/ui/react-app/src/pages/graph/QueryStatsView.test.tsx
@@ -13,7 +13,7 @@ describe('QueryStatsView', () => {
     const queryStatsView = shallow(<QueryStatsView {...queryStatsProps} />);
     expect(queryStatsView.prop('className')).toEqual('query-stats');
     expect(queryStatsView.children().prop('className')).toEqual('float-right');
-    expect(queryStatsView.children().text()).toEqual(
+    expect(queryStatsView.children().render()).toEqual(
       'Load time: 100ms   Resolution: 5s   Result series: 10000   Trace ID: 300277e5ef87c55f0d723965fbd8b7fd'
     );
   });

--- a/pkg/ui/react-app/src/pages/graph/QueryStatsView.test.tsx
+++ b/pkg/ui/react-app/src/pages/graph/QueryStatsView.test.tsx
@@ -13,7 +13,7 @@ describe('QueryStatsView', () => {
     const queryStatsView = shallow(<QueryStatsView {...queryStatsProps} />);
     expect(queryStatsView.prop('className')).toEqual('query-stats');
     expect(queryStatsView.children().prop('className')).toEqual('float-right');
-    expect(queryStatsView.children().render()).toEqual(
+    expect(queryStatsView.children().text()).toEqual(
       'Load time: 100ms   Resolution: 5s   Result series: 10000   Trace ID: 300277e5ef87c55f0d723965fbd8b7fd'
     );
   });

--- a/pkg/ui/react-app/src/pages/graph/QueryStatsView.test.tsx
+++ b/pkg/ui/react-app/src/pages/graph/QueryStatsView.test.tsx
@@ -8,6 +8,7 @@ describe('QueryStatsView', () => {
       loadTime: 100,
       resolution: 5,
       resultSeries: 10000,
+      traceID: "300277e5ef87c55f0d723965fbd8b7fd"
     };
     const queryStatsView = shallow(<QueryStatsView {...queryStatsProps} />);
     expect(queryStatsView.prop('className')).toEqual('query-stats');

--- a/pkg/ui/react-app/src/pages/graph/QueryStatsView.test.tsx
+++ b/pkg/ui/react-app/src/pages/graph/QueryStatsView.test.tsx
@@ -18,3 +18,20 @@ describe('QueryStatsView', () => {
     );
   });
 });
+
+describe('QueryStatsView', () => {
+  it('does not render missing trace id', () => {
+    const queryStatsProps = {
+      loadTime: 100,
+      resolution: 5,
+      resultSeries: 10000,
+      traceID: '',
+    };
+    const queryStatsView = shallow(<QueryStatsView {...queryStatsProps} />);
+    expect(queryStatsView.prop('className')).toEqual('query-stats');
+    expect(queryStatsView.children().prop('className')).toEqual('float-right');
+    expect(queryStatsView.children().text()).toEqual(
+      'Load time: 100ms   Resolution: 5s   Result series: 10000'
+    );
+  });
+});

--- a/pkg/ui/react-app/src/pages/graph/QueryStatsView.tsx
+++ b/pkg/ui/react-app/src/pages/graph/QueryStatsView.tsx
@@ -4,15 +4,16 @@ export interface QueryStats {
   loadTime: number;
   resolution: number;
   resultSeries: number;
+  traceID: string;
 }
 
 const QueryStatsView: FC<QueryStats> = (props) => {
-  const { loadTime, resolution, resultSeries } = props;
+  const { loadTime, resolution, resultSeries, traceID } = props;
 
   return (
     <div className="query-stats">
       <span className="float-right">
-        Load time: {loadTime}ms &ensp; Resolution: {resolution}s &ensp; Result series: {resultSeries}
+        Load time: {loadTime}ms &ensp; Resolution: {resolution}s &ensp; Result series: {resultSeries} &ensp; TraceID: {traceID}
       </span>
     </div>
   );

--- a/pkg/ui/react-app/src/pages/graph/QueryStatsView.tsx
+++ b/pkg/ui/react-app/src/pages/graph/QueryStatsView.tsx
@@ -11,7 +11,7 @@ const QueryStatsView: FC<QueryStats> = (props) => {
   const { loadTime, resolution, resultSeries, traceID } = props;
 
   const base = `Load time: ${loadTime}ms &ensp; Resolution: ${resolution}s &ensp; Result series: ${resultSeries}`;
-  const str = traceID ? base + `&ensp; TraceID: ${traceID}` : base;
+  const str = traceID ? base + ` &ensp; TraceID: ${traceID}` : base;
 
   return (
     <div className="query-stats">

--- a/pkg/ui/react-app/src/pages/graph/QueryStatsView.tsx
+++ b/pkg/ui/react-app/src/pages/graph/QueryStatsView.tsx
@@ -10,11 +10,12 @@ export interface QueryStats {
 const QueryStatsView: FC<QueryStats> = (props) => {
   const { loadTime, resolution, resultSeries, traceID } = props;
 
+  const base = `Load time: ${loadTime}ms &ensp; Resolution: ${resolution}s &ensp; Result series: ${resultSeries}`;
+  const str = traceID ? base + `&ensp; TraceID: ${traceID}` : base;
+
   return (
     <div className="query-stats">
-      <span className="float-right">
-        Load time: {loadTime}ms &ensp; Resolution: {resolution}s &ensp; Result series: {resultSeries} &ensp; TraceID: {traceID}
-      </span>
+      <span className="float-right" dangerouslySetInnerHTML={{ __html: str }}></span>
     </div>
   );
 };


### PR DESCRIPTION
Fixes #5651

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

 - Extract traceID from response headers and display it in the QueryStatsViewer component
 - If no trace ID, the field is suppressed (only the response time, resolution, and number of series are shown)

## Verification

<!-- How you tested it? How do you know it works? -->

 - Built locally and manually changed props with React Dev Tools
 - Updated the test but one is failing - for the life of me I cannot workout why this is (yet)
