### PR TITLE
use larger histogram bucket for result series metric

### DIFF
--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -232,7 +232,7 @@ func newBucketStoreMetrics(reg prometheus.Registerer) *bucketStoreMetrics {
 	m.resultSeriesCount = promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
 		Name:    "thanos_bucket_store_series_result_series",
 		Help:    "Number of series observed in the final result of a query.",
-		Buckets: prometheus.ExponentialBuckets(1, 2, 15),
+		Buckets: prometheus.ExponentialBuckets(100, 2, 15), // From 100 to 1638400.
 	}, []string{tenancy.MetricLabel})
 
 	m.chunkSizeBytes = promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{


### PR DESCRIPTION

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Now, `thanos_bucket_store_series_result_series` histogram buckets has a range from 1 to 16384. The lower bound 1 is too small and sometimes not worth tracking. The upper bound is also small for our usecase. We have seen a single request fetching more than 1M series for a single block.

This pr changes the buckets range from to [100, 1.6M], which can be sufficiently in most of the cases.

## Verification

<!-- How you tested it? How do you know it works? -->
