### PR TITLE
Store: fix crash on empty regex matcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#6441](https://github.com/thanos-io/thanos/pull/6441) Compact: Compactor will set `index_stats` in `meta.json` file with max series and chunk size information.
 
 ### Fixed
+- [#6456](https://github.com/thanos-io/thanos/pull/6456) Store: fix crash when computing set matches from regex pattern
 - [#6427](https://github.com/thanos-io/thanos/pull/6427) Receive: increasing log level for failed uploads to error
 - [#6172](https://github.com/thanos-io/thanos/pull/6172) query-frontend: return JSON formatted errors for invalid PromQL expression in the split by interval middleware.
 - [#6171](https://github.com/thanos-io/thanos/pull/6171) Store: fix error handling on limits.

--- a/pkg/store/opts.go
+++ b/pkg/store/opts.go
@@ -25,6 +25,9 @@ func init() {
 // Copied from Prometheus querier.go, removed check for Prometheus wrapper.
 // Returns list of values that can regex matches.
 func findSetMatches(pattern string) []string {
+	if len(pattern) == 0 {
+		return nil
+	}
 	escaped := false
 	sets := []*strings.Builder{{}}
 	init := 0

--- a/pkg/store/opts_test.go
+++ b/pkg/store/opts_test.go
@@ -57,6 +57,11 @@ func TestFindSetMatches(t *testing.T) {
 				"foo|bar|baz",
 			},
 		},
+		// empty pattern
+		{
+			pattern: "",
+			exp:     nil,
+		},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Fixed crash on empty pattern in `findSetMatches`

## Verification

Added a unittest