### PR TITLE
Bucket reader: Initialize new query stats struct at each goroutine

### DIFF
--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -2382,7 +2382,6 @@ type bucketIndexReader struct {
 	dec   *index.Decoder
 	stats *queryStats
 
-	mtx             sync.Mutex
 	loadedSeriesMtx sync.Mutex
 	loadedSeries    map[storage.SeriesRef][]byte
 

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -2382,8 +2382,7 @@ type bucketIndexReader struct {
 	dec   *index.Decoder
 	stats *queryStats
 
-	mtx sync.Mutex
-	// Separate mutex to protect loadedSeries.
+	mtx             sync.Mutex
 	loadedSeriesMtx sync.Mutex
 	loadedSeries    map[storage.SeriesRef][]byte
 

--- a/pkg/store/bucket_test.go
+++ b/pkg/store/bucket_test.go
@@ -3606,6 +3606,6 @@ func TestQueryStatsMerge(t *testing.T) {
 		DataDownloadedSizeSum:              101,
 	}
 
-	output := s.merge(o)
-	testutil.Equals(t, e, output)
+	s.merge(o)
+	testutil.Equals(t, e, s)
 }


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

Instead of using a single lock and use the lock to protect access to query stats field, initialize a new query stats at the beginning of each goroutine, and finally merge the stats into the reader's stats. Then each goroutine only needs to hold lock once at the end of its goroutine.

## Verification

Existing query stats test should still pass.
