### PR TITLE
Cache: various index cache client improvements

### DIFF
--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -2345,7 +2345,7 @@ type postingPtr struct {
 }
 
 // fetchPostings fill postings requested by posting groups.
-// It returns one postings for each key, in the same order.
+// It returns one posting for each key, in the same order.
 // If postings for given key is not fetched, entry at given index will be nil.
 func (r *bucketIndexReader) fetchPostings(ctx context.Context, keys []labels.Label, bytesLimiter BytesLimiter) ([]index.Postings, []func(), error) {
 	var closeFns []func()

--- a/pkg/store/cache/cache.go
+++ b/pkg/store/cache/cache.go
@@ -47,7 +47,7 @@ type IndexCache interface {
 }
 
 type cacheKey struct {
-	block ulid.ULID
+	block string
 	key   interface{}
 }
 
@@ -79,9 +79,9 @@ func (c cacheKey) string() string {
 		// which would end up in wrong query results.
 		lbl := c.key.(cacheKeyPostings)
 		lblHash := blake2b.Sum256([]byte(lbl.Name + ":" + lbl.Value))
-		return "P:" + c.block.String() + ":" + base64.RawURLEncoding.EncodeToString(lblHash[0:])
+		return "P:" + c.block + ":" + base64.RawURLEncoding.EncodeToString(lblHash[0:])
 	case cacheKeySeries:
-		return "S:" + c.block.String() + ":" + strconv.FormatUint(uint64(c.key.(cacheKeySeries)), 10)
+		return "S:" + c.block + ":" + strconv.FormatUint(uint64(c.key.(cacheKeySeries)), 10)
 	default:
 		return ""
 	}

--- a/pkg/store/cache/cache_test.go
+++ b/pkg/store/cache/cache_test.go
@@ -26,13 +26,14 @@ func TestCacheKey_string(t *testing.T) {
 	t.Parallel()
 
 	uid := ulid.MustNew(1, nil)
+	uidStr := uid.String()
 
 	tests := map[string]struct {
 		key      cacheKey
 		expected string
 	}{
 		"should stringify postings cache key": {
-			key: cacheKey{uid, cacheKeyPostings(labels.Label{Name: "foo", Value: "bar"})},
+			key: cacheKey{uidStr, cacheKeyPostings(labels.Label{Name: "foo", Value: "bar"})},
 			expected: func() string {
 				hash := blake2b.Sum256([]byte("foo:bar"))
 				encodedHash := base64.RawURLEncoding.EncodeToString(hash[0:])
@@ -41,7 +42,7 @@ func TestCacheKey_string(t *testing.T) {
 			}(),
 		},
 		"should stringify series cache key": {
-			key:      cacheKey{uid, cacheKeySeries(12345)},
+			key:      cacheKey{uidStr, cacheKeySeries(12345)},
 			expected: fmt.Sprintf("S:%s:12345", uid.String()),
 		},
 	}
@@ -58,6 +59,7 @@ func TestCacheKey_string_ShouldGuaranteeReasonablyShortKeyLength(t *testing.T) {
 	t.Parallel()
 
 	uid := ulid.MustNew(1, nil)
+	uidStr := uid.String()
 
 	tests := map[string]struct {
 		keys        []cacheKey
@@ -66,14 +68,14 @@ func TestCacheKey_string_ShouldGuaranteeReasonablyShortKeyLength(t *testing.T) {
 		"should guarantee reasonably short key length for postings": {
 			expectedLen: 72,
 			keys: []cacheKey{
-				{uid, cacheKeyPostings(labels.Label{Name: "a", Value: "b"})},
-				{uid, cacheKeyPostings(labels.Label{Name: strings.Repeat("a", 100), Value: strings.Repeat("a", 1000)})},
+				{uidStr, cacheKeyPostings(labels.Label{Name: "a", Value: "b"})},
+				{uidStr, cacheKeyPostings(labels.Label{Name: strings.Repeat("a", 100), Value: strings.Repeat("a", 1000)})},
 			},
 		},
 		"should guarantee reasonably short key length for series": {
 			expectedLen: 49,
 			keys: []cacheKey{
-				{uid, cacheKeySeries(math.MaxUint64)},
+				{uidStr, cacheKeySeries(math.MaxUint64)},
 			},
 		},
 	}
@@ -89,7 +91,7 @@ func TestCacheKey_string_ShouldGuaranteeReasonablyShortKeyLength(t *testing.T) {
 
 func BenchmarkCacheKey_string_Postings(b *testing.B) {
 	uid := ulid.MustNew(1, nil)
-	key := cacheKey{uid, cacheKeyPostings(labels.Label{Name: strings.Repeat("a", 100), Value: strings.Repeat("a", 1000)})}
+	key := cacheKey{uid.String(), cacheKeyPostings(labels.Label{Name: strings.Repeat("a", 100), Value: strings.Repeat("a", 1000)})}
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -99,7 +101,7 @@ func BenchmarkCacheKey_string_Postings(b *testing.B) {
 
 func BenchmarkCacheKey_string_Series(b *testing.B) {
 	uid := ulid.MustNew(1, nil)
-	key := cacheKey{uid, cacheKeySeries(math.MaxUint64)}
+	key := cacheKey{uid.String(), cacheKeySeries(math.MaxUint64)}
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {

--- a/pkg/store/cache/cache_test.go
+++ b/pkg/store/cache/cache_test.go
@@ -26,14 +26,14 @@ func TestCacheKey_string(t *testing.T) {
 	t.Parallel()
 
 	uid := ulid.MustNew(1, nil)
-	uidStr := uid.String()
+	ulidString := uid.String()
 
 	tests := map[string]struct {
 		key      cacheKey
 		expected string
 	}{
 		"should stringify postings cache key": {
-			key: cacheKey{uidStr, cacheKeyPostings(labels.Label{Name: "foo", Value: "bar"})},
+			key: cacheKey{ulidString, cacheKeyPostings(labels.Label{Name: "foo", Value: "bar"})},
 			expected: func() string {
 				hash := blake2b.Sum256([]byte("foo:bar"))
 				encodedHash := base64.RawURLEncoding.EncodeToString(hash[0:])
@@ -42,7 +42,7 @@ func TestCacheKey_string(t *testing.T) {
 			}(),
 		},
 		"should stringify series cache key": {
-			key:      cacheKey{uidStr, cacheKeySeries(12345)},
+			key:      cacheKey{ulidString, cacheKeySeries(12345)},
 			expected: fmt.Sprintf("S:%s:12345", uid.String()),
 		},
 	}
@@ -59,7 +59,7 @@ func TestCacheKey_string_ShouldGuaranteeReasonablyShortKeyLength(t *testing.T) {
 	t.Parallel()
 
 	uid := ulid.MustNew(1, nil)
-	uidStr := uid.String()
+	ulidString := uid.String()
 
 	tests := map[string]struct {
 		keys        []cacheKey
@@ -68,14 +68,14 @@ func TestCacheKey_string_ShouldGuaranteeReasonablyShortKeyLength(t *testing.T) {
 		"should guarantee reasonably short key length for postings": {
 			expectedLen: 72,
 			keys: []cacheKey{
-				{uidStr, cacheKeyPostings(labels.Label{Name: "a", Value: "b"})},
-				{uidStr, cacheKeyPostings(labels.Label{Name: strings.Repeat("a", 100), Value: strings.Repeat("a", 1000)})},
+				{ulidString, cacheKeyPostings(labels.Label{Name: "a", Value: "b"})},
+				{ulidString, cacheKeyPostings(labels.Label{Name: strings.Repeat("a", 100), Value: strings.Repeat("a", 1000)})},
 			},
 		},
 		"should guarantee reasonably short key length for series": {
 			expectedLen: 49,
 			keys: []cacheKey{
-				{uidStr, cacheKeySeries(math.MaxUint64)},
+				{ulidString, cacheKeySeries(math.MaxUint64)},
 			},
 		},
 	}

--- a/pkg/store/cache/inmemory.go
+++ b/pkg/store/cache/inmemory.go
@@ -290,7 +290,7 @@ func copyToKey(l labels.Label) cacheKeyPostings {
 // StorePostings sets the postings identified by the ulid and label to the value v,
 // if the postings already exists in the cache it is not mutated.
 func (c *InMemoryIndexCache) StorePostings(blockID ulid.ULID, l labels.Label, v []byte) {
-	c.set(cacheTypePostings, cacheKey{block: blockID, key: copyToKey(l)}, v)
+	c.set(cacheTypePostings, cacheKey{block: blockID.String(), key: copyToKey(l)}, v)
 }
 
 // FetchMultiPostings fetches multiple postings - each identified by a label -
@@ -298,8 +298,9 @@ func (c *InMemoryIndexCache) StorePostings(blockID ulid.ULID, l labels.Label, v 
 func (c *InMemoryIndexCache) FetchMultiPostings(_ context.Context, blockID ulid.ULID, keys []labels.Label) (hits map[labels.Label][]byte, misses []labels.Label) {
 	hits = map[labels.Label][]byte{}
 
+	blockIDKey := blockID.String()
 	for _, key := range keys {
-		if b, ok := c.get(cacheTypePostings, cacheKey{blockID, cacheKeyPostings(key)}); ok {
+		if b, ok := c.get(cacheTypePostings, cacheKey{blockIDKey, cacheKeyPostings(key)}); ok {
 			hits[key] = b
 			continue
 		}
@@ -313,7 +314,7 @@ func (c *InMemoryIndexCache) FetchMultiPostings(_ context.Context, blockID ulid.
 // StoreSeries sets the series identified by the ulid and id to the value v,
 // if the series already exists in the cache it is not mutated.
 func (c *InMemoryIndexCache) StoreSeries(blockID ulid.ULID, id storage.SeriesRef, v []byte) {
-	c.set(cacheTypeSeries, cacheKey{blockID, cacheKeySeries(id)}, v)
+	c.set(cacheTypeSeries, cacheKey{blockID.String(), cacheKeySeries(id)}, v)
 }
 
 // FetchMultiSeries fetches multiple series - each identified by ID - from the cache
@@ -321,8 +322,9 @@ func (c *InMemoryIndexCache) StoreSeries(blockID ulid.ULID, id storage.SeriesRef
 func (c *InMemoryIndexCache) FetchMultiSeries(_ context.Context, blockID ulid.ULID, ids []storage.SeriesRef) (hits map[storage.SeriesRef][]byte, misses []storage.SeriesRef) {
 	hits = map[storage.SeriesRef][]byte{}
 
+	blockIDKey := blockID.String()
 	for _, id := range ids {
-		if b, ok := c.get(cacheTypeSeries, cacheKey{blockID, cacheKeySeries(id)}); ok {
+		if b, ok := c.get(cacheTypeSeries, cacheKey{blockIDKey, cacheKeySeries(id)}); ok {
 			hits[id] = b
 			continue
 		}


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

I made several small improvements in this pr:
1. make `blockID` in cacheKey string type rather than `ulid.ULID`. Each time when we build the cache key,  `c.block.String()` allocates a buffer every time.
2. Remove maps used for `keysMapping`. The mapping is unnecessary and we can just use index to access the key.
3. Pre allocate the hits map.

## Verification

<!-- How you tested it? How do you know it works? -->
