### PR TITLE
Add absolute total download time metrics for series and chunks

### DIFF
--- a/pkg/store/bucket_test.go
+++ b/pkg/store/bucket_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/cespare/xxhash"
+	"github.com/efficientgo/core/testutil"
 	"github.com/go-kit/log"
 	"github.com/gogo/protobuf/proto"
 	"github.com/gogo/protobuf/types"
@@ -44,9 +45,8 @@ import (
 	"go.uber.org/atomic"
 	"golang.org/x/exp/slices"
 
+	"github.com/thanos-io/objstore"
 	"github.com/thanos-io/objstore/providers/filesystem"
-
-	"github.com/efficientgo/core/testutil"
 
 	"github.com/thanos-io/thanos/pkg/block"
 	"github.com/thanos-io/thanos/pkg/block/indexheader"

--- a/pkg/store/bucket_test.go
+++ b/pkg/store/bucket_test.go
@@ -44,7 +44,6 @@ import (
 	"go.uber.org/atomic"
 	"golang.org/x/exp/slices"
 
-	"github.com/thanos-io/objstore"
 	"github.com/thanos-io/objstore/providers/filesystem"
 
 	"github.com/efficientgo/core/testutil"
@@ -2766,6 +2765,8 @@ func benchmarkBlockSeriesWithConcurrency(b *testing.B, concurrency int, blockMet
 					nil,
 					false,
 					SeriesBatchSize,
+					dummyHistogram,
+					dummyHistogram,
 					dummyHistogram,
 					nil,
 					false,


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

We have two histograms for series and chunks fetch latency. However, they have some issues. 

For the series latency histogram metric `thanos_bucket_store_series_fetch_duration_seconds`, it only considers a single batch. So if the request matches more than > 10K series and we download more batches, it couldn't reflect how much time we spent on fetching multiple batches.

For the chunk latency histogram metric `thanos_bucket_store_chunks_fetch_duration_seconds`, it considers all the series batches. But the latency it used is not the absolute latency. It counts the wall time to fetch chunks, which is the total latency for all goroutines we use to download chunks. A histogram metric for absolute time is also helpful.

## Verification

<!-- How you tested it? How do you know it works? -->
