### PR TITLE
Fix nil pointer and data race in parallel_bucket

### DIFF
--- a/pkg/block/indexheader/parallel_bucket.go
+++ b/pkg/block/indexheader/parallel_bucket.go
@@ -67,14 +67,17 @@ func (b *parallelBucketReader) GetRange(ctx context.Context, name string, off in
 		}
 		parts = append(parts, part)
 
+		// Assign partId to another variable to avoid modifying
+		// `partId` concurrently in multiple goroutines.
+		idx := partId
 		g.Go(func() error {
 			rc, err := b.BucketReader.GetRange(gctx, name, partOff, partLength)
 			if err != nil {
-				return errors.Wrap(err, fmt.Sprintf("get range part %v", partId))
+				return errors.Wrap(err, fmt.Sprintf("get range part %v", idx))
 			}
 			defer runutil.CloseWithErrCapture(&err, rc, "close object")
 			if _, err := io.Copy(part, rc); err != nil {
-				return errors.Wrap(err, fmt.Sprintf("get range part %v", partId))
+				return errors.Wrap(err, fmt.Sprintf("get range part %v", idx))
 			}
 			return part.Flush()
 		})


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

```
==================
WARNING: DATA RACE
Read at 0x00c00161f2b8 by goroutine 41154:
  github.com/thanos-io/thanos/pkg/block/indexheader.(*parallelBucketReader).GetRange.func1()
      /__w/cortex/cortex/vendor/github.com/thanos-io/thanos/pkg/block/indexheader/parallel_bucket.go:73 +0x324
  golang.org/x/sync/errgroup.(*Group).Go.func1()
      /__w/cortex/cortex/vendor/golang.org/x/sync/errgroup/errgroup.go:75 +0x82

Previous write at 0x00c00161f2b8 by goroutine 41066:
  github.com/thanos-io/thanos/pkg/block/indexheader.(*parallelBucketReader).GetRange()
      /__w/cortex/cortex/vendor/github.com/thanos-io/thanos/pkg/block/indexheader/parallel_bucket.go:80 +0x25c
  github.com/thanos-io/thanos/pkg/block/indexheader.(*chunkedIndexReader).CopySymbols()
      /__w/cortex/cortex/vendor/github.com/thanos-io/thanos/pkg/block/indexheader/binary_reader.go:220 +0x1d4
  github.com/thanos-io/thanos/pkg/block/indexheader.WriteBinary()
      /__w/cortex/cortex/vendor/github.com/thanos-io/thanos/pkg/block/indexheader/binary_reader.go:104 +0x404
  github.com/thanos-io/thanos/pkg/block/indexheader.NewBinaryReader()
      /__w/cortex/cortex/vendor/github.com/thanos-io/thanos/pkg/block/indexheader/binary_reader.go:546 +0x506
  github.com/thanos-io/thanos/pkg/block/indexheader.(*ReaderPool).NewBinaryReader()
      /__w/cortex/cortex/vendor/github.com/thanos-io/thanos/pkg/block/indexheader/reader_pool.go:89 +0x21a
  github.com/thanos-io/thanos/pkg/store.(*BucketStore).addBlock()
      /__w/cortex/cortex/vendor/github.com/thanos-io/thanos/pkg/store/bucket.go:744 +0x747
  github.com/thanos-io/thanos/pkg/store.(*BucketStore).SyncBlocks.func1()
      /__w/cortex/cortex/vendor/github.com/thanos-io/thanos/pkg/store/bucket.go:621 +0x7b

Goroutine 41154 (running) created at:
  golang.org/x/sync/errgroup.(*Group).Go()
      /__w/cortex/cortex/vendor/golang.org/x/sync/errgroup/errgroup.go:72 +0x12e
  github.com/thanos-io/thanos/pkg/block/indexheader.(*parallelBucketReader).GetRange()
      /__w/cortex/cortex/vendor/github.com/thanos-io/thanos/pkg/block/indexheader/parallel_bucket.go:69 +0x236
  github.com/thanos-io/thanos/pkg/block/indexheader.(*chunkedIndexReader).CopySymbols()
      /__w/cortex/cortex/vendor/github.com/thanos-io/thanos/pkg/block/indexheader/binary_reader.go:220 +0x1d4
  github.com/thanos-io/thanos/pkg/block/indexheader.WriteBinary()
      /__w/cortex/cortex/vendor/github.com/thanos-io/thanos/pkg/block/indexheader/binary_reader.go:104 +0x404
  github.com/thanos-io/thanos/pkg/block/indexheader.NewBinaryReader()
      /__w/cortex/cortex/vendor/github.com/thanos-io/thanos/pkg/block/indexheader/binary_reader.go:546 +0x506
  github.com/thanos-io/thanos/pkg/block/indexheader.(*ReaderPool).NewBinaryReader()
      /__w/cortex/cortex/vendor/github.com/thanos-io/thanos/pkg/block/indexheader/reader_pool.go:89 +0x21a
  github.com/thanos-io/thanos/pkg/store.(*BucketStore).addBlock()
      /__w/cortex/cortex/vendor/github.com/thanos-io/thanos/pkg/store/bucket.go:744 +0x747
  github.com/thanos-io/thanos/pkg/store.(*BucketStore).SyncBlocks.func1()
      /__w/cortex/cortex/vendor/github.com/thanos-io/thanos/pkg/store/bucket.go:621 +0x7b

Goroutine 41066 (running) created at:
  github.com/thanos-io/thanos/pkg/store.(*BucketStore).SyncBlocks()
      /__w/cortex/cortex/vendor/github.com/thanos-io/thanos/pkg/store/bucket.go:619 +0x126
  github.com/cortexproject/cortex/pkg/storegateway.(*BucketStores).SyncBlocks.func1()
      /__w/cortex/cortex/pkg/storegateway/bucket_stores.go:171 +0x44
  github.com/cortexproject/cortex/pkg/storegateway.(*BucketStores).syncUsersBlocks.func2()
      /__w/cortex/cortex/pkg/storegateway/bucket_stores.go:242 +0x17c
==================
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0xba8a07]

goroutine 4[112](https://github.com/cortexproject/cortex/actions/runs/6443194007/job/17494849155?pr=5593#step:6:113)9 [running]:
github.com/thanos-io/thanos/pkg/runutil.CloseWithErrCapture(0xc00104dee8, {0x0, 0x0}, {0x27d1e4b, 0xc}, {0x0, 0x0, 0x0})
	/__w/cortex/cortex/vendor/github.com/thanos-io/thanos/pkg/runutil/runutil.go:[144](https://github.com/cortexproject/cortex/actions/runs/6443194007/job/17494849155?pr=5593#step:6:145) +0x307
github.com/thanos-io/thanos/pkg/block/indexheader.(*parallelBucketReader).GetRange.func1()
	/__w/cortex/cortex/vendor/github.com/thanos-io/thanos/pkg/block/indexheader/parallel_bucket.go:73 +0x3a6
golang.org/x/sync/errgroup.(*Group).Go.func1()
	/__w/cortex/cortex/vendor/golang.org/x/sync/errgroup/errgroup.go:75 +0x83
created by golang.org/x/sync/errgroup.(*Group).Go
	/__w/cortex/cortex/vendor/golang.org/x/sync/errgroup/errgroup.go:72 +0x12f
FAIL	github.com/cortexproject/cortex/pkg/storegateway	215.222s
```

We saw the both data race and nil pointer error from the parallel bucket in Cortex unit test. This pr fixes the issue.

## Changes

For nil pointer error, we should only call defer `CloseWithErrCapture` after we make sure there is no error.

For data race, the error said that we are concurrently reading and modifying the `partId` variable. So I just create a new variable and avoiding modifying the new var that needs to be read in the goroutine.

## Verification

<!-- How you tested it? How do you know it works? -->
