### PR TITLE
Fix devcontainer image

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # For details, see https://github.com/devcontainers/images/tree/main/src/go
-FROM mcr.microsoft.com/devcontainers/go:0-1.21
+FROM mcr.microsoft.com/devcontainers/go:1.21
 
 RUN echo "Downloading prometheus..." \
     && curl -sSL -H "Accept: application/vnd.github.v3+json" "https://api.github.com/repos/prometheus/prometheus/tags" -o /tmp/tags.json \


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

Fixes https://github.com/thanos-io/thanos/issues/6813

Use the correct devcontainer image for go 1.21

## Verification

<!-- How you tested it? How do you know it works? -->
