### PR TITLE
Fix double-counting bug in http_request_duration metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#6330](https://github.com/thanos-io/thanos/pull/6330) Store: Fix inconsistent error for series limits.
 - [#6342](https://github.com/thanos-io/thanos/pull/6342) Cache/Redis: Upgrade `rueidis` to v1.0.2 to to improve error handling while shrinking a redis cluster.
 - [#6325](https://github.com/thanos-io/thanos/pull/6325) Store: return gRPC resource exhausted error for byte limiter.
+- [#6399](https://github.com/thanos-io/thanos/pull/6399) *: Fix double-counting bug in http_request_duration metric
 
 ### Changed
 - [#6168](https://github.com/thanos-io/thanos/pull/6168) Receiver: Make ketama hashring fail early when configured with number of nodes lower than the replication factor.

--- a/pkg/extprom/http/instrument_server.go
+++ b/pkg/extprom/http/instrument_server.go
@@ -76,7 +76,7 @@ func httpInstrumentationHandler(baseLabels prometheus.Labels, metrics *defaultMe
 
 						requestLabels := prometheus.Labels{"code": wd.Status(), "method": strings.ToLower(r.Method)}
 						observer := metrics.requestDuration.MustCurryWith(baseLabels).With(requestLabels)
-						observer.Observe(time.Since(now).Seconds())
+						requestDuration := time.Since(now).Seconds()
 
 						// If we find a tracingID we'll expose it as Exemplar.
 						var (
@@ -104,11 +104,13 @@ func httpInstrumentationHandler(baseLabels prometheus.Labels, metrics *defaultMe
 
 						if traceID != "" {
 							observer.(prometheus.ExemplarObserver).ObserveWithExemplar(
-								time.Since(now).Seconds(),
+								requestDuration,
 								prometheus.Labels{
 									"traceID": traceID,
 								},
 							)
+						} else {
+							observer.Observe(requestDuration)
 						}
 					}),
 				),


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

If you have traceId, http_request_duration metric increases twice.

## Verification

<!-- How you tested it? How do you know it works? -->
