### PR TITLE
Add series size to index stats

### DIFF
--- a/pkg/block/index.go
+++ b/pkg/block/index.go
@@ -85,6 +85,10 @@ type HealthStats struct {
 	ChunkAvgSize int64
 	ChunkMaxSize int64
 
+	SeriesMinSize int64
+	SeriesAvgSize int64
+	SeriesMaxSize int64
+
 	SingleSampleSeries int64
 	SingleSampleChunks int64
 
@@ -231,6 +235,7 @@ func GatherIndexHealthStats(logger log.Logger, fn string, minTime, maxTime int64
 		seriesChunks                                = newMinMaxSumInt64()
 		chunkDuration                               = newMinMaxSumInt64()
 		chunkSize                                   = newMinMaxSumInt64()
+		seriesSize                                  = newMinMaxSumInt64()
 	)
 
 	lnames, err := r.LabelNames()
@@ -245,11 +250,25 @@ func GatherIndexHealthStats(logger log.Logger, fn string, minTime, maxTime int64
 	}
 	stats.MetricLabelValuesCount = int64(len(lvals))
 
+	// As of version two all series entries are 16 byte padded. All references
+	// we get have to account for that to get the correct offset.
+	offsetMultiplier := 1
+	version := r.Version()
+	if version >= 2 {
+		offsetMultiplier = 16
+	}
+
 	// Per series.
+	var prevId storage.SeriesRef
 	for p.Next() {
 		lastLset = append(lastLset[:0], lset...)
 
 		id := p.At()
+		if prevId != 0 {
+			// Approximate size.
+			seriesSize.Add(int64(id-prevId) * int64(offsetMultiplier))
+		}
+		prevId = id
 		stats.TotalSeries++
 
 		if err := r.Series(id, &builder, &chks); err != nil {
@@ -361,6 +380,10 @@ func GatherIndexHealthStats(logger log.Logger, fn string, minTime, maxTime int64
 	stats.ChunkMaxSize = chunkSize.max
 	stats.ChunkAvgSize = chunkSize.Avg()
 	stats.ChunkMinSize = chunkSize.min
+
+	stats.SeriesMaxSize = seriesSize.max
+	stats.SeriesAvgSize = seriesSize.Avg()
+	stats.SeriesMinSize = seriesSize.min
 
 	stats.ChunkMaxDuration = time.Duration(chunkDuration.max) * time.Millisecond
 	stats.ChunkAvgDuration = time.Duration(chunkDuration.Avg()) * time.Millisecond


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

This is helpful in understanding the series size of a block.
I tried to add a bucket tool to scan blocks and it gives some useful information on our data.

```
thanos tools index-stats --dir 01GW8VY3ND45ZETHFD9YAQ8ZSW
block 01GW8VY3ND45ZETHFD9YAQ8ZSW
block range 86400000
Chunk MinSize 23
Chunk MaxSize 2476
Chunk AvgSize 335
Series MinSize 44
Series MaxSize 668
Series AvgSize 184
```

## Verification

<!-- How you tested it? How do you know it works? -->
