### PR TITLE
index cache: Cache expanded postings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#6163](https://github.com/thanos-io/thanos/pull/6163) Receiver: Add hidden flag `--receive-forward-max-backoff` to configure the max backoff for forwarding requests.
 - [#5777](https://github.com/thanos-io/thanos/pull/5777) Receive: Allow specifying tenant-specific external labels in Router Ingestor.
 - [#6352](https://github.com/thanos-io/thanos/pull/6352) Store: Expose store gateway query stats in series response hints.
+- [#6420](https://github.com/thanos-io/thanos/pull/6420) Index Cache: Cache expanded postings.
 
 ### Fixed
 - [#6427](https://github.com/thanos-io/thanos/pull/6427) Receive: increasing log level for failed uploads to error

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -2545,8 +2545,6 @@ func (r *bucketIndexReader) fetchPostings(ctx context.Context, keys []labels.Lab
 					return err
 				}
 
-				dataToCache := pBytes
-
 				// Reencode postings before storing to cache. If that fails, we store original bytes.
 				// This can only fail, if postings data was somehow corrupted,
 				// and there is nothing we can do about it.

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -2160,7 +2160,7 @@ func (r *bucketIndexReader) ExpandedPostings(ctx context.Context, ms []*labels.M
 	sort.Slice(ms, func(i, j int) bool {
 		if ms[i].Type == ms[j].Type {
 			if ms[i].Name == ms[j].Name {
-				return ms[i].Value == ms[j].Value
+				return ms[i].Value < ms[j].Value
 			}
 			return ms[i].Name < ms[j].Name
 		}
@@ -2184,6 +2184,20 @@ func (r *bucketIndexReader) ExpandedPostings(ctx context.Context, ms []*labels.M
 			ps, err := index.ExpandPostings(p)
 			if err != nil {
 				return nil, errors.Wrap(err, "expand")
+			}
+
+			if len(ps) > 0 {
+				// As of version two all series entries are 16 byte padded. All references
+				// we get have to account for that to get the correct offset.
+				version, err := r.block.indexHeaderReader.IndexVersion()
+				if err != nil {
+					return nil, errors.Wrap(err, "get index version")
+				}
+				if version >= 2 {
+					for i, id := range ps {
+						ps[i] = id * 16
+					}
+				}
 			}
 			return ps, nil
 		}
@@ -2284,18 +2298,8 @@ func (r *bucketIndexReader) ExpandedPostings(ctx context.Context, ms []*labels.M
 		return nil, errors.Wrap(err, "expand")
 	}
 
-	// As of version two all series entries are 16 byte padded. All references
-	// we get have to account for that to get the correct offset.
-	version, err := r.block.indexHeaderReader.IndexVersion()
-	if err != nil {
-		return nil, errors.Wrap(err, "get index version")
-	}
-	if version >= 2 {
-		for i, id := range ps {
-			ps[i] = id * 16
-		}
-	}
-	// Encode postings to cache.
+	// Encode postings to cache. We compress and cache postings before adding
+	// 16 bytes padding in order to make compressed size smaller.
 	dataToCache, compressionDuration, compressionErrors, compressedSize := r.encodePostingsToCache(index.NewListPostings(ps), len(ps))
 	r.stats.cachedPostingsCompressions++
 	r.stats.cachedPostingsCompressionErrors += compressionErrors
@@ -2303,6 +2307,20 @@ func (r *bucketIndexReader) ExpandedPostings(ctx context.Context, ms []*labels.M
 	r.stats.CachedPostingsCompressedSizeSum += units.Base2Bytes(compressedSize)
 	r.stats.CachedPostingsOriginalSizeSum += units.Base2Bytes(len(ps) * 4) // Estimate the posting list size.
 	r.block.indexCache.StoreExpandedPostings(r.block.meta.ULID, ms, dataToCache)
+
+	if len(ps) > 0 {
+		// As of version two all series entries are 16 byte padded. All references
+		// we get have to account for that to get the correct offset.
+		version, err := r.block.indexHeaderReader.IndexVersion()
+		if err != nil {
+			return nil, errors.Wrap(err, "get index version")
+		}
+		if version >= 2 {
+			for i, id := range ps {
+				ps[i] = id * 16
+			}
+		}
+	}
 	return ps, nil
 }
 
@@ -2452,7 +2470,7 @@ func (r *bucketIndexReader) fetchPostings(ctx context.Context, keys []labels.Lab
 
 			l, closer, err := r.decodeCachedPostings(b)
 			if err != nil {
-
+				return nil, closeFns, errors.Wrap(err, "decode postings")
 			}
 			output[ix] = l
 			closeFns = append(closeFns, closer...)

--- a/pkg/store/bucket_e2e_test.go
+++ b/pkg/store/bucket_e2e_test.go
@@ -66,6 +66,15 @@ func (c *swappableCache) FetchMultiPostings(ctx context.Context, blockID ulid.UL
 	return c.ptr.FetchMultiPostings(ctx, blockID, keys)
 }
 
+func (c *swappableCache) StoreExpandedPostings(blockID ulid.ULID, matchers []*labels.Matcher, v []byte) {
+	c.ptr.StoreExpandedPostings(blockID, matchers, v)
+}
+
+// FetchExpandedPostings fetches expanded postings.
+func (c *swappableCache) FetchExpandedPostings(ctx context.Context, blockID ulid.ULID, matchers []*labels.Matcher) ([]byte, bool) {
+	return c.ptr.FetchExpandedPostings(ctx, blockID, matchers)
+}
+
 func (c *swappableCache) StoreSeries(blockID ulid.ULID, id storage.SeriesRef, v []byte) {
 	c.ptr.StoreSeries(blockID, id, v)
 }

--- a/pkg/store/bucket_e2e_test.go
+++ b/pkg/store/bucket_e2e_test.go
@@ -70,7 +70,6 @@ func (c *swappableCache) StoreExpandedPostings(blockID ulid.ULID, matchers []*la
 	c.ptr.StoreExpandedPostings(blockID, matchers, v)
 }
 
-// FetchExpandedPostings fetches expanded postings.
 func (c *swappableCache) FetchExpandedPostings(ctx context.Context, blockID ulid.ULID, matchers []*labels.Matcher) ([]byte, bool) {
 	return c.ptr.FetchExpandedPostings(ctx, blockID, matchers)
 }

--- a/pkg/store/cache/cache.go
+++ b/pkg/store/cache/cache.go
@@ -42,7 +42,7 @@ type IndexCache interface {
 	// StoreExpandedPostings stores expanded postings for a set of label matchers.
 	StoreExpandedPostings(blockID ulid.ULID, matchers []*labels.Matcher, v []byte)
 
-	// FetchExpandedPostings fetches expanded postings.
+	// FetchExpandedPostings fetches expanded postings and returns cached data and a boolean value representing whether it is a cache hit or not.
 	FetchExpandedPostings(ctx context.Context, blockID ulid.ULID, matchers []*labels.Matcher) ([]byte, bool)
 
 	// StoreSeries stores a single series.

--- a/pkg/store/cache/cache.go
+++ b/pkg/store/cache/cache.go
@@ -6,17 +6,17 @@ package storecache
 import (
 	"context"
 	"encoding/base64"
-	"strconv"
-
 	"github.com/oklog/ulid"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
 	"golang.org/x/crypto/blake2b"
+	"strconv"
 )
 
 const (
-	cacheTypePostings string = "Postings"
-	cacheTypeSeries   string = "Series"
+	cacheTypePostings         string = "Postings"
+	cacheTypeExpandedPostings string = "ExpandedPostings"
+	cacheTypeSeries           string = "Series"
 
 	sliceHeaderSize = 16
 )
@@ -37,6 +37,12 @@ type IndexCache interface {
 	// FetchMultiPostings fetches multiple postings - each identified by a label -
 	// and returns a map containing cache hits, along with a list of missing keys.
 	FetchMultiPostings(ctx context.Context, blockID ulid.ULID, keys []labels.Label) (hits map[labels.Label][]byte, misses []labels.Label)
+
+	// StoreExpandedPostings stores expanded postings for a set of label matchers.
+	StoreExpandedPostings(blockID ulid.ULID, matchers []*labels.Matcher, v []byte)
+
+	// FetchExpandedPostings fetches expanded postings.
+	FetchExpandedPostings(ctx context.Context, blockID ulid.ULID, matchers []*labels.Matcher) ([]byte, bool)
 
 	// StoreSeries stores a single series.
 	StoreSeries(blockID ulid.ULID, id storage.SeriesRef, v []byte)
@@ -59,6 +65,8 @@ func (c cacheKey) keyType() string {
 		return cacheTypePostings
 	case cacheKeySeries:
 		return cacheTypeSeries
+	case cacheKeyExpandedPostings:
+		return cacheTypeExpandedPostings
 	}
 	return "<unknown>"
 }
@@ -68,6 +76,8 @@ func (c cacheKey) size() uint64 {
 	case cacheKeyPostings:
 		// ULID + 2 slice headers + number of chars in value and name.
 		return ulidSize + 2*sliceHeaderSize + uint64(len(k.Value)+len(k.Name))
+	case cacheKeyExpandedPostings:
+		return ulidSize + sliceHeaderSize + uint64(len(k))
 	case cacheKeySeries:
 		return ulidSize + 8 // ULID + uint64.
 	}
@@ -86,6 +96,12 @@ func (c cacheKey) string() string {
 			key += ":" + c.compression
 		}
 		return key
+	case cacheKeyExpandedPostings:
+		// Use cryptographically hash functions to avoid hash collisions
+		// which would end up in wrong query results.
+		matchers := c.key.(cacheKeyExpandedPostings)
+		matchersHash := blake2b.Sum256([]byte(matchers))
+		return "EP:" + c.block + ":" + base64.RawURLEncoding.EncodeToString(matchersHash[0:])
 	case cacheKeySeries:
 		return "S:" + c.block + ":" + strconv.FormatUint(uint64(c.key.(cacheKeySeries)), 10)
 	default:
@@ -93,5 +109,17 @@ func (c cacheKey) string() string {
 	}
 }
 
+func labelMatchersToString(matchers []*labels.Matcher) string {
+	matchersString := ""
+	for i, lbl := range matchers {
+		matchersString += lbl.String()
+		if i < len(matchers)-1 {
+			matchersString += ";"
+		}
+	}
+	return matchersString
+}
+
 type cacheKeyPostings labels.Label
+type cacheKeyExpandedPostings string
 type cacheKeySeries uint64

--- a/pkg/store/cache/cache.go
+++ b/pkg/store/cache/cache.go
@@ -6,11 +6,12 @@ package storecache
 import (
 	"context"
 	"encoding/base64"
+	"strconv"
+
 	"github.com/oklog/ulid"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
 	"golang.org/x/crypto/blake2b"
-	"strconv"
 )
 
 const (

--- a/pkg/store/cache/cache_test.go
+++ b/pkg/store/cache/cache_test.go
@@ -27,6 +27,8 @@ func TestCacheKey_string(t *testing.T) {
 
 	uid := ulid.MustNew(1, nil)
 	ulidString := uid.String()
+	matcher := labels.MustNewMatcher(labels.MatchRegexp, "aaa", "bbb")
+	matcher2 := labels.MustNewMatcher(labels.MatchNotEqual, "foo", "bar")
 
 	tests := map[string]struct {
 		key      cacheKey
@@ -44,6 +46,24 @@ func TestCacheKey_string(t *testing.T) {
 		"should stringify series cache key": {
 			key:      cacheKey{ulidString, cacheKeySeries(12345), ""},
 			expected: fmt.Sprintf("S:%s:12345", uid.String()),
+		},
+		"should stringify expanded postings cache key": {
+			key: cacheKey{ulidString, cacheKeyExpandedPostings(labelMatchersToString([]*labels.Matcher{matcher}))},
+			expected: func() string {
+				hash := blake2b.Sum256([]byte(matcher.String()))
+				encodedHash := base64.RawURLEncoding.EncodeToString(hash[0:])
+
+				return fmt.Sprintf("EP:%s:%s", uid.String(), encodedHash)
+			}(),
+		},
+		"should stringify expanded postings cache key when multiple matchers": {
+			key: cacheKey{ulidString, cacheKeyExpandedPostings(labelMatchersToString([]*labels.Matcher{matcher, matcher2}))},
+			expected: func() string {
+				hash := blake2b.Sum256([]byte(fmt.Sprintf("%s;%s", matcher.String(), matcher2.String())))
+				encodedHash := base64.RawURLEncoding.EncodeToString(hash[0:])
+
+				return fmt.Sprintf("EP:%s:%s", uid.String(), encodedHash)
+			}(),
 		},
 	}
 
@@ -76,6 +96,21 @@ func TestCacheKey_string_ShouldGuaranteeReasonablyShortKeyLength(t *testing.T) {
 			expectedLen: 49,
 			keys: []cacheKey{
 				{ulidString, cacheKeySeries(math.MaxUint64), ""},
+			},
+		},
+		"should guarantee reasonably short key length for expanded postings": {
+			expectedLen: 73,
+			keys: []cacheKey{
+				{ulidString, func() interface{} {
+					matchers := make([]*labels.Matcher, 0, 100)
+					name := strings.Repeat("a", 100)
+					value := strings.Repeat("a", 1000)
+					for i := 0; i < 100; i++ {
+						t := labels.MatchType(i % 4)
+						matchers = append(matchers, labels.MustNewMatcher(t, name, value))
+					}
+					return cacheKeyExpandedPostings(labelMatchersToString(matchers))
+				}()},
 			},
 		},
 	}

--- a/pkg/store/cache/inmemory.go
+++ b/pkg/store/cache/inmemory.go
@@ -324,7 +324,7 @@ func (c *InMemoryIndexCache) StoreExpandedPostings(blockID ulid.ULID, matchers [
 	c.set(cacheTypeExpandedPostings, cacheKey{block: blockID.String(), key: cacheKeyExpandedPostings(labelMatchersToString(matchers))}, v)
 }
 
-// FetchExpandedPostings fetches expanded postings.
+// FetchExpandedPostings fetches expanded postings and returns cached data and a boolean value representing whether it is a cache hit or not.
 func (c *InMemoryIndexCache) FetchExpandedPostings(_ context.Context, blockID ulid.ULID, matchers []*labels.Matcher) ([]byte, bool) {
 	if b, ok := c.get(cacheTypeExpandedPostings, cacheKey{blockID.String(), cacheKeyExpandedPostings(labelMatchersToString(matchers))}); ok {
 		return b, true

--- a/pkg/store/cache/inmemory.go
+++ b/pkg/store/cache/inmemory.go
@@ -326,7 +326,7 @@ func (c *InMemoryIndexCache) StoreExpandedPostings(blockID ulid.ULID, matchers [
 
 // FetchExpandedPostings fetches expanded postings and returns cached data and a boolean value representing whether it is a cache hit or not.
 func (c *InMemoryIndexCache) FetchExpandedPostings(_ context.Context, blockID ulid.ULID, matchers []*labels.Matcher) ([]byte, bool) {
-	if b, ok := c.get(cacheTypeExpandedPostings, cacheKey{blockID.String(), cacheKeyExpandedPostings(labelMatchersToString(matchers))}); ok {
+	if b, ok := c.get(cacheTypeExpandedPostings, cacheKey{blockID.String(), cacheKeyExpandedPostings(labelMatchersToString(matchers)), ""}); ok {
 		return b, true
 	}
 	return nil, false

--- a/pkg/store/cache/inmemory.go
+++ b/pkg/store/cache/inmemory.go
@@ -326,7 +326,7 @@ func (c *InMemoryIndexCache) StoreExpandedPostings(blockID ulid.ULID, matchers [
 
 // FetchExpandedPostings fetches expanded postings.
 func (c *InMemoryIndexCache) FetchExpandedPostings(_ context.Context, blockID ulid.ULID, matchers []*labels.Matcher) ([]byte, bool) {
-	if b, ok := c.get(cacheTypePostings, cacheKey{blockID.String(), cacheKeyExpandedPostings(labelMatchersToString(matchers))}); ok {
+	if b, ok := c.get(cacheTypeExpandedPostings, cacheKey{blockID.String(), cacheKeyExpandedPostings(labelMatchersToString(matchers))}); ok {
 		return b, true
 	}
 	return nil, false

--- a/pkg/store/cache/inmemory_test.go
+++ b/pkg/store/cache/inmemory_test.go
@@ -122,6 +122,7 @@ func TestInMemoryIndexCache_UpdateItem(t *testing.T) {
 
 	uid := func(id storage.SeriesRef) ulid.ULID { return ulid.MustNew(uint64(id), nil) }
 	lbl := labels.Label{Name: "foo", Value: "bar"}
+	matcher := labels.MustNewMatcher(labels.MatchEqual, "foo", "bar")
 	ctx := context.Background()
 
 	for _, tt := range []struct {
@@ -147,6 +148,15 @@ func TestInMemoryIndexCache_UpdateItem(t *testing.T) {
 				b, ok := hits[id]
 
 				return b, ok
+			},
+		},
+		{
+			typ: cacheTypeExpandedPostings,
+			set: func(id storage.SeriesRef, b []byte) {
+				cache.StoreExpandedPostings(uid(id), []*labels.Matcher{matcher}, b)
+			},
+			get: func(id storage.SeriesRef) ([]byte, bool) {
+				return cache.FetchExpandedPostings(ctx, uid(id), []*labels.Matcher{matcher})
 			},
 		},
 	} {

--- a/pkg/store/cache/memcached.go
+++ b/pkg/store/cache/memcached.go
@@ -123,7 +123,7 @@ func (c *RemoteIndexCache) FetchMultiPostings(ctx context.Context, blockID ulid.
 // The function enqueues the request and returns immediately: the entry will be
 // asynchronously stored in the cache.
 func (c *RemoteIndexCache) StoreExpandedPostings(blockID ulid.ULID, keys []*labels.Matcher, v []byte) {
-	key := cacheKey{blockID.String(), cacheKeyExpandedPostings(labelMatchersToString(keys))}.string()
+	key := cacheKey{blockID.String(), cacheKeyExpandedPostings(labelMatchersToString(keys)), ""}.string()
 
 	if err := c.memcached.SetAsync(key, v, memcachedDefaultTTL); err != nil {
 		level.Error(c.logger).Log("msg", "failed to cache expanded postings in memcached", "err", err)
@@ -134,7 +134,7 @@ func (c *RemoteIndexCache) StoreExpandedPostings(blockID ulid.ULID, keys []*labe
 // and returns a map containing cache hits, along with a list of missing keys.
 // In case of error, it logs and return an empty cache hits map.
 func (c *RemoteIndexCache) FetchExpandedPostings(ctx context.Context, blockID ulid.ULID, lbls []*labels.Matcher) ([]byte, bool) {
-	key := cacheKey{blockID.String(), cacheKeyExpandedPostings(labelMatchersToString(lbls))}.string()
+	key := cacheKey{blockID.String(), cacheKeyExpandedPostings(labelMatchersToString(lbls)), ""}.string()
 
 	// Fetch the keys from memcached in a single request.
 	c.expandedPostingRequests.Add(1)

--- a/pkg/store/cache/memcached.go
+++ b/pkg/store/cache/memcached.go
@@ -123,7 +123,7 @@ func (c *RemoteIndexCache) FetchMultiPostings(ctx context.Context, blockID ulid.
 // The function enqueues the request and returns immediately: the entry will be
 // asynchronously stored in the cache.
 func (c *RemoteIndexCache) StoreExpandedPostings(blockID ulid.ULID, keys []*labels.Matcher, v []byte) {
-	key := cacheKey{blockID.String(), cacheKeyExpandedPostings(labelMatchersToString(keys)), ""}.string()
+	key := cacheKey{blockID.String(), cacheKeyExpandedPostings(labelMatchersToString(keys)), c.compressionScheme}.string()
 
 	if err := c.memcached.SetAsync(key, v, memcachedDefaultTTL); err != nil {
 		level.Error(c.logger).Log("msg", "failed to cache expanded postings in memcached", "err", err)
@@ -134,7 +134,7 @@ func (c *RemoteIndexCache) StoreExpandedPostings(blockID ulid.ULID, keys []*labe
 // and returns a map containing cache hits, along with a list of missing keys.
 // In case of error, it logs and return an empty cache hits map.
 func (c *RemoteIndexCache) FetchExpandedPostings(ctx context.Context, blockID ulid.ULID, lbls []*labels.Matcher) ([]byte, bool) {
-	key := cacheKey{blockID.String(), cacheKeyExpandedPostings(labelMatchersToString(lbls)), ""}.string()
+	key := cacheKey{blockID.String(), cacheKeyExpandedPostings(labelMatchersToString(lbls)), c.compressionScheme}.string()
 
 	// Fetch the keys from memcached in a single request.
 	c.expandedPostingRequests.Add(1)

--- a/test/e2e/compact_test.go
+++ b/test/e2e/compact_test.go
@@ -458,7 +458,7 @@ func testCompactWithStoreGateway(t *testing.T, penaltyDedup bool) {
 	}
 
 	// Crank down the deletion mark delay since deduplication can miss blocks in the presence of replica labels it doesn't know about.
-	str := e2ethanos.NewStoreGW(e, "1", bktConfig, "", []string{"--ignore-deletion-marks-delay=2s"})
+	str := e2ethanos.NewStoreGW(e, "1", bktConfig, "", "", []string{"--ignore-deletion-marks-delay=2s"})
 	testutil.Ok(t, e2e.StartAndWaitReady(str))
 	testutil.Ok(t, str.WaitSumMetrics(e2emon.Equals(float64(len(rawBlockIDs)+8)), "thanos_blocks_meta_synced"))
 	testutil.Ok(t, str.WaitSumMetrics(e2emon.Equals(0), "thanos_blocks_meta_sync_failures_total"))

--- a/test/e2e/e2ethanos/services.go
+++ b/test/e2e/e2ethanos/services.go
@@ -846,7 +846,7 @@ receivers:
 	})), "http")
 }
 
-func NewStoreGW(e e2e.Environment, name string, bucketConfig client.BucketConfig, cacheConfig string, extArgs []string, relabelConfig ...relabel.Config) *e2emon.InstrumentedRunnable {
+func NewStoreGW(e e2e.Environment, name string, bucketConfig client.BucketConfig, cacheConfig, indexCacheConfig string, extArgs []string, relabelConfig ...relabel.Config) *e2emon.InstrumentedRunnable {
 	f := e.Runnable(fmt.Sprintf("store-gw-%v", name)).
 		WithPorts(map[string]int{"http": 8080, "grpc": 9091}).
 		Future()
@@ -883,6 +883,10 @@ func NewStoreGW(e e2e.Environment, name string, bucketConfig client.BucketConfig
 
 	if cacheConfig != "" {
 		args = append(args, "--store.caching-bucket.config", cacheConfig)
+	}
+
+	if indexCacheConfig != "" {
+		args = append(args, "--index-cache.config", indexCacheConfig)
 	}
 
 	return e2emon.AsInstrumented(f.Init(wrapWithDefaults(e2e.StartOptions{

--- a/test/e2e/info_api_test.go
+++ b/test/e2e/info_api_test.go
@@ -48,6 +48,7 @@ func TestInfo(t *testing.T) {
 			Config: e2ethanos.NewS3Config(bucket, m.InternalEndpoint("http"), m.InternalDir()),
 		},
 		"",
+		"",
 		nil,
 	)
 	testutil.Ok(t, e2e.StartAndWaitReady(store))

--- a/test/e2e/query_test.go
+++ b/test/e2e/query_test.go
@@ -644,6 +644,7 @@ func TestQueryStoreMetrics(t *testing.T) {
 			Config: e2ethanos.NewS3Config(bucket, minio.InternalEndpoint("http"), minio.InternalDir()),
 		},
 		"",
+		"",
 		nil,
 	)
 
@@ -778,6 +779,7 @@ func TestSidecarStorePushdown(t *testing.T) {
 			Config: e2ethanos.NewS3Config(bucket, m.InternalEndpoint("http"), m.InternalDir()),
 		},
 		"",
+		"",
 		nil,
 	)
 	testutil.Ok(t, e2e.StartAndWaitReady(s1))
@@ -880,6 +882,7 @@ func TestQueryStoreDedup(t *testing.T) {
 			Type:   client.S3,
 			Config: e2ethanos.NewS3Config(bucket, minio.InternalEndpoint("http"), minio.InternalDir()),
 		},
+		"",
 		"",
 		nil,
 	)

--- a/test/e2e/store_gateway_test.go
+++ b/test/e2e/store_gateway_test.go
@@ -72,6 +72,7 @@ metafile_content_ttl: 0s`, memcached.InternalEndpoint("memcached"))
 			Config: e2ethanos.NewS3Config(bucket, m.InternalEndpoint("http"), m.InternalDir()),
 		},
 		memcachedConfig,
+		"",
 		nil,
 		relabel.Config{
 			Action:       relabel.Drop,
@@ -340,6 +341,7 @@ func TestStoreGatewayNoCacheFile(t *testing.T) {
 			Config: e2ethanos.NewS3Config(bucket, m.InternalEndpoint("http"), m.InternalDir()),
 		},
 		"",
+		"",
 		[]string{"--no-cache-index-header"},
 		relabel.Config{
 			Action:       relabel.Drop,
@@ -571,6 +573,7 @@ blocks_iter_ttl: 0s`, memcached.InternalEndpoint("memcached"))
 			Config: e2ethanos.NewS3Config(bucket, m.InternalEndpoint("http"), m.InternalDir()),
 		},
 		memcachedConfig,
+		"",
 		nil,
 	)
 	testutil.Ok(t, e2e.StartAndWaitReady(s1))
@@ -679,6 +682,7 @@ metafile_content_ttl: 0s`
 			Config: e2ethanos.NewS3Config(bucket, m.InternalEndpoint("http"), m.InternalDir()),
 		},
 		fmt.Sprintf(groupcacheConfig, 1),
+		"",
 		nil,
 	)
 	store2 := e2ethanos.NewStoreGW(
@@ -689,6 +693,7 @@ metafile_content_ttl: 0s`
 			Config: e2ethanos.NewS3Config(bucket, m.InternalEndpoint("http"), m.InternalDir()),
 		},
 		fmt.Sprintf(groupcacheConfig, 2),
+		"",
 		nil,
 	)
 	store3 := e2ethanos.NewStoreGW(
@@ -699,6 +704,7 @@ metafile_content_ttl: 0s`
 			Config: e2ethanos.NewS3Config(bucket, m.InternalEndpoint("http"), m.InternalDir()),
 		},
 		fmt.Sprintf(groupcacheConfig, 3),
+		"",
 		nil,
 	)
 	testutil.Ok(t, e2e.StartAndWaitReady(store1, store2, store3))
@@ -795,6 +801,7 @@ config:
 			Config: e2ethanos.NewS3Config(bucket, m.InternalEndpoint("http"), m.InternalDir()),
 		},
 		string(cacheCfg),
+		"",
 		[]string{"--store.grpc.downloaded-bytes-limit=1B"},
 	)
 
@@ -806,6 +813,7 @@ config:
 			Config: e2ethanos.NewS3Config(bucket, m.InternalEndpoint("http"), m.InternalDir()),
 		},
 		string(cacheCfg),
+		"",
 		[]string{"--store.grpc.downloaded-bytes-limit=100B"},
 	)
 	store3 := e2ethanos.NewStoreGW(
@@ -816,6 +824,7 @@ config:
 			Config: e2ethanos.NewS3Config(bucket, m.InternalEndpoint("http"), m.InternalDir()),
 		},
 		string(cacheCfg),
+		"",
 		[]string{"--store.grpc.downloaded-bytes-limit=196627B"},
 	)
 
@@ -920,4 +929,109 @@ func TestRedisClient_Rueidis(t *testing.T) {
 	returnedVals := redisClient.GetMulti(context.TODO(), []string{"foo"})
 	testutil.Equals(t, 1, len(returnedVals))
 	testutil.Equals(t, []byte("bar"), returnedVals["foo"])
+}
+
+func TestStoreGatewayMemcachedIndexCacheExpandedPostings(t *testing.T) {
+	t.Parallel()
+
+	e, err := e2e.NewDockerEnvironment("memcached-exp")
+	testutil.Ok(t, err)
+	t.Cleanup(e2ethanos.CleanScenario(t, e))
+
+	const bucket = "store-gateway-memcached-index-cache-expanded-postings-test"
+	m := e2edb.NewMinio(e, "thanos-minio", bucket, e2edb.WithMinioTLS())
+	testutil.Ok(t, e2e.StartAndWaitReady(m))
+
+	memcached := e2ethanos.NewMemcached(e, "1")
+	testutil.Ok(t, e2e.StartAndWaitReady(memcached))
+
+	indexCacheConfig := fmt.Sprintf(`type: MEMCACHED
+config:
+  addresses: [%s]
+  max_async_concurrency: 10
+  max_async_concurrency: 10
+  auto_discovery: false`, memcached.InternalEndpoint("memcached"))
+
+	s1 := e2ethanos.NewStoreGW(
+		e,
+		"1",
+		client.BucketConfig{
+			Type:   client.S3,
+			Config: e2ethanos.NewS3Config(bucket, m.InternalEndpoint("http"), m.InternalDir()),
+		},
+		"",
+		indexCacheConfig,
+		nil,
+	)
+	testutil.Ok(t, e2e.StartAndWaitReady(s1))
+
+	q := e2ethanos.NewQuerierBuilder(e, "1", s1.InternalEndpoint("grpc")).Init()
+	testutil.Ok(t, e2e.StartAndWaitReady(q))
+
+	dir := filepath.Join(e.SharedDir(), "tmp")
+	testutil.Ok(t, os.MkdirAll(dir, os.ModePerm))
+
+	series := []labels.Labels{labels.FromStrings("a", "1", "b", "2")}
+	extLset := labels.FromStrings("ext1", "value1", "replica", "1")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	t.Cleanup(cancel)
+
+	now := time.Now()
+	id, err := e2eutil.CreateBlockWithBlockDelay(ctx, dir, series, 10, timestamp.FromTime(now), timestamp.FromTime(now.Add(2*time.Hour)), 30*time.Minute, extLset, 0, metadata.NoneFunc)
+	testutil.Ok(t, err)
+
+	l := log.NewLogfmtLogger(os.Stdout)
+	bkt, err := s3.NewBucketWithConfig(l,
+		e2ethanos.NewS3Config(bucket, m.Endpoint("http"), m.Dir()), "test-feed")
+	testutil.Ok(t, err)
+
+	testutil.Ok(t, objstore.UploadDir(ctx, l, bkt, path.Join(dir, id.String()), id.String()))
+
+	// Wait for store to sync blocks.
+	// thanos_blocks_meta_synced: 1x loadedMeta 0x labelExcludedMeta 0x TooFreshMeta.
+	testutil.Ok(t, s1.WaitSumMetrics(e2emon.Equals(1), "thanos_blocks_meta_synced"))
+	testutil.Ok(t, s1.WaitSumMetrics(e2emon.Equals(0), "thanos_blocks_meta_sync_failures_total"))
+
+	testutil.Ok(t, s1.WaitSumMetrics(e2emon.Equals(1), "thanos_bucket_store_blocks_loaded"))
+	testutil.Ok(t, s1.WaitSumMetrics(e2emon.Equals(0), "thanos_bucket_store_block_drops_total"))
+	testutil.Ok(t, s1.WaitSumMetrics(e2emon.Equals(0), "thanos_bucket_store_block_load_failures_total"))
+
+	t.Run("query with cache miss", func(t *testing.T) {
+		queryAndAssertSeries(t, ctx, q.Endpoint("http"), func() string { return testQuery },
+			time.Now, promclient.QueryOptions{
+				Deduplicate: false,
+			},
+			[]model.Metric{
+				{
+					"a":       "1",
+					"b":       "2",
+					"ext1":    "value1",
+					"replica": "1",
+				},
+			},
+		)
+
+		testutil.Ok(t, s1.WaitSumMetricsWithOptions(e2emon.Equals(1), []string{`thanos_store_index_cache_requests_total`}, e2emon.WithLabelMatchers(matchers.MustNewMatcher(matchers.MatchEqual, "item_type", "ExpandedPostings"))))
+		testutil.Ok(t, s1.WaitSumMetricsWithOptions(e2emon.Equals(0), []string{`thanos_store_index_cache_hits_total`}, e2emon.WithLabelMatchers(matchers.MustNewMatcher(matchers.MatchEqual, "item_type", "ExpandedPostings"))))
+	})
+
+	t.Run("query with cache hit", func(t *testing.T) {
+		queryAndAssertSeries(t, ctx, q.Endpoint("http"), func() string { return testQuery },
+			time.Now, promclient.QueryOptions{
+				Deduplicate: false,
+			},
+			[]model.Metric{
+				{
+					"a":       "1",
+					"b":       "2",
+					"ext1":    "value1",
+					"replica": "1",
+				},
+			},
+		)
+
+		testutil.Ok(t, s1.WaitSumMetricsWithOptions(e2emon.Equals(2), []string{`thanos_store_index_cache_requests_total`}, e2emon.WithLabelMatchers(matchers.MustNewMatcher(matchers.MatchEqual, "item_type", "ExpandedPostings"))))
+		testutil.Ok(t, s1.WaitSumMetricsWithOptions(e2emon.Equals(1), []string{`thanos_store_index_cache_hits_total`}, e2emon.WithLabelMatchers(matchers.MustNewMatcher(matchers.MatchEqual, "item_type", "ExpandedPostings"))))
+	})
 }

--- a/test/e2e/store_gateway_test.go
+++ b/test/e2e/store_gateway_test.go
@@ -949,7 +949,7 @@ func TestStoreGatewayMemcachedIndexCacheExpandedPostings(t *testing.T) {
 config:
   addresses: [%s]
   max_async_concurrency: 10
-  max_async_concurrency: 10
+  dns_provider_update_interval: 1s
   auto_discovery: false`, memcached.InternalEndpoint("memcached"))
 
 	s1 := e2ethanos.NewStoreGW(


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Fixes https://github.com/thanos-io/thanos/issues/6417.

This pr adds new methods in index cache to store and fetch expanded postings. Previously, we store postings which associated with a label. This means to calculate expanded postings, we need to fetch all postings from cache and then expand the postings. This could waste resources if the expanded posting length is mucher smaller than the size of original postings. By caching expanded postings, it saves both mem/bandwidth and CPU times to download data and calculate postings.

## Verification

Tests updated. Also tested locally with both in memory cache and memcached