### PR TITLE
Store: Don't hardcode series batch size

### DIFF
--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -1124,7 +1124,7 @@ func (b *blockSeriesClient) Recv() (*storepb.SeriesResponse, error) {
 
 func (b *blockSeriesClient) nextBatch() error {
 	start := b.i
-	end := start + SeriesBatchSize
+	end := start + uint64(b.batchSize)
 	if end > uint64(len(b.lazyPostings.postings)) {
 		end = uint64(len(b.lazyPostings.postings))
 	}

--- a/pkg/store/bucket_test.go
+++ b/pkg/store/bucket_test.go
@@ -1659,6 +1659,7 @@ func TestBucketSeries_OneBlock_InMemIndexCacheSegfault(t *testing.T) {
 		chunksLimiterFactory: NewChunksLimiterFactory(0),
 		seriesLimiterFactory: NewSeriesLimiterFactory(0),
 		bytesLimiterFactory:  NewBytesLimiterFactory(0),
+		seriesBatchSize:      SeriesBatchSize,
 	}
 
 	t.Run("invoke series for one block. Fill the cache on the way.", func(t *testing.T) {


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

There is a flag to configure series batch size called `debug.series-batch-size`. However, in `nextBatch` code, we are still using the hardcoded batch size of 10000.

## Verification

<!-- How you tested it? How do you know it works? -->
