### PR TITLE
Remove tenant header logs in store gateway

### DIFF
--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -1232,7 +1232,7 @@ func (s *BucketStore) Series(req *storepb.SeriesRequest, srv storepb.Store_Serie
 	}
 
 	tenant, _ := tenancy.GetTenantFromGRPCMetadata(srv.Context())
-	_ = tenant
+	level.Debug(s.logger).Log("msg", "Tenant for Series request", "tenant", tenant)
 
 	matchers, err := storepb.MatchersToPromMatchers(req.Matchers...)
 	if err != nil {
@@ -1484,7 +1484,7 @@ func (s *BucketStore) LabelNames(ctx context.Context, req *storepb.LabelNamesReq
 	}
 
 	tenant, _ := tenancy.GetTenantFromGRPCMetadata(ctx)
-	_ = tenant
+	level.Debug(s.logger).Log("msg", "Tenant for LabelNames request", "tenant", tenant)
 
 	resHints := &hintspb.LabelNamesResponseHints{}
 
@@ -1675,7 +1675,7 @@ func (s *BucketStore) LabelValues(ctx context.Context, req *storepb.LabelValuesR
 	}
 
 	tenant, _ := tenancy.GetTenantFromGRPCMetadata(ctx)
-	_ = tenant
+	level.Debug(s.logger).Log("msg", "Tenant for LabelValues request", "tenant", tenant)
 
 	resHints := &hintspb.LabelValuesResponseHints{}
 

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -1231,11 +1231,8 @@ func (s *BucketStore) Series(req *storepb.SeriesRequest, srv storepb.Store_Serie
 		defer s.queryGate.Done()
 	}
 
-	tenant, err := tenancy.GetTenantFromGRPCMetadata(srv.Context())
-	if err != nil {
-		level.Warn(s.logger).Log("msg", err)
-	}
-	level.Debug(s.logger).Log("msg", "Tenant for Series request", "tenant", tenant)
+	tenant, _ := tenancy.GetTenantFromGRPCMetadata(srv.Context())
+	_ = tenant
 
 	matchers, err := storepb.MatchersToPromMatchers(req.Matchers...)
 	if err != nil {
@@ -1486,11 +1483,8 @@ func (s *BucketStore) LabelNames(ctx context.Context, req *storepb.LabelNamesReq
 		return nil, status.Error(codes.InvalidArgument, errors.Wrap(err, "translate request labels matchers").Error())
 	}
 
-	tenant, err := tenancy.GetTenantFromGRPCMetadata(ctx)
-	if err != nil {
-		level.Warn(s.logger).Log("msg", err)
-	}
-	level.Debug(s.logger).Log("msg", "Tenant for LabelNames request", "tenant", tenant)
+	tenant, _ := tenancy.GetTenantFromGRPCMetadata(ctx)
+	_ = tenant
 
 	resHints := &hintspb.LabelNamesResponseHints{}
 
@@ -1680,11 +1674,8 @@ func (s *BucketStore) LabelValues(ctx context.Context, req *storepb.LabelValuesR
 		return nil, status.Error(codes.InvalidArgument, errors.Wrap(err, "translate request labels matchers").Error())
 	}
 
-	tenant, err := tenancy.GetTenantFromGRPCMetadata(ctx)
-	if err != nil {
-		level.Warn(s.logger).Log("msg", err)
-	}
-	level.Debug(s.logger).Log("msg", "Tenant for LabelValues request", "tenant", tenant)
+	tenant, _ := tenancy.GetTenantFromGRPCMetadata(ctx)
+	_ = tenant
 
 	resHints := &hintspb.LabelValuesResponseHints{}
 

--- a/pkg/store/proxy.go
+++ b/pkg/store/proxy.go
@@ -307,9 +307,8 @@ func (s *ProxyStore) Series(originalRequest *storepb.SeriesRequest, srv storepb.
 	// We may arrive here either via the promql engine
 	// or as a result of a grpc call in layered queries
 	ctx := srv.Context()
-	tenant, err := tenancy.GetTenantFromGRPCMetadata(ctx)
-	if err != nil {
-		level.Debug(s.logger).Log("msg", "using tenant from context instead of metadata")
+	tenant, foundTenant := tenancy.GetTenantFromGRPCMetadata(ctx)
+	if !foundTenant {
 		if ctx.Value(tenancy.TenantKey) != nil {
 			tenant = ctx.Value(tenancy.TenantKey).(string)
 		}
@@ -467,8 +466,8 @@ func (s *ProxyStore) LabelNames(ctx context.Context, r *storepb.LabelNamesReques
 
 	// We may arrive here either via the promql engine
 	// or as a result of a grpc call in layered queries
-	tenant, err := tenancy.GetTenantFromGRPCMetadata(gctx)
-	if err != nil {
+	tenant, foundTenant := tenancy.GetTenantFromGRPCMetadata(gctx)
+	if !foundTenant {
 		level.Debug(s.logger).Log("msg", "using tenant from context instead of metadata")
 		if gctx.Value(tenancy.TenantKey) != nil {
 			tenant = gctx.Value(tenancy.TenantKey).(string)
@@ -546,8 +545,8 @@ func (s *ProxyStore) LabelValues(ctx context.Context, r *storepb.LabelValuesRequ
 
 	// We may arrive here either via the promql engine
 	// or as a result of a grpc call in layered queries
-	tenant, err := tenancy.GetTenantFromGRPCMetadata(gctx)
-	if err != nil {
+	tenant, foundTenant := tenancy.GetTenantFromGRPCMetadata(gctx)
+	if !foundTenant {
 		level.Debug(s.logger).Log("msg", "using tenant from context instead of metadata")
 		if gctx.Value(tenancy.TenantKey) != nil {
 			tenant = gctx.Value(tenancy.TenantKey).(string)

--- a/pkg/tenancy/tenancy.go
+++ b/pkg/tenancy/tenancy.go
@@ -102,10 +102,10 @@ func getTenantFromCertificate(r *http.Request, certTenantField string) (string, 
 	return tenant, nil
 }
 
-func GetTenantFromGRPCMetadata(ctx context.Context) (string, error) {
+func GetTenantFromGRPCMetadata(ctx context.Context) (string, bool) {
 	md, ok := metadata.FromIncomingContext(ctx)
 	if !ok || len(md.Get(DefaultTenantHeader)) == 0 {
-		return DefaultTenant, errors.Errorf("could not get tenant from grpc metadata, using default: %s", DefaultTenantHeader)
+		return DefaultTenant, false
 	}
-	return md.Get(DefaultTenantHeader)[0], nil
+	return md.Get(DefaultTenantHeader)[0], true
 }

--- a/pkg/tenancy/tenancy_test.go
+++ b/pkg/tenancy/tenancy_test.go
@@ -92,16 +92,16 @@ func TestTenantFromGRPC(t *testing.T) {
 		md := metadata.New(map[string]string{tenancy.DefaultTenantHeader: testTenant})
 		ctx = metadata.NewIncomingContext(ctx, md)
 
-		tenant, err := tenancy.GetTenantFromGRPCMetadata(ctx)
-		testutil.Ok(t, err)
+		tenant, foundTenant := tenancy.GetTenantFromGRPCMetadata(ctx)
+		testutil.Equals(t, true, foundTenant)
 		testutil.Assert(t, tenant == testTenant)
 	})
 	t.Run("no-tenant", func(t *testing.T) {
 
 		ctx := context.Background()
 
-		tenant, err := tenancy.GetTenantFromGRPCMetadata(ctx)
-		testutil.NotOk(t, err)
+		tenant, foundTenant := tenancy.GetTenantFromGRPCMetadata(ctx)
+		testutil.Equals(t, false, foundTenant)
 		testutil.Assert(t, tenant == tenancy.DefaultTenant)
 	})
 }


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

It is very verbose to have a separate log line to log tenant for every requests in store gateway, especially for Cortex which uses store gateway as a library. It doesn't propagate Thanos header at all so no need to have the warning log for missing headers.

## Verification

<!-- How you tested it? How do you know it works? -->
