### PR TITLE
BinaryIndexReader: always lookup name symbol first

### DIFF
--- a/pkg/block/indexheader/binary_reader.go
+++ b/pkg/block/indexheader/binary_reader.go
@@ -505,7 +505,8 @@ type BinaryReader struct {
 	postingsV1 map[string]map[string]index.Range
 
 	// Symbols struct that keeps only 1/postingOffsetsInMemSampling in the memory, then looks up the rest via mmap.
-	symbols *index.Symbols
+	// Use Symbols as interface for ease of testing.
+	symbols Symbols
 	// Cache of the label name symbol lookups,
 	// as there are not many and they are half of all lookups.
 	nameSymbols map[uint32]string
@@ -925,14 +926,14 @@ func (r *BinaryReader) postingsOffset(name string, values ...string) ([]index.Ra
 }
 
 func (r *BinaryReader) LookupSymbol(o uint32) (string, error) {
-	if s, ok := r.nameSymbols[o]; ok {
-		return s, nil
-	}
-
 	if r.indexVersion == index.FormatV1 {
 		// For v1 little trick is needed. Refs are actual offset inside index, not index-header. This is different
 		// of the header length difference between two files.
 		o += headerLen - index.HeaderLen
+	}
+
+	if s, ok := r.nameSymbols[o]; ok {
+		return s, nil
 	}
 
 	cacheIndex := o % valueSymbolsCacheSize
@@ -1046,4 +1047,9 @@ func (b realByteSlice) Range(start, end int) []byte {
 
 func (b realByteSlice) Sub(start, end int) index.ByteSlice {
 	return b[start:end]
+}
+
+type Symbols interface {
+	Lookup(o uint32) (string, error)
+	ReverseLookup(sym string) (uint32, error)
 }


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

Fixes https://github.com/thanos-io/thanos/issues/6739

## Changes

Symbol look up requests have 50% for names and 50% for values. If it is a name lookup, we should definitely look up the `nameSymbols` map first as it is much faster. No lock contention at all.

In current implementation, we are trying to check whether it is a value or not first, this requires locking and is very expensive. With this change, I expect we have less lock contention and should help #6739 a lot.

## Verification

<!-- How you tested it? How do you know it works? -->

Tests should still pass
