### PR TITLE
sidecar initially becomes ready only after underlying prometheus is r…

### DIFF
--- a/cmd/thanos/sidecar.go
+++ b/cmd/thanos/sidecar.go
@@ -300,10 +300,8 @@ func runSidecar(
 			grpcserver.WithTLSConfig(tlsCfg),
 		)
 		g.Add(func() error {
-			statusProber.Ready()
 			return s.ListenAndServe()
 		}, func(err error) {
-			statusProber.NotReady(err)
 			s.Shutdown(err)
 		})
 	}


### PR DESCRIPTION
## Changes

Removing needless sidecar readiness on grpc-server binding

