### PR TITLE
Fix matchersToPostingGroups vals variable shadow bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 ### Fixed
 
 - [#6802](https://github.com/thanos-io/thanos/pull/6802) Receive: head series limiter should not run if no head series limit is set.
+- [#6817](https://github.com/thanos-io/thanos/pull/6817) Store Gateway: fix `matchersToPostingGroups` label values variable got shadowed bug.
 
 ### Added
 

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -2664,8 +2664,9 @@ func matchersToPostingGroups(ctx context.Context, lvalsFn func(name string) ([]s
 			}
 			// Cache label values because label name is the same.
 			if !valuesCached && vals != nil {
+				lvals := vals
 				lvalsFunc = func(_ string) ([]string, error) {
-					return vals, nil
+					return lvals, nil
 				}
 				valuesCached = true
 			}

--- a/pkg/store/bucket_test.go
+++ b/pkg/store/bucket_test.go
@@ -3132,6 +3132,29 @@ func TestMatchersToPostingGroup(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "Reproduce values shadow bug",
+			matchers: []*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchRegexp, "name", "test.*"),
+				labels.MustNewMatcher(labels.MatchNotRegexp, "name", "testfoo"),
+				labels.MustNewMatcher(labels.MatchNotEqual, "name", ""),
+			},
+			labelValues: map[string][]string{
+				"name": {"testbar", "testfoo"},
+			},
+			expected: []*postingGroup{
+				{
+					name:    "name",
+					addAll:  false,
+					addKeys: []string{"testbar"},
+					matchers: []*labels.Matcher{
+						labels.MustNewMatcher(labels.MatchNotEqual, "name", ""),
+						labels.MustNewMatcher(labels.MatchRegexp, "name", "test.*"),
+						labels.MustNewMatcher(labels.MatchNotRegexp, "name", "testfoo"),
+					},
+				},
+			},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			actual, err := matchersToPostingGroups(ctx, func(name string) ([]string, error) {


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

The problem here is that we use `vals` variable to cache label values. However, `vals` might be reset to nil during the for loop, causing `lvalsFunc` returns nil label values.

```
lvalsFunc = func(_ string) ([]string, error) {
    return vals, nil
}
```

The fix is to assign a new variable `lvals` to vals and `lvals` value won't be changed.

## Verification
I added a unit test to reproduce this issue.

On current main, the test will produce an empty posting group.
```
=== RUN   TestMatchersToPostingGroup
=== RUN   TestMatchersToPostingGroup/Reproduce_values_shadow_bug
    testutil.go:91: bucket_test.go:3165: ""
        
        	exp: []*store.postingGroup{(*store.postingGroup)(0x140008575e0)}
        
        	got: []*store.postingGroup(nil)
        
        Diff:
        --- Expected
        +++ Actual
        @@ -1,18 +1,2 @@
        -([]*store.postingGroup) (len=1) {
        - (*store.postingGroup)({
        -  addAll: (bool) false,
        -  name: (string) (len=4) "name",
        -  matchers: ([]*labels.Matcher) (len=3) {
        -   (*labels.Matcher)(name!=""),
        -   (*labels.Matcher)(name=~"test.*"),
        -   (*labels.Matcher)(name!~"testfoo")
        -  },
        -  addKeys: ([]string) (len=1) {
        -   (string) (len=7) "testbar"
        -  },
        -  removeKeys: ([]string) <nil>,
        -  cardinality: (int64) 0,
        -  lazy: (bool) false
        - })
        -}
        +([]*store.postingGroup) <nil>
```
