### PR TITLE
Avoid direct cortex vendor dependency in promclient

### DIFF
--- a/pkg/promclient/promclient.go
+++ b/pkg/promclient/promclient.go
@@ -391,7 +391,7 @@ func (p *QueryOptions) AddTo(values url.Values) error {
 
 type Explanation struct {
 	Name     string         `json:"name"`
-	Children []*Explanation `json:"children"`
+	Children []*Explanation `json:"children,omitempty"`
 }
 
 // QueryInstant performs an instant query using a default HTTP client and returns results in model.Vector type.
@@ -431,7 +431,7 @@ func (c *Client) QueryInstant(ctx context.Context, base *url.URL, query string, 
 		Data struct {
 			ResultType  string          `json:"resultType"`
 			Result      json.RawMessage `json:"result"`
-			Explanation *Explanation    `json:"explanation"`
+			Explanation *Explanation    `json:"explanation,omitempty"`
 		} `json:"data"`
 
 		Error     string `json:"error,omitempty"`
@@ -535,7 +535,7 @@ func (c *Client) QueryRange(ctx context.Context, base *url.URL, query string, st
 		Data struct {
 			ResultType  string          `json:"resultType"`
 			Result      json.RawMessage `json:"result"`
-			Explanation *Explanation    `json:"explanation"`
+			Explanation *Explanation    `json:"explanation,omitempty"`
 		} `json:"data"`
 
 		Error     string `json:"error,omitempty"`

--- a/pkg/promclient/promclient.go
+++ b/pkg/promclient/promclient.go
@@ -33,7 +33,6 @@ import (
 	"google.golang.org/grpc/codes"
 	"gopkg.in/yaml.v2"
 
-	"github.com/thanos-io/thanos/internal/cortex/querier/queryrange"
 	"github.com/thanos-io/thanos/pkg/exemplars/exemplarspb"
 	"github.com/thanos-io/thanos/pkg/httpconfig"
 	"github.com/thanos-io/thanos/pkg/metadata/metadatapb"
@@ -390,8 +389,13 @@ func (p *QueryOptions) AddTo(values url.Values) error {
 	return nil
 }
 
+type Explanation struct {
+	Name     string         `json:"name"`
+	Children []*Explanation `json:"children"`
+}
+
 // QueryInstant performs an instant query using a default HTTP client and returns results in model.Vector type.
-func (c *Client) QueryInstant(ctx context.Context, base *url.URL, query string, t time.Time, opts QueryOptions) (model.Vector, []string, *queryrange.Explanation, error) {
+func (c *Client) QueryInstant(ctx context.Context, base *url.URL, query string, t time.Time, opts QueryOptions) (model.Vector, []string, *Explanation, error) {
 	params, err := url.ParseQuery(base.RawQuery)
 	if err != nil {
 		return nil, nil, nil, errors.Wrapf(err, "parse raw query %s", base.RawQuery)
@@ -425,9 +429,9 @@ func (c *Client) QueryInstant(ctx context.Context, base *url.URL, query string, 
 	// structure of the Result yet.
 	var m struct {
 		Data struct {
-			ResultType  string                  `json:"resultType"`
-			Result      json.RawMessage         `json:"result"`
-			Explanation *queryrange.Explanation `json:"explanation"`
+			ResultType  string          `json:"resultType"`
+			Result      json.RawMessage `json:"result"`
+			Explanation *Explanation    `json:"explanation"`
 		} `json:"data"`
 
 		Error     string `json:"error,omitempty"`
@@ -498,7 +502,7 @@ func (c *Client) PromqlQueryInstant(ctx context.Context, base *url.URL, query st
 }
 
 // QueryRange performs a range query using a default HTTP client and returns results in model.Matrix type.
-func (c *Client) QueryRange(ctx context.Context, base *url.URL, query string, startTime, endTime, step int64, opts QueryOptions) (model.Matrix, []string, *queryrange.Explanation, error) {
+func (c *Client) QueryRange(ctx context.Context, base *url.URL, query string, startTime, endTime, step int64, opts QueryOptions) (model.Matrix, []string, *Explanation, error) {
 	params, err := url.ParseQuery(base.RawQuery)
 	if err != nil {
 		return nil, nil, nil, errors.Wrapf(err, "parse raw query %s", base.RawQuery)
@@ -529,9 +533,9 @@ func (c *Client) QueryRange(ctx context.Context, base *url.URL, query string, st
 	// structure of the Result yet.
 	var m struct {
 		Data struct {
-			ResultType  string                  `json:"resultType"`
-			Result      json.RawMessage         `json:"result"`
-			Explanation *queryrange.Explanation `json:"explanation"`
+			ResultType  string          `json:"resultType"`
+			Result      json.RawMessage `json:"result"`
+			Explanation *Explanation    `json:"explanation"`
 		} `json:"data"`
 
 		Error     string `json:"error,omitempty"`


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

This pr removes the import `github.com/thanos-io/thanos/internal` in promclient package to avoid cyclic dependency.

## Verification

<!-- How you tested it? How do you know it works? -->
