### PR TITLE
Don't allocate new labels if no extend labels when merging

### DIFF
--- a/pkg/store/labelpb/label.go
+++ b/pkg/store/labelpb/label.go
@@ -293,6 +293,9 @@ func (m *ZLabel) Compare(other ZLabel) int {
 // In case of existing labels already present in given label set, it will be overwritten by external one.
 // NOTE: Labels and extend has to be sorted.
 func ExtendSortedLabels(lset, extend labels.Labels) labels.Labels {
+	if len(extend) == 0 {
+		return lset
+	}
 	ret := make(labels.Labels, 0, len(lset)+len(extend))
 
 	// Inject external labels in place.

--- a/pkg/store/labelpb/label_test.go
+++ b/pkg/store/labelpb/label_test.go
@@ -63,6 +63,9 @@ func TestExtendLabels(t *testing.T) {
 	testutil.Equals(t, labels.Labels{{Name: "a", Value: "1"}, {Name: "replica", Value: "01"}, {Name: "xb", Value: "2"}},
 		ExtendSortedLabels(labels.Labels{{Name: "a", Value: "1"}, {Name: "replica", Value: "NOT01"}, {Name: "xb", Value: "2"}}, labels.FromStrings("replica", "01")))
 
+	testutil.Equals(t, labels.Labels{{Name: "a", Value: "1"}, {Name: "xb", Value: "2"}},
+		ExtendSortedLabels(labels.Labels{{Name: "a", Value: "1"}, {Name: "xb", Value: "2"}}, labels.EmptyLabels()))
+
 	testInjectExtLabels(testutil.NewTB(t))
 }
 


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

<img width="1507" alt="image" src="https://github.com/thanos-io/thanos/assets/25150124/5ff7fa61-ba25-47da-bd42-254593f3e485">

We are seeing `labelpb.ExtendedSortedLabels` function taking 0.98 GB in heap, which is 18% of the whole heap usage.
In Cortex use case, `extend` will be always empty so it is unnecessary to allocate this memory in heap.

## Changes

In `ExtendSortedLabels` function, if no extend labels, we don't have to allocate and copy new existing labels. Can just return the original labels.

## Verification

<!-- How you tested it? How do you know it works? -->
