### PR TITLE
Track failed connections to strict endpoints

### DIFF
--- a/pkg/store/storepb/disconnected_client.go
+++ b/pkg/store/storepb/disconnected_client.go
@@ -1,0 +1,32 @@
+package storepb
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"google.golang.org/grpc"
+)
+
+var ErrStoreNotConnected = errors.New("store is not connected")
+
+type disconnectedClient struct{}
+
+func NewDisconnectedClient() *disconnectedClient {
+	return &disconnectedClient{}
+}
+
+func (d disconnectedClient) Info(ctx context.Context, in *InfoRequest, opts ...grpc.CallOption) (*InfoResponse, error) {
+	return nil, ErrStoreNotConnected
+}
+
+func (d disconnectedClient) Series(ctx context.Context, in *SeriesRequest, opts ...grpc.CallOption) (Store_SeriesClient, error) {
+	return nil, ErrStoreNotConnected
+}
+
+func (d disconnectedClient) LabelNames(ctx context.Context, in *LabelNamesRequest, opts ...grpc.CallOption) (*LabelNamesResponse, error) {
+	return nil, ErrStoreNotConnected
+}
+
+func (d disconnectedClient) LabelValues(ctx context.Context, in *LabelValuesRequest, opts ...grpc.CallOption) (*LabelValuesResponse, error) {
+	return nil, ErrStoreNotConnected
+}


### PR DESCRIPTION
The EndpointSet will ignore strict endpoints if it fails to connect to them. This can lead to queries not reporting partial response if one or more such endpoints are not available when the querier starts.

This commit modifies the EndpointSet to track failed connections separately from endpoint refs. If one or more connect failures are present at query time, we inject a store client that will always return an error. This way the query will either fail, or return a warning when partial response is enabled.

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
