### PR TITLE
Remove value symbols cache

### DIFF
--- a/pkg/block/indexheader/header_test.go
+++ b/pkg/block/indexheader/header_test.go
@@ -404,7 +404,7 @@ func BenchmarkBinaryReader(t *testing.B) {
 }
 
 func BenchmarkBinaryReader_LookupSymbol(b *testing.B) {
-	for _, numSeries := range []int{valueSymbolsCacheSize, valueSymbolsCacheSize * 10} {
+	for _, numSeries := range []int{1024, 1024 * 10} {
 		b.Run(fmt.Sprintf("num series = %d", numSeries), func(b *testing.B) {
 			benchmarkBinaryReaderLookupSymbol(b, numSeries)
 		})


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

`valueSymbolsCache` is a cache in binary reader that caches value symbols in memory with a fixed size of 1024.
It is protected by a single mutex. When concurrency to SG is high and requests going to SG are touching the same block, a lot of CPU time will be spent on waiting for the lock.

`LookupLabelsSymbols` took 35% of CPU time and the actual symbol lookup took 8.5% CPU time. The rest of 26.5% is waiting for lock.

<img width="1447" alt="image" src="https://github.com/thanos-io/thanos/assets/25150124/b0310510-3371-4e20-996b-829151f349a1">


## Verification

<!-- How you tested it? How do you know it works? -->
