### PR TITLE
Add histogram metrics for index cache item size

### DIFF
--- a/pkg/store/cache/cache.go
+++ b/pkg/store/cache/cache.go
@@ -58,8 +58,9 @@ type IndexCache interface {
 
 // Common metrics that should be used by all cache implementations.
 type commonMetrics struct {
-	requestTotal *prometheus.CounterVec
-	hitsTotal    *prometheus.CounterVec
+	requestTotal  *prometheus.CounterVec
+	hitsTotal     *prometheus.CounterVec
+	dataSizeBytes *prometheus.HistogramVec
 }
 
 func newCommonMetrics(reg prometheus.Registerer) *commonMetrics {
@@ -71,6 +72,13 @@ func newCommonMetrics(reg prometheus.Registerer) *commonMetrics {
 		hitsTotal: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 			Name: "thanos_store_index_cache_hits_total",
 			Help: "Total number of items requests to the cache that were a hit.",
+		}, []string{"item_type"}),
+		dataSizeBytes: promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
+			Name: "thanos_store_index_cache_stored_data_size_bytes",
+			Help: "Histogram to track item data size stored in index cache",
+			Buckets: []float64{
+				32, 256, 512, 1024, 32 * 1024, 256 * 1024, 512 * 1024, 1024 * 1024, 32 * 1024 * 1024, 256 * 1024 * 1024, 512 * 1024 * 1024,
+			},
 		}, []string{"item_type"}),
 	}
 }

--- a/pkg/store/cache/inmemory.go
+++ b/pkg/store/cache/inmemory.go
@@ -295,6 +295,7 @@ func copyToKey(l labels.Label) cacheKeyPostings {
 // StorePostings sets the postings identified by the ulid and label to the value v,
 // if the postings already exists in the cache it is not mutated.
 func (c *InMemoryIndexCache) StorePostings(blockID ulid.ULID, l labels.Label, v []byte) {
+	c.commonMetrics.dataSizeBytes.WithLabelValues(cacheTypePostings).Observe(float64(len(v)))
 	c.set(cacheTypePostings, cacheKey{block: blockID.String(), key: copyToKey(l)}, v)
 }
 
@@ -318,6 +319,7 @@ func (c *InMemoryIndexCache) FetchMultiPostings(_ context.Context, blockID ulid.
 
 // StoreExpandedPostings stores expanded postings for a set of label matchers.
 func (c *InMemoryIndexCache) StoreExpandedPostings(blockID ulid.ULID, matchers []*labels.Matcher, v []byte) {
+	c.commonMetrics.dataSizeBytes.WithLabelValues(cacheTypeExpandedPostings).Observe(float64(len(v)))
 	c.set(cacheTypeExpandedPostings, cacheKey{block: blockID.String(), key: cacheKeyExpandedPostings(labelMatchersToString(matchers))}, v)
 }
 
@@ -332,6 +334,7 @@ func (c *InMemoryIndexCache) FetchExpandedPostings(_ context.Context, blockID ul
 // StoreSeries sets the series identified by the ulid and id to the value v,
 // if the series already exists in the cache it is not mutated.
 func (c *InMemoryIndexCache) StoreSeries(blockID ulid.ULID, id storage.SeriesRef, v []byte) {
+	c.commonMetrics.dataSizeBytes.WithLabelValues(cacheTypeSeries).Observe(float64(len(v)))
 	c.set(cacheTypeSeries, cacheKey{blockID.String(), cacheKeySeries(id), ""}, v)
 }
 


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Add a histogram to track the item size we set for index cache.

There is a similar metric for memcached client https://github.com/thanos-io/thanos/blob/main/pkg/cacheutil/memcached_client.go#L418. However, it only updates the metric when setting memcached successfully. If the item size is larger than the configured `max_item_size`, there is no way to know what's the largest item size we need to set.

This histogram also adds item type so we can differentiate item size for postings, expanded postings and series.

## Verification

Tested the metric locally.

<img width="1028" alt="image" src="https://github.com/thanos-io/thanos/assets/25150124/bcccd3c2-fa0e-48f2-ad4b-6294e0a7b4a2">

