### PR TITLE
store: grpc client use round_robin loadBalancer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#6519](https://github.com/thanos-io/thanos/pull/6519) Reloader: Use timeout for initial apply.
 - [#6509](https://github.com/thanos-io/thanos/pull/6509) Store Gateway: Remove `memWriter` from `fileWriter` to reduce memory usage when sync index headers.
 - [#6556](https://github.com/thanos-io/thanos/pull/6556) Thanos compact: respect block-files-concurrency setting when downsampling
+- [#6568](https://github.com/thanos-io/thanos/pull/6568) Store: grpc client use round_robin loadBalancer.
 
 ### Changed
 - [#6049](https://github.com/thanos-io/thanos/pull/6049) Compact: *breaking :warning:* Replace group with resolution in compact metrics to avoid cardinality explosion on compact metrics for large numbers of groups.

--- a/pkg/extgrpc/client.go
+++ b/pkg/extgrpc/client.go
@@ -65,6 +65,11 @@ func StoreClientGRPCOpts(logger log.Logger, reg *prometheus.Registry, tracer ope
 				tracing.StreamClientInterceptor(tracer),
 			),
 		),
+		grpc.WithDefaultServiceConfig(`
+{
+  "loadBalancingConfig": [ { "round_robin": {} } ]
+}
+`),
 	}
 	if reg != nil {
 		reg.MustRegister(grpcMets)


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->
grpc client default use pick_first loadBalancer, it will not load balancer when thanos store endpoint is a dns endpoint as a group. 
<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->
set grpc client config accround the doc. https://github.com/grpc/grpc/blob/master/doc/service_config.md#architecture
## Verification

<!-- How you tested it? How do you know it works? -->
1. test with --endpoint=dns://store-group-headless-service:port, it load balanced.
