### PR TITLE
Cache series matchers

### DIFF
--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -488,7 +488,7 @@ func runQuery(
 	if debugLogging {
 		options = append(options, store.WithProxyStoreDebugLogging())
 	}
-
+	matchersCache := startMatchersCache(g)
 	var (
 		endpoints = query.NewEndpointSet(
 			time.Now,
@@ -540,7 +540,7 @@ func runQuery(
 			endpointInfoTimeout,
 			queryConnMetricLabels...,
 		)
-		proxy            = store.NewProxyStore(logger, reg, endpoints.GetStoreClients, component.Query, selectorLset, storeResponseTimeout, store.RetrievalStrategy(grpcProxyStrategy), options...)
+		proxy            = store.NewProxyStore(logger, reg, endpoints.GetStoreClients, component.Query, selectorLset, storeResponseTimeout, store.RetrievalStrategy(grpcProxyStrategy), matchersCache, options...)
 		rulesProxy       = rules.NewProxy(logger, endpoints.GetRulesClients)
 		targetsProxy     = targets.NewProxy(logger, endpoints.GetTargetsClients)
 		metadataProxy    = metadata.NewProxy(logger, endpoints.GetMetricMetadataClients)
@@ -800,7 +800,7 @@ func runQuery(
 		)
 
 		defaultEngineType := querypb.EngineType(querypb.EngineType_value[defaultEngine])
-		grpcAPI := apiv1.NewGRPCAPI(time.Now, queryReplicaLabels, queryableCreator, engineFactory, defaultEngineType, lookbackDeltaCreator, instantDefaultMaxSourceResolution)
+		grpcAPI := apiv1.NewGRPCAPI(time.Now, queryReplicaLabels, queryableCreator, engineFactory, defaultEngineType, lookbackDeltaCreator, instantDefaultMaxSourceResolution, matchersCache)
 		storeServer := store.NewLimitedStoreServer(store.NewInstrumentedStoreServer(reg, proxy), reg, storeRateLimits)
 		s := grpcserver.New(logger, reg, tracer, grpcLogOpts, tagOpts, comp, grpcProbe,
 			grpcserver.WithServer(apiv1.RegisterQueryServer(grpcAPI)),

--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -488,7 +488,7 @@ func runQuery(
 	if debugLogging {
 		options = append(options, store.WithProxyStoreDebugLogging())
 	}
-	matchersCache := startMatchersCache(g)
+	matchersCache := startMatchersCache(g, reg)
 	var (
 		endpoints = query.NewEndpointSet(
 			time.Now,

--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -198,6 +198,8 @@ func runReceive(
 		return errors.Wrap(err, "parse relabel configuration")
 	}
 
+	matchersCache := startMatchersCache(g)
+
 	dbs := receive.NewMultiTSDB(
 		conf.dataDir,
 		logger,
@@ -208,6 +210,7 @@ func runReceive(
 		bkt,
 		conf.allowOutOfOrderUpload,
 		hashFunc,
+		matchersCache,
 	)
 	writer := receive.NewWriter(log.With(logger, "component", "receive-writer"), dbs, &receive.WriterOptions{
 		Intern:                   conf.writerInterning,
@@ -324,6 +327,7 @@ func runReceive(
 			labels.Labels{},
 			0,
 			store.LazyRetrieval,
+			matchersCache,
 			options...,
 		)
 		mts := store.NewLimitedStoreServer(store.NewInstrumentedStoreServer(reg, proxy), reg, conf.storeRateLimits)

--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -198,7 +198,7 @@ func runReceive(
 		return errors.Wrap(err, "parse relabel configuration")
 	}
 
-	matchersCache := startMatchersCache(g)
+	matchersCache := startMatchersCache(g, reg)
 
 	dbs := receive.NewMultiTSDB(
 		conf.dataDir,

--- a/cmd/thanos/rule.go
+++ b/cmd/thanos/rule.go
@@ -618,7 +618,7 @@ func runRule(
 	}
 	infoOptions := []info.ServerOptionFunc{info.WithRulesInfoFunc()}
 	if tsdbDB != nil {
-		matchersCache := startMatchersCache(g)
+		matchersCache := startMatchersCache(g, reg)
 		tsdbStore := store.NewTSDBStore(logger, tsdbDB, component.Rule, conf.lset, matchersCache)
 		infoOptions = append(
 			infoOptions,

--- a/cmd/thanos/rule.go
+++ b/cmd/thanos/rule.go
@@ -618,7 +618,8 @@ func runRule(
 	}
 	infoOptions := []info.ServerOptionFunc{info.WithRulesInfoFunc()}
 	if tsdbDB != nil {
-		tsdbStore := store.NewTSDBStore(logger, tsdbDB, component.Rule, conf.lset)
+		matchersCache := startMatchersCache(g)
+		tsdbStore := store.NewTSDBStore(logger, tsdbDB, component.Rule, conf.lset, matchersCache)
 		infoOptions = append(
 			infoOptions,
 			info.WithLabelSetFunc(func() []labelpb.ZLabelSet {

--- a/cmd/thanos/sidecar.go
+++ b/cmd/thanos/sidecar.go
@@ -244,7 +244,7 @@ func runSidecar(
 			cancel()
 		})
 	}
-	matchersCache := startMatchersCache(g)
+	matchersCache := startMatchersCache(g, reg)
 	{
 		c := promclient.NewWithTracingClient(logger, httpClient, httpconfig.ThanosUserAgent)
 
@@ -367,8 +367,8 @@ func runSidecar(
 	return nil
 }
 
-func startMatchersCache(g *run.Group) *storepb.MatchersCache {
-	matchersCache := storepb.NewMatchersCache()
+func startMatchersCache(g *run.Group, reg *prometheus.Registry) *storepb.MatchersCache {
+	matchersCache := storepb.NewMatchersCache(storepb.WithPromRegistry(reg))
 	{
 		ctx, cancel := context.WithCancel(context.Background())
 		g.Add(func() error {

--- a/cmd/thanos/store.go
+++ b/cmd/thanos/store.go
@@ -364,7 +364,7 @@ func runStore(
 		options = append(options, store.WithDebugLogging())
 	}
 
-	matchersCache := startMatchersCache(g)
+	matchersCache := startMatchersCache(g, reg)
 	bs, err := store.NewBucketStore(
 		bkt,
 		metaFetcher,

--- a/cmd/thanos/store.go
+++ b/cmd/thanos/store.go
@@ -364,6 +364,7 @@ func runStore(
 		options = append(options, store.WithDebugLogging())
 	}
 
+	matchersCache := startMatchersCache(g)
 	bs, err := store.NewBucketStore(
 		bkt,
 		metaFetcher,
@@ -378,6 +379,7 @@ func runStore(
 		false,
 		conf.lazyIndexReaderEnabled,
 		conf.lazyIndexReaderIdleTimeout,
+		matchersCache,
 		options...,
 	)
 	if err != nil {

--- a/pkg/api/query/grpc.go
+++ b/pkg/api/query/grpc.go
@@ -16,6 +16,7 @@ import (
 	"github.com/thanos-io/thanos/pkg/api/query/querypb"
 	"github.com/thanos-io/thanos/pkg/query"
 	"github.com/thanos-io/thanos/pkg/store/labelpb"
+	"github.com/thanos-io/thanos/pkg/store/storepb"
 	"github.com/thanos-io/thanos/pkg/store/storepb/prompb"
 )
 
@@ -27,6 +28,7 @@ type GRPCAPI struct {
 	defaultEngine               querypb.EngineType
 	lookbackDeltaCreate         func(int64) time.Duration
 	defaultMaxResolutionSeconds time.Duration
+	matchersCache               *storepb.MatchersCache
 }
 
 func NewGRPCAPI(
@@ -37,6 +39,7 @@ func NewGRPCAPI(
 	defaultEngine querypb.EngineType,
 	lookbackDeltaCreate func(int64) time.Duration,
 	defaultMaxResolutionSeconds time.Duration,
+	matchersCache *storepb.MatchersCache,
 ) *GRPCAPI {
 	return &GRPCAPI{
 		now:                         now,
@@ -46,6 +49,7 @@ func NewGRPCAPI(
 		defaultEngine:               defaultEngine,
 		lookbackDeltaCreate:         lookbackDeltaCreate,
 		defaultMaxResolutionSeconds: defaultMaxResolutionSeconds,
+		matchersCache:               matchersCache,
 	}
 }
 
@@ -81,7 +85,7 @@ func (g *GRPCAPI) Query(request *querypb.QueryRequest, server querypb.Query_Quer
 		lookbackDelta = time.Duration(request.LookbackDeltaSeconds) * time.Second
 	}
 
-	storeMatchers, err := querypb.StoreMatchersToLabelMatchers(request.StoreMatchers)
+	storeMatchers, err := querypb.StoreMatchersToLabelMatchers(g.matchersCache, request.StoreMatchers)
 	if err != nil {
 		return err
 	}
@@ -179,7 +183,7 @@ func (g *GRPCAPI) QueryRange(request *querypb.QueryRangeRequest, srv querypb.Que
 		lookbackDelta = time.Duration(request.LookbackDeltaSeconds) * time.Second
 	}
 
-	storeMatchers, err := querypb.StoreMatchersToLabelMatchers(request.StoreMatchers)
+	storeMatchers, err := querypb.StoreMatchersToLabelMatchers(g.matchersCache, request.StoreMatchers)
 	if err != nil {
 		return err
 	}

--- a/pkg/api/query/grpc_test.go
+++ b/pkg/api/query/grpc_test.go
@@ -20,12 +20,13 @@ import (
 	"github.com/thanos-io/thanos/pkg/component"
 	"github.com/thanos-io/thanos/pkg/query"
 	"github.com/thanos-io/thanos/pkg/store"
+	"github.com/thanos-io/thanos/pkg/store/storepb"
 )
 
 func TestGRPCQueryAPIErrorHandling(t *testing.T) {
 	logger := log.NewNopLogger()
 	reg := prometheus.NewRegistry()
-	proxy := store.NewProxyStore(logger, reg, func() []store.Client { return nil }, component.Store, nil, 1*time.Minute, store.LazyRetrieval)
+	proxy := store.NewProxyStore(logger, reg, func() []store.Client { return nil }, component.Store, nil, 1*time.Minute, store.LazyRetrieval, storepb.NewMatchersCache())
 	queryableCreator := query.NewQueryableCreator(logger, reg, proxy, 1, 1*time.Minute)
 	lookbackDeltaFunc := func(i int64) time.Duration { return 5 * time.Minute }
 	tests := []struct {
@@ -50,7 +51,7 @@ func TestGRPCQueryAPIErrorHandling(t *testing.T) {
 		engineFactory := &QueryEngineFactory{
 			prometheusEngine: test.engine,
 		}
-		api := NewGRPCAPI(time.Now, nil, queryableCreator, engineFactory, querypb.EngineType_prometheus, lookbackDeltaFunc, 0)
+		api := NewGRPCAPI(time.Now, nil, queryableCreator, engineFactory, querypb.EngineType_prometheus, lookbackDeltaFunc, 0, storepb.NewMatchersCache())
 		t.Run("range_query", func(t *testing.T) {
 			rangeRequest := &querypb.QueryRangeRequest{
 				Query:            "metric",

--- a/pkg/api/query/querypb/store_matchers.go
+++ b/pkg/api/query/querypb/store_matchers.go
@@ -5,17 +5,18 @@ package querypb
 
 import (
 	"github.com/prometheus/prometheus/model/labels"
+
 	"github.com/thanos-io/thanos/pkg/store/storepb"
 )
 
-func StoreMatchersToLabelMatchers(matchers []StoreMatchers) ([][]*labels.Matcher, error) {
+func StoreMatchersToLabelMatchers(matchersCache *storepb.MatchersCache, matchers []StoreMatchers) ([][]*labels.Matcher, error) {
 	if len(matchers) == 0 {
 		return nil, nil
 	}
 
 	labelMatchers := make([][]*labels.Matcher, len(matchers))
 	for i, storeMatcher := range matchers {
-		storeMatchers, err := storepb.MatchersToPromMatchers(storeMatcher.LabelMatchers...)
+		storeMatchers, err := storepb.MatchersToPromMatchers(matchersCache, storeMatcher.LabelMatchers...)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/api/query/v1_test.go
+++ b/pkg/api/query/v1_test.go
@@ -629,7 +629,7 @@ func TestQueryEndpoints(t *testing.T) {
 func newProxyStoreWithTSDBStore(db store.TSDBReader) *store.ProxyStore {
 	c := &storetestutil.TestClient{
 		Name:        "1",
-		StoreClient: storepb.ServerAsClient(store.NewTSDBStore(nil, db, component.Query, nil), 0),
+		StoreClient: storepb.ServerAsClient(store.NewTSDBStore(nil, db, component.Query, nil, storepb.NewMatchersCache()), 0),
 		MinTime:     math.MinInt64, MaxTime: math.MaxInt64,
 	}
 
@@ -641,6 +641,7 @@ func newProxyStoreWithTSDBStore(db store.TSDBReader) *store.ProxyStore {
 		nil,
 		0,
 		store.EagerRetrieval,
+		storepb.NewMatchersCache(),
 	)
 }
 

--- a/pkg/query/querier_test.go
+++ b/pkg/query/querier_test.go
@@ -351,7 +351,7 @@ func TestQuerier_Select_AfterPromQL(t *testing.T) {
 			// Regression test 1 against https://github.com/thanos-io/thanos/issues/2890.
 			name: "when switching replicas don't miss samples when set with a big enough lookback delta",
 			storeAPI: newProxyStore(func() storepb.StoreServer {
-				s, err := store.NewLocalStoreFromJSONMmappableFile(logger, component.Debug, nil, "./testdata/issue2890-seriesresponses.json", store.ScanGRPCCurlProtoStreamMessages)
+				s, err := store.NewLocalStoreFromJSONMmappableFile(logger, component.Debug, nil, "./testdata/issue2890-seriesresponses.json", store.ScanGRPCCurlProtoStreamMessages, storepb.NewMatchersCache())
 				testutil.Ok(t, err)
 				return s
 			}()),
@@ -484,7 +484,7 @@ func TestQuerier_Select(t *testing.T) {
 		{
 			name: "realistic data with stale marker",
 			storeEndpoints: []storepb.StoreServer{func() storepb.StoreServer {
-				s, err := store.NewLocalStoreFromJSONMmappableFile(logger, component.Debug, nil, "./testdata/issue2401-seriesresponses.json", store.ScanGRPCCurlProtoStreamMessages)
+				s, err := store.NewLocalStoreFromJSONMmappableFile(logger, component.Debug, nil, "./testdata/issue2401-seriesresponses.json", store.ScanGRPCCurlProtoStreamMessages, storepb.NewMatchersCache())
 				testutil.Ok(t, err)
 				return s
 			}()},
@@ -528,7 +528,7 @@ func TestQuerier_Select(t *testing.T) {
 		{
 			name: "realistic data with stale marker with 100000 step",
 			storeEndpoints: []storepb.StoreServer{func() storepb.StoreServer {
-				s, err := store.NewLocalStoreFromJSONMmappableFile(logger, component.Debug, nil, "./testdata/issue2401-seriesresponses.json", store.ScanGRPCCurlProtoStreamMessages)
+				s, err := store.NewLocalStoreFromJSONMmappableFile(logger, component.Debug, nil, "./testdata/issue2401-seriesresponses.json", store.ScanGRPCCurlProtoStreamMessages, storepb.NewMatchersCache())
 				testutil.Ok(t, err)
 				return s
 			}()},
@@ -579,7 +579,7 @@ func TestQuerier_Select(t *testing.T) {
 			// Thanks to @Superq and GitLab for real data reproducing this.
 			name: "realistic data with stale marker with hints rate function",
 			storeEndpoints: []storepb.StoreServer{func() storepb.StoreServer {
-				s, err := store.NewLocalStoreFromJSONMmappableFile(logger, component.Debug, nil, "./testdata/issue2401-seriesresponses.json", store.ScanGRPCCurlProtoStreamMessages)
+				s, err := store.NewLocalStoreFromJSONMmappableFile(logger, component.Debug, nil, "./testdata/issue2401-seriesresponses.json", store.ScanGRPCCurlProtoStreamMessages, storepb.NewMatchersCache())
 				testutil.Ok(t, err)
 				return s
 			}()},
@@ -853,6 +853,7 @@ func newProxyStore(storeAPIs ...storepb.StoreServer) *store.ProxyStore {
 		nil,
 		0,
 		store.EagerRetrieval,
+		storepb.NewMatchersCache(),
 	)
 }
 
@@ -1061,7 +1062,7 @@ func (s *mockedSeriesIterator) Err() error { return nil }
 func TestQuerierWithDedupUnderstoodByPromQL_Rate(t *testing.T) {
 	logger := log.NewLogfmtLogger(os.Stderr)
 
-	s, err := store.NewLocalStoreFromJSONMmappableFile(logger, component.Debug, nil, "./testdata/issue2401-seriesresponses.json", store.ScanGRPCCurlProtoStreamMessages)
+	s, err := store.NewLocalStoreFromJSONMmappableFile(logger, component.Debug, nil, "./testdata/issue2401-seriesresponses.json", store.ScanGRPCCurlProtoStreamMessages, storepb.NewMatchersCache())
 	testutil.Ok(t, err)
 
 	t.Run("dedup=false", func(t *testing.T) {

--- a/pkg/query/query_test.go
+++ b/pkg/query/query_test.go
@@ -37,7 +37,7 @@ func TestQuerier_Proxy(t *testing.T) {
 			logger,
 			nil,
 			store.NewProxyStore(logger, nil, func() []store.Client { return clients },
-				component.Debug, nil, 5*time.Minute, store.EagerRetrieval),
+				component.Debug, nil, 5*time.Minute, store.EagerRetrieval, storepb.NewMatchersCache()),
 			1000000,
 			5*time.Minute,
 		)
@@ -51,7 +51,7 @@ func TestQuerier_Proxy(t *testing.T) {
 				// TODO(bwplotka): Parse external labels.
 				clients = append(clients, &storetestutil.TestClient{
 					Name:        fmt.Sprintf("store number %v", i),
-					StoreClient: storepb.ServerAsClient(selectedStore(store.NewTSDBStore(logger, st.storage.DB, component.Debug, nil), m, st.mint, st.maxt), 0),
+					StoreClient: storepb.ServerAsClient(selectedStore(store.NewTSDBStore(logger, st.storage.DB, component.Debug, nil, storepb.NewMatchersCache()), m, st.mint, st.maxt), 0),
 					MinTime:     st.mint,
 					MaxTime:     st.maxt,
 				})

--- a/pkg/receive/handler_test.go
+++ b/pkg/receive/handler_test.go
@@ -947,6 +947,7 @@ func benchmarkHandlerMultiTSDBReceiveRemoteWrite(b testutil.TB) {
 		nil,
 		false,
 		metadata.NoneFunc,
+		storepb.NewMatchersCache(),
 	)
 	defer func() { testutil.Ok(b, m.Close()) }()
 	handler.writer = NewWriter(logger, m, &WriterOptions{})

--- a/pkg/receive/multitsdb.go
+++ b/pkg/receive/multitsdb.go
@@ -56,6 +56,7 @@ type MultiTSDB struct {
 	tenants               map[string]*tenant
 	allowOutOfOrderUpload bool
 	hashFunc              metadata.HashFunc
+	matchersCache         *storepb.MatchersCache
 }
 
 // NewMultiTSDB creates new MultiTSDB.
@@ -70,6 +71,7 @@ func NewMultiTSDB(
 	bucket objstore.Bucket,
 	allowOutOfOrderUpload bool,
 	hashFunc metadata.HashFunc,
+	matchersCache *storepb.MatchersCache,
 ) *MultiTSDB {
 	if l == nil {
 		l = log.NewNopLogger()
@@ -87,6 +89,7 @@ func NewMultiTSDB(
 		bucket:                bucket,
 		allowOutOfOrderUpload: allowOutOfOrderUpload,
 		hashFunc:              hashFunc,
+		matchersCache:         matchersCache,
 	}
 }
 
@@ -571,7 +574,7 @@ func (t *MultiTSDB) startTSDB(logger log.Logger, tenantID string, tenant *tenant
 			t.hashFunc,
 		)
 	}
-	tenant.set(store.NewTSDBStore(logger, s, component.Receive, lset), s, ship, exemplars.NewTSDB(s, lset))
+	tenant.set(store.NewTSDBStore(logger, s, component.Receive, lset, t.matchersCache), s, ship, exemplars.NewTSDB(s, lset))
 	level.Info(logger).Log("msg", "TSDB is now ready")
 	return nil
 }

--- a/pkg/receive/multitsdb_test.go
+++ b/pkg/receive/multitsdb_test.go
@@ -51,6 +51,7 @@ func TestMultiTSDB(t *testing.T) {
 			nil,
 			false,
 			metadata.NoneFunc,
+			storepb.NewMatchersCache(),
 		)
 		defer func() { testutil.Ok(t, m.Close()) }()
 
@@ -135,6 +136,7 @@ func TestMultiTSDB(t *testing.T) {
 			nil,
 			false,
 			metadata.NoneFunc,
+			storepb.NewMatchersCache(),
 		)
 		defer func() { testutil.Ok(t, m.Close()) }()
 
@@ -178,6 +180,7 @@ func TestMultiTSDB(t *testing.T) {
 			nil,
 			false,
 			metadata.NoneFunc,
+			storepb.NewMatchersCache(),
 		)
 		defer func() { testutil.Ok(t, m.Close()) }()
 
@@ -445,6 +448,7 @@ func TestMultiTSDBPrune(t *testing.T) {
 				test.bucket,
 				false,
 				metadata.NoneFunc,
+				storepb.NewMatchersCache(),
 			)
 			defer func() { testutil.Ok(t, m.Close()) }()
 
@@ -506,6 +510,7 @@ func TestMultiTSDBRecreatePrunedTenant(t *testing.T) {
 		objstore.NewInMemBucket(),
 		false,
 		metadata.NoneFunc,
+		storepb.NewMatchersCache(),
 	)
 	defer func() { testutil.Ok(t, m.Close()) }()
 
@@ -560,6 +565,7 @@ func TestMultiTSDBStats(t *testing.T) {
 				nil,
 				false,
 				metadata.NoneFunc,
+				storepb.NewMatchersCache(),
 			)
 			defer func() { testutil.Ok(t, m.Close()) }()
 
@@ -589,6 +595,7 @@ func TestMultiTSDBWithNilStore(t *testing.T) {
 		nil,
 		false,
 		metadata.NoneFunc,
+		storepb.NewMatchersCache(),
 	)
 	defer func() { testutil.Ok(t, m.Close()) }()
 
@@ -630,6 +637,7 @@ func TestProxyLabelValues(t *testing.T) {
 		nil,
 		false,
 		metadata.NoneFunc,
+		storepb.NewMatchersCache(),
 	)
 	defer func() { testutil.Ok(t, m.Close()) }()
 
@@ -693,7 +701,7 @@ func queryLabelValues(ctx context.Context, m *MultiTSDB) error {
 			clients[0] = &slowClient{clients[0]}
 		}
 		return clients
-	}, component.Store, nil, 1*time.Minute, store.LazyRetrieval)
+	}, component.Store, nil, 1*time.Minute, store.LazyRetrieval, storepb.NewMatchersCache())
 
 	req := &storepb.LabelValuesRequest{
 		Label: labels.MetricName,
@@ -720,6 +728,7 @@ func BenchmarkMultiTSDB(b *testing.B) {
 		nil,
 		false,
 		metadata.NoneFunc,
+		storepb.NewMatchersCache(),
 	)
 	defer func() { testutil.Ok(b, m.Close()) }()
 

--- a/pkg/receive/writer_test.go
+++ b/pkg/receive/writer_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/thanos-io/thanos/pkg/block/metadata"
 	"github.com/thanos-io/thanos/pkg/runutil"
 	"github.com/thanos-io/thanos/pkg/store/labelpb"
+	"github.com/thanos-io/thanos/pkg/store/storepb"
 	"github.com/thanos-io/thanos/pkg/store/storepb/prompb"
 )
 
@@ -320,6 +321,7 @@ func TestWriter(t *testing.T) {
 				nil,
 				false,
 				metadata.NoneFunc,
+				storepb.NewMatchersCache(),
 			)
 			t.Cleanup(func() { testutil.Ok(t, m.Close()) })
 
@@ -412,6 +414,7 @@ func benchmarkWriter(b *testing.B, labelsNum int, seriesNum int, generateHistogr
 		nil,
 		false,
 		metadata.NoneFunc,
+		storepb.NewMatchersCache(),
 	)
 	b.Cleanup(func() { testutil.Ok(b, m.Close()) })
 

--- a/pkg/store/bucket_e2e_test.go
+++ b/pkg/store/bucket_e2e_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/thanos-io/objstore/objtesting"
 
 	"github.com/efficientgo/core/testutil"
+
 	"github.com/thanos-io/thanos/pkg/block"
 	"github.com/thanos-io/thanos/pkg/block/metadata"
 	"github.com/thanos-io/thanos/pkg/model"
@@ -164,6 +165,7 @@ func prepareStoreWithTestBlocks(t testing.TB, dir string, bkt objstore.Bucket, m
 		true,
 		true,
 		time.Minute,
+		storepb.NewMatchersCache(),
 		WithLogger(s.logger),
 		WithIndexCache(s.cache),
 		WithFilterConfig(filterConf),

--- a/pkg/store/bucket_test.go
+++ b/pkg/store/bucket_test.go
@@ -656,6 +656,7 @@ func TestBucketStore_Info(t *testing.T) {
 		false,
 		false,
 		0,
+		storepb.NewMatchersCache(),
 		WithChunkPool(chunkPool),
 		WithFilterConfig(allowAllFilterConf),
 	)
@@ -898,6 +899,7 @@ func testSharding(t *testing.T, reuseDisk string, bkt objstore.Bucket, all ...ul
 				false,
 				false,
 				0,
+				storepb.NewMatchersCache(),
 				WithLogger(logger),
 				WithFilterConfig(allowAllFilterConf),
 			)
@@ -1357,6 +1359,7 @@ func benchBucketSeries(t testutil.TB, sampleType chunkenc.ValueType, skipChunk b
 		false,
 		false,
 		0,
+		storepb.NewMatchersCache(),
 		WithLogger(logger),
 		WithChunkPool(chunkPool),
 	)
@@ -1569,6 +1572,7 @@ func TestBucketSeries_OneBlock_InMemIndexCacheSegfault(t *testing.T) {
 			b1.meta.ULID: b1,
 			b2.meta.ULID: b2,
 		},
+		matchersCache:        storepb.NewMatchersCache(),
 		queryGate:            gate.NewNoop(),
 		chunksLimiterFactory: NewChunksLimiterFactory(0),
 		seriesLimiterFactory: NewSeriesLimiterFactory(0),
@@ -1728,6 +1732,7 @@ func TestSeries_ErrorUnmarshallingRequestHints(t *testing.T) {
 		true,
 		false,
 		0,
+		storepb.NewMatchersCache(),
 		WithLogger(logger),
 		WithIndexCache(indexCache),
 	)
@@ -1819,6 +1824,7 @@ func TestSeries_BlockWithMultipleChunks(t *testing.T) {
 		true,
 		false,
 		0,
+		storepb.NewMatchersCache(),
 		WithLogger(logger),
 		WithIndexCache(indexCache),
 	)
@@ -2001,6 +2007,7 @@ func setupStoreForHintsTest(t *testing.T) (testutil.TB, *BucketStore, []*storepb
 		true,
 		false,
 		0,
+		storepb.NewMatchersCache(),
 		WithLogger(logger),
 		WithIndexCache(indexCache),
 	)
@@ -2217,6 +2224,7 @@ func TestSeries_ChunksHaveHashRepresentation(t *testing.T) {
 		true,
 		false,
 		0,
+		storepb.NewMatchersCache(),
 		WithLogger(logger),
 		WithIndexCache(indexCache),
 	)
@@ -2429,6 +2437,7 @@ func benchmarkBlockSeriesWithConcurrency(b *testing.B, concurrency int, blockMet
 	wg := sync.WaitGroup{}
 	wg.Add(concurrency)
 
+	matchersCache := storepb.NewMatchersCache()
 	for w := 0; w < concurrency; w++ {
 		go func() {
 			defer wg.Done()
@@ -2449,7 +2458,7 @@ func benchmarkBlockSeriesWithConcurrency(b *testing.B, concurrency int, blockMet
 					Aggregates: aggrs,
 				}
 
-				matchers, err := storepb.MatchersToPromMatchers(req.Matchers...)
+				matchers, err := storepb.MatchersToPromMatchers(matchersCache, req.Matchers...)
 				// TODO FIXME! testutil.Ok calls b.Fatalf under the hood, which
 				// must be called only from the goroutine running the Benchmark function.
 				testutil.Ok(b, err)

--- a/pkg/store/local.go
+++ b/pkg/store/local.go
@@ -30,8 +30,9 @@ import (
 // Inefficient implementation for quick StoreAPI view.
 // Chunk order is exactly the same as in a given file.
 type LocalStore struct {
-	logger    log.Logger
-	extLabels labels.Labels
+	logger        log.Logger
+	extLabels     labels.Labels
+	matchersCache *storepb.MatchersCache
 
 	info *storepb.InfoResponse
 	c    io.Closer
@@ -52,6 +53,7 @@ func NewLocalStoreFromJSONMmappableFile(
 	extLabels labels.Labels,
 	path string,
 	split bufio.SplitFunc,
+	matchersCache *storepb.MatchersCache,
 ) (*LocalStore, error) {
 	f, err := fileutil.OpenMmapFile(path)
 	if err != nil {
@@ -64,9 +66,10 @@ func NewLocalStoreFromJSONMmappableFile(
 	}()
 
 	s := &LocalStore{
-		logger:    logger,
-		extLabels: extLabels,
-		c:         f,
+		logger:        logger,
+		extLabels:     extLabels,
+		c:             f,
+		matchersCache: matchersCache,
 		info: &storepb.InfoResponse{
 			LabelSets: []labelpb.ZLabelSet{
 				{Labels: labelpb.ZLabelsFromPromLabels(extLabels)},
@@ -151,7 +154,7 @@ func (s *LocalStore) Info(_ context.Context, _ *storepb.InfoRequest) (*storepb.I
 // Series returns all series for a requested time range and label matcher. The returned data may
 // exceed the requested time bounds.
 func (s *LocalStore) Series(r *storepb.SeriesRequest, srv storepb.Store_SeriesServer) error {
-	match, matchers, err := matchesExternalLabels(r.Matchers, s.extLabels)
+	match, matchers, err := matchesExternalLabels(s.matchersCache, r.Matchers, s.extLabels)
 	if err != nil {
 		return status.Error(codes.InvalidArgument, err.Error())
 	}

--- a/pkg/store/prometheus_test.go
+++ b/pkg/store/prometheus_test.go
@@ -67,7 +67,7 @@ func testPrometheusStoreSeriesE2e(t *testing.T, prefix string) {
 	limitMinT := int64(0)
 	proxy, err := NewPrometheusStore(nil, nil, promclient.NewDefaultClient(), u, component.Sidecar,
 		func() labels.Labels { return labels.FromStrings("region", "eu-west") },
-		func() (int64, int64) { return limitMinT, -1 }, nil) // MaxTime does not matter.
+		func() (int64, int64) { return limitMinT, -1 }, nil, storepb.NewMatchersCache()) // MaxTime does not matter.
 	testutil.Ok(t, err)
 
 	// Query all three samples except for the first one. Since we round up queried data
@@ -194,7 +194,7 @@ func TestPrometheusStore_SeriesLabels_e2e(t *testing.T) {
 
 	promStore, err := NewPrometheusStore(nil, nil, promclient.NewDefaultClient(), u, component.Sidecar,
 		func() labels.Labels { return labels.FromStrings("region", "eu-west") },
-		func() (int64, int64) { return math.MinInt64/1000 + 62135596801, math.MaxInt64/1000 - 62135596801 }, nil)
+		func() (int64, int64) { return math.MinInt64/1000 + 62135596801, math.MaxInt64/1000 - 62135596801 }, nil, storepb.NewMatchersCache())
 	testutil.Ok(t, err)
 
 	for _, tcase := range []struct {
@@ -364,7 +364,7 @@ func TestPrometheusStore_LabelAPIs(t *testing.T) {
 
 		promStore, err := NewPrometheusStore(nil, nil, promclient.NewDefaultClient(), u, component.Sidecar, func() labels.Labels {
 			return extLset
-		}, nil, func() string { return version })
+		}, nil, func() string { return version }, storepb.NewMatchersCache())
 		testutil.Ok(t, err)
 
 		return promStore
@@ -399,7 +399,7 @@ func TestPrometheusStore_Series_MatchExternalLabel(t *testing.T) {
 
 	proxy, err := NewPrometheusStore(nil, nil, promclient.NewDefaultClient(), u, component.Sidecar,
 		func() labels.Labels { return labels.FromStrings("region", "eu-west") },
-		func() (int64, int64) { return 0, math.MaxInt64 }, nil)
+		func() (int64, int64) { return 0, math.MaxInt64 }, nil, storepb.NewMatchersCache())
 	testutil.Ok(t, err)
 	srv := newStoreSeriesServer(ctx)
 
@@ -461,7 +461,7 @@ func TestPrometheusStore_Series_ChunkHashCalculation_Integration(t *testing.T) {
 
 	proxy, err := NewPrometheusStore(nil, nil, promclient.NewDefaultClient(), u, component.Sidecar,
 		func() labels.Labels { return labels.FromStrings("region", "eu-west") },
-		func() (int64, int64) { return 0, math.MaxInt64 }, nil)
+		func() (int64, int64) { return 0, math.MaxInt64 }, nil, storepb.NewMatchersCache())
 	testutil.Ok(t, err)
 	srv := newStoreSeriesServer(ctx)
 
@@ -490,7 +490,7 @@ func TestPrometheusStore_Info(t *testing.T) {
 
 	proxy, err := NewPrometheusStore(nil, nil, promclient.NewDefaultClient(), nil, component.Sidecar,
 		func() labels.Labels { return labels.FromStrings("region", "eu-west") },
-		func() (int64, int64) { return 123, 456 }, nil)
+		func() (int64, int64) { return 123, 456 }, nil, storepb.NewMatchersCache())
 	testutil.Ok(t, err)
 
 	resp, err := proxy.Info(ctx, &storepb.InfoRequest{})
@@ -568,7 +568,7 @@ func TestPrometheusStore_Series_SplitSamplesIntoChunksWithMaxSizeOf120(t *testin
 
 		proxy, err := NewPrometheusStore(nil, nil, promclient.NewDefaultClient(), u, component.Sidecar,
 			func() labels.Labels { return labels.FromStrings("region", "eu-west") },
-			func() (int64, int64) { return 0, math.MaxInt64 }, nil)
+			func() (int64, int64) { return 0, math.MaxInt64 }, nil, storepb.NewMatchersCache())
 		testutil.Ok(t, err)
 
 		// We build chunks only for SAMPLES method. Make sure we ask for SAMPLES only.

--- a/pkg/store/proxy.go
+++ b/pkg/store/proxy.go
@@ -72,6 +72,7 @@ type ProxyStore struct {
 	component      component.StoreAPI
 	selectorLabels labels.Labels
 	buffers        sync.Pool
+	matchersCache  *storepb.MatchersCache
 
 	responseTimeout   time.Duration
 	metrics           *proxyStoreMetrics
@@ -120,6 +121,7 @@ func NewProxyStore(
 	selectorLabels labels.Labels,
 	responseTimeout time.Duration,
 	retrievalStrategy RetrievalStrategy,
+	matchersCache *storepb.MatchersCache,
 	options ...ProxyStoreOption,
 ) *ProxyStore {
 	if logger == nil {
@@ -136,6 +138,7 @@ func NewProxyStore(
 			b := make([]byte, 0, initialBufSize)
 			return &b
 		}},
+		matchersCache:     matchersCache,
 		responseTimeout:   responseTimeout,
 		metrics:           metrics,
 		retrievalStrategy: retrievalStrategy,
@@ -259,7 +262,7 @@ func (s *ProxyStore) Series(originalRequest *storepb.SeriesRequest, srv storepb.
 	// tiggered by tracing span to reduce cognitive load.
 	reqLogger := log.With(s.logger, "component", "proxy", "request", originalRequest.String())
 
-	match, matchers, err := matchesExternalLabels(originalRequest.Matchers, s.selectorLabels)
+	match, matchers, err := matchesExternalLabels(s.matchersCache, originalRequest.Matchers, s.selectorLabels)
 	if err != nil {
 		return status.Error(codes.InvalidArgument, err.Error())
 	}

--- a/pkg/store/storepb/custom.go
+++ b/pkg/store/storepb/custom.go
@@ -376,30 +376,34 @@ func PromMatchersToMatchers(ms ...*labels.Matcher) ([]LabelMatcher, error) {
 
 // MatchersToPromMatchers returns Prometheus matchers from proto matchers.
 // NOTE: It allocates memory.
-func MatchersToPromMatchers(ms ...LabelMatcher) ([]*labels.Matcher, error) {
+func MatchersToPromMatchers(cache *MatchersCache, ms ...LabelMatcher) ([]*labels.Matcher, error) {
 	res := make([]*labels.Matcher, 0, len(ms))
 	for _, m := range ms {
-		var t labels.MatchType
-
-		switch m.Type {
-		case LabelMatcher_EQ:
-			t = labels.MatchEqual
-		case LabelMatcher_NEQ:
-			t = labels.MatchNotEqual
-		case LabelMatcher_RE:
-			t = labels.MatchRegexp
-		case LabelMatcher_NRE:
-			t = labels.MatchNotRegexp
-		default:
-			return nil, errors.Errorf("unrecognized label matcher type %d", m.Type)
-		}
-		m, err := labels.NewMatcher(t, m.Name, m.Value)
+		m, err := cache.GetOrSet(m, MatcherToPromMatcher)
 		if err != nil {
 			return nil, err
 		}
 		res = append(res, m)
 	}
 	return res, nil
+}
+
+func MatcherToPromMatcher(m LabelMatcher) (*labels.Matcher, error) {
+	var t labels.MatchType
+
+	switch m.Type {
+	case LabelMatcher_EQ:
+		t = labels.MatchEqual
+	case LabelMatcher_NEQ:
+		t = labels.MatchNotEqual
+	case LabelMatcher_RE:
+		t = labels.MatchRegexp
+	case LabelMatcher_NRE:
+		t = labels.MatchNotRegexp
+	default:
+		return nil, errors.Errorf("unrecognized label matcher type %d", m.Type)
+	}
+	return labels.NewMatcher(t, m.Name, m.Value)
 }
 
 // MatchersToString converts label matchers to string format.

--- a/pkg/store/storepb/custom_test.go
+++ b/pkg/store/storepb/custom_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
 
 	"github.com/efficientgo/core/testutil"
+
 	"github.com/thanos-io/thanos/pkg/store/labelpb"
 )
 
@@ -466,6 +467,7 @@ func benchmarkMergedSeriesSet(b testutil.TB, overlappingChunks bool) {
 }
 
 func TestMatchersToString_Translate(t *testing.T) {
+	cache := NewMatchersCache()
 	for _, c := range []struct {
 		ms       []LabelMatcher
 		expected string
@@ -508,7 +510,7 @@ func TestMatchersToString_Translate(t *testing.T) {
 		t.Run(c.expected, func(t *testing.T) {
 			testutil.Equals(t, c.expected, MatchersToString(c.ms...))
 
-			promMs, err := MatchersToPromMatchers(c.ms...)
+			promMs, err := MatchersToPromMatchers(cache, c.ms...)
 			testutil.Ok(t, err)
 
 			testutil.Equals(t, c.expected, PromMatchersToString(promMs...))

--- a/pkg/store/storepb/matchers_cache.go
+++ b/pkg/store/storepb/matchers_cache.go
@@ -1,0 +1,105 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package storepb
+
+import (
+	"sync"
+	"time"
+
+	"github.com/prometheus/prometheus/model/labels"
+)
+
+const CachedMatcherTTL = 5 * time.Minute
+
+type NewItemFunc func(matcher LabelMatcher) (*labels.Matcher, error)
+
+type itemExpiration struct {
+	mu        sync.Mutex
+	expiresAt time.Time
+}
+
+func (e *itemExpiration) setExpiration(t time.Time) {
+	e.mu.Lock()
+	e.expiresAt = t
+	e.mu.Unlock()
+}
+
+func newExpiration(expiresAt time.Time) *itemExpiration {
+	return &itemExpiration{
+		expiresAt: expiresAt,
+	}
+}
+
+type MatchersCache struct {
+	mu       sync.RWMutex
+	ttl      time.Duration
+	now      func() time.Time
+	itemTTLs map[LabelMatcher]*itemExpiration
+	cache    map[LabelMatcher]*labels.Matcher
+}
+
+type MatcherCacheOption func(*MatchersCache)
+
+func WithNowFunc(now func() time.Time) MatcherCacheOption {
+	return func(c *MatchersCache) {
+		c.now = now
+	}
+}
+
+func NewMatchersCache(opts ...MatcherCacheOption) *MatchersCache {
+	cache := &MatchersCache{
+		now: time.Now,
+		mu:  sync.RWMutex{},
+		// This TTL should be sufficient to allow caching matchers for alerting queries.
+		ttl:      CachedMatcherTTL,
+		itemTTLs: make(map[LabelMatcher]*itemExpiration),
+		cache:    make(map[LabelMatcher]*labels.Matcher),
+	}
+
+	for _, opt := range opts {
+		opt(cache)
+	}
+	return cache
+}
+
+func (c *MatchersCache) GetOrSet(key LabelMatcher, newItem NewItemFunc) (*labels.Matcher, error) {
+	expirationTime := c.now().Add(c.ttl)
+
+	c.mu.RLock()
+	if item, ok := c.cache[key]; ok {
+		c.itemTTLs[key].setExpiration(expirationTime)
+		c.mu.RUnlock()
+		return item, nil
+	}
+	c.mu.RUnlock()
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if item, ok := c.cache[key]; ok {
+		c.itemTTLs[key].setExpiration(expirationTime)
+		return item, nil
+	}
+
+	item, err := newItem(key)
+	if err != nil {
+		return nil, err
+	}
+	c.cache[key] = item
+	c.itemTTLs[key] = newExpiration(expirationTime)
+	return item, nil
+}
+
+func (c *MatchersCache) RemoveExpired() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	now := c.now()
+	for key, expiration := range c.itemTTLs {
+		if expiration.expiresAt.Before(now) {
+			delete(c.cache, key)
+			delete(c.itemTTLs, key)
+		}
+	}
+}

--- a/pkg/store/storepb/matchers_cache_test.go
+++ b/pkg/store/storepb/matchers_cache_test.go
@@ -1,0 +1,55 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package storepb_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/efficientgo/core/testutil"
+	"github.com/prometheus/prometheus/model/labels"
+
+	"github.com/thanos-io/thanos/pkg/store/storepb"
+)
+
+func TestMatchersCache(t *testing.T) {
+	now := time.Now()
+	nowFunc := func() time.Time {
+		return now
+	}
+	cache := storepb.NewMatchersCache(storepb.WithNowFunc(nowFunc))
+
+	matcher := storepb.LabelMatcher{
+		Type:  storepb.LabelMatcher_EQ,
+		Name:  "key",
+		Value: "val",
+	}
+
+	var cacheHit bool
+	newItem := func(matcher storepb.LabelMatcher) (*labels.Matcher, error) {
+		cacheHit = false
+		return storepb.MatcherToPromMatcher(matcher)
+
+	}
+	expected := labels.MustNewMatcher(labels.MatchEqual, "key", "val")
+
+	item, err := cache.GetOrSet(matcher, newItem)
+	testutil.Ok(t, err)
+	testutil.Equals(t, false, cacheHit)
+	testutil.Equals(t, expected, item)
+
+	cacheHit = true
+	item, err = cache.GetOrSet(matcher, newItem)
+	testutil.Ok(t, err)
+	testutil.Equals(t, true, cacheHit)
+	testutil.Equals(t, expected, item)
+
+	cacheHit = true
+	now = now.Add(storepb.CachedMatcherTTL + time.Second)
+	cache.RemoveExpired()
+	item, err = cache.GetOrSet(matcher, newItem)
+	testutil.Ok(t, err)
+	testutil.Equals(t, false, cacheHit)
+	testutil.Equals(t, expected, item)
+}


### PR DESCRIPTION
Creating Prometheus matchers from protobuf matchers is a CPU intensive process when the matcher includes a regular expression.

This commit adds a matchers cache from protobuf matcher to Prometheus matcher which is used to reduce the time spent doing this conversion.

For the time being, the cache has a TTL of 5 minutes, which should be sufficient to cover most alerting scenarios.

CPU usage in our staging environment dropped by 50% due to the large amount of alerting rules we have.

<img width="1830" alt="image" src="https://user-images.githubusercontent.com/1286231/236818025-1f0c6b66-ad8c-498c-bb68-43c864754dd5.png">

Fixes https://github.com/thanos-io/thanos/issues/6333.

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

* Cache matchers in all stores between `Series` invocations.
 
## Verification

Unit tests and testing in staging.