### PR TITLE
queryfrontend: fix explanation with query_range

### DIFF
--- a/internal/cortex/querier/queryrange/results_cache.go
+++ b/internal/cortex/querier/queryrange/results_cache.go
@@ -94,9 +94,10 @@ func (PrometheusResponseExtractor) Extract(start, end int64, from Response) Resp
 	return &PrometheusResponse{
 		Status: StatusSuccess,
 		Data: PrometheusData{
-			ResultType: promRes.Data.ResultType,
-			Result:     extractMatrix(start, end, promRes.Data.Result),
-			Stats:      extractStats(start, end, promRes.Data.Stats),
+			ResultType:  promRes.Data.ResultType,
+			Result:      extractMatrix(start, end, promRes.Data.Result),
+			Stats:       extractStats(start, end, promRes.Data.Stats),
+			Explanation: promRes.Data.Explanation,
 		},
 		Headers: promRes.Headers,
 	}
@@ -109,9 +110,10 @@ func (PrometheusResponseExtractor) ResponseWithoutHeaders(resp Response) Respons
 	return &PrometheusResponse{
 		Status: StatusSuccess,
 		Data: PrometheusData{
-			ResultType: promRes.Data.ResultType,
-			Result:     promRes.Data.Result,
-			Stats:      promRes.Data.Stats,
+			ResultType:  promRes.Data.ResultType,
+			Result:      promRes.Data.Result,
+			Stats:       promRes.Data.Stats,
+			Explanation: promRes.Data.Explanation,
 		},
 	}
 }
@@ -122,8 +124,9 @@ func (PrometheusResponseExtractor) ResponseWithoutStats(resp Response) Response 
 	return &PrometheusResponse{
 		Status: StatusSuccess,
 		Data: PrometheusData{
-			ResultType: promRes.Data.ResultType,
-			Result:     promRes.Data.Result,
+			ResultType:  promRes.Data.ResultType,
+			Result:      promRes.Data.Result,
+			Explanation: promRes.Data.Explanation,
 		},
 		Headers: promRes.Headers,
 	}

--- a/pkg/queryfrontend/queryinstant_codec.go
+++ b/pkg/queryfrontend/queryinstant_codec.go
@@ -153,7 +153,7 @@ func (c queryInstantCodec) DecodeRequest(_ context.Context, r *http.Request, for
 
 	result.Query = r.FormValue("query")
 	result.Path = r.URL.Path
-	result.Explain = r.FormValue("explain")
+	result.Explain = r.FormValue(queryv1.QueryExplainParam)
 	result.Engine = r.FormValue("engine")
 
 	for _, header := range forwardHeaders {

--- a/test/e2e/query_frontend_test.go
+++ b/test/e2e/query_frontend_test.go
@@ -90,8 +90,9 @@ func TestQFEEngineExplanation(t *testing.T) {
 		explanation := rangeQuery(t, ctx, queryFrontend.Endpoint("http"), e2ethanos.QueryUpWithoutInstance,
 			timestamp.FromTime(now.Add(-5*time.Minute)),
 			timestamp.FromTime(now), 1, promclient.QueryOptions{
-				Explain: true,
-				Engine:  "thanos",
+				Explain:     true,
+				Engine:      "thanos",
+				Deduplicate: true,
 			}, func(res model.Matrix) error {
 				if res.Len() == 0 {
 					return fmt.Errorf("expected results")
@@ -121,7 +122,7 @@ func TestQFEEngineExplanation(t *testing.T) {
 
 	t.Run("explanation works with instant query", func(t *testing.T) {
 		_, explanation := instantQuery(t, ctx, queryFrontend.Endpoint("http"), e2ethanos.QueryUpWithoutInstance, time.Now, promclient.QueryOptions{
-			Deduplicate: false,
+			Deduplicate: true,
 			Engine:      "thanos",
 			Explain:     true,
 		}, 1)


### PR DESCRIPTION
Fix explanation with query_range API and dedup enabled by passing around the explanation field from the retrieved response.
