### PR TITLE
disable store api in sidecar when prometheus is in agent mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#6753](https://github.com/thanos-io/thanos/pull/6753) mixin(Rule): *breaking :warning:* Fixed the mixin rules with duplicate names and updated the promtool version from v0.37.0 to v0.47.0
 - [#6772](https://github.com/thanos-io/thanos/pull/6772) *: Bump prometheus to v0.47.2-0.20231006112807-a5a4eab679cc
 - [#6794](https://github.com/thanos-io/thanos/pull/6794) Receive: the exported HTTP metrics now uses the specified default tenant for requests where no tenants are found.
+- [#6727](https://github.com/thanos-io/thanos/pull/6727) Sidecar: When Prometheus is used in agent mode, store api in sidecar will be disabled.
 
 ### Removed
 

--- a/cmd/thanos/sidecar.go
+++ b/cmd/thanos/sidecar.go
@@ -406,10 +406,10 @@ func validatePrometheus(ctx context.Context, client *promclient.Client, logger l
 		level.Warn(logger).Log("msg", "Prometheus is running in agent mode. StoreAPI will be disabled.")
 	}
 
-	if uploads && *promAgentModeEnabled {
-		return errors.New("uploading is not supported when Prometheus is running in agent mode")
-	}
 	if uploads {
+		if *promAgentModeEnabled {
+			return errors.New("uploading is not supported when Prometheus is running in agent mode")
+		}
 		// Check if compaction is disabled.
 		if flags.TSDBMinTime != flags.TSDBMaxTime {
 			if !ignoreBlockSize {

--- a/cmd/thanos/sidecar.go
+++ b/cmd/thanos/sidecar.go
@@ -284,6 +284,7 @@ func runSidecar(
 				}),
 				info.WithExemplarsInfoFunc(),
 			)
+		}
 		infoOptions = append(infoOptions,
 			info.WithRulesInfoFunc(),
 			info.WithTargetsInfoFunc(),
@@ -304,7 +305,7 @@ func runSidecar(
 		}
 		if !promAgentModeEnabled {
 			storeServer := store.NewLimitedStoreServer(store.NewInstrumentedStoreServer(reg, promStore), reg, conf.storeRateLimits)
-			opts = append(opts, 
+			opts = append(opts,
 				grpcserver.WithServer(store.RegisterStoreServer(storeServer, logger)),
 				grpcserver.WithServer(exemplars.RegisterExemplarsServer(exemplarSrv)),
 				grpcserver.WithServer(rules.RegisterRulesServer(rules.NewPrometheus(conf.prometheus.url, c, m.Labels))),

--- a/cmd/thanos/sidecar.go
+++ b/cmd/thanos/sidecar.go
@@ -282,8 +282,8 @@ func runSidecar(
 					}
 					return nil
 				}),
-				info.WithExemplarsInfoFunc())
-		}
+				info.WithExemplarsInfoFunc(),
+			)
 		infoOptions = append(infoOptions,
 			info.WithRulesInfoFunc(),
 			info.WithTargetsInfoFunc(),

--- a/cmd/thanos/sidecar.go
+++ b/cmd/thanos/sidecar.go
@@ -265,9 +265,10 @@ func runSidecar(
 
 		var infoOptions []info.ServerOptionFunc
 		if !promAgentModeEnabled {
-			infoOptions = append(infoOptions, info.WithLabelSetFunc(func() []labelpb.ZLabelSet {
-				return promStore.LabelSet()
-			}),
+			infoOptions = append(infoOptions,
+				info.WithLabelSetFunc(func() []labelpb.ZLabelSet {
+					return promStore.LabelSet()
+				}),
 				info.WithStoreInfoFunc(func() *infopb.StoreInfo {
 					if httpProbe.IsReady() {
 						mint, maxt := promStore.Timestamps()

--- a/cmd/thanos/sidecar.go
+++ b/cmd/thanos/sidecar.go
@@ -304,7 +304,8 @@ func runSidecar(
 		}
 		if !promAgentModeEnabled {
 			storeServer := store.NewLimitedStoreServer(store.NewInstrumentedStoreServer(reg, promStore), reg, conf.storeRateLimits)
-			opts = append(opts, grpcserver.WithServer(store.RegisterStoreServer(storeServer, logger)),
+			opts = append(opts, 
+				grpcserver.WithServer(store.RegisterStoreServer(storeServer, logger)),
 				grpcserver.WithServer(exemplars.RegisterExemplarsServer(exemplarSrv)),
 				grpcserver.WithServer(rules.RegisterRulesServer(rules.NewPrometheus(conf.prometheus.url, c, m.Labels))),
 			)

--- a/cmd/thanos/sidecar.go
+++ b/cmd/thanos/sidecar.go
@@ -403,7 +403,7 @@ func validatePrometheus(ctx context.Context, client *promclient.Client, logger l
 
 	if strings.Contains(flags.PromFeature, "agent") {
 		*promAgentModeEnabled = true
-		level.Warn(logger).Log("msg", "Prometheus is running in agent mode. StoreAPI will be disabled.")
+		level.Info(logger).Log("msg", "Prometheus is running in agent mode. StoreAPI will be disabled.")
 	}
 
 	if uploads {

--- a/pkg/promclient/promclient.go
+++ b/pkg/promclient/promclient.go
@@ -214,7 +214,7 @@ func (f *Flags) UnmarshalJSON(b []byte) error {
 		TSDBMaxTime        modelDuration `json:"storage.tsdb.max-block-duration"`
 		WebEnableAdminAPI  modelBool     `json:"web.enable-admin-api"`
 		WebEnableLifecycle modelBool     `json:"web.enable-lifecycle"`
-		PromAgentEnabled   string        `json:"enable-feature"`
+		PromFeature        string        `json:"enable-feature"`
 	}{}
 
 	if err := json.Unmarshal(b, &parsableFlags); err != nil {
@@ -228,6 +228,7 @@ func (f *Flags) UnmarshalJSON(b []byte) error {
 		TSDBMaxTime:        model.Duration(parsableFlags.TSDBMaxTime),
 		WebEnableAdminAPI:  bool(parsableFlags.WebEnableAdminAPI),
 		WebEnableLifecycle: bool(parsableFlags.WebEnableLifecycle),
+		PromFeature:        parsableFlags.PromFeature,
 	}
 	return nil
 }

--- a/pkg/promclient/promclient.go
+++ b/pkg/promclient/promclient.go
@@ -199,6 +199,7 @@ type Flags struct {
 	TSDBMaxTime        model.Duration `json:"storage.tsdb.max-block-duration"`
 	WebEnableAdminAPI  bool           `json:"web.enable-admin-api"`
 	WebEnableLifecycle bool           `json:"web.enable-lifecycle"`
+	PromFeature        string         `json:"enable-feature"`
 }
 
 // UnmarshalJSON implements the json.Unmarshaler interface.
@@ -213,6 +214,7 @@ func (f *Flags) UnmarshalJSON(b []byte) error {
 		TSDBMaxTime        modelDuration `json:"storage.tsdb.max-block-duration"`
 		WebEnableAdminAPI  modelBool     `json:"web.enable-admin-api"`
 		WebEnableLifecycle modelBool     `json:"web.enable-lifecycle"`
+		PromAgentEnabled   string        `json:"enable-feature"`
 	}{}
 
 	if err := json.Unmarshal(b, &parsableFlags); err != nil {

--- a/test/e2e/e2ethanos/services.go
+++ b/test/e2e/e2ethanos/services.go
@@ -107,17 +107,28 @@ func NewPrometheus(e e2e.Environment, name, promConfig, webConfig, promImage str
 	}
 
 	probe := e2e.NewHTTPReadinessProbe("http", "/-/ready", 200, 200)
+
 	args := e2e.BuildArgs(map[string]string{
-		"--config.file":                     filepath.Join(f.InternalDir(), "prometheus.yml"),
-		"--storage.tsdb.path":               f.InternalDir(),
-		"--storage.tsdb.max-block-duration": "2h",
-		"--log.level":                       infoLogLevel,
-		"--web.listen-address":              ":9090",
+		"--config.file":        filepath.Join(f.InternalDir(), "prometheus.yml"),
+		"--log.level":          infoLogLevel,
+		"--web.listen-address": ":9090",
 	})
 
 	if len(enableFeatures) > 0 {
 		args = append(args, fmt.Sprintf("--enable-feature=%s", strings.Join(enableFeatures, ",")))
 	}
+
+	if strings.Contains(strings.Join(enableFeatures, ","), "agent") {
+		args = append(args, e2e.BuildArgs(map[string]string{
+			"--storage.agent.path": f.InternalDir(),
+		})...)
+	} else {
+		args = append(args, e2e.BuildArgs(map[string]string{
+			"--storage.tsdb.path":               f.InternalDir(),
+			"--storage.tsdb.max-block-duration": "2h",
+		})...)
+	}
+
 	if len(webConfig) > 0 {
 		args = append(args, fmt.Sprintf("--web.config.file=%s", filepath.Join(f.InternalDir(), "web-config.yml")))
 		// If auth is enabled then prober would get 401 error.

--- a/test/e2e/sidecar_prom_agent_test.go
+++ b/test/e2e/sidecar_prom_agent_test.go
@@ -1,0 +1,155 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package e2e_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"path"
+	"testing"
+	"time"
+
+	"github.com/efficientgo/core/testutil"
+	"github.com/efficientgo/e2e"
+	e2edb "github.com/efficientgo/e2e/db"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/thanos-io/objstore/client"
+	"github.com/thanos-io/thanos/pkg/query"
+	"github.com/thanos-io/thanos/pkg/runutil"
+	"github.com/thanos-io/thanos/test/e2e/e2ethanos"
+)
+
+// e2e test to verify storeapi in sidecar is disabled when prometheus is running in agent mode.
+func TestSidecarInPromAgentMode(t *testing.T) {
+	t.Parallel()
+
+	e, err := e2e.NewDockerEnvironment("e2e-test-pa")
+	testutil.Ok(t, err)
+	t.Cleanup(e2ethanos.CleanScenario(t, e))
+
+	receiver := e2ethanos.NewReceiveBuilder(e, "1").WithIngestionEnabled().Init()
+	testutil.Ok(t, e2e.StartAndWaitReady(receiver))
+
+	prom1, sidecar1 := e2ethanos.NewPrometheusWithSidecar(e, "prom1", e2ethanos.DefaultPromConfig("prom-alone1", 0, "", "", e2ethanos.LocalPrometheusTarget), "", e2ethanos.DefaultPrometheusImage(), "")
+	prom2, sidecar2 := e2ethanos.NewPrometheusWithSidecar(e, "prom2-agent", e2ethanos.DefaultPromConfig("prom-both-remote-write-and-sidecar", 1234, e2ethanos.RemoteWriteEndpoint(receiver.InternalEndpoint("remote-write")), "", e2ethanos.LocalPrometheusTarget), "", e2ethanos.DefaultPrometheusImage(), "", "agent")
+	testutil.Ok(t, e2e.StartAndWaitReady(prom1, sidecar1, prom2, sidecar2))
+
+	const bucket = "info-api-test"
+	m := e2edb.NewMinio(e, "thanos-minio", bucket, e2edb.WithMinioTLS())
+	testutil.Ok(t, e2e.StartAndWaitReady(m))
+	store := e2ethanos.NewStoreGW(
+		e,
+		"1",
+		client.BucketConfig{
+			Type:   client.S3,
+			Config: e2ethanos.NewS3Config(bucket, m.InternalEndpoint("http"), m.InternalDir()),
+		},
+		"",
+		"",
+		nil,
+	)
+	testutil.Ok(t, e2e.StartAndWaitReady(store))
+
+	q := e2ethanos.NewQuerierBuilder(e, "1").
+		WithTargetAddresses(sidecar1.InternalEndpoint("grpc")).
+		WithMetadataAddresses(sidecar1.InternalEndpoint("grpc")).
+		WithEndpoints(
+			sidecar1.InternalEndpoint("grpc"),
+			sidecar2.InternalEndpoint("grpc"),
+			store.InternalEndpoint("grpc"),
+		).
+		Init()
+	testutil.Ok(t, e2e.StartAndWaitReady(q))
+
+	expected := map[string][]query.EndpointStatus{
+		"sidecar": {
+			{
+				Name: "e2e-test-pa-sidecar-prom1:9091",
+				LabelSets: []labels.Labels{{
+					{
+						Name:  "prometheus",
+						Value: "prom-alone1",
+					},
+					{
+						Name:  "replica",
+						Value: "0",
+					},
+				}},
+			},
+			{
+				Name:      "e2e-test-pa-sidecar-prom2-agent:9091",
+				LabelSets: []labels.Labels{},
+			},
+		},
+		"store": {
+			{
+				Name:      "e2e-test-pa-store-gw-1:9091",
+				LabelSets: []labels.Labels{},
+			},
+		},
+	}
+
+	url := "http://" + path.Join(q.Endpoint("http"), "/api/v1/stores")
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+	defer cancel()
+
+	err = runutil.Retry(time.Second, ctx.Done(), func() error {
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+		if err != nil {
+			return err
+		}
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return err
+		}
+
+		body, err := io.ReadAll(resp.Body)
+		defer runutil.CloseWithErrCapture(&err, resp.Body, "response body close")
+
+		var res struct {
+			Data map[string][]query.EndpointStatus `json:"data"`
+		}
+
+		err = json.Unmarshal(body, &res)
+		if err != nil {
+			return err
+		}
+
+		if err = assertPromAgentStoreStatus(t, "sidecar", res.Data, expected); err != nil {
+			return err
+		}
+
+		if err = assertPromAgentStoreStatus(t, "store", res.Data, expected); err != nil {
+			return err
+		}
+
+		return nil
+	})
+	testutil.Ok(t, err)
+}
+
+func assertPromAgentStoreStatus(t *testing.T, component string, res map[string][]query.EndpointStatus, expected map[string][]query.EndpointStatus) error {
+	t.Helper()
+
+	if len(res[component]) != len(expected[component]) {
+		return fmt.Errorf("expected %d %s, got: %d", len(expected[component]), component, len(res[component]))
+	}
+
+	for i, v := range res[component] {
+		// Set value of the fields which keep changing in every test run to their default value.
+		v.MaxTime = 0
+		v.MinTime = 0
+		v.LastCheck = time.Time{}
+
+		testutil.Equals(t, expected[component][i], v)
+	}
+
+	return nil
+}


### PR DESCRIPTION

When Prometheus runs in Agent mode, Store API in sidecar is disabled and will provide only target info. 
https://github.com/thanos-io/thanos/issues/6606


<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
