### PR TITLE
*: Change the engine behind `ContentPathReloader` to be completely independent of any filesystem concept.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#6467](https://github.com/thanos-io/thanos/pull/6467) Mixin (Receive): add alert for tenant reaching head series limit.
 
 ### Fixed
-- [#6503](https://github.com/thanos-io/thanos/pull/6503) *: Implement a fallback in `ContentPathReloader` to better handle symlinks. This effectively fixes this configuration reload when used with Kubernetes ConfigMaps, Secrets, or other volume mounts.
+- [#6503](https://github.com/thanos-io/thanos/pull/6503) *: Change the engine behind `ContentPathReloader` to be completely independent of any filesystem concept. This effectively fixes this configuration reload when used with Kubernetes ConfigMaps, Secrets, or other volume mounts.
 - [#6496](https://github.com/thanos-io/thanos/pull/6496) *: Remove unnecessary configuration reload from `ContentPathReloader` and improve its tests.
 - [#6456](https://github.com/thanos-io/thanos/pull/6456) Store: fix crash when computing set matches from regex pattern
 - [#6427](https://github.com/thanos-io/thanos/pull/6427) Receive: increasing log level for failed uploads to error

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,8 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#6467](https://github.com/thanos-io/thanos/pull/6467) Mixin (Receive): add alert for tenant reaching head series limit.
 
 ### Fixed
-- [#6496](https://github.com/thanos-io/thanos/pull/6496): *: Remove unnecessary configuration reload from `ContentPathReloader` and improve its tests.
+- [#6503](https://github.com/thanos-io/thanos/pull/6503) *: Fix `ContentPathReloader` to properly work when the file or its parent folder are symlinks. This effectively fixes this configuration reload when used with Kubernetes ConfigMaps, Secrets, or other volume mounts.
+- [#6496](https://github.com/thanos-io/thanos/pull/6496) *: Remove unnecessary configuration reload from `ContentPathReloader` and improve its tests.
 - [#6456](https://github.com/thanos-io/thanos/pull/6456) Store: fix crash when computing set matches from regex pattern
 - [#6427](https://github.com/thanos-io/thanos/pull/6427) Receive: increasing log level for failed uploads to error
 - [#6172](https://github.com/thanos-io/thanos/pull/6172) query-frontend: return JSON formatted errors for invalid PromQL expression in the split by interval middleware.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#6467](https://github.com/thanos-io/thanos/pull/6467) Mixin (Receive): add alert for tenant reaching head series limit.
 
 ### Fixed
-- [#6503](https://github.com/thanos-io/thanos/pull/6503) *: Fix `ContentPathReloader` to properly work when the file or its parent folder are symlinks. This effectively fixes this configuration reload when used with Kubernetes ConfigMaps, Secrets, or other volume mounts.
+- [#6503](https://github.com/thanos-io/thanos/pull/6503) *: Implement a fallback in `ContentPathReloader` to better handle symlinks. This effectively fixes this configuration reload when used with Kubernetes ConfigMaps, Secrets, or other volume mounts.
 - [#6496](https://github.com/thanos-io/thanos/pull/6496) *: Remove unnecessary configuration reload from `ContentPathReloader` and improve its tests.
 - [#6456](https://github.com/thanos-io/thanos/pull/6456) Store: fix crash when computing set matches from regex pattern
 - [#6427](https://github.com/thanos-io/thanos/pull/6427) Receive: increasing log level for failed uploads to error

--- a/docs/proposals-done/202005-query-logging.md
+++ b/docs/proposals-done/202005-query-logging.md
@@ -131,8 +131,8 @@ For HTTP, all these nice middlewares are not present, so we need to code up our 
 
 **Policy of Request Logging** : We are going to use the following middleware decider for achieving the above objectives -
 
-* [`logging.WithDecider`](https://github.com/grpc-ecosystem/go-grpc-middleware/blob/v2/interceptors/logging/options.go#L51) - This `option` would help us in deciding the logic whether a given request should be logged or not. This should help in logging specific / all queries. It is all pre request interception.
-* [`logging.WithLevels`](https://github.com/grpc-ecosystem/go-grpc-middleware/blob/v2/interceptors/logging/options.go#L58) - This `option` would help us in fixating the level of query that we might want to log. So based on a query hitting a certain criteria, we can switch the levels of it.
+* [`logging.WithDecider`](https://github.com/grpc-ecosystem/go-grpc-middleware/blob/v2.0.0-rc.5/interceptors/logging/options.go#L51) - This `option` would help us in deciding the logic whether a given request should be logged or not. This should help in logging specific / all queries. It is all pre request interception.
+* [`logging.WithLevels`](https://github.com/grpc-ecosystem/go-grpc-middleware/blob/v2.0.0-rc.5/interceptors/logging/options.go#L58) - This `option` would help us in fixating the level of query that we might want to log. So based on a query hitting a certain criteria, we can switch the levels of it.
 * For using the request-id, we can store the request-id in the metadata of the `context`, and while logging, we can use it.
 * Same equivalent for the HTTP can be implemented for mirroring the logic of *gRPC middlewares*.
 * So we would generally have request logging and options:

--- a/pkg/extkingpin/path_content_reloader.go
+++ b/pkg/extkingpin/path_content_reloader.go
@@ -46,7 +46,7 @@ func PathContentReloader(ctx context.Context, fileContent fileContent, logger lo
 	}
 	var engine reloaderEngine
 	if filePathStat.Mode()&os.ModeSymlink != 0 || parentFolderStat.Mode()&os.ModeSymlink != 0 {
-		level.Debug(logger).Log("msg", "file is a symlink, using polling approach", "file", filePath)
+		level.Debug(logger).Log("msg", "file and/or its parent folder are symlink, using polling approach", "file", filePath)
 		engine = &pollingEngine{
 			filePath:   filePath,
 			logger:     logger,

--- a/pkg/extkingpin/path_content_reloader.go
+++ b/pkg/extkingpin/path_content_reloader.go
@@ -100,7 +100,6 @@ func (p *pollingEngine) Start(ctx context.Context) error {
 		p.reloadFunc()
 		p.previousChecksum = checksum
 		level.Debug(p.logger).Log("msg", "configuration reloaded")
-		return
 	}
 	go func() {
 		for {

--- a/pkg/extkingpin/path_content_reloader.go
+++ b/pkg/extkingpin/path_content_reloader.go
@@ -63,7 +63,7 @@ func (p *pollingEngine) start(ctx context.Context) error {
 		}
 		p.reloadFunc()
 		p.previousChecksum = checksum
-		level.Debug(p.logger).Log("msg", "configuration reloaded")
+		level.Debug(p.logger).Log("msg", "configuration reloaded", "path", p.filePath)
 	}
 	go func() {
 		for {

--- a/pkg/extkingpin/path_content_reloader.go
+++ b/pkg/extkingpin/path_content_reloader.go
@@ -58,7 +58,7 @@ func PathContentReloader(ctx context.Context, fileContent fileContent, logger lo
 	return engine.Start(ctx)
 }
 
-// isSymlinkScenario identifies if the file in filePath or its parent folder are a symlink
+// isSymlinkScenario identifies if the file in filePath or its parent folder are a symlink.
 func isSymlinkScenario(filePath string) (bool, error) {
 	// Check if filePath is symlink
 	filePathStat, err := os.Lstat(filePath)

--- a/pkg/extkingpin/path_content_reloader.go
+++ b/pkg/extkingpin/path_content_reloader.go
@@ -33,7 +33,7 @@ func PathContentReloader(ctx context.Context, fileContent fileContent, logger lo
 		debounce:   debounceTime,
 		reloadFunc: reloadFunc,
 	}
-	return engine.Start(ctx)
+	return engine.start(ctx)
 }
 
 // pollingEngine is an implementation of reloaderEngine that keeps rereading the contents at filePath and when the
@@ -46,7 +46,7 @@ type pollingEngine struct {
 	previousChecksum [sha256.Size]byte
 }
 
-func (p *pollingEngine) Start(ctx context.Context) error {
+func (p *pollingEngine) start(ctx context.Context) error {
 	configReader := func() {
 		// check if file still exists
 		if _, err := os.Stat(p.filePath); os.IsNotExist(err) {

--- a/pkg/extkingpin/path_content_reloader.go
+++ b/pkg/extkingpin/path_content_reloader.go
@@ -26,9 +26,6 @@ func PathContentReloader(ctx context.Context, fileContent fileContent, logger lo
 	if err != nil {
 		return errors.Wrap(err, "getting absolute file path")
 	}
-	if filePath == "" {
-		level.Debug(logger).Log("msg", "no path detected for config reload")
-	}
 
 	engine := &pollingEngine{
 		filePath:   filePath,

--- a/pkg/extkingpin/path_content_reloader.go
+++ b/pkg/extkingpin/path_content_reloader.go
@@ -23,13 +23,7 @@ type fileContent interface {
 	Path() string
 }
 
-// PathContentReloader starts a file watcher that monitors the file indicated by fileContent.Path() and runs
-// reloadFunc whenever a change is detected.
-// A debounce timer can be configured via opts to handle situations where many "write" events are received together or
-// a "create" event is followed up by a "write" event, for example. Files will be effectively reloaded at the latest
-// after 2 times the debounce timer. By default the debouncer timer is 1 second.
-// To ensure renames and deletes are properly handled, the file watcher is put at the file's parent folder. See
-// https://github.com/fsnotify/fsnotify/issues/214 for more details.
+// PathContentReloader runs the reloadFunc when it detects that the contents of fileContent have changed.
 func PathContentReloader(ctx context.Context, fileContent fileContent, logger log.Logger, reloadFunc func(), debounceTime time.Duration) error {
 	filePath, err := filepath.Abs(fileContent.Path())
 	if err != nil {
@@ -123,6 +117,11 @@ func (p *pollingEngine) Start(ctx context.Context) error {
 
 // fsNotifyEngine is an implementation of reloaderEngine that uses fsnotify to watch for changes to a file and then
 // runs the reloadFunc.
+// A debounce timer can be configured via opts to handle situations where many "write" events are received together or
+// a "create" event is followed up by a "write" event, for example. Files will be effectively reloaded at the latest
+// after 2 times the debounce timer. By default the debouncer timer is 1 second.
+// To ensure renames and deletes are properly handled, the file watcher is put at the file's parent folder. See
+// https://github.com/fsnotify/fsnotify/issues/214 for more details.
 type fsNotifyEngine struct {
 	filePath   string
 	logger     log.Logger

--- a/pkg/extkingpin/path_content_reloader.go
+++ b/pkg/extkingpin/path_content_reloader.go
@@ -36,8 +36,7 @@ func PathContentReloader(ctx context.Context, fileContent fileContent, logger lo
 	return engine.start(ctx)
 }
 
-// pollingEngine is an implementation of reloaderEngine that keeps rereading the contents at filePath and when the
-// checksum changes it runs the reloadFunc.
+// pollingEngine keeps rereading the contents at filePath and when its checksum changes it runs the reloadFunc.
 type pollingEngine struct {
 	filePath         string
 	logger           log.Logger

--- a/pkg/extkingpin/path_content_reloader_test.go
+++ b/pkg/extkingpin/path_content_reloader_test.go
@@ -22,111 +22,6 @@ import (
 func TestPathContentReloader(t *testing.T) {
 	t.Parallel()
 	type args struct {
-		runSteps func(t *testing.T, testFile string, pathContent *staticPathContent, debounceTime time.Duration)
-	}
-	tests := []struct {
-		name        string
-		args        args
-		wantReloads int
-	}{
-		{
-			name: "Many operations, only rewrite triggers one reload",
-			args: args{
-				runSteps: func(t *testing.T, testFile string, pathContent *staticPathContent, debounceTime time.Duration) {
-					testutil.Ok(t, os.Chmod(testFile, 0777))
-					testutil.Ok(t, os.Remove(testFile))
-					testutil.Ok(t, pathContent.Rewrite([]byte("test modified")))
-				},
-			},
-			wantReloads: 1,
-		},
-		{
-			name: "Many operations, only rename triggers one reload",
-			args: args{
-				runSteps: func(t *testing.T, testFile string, pathContent *staticPathContent, debounceTime time.Duration) {
-					testutil.Ok(t, os.Chmod(testFile, 0777))
-					testutil.Ok(t, os.Rename(testFile, testFile+".tmp"))
-					testutil.Ok(t, os.Rename(testFile+".tmp", testFile))
-				},
-			},
-			wantReloads: 1,
-		},
-		{
-			name: "Many operations, two rewrites trigger two reloads",
-			args: args{
-				runSteps: func(t *testing.T, testFile string, pathContent *staticPathContent, debounceTime time.Duration) {
-					testutil.Ok(t, os.Chmod(testFile, 0777))
-					testutil.Ok(t, os.Remove(testFile))
-					testutil.Ok(t, pathContent.Rewrite([]byte("test modified")))
-					time.Sleep(2 * debounceTime)
-					testutil.Ok(t, pathContent.Rewrite([]byte("test modified again")))
-				},
-			},
-			wantReloads: 2,
-		},
-		{
-			name: "Chmod doesn't trigger reload",
-			args: args{
-				runSteps: func(t *testing.T, testFile string, pathContent *staticPathContent, debounceTime time.Duration) {
-					testutil.Ok(t, os.Chmod(testFile, 0777))
-					testutil.Ok(t, os.Chmod(testFile, 0666))
-					testutil.Ok(t, os.Chmod(testFile, 0777))
-				},
-			},
-			wantReloads: 0,
-		},
-		{
-			name: "Remove doesn't trigger reload",
-			args: args{
-				runSteps: func(t *testing.T, testFile string, pathContent *staticPathContent, debounceTime time.Duration) {
-					testutil.Ok(t, os.Remove(testFile))
-				},
-			},
-			wantReloads: 0,
-		},
-	}
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			testFile := path.Join(t.TempDir(), "test")
-			testutil.Ok(t, os.WriteFile(testFile, []byte("test"), 0666))
-			pathContent, err := NewStaticPathContent(testFile)
-			testutil.Ok(t, err)
-
-			wg := &sync.WaitGroup{}
-			wg.Add(tt.wantReloads)
-
-			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-			defer cancel()
-			reloadCount := 0
-			debounceTime := 1 * time.Second
-			err = PathContentReloader(ctx, pathContent, log.NewLogfmtLogger(os.Stdout), func() {
-				reloadCount++
-				wg.Done()
-			}, debounceTime)
-			testutil.Ok(t, err)
-
-			tt.args.runSteps(t, testFile, pathContent, debounceTime)
-			if tt.wantReloads == 0 {
-				// Give things a little time to sync. The fs watcher events are heavily async and could be delayed.
-				time.Sleep(2 * debounceTime)
-			}
-			wg.Wait()
-
-			testutil.NotOk(t, runutil.Repeat(2*debounceTime, ctx.Done(), func() error {
-				if reloadCount != tt.wantReloads {
-					return nil
-				}
-				return errors.New("reload count matched")
-			}))
-		})
-	}
-}
-
-func TestPathContentReloader_Symlink(t *testing.T) {
-	t.Parallel()
-	type args struct {
 		runSteps func(t *testing.T, testFile string, pathContent *staticPathContent, reloadTime time.Duration)
 	}
 	tests := []struct {
@@ -185,9 +80,8 @@ func TestPathContentReloader_Symlink(t *testing.T) {
 			t.Parallel()
 			testFile := path.Join(t.TempDir(), "test")
 			testutil.Ok(t, os.WriteFile(testFile, []byte("test"), 0666))
-			testutil.Ok(t, os.Symlink(testFile, testFile+"-symlink"))
 
-			pathContent, err := NewStaticPathContent(testFile + "-symlink")
+			pathContent, err := NewStaticPathContent(testFile)
 			testutil.Ok(t, err)
 
 			wg := &sync.WaitGroup{}

--- a/pkg/extkingpin/path_content_reloader_test.go
+++ b/pkg/extkingpin/path_content_reloader_test.go
@@ -6,12 +6,13 @@ package extkingpin
 import (
 	"context"
 	"errors"
-	"github.com/thanos-io/thanos/pkg/runutil"
 	"os"
 	"path"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/thanos-io/thanos/pkg/runutil"
 
 	"github.com/efficientgo/core/testutil"
 	"github.com/go-kit/log"

--- a/pkg/extkingpin/path_content_reloader_test.go
+++ b/pkg/extkingpin/path_content_reloader_test.go
@@ -5,12 +5,13 @@ package extkingpin
 
 import (
 	"context"
-	"errors"
 	"os"
 	"path"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/pkg/errors"
 
 	"github.com/thanos-io/thanos/pkg/runutil"
 

--- a/pkg/receive/handler_test.go
+++ b/pkg/receive/handler_test.go
@@ -183,7 +183,7 @@ func newTestHandlerHashring(appendables []*fakeAppendable, replicationFactor uin
 	}
 
 	ag := addrGen{}
-	limiter, _ := NewLimiter(NewNopConfig(), nil, RouterIngestor, log.NewNopLogger())
+	limiter, _ := NewLimiter(NewNopConfig(), nil, RouterIngestor, log.NewNopLogger(), 1*time.Second)
 	for i := range appendables {
 		h := NewHandler(nil, &Options{
 			TenantHeader:      tenancy.DefaultTenantHeader,
@@ -741,7 +741,7 @@ func TestReceiveWriteRequestLimits(t *testing.T) {
 			testutil.Ok(t, os.WriteFile(tmpLimitsPath, tenantConfig, 0666))
 			limitConfig, _ := extkingpin.NewStaticPathContent(tmpLimitsPath)
 			handler.Limiter, _ = NewLimiter(
-				limitConfig, nil, RouterIngestor, log.NewNopLogger(),
+				limitConfig, nil, RouterIngestor, log.NewNopLogger(), 1*time.Second,
 			)
 
 			wreq := &prompb.WriteRequest{

--- a/pkg/receive/limiter_test.go
+++ b/pkg/receive/limiter_test.go
@@ -32,7 +32,7 @@ func TestLimiter_StartConfigReloader(t *testing.T) {
 		t.Fatalf("could not load test content at %s: %s", invalidLimitsPath, err)
 	}
 
-	limiter, err := NewLimiter(goodLimits, nil, RouterIngestor, log.NewLogfmtLogger(os.Stdout))
+	limiter, err := NewLimiter(goodLimits, nil, RouterIngestor, log.NewLogfmtLogger(os.Stdout), 1*time.Second)
 	testutil.Ok(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -88,7 +88,7 @@ func TestLimiter_CanReload(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			configFile := tt.args.configFilePath
-			limiter, err := NewLimiter(configFile, nil, RouterIngestor, log.NewLogfmtLogger(os.Stdout))
+			limiter, err := NewLimiter(configFile, nil, RouterIngestor, log.NewLogfmtLogger(os.Stdout), 1*time.Second)
 			testutil.Ok(t, err)
 			if tt.wantReload {
 				testutil.Assert(t, limiter.CanReload())


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

This should solve #6491.

* Replaces the config reload logic behind the `PathContentReloader` function, which now will frequently reread a file and run the `reloadFunc` whenever the sha256 of the file's contents changes.
* Updated the `PathContentReloader` tests accordingly, including new tests covering the new engine. 
* Adds a new CLI flag to Receive, `receive.limits-config-reload-timer`, used to configure the debouncer timer of the fs notification engine or the reload time of the polling engine.
  * By default this is set to `1s`, which matches the current behavior. There's no breaking change there.


## Verification

Automated tests. Ran time quite a few times to try to capture any flakiness.
