### PR TITLE
Receive: upgrading logs for failed uploads to error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#6352](https://github.com/thanos-io/thanos/pull/6352) Store: Expose store gateway query stats in series response hints.
 
 ### Fixed
-
+- [#6427](https://github.com/thanos-io/thanos/pull/6427) Receive: increasing log level for failed uploads to error
 - [#6172](https://github.com/thanos-io/thanos/pull/6172) query-frontend: return JSON formatted errors for invalid PromQL expression in the split by interval middleware.
 - [#6171](https://github.com/thanos-io/thanos/pull/6171) Store: fix error handling on limits.
 - [#6183](https://github.com/thanos-io/thanos/pull/6183) Receiver: fix off by one in multitsdb flush that will result in empty blocks if the head only contains one sample

--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -707,12 +707,12 @@ func startTSDBAndUpload(g *run.Group,
 					case <-uploadC:
 						// Upload on demand.
 						if err := upload(ctx); err != nil {
-							level.Warn(logger).Log("msg", "on demand upload failed", "err", err)
+							level.Error(logger).Log("msg", "on demand upload failed", "err", err)
 						}
 						uploadDone <- struct{}{}
 					case <-tick.C:
 						if err := upload(ctx); err != nil {
-							level.Warn(logger).Log("msg", "recurring upload failed", "err", err)
+							level.Error(logger).Log("msg", "recurring upload failed", "err", err)
 						}
 					}
 				}


### PR DESCRIPTION
* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Increased log level for failed uploads to error, from warning. 

## Reasoning:

Since `upload` is a flag on the function and half of the receiver job, not uploading then should be a big enough failure to warrant an error log, like it is on [line 690](https://github.com/thanos-io/thanos/blob/main/cmd/thanos/receive.go#LL690C13-L690C18) for the final block upload

