### PR TITLE
query: fix hints race

### DIFF
--- a/pkg/query/querier.go
+++ b/pkg/query/querier.go
@@ -269,6 +269,13 @@ func (q *querier) Select(ctx context.Context, _ bool, hints *storage.SelectHints
 			Start: q.mint,
 			End:   q.maxt,
 		}
+	} else {
+		// NOTE(GiedriusS): need to make a copy here
+		// because the PromQL engine sorts these and
+		// we later on call String() the whole request (including this slice).
+		grouping := make([]string, 0, len(hints.Grouping))
+		grouping = append(grouping, hints.Grouping...)
+		hints.Grouping = grouping
 	}
 
 	matchers := make([]string, len(ms))


### PR DESCRIPTION
Fix the following race:

```
12:36:39 querier-1: ==================
12:36:39 querier-1: WARNING: DATA RACE
12:36:39 querier-1: Read at 0x00c000159540 by goroutine 341:
12:36:39 querier-1: reflect.Value.String()
12:36:39 querier-1: /usr/local/go/src/reflect/value.go:2589 +0xd76
12:36:39 querier-1: github.com/gogo/protobuf/proto.(*TextMarshaler).writeAny()
12:36:39 querier-1: /go/pkg/mod/github.com/gogo/protobuf@v1.3.2/proto/text.go:563 +0xd86
12:36:39 querier-1: github.com/gogo/protobuf/proto.(*TextMarshaler).writeStruct()
12:36:39 querier-1: /go/pkg/mod/github.com/gogo/protobuf@v1.3.2/proto/text.go:325 +0x19db
12:36:39 querier-1: github.com/gogo/protobuf/proto.(*TextMarshaler).writeAny()
12:36:39 querier-1: /go/pkg/mod/github.com/gogo/protobuf@v1.3.2/proto/text.go:606 +0xb2a
12:36:39 querier-1: github.com/gogo/protobuf/proto.(*TextMarshaler).writeStruct()
12:36:39 querier-1: /go/pkg/mod/github.com/gogo/protobuf@v1.3.2/proto/text.go:453 +0xdd6
12:36:39 querier-1: github.com/gogo/protobuf/proto.(*TextMarshaler).writeAny()
12:36:39 querier-1: /go/pkg/mod/github.com/gogo/protobuf@v1.3.2/proto/text.go:606 +0xb2a
12:36:39 querier-1: github.com/gogo/protobuf/proto.(*TextMarshaler).writeStruct()
12:36:39 querier-1: /go/pkg/mod/github.com/gogo/protobuf@v1.3.2/proto/text.go:453 +0xdd6
12:36:39 querier-1: github.com/gogo/protobuf/proto.(*TextMarshaler).Marshal()
12:36:39 querier-1: /go/pkg/mod/github.com/gogo/protobuf@v1.3.2/proto/text.go:896 +0x5c8
12:36:39 querier-1: github.com/gogo/protobuf/proto.(*TextMarshaler).Text()
12:36:39 querier-1: /go/pkg/mod/github.com/gogo/protobuf@v1.3.2/proto/text.go:908 +0x92
12:36:39 querier-1: github.com/gogo/protobuf/proto.CompactTextString()
12:36:39 querier-1: /go/pkg/mod/github.com/gogo/protobuf@v1.3.2/proto/text.go:930 +0x8e
12:36:39 querier-1: github.com/thanos-io/thanos/pkg/store/storepb.(*SeriesRequest).String()
12:36:39 querier-1: /go/src/github.com/thanos-io/thanos/pkg/store/storepb/rpc.pb.go:316 +0x7b
12:36:39 querier-1: github.com/thanos-io/thanos/pkg/store.(*ProxyStore).Series()
12:36:39 querier-1: /go/src/github.com/thanos-io/thanos/pkg/store/proxy.go:277 +0x8f
12:36:39 querier-1: github.com/thanos-io/thanos/pkg/query.(*querier).selectFn()

12:36:39 querier-1: Previous write at 0x00c000159540 by goroutine 339:
12:36:39 querier-1: golang.org/x/exp/slices.insertionSortOrdered[go.shape.string]()
12:36:39 querier-1: /go/pkg/mod/golang.org/x/exp@v0.0.0-20230801115018-d63ba01acd4b/slices/zsortordered.go:15 +0x357
12:36:39 querier-1: golang.org/x/exp/slices.pdqsortOrdered[go.shape.string]()
12:36:39 querier-1: /go/pkg/mod/golang.org/x/exp@v0.0.0-20230801115018-d63ba01acd4b/slices/zsortordered.go:75 +0x72f
12:36:39 querier-1: golang.org/x/exp/slices.Sort[go.shape.[]string,go.shape.string]()
12:36:39 querier-1: /go/pkg/mod/golang.org/x/exp@v0.0.0-20230801115018-d63ba01acd4b/slices/sort.go:19 +0x45a
12:36:39 querier-1: github.com/prometheus/prometheus/promql.(*evaluator).eval()
12:36:39 querier-1: /go/pkg/mod/github.com/prometheus/prometheus@v0.47.2-0.20231009162353-f6d9c84fde6b/promql/engine.go:1352 +0x432
12:36:39 querier-1: github.com/prometheus/prometheus/promql.(*evaluator).Eval()
12:36:39 querier-1: /go/pkg/mod/github.com/prometheus/prometheus@v0.47.2-0.20231009162353-f6d9c84fde6b/promql/engine.go:1052 +0x105
12:36:39 querier-1: github.com/prometheus/prometheus/promql.(*Engine).execEvalStmt()
12:36:39 querier-1: /go/pkg/mod/github.com/prometheus/prometheus@v0.47.2-0.20231009162353-f6d9c84fde6b/promql/engine.go:708 +0xb15
12:36:39 querier-1: github.com/prometheus/prometheus/promql.(*Engine).exec()
12:36:39 querier-1: /go/pkg/mod/github.com/prometheus/prometheus@v0.47.2-0.20231009162353-f6d9c84fde6b/promql/engine.go:646 +0x4c8
12:36:39 querier-1: github.com/prometheus/prometheus/promql.(*query).Exec()
12:36:39 querier-1: /go/pkg/mod/github.com/prometheus/prometheus@v0.47.2-0.20231009162353-f6d9c84fde6b/promql/engine.go:235 +0x232
12:36:39 querier-1: github.com/thanos-io/thanos/pkg/api/query.(*QueryAPI).query()
12:36:39 querier-1: /go/src/github.com/thanos-io/thanos/pkg/api/query/v1.go:681 +0xdfd
12:36:39 querier-1: github.com/thanos-io/thanos/pkg/api/query.(*QueryAPI).query-fm()
12:36:39 querier-1: <autogenerated>:1 +0x45
12:36:39 querier-1: github.com/thanos-io/thanos/pkg/api/query.(*QueryAPI).Register.GetInstr.func1.1()
12:36:39 querier-1: /go/src/github.com/thanos-io/thanos/pkg/api/api.go:212 +0x62
12:36:39 querier-1: net/http.HandlerFunc.ServeHTTP()
12:36:39 querier-1: /usr/local/go/src/net/http/server.go:2136 +0x47
12:36:39 querier-1: github.com/thanos-io/thanos/pkg/logging.(*HTTPServerMiddleware).HTTPMiddleware.func1()
```

Problem is that the same slice is sorted in the PromQL engine whereas the same hints slice could still be used in other Select() calls where String() is called and then it reads those hints.
