### PR TITLE
store: optimized snappy streamed reading

### DIFF
--- a/pkg/pool/pool.go
+++ b/pkg/pool/pool.go
@@ -40,6 +40,16 @@ type BucketedBytes struct {
 	new func(s int) *[]byte
 }
 
+// MustNewBucketedBytes is like NewBucketedBytes but panics if construction fails.
+// Useful for package internal pools.
+func MustNewBucketedBytes(minSize, maxSize int, factor float64, maxTotal uint64) *BucketedBytes {
+	pool, err := NewBucketedBytes(minSize, maxSize, factor, maxTotal)
+	if err != nil {
+		panic(err)
+	}
+	return pool
+}
+
 // NewBucketedBytes returns a new Bytes with size buckets for minSize to maxSize
 // increasing by the given factor and maximum number of used bytes.
 // No more than maxTotal bytes can be used at any given time unless maxTotal is set to 0.


### PR DESCRIPTION
Optimize snappy streamed reading by traversing through the byte slice in advance to determine how big of a buffer we will need. I have opted to rewrite snappy streamed format decoding because it is a straightforward format. Complex parts were deferred to klauspost/compress.


* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

* Rewrote snappy reader's Read() function to take into account that all bytes are available in memory already;
* Added optimization that it doesn't allocate memory when the snappy block is uncompressed, only switches the slice which is read from.
* Added optimization that we take a look in advance at how big of a buffer we will need and allocate it only once.
* Switched the order of sub benchmarks to get a nice output.
* Added `MustNewPool` which is used for decoding compressed snappy input. This also leads to nicer []byte savings because not each postings list is equally big to be put into one `sync.Pool`.

Benchmarks:

```
name                                                       old time/op    new time/op    delta
PostingsEncodingDecoding/10000/snappyStreamed/encode-16       413µs ± 2%     406µs ± 0%   -1.68%  (p=0.001 n=10+10)
PostingsEncodingDecoding/10000/snappyStreamed/decode-16       174µs ±10%      95µs ± 0%  -45.72%  (p=0.000 n=10+9)
PostingsEncodingDecoding/10000/raw/encode-16                 70.7µs ± 3%    70.1µs ± 1%     ~     (p=0.905 n=10+9)
PostingsEncodingDecoding/10000/raw/decode-16                 81.6µs ± 2%    79.7µs ± 0%   -2.30%  (p=0.000 n=10+10)
PostingsEncodingDecoding/10000/snappy/encode-16              73.3µs ± 3%    72.9µs ± 0%     ~     (p=0.500 n=10+8)
PostingsEncodingDecoding/10000/snappy/decode-16              81.0µs ± 1%    81.6µs ± 1%   +0.75%  (p=0.004 n=9+9)
PostingsEncodingDecoding/100000/raw/encode-16                 697µs ± 0%     702µs ± 1%   +0.59%  (p=0.000 n=10+9)
PostingsEncodingDecoding/100000/raw/decode-16                 790µs ± 0%     787µs ± 0%   -0.44%  (p=0.000 n=9+10)
PostingsEncodingDecoding/100000/snappy/encode-16              718µs ± 3%     722µs ± 0%     ~     (p=0.079 n=10+9)
PostingsEncodingDecoding/100000/snappy/decode-16              808µs ± 1%     806µs ± 0%     ~     (p=0.968 n=9+10)
PostingsEncodingDecoding/100000/snappyStreamed/encode-16     4.05ms ± 2%    4.01ms ± 0%     ~     (p=0.053 n=9+10)
PostingsEncodingDecoding/100000/snappyStreamed/decode-16      915µs ± 3%     942µs ± 1%   +2.88%  (p=0.002 n=9+10)
PostingsEncodingDecoding/1000000/raw/encode-16               7.05ms ± 1%    7.07ms ± 0%   +0.34%  (p=0.008 n=9+10)
PostingsEncodingDecoding/1000000/raw/decode-16               7.85ms ± 0%    7.93ms ± 1%   +1.04%  (p=0.004 n=9+9)
PostingsEncodingDecoding/1000000/snappy/encode-16            7.42ms ± 3%    7.53ms ± 3%     ~     (p=0.123 n=10+10)
PostingsEncodingDecoding/1000000/snappy/decode-16            8.09ms ± 1%    8.10ms ± 2%     ~     (p=0.661 n=9+10)
PostingsEncodingDecoding/1000000/snappyStreamed/encode-16    40.3ms ± 2%    40.2ms ± 1%     ~     (p=0.971 n=10+10)
PostingsEncodingDecoding/1000000/snappyStreamed/decode-16    7.93ms ± 1%    9.47ms ± 1%  +19.37%  (p=0.000 n=10+9)

name                                                       old alloc/op   new alloc/op   delta
PostingsEncodingDecoding/10000/snappyStreamed/encode-16      16.9kB ± 1%    17.0kB ± 0%     ~     (p=0.085 n=10+10)
PostingsEncodingDecoding/10000/snappyStreamed/decode-16      1.07MB ± 0%    0.00MB ± 0%  -99.99%  (p=0.002 n=8+10)
PostingsEncodingDecoding/10000/raw/encode-16                 13.6kB ± 0%    13.6kB ± 0%     ~     (all equal)
PostingsEncodingDecoding/10000/raw/decode-16                  96.0B ± 0%     96.0B ± 0%     ~     (all equal)
PostingsEncodingDecoding/10000/snappy/encode-16              25.9kB ± 0%    25.9kB ± 0%     ~     (all equal)
PostingsEncodingDecoding/10000/snappy/decode-16              11.0kB ± 0%    11.0kB ± 0%     ~     (all equal)
PostingsEncodingDecoding/100000/raw/encode-16                 131kB ± 0%     131kB ± 0%     ~     (all equal)
PostingsEncodingDecoding/100000/raw/decode-16                 96.0B ± 0%     96.0B ± 0%     ~     (all equal)
PostingsEncodingDecoding/100000/snappy/encode-16              254kB ± 0%     254kB ± 0%     ~     (all equal)
PostingsEncodingDecoding/100000/snappy/decode-16              107kB ± 0%     107kB ± 0%     ~     (all equal)
PostingsEncodingDecoding/100000/snappyStreamed/encode-16      152kB ± 0%     151kB ± 0%   -0.26%  (p=0.035 n=10+10)
PostingsEncodingDecoding/100000/snappyStreamed/decode-16     1.12MB ± 0%    0.00MB ± 0%  -99.99%  (p=0.002 n=8+10)
PostingsEncodingDecoding/1000000/raw/encode-16               1.25MB ± 0%    1.25MB ± 0%   -0.00%  (p=0.022 n=10+10)
PostingsEncodingDecoding/1000000/raw/decode-16                96.0B ± 0%     96.0B ± 0%     ~     (all equal)
PostingsEncodingDecoding/1000000/snappy/encode-16            2.48MB ± 0%    2.48MB ± 0%     ~     (p=0.090 n=10+10)
PostingsEncodingDecoding/1000000/snappy/decode-16            1.05MB ± 0%    1.05MB ± 0%     ~     (p=0.439 n=10+10)
PostingsEncodingDecoding/1000000/snappyStreamed/encode-16    1.50MB ± 1%    1.50MB ± 1%     ~     (p=0.353 n=10+10)
PostingsEncodingDecoding/1000000/snappyStreamed/decode-16    1.12MB ± 0%    0.00MB ± 0%  -99.99%  (p=0.000 n=9+10)

name                                                       old allocs/op  new allocs/op  delta
PostingsEncodingDecoding/10000/snappyStreamed/encode-16        10.0 ± 0%      10.0 ± 0%     ~     (all equal)
PostingsEncodingDecoding/10000/snappyStreamed/decode-16        5.00 ± 0%      2.00 ± 0%  -60.00%  (p=0.000 n=10+10)
PostingsEncodingDecoding/10000/raw/encode-16                   2.00 ± 0%      2.00 ± 0%     ~     (all equal)
PostingsEncodingDecoding/10000/raw/decode-16                   2.00 ± 0%      2.00 ± 0%     ~     (all equal)
PostingsEncodingDecoding/10000/snappy/encode-16                3.00 ± 0%      3.00 ± 0%     ~     (all equal)
PostingsEncodingDecoding/10000/snappy/decode-16                4.00 ± 0%      4.00 ± 0%     ~     (all equal)
PostingsEncodingDecoding/100000/raw/encode-16                  2.00 ± 0%      2.00 ± 0%     ~     (all equal)
PostingsEncodingDecoding/100000/raw/decode-16                  2.00 ± 0%      2.00 ± 0%     ~     (all equal)
PostingsEncodingDecoding/100000/snappy/encode-16               3.00 ± 0%      3.00 ± 0%     ~     (all equal)
PostingsEncodingDecoding/100000/snappy/decode-16               4.00 ± 0%      4.00 ± 0%     ~     (all equal)
PostingsEncodingDecoding/100000/snappyStreamed/encode-16       25.0 ± 0%      25.0 ± 0%     ~     (all equal)
PostingsEncodingDecoding/100000/snappyStreamed/decode-16       5.00 ± 0%      2.00 ± 0%  -60.00%  (p=0.000 n=10+10)
PostingsEncodingDecoding/1000000/raw/encode-16                 2.00 ± 0%      2.00 ± 0%     ~     (all equal)
PostingsEncodingDecoding/1000000/raw/decode-16                 2.00 ± 0%      2.00 ± 0%     ~     (all equal)
PostingsEncodingDecoding/1000000/snappy/encode-16              3.00 ± 0%      3.00 ± 0%     ~     (all equal)
PostingsEncodingDecoding/1000000/snappy/decode-16              4.00 ± 0%      4.00 ± 0%     ~     (all equal)
PostingsEncodingDecoding/1000000/snappyStreamed/encode-16       125 ± 0%       125 ± 1%     ~     (p=0.331 n=7+10)
PostingsEncodingDecoding/1000000/snappyStreamed/decode-16      5.00 ± 0%      2.00 ± 0%  -60.00%  (p=0.000 n=10+10)
```

## Verification

Existing tests

Fixes https://github.com/thanos-io/thanos/issues/6434.
