### PR TITLE
Vertical shard binary expression using metric name when no matching label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 
 ### Added
 
+- [#6605](https://github.com/thanos-io/thanos/pull/6605) Query Frontend: Support vertical sharding binary expression with metric name when no matching labels specified.
+
 ### Changed
 
 ### Removed

--- a/pkg/querysharding/analyzer.go
+++ b/pkg/querysharding/analyzer.go
@@ -113,7 +113,7 @@ func (a *QueryAnalyzer) Analyze(query string) (QueryAnalysis, error) {
 		case *parser.BinaryExpr:
 			if n.VectorMatching != nil {
 				shardingLabels := without(n.VectorMatching.MatchingLabels, []string{"le"})
-				if !n.VectorMatching.On && len(shardingLabels) > 0 {
+				if !n.VectorMatching.On {
 					shardingLabels = append(shardingLabels, model.MetricNameLabel)
 				}
 				analysis = analysis.scopeToLabels(shardingLabels, n.VectorMatching.On)

--- a/pkg/querysharding/analyzer_test.go
+++ b/pkg/querysharding/analyzer_test.go
@@ -203,7 +203,7 @@ sum by (container) (
 		{
 			name:           "binary expression with outer without grouping",
 			expression:     `sum(http_requests_total{code="400"} * http_requests_total) without (pod)`,
-			shardingLabels: []string{"pod"},
+			shardingLabels: []string{"__name__", "pod"},
 		},
 		{
 			name:           "binary expression with vector matching and outer without grouping",

--- a/pkg/querysharding/analyzer_test.go
+++ b/pkg/querysharding/analyzer_test.go
@@ -33,10 +33,6 @@ func TestAnalyzeQuery(t *testing.T) {
 			expression: "count(sum without (pod) (http_requests_total))",
 		},
 		{
-			name:       "binary expression",
-			expression: `http_requests_total{code="400"} / http_requests_total`,
-		},
-		{
 			name:       "binary expression with constant",
 			expression: `http_requests_total{code="400"} / 4`,
 		},
@@ -47,10 +43,6 @@ func TestAnalyzeQuery(t *testing.T) {
 		{
 			name:       "binary aggregation with different grouping labels",
 			expression: `sum by (pod) (http_requests_total{code="400"}) / sum by (cluster) (http_requests_total)`,
-		},
-		{
-			name:       "multiple binary expressions",
-			expression: `(http_requests_total{code="400"} + http_requests_total{code="500"}) / http_requests_total`,
 		},
 		{
 			name: "multiple binary expressions with empty vector matchers",
@@ -255,6 +247,26 @@ http_requests_total`,
 			name:           "aggregate without expression with label_replace",
 			expression:     `sum without (pod) (label_replace(metric, "dst_label", "$1", "src_label", "re"))`,
 			shardingLabels: []string{"pod", "dst_label"},
+		},
+		{
+			name:           "binary expression",
+			expression:     `http_requests_total{code="400"} / http_requests_total`,
+			shardingLabels: []string{model.MetricNameLabel},
+		},
+		{
+			name:           "binary expression among vector and scalar",
+			expression:     `aaaa - bbb > 1000`,
+			shardingLabels: []string{model.MetricNameLabel},
+		},
+		{
+			name:           "binary expression with set operation",
+			expression:     `aaaa and bbb`,
+			shardingLabels: []string{model.MetricNameLabel},
+		},
+		{
+			name:           "multiple binary expressions",
+			expression:     `(http_requests_total{code="400"} + http_requests_total{code="500"}) / http_requests_total`,
+			shardingLabels: []string{model.MetricNameLabel},
 		},
 	}
 


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Binary expression can be vertically sharded without `__name__` label if no matching labels are specified.

Image we have two series

```
foo{job="thanos", cluster="us"}
bar{job="thanos", cluster="eu"}
```

A query `foo - bar` is basically a join of `foo` and `bar` series. The join will ignore the metric name and will calculate hash for the rest labels in this case.

## Verification

<!-- How you tested it? How do you know it works? -->
