### PR TITLE
added objstore and promql-engine update package ecosystem in dependab…

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,18 @@ updates:
     schedule:
       interval: "weekly"
     labels: ["dependencies"]
+    ignore:
+      - dependency-name: "objstore"
+      - dependency-name: "promql-engine"
+  - package-ecosystem: "gomod"
+    directory: "/"
+    vendor: false
+    schedule:
+      interval: "daily"
+    labels: ["dependencies"]
+    allow:
+      - dependency-name: "objstore"
+      - dependency-name: "promql-engine"
   - package-ecosystem: "docker"
     directory: "/"
     schedule:


### PR DESCRIPTION
…ot.yml

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

Fixes #5915 
## Changes
I have ignored the objstore and promql-engine using ignore  tag in the existing ecosystem and then created a separate package ecosystem for them with allow tag and daily interval.

<!-- Enumerate changes you made -->

<!-- How you tested it? How do you know it works? -->
