### PR TITLE
Add `--disable-admin-operations` flag in Compactor UI and Bucket UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,9 +44,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#6264](https://github.com/thanos-io/thanos/pull/6264) Query: Add Thanos logo in navbar
 - [#6234](https://github.com/thanos-io/thanos/pull/6234) Query: Add ability to switch between `thanos` and `prometheus` engines dynamically via UI and API.
 - [#6346](https://github.com/thanos-io/thanos/pull/6346) Query: Add ability to generate SQL-like query explanations when `thanos` engine is used.
-- [#6646](https://github.com/thanos-io/thanos/pull/6646)
-Compact and Bucket: Add `--disable-admin-operations` flag in Compactor UI and Bucket UI
-
+- [#6646](https://github.com/thanos-io/thanos/pull/6646) Compact and Bucket: Add `--disable-admin-operations` flag in Compactor UI and Bucket UI
 
 ### Fixed
 - [#6503](https://github.com/thanos-io/thanos/pull/6503) *: Change the engine behind `ContentPathReloader` to be completely independent of any filesystem concept. This effectively fixes this configuration reload when used with Kubernetes ConfigMaps, Secrets, or other volume mounts.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,9 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#6264](https://github.com/thanos-io/thanos/pull/6264) Query: Add Thanos logo in navbar
 - [#6234](https://github.com/thanos-io/thanos/pull/6234) Query: Add ability to switch between `thanos` and `prometheus` engines dynamically via UI and API.
 - [#6346](https://github.com/thanos-io/thanos/pull/6346) Query: Add ability to generate SQL-like query explanations when `thanos` engine is used.
+- [#6646](https://github.com/thanos-io/thanos/pull/6646)
+Compact and Bucket: Add `--disable-admin-operations` flag in Compactor UI and Bucket UI
+
 
 ### Fixed
 - [#6503](https://github.com/thanos-io/thanos/pull/6503) *: Change the engine behind `ContentPathReloader` to be completely independent of any filesystem concept. This effectively fixes this configuration reload when used with Kubernetes ConfigMaps, Secrets, or other volume mounts.

--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -678,6 +678,7 @@ type compactConfig struct {
 	skipBlockWithOutOfOrderChunks                  bool
 	progressCalculateInterval                      time.Duration
 	filterConf                                     *store.FilterConfig
+	disableAdminOperations                         bool
 }
 
 func (cc *compactConfig) registerFlag(cmd extkingpin.FlagClause) {
@@ -786,4 +787,6 @@ func (cc *compactConfig) registerFlag(cmd extkingpin.FlagClause) {
 	cc.webConf.registerFlag(cmd)
 
 	cmd.Flag("bucket-web-label", "External block label to use as group title in the bucket web UI").StringVar(&cc.label)
+
+	cmd.Flag("disable-admin-operations", "Disable UI/API admin operations like marking blocks for deletion and no compaction.").Default("false").BoolVar(&cc.disableAdminOperations)
 }

--- a/cmd/thanos/tools_bucket.go
+++ b/cmd/thanos/tools_bucket.go
@@ -112,13 +112,14 @@ type bucketLsConfig struct {
 }
 
 type bucketWebConfig struct {
-	webRoutePrefix      string
-	webExternalPrefix   string
-	webPrefixHeaderName string
-	webDisableCORS      bool
-	interval            time.Duration
-	label               string
-	timeout             time.Duration
+	webRoutePrefix         string
+	webExternalPrefix      string
+	webPrefixHeaderName    string
+	webDisableCORS         bool
+	interval               time.Duration
+	label                  string
+	timeout                time.Duration
+	disableAdminOperations bool
 }
 
 type bucketReplicateConfig struct {
@@ -203,6 +204,8 @@ func (tbc *bucketWebConfig) registerBucketWebFlag(cmd extkingpin.FlagClause) *bu
 	cmd.Flag("timeout", "Timeout to download metadata from remote storage").Default("5m").DurationVar(&tbc.timeout)
 
 	cmd.Flag("label", "External block label to use as group title").StringVar(&tbc.label)
+
+	cmd.Flag("disable-admin-operations", "Disable UI/API admin operations like marking blocks for deletion and no compaction.").Default("false").BoolVar(&tbc.disableAdminOperations)
 	return tbc
 }
 

--- a/docs/components/compact.md
+++ b/docs/components/compact.md
@@ -355,6 +355,9 @@ Flags:
                                 block loaded, or compactor is ignoring the
                                 deletion because it's compacting the block at
                                 the same time.
+      --disable-admin-operations
+                                Disable UI/API admin operations like marking
+                                blocks for deletion and no compaction.
       --downsample.concurrency=1
                                 Number of goroutines to use when downsampling
                                 blocks.

--- a/docs/components/tools.md
+++ b/docs/components/tools.md
@@ -210,6 +210,9 @@ usage: thanos tools bucket web [<flags>]
 Web interface for remote storage bucket.
 
 Flags:
+      --disable-admin-operations
+                                Disable UI/API admin operations like marking
+                                blocks for deletion and no compaction.
   -h, --help                    Show context-sensitive help (also try
                                 --help-long and --help-man).
       --http-address="0.0.0.0:10902"
@@ -823,7 +826,7 @@ Flags:
       --rewrite.to-relabel-config-file=<file-path>
                                 Path to YAML file that contains relabel configs
                                 that will be applied to blocks
-      --tmp.dir="/tmp/thanos-rewrite"
+      --tmp.dir="/var/folders/yn/c6y00yq11klbr1pk_92j61580000gn/T/thanos-rewrite"
                                 Working directory for temporary files
       --tracing.config=<content>
                                 Alternative to 'tracing.config-file' flag

--- a/docs/components/tools.md
+++ b/docs/components/tools.md
@@ -826,7 +826,7 @@ Flags:
       --rewrite.to-relabel-config-file=<file-path>
                                 Path to YAML file that contains relabel configs
                                 that will be applied to blocks
-      --tmp.dir="/var/folders/thanos-rewrite"
+      --tmp.dir="/tmp/thanos-rewrite"
                                 Working directory for temporary files
       --tracing.config=<content>
                                 Alternative to 'tracing.config-file' flag

--- a/docs/components/tools.md
+++ b/docs/components/tools.md
@@ -826,7 +826,7 @@ Flags:
       --rewrite.to-relabel-config-file=<file-path>
                                 Path to YAML file that contains relabel configs
                                 that will be applied to blocks
-      --tmp.dir="/var/folders/yn/c6y00yq11klbr1pk_92j61580000gn/T/thanos-rewrite"
+      --tmp.dir="/var/folders/thanos-rewrite"
                                 Working directory for temporary files
       --tracing.config=<content>
                                 Alternative to 'tracing.config-file' flag

--- a/pkg/ui/react-app/src/thanos/pages/blocks/BlockDetails.test.tsx
+++ b/pkg/ui/react-app/src/thanos/pages/blocks/BlockDetails.test.tsx
@@ -15,6 +15,7 @@ describe('BlockDetails', () => {
     selectBlock: (): void => {
       // do nothing
     },
+    disableAdminOperations: false,
   };
   window.URL.createObjectURL = jest.fn();
   const blockDetails = mount(<BlockDetails {...defaultProps} />);

--- a/pkg/ui/react-app/src/thanos/pages/blocks/BlockDetails.tsx
+++ b/pkg/ui/react-app/src/thanos/pages/blocks/BlockDetails.tsx
@@ -8,9 +8,10 @@ import { download } from './helpers';
 export interface BlockDetailsProps {
   block: Block | undefined;
   selectBlock: React.Dispatch<React.SetStateAction<Block | undefined>>;
+  disableAdminOperations: boolean;
 }
 
-export const BlockDetails: FC<BlockDetailsProps> = ({ block, selectBlock }) => {
+export const BlockDetails: FC<BlockDetailsProps> = ({ block, selectBlock, disableAdminOperations }) => {
   const [modalAction, setModalAction] = useState<string>('');
   const [detailValue, setDetailValue] = useState<string | null>(null);
 
@@ -100,26 +101,30 @@ export const BlockDetails: FC<BlockDetailsProps> = ({ block, selectBlock }) => {
               <Button>Download meta.json</Button>
             </a>
           </div>
-          <div style={{ marginTop: '12px' }}>
-            <Button
-              onClick={() => {
-                setModalAction('DELETION');
-                setDetailValue('');
-              }}
-            >
-              Mark Deletion
-            </Button>
-          </div>
-          <div style={{ marginTop: '12px' }}>
-            <Button
-              onClick={() => {
-                setModalAction('NO_COMPACTION');
-                setDetailValue('');
-              }}
-            >
-              Mark No Compaction
-            </Button>
-          </div>
+          {!disableAdminOperations && (
+            <div>
+              <div style={{ marginTop: '12px' }}>
+                <Button
+                  onClick={() => {
+                    setModalAction('DELETION');
+                    setDetailValue('');
+                  }}
+                >
+                  Mark Deletion
+                </Button>
+              </div>
+              <div style={{ marginTop: '12px' }}>
+                <Button
+                  onClick={() => {
+                    setModalAction('NO_COMPACTION');
+                    setDetailValue('');
+                  }}
+                >
+                  Mark No Compaction
+                </Button>
+              </div>
+            </div>
+          )}
           <Modal isOpen={!!modalAction}>
             <ModalBody>
               <ModalHeader toggle={() => setModalAction('')}>

--- a/pkg/ui/react-app/src/thanos/pages/blocks/Blocks.tsx
+++ b/pkg/ui/react-app/src/thanos/pages/blocks/Blocks.tsx
@@ -14,6 +14,7 @@ import { sortBlocks, getBlockByUlid, getFilteredBlockPools } from './helpers';
 import styles from './blocks.module.css';
 import TimeRange from './TimeRange';
 import Checkbox from '../../../components/Checkbox';
+import { FlagMap } from '../../../pages/flags/Flags';
 
 export interface BlockListProps {
   blocks: Block[];
@@ -73,6 +74,9 @@ export const BlocksContent: FC<{ data: BlockListProps }> = ({ data }) => {
   const blockPools = useMemo(() => sortBlocks(blocks, label, findOverlappingBlocks), [blocks, label, findOverlappingBlocks]);
   const filteredBlocks = useMemo(() => getBlockByUlid(blocks, blockSearch), [blocks, blockSearch]);
   const filteredBlockPools = useMemo(() => getFilteredBlockPools(blockPools, filteredBlocks), [filteredBlocks, blockPools]);
+
+  const { response: flagsRes } = useFetch<FlagMap>(`/api/v1/status/flags`);
+  const disableAdminOperations = flagsRes?.data?.['disable-admin-operations'] === 'true' || false;
 
   const setViewTime = (times: number[]): void => {
     setQuery({
@@ -180,7 +184,7 @@ export const BlocksContent: FC<{ data: BlockListProps }> = ({ data }) => {
                 onChange={setViewTime}
               />
             </div>
-            <BlockDetails selectBlock={selectBlock} block={selectedBlock} />
+            <BlockDetails selectBlock={selectBlock} block={selectedBlock} disableAdminOperations={disableAdminOperations} />
           </div>
         </>
       ) : (


### PR DESCRIPTION
Signed-off-by: Harsh Pratap Singh <harshpratapsingh8210@gmail.com>
Fixes #5390 
<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

This PR adds a flag, named `--disable-admin-operations`, to the Compactor UI and Bucket Web UI to decide whether to disable the corresponding buttons Mark Deletion and Mark No Compaction in the UI as they are admin-level operations. It also restricts the API usage for both of them.

## Verification

It was tested locally.
The UI test:
<img width="1280" alt="Screenshot 2023-08-10 at 9 09 08 PM" src="https://github.com/thanos-io/thanos/assets/119954739/ecb0958e-a4c0-416a-874f-ad036b491f87">
<img width="1271" alt="Screenshot 2023-08-10 at 9 09 20 PM" src="https://github.com/thanos-io/thanos/assets/119954739/fdf02c23-b8ca-46c5-9eb8-076af5386cfc">
<img width="1280" alt="Screenshot 2023-08-10 at 9 08 42 PM" src="https://github.com/thanos-io/thanos/assets/119954739/48355eb1-9acb-445d-b8db-9e81d474ea86">
<img width="1278" alt="Screenshot 2023-08-10 at 9 08 52 PM" src="https://github.com/thanos-io/thanos/assets/119954739/f4b69a42-960b-428a-add4-e797e56675dd">

The API test:
```
❯ curl -X POST -d "id=_ulid&action=DELETION" http://localhost:8080/api/v1/blocks/mark
{"status":"error","errorType":"bad_data","error":"Admin operations are disabled"}
❯ curl -X POST -d "id=_ulid&action=DELETION" http://localhost:10922/api/v1/blocks/mark
{"status":"error","errorType":"bad_data","error":"Admin operations are disabled"}
```
cc @yeya24 @GiedriusS @saswatamcode