### PR TITLE
Replace inmemory cache with ristretto

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -118,6 +118,7 @@ require (
 
 require (
 	github.com/onsi/gomega v1.27.10
+	github.com/outcaste-io/ristretto v0.2.3
 	go.opentelemetry.io/contrib/propagators/autoprop v0.38.0
 	go4.org/intern v0.0.0-20230525184215-6c62f75575cb
 	golang.org/x/exp v0.0.0-20230801115018-d63ba01acd4b

--- a/go.sum
+++ b/go.sum
@@ -223,6 +223,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8Yc
 github.com/dennwc/varint v1.0.0 h1:kGNFFSSw8ToIy3obO/kKr8U9GZYUAxQEVuix4zfDWzE=
 github.com/dennwc/varint v1.0.0/go.mod h1:hnItb35rvZvJrbTALZtY/iQfDs48JKRG1RPpgziApxA=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
+github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2 h1:tdlZCpZ/P9DhczCTSixgIKmwPv6+wP5DGjqLYw5SUiA=
+github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/digitalocean/godo v1.99.0 h1:gUHO7n9bDaZFWvbzOum4bXE0/09ZuYA9yA8idQHX57E=
 github.com/dnaeon/go-vcr v1.2.0 h1:zHCHvJYTMh1N7xnV7zf1m1GPBF9Ad0Jk/whtQ1663qI=
 github.com/docker/distribution v2.8.2+incompatible h1:T3de5rq0dB1j30rp0sA2rER+m322EBzniBPB6ZIzuh8=
@@ -230,6 +232,7 @@ github.com/docker/docker v24.0.4+incompatible h1:s/LVDftw9hjblvqIeTiGYXBCD95nOEE
 github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKohAFqRJQ=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
+github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
@@ -757,6 +760,8 @@ github.com/openzipkin/zipkin-go v0.2.2/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnh
 github.com/oracle/oci-go-sdk/v65 v65.41.1 h1:+lbosOyNiib3TGJDvLq1HwEAuFqkOjPJDIkyxM15WdQ=
 github.com/oracle/oci-go-sdk/v65 v65.41.1/go.mod h1:MXMLMzHnnd9wlpgadPkdlkZ9YrwQmCOmbX5kjVEJodw=
 github.com/orisano/pixelmatch v0.0.0-20210112091706-4fa4c7ba91d5 h1:1SoBaSPudixRecmlHXb/GxmaD3fLMtHIDN13QujwQuc=
+github.com/outcaste-io/ristretto v0.2.3 h1:AK4zt/fJ76kjlYObOeNwh4T3asEuaCmp26pOvUOL9w0=
+github.com/outcaste-io/ristretto v0.2.3/go.mod h1:W8HywhmtlopSB1jeMg3JtdIhf+DYkLAr0VN/s4+MHac=
 github.com/ovh/go-ovh v1.4.1 h1:VBGa5wMyQtTP7Zb+w97zRCh9sLtM/2YKRyy+MEJmWaM=
 github.com/pact-foundation/pact-go v1.0.4/go.mod h1:uExwJY4kCzNPcHRj+hCR/HBbOOIwwtUjcrb0b5/5kLM=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
@@ -1021,6 +1026,7 @@ go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.5.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
 go.uber.org/atomic v1.5.1/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
+go.uber.org/atomic v1.9.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
 go.uber.org/atomic v1.11.0 h1:ZvwS0R+56ePWxUNi+Atn9dWONBPp/AUETXlHW0DxSjE=
 go.uber.org/atomic v1.11.0/go.mod h1:LUxbIzbOniOlMKjJjyPfpl4v+PKK2cNJn91OQbhoJI0=
 go.uber.org/automaxprocs v1.5.2 h1:2LxUOGiR3O6tw8ui5sZa2LAaHnsviZdVOUZw4fvbnME=
@@ -1282,6 +1288,7 @@ golang.org/x/sys v0.0.0-20220502124256-b6088ccd6cba/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220610221304-9f5ed59c137d/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220627191245-f75cf1eec38b/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/pkg/store/bucket_test.go
+++ b/pkg/store/bucket_test.go
@@ -1849,7 +1849,7 @@ func TestSeries_ErrorUnmarshallingRequestHints(t *testing.T) {
 	fetcher, err := block.NewMetaFetcher(logger, 10, instrBkt, tmpDir, nil, nil)
 	testutil.Ok(tb, err)
 
-	indexCache, err := storecache.NewInMemoryIndexCacheWithConfig(logger, nil, nil, storecache.InMemoryIndexCacheConfig{})
+	indexCache, err := storecache.NewInMemoryIndexCacheWithConfig(logger, nil, nil, storecache.DefaultInMemoryIndexCacheConfig)
 	testutil.Ok(tb, err)
 
 	store, err := NewBucketStore(
@@ -1940,7 +1940,7 @@ func TestSeries_BlockWithMultipleChunks(t *testing.T) {
 	fetcher, err := block.NewMetaFetcher(logger, 10, instrBkt, tmpDir, nil, nil)
 	testutil.Ok(tb, err)
 
-	indexCache, err := storecache.NewInMemoryIndexCacheWithConfig(logger, nil, nil, storecache.InMemoryIndexCacheConfig{})
+	indexCache, err := storecache.NewInMemoryIndexCacheWithConfig(logger, nil, nil, storecache.DefaultInMemoryIndexCacheConfig)
 	testutil.Ok(tb, err)
 
 	store, err := NewBucketStore(
@@ -2098,7 +2098,7 @@ func TestSeries_SeriesSortedWithoutReplicaLabels(t *testing.T) {
 			fetcher, err := block.NewMetaFetcher(logger, 10, instrBkt, tmpDir, nil, nil)
 			testutil.Ok(tb, err)
 
-			indexCache, err := storecache.NewInMemoryIndexCacheWithConfig(logger, nil, nil, storecache.InMemoryIndexCacheConfig{})
+			indexCache, err := storecache.NewInMemoryIndexCacheWithConfig(logger, nil, nil, storecache.DefaultInMemoryIndexCacheConfig)
 			testutil.Ok(tb, err)
 
 			store, err := NewBucketStore(
@@ -2284,7 +2284,7 @@ func setupStoreForHintsTest(t *testing.T) (testutil.TB, *BucketStore, []*storepb
 	fetcher, err := block.NewMetaFetcher(logger, 10, instrBkt, tmpDir, nil, nil)
 	testutil.Ok(tb, err)
 
-	indexCache, err := storecache.NewInMemoryIndexCacheWithConfig(logger, nil, nil, storecache.InMemoryIndexCacheConfig{})
+	indexCache, err := storecache.NewInMemoryIndexCacheWithConfig(logger, nil, nil, storecache.DefaultInMemoryIndexCacheConfig)
 	testutil.Ok(tb, err)
 
 	store, err := NewBucketStore(
@@ -2500,7 +2500,7 @@ func TestSeries_ChunksHaveHashRepresentation(t *testing.T) {
 	fetcher, err := block.NewMetaFetcher(logger, 10, instrBkt, tmpDir, nil, nil)
 	testutil.Ok(tb, err)
 
-	indexCache, err := storecache.NewInMemoryIndexCacheWithConfig(logger, nil, nil, storecache.InMemoryIndexCacheConfig{})
+	indexCache, err := storecache.NewInMemoryIndexCacheWithConfig(logger, nil, nil, storecache.DefaultInMemoryIndexCacheConfig)
 	testutil.Ok(tb, err)
 
 	store, err := NewBucketStore(

--- a/pkg/store/cache/cache.go
+++ b/pkg/store/cache/cache.go
@@ -25,10 +25,7 @@ const (
 	cacheTypeSeries           string = "Series"
 
 	sliceHeaderSize = 16
-)
-
-var (
-	ulidSize = uint64(len(ulid.ULID{}))
+	itemTypeSize    = 1
 )
 
 // IndexCache is the interface exported by index cache backends.
@@ -98,29 +95,16 @@ type cacheKey struct {
 	compression string
 }
 
-func (c cacheKey) keyType() string {
+func (c cacheKey) keyType() itemType {
 	switch c.key.(type) {
 	case cacheKeyPostings:
-		return cacheTypePostings
+		return itemTypePostings
 	case cacheKeySeries:
-		return cacheTypeSeries
+		return itemTypeSeries
 	case cacheKeyExpandedPostings:
-		return cacheTypeExpandedPostings
+		return itemTypeExpandedPostings
 	}
-	return "<unknown>"
-}
-
-func (c cacheKey) size() uint64 {
-	switch k := c.key.(type) {
-	case cacheKeyPostings:
-		// ULID + 2 slice headers + number of chars in value and name.
-		return ulidSize + 2*sliceHeaderSize + uint64(len(k.Value)+len(k.Name))
-	case cacheKeyExpandedPostings:
-		return ulidSize + sliceHeaderSize + uint64(len(k))
-	case cacheKeySeries:
-		return ulidSize + 8 // ULID + uint64.
-	}
-	return 0
+	return itemTypeUnknown
 }
 
 func (c cacheKey) string() string {

--- a/pkg/store/cache/filter_cache_test.go
+++ b/pkg/store/cache/filter_cache_test.go
@@ -52,6 +52,15 @@ func TestFilterCache(t *testing.T) {
 				c.StoreExpandedPostings(blockID, expandedPostingsMatchers, testExpandedPostingsData, tenancy.DefaultTenant)
 				c.StoreSeries(blockID, 1, testSeriesData, tenancy.DefaultTenant)
 
+				// Inmem index cache set method is async. Wait for set to finish in tests.
+				fic, ok := c.(*FilteredIndexCache)
+				if ok {
+					ic, ok2 := fic.cache.(*InMemoryIndexCache)
+					if ok2 {
+						ic.cache.Wait()
+					}
+				}
+
 				hits, missed := c.FetchMultiPostings(ctx, blockID, postingKeys, tenancy.DefaultTenant)
 				testutil.Equals(t, 0, len(missed))
 				testutil.Equals(t, testPostingData, hits[postingKeys[0]])
@@ -72,6 +81,15 @@ func TestFilterCache(t *testing.T) {
 				c.StorePostings(blockID, postingKeys[0], testPostingData, tenancy.DefaultTenant)
 				c.StoreExpandedPostings(blockID, expandedPostingsMatchers, testExpandedPostingsData, tenancy.DefaultTenant)
 				c.StoreSeries(blockID, 1, testSeriesData, tenancy.DefaultTenant)
+
+				// Inmem index cache set method is async. Wait for set to finish in tests.
+				fic, ok := c.(*FilteredIndexCache)
+				if ok {
+					ic, ok2 := fic.cache.(*InMemoryIndexCache)
+					if ok2 {
+						ic.cache.Wait()
+					}
+				}
 
 				hits, missed := c.FetchMultiPostings(ctx, blockID, postingKeys, tenancy.DefaultTenant)
 				testutil.Equals(t, 0, len(missed))
@@ -94,6 +112,15 @@ func TestFilterCache(t *testing.T) {
 				c.StoreExpandedPostings(blockID, expandedPostingsMatchers, testExpandedPostingsData, tenancy.DefaultTenant)
 				c.StoreSeries(blockID, 1, testSeriesData, tenancy.DefaultTenant)
 
+				// Inmem index cache set method is async. Wait for set to finish in tests.
+				fic, ok := c.(*FilteredIndexCache)
+				if ok {
+					ic, ok2 := fic.cache.(*InMemoryIndexCache)
+					if ok2 {
+						ic.cache.Wait()
+					}
+				}
+
 				hits, missed := c.FetchMultiPostings(ctx, blockID, postingKeys, tenancy.DefaultTenant)
 				testutil.Equals(t, 0, len(missed))
 				testutil.Equals(t, testPostingData, hits[postingKeys[0]])
@@ -113,6 +140,15 @@ func TestFilterCache(t *testing.T) {
 				c.StorePostings(blockID, postingKeys[0], testPostingData, tenancy.DefaultTenant)
 				c.StoreExpandedPostings(blockID, expandedPostingsMatchers, testExpandedPostingsData, tenancy.DefaultTenant)
 				c.StoreSeries(blockID, 1, testSeriesData, tenancy.DefaultTenant)
+
+				// Inmem index cache set method is async. Wait for set to finish in tests.
+				fic, ok := c.(*FilteredIndexCache)
+				if ok {
+					ic, ok2 := fic.cache.(*InMemoryIndexCache)
+					if ok2 {
+						ic.cache.Wait()
+					}
+				}
 
 				hits, missed := c.FetchMultiPostings(ctx, blockID, postingKeys, tenancy.DefaultTenant)
 				testutil.Equals(t, 1, len(missed))
@@ -134,6 +170,15 @@ func TestFilterCache(t *testing.T) {
 				c.StorePostings(blockID, postingKeys[0], testPostingData, tenancy.DefaultTenant)
 				c.StoreExpandedPostings(blockID, expandedPostingsMatchers, testExpandedPostingsData, tenancy.DefaultTenant)
 				c.StoreSeries(blockID, 1, testSeriesData, tenancy.DefaultTenant)
+
+				// Inmem index cache set method is async. Wait for set to finish in tests.
+				fic, ok := c.(*FilteredIndexCache)
+				if ok {
+					ic, ok2 := fic.cache.(*InMemoryIndexCache)
+					if ok2 {
+						ic.cache.Wait()
+					}
+				}
 
 				hits, missed := c.FetchMultiPostings(ctx, blockID, postingKeys, tenancy.DefaultTenant)
 				testutil.Equals(t, 1, len(missed))

--- a/pkg/store/cache/inmemory_test.go
+++ b/pkg/store/cache/inmemory_test.go
@@ -8,18 +8,15 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"math"
 	"testing"
 
+	"github.com/efficientgo/core/testutil"
 	"github.com/go-kit/log"
-	"github.com/hashicorp/golang-lru/simplelru"
 	"github.com/oklog/ulid"
 	"github.com/prometheus/client_golang/prometheus"
 	promtest "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
-
-	"github.com/efficientgo/core/testutil"
 
 	"github.com/thanos-io/thanos/pkg/tenancy"
 )
@@ -57,46 +54,10 @@ max_item_size: 1MB
 	cache, err = NewInMemoryIndexCache(log.NewNopLogger(), nil, nil, conf)
 	testutil.NotOk(t, err)
 	testutil.Equals(t, (*InMemoryIndexCache)(nil), cache)
-	// testutil.Equals(t, uint64(1024*1024), cache.maxSizeBytes)
-	// testutil.Equals(t, uint64(2*1024), cache.maxItemSizeBytes)
-
-	// testutil.Equals(t, uint64(1024*1024), cache.maxItemSizeBytes)
-	// testutil.Equals(t, uint64(2*1024), cache.maxSizeBytes)
-}
-
-func TestInMemoryIndexCache_AvoidsDeadlock(t *testing.T) {
-	metrics := prometheus.NewRegistry()
-	cache, err := NewInMemoryIndexCacheWithConfig(log.NewNopLogger(), nil, metrics, InMemoryIndexCacheConfig{
-		MaxItemSize: sliceHeaderSize + 5,
-		MaxSize:     sliceHeaderSize + 5,
-	})
-	testutil.Ok(t, err)
-
-	l, err := simplelru.NewLRU(math.MaxInt64, func(key, val interface{}) {
-		// Hack LRU to simulate broken accounting: evictions do not reduce current size.
-		size := cache.curSize
-		cache.onEvict(key, val)
-		cache.curSize = size
-	})
-	testutil.Ok(t, err)
-	cache.lru = l
-
-	cache.StorePostings(ulid.MustNew(0, nil), labels.Label{Name: "test2", Value: "1"}, []byte{42, 33, 14, 67, 11}, tenancy.DefaultTenant)
-
-	testutil.Equals(t, uint64(sliceHeaderSize+5), cache.curSize)
-	testutil.Equals(t, float64(cache.curSize), promtest.ToFloat64(cache.currentSize.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.current.WithLabelValues(cacheTypePostings)))
-
-	// This triggers deadlock logic.
-	cache.StorePostings(ulid.MustNew(0, nil), labels.Label{Name: "test1", Value: "1"}, []byte{42}, tenancy.DefaultTenant)
-
-	testutil.Equals(t, uint64(sliceHeaderSize+1), cache.curSize)
-	testutil.Equals(t, float64(cache.curSize), promtest.ToFloat64(cache.currentSize.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.current.WithLabelValues(cacheTypePostings)))
 }
 
 func TestInMemoryIndexCache_UpdateItem(t *testing.T) {
-	const maxSize = 2 * (sliceHeaderSize + 1)
+	maxSize := DefaultInMemoryIndexCacheConfig.MaxItemSize
 
 	var errorLogs []string
 	errorLogger := log.LoggerFunc(func(kvs ...interface{}) error {
@@ -134,7 +95,11 @@ func TestInMemoryIndexCache_UpdateItem(t *testing.T) {
 	}{
 		{
 			typ: cacheTypePostings,
-			set: func(id storage.SeriesRef, b []byte) { cache.StorePostings(uid(id), lbl, b, tenancy.DefaultTenant) },
+			set: func(id storage.SeriesRef, b []byte) {
+				cache.StorePostings(uid(id), lbl, b, tenancy.DefaultTenant)
+				// Ristretto sets data async. Wait for it to finish to avoid flakiness.
+				cache.cache.Wait()
+			},
 			get: func(id storage.SeriesRef) ([]byte, bool) {
 				hits, _ := cache.FetchMultiPostings(ctx, uid(id), []labels.Label{lbl}, tenancy.DefaultTenant)
 				b, ok := hits[lbl]
@@ -144,7 +109,11 @@ func TestInMemoryIndexCache_UpdateItem(t *testing.T) {
 		},
 		{
 			typ: cacheTypeSeries,
-			set: func(id storage.SeriesRef, b []byte) { cache.StoreSeries(uid(id), id, b, tenancy.DefaultTenant) },
+			set: func(id storage.SeriesRef, b []byte) {
+				cache.StoreSeries(uid(id), id, b, tenancy.DefaultTenant)
+				// Ristretto sets data async. Wait for it to finish to avoid flakiness.
+				cache.cache.Wait()
+			},
 			get: func(id storage.SeriesRef) ([]byte, bool) {
 				hits, _ := cache.FetchMultiSeries(ctx, uid(id), []storage.SeriesRef{id}, tenancy.DefaultTenant)
 				b, ok := hits[id]
@@ -156,6 +125,8 @@ func TestInMemoryIndexCache_UpdateItem(t *testing.T) {
 			typ: cacheTypeExpandedPostings,
 			set: func(id storage.SeriesRef, b []byte) {
 				cache.StoreExpandedPostings(uid(id), []*labels.Matcher{matcher}, b, tenancy.DefaultTenant)
+				// Ristretto sets data async. Wait for it to finish to avoid flakiness.
+				cache.cache.Wait()
 			},
 			get: func(id storage.SeriesRef) ([]byte, bool) {
 				return cache.FetchExpandedPostings(ctx, uid(id), []*labels.Matcher{matcher}, tenancy.DefaultTenant)
@@ -170,7 +141,7 @@ func TestInMemoryIndexCache_UpdateItem(t *testing.T) {
 			buf, ok := tt.get(0)
 			testutil.Equals(t, true, ok)
 			testutil.Equals(t, []byte{0}, buf)
-			testutil.Equals(t, float64(sliceHeaderSize+1), promtest.ToFloat64(cache.currentSize.WithLabelValues(tt.typ)))
+			testutil.Equals(t, float64(sliceHeaderSize+1+1), promtest.ToFloat64(cache.currentSize.WithLabelValues(tt.typ)))
 			testutil.Equals(t, float64(1), promtest.ToFloat64(cache.current.WithLabelValues(tt.typ)))
 			testutil.Equals(t, []string(nil), errorLogs)
 
@@ -180,7 +151,7 @@ func TestInMemoryIndexCache_UpdateItem(t *testing.T) {
 			buf, ok = tt.get(0)
 			testutil.Equals(t, true, ok)
 			testutil.Equals(t, []byte{0}, buf)
-			testutil.Equals(t, float64(sliceHeaderSize+1), promtest.ToFloat64(cache.currentSize.WithLabelValues(tt.typ)))
+			testutil.Equals(t, float64(sliceHeaderSize+1+1), promtest.ToFloat64(cache.currentSize.WithLabelValues(tt.typ)))
 			testutil.Equals(t, float64(1), promtest.ToFloat64(cache.current.WithLabelValues(tt.typ)))
 			testutil.Equals(t, []string(nil), errorLogs)
 
@@ -191,7 +162,7 @@ func TestInMemoryIndexCache_UpdateItem(t *testing.T) {
 			buf, ok = tt.get(1)
 			testutil.Equals(t, true, ok)
 			testutil.Equals(t, []byte{0, 1}, buf)
-			testutil.Equals(t, float64(sliceHeaderSize+2), promtest.ToFloat64(cache.currentSize.WithLabelValues(tt.typ)))
+			testutil.Equals(t, float64(sliceHeaderSize+2+1), promtest.ToFloat64(cache.currentSize.WithLabelValues(tt.typ)))
 			testutil.Equals(t, float64(1), promtest.ToFloat64(cache.current.WithLabelValues(tt.typ)))
 			testutil.Equals(t, []string(nil), errorLogs)
 
@@ -200,239 +171,9 @@ func TestInMemoryIndexCache_UpdateItem(t *testing.T) {
 			buf, ok = tt.get(1)
 			testutil.Equals(t, true, ok)
 			testutil.Equals(t, []byte{0, 1}, buf)
-			testutil.Equals(t, float64(sliceHeaderSize+2), promtest.ToFloat64(cache.currentSize.WithLabelValues(tt.typ)))
+			testutil.Equals(t, float64(sliceHeaderSize+2+1), promtest.ToFloat64(cache.currentSize.WithLabelValues(tt.typ)))
 			testutil.Equals(t, float64(1), promtest.ToFloat64(cache.current.WithLabelValues(tt.typ)))
 			testutil.Equals(t, []string(nil), errorLogs)
 		})
 	}
-}
-
-// This should not happen as we hardcode math.MaxInt, but we still add test to check this out.
-func TestInMemoryIndexCache_MaxNumberOfItemsHit(t *testing.T) {
-	metrics := prometheus.NewRegistry()
-	cache, err := NewInMemoryIndexCacheWithConfig(log.NewNopLogger(), nil, metrics, InMemoryIndexCacheConfig{
-		MaxItemSize: 2*sliceHeaderSize + 10,
-		MaxSize:     2*sliceHeaderSize + 10,
-	})
-	testutil.Ok(t, err)
-
-	l, err := simplelru.NewLRU(2, cache.onEvict)
-	testutil.Ok(t, err)
-	cache.lru = l
-
-	id := ulid.MustNew(0, nil)
-
-	cache.StorePostings(id, labels.Label{Name: "test", Value: "123"}, []byte{42, 33}, tenancy.DefaultTenant)
-	cache.StorePostings(id, labels.Label{Name: "test", Value: "124"}, []byte{42, 33}, tenancy.DefaultTenant)
-	cache.StorePostings(id, labels.Label{Name: "test", Value: "125"}, []byte{42, 33}, tenancy.DefaultTenant)
-
-	testutil.Equals(t, uint64(2*sliceHeaderSize+4), cache.curSize)
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.overflow.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.overflow.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.evicted.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.evicted.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(3), promtest.ToFloat64(cache.added.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.added.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.commonMetrics.requestTotal.WithLabelValues(cacheTypePostings, tenancy.DefaultTenant)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.commonMetrics.requestTotal.WithLabelValues(cacheTypeSeries, tenancy.DefaultTenant)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.commonMetrics.hitsTotal.WithLabelValues(cacheTypePostings, tenancy.DefaultTenant)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.commonMetrics.hitsTotal.WithLabelValues(cacheTypeSeries, tenancy.DefaultTenant)))
-}
-
-func TestInMemoryIndexCache_Eviction_WithMetrics(t *testing.T) {
-	metrics := prometheus.NewRegistry()
-	cache, err := NewInMemoryIndexCacheWithConfig(log.NewNopLogger(), nil, metrics, InMemoryIndexCacheConfig{
-		MaxItemSize: 2*sliceHeaderSize + 5,
-		MaxSize:     2*sliceHeaderSize + 5,
-	})
-	testutil.Ok(t, err)
-
-	id := ulid.MustNew(0, nil)
-	lbls := labels.Label{Name: "test", Value: "123"}
-	ctx := context.Background()
-	emptyPostingsHits := map[labels.Label][]byte{}
-	emptyPostingsMisses := []labels.Label(nil)
-	emptySeriesHits := map[storage.SeriesRef][]byte{}
-	emptySeriesMisses := []storage.SeriesRef(nil)
-
-	pHits, pMisses := cache.FetchMultiPostings(ctx, id, []labels.Label{lbls}, tenancy.DefaultTenant)
-	testutil.Equals(t, emptyPostingsHits, pHits, "no such key")
-	testutil.Equals(t, []labels.Label{lbls}, pMisses)
-
-	// Add sliceHeaderSize + 2 bytes.
-	cache.StorePostings(id, lbls, []byte{42, 33}, tenancy.DefaultTenant)
-	testutil.Equals(t, uint64(sliceHeaderSize+2), cache.curSize)
-	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.current.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(sliceHeaderSize+2), promtest.ToFloat64(cache.currentSize.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(sliceHeaderSize+2+55), promtest.ToFloat64(cache.totalCurrentSize.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.current.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.currentSize.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.totalCurrentSize.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.overflow.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.overflow.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.evicted.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.evicted.WithLabelValues(cacheTypeSeries)))
-
-	pHits, pMisses = cache.FetchMultiPostings(ctx, id, []labels.Label{lbls}, tenancy.DefaultTenant)
-	testutil.Equals(t, map[labels.Label][]byte{lbls: {42, 33}}, pHits, "key exists")
-	testutil.Equals(t, emptyPostingsMisses, pMisses)
-
-	pHits, pMisses = cache.FetchMultiPostings(ctx, ulid.MustNew(1, nil), []labels.Label{lbls}, tenancy.DefaultTenant)
-	testutil.Equals(t, emptyPostingsHits, pHits, "no such key")
-	testutil.Equals(t, []labels.Label{lbls}, pMisses)
-
-	pHits, pMisses = cache.FetchMultiPostings(ctx, id, []labels.Label{{Name: "test", Value: "124"}}, tenancy.DefaultTenant)
-	testutil.Equals(t, emptyPostingsHits, pHits, "no such key")
-	testutil.Equals(t, []labels.Label{{Name: "test", Value: "124"}}, pMisses)
-
-	// Add sliceHeaderSize + 3 more bytes.
-	cache.StoreSeries(id, 1234, []byte{222, 223, 224}, tenancy.DefaultTenant)
-	testutil.Equals(t, uint64(2*sliceHeaderSize+5), cache.curSize)
-	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.current.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(sliceHeaderSize+2), promtest.ToFloat64(cache.currentSize.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(sliceHeaderSize+2+55), promtest.ToFloat64(cache.totalCurrentSize.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.current.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(sliceHeaderSize+3), promtest.ToFloat64(cache.currentSize.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(sliceHeaderSize+3+24), promtest.ToFloat64(cache.totalCurrentSize.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.overflow.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.overflow.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.evicted.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.evicted.WithLabelValues(cacheTypeSeries)))
-
-	sHits, sMisses := cache.FetchMultiSeries(ctx, id, []storage.SeriesRef{1234}, tenancy.DefaultTenant)
-	testutil.Equals(t, map[storage.SeriesRef][]byte{1234: {222, 223, 224}}, sHits, "key exists")
-	testutil.Equals(t, emptySeriesMisses, sMisses)
-
-	lbls2 := labels.Label{Name: "test", Value: "124"}
-
-	// Add sliceHeaderSize + 5 + 16 bytes, should fully evict 2 last items.
-	v := []byte{42, 33, 14, 67, 11}
-	for i := 0; i < sliceHeaderSize; i++ {
-		v = append(v, 3)
-	}
-	cache.StorePostings(id, lbls2, v, tenancy.DefaultTenant)
-
-	testutil.Equals(t, uint64(2*sliceHeaderSize+5), cache.curSize)
-	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.current.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(2*sliceHeaderSize+5), promtest.ToFloat64(cache.currentSize.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(2*sliceHeaderSize+5+55), promtest.ToFloat64(cache.totalCurrentSize.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.current.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.currentSize.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.totalCurrentSize.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.overflow.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.overflow.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.evicted.WithLabelValues(cacheTypePostings))) // Eviction.
-	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.evicted.WithLabelValues(cacheTypeSeries)))   // Eviction.
-
-	// Evicted.
-	pHits, pMisses = cache.FetchMultiPostings(ctx, id, []labels.Label{lbls}, tenancy.DefaultTenant)
-	testutil.Equals(t, emptyPostingsHits, pHits, "no such key")
-	testutil.Equals(t, []labels.Label{lbls}, pMisses)
-
-	sHits, sMisses = cache.FetchMultiSeries(ctx, id, []storage.SeriesRef{1234}, tenancy.DefaultTenant)
-	testutil.Equals(t, emptySeriesHits, sHits, "no such key")
-	testutil.Equals(t, []storage.SeriesRef{1234}, sMisses)
-
-	pHits, pMisses = cache.FetchMultiPostings(ctx, id, []labels.Label{lbls2}, tenancy.DefaultTenant)
-	testutil.Equals(t, map[labels.Label][]byte{lbls2: v}, pHits)
-	testutil.Equals(t, emptyPostingsMisses, pMisses)
-
-	// Add same item again.
-	cache.StorePostings(id, lbls2, v, tenancy.DefaultTenant)
-
-	testutil.Equals(t, uint64(2*sliceHeaderSize+5), cache.curSize)
-	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.current.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(2*sliceHeaderSize+5), promtest.ToFloat64(cache.currentSize.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(2*sliceHeaderSize+5+55), promtest.ToFloat64(cache.totalCurrentSize.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.current.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.currentSize.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.totalCurrentSize.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.overflow.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.overflow.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.evicted.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.evicted.WithLabelValues(cacheTypeSeries)))
-
-	pHits, pMisses = cache.FetchMultiPostings(ctx, id, []labels.Label{lbls2}, tenancy.DefaultTenant)
-	testutil.Equals(t, map[labels.Label][]byte{lbls2: v}, pHits)
-	testutil.Equals(t, emptyPostingsMisses, pMisses)
-
-	// Add too big item.
-	cache.StorePostings(id, labels.Label{Name: "test", Value: "toobig"}, append(v, 5), tenancy.DefaultTenant)
-	testutil.Equals(t, uint64(2*sliceHeaderSize+5), cache.curSize)
-	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.current.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(2*sliceHeaderSize+5), promtest.ToFloat64(cache.currentSize.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(2*sliceHeaderSize+5+55), promtest.ToFloat64(cache.totalCurrentSize.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.current.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.currentSize.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.totalCurrentSize.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.overflow.WithLabelValues(cacheTypePostings))) // Overflow.
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.overflow.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.evicted.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.evicted.WithLabelValues(cacheTypeSeries)))
-
-	_, _, ok := cache.lru.RemoveOldest()
-	testutil.Assert(t, ok, "something to remove")
-
-	testutil.Equals(t, uint64(0), cache.curSize)
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.current.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.currentSize.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.totalCurrentSize.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.current.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.currentSize.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.totalCurrentSize.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.overflow.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.overflow.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(2), promtest.ToFloat64(cache.evicted.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.evicted.WithLabelValues(cacheTypeSeries)))
-
-	_, _, ok = cache.lru.RemoveOldest()
-	testutil.Assert(t, !ok, "nothing to remove")
-
-	lbls3 := labels.Label{Name: "test", Value: "124"}
-
-	cache.StorePostings(id, lbls3, []byte{}, tenancy.DefaultTenant)
-
-	testutil.Equals(t, uint64(sliceHeaderSize), cache.curSize)
-	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.current.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(sliceHeaderSize), promtest.ToFloat64(cache.currentSize.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(sliceHeaderSize+55), promtest.ToFloat64(cache.totalCurrentSize.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.current.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.currentSize.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.totalCurrentSize.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.overflow.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.overflow.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(2), promtest.ToFloat64(cache.evicted.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.evicted.WithLabelValues(cacheTypeSeries)))
-
-	pHits, pMisses = cache.FetchMultiPostings(ctx, id, []labels.Label{lbls3}, tenancy.DefaultTenant)
-	testutil.Equals(t, map[labels.Label][]byte{lbls3: {}}, pHits, "key exists")
-	testutil.Equals(t, emptyPostingsMisses, pMisses)
-
-	// nil works and still allocates empty slice.
-	lbls4 := labels.Label{Name: "test", Value: "125"}
-	cache.StorePostings(id, lbls4, []byte(nil), tenancy.DefaultTenant)
-
-	testutil.Equals(t, 2*uint64(sliceHeaderSize), cache.curSize)
-	testutil.Equals(t, float64(2), promtest.ToFloat64(cache.current.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, 2*float64(sliceHeaderSize), promtest.ToFloat64(cache.currentSize.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, 2*float64(sliceHeaderSize+55), promtest.ToFloat64(cache.totalCurrentSize.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.current.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.currentSize.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.totalCurrentSize.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.overflow.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.overflow.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(2), promtest.ToFloat64(cache.evicted.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.evicted.WithLabelValues(cacheTypeSeries)))
-
-	pHits, pMisses = cache.FetchMultiPostings(ctx, id, []labels.Label{lbls4}, tenancy.DefaultTenant)
-	testutil.Equals(t, map[labels.Label][]byte{lbls4: {}}, pHits, "key exists")
-	testutil.Equals(t, emptyPostingsMisses, pMisses)
-
-	// Other metrics.
-	testutil.Equals(t, float64(4), promtest.ToFloat64(cache.added.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.added.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(9), promtest.ToFloat64(cache.commonMetrics.requestTotal.WithLabelValues(cacheTypePostings, tenancy.DefaultTenant)))
-	testutil.Equals(t, float64(2), promtest.ToFloat64(cache.commonMetrics.requestTotal.WithLabelValues(cacheTypeSeries, tenancy.DefaultTenant)))
-	testutil.Equals(t, float64(5), promtest.ToFloat64(cache.commonMetrics.hitsTotal.WithLabelValues(cacheTypePostings, tenancy.DefaultTenant)))
-	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.commonMetrics.hitsTotal.WithLabelValues(cacheTypeSeries, tenancy.DefaultTenant)))
 }

--- a/pkg/testutil/custom/custom.go
+++ b/pkg/testutil/custom/custom.go
@@ -20,6 +20,8 @@ func TolerantVerifyLeakMain(m *testing.M) {
 		goleak.IgnoreTopFunction("k8s.io/klog.(*loggingT).flushDaemon"),
 		// https://github.com/baidubce/bce-sdk-go/blob/9a8c1139e6a3ad23080b9b8c51dec88df8ce3cda/util/log/logger.go#L359
 		goleak.IgnoreTopFunction("github.com/baidubce/bce-sdk-go/util/log.NewLogger.func1"),
+		goleak.IgnoreTopFunction("github.com/outcaste-io/ristretto.(*lfuPolicy).processItems"),
+		goleak.IgnoreTopFunction("github.com/outcaste-io/ristretto.(*Cache).processItems"),
 	)
 }
 
@@ -34,5 +36,7 @@ func TolerantVerifyLeak(t *testing.T) {
 		goleak.IgnoreTopFunction("k8s.io/klog.(*loggingT).flushDaemon"),
 		// https://github.com/baidubce/bce-sdk-go/blob/9a8c1139e6a3ad23080b9b8c51dec88df8ce3cda/util/log/logger.go#L359
 		goleak.IgnoreTopFunction("github.com/baidubce/bce-sdk-go/util/log.NewLogger.func1"),
+		goleak.IgnoreTopFunction("github.com/outcaste-io/ristretto.(*lfuPolicy).processItems"),
+		goleak.IgnoreTopFunction("github.com/outcaste-io/ristretto.(*Cache).processItems"),
 	)
 }


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Fixes https://github.com/thanos-io/thanos/issues/6762.

Replace the LRU based inmemory cache with ristretto inmemory cache.

Still WIP, need to fix tests

## Verification

<!-- How you tested it? How do you know it works? -->
