### PR TITLE
Enable race detector for e2e tests

### DIFF
--- a/Dockerfile.e2e-tests
+++ b/Dockerfile.e2e-tests
@@ -1,0 +1,18 @@
+# Taking a non-alpine image for e2e tests so that cgo can be enabled for the race detector.
+FROM golang:1.21 as builder
+
+WORKDIR $GOPATH/src/github.com/thanos-io/thanos
+
+COPY . $GOPATH/src/github.com/thanos-io/thanos
+
+RUN CGO_ENABLED=1 go build -o $GOBIN/thanos -race ./cmd/thanos
+# -----------------------------------------------------------------------------
+
+FROM golang:1.21
+LABEL maintainer="The Thanos Authors"
+
+COPY --from=builder $GOBIN/thanos /bin/thanos
+
+ENV GORACE="halt_on_error=1"
+
+ENTRYPOINT [ "/bin/thanos" ]

--- a/Makefile
+++ b/Makefile
@@ -226,6 +226,12 @@ $(TEST_DOCKER_ARCHS): docker-test-%:
 	@echo ">> testing image"
 	@docker run "thanos-linux-$*" --help
 
+.PHONY: docker-e2e
+docker-e2e: ## Builds 'thanos' docker for e2e tests
+docker-e2e:
+	@echo ">> building docker image 'thanos' with Dockerfile.e2e-tests"
+	@docker build -f Dockerfile.e2e-tests -t "thanos" .
+
 # docker-manifest push docker manifest to support multiple architectures.
 .PHONY: docker-manifest
 docker-manifest:
@@ -318,7 +324,7 @@ test-local:
 
 .PHONY: test-e2e
 test-e2e: ## Runs all Thanos e2e docker-based e2e tests from test/e2e. Required access to docker daemon.
-test-e2e: docker $(GOTESPLIT)
+test-e2e: docker-e2e $(GOTESPLIT)
 	@echo ">> cleaning docker environment."
 	@docker system prune -f --volumes
 	@echo ">> cleaning e2e test garbage."

--- a/docs/contributing/how-to-change-go-version.md
+++ b/docs/contributing/how-to-change-go-version.md
@@ -7,3 +7,4 @@ To update Thanos build system to newer Golang:
 1. Edit [.promu.yaml](../../.promu.yml) and edit `go: version: <go version>` in YAML to desired version. This will ensure that all artifacts are built with desired Golang version. How to verify? Download tarball, unpack and invoke `thanos --version`
 2. Edit [.circleci/config.yaml](../../.circleci/config.yml) and update ` - image: cimg/go:<go version>-node` to desired Golang version. This will ensure that all docker images and go tests are using desired Golang version. How to verify? Invoke `docker pull quay.io/thanos/thanos:<version> --version`
 3. Edit [.github/workflows/docs.yaml](../../.github/workflows/docs.yaml) [.github/workflows/go.yaml](../../.github/workflows/go.yaml) and update Go version.
+4. Edit [Dockerfile.e2e-tests](../../Dockerfile.e2e-tests) and update Go version.

--- a/test/e2e/compact_test.go
+++ b/test/e2e/compact_test.go
@@ -768,7 +768,6 @@ func testCompactWithStoreGateway(t *testing.T, penaltyDedup bool) {
 		testutil.Ok(t, c.WaitSumMetricsWithOptions(e2emon.Greater(0), []string{"thanos_compact_iterations_total"}, e2emon.WaitMissingMetrics()))
 		testutil.Ok(t, c.WaitSumMetricsWithOptions(e2emon.Equals(18), []string{"thanos_compact_blocks_cleaned_total"}, e2emon.WaitMissingMetrics()))
 		testutil.Ok(t, c.WaitSumMetricsWithOptions(e2emon.Equals(0), []string{"thanos_compact_block_cleanup_failures_total"}, e2emon.WaitMissingMetrics()))
-		testutil.Ok(t, c.WaitSumMetricsWithOptions(e2emon.Equals(0), []string{"thanos_compact_blocks_marked_total"}, e2emon.WaitMissingMetrics()))
 		testutil.Ok(t, c.WaitSumMetricsWithOptions(e2emon.Equals(0), []string{"thanos_compact_aborted_partial_uploads_deletion_attempts_total"}, e2emon.WaitMissingMetrics()))
 		testutil.Ok(t, c.WaitSumMetricsWithOptions(e2emon.Equals(0), []string{"thanos_compact_group_compactions_total"}, e2emon.WaitMissingMetrics()))
 		testutil.Ok(t, c.WaitSumMetricsWithOptions(e2emon.Equals(0), []string{"thanos_compact_group_vertical_compactions_total"}, e2emon.WaitMissingMetrics()))


### PR DESCRIPTION
I think I finally caught all of the race conditions so now we can enable race detector for e2e tests. Second step/PR will be to enable the same for unit tests.
