### PR TITLE
Shipper: change upload compacted type from bool to a function

### DIFF
--- a/cmd/thanos/rule.go
+++ b/cmd/thanos/rule.go
@@ -728,7 +728,7 @@ func runRule(
 			}
 		}()
 
-		s := shipper.New(logger, reg, conf.dataDir, bkt, func() labels.Labels { return conf.lset }, metadata.RulerSource, func() bool { return false }, conf.shipper.allowOutOfOrderUpload, metadata.HashFunc(conf.shipper.hashFunc))
+		s := shipper.New(logger, reg, conf.dataDir, bkt, func() labels.Labels { return conf.lset }, metadata.RulerSource, nil, conf.shipper.allowOutOfOrderUpload, metadata.HashFunc(conf.shipper.hashFunc))
 
 		ctx, cancel := context.WithCancel(context.Background())
 

--- a/cmd/thanos/rule.go
+++ b/cmd/thanos/rule.go
@@ -728,7 +728,7 @@ func runRule(
 			}
 		}()
 
-		s := shipper.New(logger, reg, conf.dataDir, bkt, func() labels.Labels { return conf.lset }, metadata.RulerSource, false, conf.shipper.allowOutOfOrderUpload, metadata.HashFunc(conf.shipper.hashFunc))
+		s := shipper.New(logger, reg, conf.dataDir, bkt, func() labels.Labels { return conf.lset }, metadata.RulerSource, func() bool { return false }, conf.shipper.allowOutOfOrderUpload, metadata.HashFunc(conf.shipper.hashFunc))
 
 		ctx, cancel := context.WithCancel(context.Background())
 

--- a/cmd/thanos/sidecar.go
+++ b/cmd/thanos/sidecar.go
@@ -341,8 +341,9 @@ func runSidecar(
 				return errors.Wrapf(err, "aborting as no external labels found after waiting %s", promReadyTimeout)
 			}
 
+			uploadCompactedFunc := func() bool { return conf.shipper.uploadCompacted }
 			s := shipper.New(logger, reg, conf.tsdb.path, bkt, m.Labels, metadata.SidecarSource,
-				conf.shipper.uploadCompacted, conf.shipper.allowOutOfOrderUpload, metadata.HashFunc(conf.shipper.hashFunc))
+				uploadCompactedFunc, conf.shipper.allowOutOfOrderUpload, metadata.HashFunc(conf.shipper.hashFunc))
 
 			return runutil.Repeat(30*time.Second, ctx.Done(), func() error {
 				if uploaded, err := s.Sync(ctx); err != nil {

--- a/pkg/receive/multitsdb.go
+++ b/pkg/receive/multitsdb.go
@@ -600,7 +600,7 @@ func (t *MultiTSDB) startTSDB(logger log.Logger, tenantID string, tenant *tenant
 			t.bucket,
 			func() labels.Labels { return lset },
 			metadata.ReceiveSource,
-			func() bool { return false },
+			nil,
 			t.allowOutOfOrderUpload,
 			t.hashFunc,
 		)

--- a/pkg/receive/multitsdb.go
+++ b/pkg/receive/multitsdb.go
@@ -600,7 +600,7 @@ func (t *MultiTSDB) startTSDB(logger log.Logger, tenantID string, tenant *tenant
 			t.bucket,
 			func() labels.Labels { return lset },
 			metadata.ReceiveSource,
-			false,
+			func() bool { return false },
 			t.allowOutOfOrderUpload,
 			t.hashFunc,
 		)

--- a/pkg/shipper/shipper.go
+++ b/pkg/shipper/shipper.go
@@ -104,6 +104,11 @@ func New(
 		lbls = func() labels.Labels { return nil }
 	}
 
+	if uploadCompactedFunc == nil {
+		uploadCompactedFunc = func() bool {
+			return false
+		}
+	}
 	return &Shipper{
 		logger:                 logger,
 		dir:                    dir,

--- a/pkg/shipper/shipper.go
+++ b/pkg/shipper/shipper.go
@@ -342,6 +342,8 @@ func (s *Shipper) Sync(ctx context.Context) (uploaded int, err error) {
 
 	if uploadCompacted {
 		s.metrics.uploadedCompacted.Set(1)
+	} else {
+		s.metrics.uploadedCompacted.Set(0)
 	}
 	return uploaded, nil
 }

--- a/pkg/shipper/shipper_e2e_test.go
+++ b/pkg/shipper/shipper_e2e_test.go
@@ -44,8 +44,7 @@ func TestShipper_SyncBlocks_e2e(t *testing.T) {
 		dir := t.TempDir()
 
 		extLset := labels.FromStrings("prometheus", "prom-1")
-		uploadCompactedFunc := func() bool { return false }
-		shipper := New(log.NewLogfmtLogger(os.Stderr), nil, dir, metricsBucket, func() labels.Labels { return extLset }, metadata.TestSource, uploadCompactedFunc, false, metadata.NoneFunc)
+		shipper := New(log.NewLogfmtLogger(os.Stderr), nil, dir, metricsBucket, func() labels.Labels { return extLset }, metadata.TestSource, nil, false, metadata.NoneFunc)
 
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()

--- a/pkg/shipper/shipper_e2e_test.go
+++ b/pkg/shipper/shipper_e2e_test.go
@@ -44,7 +44,8 @@ func TestShipper_SyncBlocks_e2e(t *testing.T) {
 		dir := t.TempDir()
 
 		extLset := labels.FromStrings("prometheus", "prom-1")
-		shipper := New(log.NewLogfmtLogger(os.Stderr), nil, dir, metricsBucket, func() labels.Labels { return extLset }, metadata.TestSource, false, false, metadata.NoneFunc)
+		uploadCompactedFunc := func() bool { return false }
+		shipper := New(log.NewLogfmtLogger(os.Stderr), nil, dir, metricsBucket, func() labels.Labels { return extLset }, metadata.TestSource, uploadCompactedFunc, false, metadata.NoneFunc)
 
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -219,7 +220,8 @@ func TestShipper_SyncBlocksWithMigrating_e2e(t *testing.T) {
 		defer upcancel2()
 		testutil.Ok(t, p.WaitPrometheusUp(upctx2, logger))
 
-		shipper := New(log.NewLogfmtLogger(os.Stderr), nil, dir, bkt, func() labels.Labels { return extLset }, metadata.TestSource, true, false, metadata.NoneFunc)
+		uploadCompactedFunc := func() bool { return true }
+		shipper := New(log.NewLogfmtLogger(os.Stderr), nil, dir, bkt, func() labels.Labels { return extLset }, metadata.TestSource, uploadCompactedFunc, false, metadata.NoneFunc)
 
 		// Create 10 new blocks. 9 of them (non compacted) should be actually uploaded.
 		var (
@@ -374,8 +376,9 @@ func TestShipper_SyncOverlapBlocks_e2e(t *testing.T) {
 	defer upcancel2()
 	testutil.Ok(t, p.WaitPrometheusUp(upctx2, logger))
 
+	uploadCompactedFunc := func() bool { return true }
 	// Here, the allowOutOfOrderUploads flag is set to true, which allows blocks with overlaps to be uploaded.
-	shipper := New(log.NewLogfmtLogger(os.Stderr), nil, dir, bkt, func() labels.Labels { return extLset }, metadata.TestSource, true, true, metadata.NoneFunc)
+	shipper := New(log.NewLogfmtLogger(os.Stderr), nil, dir, bkt, func() labels.Labels { return extLset }, metadata.TestSource, uploadCompactedFunc, true, metadata.NoneFunc)
 
 	// Creating 2 overlapping blocks - both uploaded when OOO uploads allowed.
 	var (

--- a/pkg/shipper/shipper_test.go
+++ b/pkg/shipper/shipper_test.go
@@ -29,8 +29,7 @@ import (
 func TestShipperTimestamps(t *testing.T) {
 	dir := t.TempDir()
 
-	uploadCompactedFunc := func() bool { return false }
-	s := New(nil, nil, dir, nil, nil, metadata.TestSource, uploadCompactedFunc, false, metadata.NoneFunc)
+	s := New(nil, nil, dir, nil, nil, metadata.TestSource, nil, false, metadata.NoneFunc)
 
 	// Missing thanos meta file.
 	_, _, err := s.Timestamps()
@@ -123,8 +122,7 @@ func TestIterBlockMetas(t *testing.T) {
 		},
 	}.WriteToDir(log.NewNopLogger(), path.Join(dir, id3.String())))
 
-	uploadCompactedFunc := func() bool { return false }
-	shipper := New(nil, nil, dir, nil, nil, metadata.TestSource, uploadCompactedFunc, false, metadata.NoneFunc)
+	shipper := New(nil, nil, dir, nil, nil, metadata.TestSource, nil, false, metadata.NoneFunc)
 	metas, err := shipper.blockMetasFromOldest()
 	testutil.Ok(t, err)
 	testutil.Equals(t, sort.SliceIsSorted(metas, func(i, j int) bool {
@@ -155,8 +153,7 @@ func BenchmarkIterBlockMetas(b *testing.B) {
 	})
 	b.ResetTimer()
 
-	uploadCompactedFunc := func() bool { return false }
-	shipper := New(nil, nil, dir, nil, nil, metadata.TestSource, uploadCompactedFunc, false, metadata.NoneFunc)
+	shipper := New(nil, nil, dir, nil, nil, metadata.TestSource, nil, false, metadata.NoneFunc)
 
 	_, err := shipper.blockMetasFromOldest()
 	testutil.Ok(b, err)
@@ -168,8 +165,7 @@ func TestShipperAddsSegmentFiles(t *testing.T) {
 	inmemory := objstore.NewInMemBucket()
 
 	lbls := []labels.Label{{Name: "test", Value: "test"}}
-	uploadCompactedFunc := func() bool { return false }
-	s := New(nil, nil, dir, inmemory, func() labels.Labels { return lbls }, metadata.TestSource, uploadCompactedFunc, false, metadata.NoneFunc)
+	s := New(nil, nil, dir, inmemory, func() labels.Labels { return lbls }, metadata.TestSource, nil, false, metadata.NoneFunc)
 
 	id := ulid.MustNew(1, nil)
 	blockDir := path.Join(dir, id.String())

--- a/pkg/shipper/shipper_test.go
+++ b/pkg/shipper/shipper_test.go
@@ -29,7 +29,8 @@ import (
 func TestShipperTimestamps(t *testing.T) {
 	dir := t.TempDir()
 
-	s := New(nil, nil, dir, nil, nil, metadata.TestSource, false, false, metadata.NoneFunc)
+	uploadCompactedFunc := func() bool { return false }
+	s := New(nil, nil, dir, nil, nil, metadata.TestSource, uploadCompactedFunc, false, metadata.NoneFunc)
 
 	// Missing thanos meta file.
 	_, _, err := s.Timestamps()
@@ -122,7 +123,8 @@ func TestIterBlockMetas(t *testing.T) {
 		},
 	}.WriteToDir(log.NewNopLogger(), path.Join(dir, id3.String())))
 
-	shipper := New(nil, nil, dir, nil, nil, metadata.TestSource, false, false, metadata.NoneFunc)
+	uploadCompactedFunc := func() bool { return false }
+	shipper := New(nil, nil, dir, nil, nil, metadata.TestSource, uploadCompactedFunc, false, metadata.NoneFunc)
 	metas, err := shipper.blockMetasFromOldest()
 	testutil.Ok(t, err)
 	testutil.Equals(t, sort.SliceIsSorted(metas, func(i, j int) bool {
@@ -153,7 +155,8 @@ func BenchmarkIterBlockMetas(b *testing.B) {
 	})
 	b.ResetTimer()
 
-	shipper := New(nil, nil, dir, nil, nil, metadata.TestSource, false, false, metadata.NoneFunc)
+	uploadCompactedFunc := func() bool { return false }
+	shipper := New(nil, nil, dir, nil, nil, metadata.TestSource, uploadCompactedFunc, false, metadata.NoneFunc)
 
 	_, err := shipper.blockMetasFromOldest()
 	testutil.Ok(b, err)
@@ -165,7 +168,8 @@ func TestShipperAddsSegmentFiles(t *testing.T) {
 	inmemory := objstore.NewInMemBucket()
 
 	lbls := []labels.Label{{Name: "test", Value: "test"}}
-	s := New(nil, nil, dir, inmemory, func() labels.Labels { return lbls }, metadata.TestSource, false, false, metadata.NoneFunc)
+	uploadCompactedFunc := func() bool { return false }
+	s := New(nil, nil, dir, inmemory, func() labels.Labels { return lbls }, metadata.TestSource, uploadCompactedFunc, false, metadata.NoneFunc)
 
 	id := ulid.MustNew(1, nil)
 	blockDir := path.Join(dir, id.String())


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

This pr changes upload compacted type from bool to a function so that we can make it dynamic to support hot reload.
The use case is, in Cortex we have limits that can be dynamically hot reloaded for each tenant. OOO time window is also one of the limit we have. We found out that when OOO is enabled, we need to allow uploading compacted blocks from shipper. Otherwise, the OOO compacted blocks won't be uploaded at all.

So what we need here is a function that upload compacted blocks based on whether OOO is enabled or not for the tenant during runtime.

See https://github.com/cortexproject/cortex/pull/5416

## Verification

<!-- How you tested it? How do you know it works? -->
