### PR TITLE
changed store api's --sync-block-duration to 15m

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -189,6 +189,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#6519](https://github.com/thanos-io/thanos/pull/6519) Reloader: Use timeout for initial apply.
 - [#6509](https://github.com/thanos-io/thanos/pull/6509) Store Gateway: Remove `memWriter` from `fileWriter` to reduce memory usage when sync index headers.
 - [#6556](https://github.com/thanos-io/thanos/pull/6556) Thanos compact: respect block-files-concurrency setting when downsampling
+- [#6539](https://github.com/thanos-io/thanos/pull/6539) Store : Changed `--sync-block-duration` default 3m to 15m.
 - [#6592](https://github.com/thanos-io/thanos/pull/6592) Query Frontend: fix bugs in vertical sharding `without` and `union` function to allow more queries to be shardable.
 - [#6317](https://github.com/thanos-io/thanos/pull/6317) *: Fix internal label deduplication bug, by resorting store response set.
 - [#6189](https://github.com/thanos-io/thanos/pull/6189) Rule: Fix panic when calling API `/api/v1/rules?type=alert`.

--- a/cmd/thanos/store.go
+++ b/cmd/thanos/store.go
@@ -135,7 +135,7 @@ func (sc *storeConfig) registerFlag(cmd extkingpin.FlagClause) {
 	sc.objStoreConfig = *extkingpin.RegisterCommonObjStoreFlags(cmd, "", true)
 
 	cmd.Flag("sync-block-duration", "Repeat interval for syncing the blocks between local and remote view.").
-		Default("3m").DurationVar(&sc.syncInterval)
+		Default("15m").DurationVar(&sc.syncInterval)
 
 	cmd.Flag("block-sync-concurrency", "Number of goroutines to use when constructing index-cache.json blocks from object storage. Must be equal or greater than 1.").
 		Default("20").IntVar(&sc.blockSyncConcurrency)

--- a/docs/components/store.md
+++ b/docs/components/store.md
@@ -210,7 +210,7 @@ Flags:
                                  The maximum series allowed for a single Series
                                  request. The Series call fails if this limit is
                                  exceeded. 0 means no limit.
-      --sync-block-duration=3m   Repeat interval for syncing the blocks between
+      --sync-block-duration=15m   Repeat interval for syncing the blocks between
                                  local and remote view.
       --tracing.config=<content>
                                  Alternative to 'tracing.config-file' flag


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes
Changed the --sync-block-duration in store api from 3m to 15m as suggested from the discussion #6288 
<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
