### PR TITLE
Vertically shard queries by le if no histogram_quantile function

### DIFF
--- a/pkg/querysharding/analysis.go
+++ b/pkg/querysharding/analysis.go
@@ -3,8 +3,6 @@
 
 package querysharding
 
-var excludedLabels = []string{"le"}
-
 type QueryAnalysis struct {
 	// Labels to shard on
 	shardingLabels []string
@@ -21,8 +19,6 @@ func nonShardableQuery() QueryAnalysis {
 }
 
 func (q *QueryAnalysis) scopeToLabels(labels []string, by bool) QueryAnalysis {
-	labels = without(labels, excludedLabels)
-
 	if q.shardingLabels == nil {
 		return QueryAnalysis{
 			shardBy:        by,


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

We currently exclude `le` as a sharding label at all.
However, `le` can still be used as a sharding label if the query is like `sum by (le) (xxxxx)`, when there is no `histogram_quantile` function left.

## Verification

<!-- How you tested it? How do you know it works? -->
