### PR TITLE
cache: remove unnecessary nil check

### DIFF
--- a/pkg/cache/caching_bucket_config.go
+++ b/pkg/cache/caching_bucket_config.go
@@ -38,30 +38,20 @@ func NewCachingBucketConfig() *CachingBucketConfig {
 
 // SetCacheImplementation sets the value of Cache for all configurations.
 func (cfg *CachingBucketConfig) SetCacheImplementation(c Cache) {
-	if cfg.get != nil {
-		for k := range cfg.get {
-			cfg.get[k].Cache = c
-		}
+	for k := range cfg.get {
+		cfg.get[k].Cache = c
 	}
-	if cfg.iter != nil {
-		for k := range cfg.iter {
-			cfg.iter[k].Cache = c
-		}
+	for k := range cfg.iter {
+		cfg.iter[k].Cache = c
 	}
-	if cfg.exists != nil {
-		for k := range cfg.exists {
-			cfg.exists[k].Cache = c
-		}
+	for k := range cfg.exists {
+		cfg.exists[k].Cache = c
 	}
-	if cfg.getRange != nil {
-		for k := range cfg.getRange {
-			cfg.getRange[k].Cache = c
-		}
+	for k := range cfg.getRange {
+		cfg.getRange[k].Cache = c
 	}
-	if cfg.attributes != nil {
-		for k := range cfg.attributes {
-			cfg.attributes[k].Cache = c
-		}
+	for k := range cfg.attributes {
+		cfg.attributes[k].Cache = c
 	}
 }
 


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

From the Go docs:

> "If the map is nil, the number of iterations is 0." https://go.dev/ref/spec#For_range

Therefore, an additional nil check for before the loop is unnecessary.

## Verification

<!-- How you tested it? How do you know it works? -->

https://go.dev/play/p/Cw_wnqYzemu
