### PR TITLE
Add `--disable-admin-operations` flag in Block Bucket UI

### DIFF
--- a/cmd/thanos/tools_bucket.go
+++ b/cmd/thanos/tools_bucket.go
@@ -112,13 +112,14 @@ type bucketLsConfig struct {
 }
 
 type bucketWebConfig struct {
-	webRoutePrefix      string
-	webExternalPrefix   string
-	webPrefixHeaderName string
-	webDisableCORS      bool
-	interval            time.Duration
-	label               string
-	timeout             time.Duration
+	webRoutePrefix         string
+	webExternalPrefix      string
+	webPrefixHeaderName    string
+	webDisableCORS         bool
+	interval               time.Duration
+	label                  string
+	timeout                time.Duration
+	disableAdminOperations bool
 }
 
 type bucketReplicateConfig struct {
@@ -203,6 +204,8 @@ func (tbc *bucketWebConfig) registerBucketWebFlag(cmd extkingpin.FlagClause) *bu
 	cmd.Flag("timeout", "Timeout to download metadata from remote storage").Default("5m").DurationVar(&tbc.timeout)
 
 	cmd.Flag("label", "External block label to use as group title").StringVar(&tbc.label)
+
+	cmd.Flag("disable-admin-operations", "Restrict access to Block Mark deletion and no compaction").Default("false").BoolVar(&tbc.disableAdminOperations)
 	return tbc
 }
 

--- a/pkg/api/blocks/v1.go
+++ b/pkg/api/blocks/v1.go
@@ -25,12 +25,13 @@ import (
 
 // BlocksAPI is a very simple API used by Thanos Block Viewer.
 type BlocksAPI struct {
-	baseAPI          *api.BaseAPI
-	logger           log.Logger
-	globalBlocksInfo *BlocksInfo
-	loadedBlocksInfo *BlocksInfo
-	disableCORS      bool
-	bkt              objstore.Bucket
+	baseAPI                *api.BaseAPI
+	logger                 log.Logger
+	globalBlocksInfo       *BlocksInfo
+	loadedBlocksInfo       *BlocksInfo
+	disableCORS            bool
+	bkt                    objstore.Bucket
+	disableAdminOperations bool
 }
 
 type BlocksInfo struct {
@@ -72,8 +73,9 @@ func NewBlocksAPI(logger log.Logger, disableCORS bool, label string, flagsMap ma
 			Blocks: []metadata.Meta{},
 			Label:  label,
 		},
-		disableCORS: disableCORS,
-		bkt:         bkt,
+		disableCORS:            disableCORS,
+		bkt:                    bkt,
+		disableAdminOperations: flagsMap["disable-admin-operations"] == "true",
 	}
 }
 
@@ -84,9 +86,18 @@ func (bapi *BlocksAPI) Register(r *route.Router, tracer opentracing.Tracer, logg
 
 	r.Get("/blocks", instr("blocks", bapi.blocks))
 	r.Post("/blocks/mark", instr("blocks_mark", bapi.markBlock))
+	r.Get("/flags", instr("flags_disableAdminOperations", bapi.disableAdminOperationsHandler))
+}
+
+func (bapi *BlocksAPI) disableAdminOperationsHandler(r *http.Request) (interface{}, []error, *api.ApiError, func()) {
+	response := map[string]bool{"disableAdminOperations": bapi.disableAdminOperations}
+	return response, nil, nil, func() {}
 }
 
 func (bapi *BlocksAPI) markBlock(r *http.Request) (interface{}, []error, *api.ApiError, func()) {
+	if bapi.disableAdminOperations {
+		return nil, nil, &api.ApiError{Typ: api.ErrorBadData, Err: errors.New("Admin operations are disabled")}, func() {}
+	}
 	idParam := r.FormValue("id")
 	actionParam := r.FormValue("action")
 	detailParam := r.FormValue("detail")

--- a/pkg/ui/react-app/src/thanos/pages/blocks/BlockDetails.tsx
+++ b/pkg/ui/react-app/src/thanos/pages/blocks/BlockDetails.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useState } from 'react';
+import React, { FC, useEffect, useState } from 'react';
 import { Block } from './block';
 import styles from './blocks.module.css';
 import moment from 'moment';
@@ -13,6 +13,7 @@ export interface BlockDetailsProps {
 export const BlockDetails: FC<BlockDetailsProps> = ({ block, selectBlock }) => {
   const [modalAction, setModalAction] = useState<string>('');
   const [detailValue, setDetailValue] = useState<string | null>(null);
+  const [disableAdminOperations, setDisableAdminOperations] = useState<boolean>(false);
 
   const submitMarkBlock = async (action: string, ulid: string, detail: string | null) => {
     try {
@@ -39,6 +40,17 @@ export const BlockDetails: FC<BlockDetailsProps> = ({ block, selectBlock }) => {
       setModalAction('');
     }
   };
+
+  const fetchDisableAdminOperations = async () => {
+    const response = await fetch('/api/v1/flags');
+    const result = await response.json();
+    setDisableAdminOperations(result.data.disableAdminOperations);
+    console.log('disableAdminOperations', result.data.disableAdminOperations);
+  };
+
+  useEffect(() => {
+    fetchDisableAdminOperations();
+  }, []);
 
   return (
     <div className={`${styles.blockDetails} ${block && styles.open}`}>
@@ -100,26 +112,30 @@ export const BlockDetails: FC<BlockDetailsProps> = ({ block, selectBlock }) => {
               <Button>Download meta.json</Button>
             </a>
           </div>
-          <div style={{ marginTop: '12px' }}>
-            <Button
-              onClick={() => {
-                setModalAction('DELETION');
-                setDetailValue('');
-              }}
-            >
-              Mark Deletion
-            </Button>
-          </div>
-          <div style={{ marginTop: '12px' }}>
-            <Button
-              onClick={() => {
-                setModalAction('NO_COMPACTION');
-                setDetailValue('');
-              }}
-            >
-              Mark No Compaction
-            </Button>
-          </div>
+          {!disableAdminOperations && (
+            <div style={{ marginTop: '12px' }}>
+              <Button
+                onClick={() => {
+                  setModalAction('DELETION');
+                  setDetailValue('');
+                }}
+              >
+                Mark Deletion
+              </Button>
+            </div>
+          )}
+          {!disableAdminOperations && (
+            <div style={{ marginTop: '12px' }}>
+              <Button
+                onClick={() => {
+                  setModalAction('NO_COMPACTION');
+                  setDetailValue('');
+                }}
+              >
+                Mark No Compaction
+              </Button>
+            </div>
+          )}
           <Modal isOpen={!!modalAction}>
             <ModalBody>
               <ModalHeader toggle={() => setModalAction('')}>


### PR DESCRIPTION
Signed-off-by: Harsh Pratap Singh <harshpratapsingh8210@gmail.com>
Fixes #5390 
<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

This PR adds a flag, named `--disable-admin-operations`, to Bucket Web UI to decide whether to disable the corresponding buttons Mark Deletion and Mark No Compaction in the UI as they are admin-level operations. It also restricts the API usage.

## Verification

It was tested locally.
The UI test:
<img width="1280" alt="Screenshot 2023-08-10 at 11 52 37 AM" src="https://github.com/thanos-io/thanos/assets/119954739/eb62b386-9d1d-4b41-bb1b-3fb0290b6a6c">
<img width="1280" alt="Screenshot 2023-08-10 at 12 04 49 PM" src="https://github.com/thanos-io/thanos/assets/119954739/5bac237b-80a0-4194-88bb-98b2063924a2">
The API test:
```
❯ curl -X POST -d "id=_ulid&action=DELETION" http://localhost:8080/api/v1/blocks/mark

{"status":"error","errorType":"bad_data","error":"Admin operations are disabled"}
```
cc @yeya24 @GiedriusS @saswatamcode