### PR TITLE
Fix: Removes Deprecated ioutil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 ## Unreleased
 
 ### Fixed
-- [#6834](https://github.com/thanos-io/thanos/pull/6834) Replaces instances of io/ioutil with io and os in Go code
 - [#6817](https://github.com/thanos-io/thanos/pull/6817) Store Gateway: fix `matchersToPostingGroups` label values variable got shadowed bug.
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 ## Unreleased
 
 ### Fixed
-
+- [#6834](https://github.com/thanos-io/thanos/pull/6834) Replaces instances of io/ioutil with io and os in Go code
 - [#6817](https://github.com/thanos-io/thanos/pull/6817) Store Gateway: fix `matchersToPostingGroups` label values variable got shadowed bug.
 
 ### Added

--- a/internal/cortex/frontend/transport/handler.go
+++ b/internal/cortex/frontend/transport/handler.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -120,7 +119,7 @@ func (f *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Buffer the body for later use to track slow queries.
 	var buf bytes.Buffer
 	r.Body = http.MaxBytesReader(w, r.Body, f.cfg.MaxBodySize)
-	r.Body = ioutil.NopCloser(io.TeeReader(r.Body, &buf))
+	r.Body = io.NopCloser(io.TeeReader(r.Body, &buf))
 
 	startTime := time.Now()
 	resp, err := f.roundTripper.RoundTrip(r)
@@ -231,7 +230,7 @@ func (f *Handler) reportQueryStats(r *http.Request, queryString url.Values, quer
 
 func (f *Handler) parseRequestQueryString(r *http.Request, bodyBuf bytes.Buffer) url.Values {
 	// Use previously buffered body.
-	r.Body = ioutil.NopCloser(&bodyBuf)
+	r.Body = io.NopCloser(&bodyBuf)
 
 	// Ensure the form has been parsed so all the parameters are present
 	err := r.ParseForm()

--- a/internal/cortex/querier/queryrange/marshaling_test.go
+++ b/internal/cortex/querier/queryrange/marshaling_test.go
@@ -6,7 +6,7 @@ package queryrange
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	io "io"
 	"math/rand"
 	"net/http"
 	"testing"
@@ -34,7 +34,7 @@ func BenchmarkPrometheusCodec_DecodeResponse(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		_, err := PrometheusCodec.DecodeResponse(context.Background(), &http.Response{
 			StatusCode:    200,
-			Body:          ioutil.NopCloser(bytes.NewReader(encodedRes)),
+			Body:          io.NopCloser(bytes.NewReader(encodedRes)),
 			ContentLength: int64(len(encodedRes)),
 		}, nil)
 		require.NoError(b, err)

--- a/internal/cortex/querier/queryrange/query_range.go
+++ b/internal/cortex/querier/queryrange/query_range.go
@@ -8,7 +8,7 @@ import (
 	"context"
 	stdjson "encoding/json"
 	"fmt"
-	"io/ioutil"
+	io "io"
 	"math"
 	"net/http"
 	"net/url"
@@ -346,7 +346,7 @@ func (prometheusCodec) EncodeRequest(ctx context.Context, r Request) (*http.Requ
 
 func (prometheusCodec) DecodeResponse(ctx context.Context, r *http.Response, _ Request) (Response, error) {
 	if r.StatusCode/100 != 2 {
-		body, _ := ioutil.ReadAll(r.Body)
+		body, _ := io.ReadAll(r.Body)
 		return nil, httpgrpc.Errorf(r.StatusCode, string(body))
 	}
 	log, ctx := spanlogger.New(ctx, "ParseQueryRangeResponse") //nolint:ineffassign,staticcheck
@@ -415,7 +415,7 @@ func (prometheusCodec) EncodeResponse(ctx context.Context, res Response) (*http.
 		Header: http.Header{
 			"Content-Type": []string{"application/json"},
 		},
-		Body:          ioutil.NopCloser(bytes.NewBuffer(b)),
+		Body:          io.NopCloser(bytes.NewBuffer(b)),
 		StatusCode:    http.StatusOK,
 		ContentLength: int64(len(b)),
 	}

--- a/internal/cortex/querier/queryrange/query_range_test.go
+++ b/internal/cortex/querier/queryrange/query_range_test.go
@@ -6,14 +6,13 @@ package queryrange
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	io "io"
 	"net/http"
 	"strconv"
 	"testing"
 
-	"github.com/prometheus/common/model"
-
 	jsoniter "github.com/json-iterator/go"
+	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/weaveworks/common/httpgrpc"
@@ -103,7 +102,7 @@ func TestResponse(t *testing.T) {
 			response := &http.Response{
 				StatusCode: 200,
 				Header:     http.Header{"Content-Type": []string{"application/json"}},
-				Body:       ioutil.NopCloser(bytes.NewBuffer([]byte(tc.body))),
+				Body:       io.NopCloser(bytes.NewBuffer([]byte(tc.body))),
 			}
 			resp, err := PrometheusCodec.DecodeResponse(context.Background(), response, nil)
 			require.NoError(t, err)
@@ -113,7 +112,7 @@ func TestResponse(t *testing.T) {
 			response = &http.Response{
 				StatusCode:    200,
 				Header:        http.Header{"Content-Type": []string{"application/json"}},
-				Body:          ioutil.NopCloser(bytes.NewBuffer([]byte(tc.body))),
+				Body:          io.NopCloser(bytes.NewBuffer([]byte(tc.body))),
 				ContentLength: int64(len(tc.body)),
 			}
 			resp2, err := PrometheusCodec.EncodeResponse(context.Background(), resp)
@@ -163,7 +162,7 @@ func TestResponseWithStats(t *testing.T) {
 			response := &http.Response{
 				StatusCode: 200,
 				Header:     http.Header{"Content-Type": []string{"application/json"}},
-				Body:       ioutil.NopCloser(bytes.NewBuffer([]byte(tc.body))),
+				Body:       io.NopCloser(bytes.NewBuffer([]byte(tc.body))),
 			}
 			resp, err := PrometheusCodec.DecodeResponse(context.Background(), response, nil)
 			require.NoError(t, err)
@@ -173,7 +172,7 @@ func TestResponseWithStats(t *testing.T) {
 			response = &http.Response{
 				StatusCode:    200,
 				Header:        http.Header{"Content-Type": []string{"application/json"}},
-				Body:          ioutil.NopCloser(bytes.NewBuffer([]byte(tc.body))),
+				Body:          io.NopCloser(bytes.NewBuffer([]byte(tc.body))),
 				ContentLength: int64(len(tc.body)),
 			}
 			resp2, err := PrometheusCodec.EncodeResponse(context.Background(), resp)

--- a/internal/cortex/querier/queryrange/roundtrip.go
+++ b/internal/cortex/querier/queryrange/roundtrip.go
@@ -21,7 +21,6 @@ package queryrange
 import (
 	"context"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 	"time"
@@ -268,7 +267,7 @@ func (q roundTripper) Do(ctx context.Context, r Request) (Response, error) {
 		return nil, err
 	}
 	defer func() {
-		io.Copy(ioutil.Discard, io.LimitReader(response.Body, 1024))
+		io.Copy(io.Discard, io.LimitReader(response.Body, 1024))
 		_ = response.Body.Close()
 	}()
 

--- a/internal/cortex/querier/queryrange/roundtrip_test.go
+++ b/internal/cortex/querier/queryrange/roundtrip_test.go
@@ -5,7 +5,7 @@ package queryrange
 
 import (
 	"context"
-	"io/ioutil"
+	io "io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -88,7 +88,7 @@ func TestRoundTrip(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, 200, resp.StatusCode)
 
-			bs, err := ioutil.ReadAll(resp.Body)
+			bs, err := io.ReadAll(resp.Body)
 			require.NoError(t, err)
 			require.Equal(t, tc.expectedBody, string(bs))
 		})

--- a/internal/cortex/querier/queryrange/split_by_interval_test.go
+++ b/internal/cortex/querier/queryrange/split_by_interval_test.go
@@ -5,7 +5,7 @@ package queryrange
 
 import (
 	"context"
-	"io/ioutil"
+	io "io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -13,10 +13,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/weaveworks/common/httpgrpc"
-
 	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/stretchr/testify/require"
+	"github.com/weaveworks/common/httpgrpc"
 	"github.com/weaveworks/common/middleware"
 	"github.com/weaveworks/common/user"
 	"go.uber.org/atomic"
@@ -273,7 +272,7 @@ func TestSplitByDay(t *testing.T) {
 	mergedHTTPResponse, err := PrometheusCodec.EncodeResponse(context.Background(), mergedResponse)
 	require.NoError(t, err)
 
-	mergedHTTPResponseBody, err := ioutil.ReadAll(mergedHTTPResponse.Body)
+	mergedHTTPResponseBody, err := io.ReadAll(mergedHTTPResponse.Body)
 	require.NoError(t, err)
 
 	for i, tc := range []struct {
@@ -313,7 +312,7 @@ func TestSplitByDay(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, 200, resp.StatusCode)
 
-			bs, err := ioutil.ReadAll(resp.Body)
+			bs, err := io.ReadAll(resp.Body)
 			require.NoError(t, err)
 			require.Equal(t, tc.expectedBody, string(bs))
 			require.Equal(t, tc.expectedQueryCount, actualCount.Load())


### PR DESCRIPTION
In Go, io/ioutil has been recently deprecated in favor of the drop in replacements "io" and "os". With the exception of the generated code in the file marked "DO NOT EDIT", this commit addresses those instances of ioutil with the respective function replacements.

Happy Hacktoberfest! Thank you for taking a moment to review my PR!

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

Replaced instances of the deprecated `io/ioutil` with `io` and `os` where required

## Verification

I have not tested it, however this change is a drop in replacement that is common to Go.
