### PR TITLE
compact: return metas copy from syncer

### DIFF
--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -154,7 +154,12 @@ func (s *Syncer) Metas() map[ulid.ULID]*metadata.Meta {
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
 
-	return s.blocks
+	metas := make(map[ulid.ULID]*metadata.Meta, len(s.blocks))
+	for k, v := range s.blocks {
+		metas[k] = v
+	}
+
+	return metas
 }
 
 // GarbageCollect marks blocks for deletion from bucket if their data is available as part of a


### PR DESCRIPTION
Return copy of the map because the compactor runs garbage collector concurrently that deletes entries from the original map. Fixes race:

```
10:55:35 compact-working-dedup: ==================
10:55:35 compact-working-dedup: WARNING: DATA RACE
10:55:35 compact-working-dedup: Write at 0x00c001822150 by goroutine 220:
10:55:35 compact-working-dedup: runtime.mapdelete()
10:55:35 compact-working-dedup: /usr/local/go/src/runtime/map.go:696 +0x0
10:55:35 compact-working-dedup: github.com/thanos-io/thanos/pkg/compact.(*Syncer).GarbageCollect()
10:55:35 compact-working-dedup: /go/src/github.com/thanos-io/thanos/pkg/compact/compact.go:201 +0x324
10:55:35 compact-working-dedup: github.com/thanos-io/thanos/pkg/compact.(*BucketCompactor).Compact()
10:55:35 compact-working-dedup: /go/src/github.com/thanos-io/thanos/pkg/compact/compact.go:1422 +0x60f
10:55:35 compact-working-dedup: main.runCompact.func7()
10:55:35 compact-working-dedup: /go/src/github.com/thanos-io/thanos/cmd/thanos/compact.go:426 +0xfa
10:55:35 compact-working-dedup: main.runCompact.func8.1()
10:55:35 compact-working-dedup: /go/src/github.com/thanos-io/thanos/cmd/thanos/compact.go:481 +0x69
10:55:35 compact-working-dedup: github.com/thanos-io/thanos/pkg/runutil.Repeat()
10:55:35 compact-working-dedup: /go/src/github.com/thanos-io/thanos/pkg/runutil/runutil.go:74 +0xc3
10:55:35 compact-working-dedup: main.runCompact.func8()
10:55:35 compact-working-dedup: /go/src/github.com/thanos-io/thanos/cmd/thanos/compact.go:480 +0x224
10:55:35 compact-working-dedup: github.com/oklog/run.(*Group).Run.func1()
10:55:35 compact-working-dedup: /go/pkg/mod/github.com/oklog/run@v1.1.0/group.go:38 +0x39
10:55:35 compact-working-dedup: github.com/oklog/run.(*Group).Run.func2()
10:55:35 compact-working-dedup: /go/pkg/mod/github.com/oklog/run@v1.1.0/group.go:39 +0x4f
10:55:35 compact-working-dedup: Previous read at 0x00c001822150 by goroutine 223:
10:55:35 compact-working-dedup: runtime.mapiternext()
10:55:35 compact-working-dedup: /usr/local/go/src/runtime/map.go:867 +0x0
10:55:35 compact-working-dedup: github.com/thanos-io/thanos/pkg/compact.(*DefaultGrouper).Groups()
10:55:35 compact-working-dedup: /go/src/github.com/thanos-io/thanos/pkg/compact/compact.go:289 +0xfd
10:55:35 compact-working-dedup: main.runCompact.func16.1()
10:55:35 compact-working-dedup: /go/src/github.com/thanos-io/thanos/cmd/thanos/compact.go:626 +0x4ae
10:55:35 compact-working-dedup: github.com/thanos-io/thanos/pkg/runutil.Repeat()
10:55:35 compact-working-dedup: /go/src/github.com/thanos-io/thanos/pkg/runutil/runutil.go:74 +0xc3
10:55:35 compact-working-dedup: main.runCompact.func16()
10:55:35 compact-working-dedup: /go/src/github.com/thanos-io/thanos/cmd/thanos/compact.go:591 +0x3f9
10:55:35 compact-working-dedup: github.com/oklog/run.(*Group).Run.func1()
10:55:35 compact-working-dedup: /go/pkg/mod/github.com/oklog/run@v1.1.0/group.go:38 +0x39
10:55:35 compact-working-dedup: github.com/oklog/run.(*Group).Run.func2()
10:55:35 compact-working-dedup: /go/pkg/mod/github.com/oklog/run@v1.1.0/group.go:39 +0x4f
10:55:35 compact-working-dedup: Goroutine 220 (running) created at:
10:55:35 compact-working-dedup: github.com/oklog/run.(*Group).Run()
10:55:35 compact-working-dedup: /go/pkg/mod/github.com/oklog/run@v1.1.0/group.go:37 +0xad
10:55:35 compact-working-dedup: main.main()
10:55:35 compact-working-dedup: /go/src/github.com/thanos-io/thanos/cmd/thanos/main.go:159 +0x2964
```

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
