### PR TITLE
test/e2e: do not share chromedp allocators

### DIFF
--- a/test/e2e/query_test.go
+++ b/test/e2e/query_test.go
@@ -1448,8 +1448,32 @@ func TestSidecarQueryEvaluation(t *testing.T) {
 	}
 }
 
+// An emptyCtx is never canceled, has no values, and has no deadline. It is not
+// struct{}, since vars of this type must have distinct addresses.
+type emptyCtx int
+
+func (*emptyCtx) Deadline() (deadline time.Time, ok bool) {
+	return
+}
+
+func (*emptyCtx) Done() <-chan struct{} {
+	return nil
+}
+
+func (*emptyCtx) Err() error {
+	return nil
+}
+
+func (*emptyCtx) Value(key any) any {
+	return nil
+}
+
+func (e *emptyCtx) String() string {
+	return "Context"
+}
+
 func checkNetworkRequests(t *testing.T, addr string) {
-	ctx, cancel := chromedp.NewContext(context.Background())
+	ctx, cancel := chromedp.NewContext(new(emptyCtx))
 	t.Cleanup(cancel)
 
 	testutil.Ok(t, runutil.Retry(1*time.Minute, ctx.Done(), func() error {


### PR DESCRIPTION
Tests crash sometimes now with:
```
panic: close of closed channel

goroutine 1793 [running]:
github.com/chromedp/chromedp.(*ExecAllocator).Allocate.func2()
	/home/runner/go/pkg/mod/github.com/chromedp/chromedp@v0.8.2/allocate.go:224 +0xca
created by github.com/chromedp/chromedp.(*ExecAllocator).Allocate
	/home/runner/go/pkg/mod/github.com/chromedp/chromedp@v0.8.2/allocate.go:210 +0xd05
```

context.Background() returns the same context for each call and chromedp shares allocators using that context. If we are unfortunate then they both try to close a channel at the same time.

Try to workaround this by allocating a context for each checkNetworkRequests call.
