### PR TITLE
*: Add promu build for `darwin/arm64`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ jobs:
     working_directory: /home/circleci/.go_workspace/src/github.com/thanos-io/thanos
     environment:
       GOBIN: "/home/circleci/.go_workspace/go/bin"
-      PROMU_VERSION: "0.5.0"
+      PROMU_VERSION: "0.15.0"
     steps:
       - git-shallow-clone/checkout
       - run: mkdir -p ${GOBIN}

--- a/.promu.yml
+++ b/.promu.yml
@@ -17,6 +17,7 @@ crossbuild:
   platforms:
     - linux/amd64
     - darwin/amd64
+    - darwin/arm64
     - linux/arm64
     - windows/amd64
     - freebsd/amd64


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Helps with running binaries on apple silicon. 
Should kick in from next release, but promu already supports it from v0.8.

## Verification

<!-- How you tested it? How do you know it works? -->
