### PR TITLE
Store: fix prometheus store label values for matches on external labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 ### Fixed
 
 - [#6802](https://github.com/thanos-io/thanos/pull/6802) Receive: head series limiter should not run if no head series limit is set.
+- [#6816](https://github.com/thanos-io/thanos/pull/6816) Store: fix prometheus store label values matches for external labels
 - [#6817](https://github.com/thanos-io/thanos/pull/6817) Store Gateway: fix `matchersToPostingGroups` label values variable got shadowed bug.
 
 ### Added

--- a/pkg/store/acceptance_test.go
+++ b/pkg/store/acceptance_test.go
@@ -187,6 +187,13 @@ func testStoreAPIsAcceptance(t *testing.T, startStore func(t *testing.T, extLset
 				{
 					start:          timestamp.FromTime(minTime),
 					end:            timestamp.FromTime(maxTime),
+					label:          "region",
+					expectedValues: []string(nil),
+					matchers:       []storepb.LabelMatcher{{Type: storepb.LabelMatcher_EQ, Name: "region", Value: "eu-east"}},
+				},
+				{
+					start:          timestamp.FromTime(minTime),
+					end:            timestamp.FromTime(maxTime),
 					label:          "foo",
 					expectedValues: []string{"foovalue1", "foovalue2"},
 					matchers:       []storepb.LabelMatcher{{Type: storepb.LabelMatcher_EQ, Name: "region", Value: "eu-west"}},

--- a/pkg/store/prometheus.go
+++ b/pkg/store/prometheus.go
@@ -699,17 +699,17 @@ func (p *PrometheusStore) LabelValues(ctx context.Context, r *storepb.LabelValue
 
 	extLset := p.externalLabelsFn()
 
-	// First check for matching external label which has priority.
-	if l := extLset.Get(r.Label); l != "" {
-		return &storepb.LabelValuesResponse{Values: []string{l}}, nil
-	}
-
 	match, matchers, err := matchesExternalLabels(r.Matchers, extLset)
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 	if !match {
 		return &storepb.LabelValuesResponse{Values: nil}, nil
+	}
+
+	// First check for matching external label which has priority.
+	if l := extLset.Get(r.Label); l != "" {
+		return &storepb.LabelValuesResponse{Values: []string{l}}, nil
 	}
 
 	var (


### PR DESCRIPTION
External Labels should also be tested for matches against the matchers.

Should fix: #6803

* [x] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

Fixed the order of operations in LabelValues checks in Prometheus Store API

## Verification

Added an acceptance test to also verify it for other store implementations.
