### PR TITLE
Added follow_redirect flag in http_client

### DIFF
--- a/cmd/thanos/config.go
+++ b/cmd/thanos/config.go
@@ -52,6 +52,7 @@ type httpConfig struct {
 	bindAddress string
 	tlsConfig   string
 	gracePeriod model.Duration
+	follow_redirect bool
 }
 
 func (hc *httpConfig) registerFlag(cmd extkingpin.FlagClause) *httpConfig {
@@ -65,6 +66,10 @@ func (hc *httpConfig) registerFlag(cmd extkingpin.FlagClause) *httpConfig {
 		"http.config",
 		"[EXPERIMENTAL] Path to the configuration file that can enable TLS or authentication for all HTTP endpoints.",
 	).Default("").StringVar(&hc.tlsConfig)
+	cmd.Flag(
+		"http.config",
+		"[EXPERIMENTAL] Will decide the followRedirect.",
+	).Default("false").StringVar(&hc.follow_redirect)
 	return hc
 }
 
@@ -217,6 +222,7 @@ type alertMgrConfig struct {
 	alertExcludeLabels     []string
 	alertQueryURL          *string
 	alertRelabelConfigPath *extflag.PathOrContent
+	follow_redirect        bool
 }
 
 func (ac *alertMgrConfig) registerFlag(cmd extflag.FlagClause) *alertMgrConfig {
@@ -231,5 +237,7 @@ func (ac *alertMgrConfig) registerFlag(cmd extflag.FlagClause) *alertMgrConfig {
 	cmd.Flag("alert.label-drop", "Labels by name to drop before sending to alertmanager. This allows alert to be deduplicated on replica label (repeated). Similar Prometheus alert relabelling").
 		StringsVar(&ac.alertExcludeLabels)
 	ac.alertRelabelConfigPath = extflag.RegisterPathOrContent(cmd, "alert.relabel-config", "YAML file that contains alert relabelling configuration.", extflag.WithEnvSubstitution())
+	cmd.Flag("alertmanagers.follow_redirect", "To follows redirects to the OAuth provider.").
+		Default("false").BoolVar(&ac.follow_redirect)
 	return ac
 }


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes
Fixes : #5941

<!-- Enumerate changes you made -->
I have added a follow_redirect flag in http_config struct and its default value have been set to false.
Refrence : https://github.com/prometheus/common/blob/main/config/http_config.go#L287
## Verification

<!-- How you tested it? How do you know it works? -->
