### PR TITLE
BucketedBytes to buffer byte slices when decoding postings from cache

### DIFF
--- a/pkg/store/postings_codec.go
+++ b/pkg/store/postings_codec.go
@@ -423,7 +423,7 @@ func diffVarintEncodeNoHeader(p index.Postings, length int) ([]byte, error) {
 	return buf.B, nil
 }
 
-// Creating 15 buckets from 1k to 32mb
+// Creating 15 buckets from 1k to 32mb.
 var snappyDecodePool = pool.MustNewBucketedBytes(1024, 32*1024*1024, 2, 0)
 
 type closeablePostings interface {

--- a/pkg/store/postings_codec.go
+++ b/pkg/store/postings_codec.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"hash/crc32"
 	"io"
-	"sync"
 
 	"github.com/golang/snappy"
 	"github.com/klauspost/compress/s2"
@@ -424,7 +423,8 @@ func diffVarintEncodeNoHeader(p index.Postings, length int) ([]byte, error) {
 	return buf.B, nil
 }
 
-var snappyDecodePool sync.Pool
+// Creating 15 buckets from 1k to 32mb
+var snappyDecodePool = pool.MustNewBucketedBytes(1024, 32*1024*1024, 2, 0)
 
 type closeablePostings interface {
 	index.Postings
@@ -447,10 +447,11 @@ func diffVarintSnappyDecode(input []byte, disablePooling bool) (closeablePosting
 
 	var dstBuf []byte
 	if !disablePooling {
-		decodeBuf := snappyDecodePool.Get()
-		if decodeBuf != nil {
-			dstBuf = *(decodeBuf.(*[]byte))
-			toFree = append(toFree, dstBuf)
+		if len, err := s2.DecodedLen(input[len(codecHeaderSnappy):]); err == nil {
+			if decodeBuf, err := snappyDecodePool.Get(len); err == nil && decodeBuf != nil {
+				dstBuf = *decodeBuf
+				toFree = append(toFree, dstBuf)
+			}
 		}
 	}
 


### PR DESCRIPTION
Hi,

Store gateways can hold to a lot memory (and eventually going OOM) when we fetching large postings from memcache as shown below:

![Screenshot 2023-07-14 at 5 50 08 PM](https://github.com/thanos-io/thanos/assets/4027760/821f13bc-3eb4-4c3a-afb7-30ceaefc807a)

We pool the byte slices used on the `s2.Decode` in a single `sync.Pool` making this pooling very inefficient:

Ex:
* T1:  Start decoding the first posting (P1) with size 100mb (decoded)
    * Create a new byte slice (S1) with 100mb as the pool is empty
* T2: Finish the decode of P1 and put the array back on the `sync.Pool`
* T3: Start decoding the second posting (P2) with size 1MB
   * Use the 100mb byte slice to decode the 1MB posting 
* T4: Meanwhile, we start decoding the second posting (P3) with size 100MB
    * Create yet another byte slice with 100mb as the pool is empty - as the S1 is being used to decode P2
T5: Finish the decode of P2 and put the array back on the `sync.Pool`
T6: Finish the decode of P3 and put the array back on the `sync.Pool`
* Over time we will allocate lots of 100mb slices but most of them are being used to decode very small postings.

Seems that this can even be amplified as the `s2.Decode` implementation would throw away the buffer and create a new one if the decoded size if > than the `dst` buffer capacity, and the bigger slice will be returned to the pool - this means that eventually all slices in the pool could be the size of the biggest posting:

```
func Decode(dst, src []byte) ([]byte, error) {
	dLen, s, err := decodedLen(src)
	if err != nil {
		return nil, err
	}
	if dLen <= cap(dst) {
		dst = dst[:dLen]
	} else {
		dst = make([]byte, dLen)
	}
	if s2Decode(dst, src[s:]) != 0 {
		return nil, ErrCorrupt
	}
	return dst, nil
}
```

This change is just using the `BucketedBytes` pool to make this allocation more efficient. Also, this will not reuse any pool that is bigger than 32mb preventing keeping huge slices around which could cause OOMs.

* [] I added CHANGELOG entry for this change.
* [X] Change is not relevant to the end user.

## Changes

* Use `BucketedBytes` on the `snappyDecodePool`

## Verification

Unit test already cover this code.