### PR TITLE
Resort store response set on internal label dedup

### DIFF
--- a/pkg/query/querier.go
+++ b/pkg/query/querier.go
@@ -164,11 +164,6 @@ func newQuerier(
 	}
 	ctx, cancel := context.WithCancel(ctx)
 
-	rl := make(map[string]struct{})
-	for _, replicaLabel := range replicaLabels {
-		rl[replicaLabel] = struct{}{}
-	}
-
 	partialResponseStrategy := storepb.PartialResponseStrategy_ABORT
 	if partialResponse {
 		partialResponseStrategy = storepb.PartialResponseStrategy_WARN

--- a/test/e2e/query_test.go
+++ b/test/e2e/query_test.go
@@ -1050,8 +1050,8 @@ func TestQueryStoreDedup(t *testing.T) {
 			},
 			blockFinderLabel: "dedupint",
 			expectedSeries:   1,
-			// This test is expected to fail until the bug outlined in https://github.com/thanos-io/thanos/issues/6257
-			// is fixed. This means that it will return double the expected series until then.
+			// This is a regression test for the bug outlined in https://github.com/thanos-io/thanos/issues/6257.
+			// Until the bug was fixed, this testcase would return double the expected series.
 			expectedDedupBug: true,
 		},
 		{
@@ -1073,8 +1073,8 @@ func TestQueryStoreDedup(t *testing.T) {
 			},
 			blockFinderLabel: "dedupintresort",
 			expectedSeries:   2,
-			// This test is expected to fail until the bug outlined in https://github.com/thanos-io/thanos/issues/6257
-			// is fixed. This means that it will return double the expected series until then.
+			// This is a regression test for the bug outlined in https://github.com/thanos-io/thanos/issues/6257.
+			// Until the bug was fixed, this testcase would return double the expected series.
 			expectedDedupBug: true,
 		},
 		{
@@ -1096,8 +1096,8 @@ func TestQueryStoreDedup(t *testing.T) {
 			},
 			blockFinderLabel: "dedupintextra",
 			expectedSeries:   2,
-			// This test is expected to fail until the bug outlined in https://github.com/thanos-io/thanos/issues/6257
-			// is fixed. This means that it will return double the expected series until then.
+			// This is a regression test for the bug outlined in https://github.com/thanos-io/thanos/issues/6257.
+			// Until the bug was fixed, this testcase would return double the expected series.
 			expectedDedupBug: true,
 		},
 		{
@@ -1116,8 +1116,8 @@ func TestQueryStoreDedup(t *testing.T) {
 			},
 			blockFinderLabel: "dedupintext",
 			expectedSeries:   1,
-			// This test is expected to fail until the bug outlined in https://github.com/thanos-io/thanos/issues/6257
-			// is fixed. This means that it will return double the expected series until then.
+			// This is a regression test for the bug outlined in https://github.com/thanos-io/thanos/issues/6257.
+			// Until the bug was fixed, this testcase would return double the expected series.
 			expectedDedupBug: true,
 		},
 	}
@@ -1165,9 +1165,10 @@ func TestQueryStoreDedup(t *testing.T) {
 			testutil.Ok(t, e2e.StartAndWaitReady(querier))
 
 			expectedSeries := tt.expectedSeries
-			if tt.expectedDedupBug {
-				expectedSeries *= 2
-			}
+			// The below commented condition checks for the bug outlined in https://github.com/thanos-io/thanos/issues/6257.
+			// if tt.expectedDedupBug {
+			// 	expectedSeries *= 2
+			// }
 			instantQuery(t, ctx, querier.Endpoint("http"), func() string {
 				return fmt.Sprintf("max_over_time(simple_series{block_finder='%s'}[2h])", tt.blockFinderLabel)
 			}, time.Now, promclient.QueryOptions{
@@ -1298,13 +1299,13 @@ func TestSidecarQueryDedup(t *testing.T) {
 
 	t.Run("deduplication on internal label with reorder", func(t *testing.T) {
 		// Uses "a" as replica label, which is an internal label from the samples used.
-		// Should return 4 samples as long as the bug described by https://github.com/thanos-io/thanos/issues/6257#issuecomment-1544023978
-		// is not fixed. When it is fixed, it should return 2 samples.
+		// This is a regression test for the bug outlined in https://github.com/thanos-io/thanos/issues/6257.
+		// Until the bug was fixed, this testcase would return 4 samples instead of 2.
 		instantQuery(t, ctx, query4.Endpoint("http"), func() string {
 			return "my_fake_metric"
 		}, time.Now, promclient.QueryOptions{
 			Deduplicate: true,
-		}, 4)
+		}, 2)
 	})
 }
 

--- a/test/e2e/receive_test.go
+++ b/test/e2e/receive_test.go
@@ -233,13 +233,13 @@ test_metric{a="2", b="2"} 1`)
 			},
 		})
 
-		// This should've returned only 2 series, but is returning 4 until the problem reported in
-		// https://github.com/thanos-io/thanos/issues/6257 is fixed
+		// This is a regression test for the bug outlined in https://github.com/thanos-io/thanos/issues/6257.
+		// Until the bug was fixed, this testcase would return 4 series instead of 2.
 		instantQuery(t, ctx, qStatic.Endpoint("http"), func() string {
 			return "test_metric"
 		}, time.Now, promclient.QueryOptions{
 			Deduplicate: true,
-		}, 4)
+		}, 2)
 	})
 
 	t.Run("router_replication", func(t *testing.T) {


### PR DESCRIPTION
* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

This PR does a couple of things,

- Modifies `TestQueryStoreDedup` to start a new StoreGW and minio instance on every testcase.  The main motivation for doing this is that each testcase needs to allow StoreGW to advertise a different set of labels as external labels and that no two cases interfere with each other.
- Resorts the store response set on internal label deduplication. When deduplicating on labels which are stored internally in TSDB, the store response set needs to be resorted after replica labels are removed. This PR detects when internal labels are being used for dedup, by checking for their presence in the Store client's external labels.

Aims to fix #6257. Takes after @fpetkovski's earlier work in #6317 (but inverts the approach).

## Verification

Modified regression test cases for Store, Sidecar and Receive dedup and tested locally.