### PR TITLE
preallocate loaded series map size

### DIFF
--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -1163,7 +1163,7 @@ func (b *blockSeriesClient) nextBatch(tenant string) error {
 		return nil
 	}
 
-	b.indexr.reset()
+	b.indexr.reset(len(postingsBatch))
 	if !b.skipChunks {
 		b.chunkr.reset()
 	}
@@ -2413,8 +2413,8 @@ func (r *bucketIndexReader) IndexVersion() (int, error) {
 	return v, nil
 }
 
-func (r *bucketIndexReader) reset() {
-	r.loadedSeries = map[storage.SeriesRef][]byte{}
+func (r *bucketIndexReader) reset(size int) {
+	r.loadedSeries = make(map[storage.SeriesRef][]byte, size)
 }
 
 // ExpandedPostings returns postings in expanded list instead of index.Postings.


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

Before this change, `PreloadSeries` took 41.77% CPU time while `mapassign` function took about 6.49% CPU time. 3.3% CPU time was spent on growing the map.
<img width="1451" alt="image" src="https://github.com/thanos-io/thanos/assets/25150124/4e84557c-2c9f-4d4e-aeab-7c55cc9492cf">

After this change, `PreloadSeries` took 17.89% of CPU time while `mapassign` function took only 1.2%. And no need to grow and reallocate map due to growing.

<img width="1430" alt="image" src="https://github.com/thanos-io/thanos/assets/25150124/fbf709b6-e25b-4054-9195-8bdbeed1d633">

## Changes

For each batch of series fetch, since we know the batch size beforhand, we can preallocate the size of `loadedSeries` map.

## Verification

<!-- How you tested it? How do you know it works? -->
