### PR TITLE
Add fastcache as inmemory cache

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -117,6 +117,7 @@ require (
 )
 
 require (
+	github.com/VictoriaMetrics/fastcache v1.12.1
 	github.com/onsi/gomega v1.27.10
 	go.opentelemetry.io/contrib/propagators/autoprop v0.38.0
 	go4.org/intern v0.0.0-20230525184215-6c62f75575cb

--- a/go.sum
+++ b/go.sum
@@ -103,6 +103,8 @@ github.com/QcloudApi/qcloud_sign_golang v0.0.0-20141224014652-e4130a326409/go.mo
 github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWXgklEdEo=
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
 github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
+github.com/VictoriaMetrics/fastcache v1.12.1 h1:i0mICQuojGDL3KblA7wUNlY5lOK6a4bwt3uRKnkZU40=
+github.com/VictoriaMetrics/fastcache v1.12.1/go.mod h1:tX04vaqcNoQeGLD+ra5pU5sWkuxnzWhEzLwhP9w653o=
 github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/4+TcAqDqk/vUH7g=
 github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5/go.mod h1:SkGFH1ia65gfNATL8TAiHDNxPzPdmEL5uirI2Uyuz6c=
 github.com/alecthomas/kingpin v1.3.8-0.20210301060133-17f40c25f497 h1:aDITxVUQ/3KBhpVWX57Vo9ntGTxoRw1F0T6/x/tRzNU=
@@ -122,6 +124,8 @@ github.com/alicebob/miniredis/v2 v2.22.0 h1:lIHHiSkEyS1MkKHCHzN+0mWrA4YdbGdimE5i
 github.com/alicebob/miniredis/v2 v2.22.0/go.mod h1:XNqvJdQJv5mSuVMc0ynneafpnL/zv52acZ6kqeS0t88=
 github.com/aliyun/aliyun-oss-go-sdk v2.2.2+incompatible h1:9gWa46nstkJ9miBReJcN8Gq34cBFbzSpQZVVT9N09TM=
 github.com/aliyun/aliyun-oss-go-sdk v2.2.2+incompatible/go.mod h1:T/Aws4fEfogEE9v+HPhhw+CntffsBHJ8nXQCwKr0/g8=
+github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156 h1:eMwmnE/GDgah4HI848JfFxHt+iPb26b4zyfspmqY0/8=
+github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax3seSYIx7SuZdm2G2xzfwmv3TPSk2ucNfQESPXM=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=

--- a/pkg/store/cache/cache.go
+++ b/pkg/store/cache/cache.go
@@ -23,12 +23,6 @@ const (
 	cacheTypePostings         string = "Postings"
 	cacheTypeExpandedPostings string = "ExpandedPostings"
 	cacheTypeSeries           string = "Series"
-
-	sliceHeaderSize = 16
-)
-
-var (
-	ulidSize = uint64(len(ulid.ULID{}))
 )
 
 // IndexCache is the interface exported by index cache backends.
@@ -108,19 +102,6 @@ func (c cacheKey) keyType() string {
 		return cacheTypeExpandedPostings
 	}
 	return "<unknown>"
-}
-
-func (c cacheKey) size() uint64 {
-	switch k := c.key.(type) {
-	case cacheKeyPostings:
-		// ULID + 2 slice headers + number of chars in value and name.
-		return ulidSize + 2*sliceHeaderSize + uint64(len(k.Value)+len(k.Name))
-	case cacheKeyExpandedPostings:
-		return ulidSize + sliceHeaderSize + uint64(len(k))
-	case cacheKeySeries:
-		return ulidSize + 8 // ULID + uint64.
-	}
-	return 0
 }
 
 func (c cacheKey) string() string {

--- a/pkg/store/cache/cache.go
+++ b/pkg/store/cache/cache.go
@@ -92,18 +92,6 @@ type cacheKey struct {
 	compression string
 }
 
-func (c cacheKey) keyType() string {
-	switch c.key.(type) {
-	case cacheKeyPostings:
-		return cacheTypePostings
-	case cacheKeySeries:
-		return cacheTypeSeries
-	case cacheKeyExpandedPostings:
-		return cacheTypeExpandedPostings
-	}
-	return "<unknown>"
-}
-
 func (c cacheKey) string() string {
 	switch c.key.(type) {
 	case cacheKeyPostings:

--- a/pkg/store/cache/inmemory.go
+++ b/pkg/store/cache/inmemory.go
@@ -44,7 +44,6 @@ var (
 type InMemoryIndexCache struct {
 	logger           log.Logger
 	cache            *fastcache.Cache
-	maxSizeBytes     uint64
 	maxItemSizeBytes uint64
 
 	added     *prometheus.CounterVec
@@ -101,7 +100,6 @@ func NewInMemoryIndexCacheWithConfig(logger log.Logger, commonMetrics *commonMet
 
 	c := &InMemoryIndexCache{
 		logger:           logger,
-		maxSizeBytes:     uint64(config.MaxSize),
 		maxItemSizeBytes: uint64(config.MaxItemSize),
 		commonMetrics:    commonMetrics,
 	}
@@ -142,8 +140,7 @@ func NewInMemoryIndexCacheWithConfig(logger log.Logger, commonMetrics *commonMet
 	level.Info(logger).Log(
 		"msg", "created in-memory index cache",
 		"maxItemSizeBytes", c.maxItemSizeBytes,
-		"maxSizeBytes", c.maxSizeBytes,
-		"maxItems", "maxInt",
+		"maxSizeBytes", config.MaxSize,
 	)
 	return c, nil
 }
@@ -183,7 +180,6 @@ func (c *InMemoryIndexCache) set(typ string, key cacheKey, val []byte) {
 		level.Info(c.logger).Log(
 			"msg", "item bigger than maxItemSizeBytes. Ignoring..",
 			"maxItemSizeBytes", c.maxItemSizeBytes,
-			"maxSizeBytes", c.maxSizeBytes,
 			"cacheType", typ,
 		)
 		c.overflow.WithLabelValues(typ).Inc()

--- a/pkg/store/cache/inmemory.go
+++ b/pkg/store/cache/inmemory.go
@@ -30,7 +30,7 @@ const (
 	//
 	// - 16 bytes are for (hash + valueLen)
 	// - 4 bytes are for len(key)+len(subkey)
-	// - 1 byte is implementation detail of fastcache
+	// - 1 byte is implementation detail of fastcache.
 	maxKeyLen = chunkSize - 16 - 4 - 1
 )
 

--- a/pkg/store/cache/inmemory_test.go
+++ b/pkg/store/cache/inmemory_test.go
@@ -8,14 +8,11 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"math"
 	"testing"
 
 	"github.com/go-kit/log"
-	"github.com/hashicorp/golang-lru/simplelru"
 	"github.com/oklog/ulid"
 	"github.com/prometheus/client_golang/prometheus"
-	promtest "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
 
@@ -64,40 +61,7 @@ max_item_size: 1MB
 	// testutil.Equals(t, uint64(2*1024), cache.maxSizeBytes)
 }
 
-func TestInMemoryIndexCache_AvoidsDeadlock(t *testing.T) {
-	metrics := prometheus.NewRegistry()
-	cache, err := NewInMemoryIndexCacheWithConfig(log.NewNopLogger(), nil, metrics, InMemoryIndexCacheConfig{
-		MaxItemSize: sliceHeaderSize + 5,
-		MaxSize:     sliceHeaderSize + 5,
-	})
-	testutil.Ok(t, err)
-
-	l, err := simplelru.NewLRU(math.MaxInt64, func(key, val interface{}) {
-		// Hack LRU to simulate broken accounting: evictions do not reduce current size.
-		size := cache.curSize
-		cache.onEvict(key, val)
-		cache.curSize = size
-	})
-	testutil.Ok(t, err)
-	cache.lru = l
-
-	cache.StorePostings(ulid.MustNew(0, nil), labels.Label{Name: "test2", Value: "1"}, []byte{42, 33, 14, 67, 11}, tenancy.DefaultTenant)
-
-	testutil.Equals(t, uint64(sliceHeaderSize+5), cache.curSize)
-	testutil.Equals(t, float64(cache.curSize), promtest.ToFloat64(cache.currentSize.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.current.WithLabelValues(cacheTypePostings)))
-
-	// This triggers deadlock logic.
-	cache.StorePostings(ulid.MustNew(0, nil), labels.Label{Name: "test1", Value: "1"}, []byte{42}, tenancy.DefaultTenant)
-
-	testutil.Equals(t, uint64(sliceHeaderSize+1), cache.curSize)
-	testutil.Equals(t, float64(cache.curSize), promtest.ToFloat64(cache.currentSize.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.current.WithLabelValues(cacheTypePostings)))
-}
-
 func TestInMemoryIndexCache_UpdateItem(t *testing.T) {
-	const maxSize = 2 * (sliceHeaderSize + 1)
-
 	var errorLogs []string
 	errorLogger := log.LoggerFunc(func(kvs ...interface{}) error {
 		var lvl string
@@ -117,8 +81,8 @@ func TestInMemoryIndexCache_UpdateItem(t *testing.T) {
 
 	metrics := prometheus.NewRegistry()
 	cache, err := NewInMemoryIndexCacheWithConfig(log.NewSyncLogger(errorLogger), nil, metrics, InMemoryIndexCacheConfig{
-		MaxItemSize: maxSize,
-		MaxSize:     maxSize,
+		MaxItemSize: 1024,
+		MaxSize:     1024,
 	})
 	testutil.Ok(t, err)
 
@@ -170,29 +134,20 @@ func TestInMemoryIndexCache_UpdateItem(t *testing.T) {
 			buf, ok := tt.get(0)
 			testutil.Equals(t, true, ok)
 			testutil.Equals(t, []byte{0}, buf)
-			testutil.Equals(t, float64(sliceHeaderSize+1), promtest.ToFloat64(cache.currentSize.WithLabelValues(tt.typ)))
-			testutil.Equals(t, float64(1), promtest.ToFloat64(cache.current.WithLabelValues(tt.typ)))
 			testutil.Equals(t, []string(nil), errorLogs)
 
 			// Set the same value again.
-			// NB: This used to over-count the value.
 			tt.set(0, []byte{0})
 			buf, ok = tt.get(0)
 			testutil.Equals(t, true, ok)
 			testutil.Equals(t, []byte{0}, buf)
-			testutil.Equals(t, float64(sliceHeaderSize+1), promtest.ToFloat64(cache.currentSize.WithLabelValues(tt.typ)))
-			testutil.Equals(t, float64(1), promtest.ToFloat64(cache.current.WithLabelValues(tt.typ)))
 			testutil.Equals(t, []string(nil), errorLogs)
 
 			// Set a larger value.
-			// NB: This used to deadlock when enough values were over-counted and it
-			// couldn't clear enough space -- repeatedly removing oldest after empty.
 			tt.set(1, []byte{0, 1})
 			buf, ok = tt.get(1)
 			testutil.Equals(t, true, ok)
 			testutil.Equals(t, []byte{0, 1}, buf)
-			testutil.Equals(t, float64(sliceHeaderSize+2), promtest.ToFloat64(cache.currentSize.WithLabelValues(tt.typ)))
-			testutil.Equals(t, float64(1), promtest.ToFloat64(cache.current.WithLabelValues(tt.typ)))
 			testutil.Equals(t, []string(nil), errorLogs)
 
 			// Mutations to existing values will be ignored.
@@ -200,239 +155,7 @@ func TestInMemoryIndexCache_UpdateItem(t *testing.T) {
 			buf, ok = tt.get(1)
 			testutil.Equals(t, true, ok)
 			testutil.Equals(t, []byte{0, 1}, buf)
-			testutil.Equals(t, float64(sliceHeaderSize+2), promtest.ToFloat64(cache.currentSize.WithLabelValues(tt.typ)))
-			testutil.Equals(t, float64(1), promtest.ToFloat64(cache.current.WithLabelValues(tt.typ)))
 			testutil.Equals(t, []string(nil), errorLogs)
 		})
 	}
-}
-
-// This should not happen as we hardcode math.MaxInt, but we still add test to check this out.
-func TestInMemoryIndexCache_MaxNumberOfItemsHit(t *testing.T) {
-	metrics := prometheus.NewRegistry()
-	cache, err := NewInMemoryIndexCacheWithConfig(log.NewNopLogger(), nil, metrics, InMemoryIndexCacheConfig{
-		MaxItemSize: 2*sliceHeaderSize + 10,
-		MaxSize:     2*sliceHeaderSize + 10,
-	})
-	testutil.Ok(t, err)
-
-	l, err := simplelru.NewLRU(2, cache.onEvict)
-	testutil.Ok(t, err)
-	cache.lru = l
-
-	id := ulid.MustNew(0, nil)
-
-	cache.StorePostings(id, labels.Label{Name: "test", Value: "123"}, []byte{42, 33}, tenancy.DefaultTenant)
-	cache.StorePostings(id, labels.Label{Name: "test", Value: "124"}, []byte{42, 33}, tenancy.DefaultTenant)
-	cache.StorePostings(id, labels.Label{Name: "test", Value: "125"}, []byte{42, 33}, tenancy.DefaultTenant)
-
-	testutil.Equals(t, uint64(2*sliceHeaderSize+4), cache.curSize)
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.overflow.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.overflow.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.evicted.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.evicted.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(3), promtest.ToFloat64(cache.added.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.added.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.commonMetrics.requestTotal.WithLabelValues(cacheTypePostings, tenancy.DefaultTenant)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.commonMetrics.requestTotal.WithLabelValues(cacheTypeSeries, tenancy.DefaultTenant)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.commonMetrics.hitsTotal.WithLabelValues(cacheTypePostings, tenancy.DefaultTenant)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.commonMetrics.hitsTotal.WithLabelValues(cacheTypeSeries, tenancy.DefaultTenant)))
-}
-
-func TestInMemoryIndexCache_Eviction_WithMetrics(t *testing.T) {
-	metrics := prometheus.NewRegistry()
-	cache, err := NewInMemoryIndexCacheWithConfig(log.NewNopLogger(), nil, metrics, InMemoryIndexCacheConfig{
-		MaxItemSize: 2*sliceHeaderSize + 5,
-		MaxSize:     2*sliceHeaderSize + 5,
-	})
-	testutil.Ok(t, err)
-
-	id := ulid.MustNew(0, nil)
-	lbls := labels.Label{Name: "test", Value: "123"}
-	ctx := context.Background()
-	emptyPostingsHits := map[labels.Label][]byte{}
-	emptyPostingsMisses := []labels.Label(nil)
-	emptySeriesHits := map[storage.SeriesRef][]byte{}
-	emptySeriesMisses := []storage.SeriesRef(nil)
-
-	pHits, pMisses := cache.FetchMultiPostings(ctx, id, []labels.Label{lbls}, tenancy.DefaultTenant)
-	testutil.Equals(t, emptyPostingsHits, pHits, "no such key")
-	testutil.Equals(t, []labels.Label{lbls}, pMisses)
-
-	// Add sliceHeaderSize + 2 bytes.
-	cache.StorePostings(id, lbls, []byte{42, 33}, tenancy.DefaultTenant)
-	testutil.Equals(t, uint64(sliceHeaderSize+2), cache.curSize)
-	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.current.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(sliceHeaderSize+2), promtest.ToFloat64(cache.currentSize.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(sliceHeaderSize+2+55), promtest.ToFloat64(cache.totalCurrentSize.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.current.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.currentSize.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.totalCurrentSize.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.overflow.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.overflow.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.evicted.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.evicted.WithLabelValues(cacheTypeSeries)))
-
-	pHits, pMisses = cache.FetchMultiPostings(ctx, id, []labels.Label{lbls}, tenancy.DefaultTenant)
-	testutil.Equals(t, map[labels.Label][]byte{lbls: {42, 33}}, pHits, "key exists")
-	testutil.Equals(t, emptyPostingsMisses, pMisses)
-
-	pHits, pMisses = cache.FetchMultiPostings(ctx, ulid.MustNew(1, nil), []labels.Label{lbls}, tenancy.DefaultTenant)
-	testutil.Equals(t, emptyPostingsHits, pHits, "no such key")
-	testutil.Equals(t, []labels.Label{lbls}, pMisses)
-
-	pHits, pMisses = cache.FetchMultiPostings(ctx, id, []labels.Label{{Name: "test", Value: "124"}}, tenancy.DefaultTenant)
-	testutil.Equals(t, emptyPostingsHits, pHits, "no such key")
-	testutil.Equals(t, []labels.Label{{Name: "test", Value: "124"}}, pMisses)
-
-	// Add sliceHeaderSize + 3 more bytes.
-	cache.StoreSeries(id, 1234, []byte{222, 223, 224}, tenancy.DefaultTenant)
-	testutil.Equals(t, uint64(2*sliceHeaderSize+5), cache.curSize)
-	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.current.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(sliceHeaderSize+2), promtest.ToFloat64(cache.currentSize.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(sliceHeaderSize+2+55), promtest.ToFloat64(cache.totalCurrentSize.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.current.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(sliceHeaderSize+3), promtest.ToFloat64(cache.currentSize.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(sliceHeaderSize+3+24), promtest.ToFloat64(cache.totalCurrentSize.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.overflow.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.overflow.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.evicted.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.evicted.WithLabelValues(cacheTypeSeries)))
-
-	sHits, sMisses := cache.FetchMultiSeries(ctx, id, []storage.SeriesRef{1234}, tenancy.DefaultTenant)
-	testutil.Equals(t, map[storage.SeriesRef][]byte{1234: {222, 223, 224}}, sHits, "key exists")
-	testutil.Equals(t, emptySeriesMisses, sMisses)
-
-	lbls2 := labels.Label{Name: "test", Value: "124"}
-
-	// Add sliceHeaderSize + 5 + 16 bytes, should fully evict 2 last items.
-	v := []byte{42, 33, 14, 67, 11}
-	for i := 0; i < sliceHeaderSize; i++ {
-		v = append(v, 3)
-	}
-	cache.StorePostings(id, lbls2, v, tenancy.DefaultTenant)
-
-	testutil.Equals(t, uint64(2*sliceHeaderSize+5), cache.curSize)
-	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.current.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(2*sliceHeaderSize+5), promtest.ToFloat64(cache.currentSize.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(2*sliceHeaderSize+5+55), promtest.ToFloat64(cache.totalCurrentSize.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.current.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.currentSize.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.totalCurrentSize.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.overflow.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.overflow.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.evicted.WithLabelValues(cacheTypePostings))) // Eviction.
-	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.evicted.WithLabelValues(cacheTypeSeries)))   // Eviction.
-
-	// Evicted.
-	pHits, pMisses = cache.FetchMultiPostings(ctx, id, []labels.Label{lbls}, tenancy.DefaultTenant)
-	testutil.Equals(t, emptyPostingsHits, pHits, "no such key")
-	testutil.Equals(t, []labels.Label{lbls}, pMisses)
-
-	sHits, sMisses = cache.FetchMultiSeries(ctx, id, []storage.SeriesRef{1234}, tenancy.DefaultTenant)
-	testutil.Equals(t, emptySeriesHits, sHits, "no such key")
-	testutil.Equals(t, []storage.SeriesRef{1234}, sMisses)
-
-	pHits, pMisses = cache.FetchMultiPostings(ctx, id, []labels.Label{lbls2}, tenancy.DefaultTenant)
-	testutil.Equals(t, map[labels.Label][]byte{lbls2: v}, pHits)
-	testutil.Equals(t, emptyPostingsMisses, pMisses)
-
-	// Add same item again.
-	cache.StorePostings(id, lbls2, v, tenancy.DefaultTenant)
-
-	testutil.Equals(t, uint64(2*sliceHeaderSize+5), cache.curSize)
-	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.current.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(2*sliceHeaderSize+5), promtest.ToFloat64(cache.currentSize.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(2*sliceHeaderSize+5+55), promtest.ToFloat64(cache.totalCurrentSize.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.current.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.currentSize.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.totalCurrentSize.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.overflow.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.overflow.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.evicted.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.evicted.WithLabelValues(cacheTypeSeries)))
-
-	pHits, pMisses = cache.FetchMultiPostings(ctx, id, []labels.Label{lbls2}, tenancy.DefaultTenant)
-	testutil.Equals(t, map[labels.Label][]byte{lbls2: v}, pHits)
-	testutil.Equals(t, emptyPostingsMisses, pMisses)
-
-	// Add too big item.
-	cache.StorePostings(id, labels.Label{Name: "test", Value: "toobig"}, append(v, 5), tenancy.DefaultTenant)
-	testutil.Equals(t, uint64(2*sliceHeaderSize+5), cache.curSize)
-	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.current.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(2*sliceHeaderSize+5), promtest.ToFloat64(cache.currentSize.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(2*sliceHeaderSize+5+55), promtest.ToFloat64(cache.totalCurrentSize.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.current.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.currentSize.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.totalCurrentSize.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.overflow.WithLabelValues(cacheTypePostings))) // Overflow.
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.overflow.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.evicted.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.evicted.WithLabelValues(cacheTypeSeries)))
-
-	_, _, ok := cache.lru.RemoveOldest()
-	testutil.Assert(t, ok, "something to remove")
-
-	testutil.Equals(t, uint64(0), cache.curSize)
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.current.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.currentSize.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.totalCurrentSize.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.current.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.currentSize.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.totalCurrentSize.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.overflow.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.overflow.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(2), promtest.ToFloat64(cache.evicted.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.evicted.WithLabelValues(cacheTypeSeries)))
-
-	_, _, ok = cache.lru.RemoveOldest()
-	testutil.Assert(t, !ok, "nothing to remove")
-
-	lbls3 := labels.Label{Name: "test", Value: "124"}
-
-	cache.StorePostings(id, lbls3, []byte{}, tenancy.DefaultTenant)
-
-	testutil.Equals(t, uint64(sliceHeaderSize), cache.curSize)
-	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.current.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(sliceHeaderSize), promtest.ToFloat64(cache.currentSize.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(sliceHeaderSize+55), promtest.ToFloat64(cache.totalCurrentSize.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.current.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.currentSize.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.totalCurrentSize.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.overflow.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.overflow.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(2), promtest.ToFloat64(cache.evicted.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.evicted.WithLabelValues(cacheTypeSeries)))
-
-	pHits, pMisses = cache.FetchMultiPostings(ctx, id, []labels.Label{lbls3}, tenancy.DefaultTenant)
-	testutil.Equals(t, map[labels.Label][]byte{lbls3: {}}, pHits, "key exists")
-	testutil.Equals(t, emptyPostingsMisses, pMisses)
-
-	// nil works and still allocates empty slice.
-	lbls4 := labels.Label{Name: "test", Value: "125"}
-	cache.StorePostings(id, lbls4, []byte(nil), tenancy.DefaultTenant)
-
-	testutil.Equals(t, 2*uint64(sliceHeaderSize), cache.curSize)
-	testutil.Equals(t, float64(2), promtest.ToFloat64(cache.current.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, 2*float64(sliceHeaderSize), promtest.ToFloat64(cache.currentSize.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, 2*float64(sliceHeaderSize+55), promtest.ToFloat64(cache.totalCurrentSize.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.current.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.currentSize.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.totalCurrentSize.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.overflow.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.overflow.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(2), promtest.ToFloat64(cache.evicted.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.evicted.WithLabelValues(cacheTypeSeries)))
-
-	pHits, pMisses = cache.FetchMultiPostings(ctx, id, []labels.Label{lbls4}, tenancy.DefaultTenant)
-	testutil.Equals(t, map[labels.Label][]byte{lbls4: {}}, pHits, "key exists")
-	testutil.Equals(t, emptyPostingsMisses, pMisses)
-
-	// Other metrics.
-	testutil.Equals(t, float64(4), promtest.ToFloat64(cache.added.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.added.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(9), promtest.ToFloat64(cache.commonMetrics.requestTotal.WithLabelValues(cacheTypePostings, tenancy.DefaultTenant)))
-	testutil.Equals(t, float64(2), promtest.ToFloat64(cache.commonMetrics.requestTotal.WithLabelValues(cacheTypeSeries, tenancy.DefaultTenant)))
-	testutil.Equals(t, float64(5), promtest.ToFloat64(cache.commonMetrics.hitsTotal.WithLabelValues(cacheTypePostings, tenancy.DefaultTenant)))
-	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.commonMetrics.hitsTotal.WithLabelValues(cacheTypeSeries, tenancy.DefaultTenant)))
 }

--- a/pkg/store/cache/inmemory_test.go
+++ b/pkg/store/cache/inmemory_test.go
@@ -33,7 +33,6 @@ func TestNewInMemoryIndexCache(t *testing.T) {
 	conf = []byte{}
 	cache, err = NewInMemoryIndexCache(log.NewNopLogger(), nil, nil, conf)
 	testutil.Ok(t, err)
-	testutil.Equals(t, uint64(DefaultInMemoryIndexCacheConfig.MaxSize), cache.maxSizeBytes)
 	testutil.Equals(t, uint64(DefaultInMemoryIndexCacheConfig.MaxItemSize), cache.maxItemSizeBytes)
 
 	// Should instance an in-memory index cache with specified YAML config.s with units.
@@ -43,7 +42,6 @@ max_item_size: 2KB
 `)
 	cache, err = NewInMemoryIndexCache(log.NewNopLogger(), nil, nil, conf)
 	testutil.Ok(t, err)
-	testutil.Equals(t, uint64(1024*1024), cache.maxSizeBytes)
 	testutil.Equals(t, uint64(2*1024), cache.maxItemSizeBytes)
 
 	// Should instance an in-memory index cache with specified YAML config.s with units.


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Compared to Ristretto based inmemory cache added in https://github.com/thanos-io/thanos/pull/6800, this pr uses `fastcache` https://github.com/VictoriaMetrics/fastcache instead, which seems to have a much better performance from my testing.

The downside is that on eviction interface is exposed so we have no way to track it. Some metrics have to be removed due to this restriction.

## Verification

<!-- How you tested it? How do you know it works? -->
