### PR TITLE
Add default keepalive to EndpointGroupGRPCOpts

### DIFF
--- a/pkg/extgrpc/client.go
+++ b/pkg/extgrpc/client.go
@@ -5,6 +5,7 @@ package extgrpc
 
 import (
 	"math"
+	"time"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
@@ -15,6 +16,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/keepalive"
 
 	"github.com/thanos-io/thanos/pkg/tls"
 	"github.com/thanos-io/thanos/pkg/tracing"
@@ -38,6 +40,7 @@ func EndpointGroupGRPCOpts() []grpc.DialOption {
 
 	return []grpc.DialOption{
 		grpc.WithDefaultServiceConfig(serviceConfig),
+		grpc.WithKeepaliveParams(keepalive.ClientParameters{Time: 10 * time.Second, Timeout: 5 * time.Second}),
 	}
 }
 


### PR DESCRIPTION
Looks like the querier [marks an endpoint](https://github.com/thanos-io/thanos/blob/main/pkg/query/endpointset.go#L695) group as non-queryable if only one of its addresses is unhealthy. It should probably exclude only the unhealthy ones, but I think Thanos manages the group as a single endpoint since the load balancing is performed within the gRPC client

This change adds a keepalive config in endpoint groups to monitor the endpoints' health in the gRPC client. This way, the client can exclude unhealthy ones and reconnect them when they are back and ready.

I read that there has been some recent work to add flags for configuring endpoints in https://github.com/thanos-io/thanos/pull/5505, so I am adding default values for now.

* [ ] I added CHANGELOG entry for this change.
* [X] Change is not relevant to the end user.

## Changes

- Add a keep-alive value to EndpointGroupGRPCOpts. Default to time 10s and timeout 5s.

## Verification

I tested the change by deploying a patched version. We've been monitoring it for weeks, and it definitely fixed the issue we were seeing. The image below shows a drop in 422s after deploying the patch, and is currently 0. Our system is a querier with endpoint groups to queriers in separate clusters.

![image](https://github.com/thanos-io/thanos/assets/24930070/6e0a231e-e637-4e65-bd07-cc1ecb82bc7a)

