### PR TITLE
Standardize index cache metrics

### DIFF
--- a/cmd/thanos/store.go
+++ b/cmd/thanos/store.go
@@ -323,7 +323,7 @@ func runStore(
 	if len(indexCacheContentYaml) > 0 {
 		indexCache, err = storecache.NewIndexCache(logger, indexCacheContentYaml, reg)
 	} else {
-		indexCache, err = storecache.NewInMemoryIndexCacheWithConfig(logger, reg, storecache.InMemoryIndexCacheConfig{
+		indexCache, err = storecache.NewInMemoryIndexCacheWithConfig(logger, nil, reg, storecache.InMemoryIndexCacheConfig{
 			MaxSize:     model.Bytes(conf.indexCacheSizeBytes),
 			MaxItemSize: storecache.DefaultInMemoryIndexCacheConfig.MaxItemSize,
 		})

--- a/pkg/store/bucket_e2e_test.go
+++ b/pkg/store/bucket_e2e_test.go
@@ -495,7 +495,7 @@ func TestBucketStore_e2e(t *testing.T) {
 		}
 
 		if ok := t.Run("with large, sufficient index cache", func(t *testing.T) {
-			indexCache, err := storecache.NewInMemoryIndexCacheWithConfig(s.logger, nil, storecache.InMemoryIndexCacheConfig{
+			indexCache, err := storecache.NewInMemoryIndexCacheWithConfig(s.logger, nil, nil, storecache.InMemoryIndexCacheConfig{
 				MaxItemSize: 1e5,
 				MaxSize:     2e5,
 			})
@@ -507,7 +507,7 @@ func TestBucketStore_e2e(t *testing.T) {
 		}
 
 		t.Run("with small index cache", func(t *testing.T) {
-			indexCache2, err := storecache.NewInMemoryIndexCacheWithConfig(s.logger, nil, storecache.InMemoryIndexCacheConfig{
+			indexCache2, err := storecache.NewInMemoryIndexCacheWithConfig(s.logger, nil, nil, storecache.InMemoryIndexCacheConfig{
 				MaxItemSize: 50,
 				MaxSize:     100,
 			})
@@ -540,7 +540,7 @@ func TestBucketStore_ManyParts_e2e(t *testing.T) {
 
 		s := prepareStoreWithTestBlocks(t, dir, bkt, true, NewChunksLimiterFactory(0), NewSeriesLimiterFactory(0), NewBytesLimiterFactory(0), emptyRelabelConfig, allowAllFilterConf)
 
-		indexCache, err := storecache.NewInMemoryIndexCacheWithConfig(s.logger, nil, storecache.InMemoryIndexCacheConfig{
+		indexCache, err := storecache.NewInMemoryIndexCacheWithConfig(s.logger, nil, nil, storecache.InMemoryIndexCacheConfig{
 			MaxItemSize: 1e5,
 			MaxSize:     2e5,
 		})

--- a/pkg/store/bucket_test.go
+++ b/pkg/store/bucket_test.go
@@ -1517,7 +1517,7 @@ func TestBucketSeries_OneBlock_InMemIndexCacheSegfault(t *testing.T) {
 	chunkPool, err := pool.NewBucketedBytes(chunkBytesPoolMinSize, chunkBytesPoolMaxSize, 2, 100e7)
 	testutil.Ok(t, err)
 
-	indexCache, err := storecache.NewInMemoryIndexCacheWithConfig(logger, nil, storecache.InMemoryIndexCacheConfig{
+	indexCache, err := storecache.NewInMemoryIndexCacheWithConfig(logger, nil, nil, storecache.InMemoryIndexCacheConfig{
 		MaxItemSize: 3000,
 		// This is the exact size of cache needed for our *single request*.
 		// This is limited in order to make sure we test evictions.
@@ -1820,7 +1820,7 @@ func TestSeries_ErrorUnmarshallingRequestHints(t *testing.T) {
 	fetcher, err := block.NewMetaFetcher(logger, 10, instrBkt, tmpDir, nil, nil)
 	testutil.Ok(tb, err)
 
-	indexCache, err := storecache.NewInMemoryIndexCacheWithConfig(logger, nil, storecache.InMemoryIndexCacheConfig{})
+	indexCache, err := storecache.NewInMemoryIndexCacheWithConfig(logger, nil, nil, storecache.InMemoryIndexCacheConfig{})
 	testutil.Ok(tb, err)
 
 	store, err := NewBucketStore(
@@ -1911,7 +1911,7 @@ func TestSeries_BlockWithMultipleChunks(t *testing.T) {
 	fetcher, err := block.NewMetaFetcher(logger, 10, instrBkt, tmpDir, nil, nil)
 	testutil.Ok(tb, err)
 
-	indexCache, err := storecache.NewInMemoryIndexCacheWithConfig(logger, nil, storecache.InMemoryIndexCacheConfig{})
+	indexCache, err := storecache.NewInMemoryIndexCacheWithConfig(logger, nil, nil, storecache.InMemoryIndexCacheConfig{})
 	testutil.Ok(tb, err)
 
 	store, err := NewBucketStore(
@@ -2093,7 +2093,7 @@ func setupStoreForHintsTest(t *testing.T) (testutil.TB, *BucketStore, []*storepb
 	fetcher, err := block.NewMetaFetcher(logger, 10, instrBkt, tmpDir, nil, nil)
 	testutil.Ok(tb, err)
 
-	indexCache, err := storecache.NewInMemoryIndexCacheWithConfig(logger, nil, storecache.InMemoryIndexCacheConfig{})
+	indexCache, err := storecache.NewInMemoryIndexCacheWithConfig(logger, nil, nil, storecache.InMemoryIndexCacheConfig{})
 	testutil.Ok(tb, err)
 
 	store, err := NewBucketStore(
@@ -2309,7 +2309,7 @@ func TestSeries_ChunksHaveHashRepresentation(t *testing.T) {
 	fetcher, err := block.NewMetaFetcher(logger, 10, instrBkt, tmpDir, nil, nil)
 	testutil.Ok(tb, err)
 
-	indexCache, err := storecache.NewInMemoryIndexCacheWithConfig(logger, nil, storecache.InMemoryIndexCacheConfig{})
+	indexCache, err := storecache.NewInMemoryIndexCacheWithConfig(logger, nil, nil, storecache.InMemoryIndexCacheConfig{})
 	testutil.Ok(tb, err)
 
 	store, err := NewBucketStore(
@@ -2516,7 +2516,7 @@ func prepareBucket(b *testing.B, resolutionLevel compact.ResolutionLevel) (*buck
 	// Create an index header reader.
 	indexHeaderReader, err := indexheader.NewBinaryReader(ctx, logger, bkt, tmpDir, blockMeta.ULID, DefaultPostingOffsetInMemorySampling)
 	testutil.Ok(b, err)
-	indexCache, err := storecache.NewInMemoryIndexCacheWithConfig(logger, nil, storecache.DefaultInMemoryIndexCacheConfig)
+	indexCache, err := storecache.NewInMemoryIndexCacheWithConfig(logger, nil, nil, storecache.DefaultInMemoryIndexCacheConfig)
 	testutil.Ok(b, err)
 
 	// Create a bucket block with only the dependencies we need for the benchmark.

--- a/pkg/store/cache/cache.go
+++ b/pkg/store/cache/cache.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 
 	"github.com/oklog/ulid"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
 	"golang.org/x/crypto/blake2b"
@@ -52,6 +54,25 @@ type IndexCache interface {
 	// FetchMultiSeries fetches multiple series - each identified by ID - from the cache
 	// and returns a map containing cache hits, along with a list of missing IDs.
 	FetchMultiSeries(ctx context.Context, blockID ulid.ULID, ids []storage.SeriesRef) (hits map[storage.SeriesRef][]byte, misses []storage.SeriesRef)
+}
+
+// Common metrics that should be used by all cache implementations.
+type commonMetrics struct {
+	requestTotal *prometheus.CounterVec
+	hitsTotal    *prometheus.CounterVec
+}
+
+func newCommonMetrics(reg prometheus.Registerer) *commonMetrics {
+	return &commonMetrics{
+		requestTotal: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "thanos_store_index_cache_requests_total",
+			Help: "Total number of items requests to the cache.",
+		}, []string{"item_type"}),
+		hitsTotal: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "thanos_store_index_cache_hits_total",
+			Help: "Total number of items requests to the cache that were a hit.",
+		}, []string{"item_type"}),
+	}
 }
 
 type cacheKey struct {

--- a/pkg/store/cache/factory_test.go
+++ b/pkg/store/cache/factory_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
 package storecache
 
 import (
@@ -19,6 +22,8 @@ func TestIndexCacheMetrics(t *testing.T) {
 max_size: 10MB
 max_item_size: 1MB
 `)
+	// Make sure that the in memory cache does not register the same metrics of the remote index cache.
+	// If so, we should move those metrics to the `commonMetrics`
 	_, err = NewInMemoryIndexCache(log.NewNopLogger(), commonMetrics, reg, conf)
 	testutil.Ok(t, err)
 }

--- a/pkg/store/cache/factory_test.go
+++ b/pkg/store/cache/factory_test.go
@@ -1,0 +1,24 @@
+package storecache
+
+import (
+	"testing"
+
+	"github.com/efficientgo/core/testutil"
+	"github.com/go-kit/log"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func TestIndexCacheMetrics(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	commonMetrics := newCommonMetrics(reg)
+
+	memcached := newMockedMemcachedClient(nil)
+	_, err := NewRemoteIndexCache(log.NewNopLogger(), memcached, commonMetrics, reg)
+	testutil.Ok(t, err)
+	conf := []byte(`
+max_size: 10MB
+max_item_size: 1MB
+`)
+	_, err = NewInMemoryIndexCache(log.NewNopLogger(), commonMetrics, reg, conf)
+	testutil.Ok(t, err)
+}

--- a/pkg/store/cache/inmemory_test.go
+++ b/pkg/store/cache/inmemory_test.go
@@ -25,14 +25,14 @@ import (
 func TestNewInMemoryIndexCache(t *testing.T) {
 	// Should return error on invalid YAML config.
 	conf := []byte("invalid")
-	cache, err := NewInMemoryIndexCache(log.NewNopLogger(), nil, conf)
+	cache, err := NewInMemoryIndexCache(log.NewNopLogger(), nil, nil, conf)
 	testutil.NotOk(t, err)
 	testutil.Equals(t, (*InMemoryIndexCache)(nil), cache)
 
 	// Should instance an in-memory index cache with default config
 	// on empty YAML config.
 	conf = []byte{}
-	cache, err = NewInMemoryIndexCache(log.NewNopLogger(), nil, conf)
+	cache, err = NewInMemoryIndexCache(log.NewNopLogger(), nil, nil, conf)
 	testutil.Ok(t, err)
 	testutil.Equals(t, uint64(DefaultInMemoryIndexCacheConfig.MaxSize), cache.maxSizeBytes)
 	testutil.Equals(t, uint64(DefaultInMemoryIndexCacheConfig.MaxItemSize), cache.maxItemSizeBytes)
@@ -42,7 +42,7 @@ func TestNewInMemoryIndexCache(t *testing.T) {
 max_size: 1MB
 max_item_size: 2KB
 `)
-	cache, err = NewInMemoryIndexCache(log.NewNopLogger(), nil, conf)
+	cache, err = NewInMemoryIndexCache(log.NewNopLogger(), nil, nil, conf)
 	testutil.Ok(t, err)
 	testutil.Equals(t, uint64(1024*1024), cache.maxSizeBytes)
 	testutil.Equals(t, uint64(2*1024), cache.maxItemSizeBytes)
@@ -52,7 +52,7 @@ max_item_size: 2KB
 max_size: 2KB
 max_item_size: 1MB
 `)
-	cache, err = NewInMemoryIndexCache(log.NewNopLogger(), nil, conf)
+	cache, err = NewInMemoryIndexCache(log.NewNopLogger(), nil, nil, conf)
 	testutil.NotOk(t, err)
 	testutil.Equals(t, (*InMemoryIndexCache)(nil), cache)
 	// testutil.Equals(t, uint64(1024*1024), cache.maxSizeBytes)
@@ -64,7 +64,7 @@ max_item_size: 1MB
 
 func TestInMemoryIndexCache_AvoidsDeadlock(t *testing.T) {
 	metrics := prometheus.NewRegistry()
-	cache, err := NewInMemoryIndexCacheWithConfig(log.NewNopLogger(), metrics, InMemoryIndexCacheConfig{
+	cache, err := NewInMemoryIndexCacheWithConfig(log.NewNopLogger(), nil, metrics, InMemoryIndexCacheConfig{
 		MaxItemSize: sliceHeaderSize + 5,
 		MaxSize:     sliceHeaderSize + 5,
 	})
@@ -114,7 +114,7 @@ func TestInMemoryIndexCache_UpdateItem(t *testing.T) {
 	})
 
 	metrics := prometheus.NewRegistry()
-	cache, err := NewInMemoryIndexCacheWithConfig(log.NewSyncLogger(errorLogger), metrics, InMemoryIndexCacheConfig{
+	cache, err := NewInMemoryIndexCacheWithConfig(log.NewSyncLogger(errorLogger), nil, metrics, InMemoryIndexCacheConfig{
 		MaxItemSize: maxSize,
 		MaxSize:     maxSize,
 	})
@@ -208,7 +208,7 @@ func TestInMemoryIndexCache_UpdateItem(t *testing.T) {
 // This should not happen as we hardcode math.MaxInt, but we still add test to check this out.
 func TestInMemoryIndexCache_MaxNumberOfItemsHit(t *testing.T) {
 	metrics := prometheus.NewRegistry()
-	cache, err := NewInMemoryIndexCacheWithConfig(log.NewNopLogger(), metrics, InMemoryIndexCacheConfig{
+	cache, err := NewInMemoryIndexCacheWithConfig(log.NewNopLogger(), nil, metrics, InMemoryIndexCacheConfig{
 		MaxItemSize: 2*sliceHeaderSize + 10,
 		MaxSize:     2*sliceHeaderSize + 10,
 	})
@@ -231,15 +231,15 @@ func TestInMemoryIndexCache_MaxNumberOfItemsHit(t *testing.T) {
 	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.evicted.WithLabelValues(cacheTypeSeries)))
 	testutil.Equals(t, float64(3), promtest.ToFloat64(cache.added.WithLabelValues(cacheTypePostings)))
 	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.added.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.requests.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.requests.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.hits.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.hits.WithLabelValues(cacheTypeSeries)))
+	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.commonMetrics.requestTotal.WithLabelValues(cacheTypePostings)))
+	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.commonMetrics.requestTotal.WithLabelValues(cacheTypeSeries)))
+	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.commonMetrics.hitsTotal.WithLabelValues(cacheTypePostings)))
+	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.commonMetrics.hitsTotal.WithLabelValues(cacheTypeSeries)))
 }
 
 func TestInMemoryIndexCache_Eviction_WithMetrics(t *testing.T) {
 	metrics := prometheus.NewRegistry()
-	cache, err := NewInMemoryIndexCacheWithConfig(log.NewNopLogger(), metrics, InMemoryIndexCacheConfig{
+	cache, err := NewInMemoryIndexCacheWithConfig(log.NewNopLogger(), nil, metrics, InMemoryIndexCacheConfig{
 		MaxItemSize: 2*sliceHeaderSize + 5,
 		MaxSize:     2*sliceHeaderSize + 5,
 	})
@@ -429,8 +429,8 @@ func TestInMemoryIndexCache_Eviction_WithMetrics(t *testing.T) {
 	// Other metrics.
 	testutil.Equals(t, float64(4), promtest.ToFloat64(cache.added.WithLabelValues(cacheTypePostings)))
 	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.added.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(9), promtest.ToFloat64(cache.requests.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(2), promtest.ToFloat64(cache.requests.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(5), promtest.ToFloat64(cache.hits.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.hits.WithLabelValues(cacheTypeSeries)))
+	testutil.Equals(t, float64(9), promtest.ToFloat64(cache.commonMetrics.requestTotal.WithLabelValues(cacheTypePostings)))
+	testutil.Equals(t, float64(2), promtest.ToFloat64(cache.commonMetrics.requestTotal.WithLabelValues(cacheTypeSeries)))
+	testutil.Equals(t, float64(5), promtest.ToFloat64(cache.commonMetrics.hitsTotal.WithLabelValues(cacheTypePostings)))
+	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.commonMetrics.hitsTotal.WithLabelValues(cacheTypeSeries)))
 }

--- a/pkg/store/cache/memcached_test.go
+++ b/pkg/store/cache/memcached_test.go
@@ -86,7 +86,7 @@ func TestMemcachedIndexCache_FetchMultiPostings(t *testing.T) {
 	for testName, testData := range tests {
 		t.Run(testName, func(t *testing.T) {
 			memcached := newMockedMemcachedClient(testData.mockedErr)
-			c, err := NewRemoteIndexCache(log.NewNopLogger(), memcached, nil)
+			c, err := NewRemoteIndexCache(log.NewNopLogger(), memcached, nil, nil)
 			testutil.Ok(t, err)
 
 			// Store the postings expected before running the test.
@@ -167,7 +167,7 @@ func TestMemcachedIndexCache_FetchExpandedPostings(t *testing.T) {
 	for testName, testData := range tests {
 		t.Run(testName, func(t *testing.T) {
 			memcached := newMockedMemcachedClient(testData.mockedErr)
-			c, err := NewRemoteIndexCache(log.NewNopLogger(), memcached, nil)
+			c, err := NewRemoteIndexCache(log.NewNopLogger(), memcached, nil, nil)
 			testutil.Ok(t, err)
 
 			// Store the postings expected before running the test.
@@ -262,7 +262,7 @@ func TestMemcachedIndexCache_FetchMultiSeries(t *testing.T) {
 	for testName, testData := range tests {
 		t.Run(testName, func(t *testing.T) {
 			memcached := newMockedMemcachedClient(testData.mockedErr)
-			c, err := NewRemoteIndexCache(log.NewNopLogger(), memcached, nil)
+			c, err := NewRemoteIndexCache(log.NewNopLogger(), memcached, nil, nil)
 			testutil.Ok(t, err)
 
 			// Store the series expected before running the test.


### PR DESCRIPTION
This is a small refactor to have a common place where the metrics `thanos_store_index_cache_requests_total` and `thanos_store_index_cache_hits_total` are created.

Those metrics where before being created on 2 places and the description were not matching:

https://github.com/thanos-io/thanos/blob/df3a5f8087268d069a13a062a77d7f650eb6760a/pkg/store/cache/memcached.go#L62-L63

https://github.com/thanos-io/thanos/blob/df3a5f8087268d069a13a062a77d7f650eb6760a/pkg/store/cache/inmemory.go#L130-L131

Context:

We were trying to do a multi tier cache (L1,L2 caching layers) for index-cache on cortex (https://github.com/cortexproject/cortex/pull/5451) using in-memory and remote cache implementations and even wrapping the `prometheus.Registerer` with custom labels, we were unable to get it working due:

```
panic: a previously registered descriptor with the same fully-qualified name as Desc{fqName: "thanos_store_index_cache_hits_total", help: "Total number of items requests to the cache that were a hit.", constLabels: {level="l1"}, variableLabels: [{item_type <nil>}]} has different label names or a different help string [recovered]
```

PS: If thanos is interested on this we could also open a PR for it. I just did not do as if we wanted to do in a "non breaking" way on thanos the cache configuration would become very confusing - as it does not have a entry per cache type:

Ex: https://thanos.io/tip/components/store.md/#redis-index-cache

* [ ] I added CHANGELOG entry for this change.
* [X] Change is not relevant to the end user.

## Changes

* Creating `thanos_store_index_cache_requests_total` and `thanos_store_index_cache_hits_total`  metrics in a common place.

## Verification

Unit tests.