### PR TITLE
compact: atomically replace no compact marked map

### DIFF
--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -1392,9 +1392,9 @@ func (f *GatherNoCompactionMarkFilter) NoCompactMarkedBlocks() map[ulid.ULID]*me
 
 // Filter passes all metas, while gathering no compact markers.
 func (f *GatherNoCompactionMarkFilter) Filter(ctx context.Context, metas map[ulid.ULID]*metadata.Meta, synced block.GaugeVec, modified block.GaugeVec) error {
-	f.mtx.Lock()
-	f.noCompactMarkedMap = make(map[ulid.ULID]*metadata.NoCompactMark)
-	f.mtx.Unlock()
+	var localNoCompactMapMtx sync.Mutex
+
+	noCompactMarkedMap := make(map[ulid.ULID]*metadata.NoCompactMark)
 
 	// Make a copy of block IDs to check, in order to avoid concurrency issues
 	// between the scheduler and workers.
@@ -1427,9 +1427,9 @@ func (f *GatherNoCompactionMarkFilter) Filter(ctx context.Context, metas map[uli
 					continue
 				}
 
-				f.mtx.Lock()
-				f.noCompactMarkedMap[id] = m
-				f.mtx.Unlock()
+				localNoCompactMapMtx.Lock()
+				noCompactMarkedMap[id] = m
+				localNoCompactMapMtx.Unlock()
 				synced.WithLabelValues(block.MarkedForNoCompactionMeta).Inc()
 			}
 
@@ -1456,6 +1456,10 @@ func (f *GatherNoCompactionMarkFilter) Filter(ctx context.Context, metas map[uli
 	if err := eg.Wait(); err != nil {
 		return errors.Wrap(err, "filter blocks marked for no compaction")
 	}
+
+	f.mtx.Lock()
+	f.noCompactMarkedMap = noCompactMarkedMap
+	f.mtx.Unlock()
 
 	return nil
 }


### PR DESCRIPTION
With lots of blocks, it could take some time to fill this no-compact marked map hence replace it atomically. I believe this leads to problems in the compaction planner where it picks up no compact marked blocks because meta syncer does synchronizations concurrently. Deletion mark filter already has a similar atomic replacement logic.

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

Changes no compact marked blocks map automatically.

## Verification

A new test that doesn't fail with these changes.
