### PR TITLE
Expose common structs/types for index cache

### DIFF
--- a/pkg/store/cache/cache_test.go
+++ b/pkg/store/cache/cache_test.go
@@ -148,7 +148,7 @@ func BenchmarkCacheKey_string_Postings(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		key.String()
+		_ = key.String()
 	}
 }
 
@@ -158,6 +158,6 @@ func BenchmarkCacheKey_string_Series(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		key.String()
+		_ = key.String()
 	}
 }

--- a/pkg/store/cache/cache_test.go
+++ b/pkg/store/cache/cache_test.go
@@ -31,11 +31,11 @@ func TestCacheKey_string(t *testing.T) {
 	matcher2 := labels.MustNewMatcher(labels.MatchNotEqual, "foo", "bar")
 
 	tests := map[string]struct {
-		key      cacheKey
+		key      CacheKey
 		expected string
 	}{
 		"should stringify postings cache key": {
-			key: cacheKey{ulidString, cacheKeyPostings(labels.Label{Name: "foo", Value: "bar"}), ""},
+			key: CacheKey{ulidString, CacheKeyPostings(labels.Label{Name: "foo", Value: "bar"}), ""},
 			expected: func() string {
 				hash := blake2b.Sum256([]byte("foo:bar"))
 				encodedHash := base64.RawURLEncoding.EncodeToString(hash[0:])
@@ -44,7 +44,7 @@ func TestCacheKey_string(t *testing.T) {
 			}(),
 		},
 		"postings cache key includes compression scheme": {
-			key: cacheKey{ulidString, cacheKeyPostings(labels.Label{Name: "foo", Value: "bar"}), compressionSchemeStreamedSnappy},
+			key: CacheKey{ulidString, CacheKeyPostings(labels.Label{Name: "foo", Value: "bar"}), compressionSchemeStreamedSnappy},
 			expected: func() string {
 				hash := blake2b.Sum256([]byte("foo:bar"))
 				encodedHash := base64.RawURLEncoding.EncodeToString(hash[0:])
@@ -53,11 +53,11 @@ func TestCacheKey_string(t *testing.T) {
 			}(),
 		},
 		"should stringify series cache key": {
-			key:      cacheKey{ulidString, cacheKeySeries(12345), ""},
+			key:      CacheKey{ulidString, CacheKeySeries(12345), ""},
 			expected: fmt.Sprintf("S:%s:12345", uid.String()),
 		},
 		"should stringify expanded postings cache key": {
-			key: cacheKey{ulidString, cacheKeyExpandedPostings(labelMatchersToString([]*labels.Matcher{matcher})), ""},
+			key: CacheKey{ulidString, CacheKeyExpandedPostings(LabelMatchersToString([]*labels.Matcher{matcher})), ""},
 			expected: func() string {
 				hash := blake2b.Sum256([]byte(matcher.String()))
 				encodedHash := base64.RawURLEncoding.EncodeToString(hash[0:])
@@ -66,7 +66,7 @@ func TestCacheKey_string(t *testing.T) {
 			}(),
 		},
 		"should stringify expanded postings cache key when multiple matchers": {
-			key: cacheKey{ulidString, cacheKeyExpandedPostings(labelMatchersToString([]*labels.Matcher{matcher, matcher2})), ""},
+			key: CacheKey{ulidString, CacheKeyExpandedPostings(LabelMatchersToString([]*labels.Matcher{matcher, matcher2})), ""},
 			expected: func() string {
 				hash := blake2b.Sum256([]byte(fmt.Sprintf("%s;%s", matcher.String(), matcher2.String())))
 				encodedHash := base64.RawURLEncoding.EncodeToString(hash[0:])
@@ -75,7 +75,7 @@ func TestCacheKey_string(t *testing.T) {
 			}(),
 		},
 		"expanded postings cache key includes compression scheme": {
-			key: cacheKey{ulidString, cacheKeyExpandedPostings(labelMatchersToString([]*labels.Matcher{matcher})), compressionSchemeStreamedSnappy},
+			key: CacheKey{ulidString, CacheKeyExpandedPostings(LabelMatchersToString([]*labels.Matcher{matcher})), compressionSchemeStreamedSnappy},
 			expected: func() string {
 				hash := blake2b.Sum256([]byte(matcher.String()))
 				encodedHash := base64.RawURLEncoding.EncodeToString(hash[0:])
@@ -87,7 +87,7 @@ func TestCacheKey_string(t *testing.T) {
 
 	for testName, testData := range tests {
 		t.Run(testName, func(t *testing.T) {
-			actual := testData.key.string()
+			actual := testData.key.String()
 			testutil.Equals(t, testData.expected, actual)
 		})
 	}
@@ -100,25 +100,25 @@ func TestCacheKey_string_ShouldGuaranteeReasonablyShortKeyLength(t *testing.T) {
 	ulidString := uid.String()
 
 	tests := map[string]struct {
-		keys        []cacheKey
+		keys        []CacheKey
 		expectedLen int
 	}{
 		"should guarantee reasonably short key length for postings": {
 			expectedLen: 72,
-			keys: []cacheKey{
-				{ulidString, cacheKeyPostings(labels.Label{Name: "a", Value: "b"}), ""},
-				{ulidString, cacheKeyPostings(labels.Label{Name: strings.Repeat("a", 100), Value: strings.Repeat("a", 1000)}), ""},
+			keys: []CacheKey{
+				{ulidString, CacheKeyPostings(labels.Label{Name: "a", Value: "b"}), ""},
+				{ulidString, CacheKeyPostings(labels.Label{Name: strings.Repeat("a", 100), Value: strings.Repeat("a", 1000)}), ""},
 			},
 		},
 		"should guarantee reasonably short key length for series": {
 			expectedLen: 49,
-			keys: []cacheKey{
-				{ulidString, cacheKeySeries(math.MaxUint64), ""},
+			keys: []CacheKey{
+				{ulidString, CacheKeySeries(math.MaxUint64), ""},
 			},
 		},
 		"should guarantee reasonably short key length for expanded postings": {
 			expectedLen: 73,
-			keys: []cacheKey{
+			keys: []CacheKey{
 				{ulidString, func() interface{} {
 					matchers := make([]*labels.Matcher, 0, 100)
 					name := strings.Repeat("a", 100)
@@ -127,7 +127,7 @@ func TestCacheKey_string_ShouldGuaranteeReasonablyShortKeyLength(t *testing.T) {
 						t := labels.MatchType(i % 4)
 						matchers = append(matchers, labels.MustNewMatcher(t, name, value))
 					}
-					return cacheKeyExpandedPostings(labelMatchersToString(matchers))
+					return CacheKeyExpandedPostings(LabelMatchersToString(matchers))
 				}(), ""},
 			},
 		},
@@ -136,7 +136,7 @@ func TestCacheKey_string_ShouldGuaranteeReasonablyShortKeyLength(t *testing.T) {
 	for testName, testData := range tests {
 		t.Run(testName, func(t *testing.T) {
 			for _, key := range testData.keys {
-				testutil.Equals(t, testData.expectedLen, len(key.string()))
+				testutil.Equals(t, testData.expectedLen, len(key.String()))
 			}
 		})
 	}
@@ -144,20 +144,20 @@ func TestCacheKey_string_ShouldGuaranteeReasonablyShortKeyLength(t *testing.T) {
 
 func BenchmarkCacheKey_string_Postings(b *testing.B) {
 	uid := ulid.MustNew(1, nil)
-	key := cacheKey{uid.String(), cacheKeyPostings(labels.Label{Name: strings.Repeat("a", 100), Value: strings.Repeat("a", 1000)}), ""}
+	key := CacheKey{uid.String(), CacheKeyPostings(labels.Label{Name: strings.Repeat("a", 100), Value: strings.Repeat("a", 1000)}), ""}
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		key.string()
+		key.String()
 	}
 }
 
 func BenchmarkCacheKey_string_Series(b *testing.B) {
 	uid := ulid.MustNew(1, nil)
-	key := cacheKey{uid.String(), cacheKeySeries(math.MaxUint64), ""}
+	key := CacheKey{uid.String(), CacheKeySeries(math.MaxUint64), ""}
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		key.string()
+		key.String()
 	}
 }

--- a/pkg/store/cache/factory.go
+++ b/pkg/store/cache/factory.go
@@ -41,7 +41,7 @@ type IndexCacheConfig struct {
 func NewIndexCache(logger log.Logger, confContentYaml []byte, reg prometheus.Registerer) (IndexCache, error) {
 	level.Info(logger).Log("msg", "loading index cache configuration")
 	cacheConfig := &IndexCacheConfig{}
-	cacheMetrics := newCommonMetrics(reg)
+	cacheMetrics := NewCommonMetrics(reg)
 	if err := yaml.UnmarshalStrict(confContentYaml, cacheConfig); err != nil {
 		return nil, errors.Wrap(err, "parsing config YAML file")
 	}

--- a/pkg/store/cache/factory_test.go
+++ b/pkg/store/cache/factory_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestIndexCacheMetrics(t *testing.T) {
 	reg := prometheus.NewRegistry()
-	commonMetrics := newCommonMetrics(reg)
+	commonMetrics := NewCommonMetrics(reg)
 
 	memcached := newMockedMemcachedClient(nil)
 	_, err := NewRemoteIndexCache(log.NewNopLogger(), memcached, commonMetrics, reg, memcachedDefaultTTL)

--- a/pkg/store/cache/filter_cache.go
+++ b/pkg/store/cache/filter_cache.go
@@ -29,7 +29,7 @@ func NewFilteredIndexCache(cache IndexCache, enabledItems []string) *FilteredInd
 // StorePostings sets the postings identified by the ulid and label to the value v,
 // if the postings already exists in the cache it is not mutated.
 func (c *FilteredIndexCache) StorePostings(blockID ulid.ULID, l labels.Label, v []byte, tenant string) {
-	if len(c.enabledItems) == 0 || slices.Contains(c.enabledItems, cacheTypePostings) {
+	if len(c.enabledItems) == 0 || slices.Contains(c.enabledItems, CacheTypePostings) {
 		c.cache.StorePostings(blockID, l, v, tenant)
 	}
 }
@@ -37,7 +37,7 @@ func (c *FilteredIndexCache) StorePostings(blockID ulid.ULID, l labels.Label, v 
 // FetchMultiPostings fetches multiple postings - each identified by a label -
 // and returns a map containing cache hits, along with a list of missing keys.
 func (c *FilteredIndexCache) FetchMultiPostings(ctx context.Context, blockID ulid.ULID, keys []labels.Label, tenant string) (hits map[labels.Label][]byte, misses []labels.Label) {
-	if len(c.enabledItems) == 0 || slices.Contains(c.enabledItems, cacheTypePostings) {
+	if len(c.enabledItems) == 0 || slices.Contains(c.enabledItems, CacheTypePostings) {
 		return c.cache.FetchMultiPostings(ctx, blockID, keys, tenant)
 	}
 	return nil, keys
@@ -45,14 +45,14 @@ func (c *FilteredIndexCache) FetchMultiPostings(ctx context.Context, blockID uli
 
 // StoreExpandedPostings stores expanded postings for a set of label matchers.
 func (c *FilteredIndexCache) StoreExpandedPostings(blockID ulid.ULID, matchers []*labels.Matcher, v []byte, tenant string) {
-	if len(c.enabledItems) == 0 || slices.Contains(c.enabledItems, cacheTypeExpandedPostings) {
+	if len(c.enabledItems) == 0 || slices.Contains(c.enabledItems, CacheTypeExpandedPostings) {
 		c.cache.StoreExpandedPostings(blockID, matchers, v, tenant)
 	}
 }
 
 // FetchExpandedPostings fetches expanded postings and returns cached data and a boolean value representing whether it is a cache hit or not.
 func (c *FilteredIndexCache) FetchExpandedPostings(ctx context.Context, blockID ulid.ULID, matchers []*labels.Matcher, tenant string) ([]byte, bool) {
-	if len(c.enabledItems) == 0 || slices.Contains(c.enabledItems, cacheTypeExpandedPostings) {
+	if len(c.enabledItems) == 0 || slices.Contains(c.enabledItems, CacheTypeExpandedPostings) {
 		return c.cache.FetchExpandedPostings(ctx, blockID, matchers, tenant)
 	}
 	return nil, false
@@ -61,7 +61,7 @@ func (c *FilteredIndexCache) FetchExpandedPostings(ctx context.Context, blockID 
 // StoreSeries sets the series identified by the ulid and id to the value v,
 // if the series already exists in the cache it is not mutated.
 func (c *FilteredIndexCache) StoreSeries(blockID ulid.ULID, id storage.SeriesRef, v []byte, tenant string) {
-	if len(c.enabledItems) == 0 || slices.Contains(c.enabledItems, cacheTypeSeries) {
+	if len(c.enabledItems) == 0 || slices.Contains(c.enabledItems, CacheTypeSeries) {
 		c.cache.StoreSeries(blockID, id, v, tenant)
 	}
 }
@@ -69,7 +69,7 @@ func (c *FilteredIndexCache) StoreSeries(blockID ulid.ULID, id storage.SeriesRef
 // FetchMultiSeries fetches multiple series - each identified by ID - from the cache
 // and returns a map containing cache hits, along with a list of missing IDs.
 func (c *FilteredIndexCache) FetchMultiSeries(ctx context.Context, blockID ulid.ULID, ids []storage.SeriesRef, tenant string) (hits map[storage.SeriesRef][]byte, misses []storage.SeriesRef) {
-	if len(c.enabledItems) == 0 || slices.Contains(c.enabledItems, cacheTypeSeries) {
+	if len(c.enabledItems) == 0 || slices.Contains(c.enabledItems, CacheTypeSeries) {
 		return c.cache.FetchMultiSeries(ctx, blockID, ids, tenant)
 	}
 	return nil, ids
@@ -79,7 +79,7 @@ func ValidateEnabledItems(enabledItems []string) error {
 	for _, item := range enabledItems {
 		switch item {
 		// valid
-		case cacheTypePostings, cacheTypeExpandedPostings, cacheTypeSeries:
+		case CacheTypePostings, CacheTypeExpandedPostings, CacheTypeSeries:
 		default:
 			return fmt.Errorf("unsupported item type %s", item)
 		}

--- a/pkg/store/cache/filter_cache_test.go
+++ b/pkg/store/cache/filter_cache_test.go
@@ -43,7 +43,7 @@ func TestFilterCache(t *testing.T) {
 		{
 			name:          "invalid item type with 1 valid cache type",
 			expectedError: "unsupported item type foo",
-			enabledItems:  []string{cacheTypeExpandedPostings, "foo"},
+			enabledItems:  []string{CacheTypeExpandedPostings, "foo"},
 		},
 		{
 			name: "empty enabled items",
@@ -67,7 +67,7 @@ func TestFilterCache(t *testing.T) {
 		},
 		{
 			name:         "all enabled items",
-			enabledItems: []string{cacheTypeSeries, cacheTypePostings, cacheTypeExpandedPostings},
+			enabledItems: []string{CacheTypeSeries, CacheTypePostings, CacheTypeExpandedPostings},
 			verifyFunc: func(t *testing.T, c IndexCache) {
 				c.StorePostings(blockID, postingKeys[0], testPostingData, tenancy.DefaultTenant)
 				c.StoreExpandedPostings(blockID, expandedPostingsMatchers, testExpandedPostingsData, tenancy.DefaultTenant)
@@ -88,7 +88,7 @@ func TestFilterCache(t *testing.T) {
 		},
 		{
 			name:         "only enable postings",
-			enabledItems: []string{cacheTypePostings},
+			enabledItems: []string{CacheTypePostings},
 			verifyFunc: func(t *testing.T, c IndexCache) {
 				c.StorePostings(blockID, postingKeys[0], testPostingData, tenancy.DefaultTenant)
 				c.StoreExpandedPostings(blockID, expandedPostingsMatchers, testExpandedPostingsData, tenancy.DefaultTenant)
@@ -108,7 +108,7 @@ func TestFilterCache(t *testing.T) {
 		},
 		{
 			name:         "only enable expanded postings",
-			enabledItems: []string{cacheTypeExpandedPostings},
+			enabledItems: []string{CacheTypeExpandedPostings},
 			verifyFunc: func(t *testing.T, c IndexCache) {
 				c.StorePostings(blockID, postingKeys[0], testPostingData, tenancy.DefaultTenant)
 				c.StoreExpandedPostings(blockID, expandedPostingsMatchers, testExpandedPostingsData, tenancy.DefaultTenant)
@@ -129,7 +129,7 @@ func TestFilterCache(t *testing.T) {
 		},
 		{
 			name:         "only enable series",
-			enabledItems: []string{cacheTypeSeries},
+			enabledItems: []string{CacheTypeSeries},
 			verifyFunc: func(t *testing.T, c IndexCache) {
 				c.StorePostings(blockID, postingKeys[0], testPostingData, tenancy.DefaultTenant)
 				c.StoreExpandedPostings(blockID, expandedPostingsMatchers, testExpandedPostingsData, tenancy.DefaultTenant)

--- a/pkg/store/cache/inmemory.go
+++ b/pkg/store/cache/inmemory.go
@@ -50,7 +50,7 @@ type InMemoryIndexCache struct {
 	totalCurrentSize *prometheus.GaugeVec
 	overflow         *prometheus.CounterVec
 
-	commonMetrics *commonMetrics
+	commonMetrics *CommonMetrics
 }
 
 // InMemoryIndexCacheConfig holds the in-memory index cache config.
@@ -73,7 +73,7 @@ func parseInMemoryIndexCacheConfig(conf []byte) (InMemoryIndexCacheConfig, error
 
 // NewInMemoryIndexCache creates a new thread-safe LRU cache for index entries and ensures the total cache
 // size approximately does not exceed maxBytes.
-func NewInMemoryIndexCache(logger log.Logger, commonMetrics *commonMetrics, reg prometheus.Registerer, conf []byte) (*InMemoryIndexCache, error) {
+func NewInMemoryIndexCache(logger log.Logger, commonMetrics *CommonMetrics, reg prometheus.Registerer, conf []byte) (*InMemoryIndexCache, error) {
 	config, err := parseInMemoryIndexCacheConfig(conf)
 	if err != nil {
 		return nil, err
@@ -84,13 +84,13 @@ func NewInMemoryIndexCache(logger log.Logger, commonMetrics *commonMetrics, reg 
 
 // NewInMemoryIndexCacheWithConfig creates a new thread-safe LRU cache for index entries and ensures the total cache
 // size approximately does not exceed maxBytes.
-func NewInMemoryIndexCacheWithConfig(logger log.Logger, commonMetrics *commonMetrics, reg prometheus.Registerer, config InMemoryIndexCacheConfig) (*InMemoryIndexCache, error) {
+func NewInMemoryIndexCacheWithConfig(logger log.Logger, commonMetrics *CommonMetrics, reg prometheus.Registerer, config InMemoryIndexCacheConfig) (*InMemoryIndexCache, error) {
 	if config.MaxItemSize > config.MaxSize {
 		return nil, errors.Errorf("max item size (%v) cannot be bigger than overall cache size (%v)", config.MaxItemSize, config.MaxSize)
 	}
 
 	if commonMetrics == nil {
-		commonMetrics = newCommonMetrics(reg)
+		commonMetrics = NewCommonMetrics(reg)
 	}
 
 	c := &InMemoryIndexCache{
@@ -104,57 +104,57 @@ func NewInMemoryIndexCacheWithConfig(logger log.Logger, commonMetrics *commonMet
 		Name: "thanos_store_index_cache_items_evicted_total",
 		Help: "Total number of items that were evicted from the index cache.",
 	}, []string{"item_type"})
-	c.evicted.WithLabelValues(cacheTypePostings)
-	c.evicted.WithLabelValues(cacheTypeSeries)
-	c.evicted.WithLabelValues(cacheTypeExpandedPostings)
+	c.evicted.WithLabelValues(CacheTypePostings)
+	c.evicted.WithLabelValues(CacheTypeSeries)
+	c.evicted.WithLabelValues(CacheTypeExpandedPostings)
 
 	c.added = promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 		Name: "thanos_store_index_cache_items_added_total",
 		Help: "Total number of items that were added to the index cache.",
 	}, []string{"item_type"})
-	c.added.WithLabelValues(cacheTypePostings)
-	c.added.WithLabelValues(cacheTypeSeries)
-	c.added.WithLabelValues(cacheTypeExpandedPostings)
+	c.added.WithLabelValues(CacheTypePostings)
+	c.added.WithLabelValues(CacheTypeSeries)
+	c.added.WithLabelValues(CacheTypeExpandedPostings)
 
-	c.commonMetrics.requestTotal.WithLabelValues(cacheTypePostings, tenancy.DefaultTenant)
-	c.commonMetrics.requestTotal.WithLabelValues(cacheTypeSeries, tenancy.DefaultTenant)
-	c.commonMetrics.requestTotal.WithLabelValues(cacheTypeExpandedPostings, tenancy.DefaultTenant)
+	c.commonMetrics.RequestTotal.WithLabelValues(CacheTypePostings, tenancy.DefaultTenant)
+	c.commonMetrics.RequestTotal.WithLabelValues(CacheTypeSeries, tenancy.DefaultTenant)
+	c.commonMetrics.RequestTotal.WithLabelValues(CacheTypeExpandedPostings, tenancy.DefaultTenant)
 
 	c.overflow = promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 		Name: "thanos_store_index_cache_items_overflowed_total",
 		Help: "Total number of items that could not be added to the cache due to being too big.",
 	}, []string{"item_type"})
-	c.overflow.WithLabelValues(cacheTypePostings)
-	c.overflow.WithLabelValues(cacheTypeSeries)
-	c.overflow.WithLabelValues(cacheTypeExpandedPostings)
+	c.overflow.WithLabelValues(CacheTypePostings)
+	c.overflow.WithLabelValues(CacheTypeSeries)
+	c.overflow.WithLabelValues(CacheTypeExpandedPostings)
 
-	c.commonMetrics.hitsTotal.WithLabelValues(cacheTypePostings, tenancy.DefaultTenant)
-	c.commonMetrics.hitsTotal.WithLabelValues(cacheTypeSeries, tenancy.DefaultTenant)
-	c.commonMetrics.hitsTotal.WithLabelValues(cacheTypeExpandedPostings, tenancy.DefaultTenant)
+	c.commonMetrics.HitsTotal.WithLabelValues(CacheTypePostings, tenancy.DefaultTenant)
+	c.commonMetrics.HitsTotal.WithLabelValues(CacheTypeSeries, tenancy.DefaultTenant)
+	c.commonMetrics.HitsTotal.WithLabelValues(CacheTypeExpandedPostings, tenancy.DefaultTenant)
 
 	c.current = promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
 		Name: "thanos_store_index_cache_items",
 		Help: "Current number of items in the index cache.",
 	}, []string{"item_type"})
-	c.current.WithLabelValues(cacheTypePostings)
-	c.current.WithLabelValues(cacheTypeSeries)
-	c.current.WithLabelValues(cacheTypeExpandedPostings)
+	c.current.WithLabelValues(CacheTypePostings)
+	c.current.WithLabelValues(CacheTypeSeries)
+	c.current.WithLabelValues(CacheTypeExpandedPostings)
 
 	c.currentSize = promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
 		Name: "thanos_store_index_cache_items_size_bytes",
 		Help: "Current byte size of items in the index cache.",
 	}, []string{"item_type"})
-	c.currentSize.WithLabelValues(cacheTypePostings)
-	c.currentSize.WithLabelValues(cacheTypeSeries)
-	c.currentSize.WithLabelValues(cacheTypeExpandedPostings)
+	c.currentSize.WithLabelValues(CacheTypePostings)
+	c.currentSize.WithLabelValues(CacheTypeSeries)
+	c.currentSize.WithLabelValues(CacheTypeExpandedPostings)
 
 	c.totalCurrentSize = promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
 		Name: "thanos_store_index_cache_total_size_bytes",
 		Help: "Current byte size of items (both value and key) in the index cache.",
 	}, []string{"item_type"})
-	c.totalCurrentSize.WithLabelValues(cacheTypePostings)
-	c.totalCurrentSize.WithLabelValues(cacheTypeSeries)
-	c.totalCurrentSize.WithLabelValues(cacheTypeExpandedPostings)
+	c.totalCurrentSize.WithLabelValues(CacheTypePostings)
+	c.totalCurrentSize.WithLabelValues(CacheTypeSeries)
+	c.totalCurrentSize.WithLabelValues(CacheTypeExpandedPostings)
 
 	_ = promauto.With(reg).NewGaugeFunc(prometheus.GaugeOpts{
 		Name: "thanos_store_index_cache_max_size_bytes",
@@ -187,18 +187,18 @@ func NewInMemoryIndexCacheWithConfig(logger log.Logger, commonMetrics *commonMet
 }
 
 func (c *InMemoryIndexCache) onEvict(key, val interface{}) {
-	k := key.(cacheKey).keyType()
+	k := key.(CacheKey).KeyType()
 	entrySize := sliceHeaderSize + uint64(len(val.([]byte)))
 
 	c.evicted.WithLabelValues(k).Inc()
 	c.current.WithLabelValues(k).Dec()
 	c.currentSize.WithLabelValues(k).Sub(float64(entrySize))
-	c.totalCurrentSize.WithLabelValues(k).Sub(float64(entrySize + key.(cacheKey).size()))
+	c.totalCurrentSize.WithLabelValues(k).Sub(float64(entrySize + key.(CacheKey).Size()))
 
 	c.curSize -= entrySize
 }
 
-func (c *InMemoryIndexCache) get(key cacheKey) ([]byte, bool) {
+func (c *InMemoryIndexCache) get(key CacheKey) ([]byte, bool) {
 	c.mtx.Lock()
 	defer c.mtx.Unlock()
 
@@ -209,7 +209,7 @@ func (c *InMemoryIndexCache) get(key cacheKey) ([]byte, bool) {
 	return v.([]byte), true
 }
 
-func (c *InMemoryIndexCache) set(typ string, key cacheKey, val []byte) {
+func (c *InMemoryIndexCache) set(typ string, key CacheKey, val []byte) {
 	var size = sliceHeaderSize + uint64(len(val))
 
 	c.mtx.Lock()
@@ -232,7 +232,7 @@ func (c *InMemoryIndexCache) set(typ string, key cacheKey, val []byte) {
 
 	c.added.WithLabelValues(typ).Inc()
 	c.currentSize.WithLabelValues(typ).Add(float64(size))
-	c.totalCurrentSize.WithLabelValues(typ).Add(float64(size + key.size()))
+	c.totalCurrentSize.WithLabelValues(typ).Add(float64(size + key.Size()))
 	c.current.WithLabelValues(typ).Inc()
 	c.curSize += size
 }
@@ -286,21 +286,21 @@ func copyString(s string) string {
 }
 
 // copyToKey is required as underlying strings might be mmaped.
-func copyToKey(l labels.Label) cacheKeyPostings {
-	return cacheKeyPostings(labels.Label{Value: copyString(l.Value), Name: copyString(l.Name)})
+func copyToKey(l labels.Label) CacheKeyPostings {
+	return CacheKeyPostings(labels.Label{Value: copyString(l.Value), Name: copyString(l.Name)})
 }
 
 // StorePostings sets the postings identified by the ulid and label to the value v,
 // if the postings already exists in the cache it is not mutated.
 func (c *InMemoryIndexCache) StorePostings(blockID ulid.ULID, l labels.Label, v []byte, tenant string) {
-	c.commonMetrics.dataSizeBytes.WithLabelValues(cacheTypePostings, tenant).Observe(float64(len(v)))
-	c.set(cacheTypePostings, cacheKey{block: blockID.String(), key: copyToKey(l)}, v)
+	c.commonMetrics.DataSizeBytes.WithLabelValues(CacheTypePostings, tenant).Observe(float64(len(v)))
+	c.set(CacheTypePostings, CacheKey{Block: blockID.String(), Key: copyToKey(l)}, v)
 }
 
 // FetchMultiPostings fetches multiple postings - each identified by a label -
 // and returns a map containing cache hits, along with a list of missing keys.
 func (c *InMemoryIndexCache) FetchMultiPostings(ctx context.Context, blockID ulid.ULID, keys []labels.Label, tenant string) (hits map[labels.Label][]byte, misses []labels.Label) {
-	timer := prometheus.NewTimer(c.commonMetrics.fetchLatency.WithLabelValues(cacheTypePostings, tenant))
+	timer := prometheus.NewTimer(c.commonMetrics.FetchLatency.WithLabelValues(CacheTypePostings, tenant))
 	defer timer.ObserveDuration()
 
 	hits = map[labels.Label][]byte{}
@@ -310,12 +310,12 @@ func (c *InMemoryIndexCache) FetchMultiPostings(ctx context.Context, blockID uli
 	hit := 0
 	for _, key := range keys {
 		if ctx.Err() != nil {
-			c.commonMetrics.requestTotal.WithLabelValues(cacheTypePostings, tenant).Add(float64(requests))
-			c.commonMetrics.hitsTotal.WithLabelValues(cacheTypePostings, tenant).Add(float64(hit))
+			c.commonMetrics.RequestTotal.WithLabelValues(CacheTypePostings, tenant).Add(float64(requests))
+			c.commonMetrics.HitsTotal.WithLabelValues(CacheTypePostings, tenant).Add(float64(hit))
 			return hits, misses
 		}
 		requests++
-		if b, ok := c.get(cacheKey{blockIDKey, cacheKeyPostings(key), ""}); ok {
+		if b, ok := c.get(CacheKey{blockIDKey, CacheKeyPostings(key), ""}); ok {
 			hit++
 			hits[key] = b
 			continue
@@ -323,29 +323,29 @@ func (c *InMemoryIndexCache) FetchMultiPostings(ctx context.Context, blockID uli
 
 		misses = append(misses, key)
 	}
-	c.commonMetrics.requestTotal.WithLabelValues(cacheTypePostings, tenant).Add(float64(requests))
-	c.commonMetrics.hitsTotal.WithLabelValues(cacheTypePostings, tenant).Add(float64(hit))
+	c.commonMetrics.RequestTotal.WithLabelValues(CacheTypePostings, tenant).Add(float64(requests))
+	c.commonMetrics.HitsTotal.WithLabelValues(CacheTypePostings, tenant).Add(float64(hit))
 
 	return hits, misses
 }
 
 // StoreExpandedPostings stores expanded postings for a set of label matchers.
 func (c *InMemoryIndexCache) StoreExpandedPostings(blockID ulid.ULID, matchers []*labels.Matcher, v []byte, tenant string) {
-	c.commonMetrics.dataSizeBytes.WithLabelValues(cacheTypeExpandedPostings, tenant).Observe(float64(len(v)))
-	c.set(cacheTypeExpandedPostings, cacheKey{block: blockID.String(), key: cacheKeyExpandedPostings(labelMatchersToString(matchers))}, v)
+	c.commonMetrics.DataSizeBytes.WithLabelValues(CacheTypeExpandedPostings, tenant).Observe(float64(len(v)))
+	c.set(CacheTypeExpandedPostings, CacheKey{Block: blockID.String(), Key: CacheKeyExpandedPostings(LabelMatchersToString(matchers))}, v)
 }
 
 // FetchExpandedPostings fetches expanded postings and returns cached data and a boolean value representing whether it is a cache hit or not.
 func (c *InMemoryIndexCache) FetchExpandedPostings(ctx context.Context, blockID ulid.ULID, matchers []*labels.Matcher, tenant string) ([]byte, bool) {
-	timer := prometheus.NewTimer(c.commonMetrics.fetchLatency.WithLabelValues(cacheTypeExpandedPostings, tenant))
+	timer := prometheus.NewTimer(c.commonMetrics.FetchLatency.WithLabelValues(CacheTypeExpandedPostings, tenant))
 	defer timer.ObserveDuration()
 
 	if ctx.Err() != nil {
 		return nil, false
 	}
-	c.commonMetrics.requestTotal.WithLabelValues(cacheTypeExpandedPostings, tenant).Inc()
-	if b, ok := c.get(cacheKey{blockID.String(), cacheKeyExpandedPostings(labelMatchersToString(matchers)), ""}); ok {
-		c.commonMetrics.hitsTotal.WithLabelValues(cacheTypeExpandedPostings, tenant).Inc()
+	c.commonMetrics.RequestTotal.WithLabelValues(CacheTypeExpandedPostings, tenant).Inc()
+	if b, ok := c.get(CacheKey{blockID.String(), CacheKeyExpandedPostings(LabelMatchersToString(matchers)), ""}); ok {
+		c.commonMetrics.HitsTotal.WithLabelValues(CacheTypeExpandedPostings, tenant).Inc()
 		return b, true
 	}
 	return nil, false
@@ -354,14 +354,14 @@ func (c *InMemoryIndexCache) FetchExpandedPostings(ctx context.Context, blockID 
 // StoreSeries sets the series identified by the ulid and id to the value v,
 // if the series already exists in the cache it is not mutated.
 func (c *InMemoryIndexCache) StoreSeries(blockID ulid.ULID, id storage.SeriesRef, v []byte, tenant string) {
-	c.commonMetrics.dataSizeBytes.WithLabelValues(cacheTypeSeries, tenant).Observe(float64(len(v)))
-	c.set(cacheTypeSeries, cacheKey{blockID.String(), cacheKeySeries(id), ""}, v)
+	c.commonMetrics.DataSizeBytes.WithLabelValues(CacheTypeSeries, tenant).Observe(float64(len(v)))
+	c.set(CacheTypeSeries, CacheKey{blockID.String(), CacheKeySeries(id), ""}, v)
 }
 
 // FetchMultiSeries fetches multiple series - each identified by ID - from the cache
 // and returns a map containing cache hits, along with a list of missing IDs.
 func (c *InMemoryIndexCache) FetchMultiSeries(ctx context.Context, blockID ulid.ULID, ids []storage.SeriesRef, tenant string) (hits map[storage.SeriesRef][]byte, misses []storage.SeriesRef) {
-	timer := prometheus.NewTimer(c.commonMetrics.fetchLatency.WithLabelValues(cacheTypeSeries, tenant))
+	timer := prometheus.NewTimer(c.commonMetrics.FetchLatency.WithLabelValues(CacheTypeSeries, tenant))
 	defer timer.ObserveDuration()
 
 	hits = map[storage.SeriesRef][]byte{}
@@ -371,12 +371,12 @@ func (c *InMemoryIndexCache) FetchMultiSeries(ctx context.Context, blockID ulid.
 	hit := 0
 	for _, id := range ids {
 		if ctx.Err() != nil {
-			c.commonMetrics.requestTotal.WithLabelValues(cacheTypeSeries, tenant).Add(float64(requests))
-			c.commonMetrics.hitsTotal.WithLabelValues(cacheTypeSeries, tenant).Add(float64(hit))
+			c.commonMetrics.RequestTotal.WithLabelValues(CacheTypeSeries, tenant).Add(float64(requests))
+			c.commonMetrics.HitsTotal.WithLabelValues(CacheTypeSeries, tenant).Add(float64(hit))
 			return hits, misses
 		}
 		requests++
-		if b, ok := c.get(cacheKey{blockIDKey, cacheKeySeries(id), ""}); ok {
+		if b, ok := c.get(CacheKey{blockIDKey, CacheKeySeries(id), ""}); ok {
 			hit++
 			hits[id] = b
 			continue
@@ -384,8 +384,8 @@ func (c *InMemoryIndexCache) FetchMultiSeries(ctx context.Context, blockID ulid.
 
 		misses = append(misses, id)
 	}
-	c.commonMetrics.requestTotal.WithLabelValues(cacheTypeSeries, tenant).Add(float64(requests))
-	c.commonMetrics.hitsTotal.WithLabelValues(cacheTypeSeries, tenant).Add(float64(hit))
+	c.commonMetrics.RequestTotal.WithLabelValues(CacheTypeSeries, tenant).Add(float64(requests))
+	c.commonMetrics.HitsTotal.WithLabelValues(CacheTypeSeries, tenant).Add(float64(hit))
 
 	return hits, misses
 }

--- a/pkg/store/cache/inmemory_test.go
+++ b/pkg/store/cache/inmemory_test.go
@@ -84,15 +84,15 @@ func TestInMemoryIndexCache_AvoidsDeadlock(t *testing.T) {
 	cache.StorePostings(ulid.MustNew(0, nil), labels.Label{Name: "test2", Value: "1"}, []byte{42, 33, 14, 67, 11}, tenancy.DefaultTenant)
 
 	testutil.Equals(t, uint64(sliceHeaderSize+5), cache.curSize)
-	testutil.Equals(t, float64(cache.curSize), promtest.ToFloat64(cache.currentSize.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.current.WithLabelValues(cacheTypePostings)))
+	testutil.Equals(t, float64(cache.curSize), promtest.ToFloat64(cache.currentSize.WithLabelValues(CacheTypePostings)))
+	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.current.WithLabelValues(CacheTypePostings)))
 
 	// This triggers deadlock logic.
 	cache.StorePostings(ulid.MustNew(0, nil), labels.Label{Name: "test1", Value: "1"}, []byte{42}, tenancy.DefaultTenant)
 
 	testutil.Equals(t, uint64(sliceHeaderSize+1), cache.curSize)
-	testutil.Equals(t, float64(cache.curSize), promtest.ToFloat64(cache.currentSize.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.current.WithLabelValues(cacheTypePostings)))
+	testutil.Equals(t, float64(cache.curSize), promtest.ToFloat64(cache.currentSize.WithLabelValues(CacheTypePostings)))
+	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.current.WithLabelValues(CacheTypePostings)))
 }
 
 func TestInMemoryIndexCache_UpdateItem(t *testing.T) {
@@ -133,7 +133,7 @@ func TestInMemoryIndexCache_UpdateItem(t *testing.T) {
 		get func(storage.SeriesRef) ([]byte, bool)
 	}{
 		{
-			typ: cacheTypePostings,
+			typ: CacheTypePostings,
 			set: func(id storage.SeriesRef, b []byte) { cache.StorePostings(uid(id), lbl, b, tenancy.DefaultTenant) },
 			get: func(id storage.SeriesRef) ([]byte, bool) {
 				hits, _ := cache.FetchMultiPostings(ctx, uid(id), []labels.Label{lbl}, tenancy.DefaultTenant)
@@ -143,7 +143,7 @@ func TestInMemoryIndexCache_UpdateItem(t *testing.T) {
 			},
 		},
 		{
-			typ: cacheTypeSeries,
+			typ: CacheTypeSeries,
 			set: func(id storage.SeriesRef, b []byte) { cache.StoreSeries(uid(id), id, b, tenancy.DefaultTenant) },
 			get: func(id storage.SeriesRef) ([]byte, bool) {
 				hits, _ := cache.FetchMultiSeries(ctx, uid(id), []storage.SeriesRef{id}, tenancy.DefaultTenant)
@@ -153,7 +153,7 @@ func TestInMemoryIndexCache_UpdateItem(t *testing.T) {
 			},
 		},
 		{
-			typ: cacheTypeExpandedPostings,
+			typ: CacheTypeExpandedPostings,
 			set: func(id storage.SeriesRef, b []byte) {
 				cache.StoreExpandedPostings(uid(id), []*labels.Matcher{matcher}, b, tenancy.DefaultTenant)
 			},
@@ -227,16 +227,16 @@ func TestInMemoryIndexCache_MaxNumberOfItemsHit(t *testing.T) {
 	cache.StorePostings(id, labels.Label{Name: "test", Value: "125"}, []byte{42, 33}, tenancy.DefaultTenant)
 
 	testutil.Equals(t, uint64(2*sliceHeaderSize+4), cache.curSize)
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.overflow.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.overflow.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.evicted.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.evicted.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(3), promtest.ToFloat64(cache.added.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.added.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.commonMetrics.requestTotal.WithLabelValues(cacheTypePostings, tenancy.DefaultTenant)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.commonMetrics.requestTotal.WithLabelValues(cacheTypeSeries, tenancy.DefaultTenant)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.commonMetrics.hitsTotal.WithLabelValues(cacheTypePostings, tenancy.DefaultTenant)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.commonMetrics.hitsTotal.WithLabelValues(cacheTypeSeries, tenancy.DefaultTenant)))
+	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.overflow.WithLabelValues(CacheTypePostings)))
+	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.overflow.WithLabelValues(CacheTypeSeries)))
+	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.evicted.WithLabelValues(CacheTypePostings)))
+	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.evicted.WithLabelValues(CacheTypeSeries)))
+	testutil.Equals(t, float64(3), promtest.ToFloat64(cache.added.WithLabelValues(CacheTypePostings)))
+	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.added.WithLabelValues(CacheTypeSeries)))
+	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.commonMetrics.RequestTotal.WithLabelValues(CacheTypePostings, tenancy.DefaultTenant)))
+	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.commonMetrics.RequestTotal.WithLabelValues(CacheTypeSeries, tenancy.DefaultTenant)))
+	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.commonMetrics.HitsTotal.WithLabelValues(CacheTypePostings, tenancy.DefaultTenant)))
+	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.commonMetrics.HitsTotal.WithLabelValues(CacheTypeSeries, tenancy.DefaultTenant)))
 }
 
 func TestInMemoryIndexCache_Eviction_WithMetrics(t *testing.T) {
@@ -262,16 +262,16 @@ func TestInMemoryIndexCache_Eviction_WithMetrics(t *testing.T) {
 	// Add sliceHeaderSize + 2 bytes.
 	cache.StorePostings(id, lbls, []byte{42, 33}, tenancy.DefaultTenant)
 	testutil.Equals(t, uint64(sliceHeaderSize+2), cache.curSize)
-	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.current.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(sliceHeaderSize+2), promtest.ToFloat64(cache.currentSize.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(sliceHeaderSize+2+55), promtest.ToFloat64(cache.totalCurrentSize.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.current.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.currentSize.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.totalCurrentSize.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.overflow.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.overflow.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.evicted.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.evicted.WithLabelValues(cacheTypeSeries)))
+	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.current.WithLabelValues(CacheTypePostings)))
+	testutil.Equals(t, float64(sliceHeaderSize+2), promtest.ToFloat64(cache.currentSize.WithLabelValues(CacheTypePostings)))
+	testutil.Equals(t, float64(sliceHeaderSize+2+55), promtest.ToFloat64(cache.totalCurrentSize.WithLabelValues(CacheTypePostings)))
+	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.current.WithLabelValues(CacheTypeSeries)))
+	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.currentSize.WithLabelValues(CacheTypeSeries)))
+	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.totalCurrentSize.WithLabelValues(CacheTypeSeries)))
+	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.overflow.WithLabelValues(CacheTypePostings)))
+	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.overflow.WithLabelValues(CacheTypeSeries)))
+	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.evicted.WithLabelValues(CacheTypePostings)))
+	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.evicted.WithLabelValues(CacheTypeSeries)))
 
 	pHits, pMisses = cache.FetchMultiPostings(ctx, id, []labels.Label{lbls}, tenancy.DefaultTenant)
 	testutil.Equals(t, map[labels.Label][]byte{lbls: {42, 33}}, pHits, "key exists")
@@ -288,16 +288,16 @@ func TestInMemoryIndexCache_Eviction_WithMetrics(t *testing.T) {
 	// Add sliceHeaderSize + 3 more bytes.
 	cache.StoreSeries(id, 1234, []byte{222, 223, 224}, tenancy.DefaultTenant)
 	testutil.Equals(t, uint64(2*sliceHeaderSize+5), cache.curSize)
-	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.current.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(sliceHeaderSize+2), promtest.ToFloat64(cache.currentSize.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(sliceHeaderSize+2+55), promtest.ToFloat64(cache.totalCurrentSize.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.current.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(sliceHeaderSize+3), promtest.ToFloat64(cache.currentSize.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(sliceHeaderSize+3+24), promtest.ToFloat64(cache.totalCurrentSize.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.overflow.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.overflow.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.evicted.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.evicted.WithLabelValues(cacheTypeSeries)))
+	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.current.WithLabelValues(CacheTypePostings)))
+	testutil.Equals(t, float64(sliceHeaderSize+2), promtest.ToFloat64(cache.currentSize.WithLabelValues(CacheTypePostings)))
+	testutil.Equals(t, float64(sliceHeaderSize+2+55), promtest.ToFloat64(cache.totalCurrentSize.WithLabelValues(CacheTypePostings)))
+	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.current.WithLabelValues(CacheTypeSeries)))
+	testutil.Equals(t, float64(sliceHeaderSize+3), promtest.ToFloat64(cache.currentSize.WithLabelValues(CacheTypeSeries)))
+	testutil.Equals(t, float64(sliceHeaderSize+3+24), promtest.ToFloat64(cache.totalCurrentSize.WithLabelValues(CacheTypeSeries)))
+	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.overflow.WithLabelValues(CacheTypePostings)))
+	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.overflow.WithLabelValues(CacheTypeSeries)))
+	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.evicted.WithLabelValues(CacheTypePostings)))
+	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.evicted.WithLabelValues(CacheTypeSeries)))
 
 	sHits, sMisses := cache.FetchMultiSeries(ctx, id, []storage.SeriesRef{1234}, tenancy.DefaultTenant)
 	testutil.Equals(t, map[storage.SeriesRef][]byte{1234: {222, 223, 224}}, sHits, "key exists")
@@ -313,16 +313,16 @@ func TestInMemoryIndexCache_Eviction_WithMetrics(t *testing.T) {
 	cache.StorePostings(id, lbls2, v, tenancy.DefaultTenant)
 
 	testutil.Equals(t, uint64(2*sliceHeaderSize+5), cache.curSize)
-	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.current.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(2*sliceHeaderSize+5), promtest.ToFloat64(cache.currentSize.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(2*sliceHeaderSize+5+55), promtest.ToFloat64(cache.totalCurrentSize.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.current.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.currentSize.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.totalCurrentSize.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.overflow.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.overflow.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.evicted.WithLabelValues(cacheTypePostings))) // Eviction.
-	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.evicted.WithLabelValues(cacheTypeSeries)))   // Eviction.
+	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.current.WithLabelValues(CacheTypePostings)))
+	testutil.Equals(t, float64(2*sliceHeaderSize+5), promtest.ToFloat64(cache.currentSize.WithLabelValues(CacheTypePostings)))
+	testutil.Equals(t, float64(2*sliceHeaderSize+5+55), promtest.ToFloat64(cache.totalCurrentSize.WithLabelValues(CacheTypePostings)))
+	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.current.WithLabelValues(CacheTypeSeries)))
+	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.currentSize.WithLabelValues(CacheTypeSeries)))
+	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.totalCurrentSize.WithLabelValues(CacheTypeSeries)))
+	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.overflow.WithLabelValues(CacheTypePostings)))
+	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.overflow.WithLabelValues(CacheTypeSeries)))
+	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.evicted.WithLabelValues(CacheTypePostings))) // Eviction.
+	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.evicted.WithLabelValues(CacheTypeSeries)))   // Eviction.
 
 	// Evicted.
 	pHits, pMisses = cache.FetchMultiPostings(ctx, id, []labels.Label{lbls}, tenancy.DefaultTenant)
@@ -341,16 +341,16 @@ func TestInMemoryIndexCache_Eviction_WithMetrics(t *testing.T) {
 	cache.StorePostings(id, lbls2, v, tenancy.DefaultTenant)
 
 	testutil.Equals(t, uint64(2*sliceHeaderSize+5), cache.curSize)
-	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.current.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(2*sliceHeaderSize+5), promtest.ToFloat64(cache.currentSize.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(2*sliceHeaderSize+5+55), promtest.ToFloat64(cache.totalCurrentSize.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.current.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.currentSize.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.totalCurrentSize.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.overflow.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.overflow.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.evicted.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.evicted.WithLabelValues(cacheTypeSeries)))
+	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.current.WithLabelValues(CacheTypePostings)))
+	testutil.Equals(t, float64(2*sliceHeaderSize+5), promtest.ToFloat64(cache.currentSize.WithLabelValues(CacheTypePostings)))
+	testutil.Equals(t, float64(2*sliceHeaderSize+5+55), promtest.ToFloat64(cache.totalCurrentSize.WithLabelValues(CacheTypePostings)))
+	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.current.WithLabelValues(CacheTypeSeries)))
+	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.currentSize.WithLabelValues(CacheTypeSeries)))
+	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.totalCurrentSize.WithLabelValues(CacheTypeSeries)))
+	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.overflow.WithLabelValues(CacheTypePostings)))
+	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.overflow.WithLabelValues(CacheTypeSeries)))
+	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.evicted.WithLabelValues(CacheTypePostings)))
+	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.evicted.WithLabelValues(CacheTypeSeries)))
 
 	pHits, pMisses = cache.FetchMultiPostings(ctx, id, []labels.Label{lbls2}, tenancy.DefaultTenant)
 	testutil.Equals(t, map[labels.Label][]byte{lbls2: v}, pHits)
@@ -359,31 +359,31 @@ func TestInMemoryIndexCache_Eviction_WithMetrics(t *testing.T) {
 	// Add too big item.
 	cache.StorePostings(id, labels.Label{Name: "test", Value: "toobig"}, append(v, 5), tenancy.DefaultTenant)
 	testutil.Equals(t, uint64(2*sliceHeaderSize+5), cache.curSize)
-	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.current.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(2*sliceHeaderSize+5), promtest.ToFloat64(cache.currentSize.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(2*sliceHeaderSize+5+55), promtest.ToFloat64(cache.totalCurrentSize.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.current.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.currentSize.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.totalCurrentSize.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.overflow.WithLabelValues(cacheTypePostings))) // Overflow.
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.overflow.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.evicted.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.evicted.WithLabelValues(cacheTypeSeries)))
+	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.current.WithLabelValues(CacheTypePostings)))
+	testutil.Equals(t, float64(2*sliceHeaderSize+5), promtest.ToFloat64(cache.currentSize.WithLabelValues(CacheTypePostings)))
+	testutil.Equals(t, float64(2*sliceHeaderSize+5+55), promtest.ToFloat64(cache.totalCurrentSize.WithLabelValues(CacheTypePostings)))
+	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.current.WithLabelValues(CacheTypeSeries)))
+	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.currentSize.WithLabelValues(CacheTypeSeries)))
+	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.totalCurrentSize.WithLabelValues(CacheTypeSeries)))
+	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.overflow.WithLabelValues(CacheTypePostings))) // Overflow.
+	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.overflow.WithLabelValues(CacheTypeSeries)))
+	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.evicted.WithLabelValues(CacheTypePostings)))
+	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.evicted.WithLabelValues(CacheTypeSeries)))
 
 	_, _, ok := cache.lru.RemoveOldest()
 	testutil.Assert(t, ok, "something to remove")
 
 	testutil.Equals(t, uint64(0), cache.curSize)
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.current.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.currentSize.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.totalCurrentSize.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.current.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.currentSize.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.totalCurrentSize.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.overflow.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.overflow.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(2), promtest.ToFloat64(cache.evicted.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.evicted.WithLabelValues(cacheTypeSeries)))
+	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.current.WithLabelValues(CacheTypePostings)))
+	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.currentSize.WithLabelValues(CacheTypePostings)))
+	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.totalCurrentSize.WithLabelValues(CacheTypePostings)))
+	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.current.WithLabelValues(CacheTypeSeries)))
+	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.currentSize.WithLabelValues(CacheTypeSeries)))
+	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.totalCurrentSize.WithLabelValues(CacheTypeSeries)))
+	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.overflow.WithLabelValues(CacheTypePostings)))
+	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.overflow.WithLabelValues(CacheTypeSeries)))
+	testutil.Equals(t, float64(2), promtest.ToFloat64(cache.evicted.WithLabelValues(CacheTypePostings)))
+	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.evicted.WithLabelValues(CacheTypeSeries)))
 
 	_, _, ok = cache.lru.RemoveOldest()
 	testutil.Assert(t, !ok, "nothing to remove")
@@ -393,16 +393,16 @@ func TestInMemoryIndexCache_Eviction_WithMetrics(t *testing.T) {
 	cache.StorePostings(id, lbls3, []byte{}, tenancy.DefaultTenant)
 
 	testutil.Equals(t, uint64(sliceHeaderSize), cache.curSize)
-	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.current.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(sliceHeaderSize), promtest.ToFloat64(cache.currentSize.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(sliceHeaderSize+55), promtest.ToFloat64(cache.totalCurrentSize.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.current.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.currentSize.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.totalCurrentSize.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.overflow.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.overflow.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(2), promtest.ToFloat64(cache.evicted.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.evicted.WithLabelValues(cacheTypeSeries)))
+	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.current.WithLabelValues(CacheTypePostings)))
+	testutil.Equals(t, float64(sliceHeaderSize), promtest.ToFloat64(cache.currentSize.WithLabelValues(CacheTypePostings)))
+	testutil.Equals(t, float64(sliceHeaderSize+55), promtest.ToFloat64(cache.totalCurrentSize.WithLabelValues(CacheTypePostings)))
+	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.current.WithLabelValues(CacheTypeSeries)))
+	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.currentSize.WithLabelValues(CacheTypeSeries)))
+	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.totalCurrentSize.WithLabelValues(CacheTypeSeries)))
+	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.overflow.WithLabelValues(CacheTypePostings)))
+	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.overflow.WithLabelValues(CacheTypeSeries)))
+	testutil.Equals(t, float64(2), promtest.ToFloat64(cache.evicted.WithLabelValues(CacheTypePostings)))
+	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.evicted.WithLabelValues(CacheTypeSeries)))
 
 	pHits, pMisses = cache.FetchMultiPostings(ctx, id, []labels.Label{lbls3}, tenancy.DefaultTenant)
 	testutil.Equals(t, map[labels.Label][]byte{lbls3: {}}, pHits, "key exists")
@@ -413,26 +413,26 @@ func TestInMemoryIndexCache_Eviction_WithMetrics(t *testing.T) {
 	cache.StorePostings(id, lbls4, []byte(nil), tenancy.DefaultTenant)
 
 	testutil.Equals(t, 2*uint64(sliceHeaderSize), cache.curSize)
-	testutil.Equals(t, float64(2), promtest.ToFloat64(cache.current.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, 2*float64(sliceHeaderSize), promtest.ToFloat64(cache.currentSize.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, 2*float64(sliceHeaderSize+55), promtest.ToFloat64(cache.totalCurrentSize.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.current.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.currentSize.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.totalCurrentSize.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.overflow.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.overflow.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(2), promtest.ToFloat64(cache.evicted.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.evicted.WithLabelValues(cacheTypeSeries)))
+	testutil.Equals(t, float64(2), promtest.ToFloat64(cache.current.WithLabelValues(CacheTypePostings)))
+	testutil.Equals(t, 2*float64(sliceHeaderSize), promtest.ToFloat64(cache.currentSize.WithLabelValues(CacheTypePostings)))
+	testutil.Equals(t, 2*float64(sliceHeaderSize+55), promtest.ToFloat64(cache.totalCurrentSize.WithLabelValues(CacheTypePostings)))
+	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.current.WithLabelValues(CacheTypeSeries)))
+	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.currentSize.WithLabelValues(CacheTypeSeries)))
+	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.totalCurrentSize.WithLabelValues(CacheTypeSeries)))
+	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.overflow.WithLabelValues(CacheTypePostings)))
+	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.overflow.WithLabelValues(CacheTypeSeries)))
+	testutil.Equals(t, float64(2), promtest.ToFloat64(cache.evicted.WithLabelValues(CacheTypePostings)))
+	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.evicted.WithLabelValues(CacheTypeSeries)))
 
 	pHits, pMisses = cache.FetchMultiPostings(ctx, id, []labels.Label{lbls4}, tenancy.DefaultTenant)
 	testutil.Equals(t, map[labels.Label][]byte{lbls4: {}}, pHits, "key exists")
 	testutil.Equals(t, emptyPostingsMisses, pMisses)
 
 	// Other metrics.
-	testutil.Equals(t, float64(4), promtest.ToFloat64(cache.added.WithLabelValues(cacheTypePostings)))
-	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.added.WithLabelValues(cacheTypeSeries)))
-	testutil.Equals(t, float64(9), promtest.ToFloat64(cache.commonMetrics.requestTotal.WithLabelValues(cacheTypePostings, tenancy.DefaultTenant)))
-	testutil.Equals(t, float64(2), promtest.ToFloat64(cache.commonMetrics.requestTotal.WithLabelValues(cacheTypeSeries, tenancy.DefaultTenant)))
-	testutil.Equals(t, float64(5), promtest.ToFloat64(cache.commonMetrics.hitsTotal.WithLabelValues(cacheTypePostings, tenancy.DefaultTenant)))
-	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.commonMetrics.hitsTotal.WithLabelValues(cacheTypeSeries, tenancy.DefaultTenant)))
+	testutil.Equals(t, float64(4), promtest.ToFloat64(cache.added.WithLabelValues(CacheTypePostings)))
+	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.added.WithLabelValues(CacheTypeSeries)))
+	testutil.Equals(t, float64(9), promtest.ToFloat64(cache.commonMetrics.RequestTotal.WithLabelValues(CacheTypePostings, tenancy.DefaultTenant)))
+	testutil.Equals(t, float64(2), promtest.ToFloat64(cache.commonMetrics.RequestTotal.WithLabelValues(CacheTypeSeries, tenancy.DefaultTenant)))
+	testutil.Equals(t, float64(5), promtest.ToFloat64(cache.commonMetrics.HitsTotal.WithLabelValues(CacheTypePostings, tenancy.DefaultTenant)))
+	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.commonMetrics.HitsTotal.WithLabelValues(CacheTypeSeries, tenancy.DefaultTenant)))
 }

--- a/pkg/store/cache/memcached.go
+++ b/pkg/store/cache/memcached.go
@@ -43,7 +43,7 @@ type RemoteIndexCache struct {
 }
 
 // NewRemoteIndexCache makes a new RemoteIndexCache.
-func NewRemoteIndexCache(logger log.Logger, cacheClient cacheutil.RemoteCacheClient, commonMetrics *commonMetrics, reg prometheus.Registerer, ttl time.Duration) (*RemoteIndexCache, error) {
+func NewRemoteIndexCache(logger log.Logger, cacheClient cacheutil.RemoteCacheClient, commonMetrics *CommonMetrics, reg prometheus.Registerer, ttl time.Duration) (*RemoteIndexCache, error) {
 	c := &RemoteIndexCache{
 		ttl:               ttl,
 		logger:            logger,
@@ -52,26 +52,26 @@ func NewRemoteIndexCache(logger log.Logger, cacheClient cacheutil.RemoteCacheCli
 	}
 
 	if commonMetrics == nil {
-		commonMetrics = newCommonMetrics(reg)
+		commonMetrics = NewCommonMetrics(reg)
 	}
 
-	c.requestTotal = commonMetrics.requestTotal
-	c.hitsTotal = commonMetrics.hitsTotal
-	c.dataSizeBytes = commonMetrics.dataSizeBytes
-	c.fetchLatency = commonMetrics.fetchLatency
+	c.requestTotal = commonMetrics.RequestTotal
+	c.hitsTotal = commonMetrics.HitsTotal
+	c.dataSizeBytes = commonMetrics.DataSizeBytes
+	c.fetchLatency = commonMetrics.FetchLatency
 
 	// Init requestTtotal and hitsTotal with default tenant
-	c.requestTotal.WithLabelValues(cacheTypePostings, tenancy.DefaultTenant)
-	c.requestTotal.WithLabelValues(cacheTypeSeries, tenancy.DefaultTenant)
-	c.requestTotal.WithLabelValues(cacheTypeExpandedPostings, tenancy.DefaultTenant)
+	c.requestTotal.WithLabelValues(CacheTypePostings, tenancy.DefaultTenant)
+	c.requestTotal.WithLabelValues(CacheTypeSeries, tenancy.DefaultTenant)
+	c.requestTotal.WithLabelValues(CacheTypeExpandedPostings, tenancy.DefaultTenant)
 
-	c.hitsTotal.WithLabelValues(cacheTypePostings, tenancy.DefaultTenant)
-	c.hitsTotal.WithLabelValues(cacheTypeSeries, tenancy.DefaultTenant)
-	c.hitsTotal.WithLabelValues(cacheTypeExpandedPostings, tenancy.DefaultTenant)
+	c.hitsTotal.WithLabelValues(CacheTypePostings, tenancy.DefaultTenant)
+	c.hitsTotal.WithLabelValues(CacheTypeSeries, tenancy.DefaultTenant)
+	c.hitsTotal.WithLabelValues(CacheTypeExpandedPostings, tenancy.DefaultTenant)
 
-	c.fetchLatency.WithLabelValues(cacheTypePostings, tenancy.DefaultTenant)
-	c.fetchLatency.WithLabelValues(cacheTypeSeries, tenancy.DefaultTenant)
-	c.fetchLatency.WithLabelValues(cacheTypeExpandedPostings, tenancy.DefaultTenant)
+	c.fetchLatency.WithLabelValues(CacheTypePostings, tenancy.DefaultTenant)
+	c.fetchLatency.WithLabelValues(CacheTypeSeries, tenancy.DefaultTenant)
+	c.fetchLatency.WithLabelValues(CacheTypeExpandedPostings, tenancy.DefaultTenant)
 
 	level.Info(logger).Log("msg", "created index cache")
 
@@ -82,8 +82,8 @@ func NewRemoteIndexCache(logger log.Logger, cacheClient cacheutil.RemoteCacheCli
 // The function enqueues the request and returns immediately: the entry will be
 // asynchronously stored in the cache.
 func (c *RemoteIndexCache) StorePostings(blockID ulid.ULID, l labels.Label, v []byte, tenant string) {
-	c.dataSizeBytes.WithLabelValues(cacheTypePostings, tenant).Observe(float64(len(v)))
-	key := cacheKey{blockID.String(), cacheKeyPostings(l), c.compressionScheme}.string()
+	c.dataSizeBytes.WithLabelValues(CacheTypePostings, tenant).Observe(float64(len(v)))
+	key := CacheKey{blockID.String(), CacheKeyPostings(l), c.compressionScheme}.String()
 	if err := c.memcached.SetAsync(key, v, c.ttl); err != nil {
 		level.Error(c.logger).Log("msg", "failed to cache postings in memcached", "err", err)
 	}
@@ -93,19 +93,19 @@ func (c *RemoteIndexCache) StorePostings(blockID ulid.ULID, l labels.Label, v []
 // and returns a map containing cache hits, along with a list of missing keys.
 // In case of error, it logs and return an empty cache hits map.
 func (c *RemoteIndexCache) FetchMultiPostings(ctx context.Context, blockID ulid.ULID, lbls []labels.Label, tenant string) (hits map[labels.Label][]byte, misses []labels.Label) {
-	timer := prometheus.NewTimer(c.fetchLatency.WithLabelValues(cacheTypePostings, tenant))
+	timer := prometheus.NewTimer(c.fetchLatency.WithLabelValues(CacheTypePostings, tenant))
 	defer timer.ObserveDuration()
 
 	keys := make([]string, 0, len(lbls))
 
 	blockIDKey := blockID.String()
 	for _, lbl := range lbls {
-		key := cacheKey{blockIDKey, cacheKeyPostings(lbl), c.compressionScheme}.string()
+		key := CacheKey{blockIDKey, CacheKeyPostings(lbl), c.compressionScheme}.String()
 		keys = append(keys, key)
 	}
 
 	// Fetch the keys from memcached in a single request.
-	c.requestTotal.WithLabelValues(cacheTypePostings, tenant).Add(float64(len(keys)))
+	c.requestTotal.WithLabelValues(CacheTypePostings, tenant).Add(float64(len(keys)))
 
 	results := c.memcached.GetMulti(ctx, keys)
 	if len(results) == 0 {
@@ -126,7 +126,7 @@ func (c *RemoteIndexCache) FetchMultiPostings(ctx context.Context, blockID ulid.
 
 		hits[lbl] = value
 	}
-	c.hitsTotal.WithLabelValues(cacheTypePostings, tenant).Add(float64(len(hits)))
+	c.hitsTotal.WithLabelValues(CacheTypePostings, tenant).Add(float64(len(hits)))
 	return hits, misses
 }
 
@@ -134,8 +134,8 @@ func (c *RemoteIndexCache) FetchMultiPostings(ctx context.Context, blockID ulid.
 // The function enqueues the request and returns immediately: the entry will be
 // asynchronously stored in the cache.
 func (c *RemoteIndexCache) StoreExpandedPostings(blockID ulid.ULID, keys []*labels.Matcher, v []byte, tenant string) {
-	c.dataSizeBytes.WithLabelValues(cacheTypeExpandedPostings, tenant).Observe(float64(len(v)))
-	key := cacheKey{blockID.String(), cacheKeyExpandedPostings(labelMatchersToString(keys)), c.compressionScheme}.string()
+	c.dataSizeBytes.WithLabelValues(CacheTypeExpandedPostings, tenant).Observe(float64(len(v)))
+	key := CacheKey{blockID.String(), CacheKeyExpandedPostings(LabelMatchersToString(keys)), c.compressionScheme}.String()
 
 	if err := c.memcached.SetAsync(key, v, c.ttl); err != nil {
 		level.Error(c.logger).Log("msg", "failed to cache expanded postings in memcached", "err", err)
@@ -146,19 +146,19 @@ func (c *RemoteIndexCache) StoreExpandedPostings(blockID ulid.ULID, keys []*labe
 // and returns a map containing cache hits, along with a list of missing keys.
 // In case of error, it logs and return an empty cache hits map.
 func (c *RemoteIndexCache) FetchExpandedPostings(ctx context.Context, blockID ulid.ULID, lbls []*labels.Matcher, tenant string) ([]byte, bool) {
-	timer := prometheus.NewTimer(c.fetchLatency.WithLabelValues(cacheTypeExpandedPostings, tenant))
+	timer := prometheus.NewTimer(c.fetchLatency.WithLabelValues(CacheTypeExpandedPostings, tenant))
 	defer timer.ObserveDuration()
 
-	key := cacheKey{blockID.String(), cacheKeyExpandedPostings(labelMatchersToString(lbls)), c.compressionScheme}.string()
+	key := CacheKey{blockID.String(), CacheKeyExpandedPostings(LabelMatchersToString(lbls)), c.compressionScheme}.String()
 
 	// Fetch the keys from memcached in a single request.
-	c.requestTotal.WithLabelValues(cacheTypeExpandedPostings, tenant).Add(1)
+	c.requestTotal.WithLabelValues(CacheTypeExpandedPostings, tenant).Add(1)
 	results := c.memcached.GetMulti(ctx, []string{key})
 	if len(results) == 0 {
 		return nil, false
 	}
 	if res, ok := results[key]; ok {
-		c.hitsTotal.WithLabelValues(cacheTypeExpandedPostings, tenant).Add(1)
+		c.hitsTotal.WithLabelValues(CacheTypeExpandedPostings, tenant).Add(1)
 		return res, true
 	}
 	return nil, false
@@ -168,8 +168,8 @@ func (c *RemoteIndexCache) FetchExpandedPostings(ctx context.Context, blockID ul
 // The function enqueues the request and returns immediately: the entry will be
 // asynchronously stored in the cache.
 func (c *RemoteIndexCache) StoreSeries(blockID ulid.ULID, id storage.SeriesRef, v []byte, tenant string) {
-	c.dataSizeBytes.WithLabelValues(cacheTypeSeries, tenant).Observe(float64(len(v)))
-	key := cacheKey{blockID.String(), cacheKeySeries(id), ""}.string()
+	c.dataSizeBytes.WithLabelValues(CacheTypeSeries, tenant).Observe(float64(len(v)))
+	key := CacheKey{blockID.String(), CacheKeySeries(id), ""}.String()
 
 	if err := c.memcached.SetAsync(key, v, c.ttl); err != nil {
 		level.Error(c.logger).Log("msg", "failed to cache series in memcached", "err", err)
@@ -180,19 +180,19 @@ func (c *RemoteIndexCache) StoreSeries(blockID ulid.ULID, id storage.SeriesRef, 
 // and returns a map containing cache hits, along with a list of missing IDs.
 // In case of error, it logs and return an empty cache hits map.
 func (c *RemoteIndexCache) FetchMultiSeries(ctx context.Context, blockID ulid.ULID, ids []storage.SeriesRef, tenant string) (hits map[storage.SeriesRef][]byte, misses []storage.SeriesRef) {
-	timer := prometheus.NewTimer(c.fetchLatency.WithLabelValues(cacheTypeSeries, tenant))
+	timer := prometheus.NewTimer(c.fetchLatency.WithLabelValues(CacheTypeSeries, tenant))
 	defer timer.ObserveDuration()
 
 	keys := make([]string, 0, len(ids))
 
 	blockIDKey := blockID.String()
 	for _, id := range ids {
-		key := cacheKey{blockIDKey, cacheKeySeries(id), ""}.string()
+		key := CacheKey{blockIDKey, CacheKeySeries(id), ""}.String()
 		keys = append(keys, key)
 	}
 
 	// Fetch the keys from memcached in a single request.
-	c.requestTotal.WithLabelValues(cacheTypeSeries, tenant).Add(float64(len(ids)))
+	c.requestTotal.WithLabelValues(CacheTypeSeries, tenant).Add(float64(len(ids)))
 	results := c.memcached.GetMulti(ctx, keys)
 	if len(results) == 0 {
 		return nil, ids
@@ -212,7 +212,7 @@ func (c *RemoteIndexCache) FetchMultiSeries(ctx context.Context, blockID ulid.UL
 
 		hits[id] = value
 	}
-	c.hitsTotal.WithLabelValues(cacheTypeSeries, tenant).Add(float64(len(hits)))
+	c.hitsTotal.WithLabelValues(CacheTypeSeries, tenant).Add(float64(len(hits)))
 	return hits, misses
 }
 

--- a/pkg/store/cache/memcached_test.go
+++ b/pkg/store/cache/memcached_test.go
@@ -103,10 +103,10 @@ func TestMemcachedIndexCache_FetchMultiPostings(t *testing.T) {
 			testutil.Equals(t, testData.expectedMisses, misses)
 
 			// Assert on metrics.
-			testutil.Equals(t, float64(len(testData.fetchLabels)), prom_testutil.ToFloat64(c.requestTotal.WithLabelValues(cacheTypePostings, tenancy.DefaultTenant)))
-			testutil.Equals(t, float64(len(testData.expectedHits)), prom_testutil.ToFloat64(c.hitsTotal.WithLabelValues(cacheTypePostings, tenancy.DefaultTenant)))
-			testutil.Equals(t, 0.0, prom_testutil.ToFloat64(c.requestTotal.WithLabelValues(cacheTypeSeries, tenancy.DefaultTenant)))
-			testutil.Equals(t, 0.0, prom_testutil.ToFloat64(c.hitsTotal.WithLabelValues(cacheTypeSeries, tenancy.DefaultTenant)))
+			testutil.Equals(t, float64(len(testData.fetchLabels)), prom_testutil.ToFloat64(c.requestTotal.WithLabelValues(CacheTypePostings, tenancy.DefaultTenant)))
+			testutil.Equals(t, float64(len(testData.expectedHits)), prom_testutil.ToFloat64(c.hitsTotal.WithLabelValues(CacheTypePostings, tenancy.DefaultTenant)))
+			testutil.Equals(t, 0.0, prom_testutil.ToFloat64(c.requestTotal.WithLabelValues(CacheTypeSeries, tenancy.DefaultTenant)))
+			testutil.Equals(t, 0.0, prom_testutil.ToFloat64(c.hitsTotal.WithLabelValues(CacheTypeSeries, tenancy.DefaultTenant)))
 		})
 	}
 }
@@ -186,14 +186,14 @@ func TestMemcachedIndexCache_FetchExpandedPostings(t *testing.T) {
 			}
 
 			// Assert on metrics.
-			testutil.Equals(t, 1.0, prom_testutil.ToFloat64(c.requestTotal.WithLabelValues(cacheTypeExpandedPostings, tenancy.DefaultTenant)))
+			testutil.Equals(t, 1.0, prom_testutil.ToFloat64(c.requestTotal.WithLabelValues(CacheTypeExpandedPostings, tenancy.DefaultTenant)))
 			if testData.expectedHit {
-				testutil.Equals(t, 1.0, prom_testutil.ToFloat64(c.hitsTotal.WithLabelValues(cacheTypeExpandedPostings, tenancy.DefaultTenant)))
+				testutil.Equals(t, 1.0, prom_testutil.ToFloat64(c.hitsTotal.WithLabelValues(CacheTypeExpandedPostings, tenancy.DefaultTenant)))
 			}
-			testutil.Equals(t, 0.0, prom_testutil.ToFloat64(c.requestTotal.WithLabelValues(cacheTypePostings, tenancy.DefaultTenant)))
-			testutil.Equals(t, 0.0, prom_testutil.ToFloat64(c.hitsTotal.WithLabelValues(cacheTypePostings, tenancy.DefaultTenant)))
-			testutil.Equals(t, 0.0, prom_testutil.ToFloat64(c.requestTotal.WithLabelValues(cacheTypeSeries, tenancy.DefaultTenant)))
-			testutil.Equals(t, 0.0, prom_testutil.ToFloat64(c.hitsTotal.WithLabelValues(cacheTypeSeries, tenancy.DefaultTenant)))
+			testutil.Equals(t, 0.0, prom_testutil.ToFloat64(c.requestTotal.WithLabelValues(CacheTypePostings, tenancy.DefaultTenant)))
+			testutil.Equals(t, 0.0, prom_testutil.ToFloat64(c.hitsTotal.WithLabelValues(CacheTypePostings, tenancy.DefaultTenant)))
+			testutil.Equals(t, 0.0, prom_testutil.ToFloat64(c.requestTotal.WithLabelValues(CacheTypeSeries, tenancy.DefaultTenant)))
+			testutil.Equals(t, 0.0, prom_testutil.ToFloat64(c.hitsTotal.WithLabelValues(CacheTypeSeries, tenancy.DefaultTenant)))
 		})
 	}
 }
@@ -279,10 +279,10 @@ func TestMemcachedIndexCache_FetchMultiSeries(t *testing.T) {
 			testutil.Equals(t, testData.expectedMisses, misses)
 
 			// Assert on metrics.
-			testutil.Equals(t, float64(len(testData.fetchIds)), prom_testutil.ToFloat64(c.requestTotal.WithLabelValues(cacheTypeSeries, tenancy.DefaultTenant)))
-			testutil.Equals(t, float64(len(testData.expectedHits)), prom_testutil.ToFloat64(c.hitsTotal.WithLabelValues(cacheTypeSeries, tenancy.DefaultTenant)))
-			testutil.Equals(t, 0.0, prom_testutil.ToFloat64(c.requestTotal.WithLabelValues(cacheTypePostings, tenancy.DefaultTenant)))
-			testutil.Equals(t, 0.0, prom_testutil.ToFloat64(c.hitsTotal.WithLabelValues(cacheTypePostings, tenancy.DefaultTenant)))
+			testutil.Equals(t, float64(len(testData.fetchIds)), prom_testutil.ToFloat64(c.requestTotal.WithLabelValues(CacheTypeSeries, tenancy.DefaultTenant)))
+			testutil.Equals(t, float64(len(testData.expectedHits)), prom_testutil.ToFloat64(c.hitsTotal.WithLabelValues(CacheTypeSeries, tenancy.DefaultTenant)))
+			testutil.Equals(t, 0.0, prom_testutil.ToFloat64(c.requestTotal.WithLabelValues(CacheTypePostings, tenancy.DefaultTenant)))
+			testutil.Equals(t, 0.0, prom_testutil.ToFloat64(c.hitsTotal.WithLabelValues(CacheTypePostings, tenancy.DefaultTenant)))
 		})
 	}
 }


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

Expose some common structs/types used in index cache. This allows other projects like Cortex to have its own index cache implementation with existing types from Thanos.

## Verification

<!-- How you tested it? How do you know it works? -->
