### PR TITLE
Store: smaller block size for snappy decoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#6466](https://github.com/thanos-io/thanos/pull/6466) Mixin (Receive): add limits alerting for configuration reload and meta-monitoring.
 
 ### Fixed
+- [#6463](https://github.com/thanos-io/thanos/pull/6463) Store: smaller block size for snappy decoding
 - [#6456](https://github.com/thanos-io/thanos/pull/6456) Store: fix crash when computing set matches from regex pattern
 - [#6427](https://github.com/thanos-io/thanos/pull/6427) Receive: increasing log level for failed uploads to error
 - [#6172](https://github.com/thanos-io/thanos/pull/6172) query-frontend: return JSON formatted errors for invalid PromQL expression in the split by interval middleware.

--- a/pkg/extgrpc/snappy/snappy.go
+++ b/pkg/extgrpc/snappy/snappy.go
@@ -50,12 +50,6 @@ func (c *compressor) Compress(w io.Writer) (io.WriteCloser, error) {
 	return writeCloser{wr, &c.writersPool}, nil
 }
 
-func (c *compressor) DecompressByteReader(r io.Reader) (io.ByteReader, error) {
-	dr := c.readersPool.Get().(*snappy.Reader)
-	dr.Reset(r)
-	return reader{dr, &c.readersPool}, nil
-}
-
 func (c *compressor) Decompress(r io.Reader) (io.Reader, error) {
 	dr := c.readersPool.Get().(*snappy.Reader)
 	dr.Reset(r)
@@ -95,14 +89,4 @@ func (r reader) Read(p []byte) (n int, err error) {
 		r.pool.Put(r.reader)
 	}
 	return n, err
-}
-
-func (r reader) ReadByte() (n byte, err error) {
-	n, err = r.reader.ReadByte()
-	if err == io.EOF {
-		r.reader.Reset(nil)
-		r.pool.Put(r.reader)
-	}
-	return n, err
-
 }


### PR DESCRIPTION
wants to address #6434

* [x] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes
* use a smaller block size for snappy readers when stream decoding postings
* duplicates some code from `extsnappy` to ensure the contract that postings were encoded with a valid block size

## Verification
* passes previous unittests

## Benchmarks

```
pkg: github.com/thanos-io/thanos/pkg/store
cpu: 11th Gen Intel(R) Core(TM) i5-1135G7 @ 2.40GHz
                                                         │  main.bench   │              pr.bench               │
                                                         │    sec/op     │    sec/op     vs base               │
PostingsEncodingDecoding/10000/snappyStreamed/encode-8      900.7µ ± ∞ ¹   905.5µ ± ∞ ¹        ~ (p=1.000 n=5)
PostingsEncodingDecoding/10000/snappyStreamed/decode-8     17.804µ ± ∞ ¹   1.485µ ± ∞ ¹  -91.66% (p=0.008 n=5)
PostingsEncodingDecoding/100000/snappyStreamed/encode-8     7.514m ± ∞ ¹   8.899m ± ∞ ¹  +18.43% (p=0.008 n=5)
PostingsEncodingDecoding/100000/snappyStreamed/decode-8    17.039µ ± ∞ ¹   1.377µ ± ∞ ¹  -91.92% (p=0.008 n=5)
PostingsEncodingDecoding/1000000/snappyStreamed/encode-8    74.93m ± ∞ ¹   86.94m ± ∞ ¹  +16.03% (p=0.008 n=5)
PostingsEncodingDecoding/1000000/snappyStreamed/decode-8   18.290µ ± ∞ ¹   1.280µ ± ∞ ¹  -93.00% (p=0.008 n=5)
geomean                                                     375.7µ         110.6µ        -70.56%
¹ need >= 6 samples for confidence interval at level 0.95

                                                         │   main.bench   │               pr.bench               │
                                                         │      B/op      │     B/op       vs base               │
PostingsEncodingDecoding/10000/snappyStreamed/encode-8      16.51Ki ± ∞ ¹   17.50Ki ± ∞ ¹   +6.00% (p=0.008 n=5)
PostingsEncodingDecoding/10000/snappyStreamed/decode-8     73.364Ki ± ∞ ¹   2.484Ki ± ∞ ¹  -96.61% (p=0.008 n=5)
PostingsEncodingDecoding/100000/snappyStreamed/encode-8     147.9Ki ± ∞ ¹   152.8Ki ± ∞ ¹   +3.33% (p=0.008 n=5)
PostingsEncodingDecoding/100000/snappyStreamed/decode-8    73.364Ki ± ∞ ¹   2.484Ki ± ∞ ¹  -96.61% (p=0.008 n=5)
PostingsEncodingDecoding/1000000/snappyStreamed/encode-8    1.424Mi ± ∞ ¹   1.477Mi ± ∞ ¹   +3.73% (p=0.008 n=5)
PostingsEncodingDecoding/1000000/snappyStreamed/decode-8   73.364Ki ± ∞ ¹   2.484Ki ± ∞ ¹  -96.61% (p=0.008 n=5)
geomean                                                     105.8Ki         19.90Ki        -81.20%
¹ need >= 6 samples for confidence interval at level 0.95

                                                         │ main.bench  │                pr.bench                 │
                                                         │  allocs/op  │  allocs/op    vs base                   │
PostingsEncodingDecoding/10000/snappyStreamed/encode-8     10.00 ± ∞ ¹    32.00 ± ∞ ¹   +220.00% (p=0.008 n=5)
PostingsEncodingDecoding/10000/snappyStreamed/decode-8     5.000 ± ∞ ¹    5.000 ± ∞ ¹          ~ (p=1.000 n=5) ²
PostingsEncodingDecoding/100000/snappyStreamed/encode-8    25.00 ± ∞ ¹   193.00 ± ∞ ¹   +672.00% (p=0.008 n=5)
PostingsEncodingDecoding/100000/snappyStreamed/decode-8    5.000 ± ∞ ¹    5.000 ± ∞ ¹          ~ (p=1.000 n=5) ²
PostingsEncodingDecoding/1000000/snappyStreamed/encode-8   125.0 ± ∞ ¹   1806.0 ± ∞ ¹  +1344.80% (p=0.008 n=5)
PostingsEncodingDecoding/1000000/snappyStreamed/decode-8   5.000 ± ∞ ¹    5.000 ± ∞ ¹          ~ (p=1.000 n=5) ²
geomean                                                    12.55          33.42         +166.34%
¹ need >= 6 samples for confidence interval at level 0.95
² all samples are equal

```