### PR TITLE
Implementing Regex optimization on the `MatchNotRegexp` and `MatchNotEqual` matcher type

### DIFF
--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -2292,6 +2292,7 @@ func toPostingGroup(ctx context.Context, lvalsFn func(name string) ([]string, er
 	if m.Matches("") {
 		var toRemove []labels.Label
 
+		// Fast-path for MatchNotRegexp matching.
 		// Inverse of a MatchNotRegexp is MatchRegexp (double negation).
 		// Fast-path for set matching.
 		if m.Type == labels.MatchNotRegexp {
@@ -2299,6 +2300,12 @@ func toPostingGroup(ctx context.Context, lvalsFn func(name string) ([]string, er
 				toRemove = labelsFromSetMatchers(m.Name, vals)
 				return newPostingGroup(true, nil, toRemove), nil
 			}
+		}
+
+		// Fast-path for MatchNotEqual matching.
+		// Inverse of a MatchNotEqual is MatchEqual (double negation).
+		if m.Type == labels.MatchNotEqual {
+			return newPostingGroup(true, nil, []labels.Label{{Name: m.Name, Value: m.Value}}), nil
 		}
 
 		vals, err := lvalsFn(m.Name)

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -2282,15 +2282,7 @@ func checkNilPosting(l labels.Label, p index.Postings) index.Postings {
 func toPostingGroup(ctx context.Context, lvalsFn func(name string) ([]string, error), m *labels.Matcher) (*postingGroup, error) {
 	if m.Type == labels.MatchRegexp {
 		if vals := findSetMatches(m.Value); len(vals) > 0 {
-			// Sorting will improve the performance dramatically if the dataset is relatively large
-			// since entries in the postings offset table was sorted by label name and value,
-			// the sequential reading is much faster.
-			sort.Strings(vals)
-			toAdd := make([]labels.Label, 0, len(vals))
-			for _, val := range vals {
-				toAdd = append(toAdd, labels.Label{Name: m.Name, Value: val})
-			}
-			return newPostingGroup(false, toAdd, nil), nil
+			return newPostingGroup(false, labelsFromSetMatchers(m.Name, vals), nil), nil
 		}
 	}
 
@@ -2298,12 +2290,22 @@ func toPostingGroup(ctx context.Context, lvalsFn func(name string) ([]string, er
 	// have the label name set too. See: https://github.com/prometheus/prometheus/issues/3575
 	// and https://github.com/prometheus/prometheus/pull/3578#issuecomment-351653555.
 	if m.Matches("") {
+		var toRemove []labels.Label
+
+		// Inverse of a MatchNotRegexp is MatchRegexp (double negation).
+		// Fast-path for set matching.
+		if m.Type == labels.MatchNotRegexp {
+			if vals := findSetMatches(m.Value); len(vals) > 0 {
+				toRemove = labelsFromSetMatchers(m.Name, vals)
+				return newPostingGroup(true, nil, toRemove), nil
+			}
+		}
+
 		vals, err := lvalsFn(m.Name)
 		if err != nil {
 			return nil, err
 		}
 
-		var toRemove []labels.Label
 		for _, val := range vals {
 			if ctx.Err() != nil {
 				return nil, ctx.Err()
@@ -2337,6 +2339,18 @@ func toPostingGroup(ctx context.Context, lvalsFn func(name string) ([]string, er
 	}
 
 	return newPostingGroup(false, toAdd, nil), nil
+}
+
+func labelsFromSetMatchers(name string, vals []string) []labels.Label {
+	// Sorting will improve the performance dramatically if the dataset is relatively large
+	// since entries in the postings offset table was sorted by label name and value,
+	// the sequential reading is much faster.
+	sort.Strings(vals)
+	toAdd := make([]labels.Label, 0, len(vals))
+	for _, val := range vals {
+		toAdd = append(toAdd, labels.Label{Name: name, Value: val})
+	}
+	return toAdd
 }
 
 type postingPtr struct {

--- a/pkg/store/bucket_test.go
+++ b/pkg/store/bucket_test.go
@@ -1387,6 +1387,8 @@ func benchBucketSeries(t testutil.TB, sampleType chunkenc.ValueType, skipChunk b
 		matchersCase := []*labels.Matcher{
 			labels.MustNewMatcher(labels.MatchEqual, "foo", "bar"),
 			labels.MustNewMatcher(labels.MatchNotEqual, "foo", "bar"),
+			labels.MustNewMatcher(labels.MatchEqual, "j", "0"),
+			labels.MustNewMatcher(labels.MatchNotEqual, "j", "0"),
 			labels.MustNewMatcher(labels.MatchRegexp, "j", "(0|1)"),
 			labels.MustNewMatcher(labels.MatchRegexp, "j", "0|1"),
 			labels.MustNewMatcher(labels.MatchNotRegexp, "j", "(0|1)"),


### PR DESCRIPTION
Similar to https://github.com/prometheus/prometheus/pull/12351 but here we also added a fast-path for `MatchNotEqual`

```
goos: linux
goarch: amd64
pkg: github.com/thanos-io/thanos/pkg/store
cpu: Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz
                                                                          │   /tmp/old    │              /tmp/new               │
                                                                          │    sec/op     │    sec/op     vs base               │
BucketSeries/1000000SeriesWith1Samples/1of1000000[j!="0"]-32                 95.90m ± ∞ ¹   88.34m ± ∞ ¹   -7.88% (p=0.008 n=5)
BucketSeries/1000000SeriesWith1Samples/1of1000000[j!~"(0|1)"]-32            111.88m ± ∞ ¹   87.25m ± ∞ ¹  -22.02% (p=0.008 n=5)
BucketSeries/1000000SeriesWith1Samples/1of1000000[j!~"0|1"]-32              108.86m ± ∞ ¹   87.28m ± ∞ ¹  -19.82% (p=0.008 n=5)
BucketSeries/1000000SeriesWith1Samples/10of1000000[j!="0"]-32                95.50m ± ∞ ¹   86.74m ± ∞ ¹   -9.17% (p=0.008 n=5)
BucketSeries/1000000SeriesWith1Samples/10of1000000[j!~"(0|1)"]-32           110.94m ± ∞ ¹   86.86m ± ∞ ¹  -21.71% (p=0.008 n=5)
BucketSeries/1000000SeriesWith1Samples/10of1000000[j!~"0|1"]-32             108.38m ± ∞ ¹   85.90m ± ∞ ¹  -20.74% (p=0.008 n=5)
BucketSeries/1000000SeriesWith1Samples/1000000of1000000[j!="0"]-32            1.564 ± ∞ ¹    1.564 ± ∞ ¹        ~ (p=0.841 n=5)
BucketSeries/1000000SeriesWith1Samples/1000000of1000000[j!~"(0|1)"]-32        1.549 ± ∞ ¹    1.588 ± ∞ ¹        ~ (p=0.841 n=5)
BucketSeries/1000000SeriesWith1Samples/1000000of1000000[j!~"0|1"]-32          1.587 ± ∞ ¹    1.558 ± ∞ ¹        ~ (p=0.548 n=5)
BucketSeries/100000SeriesWith100Samples/1of10000000[j!="0"]-32               9.062m ± ∞ ¹   8.359m ± ∞ ¹   -7.76% (p=0.008 n=5)
BucketSeries/100000SeriesWith100Samples/1of10000000[j!~"(0|1)"]-32          10.493m ± ∞ ¹   8.385m ± ∞ ¹  -20.09% (p=0.008 n=5)
BucketSeries/100000SeriesWith100Samples/1of10000000[j!~"0|1"]-32            10.397m ± ∞ ¹   8.415m ± ∞ ¹  -19.07% (p=0.008 n=5)
BucketSeries/100000SeriesWith100Samples/100of10000000[j!="0"]-32             9.180m ± ∞ ¹   8.428m ± ∞ ¹   -8.19% (p=0.008 n=5)
BucketSeries/100000SeriesWith100Samples/100of10000000[j!~"(0|1)"]-32        10.594m ± ∞ ¹   8.438m ± ∞ ¹  -20.35% (p=0.008 n=5)
BucketSeries/100000SeriesWith100Samples/100of10000000[j!~"0|1"]-32          10.523m ± ∞ ¹   8.416m ± ∞ ¹  -20.02% (p=0.008 n=5)
BucketSeries/100000SeriesWith100Samples/10000000of10000000[j!="0"]-32        159.5m ± ∞ ¹   158.0m ± ∞ ¹        ~ (p=0.548 n=5)
BucketSeries/100000SeriesWith100Samples/10000000of10000000[j!~"(0|1)"]-32    160.6m ± ∞ ¹   157.7m ± ∞ ¹        ~ (p=0.690 n=5)
BucketSeries/100000SeriesWith100Samples/10000000of10000000[j!~"0|1"]-32      158.4m ± ∞ ¹   155.5m ± ∞ ¹   -1.82% (p=0.032 n=5)
BucketSeries/1SeriesWith10000000Samples/1of10000000[j!="0"]-32               65.12µ ± ∞ ¹   64.74µ ± ∞ ¹        ~ (p=0.056 n=5)
BucketSeries/1SeriesWith10000000Samples/1of10000000[j!~"(0|1)"]-32           74.65µ ± ∞ ¹   75.14µ ± ∞ ¹        ~ (p=0.095 n=5)
BucketSeries/1SeriesWith10000000Samples/1of10000000[j!~"0|1"]-32             72.93µ ± ∞ ¹   73.27µ ± ∞ ¹        ~ (p=0.056 n=5)
BucketSeries/1SeriesWith10000000Samples/100of10000000[j!="0"]-32             65.00µ ± ∞ ¹   64.38µ ± ∞ ¹   -0.95% (p=0.008 n=5)
BucketSeries/1SeriesWith10000000Samples/100of10000000[j!~"(0|1)"]-32         74.58µ ± ∞ ¹   74.88µ ± ∞ ¹        ~ (p=0.056 n=5)
BucketSeries/1SeriesWith10000000Samples/100of10000000[j!~"0|1"]-32           73.44µ ± ∞ ¹   73.46µ ± ∞ ¹        ~ (p=0.421 n=5)
BucketSeries/1SeriesWith10000000Samples/10000000of10000000[j!="0"]-32        56.25m ± ∞ ¹   55.67m ± ∞ ¹        ~ (p=0.310 n=5)
BucketSeries/1SeriesWith10000000Samples/10000000of10000000[j!~"(0|1)"]-32    56.43m ± ∞ ¹   56.40m ± ∞ ¹        ~ (p=0.841 n=5)
BucketSeries/1SeriesWith10000000Samples/10000000of10000000[j!~"0|1"]-32      56.29m ± ∞ ¹   55.94m ± ∞ ¹        ~ (p=0.841 n=5)
geomean                                                                      16.23m         14.94m         -7.94%
¹ need >= 6 samples for confidence interval at level 0.95

                                                                          │   /tmp/old    │              /tmp/new               │
                                                                          │     B/op      │     B/op       vs base              │
BucketSeries/1000000SeriesWith1Samples/1of1000000[j!="0"]-32                58.05Mi ± ∞ ¹   54.22Mi ± ∞ ¹  -6.60% (p=0.008 n=5)
BucketSeries/1000000SeriesWith1Samples/1of1000000[j!~"(0|1)"]-32            58.02Mi ± ∞ ¹   54.23Mi ± ∞ ¹  -6.52% (p=0.008 n=5)
BucketSeries/1000000SeriesWith1Samples/1of1000000[j!~"0|1"]-32              58.03Mi ± ∞ ¹   54.20Mi ± ∞ ¹  -6.61% (p=0.008 n=5)
BucketSeries/1000000SeriesWith1Samples/10of1000000[j!="0"]-32               58.06Mi ± ∞ ¹   54.24Mi ± ∞ ¹  -6.58% (p=0.008 n=5)
BucketSeries/1000000SeriesWith1Samples/10of1000000[j!~"(0|1)"]-32           58.06Mi ± ∞ ¹   54.24Mi ± ∞ ¹  -6.58% (p=0.008 n=5)
BucketSeries/1000000SeriesWith1Samples/10of1000000[j!~"0|1"]-32             58.10Mi ± ∞ ¹   54.25Mi ± ∞ ¹  -6.63% (p=0.008 n=5)
BucketSeries/1000000SeriesWith1Samples/1000000of1000000[j!="0"]-32          1.487Gi ± ∞ ¹   1.471Gi ± ∞ ¹  -1.05% (p=0.008 n=5)
BucketSeries/1000000SeriesWith1Samples/1000000of1000000[j!~"(0|1)"]-32      1.487Gi ± ∞ ¹   1.471Gi ± ∞ ¹  -1.05% (p=0.008 n=5)
BucketSeries/1000000SeriesWith1Samples/1000000of1000000[j!~"0|1"]-32        1.486Gi ± ∞ ¹   1.472Gi ± ∞ ¹  -0.99% (p=0.008 n=5)
BucketSeries/100000SeriesWith100Samples/1of10000000[j!="0"]-32              6.714Mi ± ∞ ¹   6.337Mi ± ∞ ¹  -5.60% (p=0.008 n=5)
BucketSeries/100000SeriesWith100Samples/1of10000000[j!~"(0|1)"]-32          6.718Mi ± ∞ ¹   6.338Mi ± ∞ ¹  -5.66% (p=0.008 n=5)
BucketSeries/100000SeriesWith100Samples/1of10000000[j!~"0|1"]-32            6.716Mi ± ∞ ¹   6.341Mi ± ∞ ¹  -5.59% (p=0.008 n=5)
BucketSeries/100000SeriesWith100Samples/100of10000000[j!="0"]-32            6.764Mi ± ∞ ¹   6.381Mi ± ∞ ¹  -5.68% (p=0.008 n=5)
BucketSeries/100000SeriesWith100Samples/100of10000000[j!~"(0|1)"]-32        6.758Mi ± ∞ ¹   6.384Mi ± ∞ ¹  -5.53% (p=0.008 n=5)
BucketSeries/100000SeriesWith100Samples/100of10000000[j!~"0|1"]-32          6.764Mi ± ∞ ¹   6.384Mi ± ∞ ¹  -5.61% (p=0.008 n=5)
BucketSeries/100000SeriesWith100Samples/10000000of10000000[j!="0"]-32       149.0Mi ± ∞ ¹   148.1Mi ± ∞ ¹       ~ (p=0.310 n=5)
BucketSeries/100000SeriesWith100Samples/10000000of10000000[j!~"(0|1)"]-32   149.1Mi ± ∞ ¹   148.2Mi ± ∞ ¹       ~ (p=0.421 n=5)
BucketSeries/100000SeriesWith100Samples/10000000of10000000[j!~"0|1"]-32     149.9Mi ± ∞ ¹   147.6Mi ± ∞ ¹       ~ (p=0.095 n=5)
BucketSeries/1SeriesWith10000000Samples/1of10000000[j!="0"]-32              12.82Ki ± ∞ ¹   12.23Ki ± ∞ ¹  -4.65% (p=0.008 n=5)
BucketSeries/1SeriesWith10000000Samples/1of10000000[j!~"(0|1)"]-32          16.61Ki ± ∞ ¹   16.44Ki ± ∞ ¹       ~ (p=0.056 n=5)
BucketSeries/1SeriesWith10000000Samples/1of10000000[j!~"0|1"]-32            16.08Ki ± ∞ ¹   16.02Ki ± ∞ ¹       ~ (p=0.167 n=5)
BucketSeries/1SeriesWith10000000Samples/100of10000000[j!="0"]-32            12.83Ki ± ∞ ¹   12.23Ki ± ∞ ¹  -4.67% (p=0.008 n=5)
BucketSeries/1SeriesWith10000000Samples/100of10000000[j!~"(0|1)"]-32        16.59Ki ± ∞ ¹   16.48Ki ± ∞ ¹  -0.67% (p=0.032 n=5)
BucketSeries/1SeriesWith10000000Samples/100of10000000[j!~"0|1"]-32          16.01Ki ± ∞ ¹   15.97Ki ± ∞ ¹       ~ (p=0.222 n=5)
BucketSeries/1SeriesWith10000000Samples/10000000of10000000[j!="0"]-32       45.22Mi ± ∞ ¹   45.20Mi ± ∞ ¹       ~ (p=0.310 n=5)
BucketSeries/1SeriesWith10000000Samples/10000000of10000000[j!~"(0|1)"]-32   45.23Mi ± ∞ ¹   45.23Mi ± ∞ ¹       ~ (p=1.000 n=5)
BucketSeries/1SeriesWith10000000Samples/10000000of10000000[j!~"0|1"]-32     45.22Mi ± ∞ ¹   45.22Mi ± ∞ ¹       ~ (p=1.000 n=5)
geomean                                                                     8.871Mi         8.570Mi        -3.40%
¹ need >= 6 samples for confidence interval at level 0.95

                                                                          │   /tmp/old   │              /tmp/new              │
                                                                          │  allocs/op   │  allocs/op    vs base              │
BucketSeries/1000000SeriesWith1Samples/1of1000000[j!="0"]-32                6.384k ± ∞ ¹   6.408k ± ∞ ¹       ~ (p=0.421 n=5)
BucketSeries/1000000SeriesWith1Samples/1of1000000[j!~"(0|1)"]-32            6.460k ± ∞ ¹   6.456k ± ∞ ¹       ~ (p=0.579 n=5)
BucketSeries/1000000SeriesWith1Samples/1of1000000[j!~"0|1"]-32              6.423k ± ∞ ¹   6.437k ± ∞ ¹       ~ (p=0.460 n=5)
BucketSeries/1000000SeriesWith1Samples/10of1000000[j!="0"]-32               6.599k ± ∞ ¹   6.571k ± ∞ ¹       ~ (p=0.341 n=5)
BucketSeries/1000000SeriesWith1Samples/10of1000000[j!~"(0|1)"]-32           6.625k ± ∞ ¹   6.635k ± ∞ ¹       ~ (p=0.690 n=5)
BucketSeries/1000000SeriesWith1Samples/10of1000000[j!~"0|1"]-32             6.615k ± ∞ ¹   6.638k ± ∞ ¹  +0.35% (p=0.016 n=5)
BucketSeries/1000000SeriesWith1Samples/1000000of1000000[j!="0"]-32          18.53M ± ∞ ¹   18.53M ± ∞ ¹       ~ (p=0.310 n=5)
BucketSeries/1000000SeriesWith1Samples/1000000of1000000[j!~"(0|1)"]-32      18.53M ± ∞ ¹   18.53M ± ∞ ¹       ~ (p=0.056 n=5)
BucketSeries/1000000SeriesWith1Samples/1000000of1000000[j!~"0|1"]-32        18.53M ± ∞ ¹   18.53M ± ∞ ¹       ~ (p=1.000 n=5)
BucketSeries/100000SeriesWith100Samples/1of10000000[j!="0"]-32               904.0 ± ∞ ¹    904.0 ± ∞ ¹       ~ (p=0.810 n=5)
BucketSeries/100000SeriesWith100Samples/1of10000000[j!~"(0|1)"]-32           952.0 ± ∞ ¹    962.0 ± ∞ ¹  +1.05% (p=0.008 n=5)
BucketSeries/100000SeriesWith100Samples/1of10000000[j!~"0|1"]-32             947.0 ± ∞ ¹    959.0 ± ∞ ¹  +1.27% (p=0.008 n=5)
BucketSeries/100000SeriesWith100Samples/100of10000000[j!="0"]-32             991.0 ± ∞ ¹    989.0 ± ∞ ¹       ~ (p=0.413 n=5)
BucketSeries/100000SeriesWith100Samples/100of10000000[j!~"(0|1)"]-32        1.038k ± ∞ ¹   1.050k ± ∞ ¹  +1.16% (p=0.008 n=5)
BucketSeries/100000SeriesWith100Samples/100of10000000[j!~"0|1"]-32          1.034k ± ∞ ¹   1.045k ± ∞ ¹  +1.06% (p=0.008 n=5)
BucketSeries/100000SeriesWith100Samples/10000000of10000000[j!="0"]-32       1.854M ± ∞ ¹   1.854M ± ∞ ¹       ~ (p=0.421 n=5)
BucketSeries/100000SeriesWith100Samples/10000000of10000000[j!~"(0|1)"]-32   1.854M ± ∞ ¹   1.854M ± ∞ ¹  +0.00% (p=0.016 n=5)
BucketSeries/100000SeriesWith100Samples/10000000of10000000[j!~"0|1"]-32     1.854M ± ∞ ¹   1.854M ± ∞ ¹       ~ (p=0.690 n=5)
BucketSeries/1SeriesWith10000000Samples/1of10000000[j!="0"]-32               248.0 ± ∞ ¹    247.0 ± ∞ ¹  -0.40% (p=0.008 n=5)
BucketSeries/1SeriesWith10000000Samples/1of10000000[j!~"(0|1)"]-32           295.0 ± ∞ ¹    306.0 ± ∞ ¹  +3.73% (p=0.008 n=5)
BucketSeries/1SeriesWith10000000Samples/1of10000000[j!~"0|1"]-32             290.0 ± ∞ ¹    301.0 ± ∞ ¹  +3.79% (p=0.008 n=5)
BucketSeries/1SeriesWith10000000Samples/100of10000000[j!="0"]-32             248.0 ± ∞ ¹    247.0 ± ∞ ¹  -0.40% (p=0.008 n=5)
BucketSeries/1SeriesWith10000000Samples/100of10000000[j!~"(0|1)"]-32         295.0 ± ∞ ¹    306.0 ± ∞ ¹  +3.73% (p=0.008 n=5)
BucketSeries/1SeriesWith10000000Samples/100of10000000[j!~"0|1"]-32           290.0 ± ∞ ¹    301.0 ± ∞ ¹  +3.79% (p=0.008 n=5)
BucketSeries/1SeriesWith10000000Samples/10000000of10000000[j!="0"]-32       190.0k ± ∞ ¹   190.0k ± ∞ ¹       ~ (p=0.389 n=5)
BucketSeries/1SeriesWith10000000Samples/10000000of10000000[j!~"(0|1)"]-32   190.0k ± ∞ ¹   190.1k ± ∞ ¹  +0.03% (p=0.008 n=5)
BucketSeries/1SeriesWith10000000Samples/10000000of10000000[j!~"0|1"]-32     190.0k ± ∞ ¹   190.1k ± ∞ ¹  +0.03% (p=0.008 n=5)
geomean                                                                     13.97k         14.07k        +0.70%
```

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
