### PR TITLE
compact: Add Index Stats to block metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#5777](https://github.com/thanos-io/thanos/pull/5777) Receive: Allow specifying tenant-specific external labels in Router Ingestor.
 - [#6352](https://github.com/thanos-io/thanos/pull/6352) Store: Expose store gateway query stats in series response hints.
 - [#6420](https://github.com/thanos-io/thanos/pull/6420) Index Cache: Cache expanded postings.
+- [#6441](https://github.com/thanos-io/thanos/pull/6441) Compact: Compactor will set `index_stats` in `meta.json` file with max series and chunk size information.
 
 ### Fixed
 - [#6427](https://github.com/thanos-io/thanos/pull/6427) Receive: increasing log level for failed uploads to error

--- a/cmd/thanos/downsample.go
+++ b/cmd/thanos/downsample.go
@@ -398,9 +398,11 @@ func processDownsampling(
 		return errors.Wrap(err, "read meta")
 	}
 
-	meta.Thanos.IndexStats = metadata.IndexStats{
-		SeriesMaxSize: stats.SeriesMaxSize,
-		ChunkMaxSize:  stats.ChunkMaxSize,
+	if stats.ChunkMaxSize > 0 {
+		meta.Thanos.IndexStats.ChunkMaxSize = stats.ChunkMaxSize
+	}
+	if stats.SeriesMaxSize > 0 {
+		meta.Thanos.IndexStats.SeriesMaxSize = stats.SeriesMaxSize
 	}
 	if err := meta.WriteToDir(logger, resdir); err != nil {
 		return errors.Wrap(err, "write meta")

--- a/pkg/block/block_test.go
+++ b/pkg/block/block_test.go
@@ -142,7 +142,7 @@ func TestUpload(t *testing.T) {
 		testutil.Equals(t, 3, len(bkt.Objects()))
 		testutil.Equals(t, 3727, len(bkt.Objects()[path.Join(b1.String(), ChunksDirname, "000001")]))
 		testutil.Equals(t, 401, len(bkt.Objects()[path.Join(b1.String(), IndexFilename)]))
-		testutil.Equals(t, 546, len(bkt.Objects()[path.Join(b1.String(), MetaFilename)]))
+		testutil.Equals(t, 567, len(bkt.Objects()[path.Join(b1.String(), MetaFilename)]))
 
 		// File stats are gathered.
 		testutil.Equals(t, fmt.Sprintf(`{
@@ -192,7 +192,7 @@ func TestUpload(t *testing.T) {
 		testutil.Equals(t, 3, len(bkt.Objects()))
 		testutil.Equals(t, 3727, len(bkt.Objects()[path.Join(b1.String(), ChunksDirname, "000001")]))
 		testutil.Equals(t, 401, len(bkt.Objects()[path.Join(b1.String(), IndexFilename)]))
-		testutil.Equals(t, 546, len(bkt.Objects()[path.Join(b1.String(), MetaFilename)]))
+		testutil.Equals(t, 567, len(bkt.Objects()[path.Join(b1.String(), MetaFilename)]))
 	}
 	{
 		// Upload with no external labels should be blocked.

--- a/pkg/block/block_test.go
+++ b/pkg/block/block_test.go
@@ -181,7 +181,8 @@ func TestUpload(t *testing.T) {
 			{
 				"rel_path": "meta.json"
 			}
-		]
+		],
+		"index_stats": {}
 	}
 }
 `, b1.String(), b1.String()), string(bkt.Objects()[path.Join(b1.String(), MetaFilename)]))
@@ -224,7 +225,7 @@ func TestUpload(t *testing.T) {
 		testutil.Equals(t, 6, len(bkt.Objects()))
 		testutil.Equals(t, 3727, len(bkt.Objects()[path.Join(b2.String(), ChunksDirname, "000001")]))
 		testutil.Equals(t, 401, len(bkt.Objects()[path.Join(b2.String(), IndexFilename)]))
-		testutil.Equals(t, 525, len(bkt.Objects()[path.Join(b2.String(), MetaFilename)]))
+		testutil.Equals(t, 546, len(bkt.Objects()[path.Join(b2.String(), MetaFilename)]))
 	}
 }
 

--- a/pkg/block/metadata/meta.go
+++ b/pkg/block/metadata/meta.go
@@ -90,6 +90,18 @@ type Thanos struct {
 
 	// Rewrites is present when any rewrite (deletion, relabel etc) were applied to this block. Optional.
 	Rewrites []Rewrite `json:"rewrites,omitempty"`
+
+	IndexStats IndexStats `json:"index_stats,omitempty"`
+}
+
+type IndexStats struct {
+	SeriesMinSize int64 `json:"series_min_size,omitempty"`
+	SeriesMaxSize int64 `json:"series_max_size,omitempty"`
+	SeriesAvgSize int64 `json:"series_avg_size,omitempty"`
+
+	ChunkMinSize int64 `json:"chunk_min_size,omitempty"`
+	ChunkMaxSize int64 `json:"chunk_max_size,omitempty"`
+	ChunkAvgSize int64 `json:"chunk_avg_size,omitempty"`
 }
 
 type Rewrite struct {

--- a/pkg/block/metadata/meta.go
+++ b/pkg/block/metadata/meta.go
@@ -91,6 +91,7 @@ type Thanos struct {
 	// Rewrites is present when any rewrite (deletion, relabel etc) were applied to this block. Optional.
 	Rewrites []Rewrite `json:"rewrites,omitempty"`
 
+	// IndexStats contains stats info related to block index.
 	IndexStats IndexStats `json:"index_stats,omitempty"`
 }
 

--- a/pkg/block/metadata/meta.go
+++ b/pkg/block/metadata/meta.go
@@ -96,13 +96,8 @@ type Thanos struct {
 }
 
 type IndexStats struct {
-	SeriesMinSize int64 `json:"series_min_size,omitempty"`
 	SeriesMaxSize int64 `json:"series_max_size,omitempty"`
-	SeriesAvgSize int64 `json:"series_avg_size,omitempty"`
-
-	ChunkMinSize int64 `json:"chunk_min_size,omitempty"`
-	ChunkMaxSize int64 `json:"chunk_max_size,omitempty"`
-	ChunkAvgSize int64 `json:"chunk_avg_size,omitempty"`
+	ChunkMaxSize  int64 `json:"chunk_max_size,omitempty"`
 }
 
 type Rewrite struct {

--- a/pkg/block/metadata/meta_test.go
+++ b/pkg/block/metadata/meta_test.go
@@ -74,6 +74,10 @@ func TestMeta_ReadWrite(t *testing.T) {
 				Downsample: ThanosDownsample{
 					Resolution: 123144,
 				},
+				IndexStats: IndexStats{
+					SeriesMaxSize: 2000,
+					ChunkMaxSize:  1000,
+				},
 			},
 		}
 		testutil.Ok(t, m1.Write(&b))
@@ -123,7 +127,10 @@ func TestMeta_ReadWrite(t *testing.T) {
 				"rel_path": "meta.json"
 			}
 		],
-		"index_stats": {}
+		"index_stats": {
+			"series_max_size": 2000,
+			"chunk_max_size": 1000
+		}
 	}
 }
 `, b.String())

--- a/pkg/block/metadata/meta_test.go
+++ b/pkg/block/metadata/meta_test.go
@@ -31,7 +31,8 @@ func TestMeta_ReadWrite(t *testing.T) {
 		"downsample": {
 			"resolution": 0
 		},
-		"source": ""
+		"source": "",
+		"index_stats": {}
 	}
 }
 `, b.String())
@@ -121,7 +122,8 @@ func TestMeta_ReadWrite(t *testing.T) {
 			{
 				"rel_path": "meta.json"
 			}
-		]
+		],
+		"index_stats": {}
 	}
 }
 `, b.String())
@@ -199,7 +201,8 @@ func TestMeta_ReadWrite(t *testing.T) {
 				"rel_path": "index",
 				"size_bytes": 1313
 			}
-		]
+		],
+		"index_stats": {}
 	}
 }
 `, b.String())

--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -818,7 +818,7 @@ func outOfOrderChunkError(err error, brokenBlock ulid.ULID) OutOfOrderChunksErro
 	return OutOfOrderChunksError{err: err, id: brokenBlock}
 }
 
-// IsOutOfOrderChunk returns true if the base error is a OutOfOrderChunkError.
+// IsOutOfOrderChunkError returns true if the base error is a OutOfOrderChunkError.
 func IsOutOfOrderChunkError(err error) bool {
 	_, ok := errors.Cause(err).(OutOfOrderChunksError)
 	return ok
@@ -1100,26 +1100,44 @@ func (cg *Group) compact(ctx context.Context, dir string, planner Planner, comp 
 	bdir := filepath.Join(dir, compID.String())
 	index := filepath.Join(bdir, block.IndexFilename)
 
-	newMeta, err := metadata.InjectThanos(cg.logger, bdir, metadata.Thanos{
+	if err := os.Remove(filepath.Join(bdir, "tombstones")); err != nil {
+		return false, ulid.ULID{}, errors.Wrap(err, "remove tombstones")
+	}
+
+	newMeta, err := metadata.ReadFromDir(bdir)
+	if err != nil {
+		return false, ulid.ULID{}, errors.Wrap(err, "read new meta")
+	}
+
+	var stats block.HealthStats
+	// Ensure the output block is valid.
+	err = tracing.DoInSpanWithErr(ctx, "compaction_verify_index", func(ctx context.Context) error {
+		stats, err = block.GatherIndexHealthStats(cg.logger, index, newMeta.MinTime, newMeta.MaxTime)
+		if err != nil {
+			return err
+		}
+		return stats.AnyErr()
+	})
+	if !cg.acceptMalformedIndex && err != nil {
+		return false, ulid.ULID{}, halt(errors.Wrapf(err, "invalid result block %s", bdir))
+	}
+
+	newMeta, err = metadata.InjectThanos(cg.logger, bdir, metadata.Thanos{
 		Labels:       cg.labels.Map(),
 		Downsample:   metadata.ThanosDownsample{Resolution: cg.resolution},
 		Source:       metadata.CompactorSource,
 		SegmentFiles: block.GetSegmentFiles(bdir),
+		IndexStats: metadata.IndexStats{
+			SeriesMinSize: stats.SeriesMinSize,
+			SeriesMaxSize: stats.SeriesMaxSize,
+			SeriesAvgSize: stats.SeriesAvgSize,
+			ChunkMinSize:  stats.ChunkMinSize,
+			ChunkMaxSize:  stats.ChunkMaxSize,
+			ChunkAvgSize:  stats.ChunkAvgSize,
+		},
 	}, nil)
 	if err != nil {
 		return false, ulid.ULID{}, errors.Wrapf(err, "failed to finalize the block %s", bdir)
-	}
-
-	if err = os.Remove(filepath.Join(bdir, "tombstones")); err != nil {
-		return false, ulid.ULID{}, errors.Wrap(err, "remove tombstones")
-	}
-
-	// Ensure the output block is valid.
-	err = tracing.DoInSpanWithErr(ctx, "compaction_verify_index", func(ctx context.Context) error {
-		return block.VerifyIndex(cg.logger, index, newMeta.MinTime, newMeta.MaxTime)
-	})
-	if !cg.acceptMalformedIndex && err != nil {
-		return false, ulid.ULID{}, halt(errors.Wrapf(err, "invalid result block %s", bdir))
 	}
 
 	// Ensure the output block is not overlapping with anything else,

--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -1128,12 +1128,8 @@ func (cg *Group) compact(ctx context.Context, dir string, planner Planner, comp 
 		Source:       metadata.CompactorSource,
 		SegmentFiles: block.GetSegmentFiles(bdir),
 		IndexStats: metadata.IndexStats{
-			SeriesMinSize: stats.SeriesMinSize,
 			SeriesMaxSize: stats.SeriesMaxSize,
-			SeriesAvgSize: stats.SeriesAvgSize,
-			ChunkMinSize:  stats.ChunkMinSize,
 			ChunkMaxSize:  stats.ChunkMaxSize,
-			ChunkAvgSize:  stats.ChunkAvgSize,
 		},
 	}, nil)
 	if err != nil {

--- a/pkg/compact/compact_e2e_test.go
+++ b/pkg/compact/compact_e2e_test.go
@@ -399,6 +399,8 @@ func testGroupCompactE2e(t *testing.T, mergeFunc storage.VerticalChunkSeriesMerg
 			testutil.Assert(t, labels.Equal(extLabels, labels.FromMap(meta.Thanos.Labels)), "ext labels does not match")
 			testutil.Equals(t, int64(124), meta.Thanos.Downsample.Resolution)
 			testutil.Assert(t, len(meta.Thanos.SegmentFiles) > 0, "compacted blocks have segment files set")
+			testutil.Assert(t, meta.Thanos.IndexStats.ChunkMaxSize > 0, "compacted blocks have index stats chunk max size set")
+			testutil.Assert(t, meta.Thanos.IndexStats.SeriesMaxSize > 0, "compacted blocks have index stats chunk max size set")
 		}
 		{
 			meta, ok := others[groupKey2]
@@ -415,6 +417,8 @@ func testGroupCompactE2e(t *testing.T, mergeFunc storage.VerticalChunkSeriesMerg
 			testutil.Assert(t, labels.Equal(extLabels2, labels.FromMap(meta.Thanos.Labels)), "ext labels does not match")
 			testutil.Equals(t, int64(124), meta.Thanos.Downsample.Resolution)
 			testutil.Assert(t, len(meta.Thanos.SegmentFiles) > 0, "compacted blocks have segment files set")
+			testutil.Assert(t, meta.Thanos.IndexStats.ChunkMaxSize > 0, "compacted blocks have index stats chunk max size set")
+			testutil.Assert(t, meta.Thanos.IndexStats.SeriesMaxSize > 0, "compacted blocks have index stats chunk max size set")
 		}
 	})
 }

--- a/pkg/compact/compact_e2e_test.go
+++ b/pkg/compact/compact_e2e_test.go
@@ -399,8 +399,8 @@ func testGroupCompactE2e(t *testing.T, mergeFunc storage.VerticalChunkSeriesMerg
 			testutil.Assert(t, labels.Equal(extLabels, labels.FromMap(meta.Thanos.Labels)), "ext labels does not match")
 			testutil.Equals(t, int64(124), meta.Thanos.Downsample.Resolution)
 			testutil.Assert(t, len(meta.Thanos.SegmentFiles) > 0, "compacted blocks have segment files set")
-			testutil.Assert(t, meta.Thanos.IndexStats.ChunkMaxSize > 0, "compacted blocks have index stats chunk max size set")
-			testutil.Assert(t, meta.Thanos.IndexStats.SeriesMaxSize > 0, "compacted blocks have index stats chunk max size set")
+			// Only one chunk will be generated in that block, so we won't set chunk size.
+			testutil.Assert(t, meta.Thanos.IndexStats.SeriesMaxSize > 0, "compacted blocks have index stats series max size set")
 		}
 		{
 			meta, ok := others[groupKey2]
@@ -417,8 +417,8 @@ func testGroupCompactE2e(t *testing.T, mergeFunc storage.VerticalChunkSeriesMerg
 			testutil.Assert(t, labels.Equal(extLabels2, labels.FromMap(meta.Thanos.Labels)), "ext labels does not match")
 			testutil.Equals(t, int64(124), meta.Thanos.Downsample.Resolution)
 			testutil.Assert(t, len(meta.Thanos.SegmentFiles) > 0, "compacted blocks have segment files set")
-			testutil.Assert(t, meta.Thanos.IndexStats.ChunkMaxSize > 0, "compacted blocks have index stats chunk max size set")
-			testutil.Assert(t, meta.Thanos.IndexStats.SeriesMaxSize > 0, "compacted blocks have index stats chunk max size set")
+			// Only one chunk will be generated in that block, so we won't set chunk size.
+			testutil.Assert(t, meta.Thanos.IndexStats.SeriesMaxSize > 0, "compacted blocks have index stats series max size set")
 		}
 	})
 }


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

After compaction and downsampling, compactor gathers information from the block index.
The index stats gathered are actually helpful when querying the block. For example, to estimate the series and chunk size for a block.

This pr changes the meta.json file format and adds a new `IndexStats` section. Now it contains `ChunkMaxSize` and `SeriesMaxSize`

## Verification

<!-- How you tested it? How do you know it works? -->
