### PR TITLE
Improve index header metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#6765](https://github.com/thanos-io/thanos/pull/6765) Index Cache: Add `enabled_items` to index cache config to selectively cache configured items. Available item types are `Postings`, `Series` and `ExpandedPostings`.
 - [#6773](https://github.com/thanos-io/thanos/pull/6773) Index Cache: Add `ttl` to control the ttl to store items in remote index caches like memcached and redis.
 - [#6794](https://github.com/thanos-io/thanos/pull/6794) Query: *breaking :warning:* Add tenant label to relevant exported metrics. Note that this change may cause some pre-existing custom dashboard queries to be incorrect due to the added label.
+- [#6847](https://github.com/thanos-io/thanos/pull/6847) Store: Add `thanos_bucket_store_indexheader_download_duration_seconds` and `thanos_bucket_store_indexheader_load_duration_seconds` metrics for tracking latency of downloading and initializing the index-header.
 
 ### Changed
 

--- a/pkg/block/indexheader/binary_reader.go
+++ b/pkg/block/indexheader/binary_reader.go
@@ -23,6 +23,8 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/oklog/ulid"
 	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/prometheus/tsdb/encoding"
 	"github.com/prometheus/prometheus/tsdb/fileutil"
 	"github.com/prometheus/prometheus/tsdb/index"
@@ -62,6 +64,28 @@ func init() {
 // polynomial may be easily changed in one location at a later time, if necessary.
 func newCRC32() hash.Hash32 {
 	return crc32.New(castagnoliTable)
+}
+
+// LazyBinaryReaderMetrics holds metrics tracked by LazyBinaryReader.
+type BinaryReaderMetrics struct {
+	downloadDuration prometheus.Histogram
+	loadDuration     prometheus.Histogram
+}
+
+// NewBinaryReaderMetrics makes new BinaryReaderMetrics.
+func NewBinaryReaderMetrics(reg prometheus.Registerer) *BinaryReaderMetrics {
+	return &BinaryReaderMetrics{
+		downloadDuration: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
+			Name:    "indexheader_download_duration_seconds",
+			Help:    "Duration of the index-header download from objstore in seconds.",
+			Buckets: []float64{0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1, 2, 5, 15, 30, 60, 90, 120, 300},
+		}),
+		loadDuration: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
+			Name:    "indexheader_load_duration_seconds",
+			Help:    "Duration of the index-header loading in seconds.",
+			Buckets: []float64{0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1, 2, 5, 15, 30, 60, 90, 120, 300},
+		}),
+	}
 }
 
 // BinaryTOC is a table of content for index-header file.
@@ -529,13 +553,15 @@ type BinaryReader struct {
 	indexLastPostingEnd int64
 
 	postingOffsetsInMemSampling int
+
+	metrics *BinaryReaderMetrics
 }
 
 // NewBinaryReader loads or builds new index-header if not present on disk.
-func NewBinaryReader(ctx context.Context, logger log.Logger, bkt objstore.BucketReader, dir string, id ulid.ULID, postingOffsetsInMemSampling int) (*BinaryReader, error) {
+func NewBinaryReader(ctx context.Context, logger log.Logger, bkt objstore.BucketReader, dir string, id ulid.ULID, postingOffsetsInMemSampling int, metrics *BinaryReaderMetrics) (*BinaryReader, error) {
 	if dir != "" {
 		binfn := filepath.Join(dir, id.String(), block.IndexHeaderFilename)
-		br, err := newFileBinaryReader(binfn, postingOffsetsInMemSampling)
+		br, err := newFileBinaryReader(binfn, postingOffsetsInMemSampling, metrics)
 		if err == nil {
 			return br, nil
 		}
@@ -546,25 +572,27 @@ func NewBinaryReader(ctx context.Context, logger log.Logger, bkt objstore.Bucket
 		if _, err := WriteBinary(ctx, bkt, id, binfn); err != nil {
 			return nil, errors.Wrap(err, "write index header")
 		}
+		metrics.loadDuration.Observe(time.Since(start).Seconds())
 
 		level.Debug(logger).Log("msg", "built index-header file", "path", binfn, "elapsed", time.Since(start))
-		return newFileBinaryReader(binfn, postingOffsetsInMemSampling)
+		return newFileBinaryReader(binfn, postingOffsetsInMemSampling, metrics)
 	} else {
 		buf, err := WriteBinary(ctx, bkt, id, "")
 		if err != nil {
 			return nil, errors.Wrap(err, "generate index header")
 		}
 
-		return newMemoryBinaryReader(buf, postingOffsetsInMemSampling)
+		return newMemoryBinaryReader(buf, postingOffsetsInMemSampling, metrics)
 	}
 }
 
-func newMemoryBinaryReader(buf []byte, postingOffsetsInMemSampling int) (bw *BinaryReader, err error) {
+func newMemoryBinaryReader(buf []byte, postingOffsetsInMemSampling int, metrics *BinaryReaderMetrics) (bw *BinaryReader, err error) {
 	r := &BinaryReader{
 		b:                           realByteSlice(buf),
 		c:                           nil,
 		postings:                    map[string]*postingValueOffsets{},
 		postingOffsetsInMemSampling: postingOffsetsInMemSampling,
+		metrics:                     metrics,
 	}
 
 	if err := r.init(); err != nil {
@@ -574,7 +602,7 @@ func newMemoryBinaryReader(buf []byte, postingOffsetsInMemSampling int) (bw *Bin
 	return r, nil
 }
 
-func newFileBinaryReader(path string, postingOffsetsInMemSampling int) (bw *BinaryReader, err error) {
+func newFileBinaryReader(path string, postingOffsetsInMemSampling int, metrics *BinaryReaderMetrics) (bw *BinaryReader, err error) {
 	f, err := fileutil.OpenMmapFile(path)
 	if err != nil {
 		return nil, err
@@ -590,6 +618,7 @@ func newFileBinaryReader(path string, postingOffsetsInMemSampling int) (bw *Bina
 		c:                           f,
 		postings:                    map[string]*postingValueOffsets{},
 		postingOffsetsInMemSampling: postingOffsetsInMemSampling,
+		metrics:                     metrics,
 	}
 
 	if err := r.init(); err != nil {
@@ -624,6 +653,11 @@ func newBinaryTOCFromByteSlice(bs index.ByteSlice) (*BinaryTOC, error) {
 }
 
 func (r *BinaryReader) init() (err error) {
+	start := time.Now()
+
+	defer func() {
+		r.metrics.loadDuration.Observe(time.Since(start).Seconds())
+	}()
 	// Verify header.
 	if r.b.Len() < headerLen {
 		return errors.Wrap(encoding.ErrInvalidSize, "index header's header")

--- a/pkg/block/indexheader/binary_reader.go
+++ b/pkg/block/indexheader/binary_reader.go
@@ -78,7 +78,7 @@ func NewBinaryReaderMetrics(reg prometheus.Registerer) *BinaryReaderMetrics {
 		downloadDuration: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
 			Name:    "indexheader_download_duration_seconds",
 			Help:    "Duration of the index-header download from objstore in seconds.",
-			Buckets: []float64{0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1, 2, 5, 15, 30, 60, 90, 120, 300},
+			Buckets: []float64{0.1, 0.2, 0.5, 1, 2, 5, 15, 30, 60, 90, 120, 300},
 		}),
 		loadDuration: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
 			Name:    "indexheader_load_duration_seconds",

--- a/pkg/block/indexheader/header_test.go
+++ b/pkg/block/indexheader/header_test.go
@@ -100,7 +100,7 @@ func TestReaders(t *testing.T) {
 				_, err := WriteBinary(ctx, bkt, id, fn)
 				testutil.Ok(t, err)
 
-				br, err := NewBinaryReader(ctx, log.NewNopLogger(), nil, tmpDir, id, 3)
+				br, err := NewBinaryReader(ctx, log.NewNopLogger(), nil, tmpDir, id, 3, NewBinaryReaderMetrics(nil))
 				testutil.Ok(t, err)
 
 				defer func() { testutil.Ok(t, br.Close()) }()
@@ -206,7 +206,7 @@ func TestReaders(t *testing.T) {
 				_, err := WriteBinary(ctx, bkt, id, fn)
 				testutil.Ok(t, err)
 
-				br, err := NewLazyBinaryReader(ctx, log.NewNopLogger(), nil, tmpDir, id, 3, NewLazyBinaryReaderMetrics(nil), nil)
+				br, err := NewLazyBinaryReader(ctx, log.NewNopLogger(), nil, tmpDir, id, 3, NewLazyBinaryReaderMetrics(nil), NewBinaryReaderMetrics(nil), nil)
 				testutil.Ok(t, err)
 
 				defer func() { testutil.Ok(t, br.Close()) }()
@@ -399,7 +399,7 @@ func BenchmarkBinaryReader(t *testing.B) {
 
 	t.ResetTimer()
 	for i := 0; i < t.N; i++ {
-		br, err := newFileBinaryReader(fn, 32)
+		br, err := newFileBinaryReader(fn, 32, NewBinaryReaderMetrics(nil))
 		testutil.Ok(t, err)
 		testutil.Ok(t, br.Close())
 	}
@@ -437,7 +437,7 @@ func benchmarkBinaryReaderLookupSymbol(b *testing.B, numSeries int) {
 	testutil.Ok(b, block.Upload(ctx, logger, bkt, filepath.Join(tmpDir, id1.String()), metadata.NoneFunc))
 
 	// Create an index reader.
-	reader, err := NewBinaryReader(ctx, logger, bkt, tmpDir, id1, postingOffsetsInMemSampling)
+	reader, err := NewBinaryReader(ctx, logger, bkt, tmpDir, id1, postingOffsetsInMemSampling, NewBinaryReaderMetrics(nil))
 	testutil.Ok(b, err)
 
 	// Get the offset of each label value symbol.

--- a/pkg/block/indexheader/lazy_binary_reader_test.go
+++ b/pkg/block/indexheader/lazy_binary_reader_test.go
@@ -31,8 +31,7 @@ func TestNewLazyBinaryReader_ShouldFailIfUnableToBuildIndexHeader(t *testing.T) 
 	bkt, err := filesystem.NewBucket(filepath.Join(tmpDir, "bkt"))
 	testutil.Ok(t, err)
 	defer func() { testutil.Ok(t, bkt.Close()) }()
-
-	_, err = NewLazyBinaryReader(ctx, log.NewNopLogger(), bkt, tmpDir, ulid.MustNew(0, nil), 3, NewLazyBinaryReaderMetrics(nil), nil)
+	_, err = NewLazyBinaryReader(ctx, log.NewNopLogger(), bkt, tmpDir, ulid.MustNew(0, nil), 3, NewLazyBinaryReaderMetrics(nil), NewBinaryReaderMetrics(nil), nil)
 	testutil.NotOk(t, err)
 }
 
@@ -54,7 +53,8 @@ func TestNewLazyBinaryReader_ShouldBuildIndexHeaderFromBucket(t *testing.T) {
 	testutil.Ok(t, block.Upload(ctx, log.NewNopLogger(), bkt, filepath.Join(tmpDir, blockID.String()), metadata.NoneFunc))
 
 	m := NewLazyBinaryReaderMetrics(nil)
-	r, err := NewLazyBinaryReader(ctx, log.NewNopLogger(), bkt, tmpDir, blockID, 3, m, nil)
+	bm := NewBinaryReaderMetrics(nil)
+	r, err := NewLazyBinaryReader(ctx, log.NewNopLogger(), bkt, tmpDir, blockID, 3, m, bm, nil)
 	testutil.Ok(t, err)
 	testutil.Assert(t, r.reader == nil)
 	testutil.Equals(t, float64(0), promtestutil.ToFloat64(m.loadCount))
@@ -97,7 +97,8 @@ func TestNewLazyBinaryReader_ShouldRebuildCorruptedIndexHeader(t *testing.T) {
 	testutil.Ok(t, os.WriteFile(headerFilename, []byte("xxx"), os.ModePerm))
 
 	m := NewLazyBinaryReaderMetrics(nil)
-	r, err := NewLazyBinaryReader(ctx, log.NewNopLogger(), bkt, tmpDir, blockID, 3, m, nil)
+	bm := NewBinaryReaderMetrics(nil)
+	r, err := NewLazyBinaryReader(ctx, log.NewNopLogger(), bkt, tmpDir, blockID, 3, m, bm, nil)
 	testutil.Ok(t, err)
 	testutil.Assert(t, r.reader == nil)
 	testutil.Equals(t, float64(0), promtestutil.ToFloat64(m.loadCount))
@@ -131,7 +132,8 @@ func TestLazyBinaryReader_ShouldReopenOnUsageAfterClose(t *testing.T) {
 	testutil.Ok(t, block.Upload(ctx, log.NewNopLogger(), bkt, filepath.Join(tmpDir, blockID.String()), metadata.NoneFunc))
 
 	m := NewLazyBinaryReaderMetrics(nil)
-	r, err := NewLazyBinaryReader(ctx, log.NewNopLogger(), bkt, tmpDir, blockID, 3, m, nil)
+	bm := NewBinaryReaderMetrics(nil)
+	r, err := NewLazyBinaryReader(ctx, log.NewNopLogger(), bkt, tmpDir, blockID, 3, m, bm, nil)
 	testutil.Ok(t, err)
 	testutil.Assert(t, r.reader == nil)
 
@@ -181,7 +183,8 @@ func TestLazyBinaryReader_unload_ShouldReturnErrorIfNotIdle(t *testing.T) {
 	testutil.Ok(t, block.Upload(ctx, log.NewNopLogger(), bkt, filepath.Join(tmpDir, blockID.String()), metadata.NoneFunc))
 
 	m := NewLazyBinaryReaderMetrics(nil)
-	r, err := NewLazyBinaryReader(ctx, log.NewNopLogger(), bkt, tmpDir, blockID, 3, m, nil)
+	bm := NewBinaryReaderMetrics(nil)
+	r, err := NewLazyBinaryReader(ctx, log.NewNopLogger(), bkt, tmpDir, blockID, 3, m, bm, nil)
 	testutil.Ok(t, err)
 	testutil.Assert(t, r.reader == nil)
 
@@ -230,7 +233,8 @@ func TestLazyBinaryReader_LoadUnloadRaceCondition(t *testing.T) {
 	testutil.Ok(t, block.Upload(ctx, log.NewNopLogger(), bkt, filepath.Join(tmpDir, blockID.String()), metadata.NoneFunc))
 
 	m := NewLazyBinaryReaderMetrics(nil)
-	r, err := NewLazyBinaryReader(ctx, log.NewNopLogger(), bkt, tmpDir, blockID, 3, m, nil)
+	bm := NewBinaryReaderMetrics(nil)
+	r, err := NewLazyBinaryReader(ctx, log.NewNopLogger(), bkt, tmpDir, blockID, 3, m, bm, nil)
 	testutil.Ok(t, err)
 	testutil.Assert(t, r.reader == nil)
 	t.Cleanup(func() {

--- a/pkg/block/indexheader/reader_pool.go
+++ b/pkg/block/indexheader/reader_pool.go
@@ -18,13 +18,15 @@ import (
 
 // ReaderPoolMetrics holds metrics tracked by ReaderPool.
 type ReaderPoolMetrics struct {
-	lazyReader *LazyBinaryReaderMetrics
+	lazyReader   *LazyBinaryReaderMetrics
+	binaryReader *BinaryReaderMetrics
 }
 
 // NewReaderPoolMetrics makes new ReaderPoolMetrics.
 func NewReaderPoolMetrics(reg prometheus.Registerer) *ReaderPoolMetrics {
 	return &ReaderPoolMetrics{
-		lazyReader: NewLazyBinaryReaderMetrics(reg),
+		lazyReader:   NewLazyBinaryReaderMetrics(reg),
+		binaryReader: NewBinaryReaderMetrics(reg),
 	}
 }
 
@@ -84,9 +86,9 @@ func (p *ReaderPool) NewBinaryReader(ctx context.Context, logger log.Logger, bkt
 	var err error
 
 	if p.lazyReaderEnabled {
-		reader, err = NewLazyBinaryReader(ctx, logger, bkt, dir, id, postingOffsetsInMemSampling, p.metrics.lazyReader, p.onLazyReaderClosed)
+		reader, err = NewLazyBinaryReader(ctx, logger, bkt, dir, id, postingOffsetsInMemSampling, p.metrics.lazyReader, p.metrics.binaryReader, p.onLazyReaderClosed)
 	} else {
-		reader, err = NewBinaryReader(ctx, logger, bkt, dir, id, postingOffsetsInMemSampling)
+		reader, err = NewBinaryReader(ctx, logger, bkt, dir, id, postingOffsetsInMemSampling, p.metrics.binaryReader)
 	}
 
 	if err != nil {

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -189,9 +189,8 @@ func newBucketStoreMetrics(reg prometheus.Registerer) *bucketStoreMetrics {
 	m.blockLoadDuration = promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
 		Name:    "thanos_bucket_store_block_load_duration_seconds",
 		Help:    "The total time taken to load a block in seconds.",
-		Buckets: []float64{0.1, 0.5, 1, 10, 20, 30, 60, 120},
+		Buckets: []float64{0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1, 2, 5, 15, 30, 60, 90, 120, 300},
 	})
-
 	m.seriesDataTouched = promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
 		Name:    "thanos_bucket_store_series_data_touched",
 		Help:    "Number of items of a data type touched to fulfill a single Store API series request.",

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -189,7 +189,7 @@ func newBucketStoreMetrics(reg prometheus.Registerer) *bucketStoreMetrics {
 	m.blockLoadDuration = promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
 		Name:    "thanos_bucket_store_block_load_duration_seconds",
 		Help:    "The total time taken to load a block in seconds.",
-		Buckets: []float64{0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1, 2, 5, 15, 30, 60, 90, 120, 300},
+		Buckets: []float64{0.1, 0.2, 0.5, 1, 2, 5, 15, 30, 60, 90, 120, 300},
 	})
 	m.seriesDataTouched = promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
 		Name:    "thanos_bucket_store_series_data_touched",

--- a/pkg/store/bucket_test.go
+++ b/pkg/store/bucket_test.go
@@ -1067,7 +1067,7 @@ func TestBucketIndexReader_ExpandedPostings(t *testing.T) {
 
 	id := uploadTestBlock(tb, tmpDir, bkt, 500)
 
-	r, err := indexheader.NewBinaryReader(context.Background(), log.NewNopLogger(), bkt, tmpDir, id, DefaultPostingOffsetInMemorySampling)
+	r, err := indexheader.NewBinaryReader(context.Background(), log.NewNopLogger(), bkt, tmpDir, id, DefaultPostingOffsetInMemorySampling, indexheader.NewBinaryReaderMetrics(nil))
 	testutil.Ok(tb, err)
 
 	benchmarkExpandedPostings(tb, bkt, id, r, 500)
@@ -1083,7 +1083,7 @@ func BenchmarkBucketIndexReader_ExpandedPostings(b *testing.B) {
 	defer func() { testutil.Ok(tb, bkt.Close()) }()
 
 	id := uploadTestBlock(tb, tmpDir, bkt, 50e5)
-	r, err := indexheader.NewBinaryReader(context.Background(), log.NewNopLogger(), bkt, tmpDir, id, DefaultPostingOffsetInMemorySampling)
+	r, err := indexheader.NewBinaryReader(context.Background(), log.NewNopLogger(), bkt, tmpDir, id, DefaultPostingOffsetInMemorySampling, indexheader.NewBinaryReaderMetrics(nil))
 	testutil.Ok(tb, err)
 
 	benchmarkExpandedPostings(tb, bkt, id, r, 50e5)
@@ -1255,7 +1255,7 @@ func TestExpandedPostingsEmptyPostings(t *testing.T) {
 
 	id := uploadTestBlock(t, tmpDir, bkt, 100)
 
-	r, err := indexheader.NewBinaryReader(context.Background(), log.NewNopLogger(), bkt, tmpDir, id, DefaultPostingOffsetInMemorySampling)
+	r, err := indexheader.NewBinaryReader(context.Background(), log.NewNopLogger(), bkt, tmpDir, id, DefaultPostingOffsetInMemorySampling, indexheader.NewBinaryReaderMetrics(nil))
 	testutil.Ok(t, err)
 	b := &bucketBlock{
 		logger:            log.NewNopLogger(),
@@ -1599,7 +1599,7 @@ func TestBucketSeries_OneBlock_InMemIndexCacheSegfault(t *testing.T) {
 			estimatedMaxSeriesSize: EstimatedMaxSeriesSize,
 			estimatedMaxChunkSize:  EstimatedMaxChunkSize,
 		}
-		b1.indexHeaderReader, err = indexheader.NewBinaryReader(context.Background(), log.NewNopLogger(), bkt, tmpDir, b1.meta.ULID, DefaultPostingOffsetInMemorySampling)
+		b1.indexHeaderReader, err = indexheader.NewBinaryReader(context.Background(), log.NewNopLogger(), bkt, tmpDir, b1.meta.ULID, DefaultPostingOffsetInMemorySampling, indexheader.NewBinaryReaderMetrics(nil))
 		testutil.Ok(t, err)
 	}
 
@@ -1640,7 +1640,7 @@ func TestBucketSeries_OneBlock_InMemIndexCacheSegfault(t *testing.T) {
 			estimatedMaxSeriesSize: EstimatedMaxSeriesSize,
 			estimatedMaxChunkSize:  EstimatedMaxChunkSize,
 		}
-		b2.indexHeaderReader, err = indexheader.NewBinaryReader(context.Background(), log.NewNopLogger(), bkt, tmpDir, b2.meta.ULID, DefaultPostingOffsetInMemorySampling)
+		b2.indexHeaderReader, err = indexheader.NewBinaryReader(context.Background(), log.NewNopLogger(), bkt, tmpDir, b2.meta.ULID, DefaultPostingOffsetInMemorySampling, indexheader.NewBinaryReaderMetrics(nil))
 		testutil.Ok(t, err)
 	}
 
@@ -2705,7 +2705,7 @@ func prepareBucket(b *testing.B, resolutionLevel compact.ResolutionLevel) (*buck
 	partitioner := NewGapBasedPartitioner(PartitionerMaxGapSize)
 
 	// Create an index header reader.
-	indexHeaderReader, err := indexheader.NewBinaryReader(ctx, logger, bkt, tmpDir, blockMeta.ULID, DefaultPostingOffsetInMemorySampling)
+	indexHeaderReader, err := indexheader.NewBinaryReader(ctx, logger, bkt, tmpDir, blockMeta.ULID, DefaultPostingOffsetInMemorySampling, indexheader.NewBinaryReaderMetrics(nil))
 	testutil.Ok(b, err)
 	indexCache, err := storecache.NewInMemoryIndexCacheWithConfig(logger, nil, nil, storecache.DefaultInMemoryIndexCacheConfig)
 	testutil.Ok(b, err)
@@ -3340,7 +3340,7 @@ func TestExpandedPostingsRace(t *testing.T) {
 		testutil.Ok(t, err)
 		testutil.Ok(t, block.Upload(context.Background(), log.NewLogfmtLogger(os.Stderr), bkt, filepath.Join(tmpDir, ul.String()), metadata.NoneFunc))
 
-		r, err := indexheader.NewBinaryReader(context.Background(), log.NewNopLogger(), bkt, tmpDir, ul, DefaultPostingOffsetInMemorySampling)
+		r, err := indexheader.NewBinaryReader(context.Background(), log.NewNopLogger(), bkt, tmpDir, ul, DefaultPostingOffsetInMemorySampling, indexheader.NewBinaryReaderMetrics(nil))
 		testutil.Ok(t, err)
 
 		blk, err := newBucketBlock(


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [X] Change is not relevant to the end user.

## Changes
- Add more histogram buckets to `thanos_bucket_store_block_load_duration_seconds` metrics.
- Add `indexheader_download_duration_seconds` for tracking how long it takes to download the indexheader from objstore.
- Add a new metrics `indexheader_load_duration_seconds` to track how long it takes to initialize the binary reader.