### PR TITLE
Fix mutable stringset memory usage

### DIFF
--- a/pkg/store/bucket_e2e_test.go
+++ b/pkg/store/bucket_e2e_test.go
@@ -799,6 +799,7 @@ func TestBucketStore_LabelNamesSet_e2e(t *testing.T) {
 		for _, n := range []string{"a", "b", "c"} {
 			testutil.Assert(t, filter.Has(n), "expected filter to have %s", n)
 		}
+		testutil.Equals(t, 3, filter.Count())
 	})
 }
 

--- a/pkg/stringset/set.go
+++ b/pkg/stringset/set.go
@@ -10,6 +10,10 @@ import (
 type Set interface {
 	Has(string) bool
 	HasAny([]string) bool
+	// Count returns the number of elements in the set.
+	// A value of -1 indicates infinite size and can be returned by a
+	// set representing all possible string values.
+	Count() int
 }
 
 type fixedSet struct {
@@ -38,6 +42,10 @@ func (f fixedSet) Has(s string) bool {
 	return f.cuckoo.Lookup([]byte(s))
 }
 
+func (f fixedSet) Count() int {
+	return int(f.cuckoo.Count())
+}
+
 type mutableSet struct {
 	cuckoo *cuckoo.ScalableCuckooFilter
 }
@@ -54,7 +62,7 @@ func New() MutableSet {
 }
 
 func (e mutableSet) Insert(s string) {
-	e.cuckoo.Insert([]byte(s))
+	e.cuckoo.InsertUnique([]byte(s))
 }
 
 func (e mutableSet) Has(s string) bool {
@@ -70,6 +78,10 @@ func (e mutableSet) HasAny(strings []string) bool {
 	return false
 }
 
+func (e mutableSet) Count() int {
+	return int(e.cuckoo.Count())
+}
+
 type allStringsSet struct{}
 
 func (e allStringsSet) HasAny(_ []string) bool {
@@ -82,4 +94,8 @@ func AllStrings() *allStringsSet {
 
 func (e allStringsSet) Has(_ string) bool {
 	return true
+}
+
+func (e allStringsSet) Count() int {
+	return -1
 }


### PR DESCRIPTION
This commit fixes the Insert function for the mutable stringset to only insert unique labels instead of adding every label to the set.

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
