### PR TITLE
store: Record stats even on ExpandPostings error

### DIFF
--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -1373,7 +1373,7 @@ func (s *BucketStore) Series(req *storepb.SeriesRequest, seriesSrv storepb.Store
 				if err := blockClient.ExpandPostings(sortedBlockMatchers, seriesLimiter); err != nil {
 					onClose()
 					span.Finish()
-					return errors.Wrapf(err, "fetch series for block %s", blk.meta.ULID)
+					return errors.Wrapf(err, "fetch postings for block %s", blk.meta.ULID)
 				}
 
 				part := newLazyRespSet(

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -1364,15 +1364,18 @@ func (s *BucketStore) Series(req *storepb.SeriesRequest, seriesSrv storepb.Store
 					"block.resolution": blk.meta.Thanos.Downsample.Resolution,
 				})
 
-				if err := blockClient.ExpandPostings(sortedBlockMatchers, seriesLimiter); err != nil {
-					span.Finish()
-					return errors.Wrapf(err, "fetch series for block %s", blk.meta.ULID)
-				}
 				onClose := func() {
 					mtx.Lock()
 					stats = blockClient.MergeStats(stats)
 					mtx.Unlock()
 				}
+
+				if err := blockClient.ExpandPostings(sortedBlockMatchers, seriesLimiter); err != nil {
+					onClose()
+					span.Finish()
+					return errors.Wrapf(err, "fetch series for block %s", blk.meta.ULID)
+				}
+
 				part := newLazyRespSet(
 					srv.Context(),
 					span,


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

Any error caused by `blockSeriesClient.ExpandPostings` leads to stats not being populated (even when postings have been fetched), for example https://cloud-native.slack.com/archives/CK5RSSC10/p1692947627757689?thread_ts=1692865102.631199&cid=CK5RSSC10

This PR calls `onClose` on error now, for helpful debugging.

## Verification

<!-- How you tested it? How do you know it works? -->
