### PR TITLE
Cache calculated mint and maxt for each remote engine

### DIFF
--- a/pkg/query/remote_engine.go
+++ b/pkg/query/remote_engine.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"io"
 	"math"
+	"sync"
 	"time"
 
 	"github.com/go-kit/log"
@@ -82,6 +83,13 @@ type remoteEngine struct {
 	logger log.Logger
 
 	client Client
+
+	mintOnce      sync.Once
+	mint          int64
+	maxtOnce      sync.Once
+	maxt          int64
+	labelSetsOnce sync.Once
+	labelSets     []labels.Labels
 }
 
 func newRemoteEngine(logger log.Logger, queryClient Client, opts Opts) api.RemoteEngine {
@@ -98,43 +106,52 @@ func newRemoteEngine(logger log.Logger, queryClient Client, opts Opts) api.Remot
 // Calculating the MinT this way makes remote queries resilient to cases where one tsdb replica would delete
 // a block due to retention before other replicas did the same.
 // See https://github.com/thanos-io/promql-engine/issues/187.
-func (r remoteEngine) MinT() int64 {
-	var (
-		hashBuf               = make([]byte, 0, 128)
-		highestMintByLabelSet = make(map[uint64]int64)
-	)
-	for _, lset := range r.infosWithoutReplicaLabels() {
-		key, _ := labelpb.ZLabelsToPromLabels(lset.Labels.Labels).HashWithoutLabels(hashBuf)
-		lsetMinT, ok := highestMintByLabelSet[key]
-		if !ok {
-			highestMintByLabelSet[key] = lset.MinTime
-			continue
+func (r *remoteEngine) MinT() int64 {
+	r.mintOnce.Do(func() {
+		var (
+			hashBuf               = make([]byte, 0, 128)
+			highestMintByLabelSet = make(map[uint64]int64)
+		)
+		for _, lset := range r.infosWithoutReplicaLabels() {
+			key, _ := labelpb.ZLabelsToPromLabels(lset.Labels.Labels).HashWithoutLabels(hashBuf)
+			lsetMinT, ok := highestMintByLabelSet[key]
+			if !ok {
+				highestMintByLabelSet[key] = lset.MinTime
+				continue
+			}
+
+			if lset.MinTime > lsetMinT {
+				highestMintByLabelSet[key] = lset.MinTime
+			}
 		}
 
-		if lset.MinTime > lsetMinT {
-			highestMintByLabelSet[key] = lset.MinTime
+		var mint int64 = math.MaxInt64
+		for _, m := range highestMintByLabelSet {
+			if m < mint {
+				mint = m
+			}
 		}
-	}
+		r.mint = mint
+	})
 
-	var mint int64 = math.MaxInt64
-	for _, m := range highestMintByLabelSet {
-		if m < mint {
-			mint = m
-		}
-	}
-
-	return mint
+	return r.mint
 }
 
-func (r remoteEngine) MaxT() int64 {
-	return r.client.tsdbInfos.MaxT()
+func (r *remoteEngine) MaxT() int64 {
+	r.maxtOnce.Do(func() {
+		r.maxt = r.client.tsdbInfos.MaxT()
+	})
+	return r.maxt
 }
 
-func (r remoteEngine) LabelSets() []labels.Labels {
-	return r.infosWithoutReplicaLabels().LabelSets()
+func (r *remoteEngine) LabelSets() []labels.Labels {
+	r.labelSetsOnce.Do(func() {
+		r.labelSets = r.infosWithoutReplicaLabels().LabelSets()
+	})
+	return r.labelSets
 }
 
-func (r remoteEngine) infosWithoutReplicaLabels() infopb.TSDBInfos {
+func (r *remoteEngine) infosWithoutReplicaLabels() infopb.TSDBInfos {
 	replicaLabelSet := make(map[string]struct{})
 	for _, lbl := range r.opts.ReplicaLabels {
 		replicaLabelSet[lbl] = struct{}{}
@@ -161,7 +178,7 @@ func (r remoteEngine) infosWithoutReplicaLabels() infopb.TSDBInfos {
 	return infos
 }
 
-func (r remoteEngine) NewRangeQuery(_ context.Context, opts *promql.QueryOpts, qs string, start, end time.Time, interval time.Duration) (promql.Query, error) {
+func (r *remoteEngine) NewRangeQuery(_ context.Context, opts *promql.QueryOpts, qs string, start, end time.Time, interval time.Duration) (promql.Query, error) {
 	return &remoteQuery{
 		logger: r.logger,
 		client: r.client,


### PR DESCRIPTION
The distributed optimizer in the Thanos engine calls MinT() and LabelSets multiple times on each remote engine. These calculations can get expensive when an engine covers a large amount of TSDBs.

This commit introduces caching of the calculated values for a remote engine's mint, maxt and label sets.

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

* Cache calculated parameters for each remote PromQL engine.

## Verification

<!-- How you tested it? How do you know it works? -->
