### PR TITLE
cacheutil: move redis SetAsync() out into worker architecture

### DIFF
--- a/docs/components/query-frontend.md
+++ b/docs/components/query-frontend.md
@@ -130,6 +130,8 @@ config:
     insecure_skip_verify: false
   cache_size: 0
   master_name: ""
+  max_async_buffer_size: 10000
+  max_async_concurrency: 20
   expiration: 24h0m0s
 ```
 

--- a/docs/components/store.md
+++ b/docs/components/store.md
@@ -355,6 +355,8 @@ config:
     insecure_skip_verify: false
   cache_size: 0
   master_name: ""
+  max_async_buffer_size: 10000
+  max_async_concurrency: 20
 ```
 
 The **required** settings are:

--- a/pkg/cacheutil/async_op.go
+++ b/pkg/cacheutil/async_op.go
@@ -1,0 +1,66 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package cacheutil
+
+import (
+	"sync"
+
+	"github.com/pkg/errors"
+)
+
+type asyncOperationProcessor struct {
+	// Channel used to notify internal goroutines when they should quit.
+	stop chan struct{}
+
+	// Channel used to enqueue async operations.
+	asyncQueue chan func()
+
+	// Wait group used to wait all workers on stopping.
+	workers sync.WaitGroup
+}
+
+func newAsyncOperationProcessor(bufferSize, concurrency int) *asyncOperationProcessor {
+	p := &asyncOperationProcessor{
+		stop:       make(chan struct{}, 1),
+		asyncQueue: make(chan func(), bufferSize),
+	}
+
+	p.workers.Add(concurrency)
+	for i := 0; i < concurrency; i++ {
+		go p.asyncQueueProcessLoop()
+	}
+
+	return p
+}
+
+func (p *asyncOperationProcessor) Stop() {
+	close(p.stop)
+
+	// Wait until all workers have terminated.
+	p.workers.Wait()
+}
+
+func (p *asyncOperationProcessor) asyncQueueProcessLoop() {
+	defer p.workers.Done()
+
+	for {
+		select {
+		case op := <-p.asyncQueue:
+			op()
+		case <-p.stop:
+			return
+		}
+	}
+}
+
+var errAsyncBufferFull = errors.New("the async buffer is full")
+
+func (p *asyncOperationProcessor) enqueueAsync(op func()) error {
+	select {
+	case p.asyncQueue <- op:
+		return nil
+	default:
+		return errAsyncBufferFull
+	}
+}

--- a/pkg/cacheutil/memcached_client.go
+++ b/pkg/cacheutil/memcached_client.go
@@ -9,7 +9,6 @@ import (
 	"net"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/bradfitz/gomemcache/memcache"
@@ -185,17 +184,8 @@ type memcachedClient struct {
 	// Address provider used to keep the memcached servers list updated.
 	addressProvider AddressProvider
 
-	// Channel used to notify internal goroutines when they should quit.
-	stop chan struct{}
-
-	// Channel used to enqueue async operations.
-	asyncQueue chan func()
-
 	// Gate used to enforce the max number of concurrent GetMulti() operations.
 	getMultiGate gate.Gate
-
-	// Wait group used to wait all workers on stopping.
-	workers sync.WaitGroup
 
 	// Tracked metrics.
 	clientInfo prometheus.GaugeFunc
@@ -204,6 +194,8 @@ type memcachedClient struct {
 	skipped    *prometheus.CounterVec
 	duration   *prometheus.HistogramVec
 	dataSize   *prometheus.HistogramVec
+
+	p *asyncOperationProcessor
 }
 
 // AddressProvider performs node address resolution given a list of clusters.
@@ -281,13 +273,12 @@ func newMemcachedClient(
 		client:          client,
 		selector:        selector,
 		addressProvider: addressProvider,
-		asyncQueue:      make(chan func(), config.MaxAsyncBufferSize),
-		stop:            make(chan struct{}, 1),
 		getMultiGate: gate.New(
 			extprom.WrapRegistererWithPrefix("thanos_memcached_getmulti_", reg),
 			config.MaxGetMultiConcurrency,
 			gate.Gets,
 		),
+		p: newAsyncOperationProcessor(config.MaxAsyncBufferSize, config.MaxAsyncConcurrency),
 	}
 
 	c.clientInfo = promauto.With(reg).NewGaugeFunc(prometheus.GaugeOpts{
@@ -364,24 +355,14 @@ func newMemcachedClient(
 		return nil, err
 	}
 
-	c.workers.Add(1)
+	c.p.workers.Add(1)
 	go c.resolveAddrsLoop()
-
-	// Start a number of goroutines - processing async operations - equal
-	// to the max concurrency we have.
-	c.workers.Add(c.config.MaxAsyncConcurrency)
-	for i := 0; i < c.config.MaxAsyncConcurrency; i++ {
-		go c.asyncQueueProcessLoop()
-	}
 
 	return c, nil
 }
 
 func (c *memcachedClient) Stop() {
-	close(c.stop)
-
-	// Wait until all workers have terminated.
-	c.workers.Wait()
+	c.p.Stop()
 }
 
 func (c *memcachedClient) SetAsync(key string, value []byte, ttl time.Duration) error {
@@ -391,7 +372,7 @@ func (c *memcachedClient) SetAsync(key string, value []byte, ttl time.Duration) 
 		return nil
 	}
 
-	err := c.enqueueAsync(func() {
+	err := c.p.enqueueAsync(func() {
 		start := time.Now()
 		c.operations.WithLabelValues(opSet).Inc()
 
@@ -421,7 +402,7 @@ func (c *memcachedClient) SetAsync(key string, value []byte, ttl time.Duration) 
 
 	if err == errMemcachedAsyncBufferFull {
 		c.skipped.WithLabelValues(opSet, reasonAsyncBufferFull).Inc()
-		level.Debug(c.logger).Log("msg", "failed to store item to memcached because the async buffer is full", "err", err, "size", len(c.asyncQueue))
+		level.Debug(c.logger).Log("msg", "failed to store item to memcached because the async buffer is full", "err", err, "size", len(c.p.asyncQueue))
 		return nil
 	}
 	return err
@@ -612,30 +593,8 @@ func (c *memcachedClient) trackError(op string, err error) {
 	}
 }
 
-func (c *memcachedClient) enqueueAsync(op func()) error {
-	select {
-	case c.asyncQueue <- op:
-		return nil
-	default:
-		return errMemcachedAsyncBufferFull
-	}
-}
-
-func (c *memcachedClient) asyncQueueProcessLoop() {
-	defer c.workers.Done()
-
-	for {
-		select {
-		case op := <-c.asyncQueue:
-			op()
-		case <-c.stop:
-			return
-		}
-	}
-}
-
 func (c *memcachedClient) resolveAddrsLoop() {
-	defer c.workers.Done()
+	defer c.p.workers.Done()
 
 	ticker := time.NewTicker(c.config.DNSProviderUpdateInterval)
 	defer ticker.Stop()
@@ -647,7 +606,7 @@ func (c *memcachedClient) resolveAddrsLoop() {
 			if err != nil {
 				level.Warn(c.logger).Log("msg", "failed update memcached servers list", "err", err)
 			}
-		case <-c.stop:
+		case <-c.p.stop:
 			return
 		}
 	}

--- a/pkg/cacheutil/redis_client_test.go
+++ b/pkg/cacheutil/redis_client_test.go
@@ -223,8 +223,10 @@ func TestMultipleRedisClient(t *testing.T) {
 	cfg.Addr = s.Addr()
 	logger := log.NewLogfmtLogger(os.Stderr)
 	reg := prometheus.NewRegistry()
-	_, err = NewRedisClientWithConfig(logger, "test1", cfg, reg)
+	cl, err := NewRedisClientWithConfig(logger, "test1", cfg, reg)
 	testutil.Ok(t, err)
-	_, err = NewRedisClientWithConfig(logger, "test2", cfg, reg)
+	t.Cleanup(cl.Stop)
+	cl, err = NewRedisClientWithConfig(logger, "test2", cfg, reg)
 	testutil.Ok(t, err)
+	t.Cleanup(cl.Stop)
 }


### PR DESCRIPTION
Move SetAsync() in the Redis client to the worker architecture so that hot loops in Thanos Store would not be blocked by the cache write operation. Since memcached client has the same functionality modulo the resolve address loop, let's refactor and move this common code into another struct & file.
