### PR TITLE
logging trace_id in HTTP middleware

### DIFF
--- a/groupcache.yml
+++ b/groupcache.yml
@@ -1,0 +1,10 @@
+type: GROUPCACHE
+config:
+  self_url: http://localhost:10906
+  peers:
+    - http://localhost:10906
+  groupcache_group: groupcache_test_group
+blocks_iter_ttl: 0s
+metafile_exists_ttl: 0s
+metafile_doesnt_exist_ttl: 0s
+metafile_content_ttl: 0s

--- a/pkg/rules/rules.go
+++ b/pkg/rules/rules.go
@@ -168,7 +168,7 @@ func dedupRules(rules []*rulespb.Rule, replicaLabels map[string]struct{}) []*rul
 					continue
 				}
 			}
-			
+
 			if existingAlert != nil && currentAlert != nil {
 				if existingAlert.Compare(currentAlert) != 0 {
 					uniqueRules = append(uniqueRules, r)

--- a/pkg/tracing/migration/bridge.go
+++ b/pkg/tracing/migration/bridge.go
@@ -57,6 +57,15 @@ func GetTraceIDFromBridgeSpan(span opentracing.Span) (string, bool) {
 
 	return "", false
 }
+func GetTraceIDFromBridgeSpanForLogging(span opentracing.Span) (string, bool) {
+	ctx := bridge.NewBridgeTracer().ContextWithSpanHook(context.Background(), span)
+	otelSpan := trace.SpanFromContext(ctx)
+	if otelSpan.SpanContext().IsValid() {
+		return otelSpan.SpanContext().TraceID().String(), true
+	}
+
+	return "", false
+}
 
 type otelErrHandler func(err error)
 


### PR DESCRIPTION
<!--
Currently we don't log trace ID as a part of the logging middleware for HTTP and GRPC. `request_id` for HTTP and GRPC respectively are being logged when request logging is enabled but there is nothing that ties the logs from the two transport mechanisms as the request id generated are different under the same request. By logging the TraceID in the logging middleware it helps in gathering log context and correlating the traces with the logs.

This PR adds the trace ID to the logs when request logging is enabled for HTTP. 

In the case of GRPC logging middleware - the latest update in the go-grpc-middleware library has a means to add trace id to the logger for every request - https://github.com/grpc-ecosystem/go-grpc-middleware/blob/36583ea2b9ec475311e4716730ebd169d413fa4c/interceptors/logging/options.go#L135

this would require an update to the  library in the thanos repo 
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
