### PR TITLE
Fix Typos in quick-tutorial example

### DIFF
--- a/docs/quick-tutorial.md
+++ b/docs/quick-tutorial.md
@@ -131,9 +131,9 @@ Below, we will set up a Thanos Querier to connect to our Sidecars, and expose it
 ```bash
 thanos query \
     --http-address 0.0.0.0:19192 \                                # HTTP Endpoint for Thanos Querier UI
-    --endpiont     1.2.3.4:19090 \                                # Static gRPC Store API Address for the query node to query
-    --endpiont     1.2.3.5:19090 \                                # Also repeatable
-    --endpiont     dnssrv+_grpc._tcp.thanos-store.monitoring.svc  # Supports DNS A & SRV records
+    --endpoint     1.2.3.4:19090 \                                # Static gRPC Store API Address for the query node to query
+    --endpoint     1.2.3.5:19090 \                                # Also repeatable
+    --endpoint     dnssrv+_grpc._tcp.thanos-store.monitoring.svc  # Supports DNS A & SRV records
 ```
 
 Go to the configured HTTP address, which should now show a UI similar to that of Prometheus. You can now query across all Prometheus instances within the cluster. You can also check out the Stores page, which shows all of your stores.


### PR DESCRIPTION
This PR fixes a typo in the quick-tutorial, where `--enpoint` was misspelled as `--endpiont`.

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [X] Change is not relevant to the end user.

## Changes

`--endpiont` is now `--endpoint`

## Verification

Not applicable
