### PR TITLE
Support reload using signal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 ### Added
 
 - [#6891](https://github.com/thanos-io/thanos/pull/6891) Objstore: Bump `objstore` which adds support for Azure Workload Identity.
+- [#6453](https://github.com/thanos-io/thanos/pull/6453) Sidecar: Added `--reloader.method` to support configuration reloads via SIHUP signal.
 
 ### Changed
 

--- a/cmd/thanos/config.go
+++ b/cmd/thanos/config.go
@@ -114,7 +114,17 @@ type reloaderConfig struct {
 	ruleDirectories []string
 	watchInterval   time.Duration
 	retryInterval   time.Duration
+	method          string
+	processName     string
 }
+
+const (
+	// HTTPReloadMethod reloads the configuration using the HTTP reload endpoint.
+	HTTPReloadMethod = "http"
+
+	// SignalReloadMethod reloads the configuration sending a SIGHUP signal to the process.
+	SignalReloadMethod = "signal"
+)
 
 func (rc *reloaderConfig) registerFlag(cmd extkingpin.FlagClause) *reloaderConfig {
 	cmd.Flag("reloader.config-file",
@@ -132,6 +142,12 @@ func (rc *reloaderConfig) registerFlag(cmd extkingpin.FlagClause) *reloaderConfi
 	cmd.Flag("reloader.retry-interval",
 		"Controls how often reloader retries config reload in case of error.").
 		Default("5s").DurationVar(&rc.retryInterval)
+	cmd.Flag("reloader.method",
+		"Method used to reload the configuration.").
+		Default(HTTPReloadMethod).EnumVar(&rc.method, HTTPReloadMethod, SignalReloadMethod)
+	cmd.Flag("reloader.process-name",
+		"Executable name used to match the process being reloaded when using the signal method.").
+		Default("prometheus").StringVar(&rc.processName)
 
 	return rc
 }

--- a/docs/components/sidecar.md
+++ b/docs/components/sidecar.md
@@ -153,6 +153,10 @@ Flags:
                                  Output file for environment variable
                                  substituted config file.
       --reloader.config-file=""  Config file watched by the reloader.
+      --reloader.method=http     Method used to reload the configuration.
+      --reloader.process-name="prometheus"
+                                 Executable name used to match the process being
+                                 reloaded when using the signal method.
       --reloader.retry-interval=5s
                                  Controls how often reloader retries config
                                  reload in case of error.

--- a/go.mod
+++ b/go.mod
@@ -117,6 +117,7 @@ require (
 )
 
 require (
+	github.com/mitchellh/go-ps v1.0.0
 	github.com/onsi/gomega v1.27.10
 	go.opentelemetry.io/contrib/propagators/autoprop v0.38.0
 	go4.org/intern v0.0.0-20230525184215-6c62f75575cb

--- a/go.sum
+++ b/go.sum
@@ -733,6 +733,8 @@ github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceT
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
+github.com/mitchellh/go-ps v1.0.0 h1:i6ampVEEF4wQFF+bkYfwYgY+F/uYJDktmvLPf7qIgjc=
+github.com/mitchellh/go-ps v1.0.0/go.mod h1:J4lOc8z8yJs6vUwklHw2XEIiT4z4C40KtWVN3nvg8Pg=
 github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
 github.com/mitchellh/gox v0.4.0/go.mod h1:Sd9lOJ0+aimLBi73mGofS1ycjY8lL3uZM3JPS42BGNg=
 github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0QubkSMEySY=

--- a/pkg/reloader/tracker.go
+++ b/pkg/reloader/tracker.go
@@ -1,0 +1,119 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package reloader
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+)
+
+// prometheusReloadTracker keeps track of the last configuration status.
+type prometheusReloadTracker struct {
+	runtimeURL *url.URL
+	client     http.Client
+	logger     log.Logger
+
+	lastReload  time.Time
+	lastSuccess bool
+}
+
+func (prt *prometheusReloadTracker) getConfigStatus(ctx context.Context) (bool, time.Time, error) {
+	r, err := http.NewRequestWithContext(ctx, "GET", prt.runtimeURL.String(), nil)
+	if err != nil {
+		return false, time.Time{}, err
+	}
+
+	resp, err := prt.client.Do(r)
+	if err != nil {
+		return false, time.Time{}, fmt.Errorf("%s: %w", r.URL.String(), err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode/100 != 2 {
+		return false, time.Time{}, fmt.Errorf("%s: invalid status code: %d", r.URL.String(), resp.StatusCode)
+	}
+
+	var runtimeInfo = struct {
+		Status string `json:"status"`
+		Data   struct {
+			ReloadConfigSuccess bool      `json:"reloadConfigSuccess"`
+			LastConfigTime      time.Time `json:"lastConfigTime"`
+		} `json:"data"`
+	}{}
+
+	if err := json.NewDecoder(resp.Body).Decode(&runtimeInfo); err != nil {
+		return false, time.Time{}, fmt.Errorf("invalid response: %w", err)
+	}
+
+	if runtimeInfo.Status != "success" {
+		return false, time.Time{}, fmt.Errorf("unexpected status: %s", runtimeInfo.Status)
+	}
+
+	return runtimeInfo.Data.ReloadConfigSuccess, runtimeInfo.Data.LastConfigTime, nil
+}
+
+func (prt *prometheusReloadTracker) preReload(ctx context.Context) error {
+	if prt.runtimeURL == nil {
+		level.Info(prt.logger).Log("msg", "Pre-reload check skipped because the runtimeInfo URL isn't defined")
+		return nil
+	}
+
+	success, last, err := prt.getConfigStatus(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get config status before reload: %w", err)
+	}
+
+	level.Debug(prt.logger).Log("msg", "Pre-reload check", "success", success, "last_config_reload", last)
+	prt.lastReload = last
+	prt.lastSuccess = success
+
+	return nil
+}
+
+func (prt *prometheusReloadTracker) postReload(ctx context.Context) error {
+	if prt.runtimeURL == nil {
+		level.Info(prt.logger).Log("msg", "Post-reload check skipped because the runtimeInfo URL isn't defined")
+		return nil
+	}
+
+	t := time.NewTicker(time.Second)
+	defer t.Stop()
+
+	for {
+		success, last, err := prt.getConfigStatus(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to get config status after reload: %w", err)
+		}
+		level.Debug(prt.logger).Log("msg", "Post-reload hook in progress", "config_reload_success", success, "config_reload_success_ts", last)
+
+		// The configuration has been updated successfully.
+		if success && last.After(prt.lastReload) {
+			level.Debug(prt.logger).Log("msg", "Post-reload hook successful")
+			return nil
+		}
+
+		// The previous configuration was valid but the current configuration
+		// isn't so there's no need to poll again for the status.
+		if prt.lastSuccess && !success {
+			return fmt.Errorf("configuration reload has failed")
+		}
+
+		select {
+		case <-ctx.Done():
+			result := "failed"
+			if success {
+				result = "successful"
+			}
+			return fmt.Errorf("%w: configuration reload %s (last successful reload at %v)", ctx.Err(), result, last)
+		case <-t.C:
+		}
+	}
+}


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Ability to reload the configuration by sending SIGHUP to a process ID instead of using a HTTP reload endpoint.

The Prometheus operator's config reloader is built around the `github.com/thanos.io/thanos/pkg/reloader` package. We have a use case to replace HTTP-based reloading by SIGHUP reloading as it doesn't require to enable the lifecycle admin which also exposes the /-/quit endpoint (see https://github.com/prometheus-operator/prometheus-operator/issues/3381 for details).

This pull request is still work-in-progress as I'm testing it in combination with https://github.com/prometheus-operator/prometheus-operator/pull/5690 but feel free to provide feedback.

_A less-involved option would be to declare the `TriggerReloader`  interface and let the caller provide its own implementation via a configuration option._

## Verification

Tested with the prometheus-operator PR mentioned above but happy to add more tests here too.
