### PR TITLE
ui: only set query url to localhost if config option is falsy

### DIFF
--- a/pkg/ui/react-app/src/thanos/config.ts
+++ b/pkg/ui/react-app/src/thanos/config.ts
@@ -1,6 +1,6 @@
 declare const THANOS_QUERY_URL: string;
 
 export let queryURL = THANOS_QUERY_URL;
-if (queryURL === '' || queryURL === '{{ .queryURL }}') {
+if (!queryURL) {
   queryURL = 'http://localhost:10902';
 }


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

The `THANOS_QUERY_URL` constant is already assigned to `{{ .queryURL }}` in `public/index.html`. Remove this comparison, as it causes the `--alert.query-url` command line option to have no effect whatsoever.

Fixes #6370

## Verification

* [ ] TODO: verification