### PR TITLE
compact: native histogram support for downsampling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#6163](https://github.com/thanos-io/thanos/pull/6163) Receiver: changed default max backoff from 30s to 5s for forwarding requests. Can be configured with `--receive-forward-max-backoff`.
 - [#6327](https://github.com/thanos-io/thanos/pull/6327) *: *breaking :warning:* Use histograms instead of summaries for instrumented handlers.
 - [#6322](https://github.com/thanos-io/thanos/pull/6322) Logging: Avoid expensive log.Valuer evaluation for disallowed levels.
+- [#6350] https://github.com/thanos-io/thanos/pull/6350 Compact: Add native histogram support for downsampling.
 - [#6358](https://github.com/thanos-io/thanos/pull/6358) Query: Add +Inf bucket to query duration metrics
 - [#6363](https://github.com/thanos-io/thanos/pull/6363) Store: Check context error when expanding postings.
 - [#6405](https://github.com/thanos-io/thanos/pull/6405) Index Cache: Change postings cache key to include the encoding format used so that older Thanos versions would not try to decode it during the deployment of a new version.

--- a/pkg/compact/downsample/aggr_test.go
+++ b/pkg/compact/downsample/aggr_test.go
@@ -14,11 +14,11 @@ import (
 func TestAggrChunk(t *testing.T) {
 	var input [5][]sample
 
-	input[AggrCount] = []sample{{100, 30}, {200, 50}, {300, 60}, {400, 67}}
-	input[AggrSum] = []sample{{100, 130}, {200, 1000}, {300, 2000}, {400, 5555}}
-	input[AggrMin] = []sample{{100, 0}, {200, -10}, {300, 1000}, {400, -9.5}}
+	input[AggrCount] = []sample{{t: 100, v: 30}, {t: 200, v: 50}, {t: 300, v: 60}, {t: 400, v: 67}}
+	input[AggrSum] = []sample{{t: 100, v: 130}, {t: 200, v: 1000}, {t: 300, v: 2000}, {t: 400, v: 5555}}
+	input[AggrMin] = []sample{{t: 100}, {t: 200, v: -10}, {t: 300, v: 1000}, {t: 400, v: -9.5}}
 	// Maximum is absent.
-	input[AggrCounter] = []sample{{100, 5}, {200, 10}, {300, 10.1}, {400, 15}, {400, 3}}
+	input[AggrCounter] = []sample{{t: 100, v: 5}, {t: 200, v: 10}, {t: 300, v: 10.1}, {t: 400, v: 15}, {t: 400, v: 3}}
 
 	var chks [5]chunkenc.Chunk
 
@@ -41,7 +41,7 @@ func TestAggrChunk(t *testing.T) {
 	for _, at := range []AggrType{AggrCount, AggrSum, AggrMin, AggrMax, AggrCounter} {
 		if c, err := ac.Get(at); err != ErrAggrNotExist {
 			testutil.Ok(t, err)
-			testutil.Ok(t, expandChunkIterator(c.Iterator(nil), &res[at]))
+			testutil.Ok(t, expandXorChunkIterator(c.Iterator(nil), &res[at]))
 		}
 	}
 	testutil.Equals(t, input, res)

--- a/pkg/compact/downsample/downsample.go
+++ b/pkg/compact/downsample/downsample.go
@@ -356,7 +356,7 @@ func (h *histogramAggregator) add(s sample) {
 	}
 
 	if h.total > 0 {
-		if fh.DetectReset(h.previous) {
+		if fh.CounterResetHint != histogram.GaugeType && fh.DetectReset(h.previous) {
 			// Counter reset, correct the value.
 			h.counter.Add(fh)
 			h.resets++

--- a/pkg/compact/downsample/downsample.go
+++ b/pkg/compact/downsample/downsample.go
@@ -1200,7 +1200,7 @@ func (it *AverageChunkIterator) Next() chunkenc.ValueType {
 
 	if st == chunkenc.ValFloatHistogram {
 		_, sumV := it.sumIt.AtFloatHistogram()
-		it.fh = sumV.Scale(1 / cntV)
+		it.fh = sumV.Mul(1 / cntV)
 		return chunkenc.ValFloatHistogram
 	}
 

--- a/pkg/compact/downsample/downsample_test.go
+++ b/pkg/compact/downsample/downsample_test.go
@@ -1039,26 +1039,6 @@ func blockFromChunks(chks []chunks.Meta) *memBlock {
 	return mb
 }
 
-func chunkFromSamples(t *testing.T, samples []sample) chunks.Meta {
-	if len(samples) == 0 {
-		return chunks.Meta{}
-	}
-
-	chk := chunkenc.NewXORChunk()
-	app, err := chk.Appender()
-	testutil.Ok(t, err)
-
-	for _, s := range samples {
-		app.Append(s.t, s.v)
-	}
-
-	return chunks.Meta{
-		MinTime: samples[0].t,
-		MaxTime: samples[len(samples)-1].t,
-		Chunk:   chk,
-	}
-}
-
 func chunksFromHistogramSamples(t *testing.T, samples []sample) []chunks.Meta {
 	if len(samples) == 0 {
 		return nil

--- a/pkg/compact/downsample/testutils.go
+++ b/pkg/compact/downsample/testutils.go
@@ -1,0 +1,71 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package downsample
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/efficientgo/core/testutil"
+	"github.com/oklog/ulid"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/tsdb/chunkenc"
+	"github.com/prometheus/prometheus/tsdb/chunks"
+	"github.com/prometheus/prometheus/tsdb/index"
+	"github.com/thanos-io/thanos/pkg/block"
+	"github.com/thanos-io/thanos/pkg/block/metadata"
+)
+
+func GetMetaAndChunks(t *testing.T, dir string, id ulid.ULID) (*metadata.Meta, []chunks.Meta) {
+	newMeta, err := metadata.ReadFromDir(filepath.Join(dir, id.String()))
+	testutil.Ok(t, err)
+
+	indexr, err := index.NewFileReader(filepath.Join(dir, id.String(), block.IndexFilename))
+	testutil.Ok(t, err)
+	defer func() { testutil.Ok(t, indexr.Close()) }()
+
+	pall, err := indexr.Postings(index.AllPostingsKey())
+	testutil.Ok(t, err)
+
+	var series []storage.SeriesRef
+	for pall.Next() {
+		series = append(series, pall.At())
+	}
+	testutil.Ok(t, pall.Err())
+
+	var chks []chunks.Meta
+	var builder labels.ScratchBuilder
+	testutil.Ok(t, indexr.Series(series[0], &builder, &chks))
+
+	return newMeta, chks
+}
+
+func GetAggregateFromChunk(t *testing.T, chunkr *chunks.Reader, c chunks.Meta, aggrType AggrType) []sample {
+	chk, err := chunkr.Chunk(c)
+	testutil.Ok(t, err)
+
+	ac, ok := chk.(*AggrChunk)
+	testutil.Assert(t, ok)
+
+	var samples []sample
+
+	subChunk, err := ac.Get(aggrType)
+	testutil.Ok(t, err)
+	it := subChunk.Iterator(nil)
+	for valueType := it.Next(); valueType != chunkenc.ValNone; valueType = it.Next() {
+		switch valueType {
+		case chunkenc.ValFloat:
+			t, v := it.At()
+			samples = append(samples, sample{t: t, v: v})
+		case chunkenc.ValFloatHistogram:
+			t, fh := it.AtFloatHistogram()
+			samples = append(samples, sample{t: t, fh: fh})
+		default:
+			t.Fatalf("unexpected value type %v", valueType)
+		}
+	}
+
+	return samples
+}

--- a/pkg/store/bucket_test.go
+++ b/pkg/store/bucket_test.go
@@ -1102,7 +1102,7 @@ func uploadTestBlock(t testing.TB, tmpDir string, bkt objstore.Bucket, series in
 	appendTestData(t, h.Appender(context.Background()), series)
 
 	testutil.Ok(t, os.MkdirAll(filepath.Join(tmpDir, "tmp"), os.ModePerm))
-	id := createBlockFromHead(t, filepath.Join(tmpDir, "tmp"), h)
+	id := storetestutil.CreateBlockFromHead(t, filepath.Join(tmpDir, "tmp"), h)
 
 	_, err = metadata.InjectThanos(log.NewNopLogger(), filepath.Join(tmpDir, "tmp", id.String()), metadata.Thanos{
 		Labels:     labels.Labels{{Name: "ext1", Value: "1"}}.Map(),
@@ -1136,19 +1136,6 @@ func appendTestData(t testing.TB, app storage.Appender, series int) {
 		}
 	}
 	testutil.Ok(t, app.Commit())
-}
-
-func createBlockFromHead(t testing.TB, dir string, head *tsdb.Head) ulid.ULID {
-	compactor, err := tsdb.NewLeveledCompactor(context.Background(), nil, log.NewNopLogger(), []int64{1000000}, nil, nil)
-	testutil.Ok(t, err)
-
-	testutil.Ok(t, os.MkdirAll(dir, 0777))
-
-	// Add +1 millisecond to block maxt because block intervals are half-open: [b.MinTime, b.MaxTime).
-	// Because of this block intervals are always +1 than the total samples it includes.
-	ulid, err := compactor.Write(dir, head, head.MinTime(), head.MaxTime()+1, nil)
-	testutil.Ok(t, err)
-	return ulid
 }
 
 // Very similar benchmark to ths: https://github.com/prometheus/prometheus/blob/1d1732bc25cc4b47f513cb98009a4eb91879f175/tsdb/querier_bench_test.go#L82,
@@ -1353,7 +1340,7 @@ func benchBucketSeries(t testutil.TB, sampleType chunkenc.ValueType, skipChunk b
 			SkipChunks:       t.IsBenchmark() || skipChunk,
 			SampleType:       sampleType,
 		})
-		id := createBlockFromHead(t, blockDir, head)
+		id := storetestutil.CreateBlockFromHead(t, blockDir, head)
 		testutil.Ok(t, head.Close())
 
 		// Histogram chunks are represented differently in memory and on disk. In order to
@@ -1554,7 +1541,7 @@ func TestBucketSeries_OneBlock_InMemIndexCacheSegfault(t *testing.T) {
 		testutil.Ok(t, app.Commit())
 
 		blockDir := filepath.Join(tmpDir, "tmp")
-		id := createBlockFromHead(t, blockDir, h)
+		id := storetestutil.CreateBlockFromHead(t, blockDir, h)
 
 		meta, err := metadata.InjectThanos(log.NewNopLogger(), filepath.Join(blockDir, id.String()), thanosMeta, nil)
 		testutil.Ok(t, err)
@@ -1595,7 +1582,7 @@ func TestBucketSeries_OneBlock_InMemIndexCacheSegfault(t *testing.T) {
 		testutil.Ok(t, app.Commit())
 
 		blockDir := filepath.Join(tmpDir, "tmp2")
-		id := createBlockFromHead(t, blockDir, h)
+		id := storetestutil.CreateBlockFromHead(t, blockDir, h)
 
 		meta, err := metadata.InjectThanos(log.NewNopLogger(), filepath.Join(blockDir, id.String()), thanosMeta, nil)
 		testutil.Ok(t, err)
@@ -1888,7 +1875,7 @@ func TestSeries_BlockWithMultipleChunks(t *testing.T) {
 		testutil.Ok(t, app.Commit())
 	}
 
-	blk := createBlockFromHead(t, headOpts.ChunkDirRoot, h)
+	blk := storetestutil.CreateBlockFromHead(t, headOpts.ChunkDirRoot, h)
 
 	thanosMeta := metadata.Thanos{
 		Labels:     labels.Labels{{Name: "ext1", Value: "1"}}.Map(),
@@ -2201,7 +2188,7 @@ func createBlockWithOneSeriesWithStep(t testutil.TB, dir string, lbls labels.Lab
 	}
 	testutil.Ok(t, app.Commit())
 
-	return createBlockFromHead(t, dir, h)
+	return storetestutil.CreateBlockFromHead(t, dir, h)
 }
 
 func setupStoreForHintsTest(t *testing.T) (testutil.TB, *BucketStore, []*storepb.Series, []*storepb.Series, ulid.ULID, ulid.ULID, func()) {
@@ -2238,7 +2225,7 @@ func setupStoreForHintsTest(t *testing.T) (testutil.TB, *BucketStore, []*storepb
 		PrependLabels:    extLset,
 		Random:           random,
 	})
-	block1 := createBlockFromHead(t, bktDir, head)
+	block1 := storetestutil.CreateBlockFromHead(t, bktDir, head)
 	testutil.Ok(t, head.Close())
 	head2, seriesSet2 := storetestutil.CreateHeadWithSeries(t, 1, storetestutil.HeadGenOptions{
 		TSDBDir:          filepath.Join(tmpDir, "1"),
@@ -2247,7 +2234,7 @@ func setupStoreForHintsTest(t *testing.T) (testutil.TB, *BucketStore, []*storepb
 		PrependLabels:    extLset,
 		Random:           random,
 	})
-	block2 := createBlockFromHead(t, bktDir, head2)
+	block2 := storetestutil.CreateBlockFromHead(t, bktDir, head2)
 	testutil.Ok(t, head2.Close())
 
 	for _, blockID := range []ulid.ULID{block1, block2} {
@@ -2450,7 +2437,7 @@ func TestSeries_ChunksHaveHashRepresentation(t *testing.T) {
 	}
 	testutil.Ok(t, app.Commit())
 
-	blk := createBlockFromHead(t, headOpts.ChunkDirRoot, h)
+	blk := storetestutil.CreateBlockFromHead(t, headOpts.ChunkDirRoot, h)
 
 	thanosMeta := metadata.Thanos{
 		Labels:     labels.Labels{{Name: "ext1", Value: "1"}}.Map(),
@@ -2614,7 +2601,7 @@ func BenchmarkBucketBlock_readChunkRange(b *testing.B) {
 }
 
 func BenchmarkBlockSeries(b *testing.B) {
-	blk, blockMeta := prepareBucket(b, compact.ResolutionLevelRaw)
+	blk, blockMeta := prepareBucket(b, compact.ResolutionLevelRaw, chunkenc.ValFloat)
 
 	aggrs := []storepb.Aggr{storepb.Aggr_RAW}
 	for _, concurrency := range []int{1, 2, 4, 8, 16, 32} {
@@ -2624,7 +2611,7 @@ func BenchmarkBlockSeries(b *testing.B) {
 	}
 }
 
-func prepareBucket(b *testing.B, resolutionLevel compact.ResolutionLevel) (*bucketBlock, *metadata.Meta) {
+func prepareBucket(b testing.TB, resolutionLevel compact.ResolutionLevel, sampleType chunkenc.ValueType) (*bucketBlock, *metadata.Meta) {
 	var (
 		ctx    = context.Background()
 		logger = log.NewNopLogger()
@@ -2647,8 +2634,9 @@ func prepareBucket(b *testing.B, resolutionLevel compact.ResolutionLevel) (*buck
 		PrependLabels:    nil,
 		Random:           rand.New(rand.NewSource(120)),
 		SkipChunks:       true,
+		SampleType:       sampleType,
 	})
-	blockID := createBlockFromHead(b, tmpDir, head)
+	blockID := storetestutil.CreateBlockFromHead(b, tmpDir, head)
 
 	// Upload the block to the bucket.
 	thanosMeta := metadata.Thanos{
@@ -2758,7 +2746,7 @@ func benchmarkBlockSeriesWithConcurrency(b *testing.B, concurrency int, blockMet
 }
 
 func BenchmarkDownsampledBlockSeries(b *testing.B) {
-	blk, blockMeta := prepareBucket(b, compact.ResolutionLevel5m)
+	blk, blockMeta := prepareBucket(b, compact.ResolutionLevel5m, chunkenc.ValFloat)
 	aggrs := []storepb.Aggr{}
 	for i := 1; i < int(storepb.Aggr_COUNTER); i++ {
 		aggrs = append(aggrs, storepb.Aggr(i))
@@ -3328,5 +3316,18 @@ func TestExpandedPostingsRace(t *testing.T) {
 			}(i, bb)
 		}
 		wg.Wait()
+	}
+}
+
+func BenchmarkDownsampledBlockSeries_NativeHistogram(b *testing.B) {
+	blk, blockMeta := prepareBucket(b, compact.ResolutionLevel5m, chunkenc.ValHistogram)
+	aggrs := []storepb.Aggr{}
+
+	// Native histograms only have aggregates for COUNT, COUNTER and SUM.
+	aggrsTypes := []storepb.Aggr{storepb.Aggr_COUNT, storepb.Aggr_COUNTER, storepb.Aggr_SUM}
+	for _, concurrency := range []int{1, 2, 4, 8, 16, 32} {
+		b.Run(fmt.Sprintf("aggregates: %v, concurrency: %d", aggrs, concurrency), func(b *testing.B) {
+			benchmarkBlockSeriesWithConcurrency(b, concurrency, blockMeta, blk, aggrsTypes)
+		})
 	}
 }

--- a/pkg/store/bucket_test.go
+++ b/pkg/store/bucket_test.go
@@ -3229,7 +3229,7 @@ func TestExpandedPostingsRace(t *testing.T) {
 		Random:           rand.New(rand.NewSource(120)),
 		SkipChunks:       true,
 	})
-	blockID := createBlockFromHead(t, tmpDir, head)
+	blockID := storetestutil.CreateBlockFromHead(t, tmpDir, head)
 
 	bucketBlocks := make([]*bucketBlock, 0, blockCount)
 

--- a/pkg/store/storepb/testutil/series.go
+++ b/pkg/store/storepb/testutil/series.go
@@ -19,7 +19,6 @@ import (
 	"github.com/efficientgo/core/testutil"
 	"github.com/go-kit/log"
 	"github.com/gogo/protobuf/types"
-	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/oklog/ulid"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"

--- a/pkg/store/storepb/testutil/series.go
+++ b/pkg/store/storepb/testutil/series.go
@@ -58,7 +58,6 @@ type HeadGenOptions struct {
 	PrependLabels labels.Labels
 	SkipChunks    bool // Skips chunks in returned slice (not in generated head!).
 	SampleType    chunkenc.ValueType
-	IncludeName   bool
 
 	Random *rand.Rand
 }
@@ -181,10 +180,7 @@ func ReadSeriesFromBlock(t testing.TB, h tsdb.BlockReader, extLabels labels.Labe
 }
 
 func appendFloatSamples(t testing.TB, app storage.Appender, tsLabel int, opts HeadGenOptions) {
-	lblSet := labels.FromStrings("foo", "bar", "i", fmt.Sprintf("%07d%s", tsLabel, LabelLongSuffix))
-	if opts.IncludeName {
-		lblSet = append(lblSet, labels.Label{Name: "__name__", Value: "test_float_metric"})
-	}
+	lblSet := labels.FromStrings("foo", "bar", "i", fmt.Sprintf("%07d%s", tsLabel, LabelLongSuffix), "j", fmt.Sprintf("%v", tsLabel))
 	ref, err := app.Append(0, lblSet, int64(tsLabel)*opts.ScrapeInterval.Milliseconds(), opts.Random.Float64())
 	testutil.Ok(t, err)
 
@@ -197,10 +193,7 @@ func appendFloatSamples(t testing.TB, app storage.Appender, tsLabel int, opts He
 func appendHistogramSamples(t testing.TB, app storage.Appender, tsLabel int, opts HeadGenOptions) {
 	histograms := tsdbutil.GenerateTestHistograms(opts.SamplesPerSeries)
 
-	lblSet := labels.FromStrings("foo", "bar", "i", fmt.Sprintf("%07d%s", tsLabel, LabelLongSuffix))
-	if opts.IncludeName {
-		lblSet = append(lblSet, labels.Label{Name: "__name__", Value: "test_metric"})
-	}
+	lblSet := labels.FromStrings("foo", "bar", "i", fmt.Sprintf("%07d%s", tsLabel, LabelLongSuffix), "j", fmt.Sprintf("%v", tsLabel))
 	ref, err := app.AppendHistogram(
 		0,
 		lblSet,

--- a/pkg/store/tsdb_test.go
+++ b/pkg/store/tsdb_test.go
@@ -13,12 +13,12 @@ import (
 	"testing"
 
 	"github.com/cespare/xxhash"
+	"github.com/efficientgo/core/testutil"
 	"github.com/go-kit/log"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb"
 
-	"github.com/efficientgo/core/testutil"
 	"github.com/thanos-io/thanos/pkg/component"
 	"github.com/thanos-io/thanos/pkg/store/labelpb"
 	"github.com/thanos-io/thanos/pkg/store/storepb"
@@ -285,7 +285,7 @@ func TestTSDBStore_SeriesAccessWithDelegateClosing(t *testing.T) {
 		Random:           random,
 		SkipChunks:       true,
 	})
-	_ = createBlockFromHead(t, tmpDir, head)
+	_ = storetestutil.CreateBlockFromHead(t, tmpDir, head)
 	testutil.Ok(t, head.Close())
 
 	head, _ = storetestutil.CreateHeadWithSeries(t, 1, storetestutil.HeadGenOptions{
@@ -454,7 +454,7 @@ func TestTSDBStore_SeriesAccessWithoutDelegateClosing(t *testing.T) {
 		Random:           random,
 		SkipChunks:       true,
 	})
-	_ = createBlockFromHead(t, tmpDir, head)
+	_ = storetestutil.CreateBlockFromHead(t, tmpDir, head)
 	testutil.Ok(t, head.Close())
 
 	head, _ = storetestutil.CreateHeadWithSeries(t, 1, storetestutil.HeadGenOptions{
@@ -594,7 +594,7 @@ func benchTSDBStoreSeries(t testutil.TB, totalSamples, totalSeries int) {
 			resps[j] = append(resps[j], storepb.NewSeriesResponse(created[i]))
 		}
 
-		_ = createBlockFromHead(t, tmpDir, head)
+		_ = storetestutil.CreateBlockFromHead(t, tmpDir, head)
 		t.Cleanup(func() {
 			testutil.Ok(t, head.Close())
 		})


### PR DESCRIPTION
This PR adds native histogram support for downsampling in compact and is part of https://github.com/thanos-io/thanos/issues/5907.

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes
- Add native histogram support for downsampling

## Verification
- Add unit tests for native histograms in downsampling
