### PR TITLE
Add dialer_timeout field to HTTP TransportConfig

### DIFF
--- a/pkg/httpconfig/http.go
+++ b/pkg/httpconfig/http.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"net"
 	"net/http"
 	"net/url"
 	"path"
@@ -125,6 +126,9 @@ func NewRoundTripperFromConfig(cfg config_util.HTTPClientConfig, transportConfig
 			ExpectContinueTimeout: time.Duration(transportConfig.ExpectContinueTimeout),
 			TLSHandshakeTimeout:   time.Duration(transportConfig.TLSHandshakeTimeout),
 			DialContext: conntrack.NewDialContextFunc(
+				conntrack.DialWithDialer(&net.Dialer{
+					Timeout: 5 * time.Second,
+				}),
 				conntrack.DialWithTracing(),
 				conntrack.DialWithName(name)),
 		}

--- a/pkg/httpconfig/http.go
+++ b/pkg/httpconfig/http.go
@@ -85,6 +85,7 @@ type TransportConfig struct {
 	MaxConnsPerHost       int   `yaml:"max_conns_per_host"`
 	DisableCompression    bool  `yaml:"disable_compression"`
 	TLSHandshakeTimeout   int64 `yaml:"tls_handshake_timeout"`
+	DialerTimeout         int64 `yaml:"dialer_timeout"`
 }
 
 var defaultTransportConfig TransportConfig = TransportConfig{
@@ -96,6 +97,7 @@ var defaultTransportConfig TransportConfig = TransportConfig{
 	ExpectContinueTimeout: int64(10 * time.Second),
 	DisableCompression:    false,
 	TLSHandshakeTimeout:   int64(10 * time.Second),
+	DialerTimeout:         int64(5 * time.Second),
 }
 
 func NewDefaultClientConfig() ClientConfig {
@@ -127,7 +129,7 @@ func NewRoundTripperFromConfig(cfg config_util.HTTPClientConfig, transportConfig
 			TLSHandshakeTimeout:   time.Duration(transportConfig.TLSHandshakeTimeout),
 			DialContext: conntrack.NewDialContextFunc(
 				conntrack.DialWithDialer(&net.Dialer{
-					Timeout: 5 * time.Second,
+					Timeout: time.Duration(transportConfig.DialerTimeout),
 				}),
 				conntrack.DialWithTracing(),
 				conntrack.DialWithName(name)),


### PR DESCRIPTION
I found a bug where the ruler stops evaluating rules if the queriers are restarted. The panel below shows the change in the evaluation rate after a querier deploy rollout or restart (time in HH:MM).

![image](https://github.com/thanos-io/thanos/assets/24930070/d03a6e0d-6882-459d-8215-624a98c25bc3)

Investigating, the error seems to come from the ruler iterating and sending a query to all the endpoints in a dnssrv if the request fails ([here](https://github.com/thanos-io/thanos/blob/main/cmd/thanos/rule.go#L846)). If the queriers are terminated after the DNS resolution in the ruler, the iteration will last for `conn_timeout * num_of_queriers`, and probably miss evaluations.

I couldn't find if the current timeout is the [RoundTripper default](https://github.com/mwitkow/go-conntrack/blob/master/dialer_wrapper.go#L82) of 30s or the zero-value [set in NewDialContextFunc](https://github.com/mwitkow/go-conntrack/blob/master/dialer_wrapper.go#L82), which uses only the OS TCP conn timeout. In the image above, the loop took 10m to iterate and time out 5 endpoints, which is too long to mitigate by only slowing down the rollout.

This change sets an explicit dialer connection timeout of 5s, and adds an option to overwrite it in the HTTP yaml config.

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

- Add a new `dialer_timeout` field to the HTTP TransportConfig and a new default of 5s

## Verification

I tested the change by deploying a patched version, and it fixed the issue. The image below shows the difference after 2 restarts. It shows a shift in requests in flight, but now it recovers sooner, and it didn't impact the evaluation rate.

![image](https://github.com/thanos-io/thanos/assets/24930070/b36ca4d8-1db4-4dbd-a001-c5ddbdfb1fa5)

