### PR TITLE
Add latency histogram for fetching index cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 
 - [#6605](https://github.com/thanos-io/thanos/pull/6605) Query Frontend: Support vertical sharding binary expression with metric name when no matching labels specified.
 - [#6308](https://github.com/thanos-io/thanos/pull/6308) Ruler: Support configuration flag that allows customizing template for alert message.
+- [#6749](https://github.com/thanos-io/thanos/pull/6308) Store Gateway: Added `thanos_store_index_cache_fetch_duration_seconds` histogram for tracking latency of fetching data from index cache. 
 
 ### Changed
 

--- a/pkg/store/cache/cache.go
+++ b/pkg/store/cache/cache.go
@@ -61,6 +61,7 @@ type commonMetrics struct {
 	requestTotal  *prometheus.CounterVec
 	hitsTotal     *prometheus.CounterVec
 	dataSizeBytes *prometheus.HistogramVec
+	fetchLatency  *prometheus.HistogramVec
 }
 
 func newCommonMetrics(reg prometheus.Registerer) *commonMetrics {
@@ -79,6 +80,11 @@ func newCommonMetrics(reg prometheus.Registerer) *commonMetrics {
 			Buckets: []float64{
 				32, 256, 512, 1024, 32 * 1024, 256 * 1024, 512 * 1024, 1024 * 1024, 32 * 1024 * 1024, 64 * 1024 * 1024, 128 * 1024 * 1024, 256 * 1024 * 1024, 512 * 1024 * 1024,
 			},
+		}, []string{"item_type"}),
+		fetchLatency: promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "thanos_store_index_cache_fetch_duration_seconds",
+			Help:    "Histogram to track latency to fetch items from index cache",
+			Buckets: []float64{0.01, 0.1, 0.3, 0.6, 1, 3, 6, 10, 15, 20, 30, 45, 60, 90, 120},
 		}, []string{"item_type"}),
 	}
 }

--- a/pkg/store/cache/inmemory.go
+++ b/pkg/store/cache/inmemory.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"reflect"
 	"sync"
-	"time"
 	"unsafe"
 
 	"github.com/go-kit/log"
@@ -303,8 +302,8 @@ func (c *InMemoryIndexCache) StorePostings(blockID ulid.ULID, l labels.Label, v 
 // FetchMultiPostings fetches multiple postings - each identified by a label -
 // and returns a map containing cache hits, along with a list of missing keys.
 func (c *InMemoryIndexCache) FetchMultiPostings(_ context.Context, blockID ulid.ULID, keys []labels.Label) (hits map[labels.Label][]byte, misses []labels.Label) {
-	begin := time.Now()
-	defer c.commonMetrics.fetchLatency.WithLabelValues(cacheTypePostings).Observe(float64(time.Since(begin)))
+	timer := prometheus.NewTimer(c.commonMetrics.fetchLatency.WithLabelValues(cacheTypePostings))
+	defer timer.ObserveDuration()
 
 	hits = map[labels.Label][]byte{}
 
@@ -329,8 +328,8 @@ func (c *InMemoryIndexCache) StoreExpandedPostings(blockID ulid.ULID, matchers [
 
 // FetchExpandedPostings fetches expanded postings and returns cached data and a boolean value representing whether it is a cache hit or not.
 func (c *InMemoryIndexCache) FetchExpandedPostings(_ context.Context, blockID ulid.ULID, matchers []*labels.Matcher) ([]byte, bool) {
-	begin := time.Now()
-	defer c.commonMetrics.fetchLatency.WithLabelValues(cacheTypeExpandedPostings).Observe(float64(time.Since(begin)))
+	timer := prometheus.NewTimer(c.commonMetrics.fetchLatency.WithLabelValues(cacheTypeExpandedPostings))
+	defer timer.ObserveDuration()
 
 	if b, ok := c.get(cacheTypeExpandedPostings, cacheKey{blockID.String(), cacheKeyExpandedPostings(labelMatchersToString(matchers)), ""}); ok {
 		return b, true
@@ -348,8 +347,8 @@ func (c *InMemoryIndexCache) StoreSeries(blockID ulid.ULID, id storage.SeriesRef
 // FetchMultiSeries fetches multiple series - each identified by ID - from the cache
 // and returns a map containing cache hits, along with a list of missing IDs.
 func (c *InMemoryIndexCache) FetchMultiSeries(_ context.Context, blockID ulid.ULID, ids []storage.SeriesRef) (hits map[storage.SeriesRef][]byte, misses []storage.SeriesRef) {
-	begin := time.Now()
-	defer c.commonMetrics.fetchLatency.WithLabelValues(cacheTypeSeries).Observe(float64(time.Since(begin)))
+	timer := prometheus.NewTimer(c.commonMetrics.fetchLatency.WithLabelValues(cacheTypeSeries))
+	defer timer.ObserveDuration()
 
 	hits = map[storage.SeriesRef][]byte{}
 

--- a/pkg/store/cache/memcached.go
+++ b/pkg/store/cache/memcached.go
@@ -33,15 +33,18 @@ type RemoteIndexCache struct {
 	compressionScheme string
 
 	// Metrics.
-	postingRequests              prometheus.Counter
-	seriesRequests               prometheus.Counter
-	expandedPostingRequests      prometheus.Counter
-	postingHits                  prometheus.Counter
-	seriesHits                   prometheus.Counter
-	expandedPostingHits          prometheus.Counter
-	postingDataSizeBytes         prometheus.Observer
-	expandedPostingDataSizeBytes prometheus.Observer
-	seriesDataSizeBytes          prometheus.Observer
+	postingRequests               prometheus.Counter
+	seriesRequests                prometheus.Counter
+	expandedPostingRequests       prometheus.Counter
+	postingHits                   prometheus.Counter
+	seriesHits                    prometheus.Counter
+	expandedPostingHits           prometheus.Counter
+	postingDataSizeBytes          prometheus.Observer
+	expandedPostingDataSizeBytes  prometheus.Observer
+	seriesDataSizeBytes           prometheus.Observer
+	postingsFetchDuration         prometheus.Observer
+	expandedPostingsFetchDuration prometheus.Observer
+	seriesFetchDuration           prometheus.Observer
 }
 
 // NewRemoteIndexCache makes a new RemoteIndexCache.
@@ -68,6 +71,10 @@ func NewRemoteIndexCache(logger log.Logger, cacheClient cacheutil.RemoteCacheCli
 	c.seriesDataSizeBytes = commonMetrics.dataSizeBytes.WithLabelValues(cacheTypeSeries)
 	c.expandedPostingDataSizeBytes = commonMetrics.dataSizeBytes.WithLabelValues(cacheTypeExpandedPostings)
 
+	c.postingsFetchDuration = commonMetrics.fetchLatency.WithLabelValues(cacheTypePostings)
+	c.seriesFetchDuration = commonMetrics.fetchLatency.WithLabelValues(cacheTypeSeries)
+	c.expandedPostingsFetchDuration = commonMetrics.fetchLatency.WithLabelValues(cacheTypeExpandedPostings)
+
 	level.Info(logger).Log("msg", "created index cache")
 
 	return c, nil
@@ -88,6 +95,9 @@ func (c *RemoteIndexCache) StorePostings(blockID ulid.ULID, l labels.Label, v []
 // and returns a map containing cache hits, along with a list of missing keys.
 // In case of error, it logs and return an empty cache hits map.
 func (c *RemoteIndexCache) FetchMultiPostings(ctx context.Context, blockID ulid.ULID, lbls []labels.Label) (hits map[labels.Label][]byte, misses []labels.Label) {
+	begin := time.Now()
+	defer c.postingsFetchDuration.Observe(float64(time.Since(begin)))
+
 	keys := make([]string, 0, len(lbls))
 
 	blockIDKey := blockID.String()
@@ -138,6 +148,9 @@ func (c *RemoteIndexCache) StoreExpandedPostings(blockID ulid.ULID, keys []*labe
 // and returns a map containing cache hits, along with a list of missing keys.
 // In case of error, it logs and return an empty cache hits map.
 func (c *RemoteIndexCache) FetchExpandedPostings(ctx context.Context, blockID ulid.ULID, lbls []*labels.Matcher) ([]byte, bool) {
+	begin := time.Now()
+	defer c.postingsFetchDuration.Observe(float64(time.Since(begin)))
+
 	key := cacheKey{blockID.String(), cacheKeyExpandedPostings(labelMatchersToString(lbls)), c.compressionScheme}.string()
 
 	// Fetch the keys from memcached in a single request.
@@ -169,6 +182,9 @@ func (c *RemoteIndexCache) StoreSeries(blockID ulid.ULID, id storage.SeriesRef, 
 // and returns a map containing cache hits, along with a list of missing IDs.
 // In case of error, it logs and return an empty cache hits map.
 func (c *RemoteIndexCache) FetchMultiSeries(ctx context.Context, blockID ulid.ULID, ids []storage.SeriesRef) (hits map[storage.SeriesRef][]byte, misses []storage.SeriesRef) {
+	begin := time.Now()
+	defer c.seriesFetchDuration.Observe(float64(time.Since(begin)))
+
 	keys := make([]string, 0, len(ids))
 
 	blockIDKey := blockID.String()

--- a/pkg/store/cache/memcached.go
+++ b/pkg/store/cache/memcached.go
@@ -95,8 +95,8 @@ func (c *RemoteIndexCache) StorePostings(blockID ulid.ULID, l labels.Label, v []
 // and returns a map containing cache hits, along with a list of missing keys.
 // In case of error, it logs and return an empty cache hits map.
 func (c *RemoteIndexCache) FetchMultiPostings(ctx context.Context, blockID ulid.ULID, lbls []labels.Label) (hits map[labels.Label][]byte, misses []labels.Label) {
-	begin := time.Now()
-	defer c.postingsFetchDuration.Observe(float64(time.Since(begin)))
+	timer := prometheus.NewTimer(c.postingsFetchDuration)
+	defer timer.ObserveDuration()
 
 	keys := make([]string, 0, len(lbls))
 
@@ -148,8 +148,8 @@ func (c *RemoteIndexCache) StoreExpandedPostings(blockID ulid.ULID, keys []*labe
 // and returns a map containing cache hits, along with a list of missing keys.
 // In case of error, it logs and return an empty cache hits map.
 func (c *RemoteIndexCache) FetchExpandedPostings(ctx context.Context, blockID ulid.ULID, lbls []*labels.Matcher) ([]byte, bool) {
-	begin := time.Now()
-	defer c.postingsFetchDuration.Observe(float64(time.Since(begin)))
+	timer := prometheus.NewTimer(c.postingsFetchDuration)
+	defer timer.ObserveDuration()
 
 	key := cacheKey{blockID.String(), cacheKeyExpandedPostings(labelMatchersToString(lbls)), c.compressionScheme}.string()
 
@@ -182,8 +182,8 @@ func (c *RemoteIndexCache) StoreSeries(blockID ulid.ULID, id storage.SeriesRef, 
 // and returns a map containing cache hits, along with a list of missing IDs.
 // In case of error, it logs and return an empty cache hits map.
 func (c *RemoteIndexCache) FetchMultiSeries(ctx context.Context, blockID ulid.ULID, ids []storage.SeriesRef) (hits map[storage.SeriesRef][]byte, misses []storage.SeriesRef) {
-	begin := time.Now()
-	defer c.seriesFetchDuration.Observe(float64(time.Since(begin)))
+	timer := prometheus.NewTimer(c.postingsFetchDuration)
+	defer timer.ObserveDuration()
 
 	keys := make([]string, 0, len(ids))
 


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Add a new histogram `thanos_store_index_cache_fetch_duration_seconds` to record the latency of fetching data from index cache.

This is useful because now there is no metric to do that. We only have cache client specific metrics, like how long it takes to fetch from memcached: `thanos_memcached_operation_duration_seconds`.

The down side of the existing `thanos_memcached_operation_duration_seconds` metric is that it is the duration of a single get multi call only. So if there are multiple batches that histogram doesn't reflect the total time used to fetch from cache. Also it cannot differentiate fetching postings, series or expanded postings.

## Verification

<!-- How you tested it? How do you know it works? -->
