### PR TITLE
store: PoC fix dedup

### DIFF
--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -1410,7 +1410,7 @@ func (s *BucketStore) Series(req *storepb.SeriesRequest, srv storepb.Store_Serie
 			}
 		}()
 		begin := time.Now()
-		set := NewDedupResponseHeap(NewProxyResponseHeap(respSets...))
+		set := NewDedupResponseHeap(NewProxyResponseHeap(req.WithoutReplicaLabels, respSets...))
 		for set.Next() {
 			at := set.At()
 			warn := at.GetWarning()

--- a/pkg/store/proxy.go
+++ b/pkg/store/proxy.go
@@ -299,7 +299,6 @@ func (s *ProxyStore) Series(originalRequest *storepb.SeriesRequest, srv storepb.
 		PartialResponseDisabled: originalRequest.PartialResponseDisabled,
 		PartialResponseStrategy: originalRequest.PartialResponseStrategy,
 		ShardInfo:               originalRequest.ShardInfo,
-		WithoutReplicaLabels:    originalRequest.WithoutReplicaLabels,
 	}
 
 	stores := []Client{}
@@ -348,7 +347,7 @@ func (s *ProxyStore) Series(originalRequest *storepb.SeriesRequest, srv storepb.
 
 	level.Debug(reqLogger).Log("msg", "Series: started fanout streams", "status", strings.Join(storeDebugMsgs, ";"))
 
-	respHeap := NewDedupResponseHeap(NewProxyResponseHeap(storeResponses...))
+	respHeap := NewDedupResponseHeap(NewProxyResponseHeap(originalRequest.WithoutReplicaLabels, storeResponses...))
 	for respHeap.Next() {
 		resp := respHeap.At()
 

--- a/pkg/store/proxy_heap_test.go
+++ b/pkg/store/proxy_heap_test.go
@@ -88,23 +88,21 @@ func TestProxyResponseHeapSort(t *testing.T) {
 				&eagerRespSet{
 					wg: &sync.WaitGroup{},
 					bufferedResponses: []*storepb.SeriesResponse{
-						storeSeriesResponse(t, labelsFromStrings("a", "1", "c", "3")),
+						storeSeriesResponse(t, labelsFromStrings("a", "1", "b", "2")),
 						storeSeriesResponse(t, labelsFromStrings("a", "1", "b", "2", "c", "3")),
 					},
-					storeLabels: map[string]struct{}{"c": {}},
 				},
 				&eagerRespSet{
 					wg: &sync.WaitGroup{},
 					bufferedResponses: []*storepb.SeriesResponse{
-						storeSeriesResponse(t, labelsFromStrings("a", "1", "c", "3")),
+						storeSeriesResponse(t, labelsFromStrings("a", "1", "b", "2")),
 						storeSeriesResponse(t, labelsFromStrings("a", "1", "b", "2", "c", "3")),
 					},
-					storeLabels: map[string]struct{}{"c": {}},
 				},
 			},
 			exp: []*storepb.SeriesResponse{
-				storeSeriesResponse(t, labelsFromStrings("a", "1", "c", "3")),
-				storeSeriesResponse(t, labelsFromStrings("a", "1", "c", "3")),
+				storeSeriesResponse(t, labelsFromStrings("a", "1", "b", "2")),
+				storeSeriesResponse(t, labelsFromStrings("a", "1", "b", "2")),
 				storeSeriesResponse(t, labelsFromStrings("a", "1", "b", "2", "c", "3")),
 				storeSeriesResponse(t, labelsFromStrings("a", "1", "b", "2", "c", "3")),
 			},
@@ -118,7 +116,6 @@ func TestProxyResponseHeapSort(t *testing.T) {
 						storeSeriesResponse(t, labelsFromStrings("a", "1", "b", "2", "ext2", "9")),
 						storeSeriesResponse(t, labelsFromStrings("a", "1", "b", "2", "ext2", "9")),
 					},
-					storeLabels: map[string]struct{}{"ext2": {}},
 				},
 				&eagerRespSet{
 					wg: &sync.WaitGroup{},
@@ -126,7 +123,6 @@ func TestProxyResponseHeapSort(t *testing.T) {
 						storeSeriesResponse(t, labelsFromStrings("a", "1", "b", "2", "ext1", "5", "ext2", "9")),
 						storeSeriesResponse(t, labelsFromStrings("a", "1", "b", "2", "ext1", "5", "ext2", "9")),
 					},
-					storeLabels: map[string]struct{}{"ext1": {}, "ext2": {}},
 				},
 			},
 			exp: []*storepb.SeriesResponse{
@@ -145,7 +141,6 @@ func TestProxyResponseHeapSort(t *testing.T) {
 						storeSeriesResponse(t, labelsFromStrings("a", "1", "b", "2", "c", "3")),
 						storeSeriesResponse(t, labelsFromStrings("a", "1", "c", "2")),
 					},
-					storeLabels: map[string]struct{}{"a": {}},
 				},
 				&eagerRespSet{
 					wg: &sync.WaitGroup{},
@@ -153,7 +148,6 @@ func TestProxyResponseHeapSort(t *testing.T) {
 						storeSeriesResponse(t, labelsFromStrings("a", "1", "b", "1", "c", "3")),
 						storeSeriesResponse(t, labelsFromStrings("a", "1", "c", "3")),
 					},
-					storeLabels: map[string]struct{}{"a": {}},
 				},
 			},
 			exp: []*storepb.SeriesResponse{
@@ -172,7 +166,6 @@ func TestProxyResponseHeapSort(t *testing.T) {
 						storeSeriesResponse(t, labelsFromStrings("a", "1", "b", "2", "ext2", "9")),
 						storeSeriesResponse(t, labelsFromStrings("a", "1", "b", "2", "ext2", "9")),
 					},
-					storeLabels: map[string]struct{}{"ext2": {}, "replica": {}},
 				},
 				&eagerRespSet{
 					wg: &sync.WaitGroup{},
@@ -180,7 +173,6 @@ func TestProxyResponseHeapSort(t *testing.T) {
 						storeSeriesResponse(t, labelsFromStrings("a", "1", "b", "2", "ext1", "5", "ext2", "9")),
 						storeSeriesResponse(t, labelsFromStrings("a", "1", "b", "2", "ext1", "5", "ext2", "9")),
 					},
-					storeLabels: map[string]struct{}{"ext1": {}, "ext2": {}, "replica": {}},
 				},
 			},
 			exp: []*storepb.SeriesResponse{
@@ -192,14 +184,12 @@ func TestProxyResponseHeapSort(t *testing.T) {
 		},
 	} {
 		t.Run(tcase.title, func(t *testing.T) {
-			h := NewProxyResponseHeap(tcase.input...)
-			if !h.Empty() {
-				got := []*storepb.SeriesResponse{h.At()}
-				for h.Next() {
-					got = append(got, h.At())
-				}
-				testutil.Equals(t, tcase.exp, got)
+			h := NewProxyResponseHeap([]string{}, tcase.input...)
+			got := []*storepb.SeriesResponse{}
+			for h.Next() {
+				got = append(got, h.At())
 			}
+			testutil.Equals(t, tcase.exp, got)
 		})
 	}
 }

--- a/pkg/store/proxy_test.go
+++ b/pkg/store/proxy_test.go
@@ -2198,7 +2198,7 @@ func TestDedupRespHeap_Deduplication(t *testing.T) {
 		},
 	} {
 		t.Run(tcase.tname, func(t *testing.T) {
-			h := NewDedupResponseHeap(NewProxyResponseHeap(
+			h := NewDedupResponseHeap(NewProxyResponseHeap([]string{},
 				&eagerRespSet{
 					wg:                &sync.WaitGroup{},
 					bufferedResponses: tcase.responses,

--- a/test/e2e/query_test.go
+++ b/test/e2e/query_test.go
@@ -1073,7 +1073,7 @@ func TestQueryStoreDedup(t *testing.T) {
 			expectedSeries:   1,
 			// This test is expected to fail until the bug outlined in https://github.com/thanos-io/thanos/issues/6257
 			// is fixed. This means that it will return double the expected series until then.
-			expectedDedupBug: true,
+			expectedDedupBug: false,
 		},
 		{
 			desc:            "Deduplication works on internal label with resorting required",
@@ -1096,7 +1096,7 @@ func TestQueryStoreDedup(t *testing.T) {
 			expectedSeries:   2,
 			// This test is expected to fail until the bug outlined in https://github.com/thanos-io/thanos/issues/6257
 			// is fixed. This means that it will return double the expected series until then.
-			expectedDedupBug: true,
+			expectedDedupBug: false,
 		},
 		{
 			desc:            "Deduplication works with extra internal label",
@@ -1119,7 +1119,7 @@ func TestQueryStoreDedup(t *testing.T) {
 			expectedSeries:   2,
 			// This test is expected to fail until the bug outlined in https://github.com/thanos-io/thanos/issues/6257
 			// is fixed. This means that it will return double the expected series until then.
-			expectedDedupBug: true,
+			expectedDedupBug: false,
 		},
 		{
 			desc:            "Deduplication works with both internal and external label",
@@ -1139,7 +1139,7 @@ func TestQueryStoreDedup(t *testing.T) {
 			expectedSeries:   1,
 			// This test is expected to fail until the bug outlined in https://github.com/thanos-io/thanos/issues/6257
 			// is fixed. This means that it will return double the expected series until then.
-			expectedDedupBug: true,
+			expectedDedupBug: false,
 		},
 	}
 
@@ -1308,7 +1308,7 @@ func TestSidecarQueryDedup(t *testing.T) {
 			return "my_fake_metric"
 		}, time.Now, promclient.QueryOptions{
 			Deduplicate: true,
-		}, 4)
+		}, 2)
 	})
 }
 

--- a/test/e2e/receive_test.go
+++ b/test/e2e/receive_test.go
@@ -239,7 +239,7 @@ test_metric{a="2", b="2"} 1`)
 			return "test_metric"
 		}, time.Now, promclient.QueryOptions{
 			Deduplicate: true,
-		}, 4)
+		}, 2)
 	})
 
 	t.Run("router_replication", func(t *testing.T) {


### PR DESCRIPTION
Proxy heap nodes are now compared by different replica labelsets seen in proxy node responses. Sorting has been updated to first compare the lowest ordered series. If those are equal then the replica label sets are compared.

Only negative is that we have to keep the series sorted by each different replica labels so it means some extra work. By using heap sort inside I think we can keep this in line with O(nlogn). The advantages are that we still don't have to globally resort everything and that streaming is still possible.