### PR TITLE
Optimizing "grafana generated" regex matchers

### DIFF
--- a/pkg/store/bucket_test.go
+++ b/pkg/store/bucket_test.go
@@ -1384,19 +1384,40 @@ func benchBucketSeries(t testutil.TB, sampleType chunkenc.ValueType, skipChunk b
 			seriesCut = expectedSamples / samplesPerSeriesPerBlock
 		}
 
-		bCases = append(bCases, &storetestutil.SeriesCase{
-			Name: fmt.Sprintf("%dof%d", expectedSamples, totalSeries*samplesPerSeries),
-			Req: &storepb.SeriesRequest{
-				MinTime: 0,
-				MaxTime: int64(expectedSamples) - 1,
-				Matchers: []storepb.LabelMatcher{
-					{Type: storepb.LabelMatcher_EQ, Name: "foo", Value: "bar"},
+		matchersCase := []*labels.Matcher{
+			labels.MustNewMatcher(labels.MatchEqual, "foo", "bar"),
+			labels.MustNewMatcher(labels.MatchNotEqual, "foo", "bar"),
+			labels.MustNewMatcher(labels.MatchRegexp, "j", "(0|1)"),
+			labels.MustNewMatcher(labels.MatchRegexp, "j", "0|1"),
+			labels.MustNewMatcher(labels.MatchNotRegexp, "j", "(0|1)"),
+			labels.MustNewMatcher(labels.MatchNotRegexp, "j", "0|1"),
+		}
+
+		for _, lm := range matchersCase {
+			expectedSeries := make([]*storepb.Series, 0, seriesCut)
+			m, err := storepb.PromMatchersToMatchers(lm)
+			testutil.Ok(t, err)
+
+			// seriesCut does not cut chunks properly, but those are assured against for non benchmarks only, where we use 100% case only.
+			for _, s := range series[:seriesCut] {
+				for _, label := range s.Labels {
+					if label.Name == lm.Name && lm.Matches(label.Value) {
+						expectedSeries = append(expectedSeries, s)
+						break
+					}
+				}
+			}
+			bCases = append(bCases, &storetestutil.SeriesCase{
+				Name: fmt.Sprintf("%dof%d[%s]", expectedSamples, totalSeries*samplesPerSeries, lm.String()),
+				Req: &storepb.SeriesRequest{
+					MinTime:    0,
+					MaxTime:    int64(expectedSamples) - 1,
+					Matchers:   m,
+					SkipChunks: skipChunk,
 				},
-				SkipChunks: skipChunk,
-			},
-			// This does not cut chunks properly, but those are assured against for non benchmarks only, where we use 100% case only.
-			ExpectedSeries: series[:seriesCut],
-		})
+				ExpectedSeries: expectedSeries,
+			})
+		}
 	}
 	storetestutil.TestServerSeries(t, st, bCases...)
 

--- a/pkg/store/bucket_test.go
+++ b/pkg/store/bucket_test.go
@@ -1394,7 +1394,7 @@ func benchBucketSeries(t testutil.TB, sampleType chunkenc.ValueType, skipChunk b
 		}
 
 		for _, lm := range matchersCase {
-			expectedSeries := make([]*storepb.Series, 0, seriesCut)
+			var expectedSeries []*storepb.Series
 			m, err := storepb.PromMatchersToMatchers(lm)
 			testutil.Ok(t, err)
 

--- a/pkg/store/opts.go
+++ b/pkg/store/opts.go
@@ -27,7 +27,14 @@ func init() {
 func findSetMatches(pattern string) []string {
 	escaped := false
 	sets := []*strings.Builder{{}}
-	for i := 0; i < len(pattern); i++ {
+	init := 0
+	end := len(pattern)
+	// If the regex is wrapped in a group we can remove the first and last parentheses
+	if pattern[init] == '(' && pattern[end-1] == ')' {
+		init++
+		end--
+	}
+	for i := init; i < end; i++ {
 		if escaped {
 			switch {
 			case isRegexMetaCharacter(pattern[i]):

--- a/pkg/store/opts_test.go
+++ b/pkg/store/opts_test.go
@@ -24,6 +24,15 @@ func TestFindSetMatches(t *testing.T) {
 				"baz",
 			},
 		},
+		// Simple sets with group wrapper.
+		{
+			pattern: "(foo|bar|baz)",
+			exp: []string{
+				"foo",
+				"bar",
+				"baz",
+			},
+		},
 		// Simple sets containing escaped characters.
 		{
 			pattern: "fo\\.o|bar\\?|\\^baz",
@@ -36,6 +45,10 @@ func TestFindSetMatches(t *testing.T) {
 		// Simple sets containing special characters without escaping.
 		{
 			pattern: "fo.o|bar?|^baz",
+			exp:     nil,
+		},
+		{
+			pattern: "(fool|bar)|(baz)",
 			exp:     nil,
 		},
 		{

--- a/pkg/store/storepb/testutil/series.go
+++ b/pkg/store/storepb/testutil/series.go
@@ -195,7 +195,7 @@ func appendHistogramSamples(t testing.TB, app storage.Appender, tsLabel int, opt
 
 	ref, err := app.AppendHistogram(
 		0,
-		labels.FromStrings("foo", "bar", "i", fmt.Sprintf("%07d%s", tsLabel, LabelLongSuffix)),
+		labels.FromStrings("foo", "bar", "i", fmt.Sprintf("%07d%s", tsLabel, LabelLongSuffix), "j", fmt.Sprintf("%v", tsLabel)),
 		int64(tsLabel)*opts.ScrapeInterval.Milliseconds(),
 		sample,
 		nil,

--- a/pkg/store/storepb/testutil/series.go
+++ b/pkg/store/storepb/testutil/series.go
@@ -167,7 +167,7 @@ func ReadSeriesFromBlock(t testing.TB, h tsdb.BlockReader, extLabels labels.Labe
 func appendFloatSamples(t testing.TB, app storage.Appender, tsLabel int, opts HeadGenOptions) {
 	ref, err := app.Append(
 		0,
-		labels.FromStrings("foo", "bar", "i", fmt.Sprintf("%07d%s", tsLabel, LabelLongSuffix)),
+		labels.FromStrings("foo", "bar", "i", fmt.Sprintf("%07d%s", tsLabel, LabelLongSuffix), "j", fmt.Sprintf("%v", tsLabel)),
 		int64(tsLabel)*opts.ScrapeInterval.Milliseconds(),
 		opts.Random.Float64(),
 	)


### PR DESCRIPTION
Same as https://github.com/prometheus/prometheus/pull/12375

When using a multi-value variable on Grafana Dashboards the default behavior is to produce regex in the format (a|b). See https://grafana.com/docs/grafana/latest/dashboards/variables/variable-syntax/#regex

This PR is expanding the optimization Prometheus already have on regexes like a|b to regexes like (a|b) and improve the query time and cpu utilization for dashboards with high cardinality variables substantially.

PS: Nothing will change for other types of queries even if they starts and ends with (), like (a|b)|(c|d)

Relevant Benchmark results:

```
                                                                          │    /tmp/old    │              /tmp/new               │
                                                                          │     sec/op     │    sec/op     vs base               │
BucketSeries/1000000SeriesWith1Samples/1of1000000[j=~"(0|1)"]-32            23815.5µ ± ∞ ¹   178.5µ ± ∞ ¹  -99.25% (p=0.008 n=5)
BucketSeries/1000000SeriesWith1Samples/10of1000000[j=~"(0|1)"]-32           23522.3µ ± ∞ ¹   186.6µ ± ∞ ¹  -99.21% (p=0.008 n=5)
BucketSeries/1000000SeriesWith1Samples/1000000of1000000[j=~"(0|1)"]-32      26111.6µ ± ∞ ¹   216.3µ ± ∞ ¹  -99.17% (p=0.008 n=5)
BucketSeries/100000SeriesWith100Samples/1of10000000[j=~"(0|1)"]-32           2317.9µ ± ∞ ¹   162.8µ ± ∞ ¹  -92.98% (p=0.008 n=5)
BucketSeries/100000SeriesWith100Samples/100of10000000[j=~"(0|1)"]-32         2319.0µ ± ∞ ¹   161.7µ ± ∞ ¹  -93.03% (p=0.008 n=5)
BucketSeries/100000SeriesWith100Samples/10000000of10000000[j=~"(0|1)"]-32    3600.6µ ± ∞ ¹   182.1µ ± ∞ ¹  -94.94% (p=0.008 n=5)

                                                                          │    /tmp/old     │               /tmp/new               │
                                                                          │      B/op       │     B/op       vs base               │
BucketSeries/1000000SeriesWith1Samples/1of1000000[j=~"(0|1)"]-32             4030.4Ki ± ∞ ¹   107.0Ki ± ∞ ¹  -97.35% (p=0.008 n=5)
BucketSeries/1000000SeriesWith1Samples/10of1000000[j=~"(0|1)"]-32            4031.1Ki ± ∞ ¹   107.7Ki ± ∞ ¹  -97.33% (p=0.008 n=5)
BucketSeries/1000000SeriesWith1Samples/1000000of1000000[j=~"(0|1)"]-32      15810.4Ki ± ∞ ¹   119.1Ki ± ∞ ¹  -99.25% (p=0.008 n=5)
BucketSeries/100000SeriesWith100Samples/1of10000000[j=~"(0|1)"]-32            501.6Ki ± ∞ ¹   108.9Ki ± ∞ ¹  -78.29% (p=0.008 n=5)
BucketSeries/100000SeriesWith100Samples/100of10000000[j=~"(0|1)"]-32          504.7Ki ± ∞ ¹   108.9Ki ± ∞ ¹  -78.43% (p=0.008 n=5)
BucketSeries/100000SeriesWith100Samples/10000000of10000000[j=~"(0|1)"]-32    1712.6Ki ± ∞ ¹   122.6Ki ± ∞ ¹  -92.84% (p=0.008 n=5)

                                                                          │   /tmp/old   │               /tmp/new                │
                                                                          │  allocs/op   │  allocs/op    vs base                 │
BucketSeries/1000000SeriesWith1Samples/1of1000000[j=~"(0|1)"]-32             378.0 ± ∞ ¹    381.0 ± ∞ ¹   +0.79% (p=0.008 n=5)
BucketSeries/1000000SeriesWith1Samples/10of1000000[j=~"(0|1)"]-32            397.0 ± ∞ ¹    400.0 ± ∞ ¹   +0.76% (p=0.008 n=5)
BucketSeries/1000000SeriesWith1Samples/1000000of1000000[j=~"(0|1)"]-32       511.0 ± ∞ ¹    584.0 ± ∞ ¹  +14.29% (p=0.008 n=5)
BucketSeries/100000SeriesWith100Samples/1of10000000[j=~"(0|1)"]-32           356.0 ± ∞ ¹    365.0 ± ∞ ¹   +2.53% (p=0.008 n=5)
BucketSeries/100000SeriesWith100Samples/100of10000000[j=~"(0|1)"]-32         356.0 ± ∞ ¹    365.0 ± ∞ ¹   +2.53% (p=0.008 n=5)
BucketSeries/100000SeriesWith100Samples/10000000of10000000[j=~"(0|1)"]-32    468.0 ± ∞ ¹    549.0 ± ∞ ¹  +17.31% (p=0.008 n=5)
BucketSeries/1SeriesWith10000000Samples/1of10000000[j=~"(0|1)"]-32           381.0 ± ∞ ¹    390.0 ± ∞ ¹   +2.36% (p=0.008 n=5)
BucketSeries/1SeriesWith10000000Samples/100of10000000[j=~"(0|1)"]-32         381.0 ± ∞ ¹    390.0 ± ∞ ¹   +2.36% (p=0.008 n=5)
BucketSeries/1SeriesWith10000000Samples/10000000of10000000[j=~"(0|1)"]-32   63.57k ± ∞ ¹   63.66k ± ∞ ¹   +0.14% (p=0.008 n=5)

```

Complete Benchmark results: https://gist.github.com/alanprot/0e734805aa15a24f2b37b3763c5fcaa5

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

* Opmize "grafana generated" regex matchers  
* Add benchmark test cases to benchmark Macher types other than "EQ"
## Verification

* Unit test
