### PR TITLE
StoreGateway: Add a metric to track block load duration

### DIFF
--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -122,6 +122,7 @@ type bucketStoreMetrics struct {
 	lastLoadedBlock       prometheus.Gauge
 	blockDrops            prometheus.Counter
 	blockDropFailures     prometheus.Counter
+	blockLoadDuration     prometheus.Histogram
 	seriesDataTouched     *prometheus.HistogramVec
 	seriesDataFetched     *prometheus.HistogramVec
 	seriesDataSizeTouched *prometheus.HistogramVec
@@ -178,6 +179,11 @@ func newBucketStoreMetrics(reg prometheus.Registerer) *bucketStoreMetrics {
 	m.lastLoadedBlock = promauto.With(reg).NewGauge(prometheus.GaugeOpts{
 		Name: "thanos_bucket_store_blocks_last_loaded_timestamp_seconds",
 		Help: "Timestamp when last block got loaded.",
+	})
+	m.blockLoadDuration = promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
+		Name: "thanos_bucket_store_block_load_duration_seconds",
+		Help: "The total time taken to load a block in seconds.",
+		Buckets: []float64{0.1, 0.5, 1, 10, 20, 30, 60, 120},
 	})
 
 	m.seriesDataTouched = promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
@@ -709,6 +715,7 @@ func (s *BucketStore) addBlock(ctx context.Context, meta *metadata.Meta) (err er
 			level.Warn(s.logger).Log("msg", "loading block failed", "elapsed", time.Since(start), "id", meta.ULID, "err", err)
 		} else {
 			level.Info(s.logger).Log("msg", "loaded new block", "elapsed", time.Since(start), "id", meta.ULID)
+			s.metrics.blockLoadDuration.Observe(time.Since(start).Seconds())
 		}
 	}()
 	s.metrics.blockLoads.Inc()

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -181,8 +181,8 @@ func newBucketStoreMetrics(reg prometheus.Registerer) *bucketStoreMetrics {
 		Help: "Timestamp when last block got loaded.",
 	})
 	m.blockLoadDuration = promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
-		Name: "thanos_bucket_store_block_load_duration_seconds",
-		Help: "The total time taken to load a block in seconds.",
+		Name:    "thanos_bucket_store_block_load_duration_seconds",
+		Help:    "The total time taken to load a block in seconds.",
 		Buckets: []float64{0.1, 0.5, 1, 10, 20, 30, 60, 120},
 	})
 


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [X] Change is not relevant to the end user.

## Changes
- Add a new histogram to track the store-gateway block sync duration.

## Verification

<!-- How you tested it? How do you know it works? -->
