### PR TITLE
Remove lift

### DIFF
--- a/.lift/config.toml
+++ b/.lift/config.toml
@@ -1,1 +1,0 @@
-ignoreRules = [ "Severe OSS Vulnerability", "Critical OSS Vulnerability" ]

--- a/.muse/config.toml
+++ b/.muse/config.toml
@@ -1,6 +1,0 @@
-ignoreRules = [ "G103", "G104", "G110",
-    "G203", "G204", "G304",
-    "G307", "G401", "G402", "G404", "G501",
-    "ST1005"
-]
-disableTools = [ "semgrep" ]


### PR DESCRIPTION
Removes the CI configuration for Lift (and 'muse' a prior branding of the same product).

An administrator will have to delete the Lift GitHub App.

Lift is being retired on August 12. If you still want results, it appears the tools benefiting this repo are Staticcheck, gosec, golangci-lint, and shellcheck. Shout and we could figure out what alternatives exist, thanks for maintaining Thanos!