### PR TITLE
Create aligned blocks when flushing TSDBs

### DIFF
--- a/pkg/receive/multitsdb.go
+++ b/pkg/receive/multitsdb.go
@@ -6,7 +6,6 @@ package receive
 import (
 	"context"
 	"fmt"
-	"math"
 	"os"
 	"path"
 	"path/filepath"
@@ -279,7 +278,7 @@ func (t *MultiTSDB) flushHead(db *tsdb.DB) error {
 		return err
 	}
 	// Flush the remainder of the head.
-	return db.CompactHead(tsdb.NewRangeHead(head, head.MinTime(), math.MaxInt64))
+	return db.CompactHead(tsdb.NewRangeHead(head, head.MinTime(), head.MaxTime()-1))
 }
 
 func (t *MultiTSDB) Close() error {

--- a/pkg/receive/multitsdb.go
+++ b/pkg/receive/multitsdb.go
@@ -272,6 +272,9 @@ func (t *MultiTSDB) Flush() error {
 
 func (t *MultiTSDB) flushHead(db *tsdb.DB) error {
 	head := db.Head()
+	if head.MinTime() == head.MaxTime() {
+		return db.CompactHead(tsdb.NewRangeHead(head, head.MinTime(), head.MaxTime()))
+	}
 	blockAlignedMaxt := head.MaxTime() - (head.MaxTime() % t.tsdbOpts.MaxBlockDuration)
 	// Flush a well aligned TSDB block.
 	if err := db.CompactHead(tsdb.NewRangeHead(head, head.MinTime(), blockAlignedMaxt-1)); err != nil {

--- a/pkg/receive/multitsdb_test.go
+++ b/pkg/receive/multitsdb_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"math"
 	"os"
+	"path"
 	"strings"
 	"testing"
 	"time"
@@ -515,6 +516,76 @@ func TestMultiTSDBRecreatePrunedTenant(t *testing.T) {
 
 	testutil.Ok(t, appendSample(m, "foo", time.UnixMilli(int64(10))))
 	testutil.Equals(t, 1, len(m.TSDBLocalClients()))
+}
+
+func TestAlignedHeadFlush(t *testing.T) {
+	tests := []struct {
+		name            string
+		tsdbStart       int64
+		bucket          objstore.Bucket
+		expectedUploads int
+		expectedMaxTs   []int64
+	}{
+		{
+			name:            "aligned head start",
+			bucket:          objstore.NewInMemBucket(),
+			expectedUploads: 2,
+			expectedMaxTs:   []int64{2 * 60 * 60 * 1000, math.MinInt64},
+		},
+		{
+			name:            "unaligned TSDB start",
+			bucket:          objstore.NewInMemBucket(),
+			tsdbStart:       90 * 60, // 90 minutes
+			expectedUploads: 2,
+			expectedMaxTs:   []int64{2 * 60 * 60 * 1000, math.MinInt64},
+		},
+	}
+
+	threeHoursInSeconds := 3 * 60 * 60
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			dir := t.TempDir()
+
+			m := NewMultiTSDB(dir, log.NewNopLogger(), prometheus.NewRegistry(),
+				&tsdb.Options{
+					MinBlockDuration:  (2 * time.Hour).Milliseconds(),
+					MaxBlockDuration:  (2 * time.Hour).Milliseconds(),
+					RetentionDuration: (6 * time.Hour).Milliseconds(),
+				},
+				labels.FromStrings("replica", "test"),
+				"tenant_id",
+				test.bucket,
+				false,
+				metadata.NoneFunc,
+			)
+			defer func() { testutil.Ok(t, m.Close()) }()
+
+			for i := 0; i < threeHoursInSeconds; i += 60 {
+				tsMillis := int64(i*1000) + test.tsdbStart
+				testutil.Ok(t, appendSample(m, "test-tenant", time.UnixMilli(tsMillis)))
+			}
+
+			testutil.Ok(t, m.Flush())
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			_, err := m.Sync(ctx)
+			testutil.Ok(t, err)
+
+			var shippedBlocks int
+			var maxts []int64
+			testutil.Ok(t, test.bucket.Iter(context.Background(), "", func(s string) error {
+				meta, err := metadata.ReadFromDir(path.Join(m.dataDir, "test-tenant", s))
+				testutil.Ok(t, err)
+
+				maxts = append(maxts, meta.MaxTime)
+				shippedBlocks++
+				return nil
+			}))
+			testutil.Equals(t, test.expectedUploads, shippedBlocks)
+			testutil.Equals(t, test.expectedMaxTs, maxts)
+		})
+	}
 }
 
 func TestMultiTSDBStats(t *testing.T) {


### PR DESCRIPTION
The receiver forces a flush on several occasions, such as when shutting down or when pruning a tenant. The flush involves compacting the entire head, which can sometimes be longer than the max block duration. Since each receiver will flush at different times, these unaligned blocks trigger vertical compaction with other aligned blocks in object storage and create a new block whose duration is outside of the pre-defined compaction levels.

This commit tries to resolve that issue by simulating a regular head compaction to create a block that fits the max duration, followed by flushing the remainder of the head which creates a separate, smaller sized block.

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

* Create duration-aligned blocks when flushing TSDBs in the Receiver.

## Verification

* Through unit tests