### PR TITLE
query: use storepb.SeriesServer

### DIFF
--- a/pkg/query/querier.go
+++ b/pkg/query/querier.go
@@ -60,7 +60,7 @@ type QueryableCreator func(
 func NewQueryableCreator(
 	logger log.Logger,
 	reg prometheus.Registerer,
-	proxy *store.ProxyStore,
+	proxy storepb.StoreServer,
 	maxConcurrentSelects int,
 	selectTimeout time.Duration,
 ) QueryableCreator {
@@ -102,7 +102,7 @@ type queryable struct {
 	logger               log.Logger
 	replicaLabels        []string
 	storeDebugMatchers   [][]*labels.Matcher
-	proxy                *store.ProxyStore
+	proxy                storepb.StoreServer
 	deduplicate          bool
 	maxResolutionMillis  int64
 	partialResponse      bool
@@ -127,7 +127,7 @@ type querier struct {
 	mint, maxt              int64
 	replicaLabels           []string
 	storeDebugMatchers      [][]*labels.Matcher
-	proxy                   *store.ProxyStore
+	proxy                   storepb.StoreServer
 	deduplicate             bool
 	maxResolutionMillis     int64
 	partialResponseStrategy storepb.PartialResponseStrategy
@@ -148,7 +148,7 @@ func newQuerier(
 	maxt int64,
 	replicaLabels []string,
 	storeDebugMatchers [][]*labels.Matcher,
-	proxy *store.ProxyStore,
+	proxy storepb.StoreServer,
 	deduplicate bool,
 	maxResolutionMillis int64,
 	partialResponse,


### PR DESCRIPTION
Use storepb.SeriesServer instead of the concrete struct. This allows for implementing functionality on top of the proxy.
