### PR TITLE
docs: replace --store with --endpoint

### DIFF
--- a/docs/components/query.md
+++ b/docs/components/query.md
@@ -11,8 +11,8 @@ Example command to run Querier:
 ```bash
 thanos query \
     --http-address     "0.0.0.0:9090" \
-    --store            "<store-api>:<grpc-port>" \
-    --store            "<store-api2>:<grpc-port>"
+    --endpoint         "<store-api>:<grpc-port>" \
+    --endpoint         "<store-api2>:<grpc-port>"
 ```
 
 ## Querier use cases, why do I need this component?
@@ -71,8 +71,8 @@ If we configure Querier like this:
 thanos query \
     --http-address        "0.0.0.0:9090" \
     --query.replica-label "replica" \
-    --store               "<store-api>:<grpc-port>" \
-    --store               "<store-api2>:<grpc-port>" \
+    --endpoint            "<store-api>:<grpc-port>" \
+    --endpoint            "<store-api2>:<grpc-port>" \
 ```
 
 And we query for metric `up{job="prometheus",env="2"}` with this option we will get 2 results:
@@ -97,8 +97,8 @@ thanos query \
     --http-address        "0.0.0.0:9090" \
     --query.replica-label "replica" \
     --query.replica-label "replicaX" \
-    --store               "<store-api>:<grpc-port>" \
-    --store               "<store-api2>:<grpc-port>" \
+    --endpoint            "<store-api>:<grpc-port>" \
+    --endpoint            "<store-api2>:<grpc-port>" \
 ```
 
 This logic can also be controlled via parameter on QueryAPI. More details below.

--- a/docs/operating/cross-cluster-tls-communication.md
+++ b/docs/operating/cross-cluster-tls-communication.md
@@ -72,15 +72,15 @@ metadata:
             - '--http-address=0.0.0.0:10902'
             - '--query.replica-label=replica'
             - >-
-              --store=dnssrv+_grpc._tcp.thanos-global-test-storegateway.thanos-global.svc.cluster.local
+              --endpoint=dnssrv+_grpc._tcp.thanos-global-test-storegateway.thanos-global.svc.cluster.local
             - >-
-              --store=dnssrv+_grpc._tcp.thanos-global-test-sidecar.thanos-global.svc.cluster.local
+              --endpoint=dnssrv+_grpc._tcp.thanos-global-test-sidecar.thanos-global.svc.cluster.local
             - >-
-              --store=dnssrv+_grpc._tcp.thanos-global-test-ruler.thanos-global.svc.cluster.local
+              --endpoint=dnssrv+_grpc._tcp.thanos-global-test-ruler.thanos-global.svc.cluster.local
             - >-
-              --store=dnssrv+_[port_name]._tcp.[service-name].[namespace].svc.cluster.local
+              --endpoint=dnssrv+_[port_name]._tcp.[service-name].[namespace].svc.cluster.local
             - >-
-              --store=dnssrv+_[port_name_2]._tcp.[service-name].[namespace].svc.cluster.local
+              --endpoint=dnssrv+_[port_name_2]._tcp.[service-name].[namespace].svc.cluster.local
           ports:
             - name: http
               containerPort: 10902

--- a/docs/quick-tutorial.md
+++ b/docs/quick-tutorial.md
@@ -131,9 +131,9 @@ Below, we will set up a Thanos Querier to connect to our Sidecars, and expose it
 ```bash
 thanos query \
     --http-address 0.0.0.0:19192 \                                # HTTP Endpoint for Thanos Querier UI
-    --store        1.2.3.4:19090 \                                # Static gRPC Store API Address for the query node to query
-    --store        1.2.3.5:19090 \                                # Also repeatable
-    --store        dnssrv+_grpc._tcp.thanos-store.monitoring.svc  # Supports DNS A & SRV records
+    --endpiont     1.2.3.4:19090 \                                # Static gRPC Store API Address for the query node to query
+    --endpiont     1.2.3.5:19090 \                                # Also repeatable
+    --endpiont     dnssrv+_grpc._tcp.thanos-store.monitoring.svc  # Supports DNS A & SRV records
 ```
 
 Go to the configured HTTP address, which should now show a UI similar to that of Prometheus. You can now query across all Prometheus instances within the cluster. You can also check out the Stores page, which shows all of your stores.
@@ -162,8 +162,8 @@ Ensure your Prometheus instances have been reloaded with the configuration you d
 ```bash
 thanos query \
     --http-address        0.0.0.0:19192 \
-    --store               1.2.3.4:19090 \
-    --store               1.2.3.5:19090 \
+    --endpoint            1.2.3.4:19090 \
+    --endpoint            1.2.3.5:19090 \
     --query.replica-label replica          # Replica label for deduplication
     --query.replica-label replicaX         # Supports multiple replica labels for deduplication
 ```
@@ -182,9 +182,9 @@ There are various ways to tell Thanos Querier about the Store APIs it should que
 thanos query \
     --http-address 0.0.0.0:19192 \              # Endpoint for Thanos Querier UI
     --grpc-address 0.0.0.0:19092 \              # gRPC endpoint for Store API
-    --store        1.2.3.4:19090 \              # Static gRPC Store API Address for the query node to query
-    --store        1.2.3.5:19090 \              # Also repeatable
-    --store        dns+rest.thanos.peers:19092  # Use DNS lookup for getting all registered IPs as separate Store APIs
+    --endpoint     1.2.3.4:19090 \              # Static gRPC Store API Address for the query node to query
+    --endpoint     1.2.3.5:19090 \              # Also repeatable
+    --endpoint     dns+rest.thanos.peers:19092  # Use DNS lookup for getting all registered IPs as separate Store APIs
 ```
 
 Read more details [here](service-discovery.md).


### PR DESCRIPTION
Replace deprecated `--store` with `--endpoint` in querier docs.

* [ ] I added CHANGELOG entry for this change.
* [X] Change is not relevant to the end user.

## Changes

Just a minor doc update

## Verification

N/A
