### PR TITLE
index stats: fix chunk size calculation

### DIFF
--- a/pkg/block/index.go
+++ b/pkg/block/index.go
@@ -293,7 +293,12 @@ func GatherIndexHealthStats(logger log.Logger, fn string, minTime, maxTime int64
 
 			// Approximate size.
 			if i < len(chks)-2 {
-				chunkSize.Add(int64(chks[i+1].Ref - c.Ref))
+				sgmIndex, chkStart := chunks.BlockChunkRef(c.Ref).Unpack()
+				sgmIndex2, chkStart2 := chunks.BlockChunkRef(chks[i+1].Ref).Unpack()
+				// Skip the case where two chunks are spread into 2 files.
+				if sgmIndex == sgmIndex2 {
+					chunkSize.Add(int64(chkStart2 - chkStart))
+				}
 			}
 
 			// Chunk vs the block ranges.


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

Chunks Ref contains its offset and the chunk file sequence. If two chunks of a single series got spread into 2 chunk files, we will get a very large max chunk size by just substracting the chunk ref.

This PR skips this case because we are unable to know the chunk size.

## Verification

<!-- How you tested it? How do you know it works? -->
