### PR TITLE
Add flag to optionally disable adding Thanos params when querying metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#6466](https://github.com/thanos-io/thanos/pull/6466) Mixin (Receive): add limits alerting for configuration reload and meta-monitoring.
 - [#6467](https://github.com/thanos-io/thanos/pull/6467) Mixin (Receive): add alert for tenant reaching head series limit.
 - [#6528](https://github.com/thanos-io/thanos/pull/6528) Index Cache: Add histogram metric `thanos_store_index_cache_stored_data_size_bytes` for item size.
+- [#6560](https://github.com/thanos-io/thanos/pull/6560) Thanos ruler: add flag to optionally disable adding Thanos params when querying metrics
 
 ### Fixed
 - [#6503](https://github.com/thanos-io/thanos/pull/6503) *: Change the engine behind `ContentPathReloader` to be completely independent of any filesystem concept. This effectively fixes this configuration reload when used with Kubernetes ConfigMaps, Secrets, or other volume mounts.

--- a/cmd/thanos/config.go
+++ b/cmd/thanos/config.go
@@ -180,14 +180,15 @@ func (wc *webConfig) registerFlag(cmd extkingpin.FlagClause) *webConfig {
 }
 
 type queryConfig struct {
-	addrs         []string
-	sdFiles       []string
-	sdInterval    time.Duration
-	configPath    *extflag.PathOrContent
-	dnsSDInterval time.Duration
-	httpMethod    string
-	dnsSDResolver string
-	step          time.Duration
+	addrs                []string
+	sdFiles              []string
+	sdInterval           time.Duration
+	configPath           *extflag.PathOrContent
+	dnsSDInterval        time.Duration
+	httpMethod           string
+	dnsSDResolver        string
+	step                 time.Duration
+	doNotAddThanosParams bool
 }
 
 func (qc *queryConfig) registerFlag(cmd extkingpin.FlagClause) *queryConfig {
@@ -206,6 +207,8 @@ func (qc *queryConfig) registerFlag(cmd extkingpin.FlagClause) *queryConfig {
 		Default("miekgdns").Hidden().StringVar(&qc.dnsSDResolver)
 	cmd.Flag("query.default-step", "Default range query step to use. This is only used in stateless Ruler and alert state restoration.").
 		Default("1s").DurationVar(&qc.step)
+	cmd.Flag("query.do-not-add-thanos-params", "Disable adding Thanos parameters (e.g dedup, partial_response) when querying for metrics.").
+		Default("false").BoolVar(&qc.doNotAddThanosParams)
 	return qc
 }
 

--- a/cmd/thanos/config.go
+++ b/cmd/thanos/config.go
@@ -207,7 +207,7 @@ func (qc *queryConfig) registerFlag(cmd extkingpin.FlagClause) *queryConfig {
 		Default("miekgdns").Hidden().StringVar(&qc.dnsSDResolver)
 	cmd.Flag("query.default-step", "Default range query step to use. This is only used in stateless Ruler and alert state restoration.").
 		Default("1s").DurationVar(&qc.step)
-	cmd.Flag("query.do-not-add-thanos-params", "Disable adding Thanos parameters (e.g dedup, partial_response) when querying for metrics.").
+	cmd.Flag("query.only-prometheus-params", "Disable adding Thanos parameters (e.g dedup, partial_response) when querying metrics. Some non-Thanos systems have strict API validation.").Hidden().
 		Default("false").BoolVar(&qc.doNotAddThanosParams)
 	return qc
 }

--- a/cmd/thanos/rule.go
+++ b/cmd/thanos/rule.go
@@ -525,7 +525,7 @@ func runRule(
 				OutageTolerance: conf.outageTolerance,
 				ForGracePeriod:  conf.forGracePeriod,
 			},
-			queryFuncCreator(logger, queryClients, promClients, metrics.duplicatedQuery, metrics.ruleEvalWarnings, conf.query.httpMethod),
+			queryFuncCreator(logger, queryClients, promClients, metrics.duplicatedQuery, metrics.ruleEvalWarnings, conf.query.httpMethod, conf.query.doNotAddThanosParams),
 			conf.lset,
 			// In our case the querying URL is the external URL because in Prometheus
 			// --web.external-url points to it i.e. it points at something where the user
@@ -808,6 +808,7 @@ func queryFuncCreator(
 	duplicatedQuery prometheus.Counter,
 	ruleEvalWarnings *prometheus.CounterVec,
 	httpMethod string,
+	doNotAddThanosParams bool,
 ) func(partialResponseStrategy storepb.PartialResponseStrategy) rules.QueryFunc {
 
 	// queryFunc returns query function that hits the HTTP query API of query peers in randomized order until we get a result
@@ -835,6 +836,7 @@ func queryFuncCreator(
 						Deduplicate:             true,
 						PartialResponseStrategy: partialResponseStrategy,
 						Method:                  httpMethod,
+						DoNotAddThanosParams:    doNotAddThanosParams,
 					})
 					span.Finish()
 

--- a/pkg/promclient/promclient.go
+++ b/pkg/promclient/promclient.go
@@ -356,6 +356,7 @@ func (c *Client) Snapshot(ctx context.Context, base *url.URL, skipHead bool) (st
 }
 
 type QueryOptions struct {
+	DoNotAddThanosParams    bool
 	Deduplicate             bool
 	PartialResponseStrategy storepb.PartialResponseStrategy
 	Method                  string
@@ -402,8 +403,10 @@ func (c *Client) QueryInstant(ctx context.Context, base *url.URL, query string, 
 	}
 	params.Add("query", query)
 	params.Add("time", t.Format(time.RFC3339Nano))
-	if err := opts.AddTo(params); err != nil {
-		return nil, nil, nil, errors.Wrap(err, "add thanos opts query params")
+	if !opts.DoNotAddThanosParams {
+		if err := opts.AddTo(params); err != nil {
+			return nil, nil, nil, errors.Wrap(err, "add thanos opts query params")
+		}
 	}
 
 	u := *base
@@ -511,8 +514,10 @@ func (c *Client) QueryRange(ctx context.Context, base *url.URL, query string, st
 	params.Add("start", formatTime(timestamp.Time(startTime)))
 	params.Add("end", formatTime(timestamp.Time(endTime)))
 	params.Add("step", strconv.FormatInt(step, 10))
-	if err := opts.AddTo(params); err != nil {
-		return nil, nil, nil, errors.Wrap(err, "add thanos opts query params")
+	if !opts.DoNotAddThanosParams {
+		if err := opts.AddTo(params); err != nil {
+			return nil, nil, nil, errors.Wrap(err, "add thanos opts query params")
+		}
 	}
 
 	u := *base


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes
Currently Thanos Ruler doesn't work with services exposing Prometheus query or query_range API that strictly validate received request parameters (e.g [GCP Managed Prometheus frontend](https://github.com/GoogleCloudPlatform/prometheus-engine/tree/main/cmd/frontend) component - GMP Frontend). 
Example error when pointing Thanos Ruler to a GMP Frontend setup URL
```json
{
  "error": {
    "code": 400,
    "message": "Invalid JSON payload received. Unknown name \"dedup\": Cannot bind query parameter. Field 'dedup' could not be found in request message.
Invalid JSON payload received. Unknown name \"partial_response\": Cannot bind query parameter. Field 'partial_response' could not be found in request message.",
    "status": "INVALID_ARGUMENT",
    "details": [
      {
        "@type": "type.googleapis.com/google.rpc.BadRequest",
        "fieldViolations": [
          {
            "description": "Invalid JSON payload received. Unknown name \"dedup\": Cannot bind query parameter. Field 'dedup' could not be found in request message."
          },
          {
            "description": "Invalid JSON payload received. Unknown name \"partial_response\": Cannot bind query parameter. Field 'partial_response' could not be found in request message."
          }
        ]
      }
    ]
  }
}
```

This change proposes to add an optional flag to disable sending Thanos specific parameters.

## Verification
The change works with GMP Frontend.

Here is a custom docker image to try: https://hub.docker.com/r/anasaso/thanos
<!-- How you tested it? How do you know it works? -->
