### PR TITLE
replicate: fix panic: duplicate metrics collector registration attempted

### DIFF
--- a/pkg/replicate/replicator.go
+++ b/pkg/replicate/replicator.go
@@ -143,7 +143,7 @@ func RunReplicate(
 	toBkt = objstoretracing.WrapWithTraces(
 		objstore.WrapWithMetrics(
 			toBkt,
-			prometheus.WrapRegistererWithPrefix("thanos_", prometheus.WrapRegistererWith(prometheus.Labels{"replicate": "from"}, reg)),
+			prometheus.WrapRegistererWithPrefix("thanos_", prometheus.WrapRegistererWith(prometheus.Labels{"replicate": "to"}, reg)),
 			toBkt.Name(),
 		),
 	)


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

This change fixes a panic in the thanos bucket tools replicate command

```
goroutine 1 [running]:
github.com/prometheus/client_golang/prometheus.(*wrappingRegisterer).MustRegister(0xc000677cb0, {0xc00095c090?, 0x1, 0x0?})
/go/pkg/mod/github.com/prometheus/client_golang@v1.15.1/prometheus/wrap.go:104 +0x151
github.com/prometheus/client_golang/prometheus/promauto.Factory.NewGaugeVec({{0x2b24c40?, 0xc000677cb0?}}, {{0x0, 0x0}, {0x0, 0x0}, {0x263a69d, 0x2b}, {0x26603fc, 0x3d}, ...}, ...)
/go/pkg/mod/github.com/prometheus/client_golang@v1.15.1/prometheus/promauto/auto.go:308 +0x1e2
github.com/thanos-io/objstore.WrapWithMetrics({0x2b41110?, 0xc000644960}, {0x2b24c40, 0xc000677cb0}, {0xc000133950, 0x9})
/go/pkg/mod/github.com/thanos-io/objstore@v0.0.0-20230713070940-eb01c83b89a4/objstore.go:434 +0x714
github.com/thanos-io/thanos/pkg/replicate.RunReplicate(0xc00063c948, {0x2b113c0?, 0xc00005f8c0?}, 0xc00063e5f0, {0x400b580?, 0xc000c15bc8?}, {0x25db079, 0xd}, {0x0, 0x0}, ...)
/app/pkg/replicate/replicator.go:144 +0xb92
main.registerBucketReplicate.func1(0x0?, {0x2b113c0, 0xc00005f8c0}, 0x6?, {0x2b24b20, 0x400b580}, 0x70?, 0x0?)
/app/cmd/thanos/tools_bucket.go:749 +0x5b3
main.main()
/app/cmd/thanos/main.go:133 +0x122e
```

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
