### PR TITLE
react-app/ListTree: only show symbol when analyze enabled

### DIFF
--- a/pkg/ui/react-app/src/components/ListTree.tsx
+++ b/pkg/ui/react-app/src/components/ListTree.tsx
@@ -43,7 +43,8 @@ const ListTree: React.FC<NodeProps> = ({ id, node }) => {
                   </div>
                 )}
                 <div id={id} style={{ cursor: `${node.children ? 'pointer' : 'inherit'}` }} onClick={toggle}>
-                  {node.name} · {node.executionTime}
+                  {node.name}
+                  {node.executionTime && ` · ${node.executionTime}`}
                 </div>
               </div>
             }


### PR DESCRIPTION
No need to show the symbol if analyze is disabled. It looks weird. Let's not do that.
