### PR TITLE
use single instance of typed error and use errors.Is() for comparison

### DIFF
--- a/pkg/cacheutil/async_op.go
+++ b/pkg/cacheutil/async_op.go
@@ -5,8 +5,6 @@ package cacheutil
 
 import (
 	"sync"
-
-	"github.com/pkg/errors"
 )
 
 type asyncOperationProcessor struct {
@@ -54,13 +52,11 @@ func (p *asyncOperationProcessor) asyncQueueProcessLoop() {
 	}
 }
 
-var errAsyncBufferFull = errors.New("the async buffer is full")
-
 func (p *asyncOperationProcessor) enqueueAsync(op func()) error {
 	select {
 	case p.asyncQueue <- op:
 		return nil
 	default:
-		return errAsyncBufferFull
+		return errMemcachedAsyncBufferFull
 	}
 }

--- a/pkg/cacheutil/memcached_client.go
+++ b/pkg/cacheutil/memcached_client.go
@@ -400,7 +400,7 @@ func (c *memcachedClient) SetAsync(key string, value []byte, ttl time.Duration) 
 		c.duration.WithLabelValues(opSet).Observe(time.Since(start).Seconds())
 	})
 
-	if err == errMemcachedAsyncBufferFull {
+	if errors.Is(err, errMemcachedAsyncBufferFull) {
 		c.skipped.WithLabelValues(opSet, reasonAsyncBufferFull).Inc()
 		level.Debug(c.logger).Log("msg", "failed to store item to memcached because the async buffer is full", "err", err, "size", len(c.p.asyncQueue))
 		return nil


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

we noticed out logs filling up with the following after moving from `v0.31.0` -> `v0.32.2`
```
thanos-store-0 thanos-store ts=2023-09-12T06:24:03.30133412Z caller=memcached.go:164 level=error msg="failed to cache series in memcached" err="the async buffer is full"
thanos-store-0 thanos-store ts=2023-09-12T06:24:03.301525112Z caller=memcached.go:164 level=error msg="failed to cache series in memcached" err="the async buffer is full"
thanos-store-0 thanos-store ts=2023-09-12T06:24:03.301541222Z caller=memcached.go:164 level=error msg="failed to cache series in memcached" err="the async buffer is full"
```
pretty sure the intended behaviour for set operations failing because the async buffers are full is to log at debug level and increment the `thanos_memcached_operation_skipped_total` metric with the label `reason:async-buffer-full`
this however was not happening as the existing condition for this code path was comparing two different instances of the error

## Verification

after this change the message is logged at the correct level
```
thanos-store-0 thanos-store ts=2023-09-12T11:25:00.89926901Z caller=memcached_client.go:405 level=debug name=index-cache msg="failed to store item to memcached because the async buffer is full" err="the async buffer is full" size=1
thanos-store-0 thanos-store ts=2023-09-12T11:25:00.89929116Z caller=memcached_client.go:405 level=debug name=index-cache msg="failed to store item to memcached because the async buffer is full" err="the async buffer is full" size=1
thanos-store-0 thanos-store ts=2023-09-12T11:25:00.89930656Z caller=memcached_client.go:405 level=debug name=index-cache msg="failed to store item to memcached because the async buffer is full" err="the async buffer is full" size=1
```
and the metric is incremented
![2023-09-12-122726_1760x984_scrot](https://github.com/thanos-io/thanos/assets/22008619/e6fb57fc-fb0a-4e6f-bfc5-933bf34b126f)
