### PR TITLE
Add flag `--enable-mark-deletion` and `--enable-mark-no-compaction` to Bucket UI

### DIFF
--- a/cmd/thanos/tools_bucket.go
+++ b/cmd/thanos/tools_bucket.go
@@ -112,13 +112,15 @@ type bucketLsConfig struct {
 }
 
 type bucketWebConfig struct {
-	webRoutePrefix      string
-	webExternalPrefix   string
-	webPrefixHeaderName string
-	webDisableCORS      bool
-	interval            time.Duration
-	label               string
-	timeout             time.Duration
+	webRoutePrefix         string
+	webExternalPrefix      string
+	webPrefixHeaderName    string
+	webDisableCORS         bool
+	interval               time.Duration
+	label                  string
+	timeout                time.Duration
+	enableMarkDeletion     bool
+	enableMarkNoCompaction bool
 }
 
 type bucketReplicateConfig struct {
@@ -203,6 +205,10 @@ func (tbc *bucketWebConfig) registerBucketWebFlag(cmd extkingpin.FlagClause) *bu
 	cmd.Flag("timeout", "Timeout to download metadata from remote storage").Default("5m").DurationVar(&tbc.timeout)
 
 	cmd.Flag("label", "External block label to use as group title").StringVar(&tbc.label)
+
+	cmd.Flag("enable-mark-deletion", "Enable Mark Deletion button in the UI").Default("false").BoolVar(&tbc.enableMarkDeletion)
+
+	cmd.Flag("enable-mark-no-compaction", "Enable Mark No Compaction button in the UI").Default("false").BoolVar(&tbc.enableMarkNoCompaction)
 	return tbc
 }
 

--- a/pkg/ui/react-app/src/thanos/pages/blocks/BlockDetails.tsx
+++ b/pkg/ui/react-app/src/thanos/pages/blocks/BlockDetails.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useState } from 'react';
+import React, { FC, useEffect, useState } from 'react';
 import { Block } from './block';
 import styles from './blocks.module.css';
 import moment from 'moment';
@@ -13,6 +13,8 @@ export interface BlockDetailsProps {
 export const BlockDetails: FC<BlockDetailsProps> = ({ block, selectBlock }) => {
   const [modalAction, setModalAction] = useState<string>('');
   const [detailValue, setDetailValue] = useState<string | null>(null);
+  const [enableMarkDeletion, setEnableMarkDeletion] = useState(false);
+  const [enableMarkNoCompaction, setEnableMarkNoCompaction] = useState(false);
 
   const submitMarkBlock = async (action: string, ulid: string, detail: string | null) => {
     try {
@@ -39,6 +41,23 @@ export const BlockDetails: FC<BlockDetailsProps> = ({ block, selectBlock }) => {
       setModalAction('');
     }
   };
+
+  const fetchEnableMarkDeletion = async () => {
+    const response = await fetch('/api/v1/flags/enableMarkDeletion');
+    const result = await response.json();
+    setEnableMarkDeletion(result.data.enableMarkDeletion);
+  };
+
+  const fetchEnableMarkNoCompaction = async () => {
+    const response = await fetch('/api/v1/flags/enableMarkNoCompaction');
+    const result = await response.json();
+    setEnableMarkNoCompaction(result.data.enableMarkNoCompaction);
+  };
+
+  useEffect(() => {
+    fetchEnableMarkDeletion();
+    fetchEnableMarkNoCompaction();
+  }, []);
 
   return (
     <div className={`${styles.blockDetails} ${block && styles.open}`}>
@@ -100,26 +119,30 @@ export const BlockDetails: FC<BlockDetailsProps> = ({ block, selectBlock }) => {
               <Button>Download meta.json</Button>
             </a>
           </div>
-          <div style={{ marginTop: '12px' }}>
-            <Button
-              onClick={() => {
-                setModalAction('DELETION');
-                setDetailValue('');
-              }}
-            >
-              Mark Deletion
-            </Button>
-          </div>
-          <div style={{ marginTop: '12px' }}>
-            <Button
-              onClick={() => {
-                setModalAction('NO_COMPACTION');
-                setDetailValue('');
-              }}
-            >
-              Mark No Compaction
-            </Button>
-          </div>
+          {enableMarkDeletion && (
+            <div style={{ marginTop: '12px' }}>
+              <Button
+                onClick={() => {
+                  setModalAction('DELETION');
+                  setDetailValue('');
+                }}
+              >
+                Mark Deletion
+              </Button>
+            </div>
+          )}
+          {enableMarkNoCompaction && (
+            <div style={{ marginTop: '12px' }}>
+              <Button
+                onClick={() => {
+                  setModalAction('NO_COMPACTION');
+                  setDetailValue('');
+                }}
+              >
+                Mark No Compaction
+              </Button>
+            </div>
+          )}
           <Modal isOpen={!!modalAction}>
             <ModalBody>
               <ModalHeader toggle={() => setModalAction('')}>


### PR DESCRIPTION
Signed-off-by: Harsh Pratap Singh harshpratapsingh8210@gmail.com
Fixes #5390 
<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

This PR adds two flags, namely `--enable-mark-deletion` and `--enable-no-compaction`, to Bucket Web UI to decide whether to show the corresponding buttons `Mark Deletion` and `Mark No Compaction` in the UI as they are admin-level operations. 

## Verification

This was tested locally. 

<img width="1278" alt="Screenshot 2023-08-10 at 12 00 55 AM" src="https://github.com/thanos-io/thanos/assets/119954739/edba5547-db4e-4c80-b85e-e82caab8a526">
<img width="1280" alt="Screenshot 2023-08-10 at 12 00 45 AM" src="https://github.com/thanos-io/thanos/assets/119954739/68392c6d-884b-4570-a6a7-3be06256c4d3">
cc: @yeya24 @fpetkovski @saswatamcode @GiedriusS 