### PR TITLE
fix(ui): add null check to find overlapping blocks logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 
 ### Fixed
 
+- [#6768](https://github.com/thanos-io/thanos/pull/6768) UI: Add null check to find overlapping blocks logic
+
 ### Added
 
 ### Changed

--- a/pkg/ui/react-app/src/thanos/pages/blocks/helpers.test.tsx
+++ b/pkg/ui/react-app/src/thanos/pages/blocks/helpers.test.tsx
@@ -571,6 +571,9 @@ const filteredBlocks = [
         },
       ],
     },
+    '5': {
+      '1-0': [],
+    },
   },
 ];
 
@@ -588,7 +591,7 @@ describe('overlapping blocks', () => {
   });
 
   const rows = Object.values(sorted[source])[0];
-  it('has 5 rows', () => {
+  it('has 6 rows', () => {
     expect(rows).toHaveLength(5);
   });
 
@@ -610,6 +613,10 @@ describe('overlapping blocks', () => {
 
   it('renders 1 block in fifth row', () => {
     expect(rows[4]).toHaveLength(1);
+  });
+
+  it('renders 0 block in fifth row', () => {
+    expect(rows[5]).toHaveLength(0);
   });
 });
 

--- a/pkg/ui/react-app/src/thanos/pages/blocks/helpers.ts
+++ b/pkg/ui/react-app/src/thanos/pages/blocks/helpers.ts
@@ -156,7 +156,10 @@ export const getFilteredBlockPools = (
     const poolArrayIndex = blockPools[key];
     const poolArray = poolArrayIndex[Object.keys(poolArrayIndex)[0]];
     for (let i = 0; i < filteredBlocks.length; i++) {
-      if (JSON.stringify(filteredBlocks[i].thanos.labels) === JSON.stringify(poolArray[0][0].thanos.labels)) {
+      if (
+        poolArray[0][0] &&
+        JSON.stringify(filteredBlocks[i].thanos.labels) === JSON.stringify(poolArray[0][0].thanos.labels)
+      ) {
         Object.assign(newblockPools, { [key]: blockPools[key] });
         break;
       }


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

Add null check to find overlapping blocks logic to solve #5359.

## Verification

I still need a real world case to validate this changes shows overlapping blocks. 
Please have a try. An image is available at `docker.io/zadki3l/thanos:0.32-fix-overlapping-blocks`, feel free to build you own one if you prefer. 
<!-- How you tested it? How do you know it works? -->
