### PR TITLE
Move to `e2eobs.Observable` API to make profiling tests easier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,8 @@ kube/.minikube
 /data/
 test/e2e/e2e_*
 scripts/data/
+examples/interactive/data/
+examples/interactive/e2e_*
 
 # Ignore benchmarks dir.
 benchmarks/

--- a/examples/interactive/interactive_test.go
+++ b/examples/interactive/interactive_test.go
@@ -14,6 +14,8 @@ import (
 	e2edb "github.com/efficientgo/e2e/db"
 	e2einteractive "github.com/efficientgo/e2e/interactive"
 	e2emon "github.com/efficientgo/e2e/monitoring"
+	e2eprof "github.com/efficientgo/e2e/profiling"
+
 	"github.com/efficientgo/e2e/monitoring/promconfig"
 	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
@@ -120,6 +122,9 @@ func TestReadOnlyThanosSetup(t *testing.T) {
 	e, err := e2e.NewDockerEnvironment("interactive")
 	testutil.Ok(t, err)
 	t.Cleanup(e.Close)
+
+	p, err := e2eprof.Start(e)
+	testutil.Ok(t, err)
 
 	m, err := e2emon.Start(e)
 	testutil.Ok(t, err)
@@ -349,6 +354,8 @@ func TestReadOnlyThanosSetup(t *testing.T) {
 
 	// Tracing endpoint.
 	testutil.Ok(t, e2einteractive.OpenInBrowser("http://"+j.Endpoint("http-front")))
+	// Profiling Endpoint.
+	testutil.Ok(t, p.OpenUserInterfaceInBrowser())
 	// Monitoring Endpoint.
 	testutil.Ok(t, m.OpenUserInterfaceInBrowser())
 	testutil.Ok(t, e2einteractive.RunUntilEndpointHit())

--- a/test/e2e/e2ethanos/services.go
+++ b/test/e2e/e2ethanos/services.go
@@ -15,7 +15,6 @@ import (
 	"github.com/efficientgo/core/backoff"
 	"github.com/efficientgo/e2e"
 	e2edb "github.com/efficientgo/e2e/db"
-	e2emon "github.com/efficientgo/e2e/monitoring"
 	e2eobs "github.com/efficientgo/e2e/observable"
 	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
@@ -91,19 +90,19 @@ func defaultPromHttpConfig() string {
 `
 }
 
-func NewPrometheus(e e2e.Environment, name, promConfig, webConfig, promImage string, enableFeatures ...string) *e2emon.InstrumentedRunnable {
+func NewPrometheus(e e2e.Environment, name, promConfig, webConfig, promImage string, enableFeatures ...string) *e2eobs.Observable {
 	f := e.Runnable(name).WithPorts(map[string]int{"http": 9090}).Future()
 	if err := os.MkdirAll(f.Dir(), 0750); err != nil {
-		return &e2emon.InstrumentedRunnable{Runnable: e2e.NewFailedRunnable(name, errors.Wrap(err, "create prometheus dir"))}
+		return &e2eobs.Observable{Runnable: e2e.NewFailedRunnable(name, errors.Wrap(err, "create prometheus dir"))}
 	}
 
 	if err := os.WriteFile(filepath.Join(f.Dir(), "prometheus.yml"), []byte(promConfig), 0600); err != nil {
-		return &e2emon.InstrumentedRunnable{Runnable: e2e.NewFailedRunnable(name, errors.Wrap(err, "creating prom config"))}
+		return &e2eobs.Observable{Runnable: e2e.NewFailedRunnable(name, errors.Wrap(err, "creating prom config"))}
 	}
 
 	if len(webConfig) > 0 {
 		if err := os.WriteFile(filepath.Join(f.Dir(), "web-config.yml"), []byte(webConfig), 0600); err != nil {
-			return &e2emon.InstrumentedRunnable{Runnable: e2e.NewFailedRunnable(name, errors.Wrap(err, "creating web-config"))}
+			return &e2eobs.Observable{Runnable: e2e.NewFailedRunnable(name, errors.Wrap(err, "creating web-config"))}
 		}
 	}
 
@@ -124,18 +123,18 @@ func NewPrometheus(e e2e.Environment, name, promConfig, webConfig, promImage str
 		// If auth is enabled then prober would get 401 error.
 		probe = e2e.NewHTTPReadinessProbe("http", "/-/ready", 401, 401)
 	}
-	return e2emon.AsInstrumented(f.Init(wrapWithDefaults(e2e.StartOptions{
+	return e2eobs.AsObservable(f.Init(wrapWithDefaults(e2e.StartOptions{
 		Image:     promImage,
 		Command:   e2e.NewCommandWithoutEntrypoint("prometheus", args...),
 		Readiness: probe,
 	})), "http")
 }
 
-func NewPrometheusWithSidecar(e e2e.Environment, name, promConfig, webConfig, promImage, minTime string, enableFeatures ...string) (*e2emon.InstrumentedRunnable, *e2emon.InstrumentedRunnable) {
+func NewPrometheusWithSidecar(e e2e.Environment, name, promConfig, webConfig, promImage, minTime string, enableFeatures ...string) (*e2eobs.Observable, *e2eobs.Observable) {
 	return NewPrometheusWithSidecarCustomImage(e, name, promConfig, webConfig, promImage, minTime, DefaultImage(), enableFeatures...)
 }
 
-func NewPrometheusWithSidecarCustomImage(e e2e.Environment, name, promConfig, webConfig, promImage, minTime string, sidecarImage string, enableFeatures ...string) (*e2emon.InstrumentedRunnable, *e2emon.InstrumentedRunnable) {
+func NewPrometheusWithSidecarCustomImage(e e2e.Environment, name, promConfig, webConfig, promImage, minTime string, sidecarImage string, enableFeatures ...string) (*e2eobs.Observable, *e2eobs.Observable) {
 	prom := NewPrometheus(e, name, promConfig, webConfig, promImage, enableFeatures...)
 
 	args := map[string]string{
@@ -160,7 +159,7 @@ func NewPrometheusWithSidecarCustomImage(e e2e.Environment, name, promConfig, we
 			Command:   e2e.NewCommand("sidecar", e2e.BuildArgs(args)...),
 			Readiness: e2e.NewHTTPReadinessProbe("http", "/-/ready", 200, 200),
 		}))
-	sidecar := e2emon.AsInstrumented(sidecarRunnable, "http")
+	sidecar := e2eobs.AsObservable(sidecarRunnable, "http")
 	return prom, sidecar
 }
 
@@ -179,7 +178,7 @@ type AvalancheOptions struct {
 	TenantID string
 }
 
-func NewAvalanche(e e2e.Environment, name string, o AvalancheOptions) *e2emon.InstrumentedRunnable {
+func NewAvalanche(e e2e.Environment, name string, o AvalancheOptions) *e2eobs.Observable {
 	f := e.Runnable(name).WithPorts(map[string]int{"http": 9001}).Future()
 
 	args := e2e.BuildArgs(map[string]string{
@@ -196,7 +195,7 @@ func NewAvalanche(e e2e.Environment, name string, o AvalancheOptions) *e2emon.In
 		"--remote-tenant":         o.TenantID,
 	})
 
-	return e2emon.AsInstrumented(f.Init(wrapWithDefaults(e2e.StartOptions{
+	return e2eobs.AsObservable(f.Init(wrapWithDefaults(e2e.StartOptions{
 		Image:   "quay.io/prometheuscommunity/avalanche:main",
 		Command: e2e.NewCommandWithoutEntrypoint("avalanche", args...),
 	})), "http")
@@ -204,7 +203,7 @@ func NewAvalanche(e e2e.Environment, name string, o AvalancheOptions) *e2emon.In
 
 func NewPrometheusWithJaegerTracingSidecarCustomImage(e e2e.Environment, name, promConfig, webConfig,
 	promImage, minTime, sidecarImage, jaegerConfig string, enableFeatures ...string) (
-	*e2emon.InstrumentedRunnable, *e2emon.InstrumentedRunnable) {
+	*e2eobs.Observable, *e2eobs.Observable) {
 	prom := NewPrometheus(e, name, promConfig, webConfig, promImage, enableFeatures...)
 
 	args := map[string]string{
@@ -231,7 +230,7 @@ func NewPrometheusWithJaegerTracingSidecarCustomImage(e e2e.Environment, name, p
 			Command:   e2e.NewCommand("sidecar", e2e.BuildArgs(args)...),
 			Readiness: e2e.NewHTTPReadinessProbe("http", "/-/ready", 200, 200),
 		}))
-	sidecar := e2emon.AsInstrumented(sidecarRunnable, "http")
+	sidecar := e2eobs.AsObservable(sidecarRunnable, "http")
 
 	return prom, sidecar
 }
@@ -386,13 +385,13 @@ func (q *QuerierBuilder) WithTelemetryQuantiles(duration []float64, samples []fl
 	return q
 }
 
-func (q *QuerierBuilder) Init() *e2emon.InstrumentedRunnable {
+func (q *QuerierBuilder) Init() *e2eobs.Observable {
 	args, err := q.collectArgs()
 	if err != nil {
-		return &e2emon.InstrumentedRunnable{Runnable: e2e.NewFailedRunnable(q.name, err)}
+		return &e2eobs.Observable{Runnable: e2e.NewFailedRunnable(q.name, err)}
 	}
 
-	return e2emon.AsInstrumented(q.f.Init(wrapWithDefaults(e2e.StartOptions{
+	return e2eobs.AsObservable(q.f.Init(wrapWithDefaults(e2e.StartOptions{
 		Image:     q.image,
 		Command:   e2e.NewCommand("query", args...),
 		Readiness: e2e.NewHTTPReadinessProbe("http", "/-/ready", 200, 200),
@@ -581,9 +580,9 @@ func (r *ReceiveBuilder) WithNativeHistograms() *ReceiveBuilder {
 // If ingestion is enabled it will be configured for ingesting samples.
 // If routing is configured (i.e. hashring configuration is provided) it routes samples to other receivers.
 // If none, it errors out.
-func (r *ReceiveBuilder) Init() *e2emon.InstrumentedRunnable {
+func (r *ReceiveBuilder) Init() *e2eobs.Observable {
 	if !r.ingestion && len(r.hashringConfigs) == 0 {
-		return &e2emon.InstrumentedRunnable{Runnable: e2e.NewFailedRunnable(r.Name(), errors.New("enable ingestion or configure routing for this receiver"))}
+		return &e2eobs.Observable{Runnable: e2e.NewFailedRunnable(r.Name(), errors.New("enable ingestion or configure routing for this receiver"))}
 	}
 
 	args := map[string]string{
@@ -626,28 +625,28 @@ func (r *ReceiveBuilder) Init() *e2emon.InstrumentedRunnable {
 
 		b, err := yaml.Marshal(cfg)
 		if err != nil {
-			return &e2emon.InstrumentedRunnable{Runnable: e2e.NewFailedRunnable(r.Name(), errors.Wrapf(err, "generate limiting file: %v", hashring))}
+			return &e2eobs.Observable{Runnable: e2e.NewFailedRunnable(r.Name(), errors.Wrapf(err, "generate limiting file: %v", hashring))}
 		}
 
 		if err := os.WriteFile(filepath.Join(r.Dir(), "limits.yaml"), b, 0600); err != nil {
-			return &e2emon.InstrumentedRunnable{Runnable: e2e.NewFailedRunnable(r.Name(), errors.Wrap(err, "creating limitin config"))}
+			return &e2eobs.Observable{Runnable: e2e.NewFailedRunnable(r.Name(), errors.Wrap(err, "creating limitin config"))}
 		}
 
 		args["--receive.limits-config-file"] = filepath.Join(r.InternalDir(), "limits.yaml")
 	}
 
 	if err := os.MkdirAll(filepath.Join(r.Dir(), "data"), 0750); err != nil {
-		return &e2emon.InstrumentedRunnable{Runnable: e2e.NewFailedRunnable(r.Name(), errors.Wrap(err, "create receive dir"))}
+		return &e2eobs.Observable{Runnable: e2e.NewFailedRunnable(r.Name(), errors.Wrap(err, "create receive dir"))}
 	}
 
 	if len(hashring) > 0 {
 		b, err := json.Marshal(hashring)
 		if err != nil {
-			return &e2emon.InstrumentedRunnable{Runnable: e2e.NewFailedRunnable(r.Name(), errors.Wrapf(err, "generate hashring file: %v", hashring))}
+			return &e2eobs.Observable{Runnable: e2e.NewFailedRunnable(r.Name(), errors.Wrapf(err, "generate hashring file: %v", hashring))}
 		}
 
 		if err := os.WriteFile(filepath.Join(r.Dir(), "hashrings.json"), b, 0600); err != nil {
-			return &e2emon.InstrumentedRunnable{Runnable: e2e.NewFailedRunnable(r.Name(), errors.Wrap(err, "creating receive config"))}
+			return &e2eobs.Observable{Runnable: e2e.NewFailedRunnable(r.Name(), errors.Wrap(err, "creating receive config"))}
 		}
 
 		args["--receive.hashrings-file"] = filepath.Join(r.InternalDir(), "hashrings.json")
@@ -658,7 +657,7 @@ func (r *ReceiveBuilder) Init() *e2emon.InstrumentedRunnable {
 	if len(r.relabelConfigs) > 0 {
 		relabelConfigBytes, err := yaml.Marshal(r.relabelConfigs)
 		if err != nil {
-			return &e2emon.InstrumentedRunnable{Runnable: e2e.NewFailedRunnable(r.Name(), errors.Wrapf(err, "generate relabel configs: %v", relabelConfigBytes))}
+			return &e2eobs.Observable{Runnable: e2e.NewFailedRunnable(r.Name(), errors.Wrapf(err, "generate relabel configs: %v", relabelConfigBytes))}
 		}
 		args["--receive.relabel-config"] = string(relabelConfigBytes)
 	}
@@ -667,7 +666,7 @@ func (r *ReceiveBuilder) Init() *e2emon.InstrumentedRunnable {
 		args["--tsdb.enable-native-histograms"] = ""
 	}
 
-	return e2emon.AsInstrumented(r.f.Init(wrapWithDefaults(e2e.StartOptions{
+	return e2eobs.AsObservable(r.f.Init(wrapWithDefaults(e2e.StartOptions{
 		Image:     r.image,
 		Command:   e2e.NewCommand("receive", e2e.BuildKingpinArgs(args)...),
 		Readiness: e2e.NewHTTPReadinessProbe("http", "/-/ready", 200, 200),
@@ -736,29 +735,29 @@ func (r *RulerBuilder) WithRestoreIgnoredLabels(labels ...string) *RulerBuilder 
 	return r
 }
 
-func (r *RulerBuilder) InitTSDB(internalRuleDir string, queryCfg []httpconfig.Config) *e2emon.InstrumentedRunnable {
+func (r *RulerBuilder) InitTSDB(internalRuleDir string, queryCfg []httpconfig.Config) *e2eobs.Observable {
 	return r.initRule(internalRuleDir, queryCfg, nil)
 }
 
-func (r *RulerBuilder) InitStateless(internalRuleDir string, queryCfg []httpconfig.Config, remoteWriteCfg []*config.RemoteWriteConfig) *e2emon.InstrumentedRunnable {
+func (r *RulerBuilder) InitStateless(internalRuleDir string, queryCfg []httpconfig.Config, remoteWriteCfg []*config.RemoteWriteConfig) *e2eobs.Observable {
 	return r.initRule(internalRuleDir, queryCfg, remoteWriteCfg)
 }
 
-func (r *RulerBuilder) initRule(internalRuleDir string, queryCfg []httpconfig.Config, remoteWriteCfg []*config.RemoteWriteConfig) *e2emon.InstrumentedRunnable {
+func (r *RulerBuilder) initRule(internalRuleDir string, queryCfg []httpconfig.Config, remoteWriteCfg []*config.RemoteWriteConfig) *e2eobs.Observable {
 	if err := os.MkdirAll(r.f.Dir(), 0750); err != nil {
-		return &e2emon.InstrumentedRunnable{Runnable: e2e.NewFailedRunnable(r.Name(), errors.Wrap(err, "create rule dir"))}
+		return &e2eobs.Observable{Runnable: e2e.NewFailedRunnable(r.Name(), errors.Wrap(err, "create rule dir"))}
 	}
 
 	amCfgBytes, err := yaml.Marshal(alert.AlertingConfig{
 		Alertmanagers: r.amCfg,
 	})
 	if err != nil {
-		return &e2emon.InstrumentedRunnable{Runnable: e2e.NewFailedRunnable(r.Name(), errors.Wrapf(err, "generate am file: %v", r.amCfg))}
+		return &e2eobs.Observable{Runnable: e2e.NewFailedRunnable(r.Name(), errors.Wrapf(err, "generate am file: %v", r.amCfg))}
 	}
 
 	queryCfgBytes, err := yaml.Marshal(queryCfg)
 	if err != nil {
-		return &e2emon.InstrumentedRunnable{Runnable: e2e.NewFailedRunnable(r.Name(), errors.Wrapf(err, "generate query file: %v", queryCfg))}
+		return &e2eobs.Observable{Runnable: e2e.NewFailedRunnable(r.Name(), errors.Wrapf(err, "generate query file: %v", queryCfg))}
 	}
 
 	ruleArgs := map[string]string{
@@ -798,7 +797,7 @@ func (r *RulerBuilder) initRule(internalRuleDir string, queryCfg []httpconfig.Co
 			RemoteWriteConfigs []*config.RemoteWriteConfig `yaml:"remote_write,omitempty"`
 		}{remoteWriteCfg})
 		if err != nil {
-			return &e2emon.InstrumentedRunnable{Runnable: e2e.NewFailedRunnable(r.Name(), errors.Wrapf(err, "generate remote write config: %v", remoteWriteCfg))}
+			return &e2eobs.Observable{Runnable: e2e.NewFailedRunnable(r.Name(), errors.Wrapf(err, "generate remote write config: %v", remoteWriteCfg))}
 		}
 		ruleArgs["--remote-write.config"] = string(rwCfgBytes)
 	}
@@ -809,20 +808,20 @@ func (r *RulerBuilder) initRule(internalRuleDir string, queryCfg []httpconfig.Co
 		args = append(args, "--restore-ignored-label="+label)
 	}
 
-	return e2emon.AsInstrumented(r.f.Init(wrapWithDefaults(e2e.StartOptions{
+	return e2eobs.AsObservable(r.f.Init(wrapWithDefaults(e2e.StartOptions{
 		Image:     r.image,
 		Command:   e2e.NewCommand("rule", args...),
 		Readiness: e2e.NewHTTPReadinessProbe("http", "/-/ready", 200, 200),
 	})), "http")
 }
 
-func NewAlertmanager(e e2e.Environment, name string) *e2emon.InstrumentedRunnable {
+func NewAlertmanager(e e2e.Environment, name string) *e2eobs.Observable {
 	f := e.Runnable(fmt.Sprintf("alertmanager-%v", name)).
 		WithPorts(map[string]int{"http": 8080}).
 		Future()
 
 	if err := os.MkdirAll(f.Dir(), 0750); err != nil {
-		return &e2emon.InstrumentedRunnable{Runnable: e2e.NewFailedRunnable(name, errors.Wrap(err, "create am dir"))}
+		return &e2eobs.Observable{Runnable: e2e.NewFailedRunnable(name, errors.Wrap(err, "create am dir"))}
 	}
 	const config = `
 route:
@@ -834,10 +833,10 @@ receivers:
 - name: 'null'
 `
 	if err := os.WriteFile(filepath.Join(f.Dir(), "config.yaml"), []byte(config), 0600); err != nil {
-		return &e2emon.InstrumentedRunnable{Runnable: e2e.NewFailedRunnable(name, errors.Wrap(err, "creating alertmanager config file failed"))}
+		return &e2eobs.Observable{Runnable: e2e.NewFailedRunnable(name, errors.Wrap(err, "creating alertmanager config file failed"))}
 	}
 
-	return e2emon.AsInstrumented(f.Init(wrapWithDefaults(e2e.StartOptions{
+	return e2eobs.AsObservable(f.Init(wrapWithDefaults(e2e.StartOptions{
 		Image: DefaultAlertmanagerImage(),
 		Command: e2e.NewCommandWithoutEntrypoint("/bin/alertmanager", e2e.BuildArgs(map[string]string{
 			"--config.file":         filepath.Join(f.InternalDir(), "config.yaml"),
@@ -853,23 +852,23 @@ receivers:
 	})), "http")
 }
 
-func NewStoreGW(e e2e.Environment, name string, bucketConfig client.BucketConfig, cacheConfig, indexCacheConfig string, extArgs []string, relabelConfig ...relabel.Config) *e2emon.InstrumentedRunnable {
+func NewStoreGW(e e2e.Environment, name string, bucketConfig client.BucketConfig, cacheConfig, indexCacheConfig string, extArgs []string, relabelConfig ...relabel.Config) *e2eobs.Observable {
 	f := e.Runnable(fmt.Sprintf("store-gw-%v", name)).
 		WithPorts(map[string]int{"http": 8080, "grpc": 9091}).
 		Future()
 
 	if err := os.MkdirAll(f.Dir(), 0750); err != nil {
-		return &e2emon.InstrumentedRunnable{Runnable: e2e.NewFailedRunnable(name, errors.Wrap(err, "create store dir"))}
+		return &e2eobs.Observable{Runnable: e2e.NewFailedRunnable(name, errors.Wrap(err, "create store dir"))}
 	}
 
 	bktConfigBytes, err := yaml.Marshal(bucketConfig)
 	if err != nil {
-		return &e2emon.InstrumentedRunnable{Runnable: e2e.NewFailedRunnable(name, errors.Wrapf(err, "generate store config file: %v", bucketConfig))}
+		return &e2eobs.Observable{Runnable: e2e.NewFailedRunnable(name, errors.Wrapf(err, "generate store config file: %v", bucketConfig))}
 	}
 
 	relabelConfigBytes, err := yaml.Marshal(relabelConfig)
 	if err != nil {
-		return &e2emon.InstrumentedRunnable{Runnable: e2e.NewFailedRunnable(name, errors.Wrapf(err, "generate store relabel file: %v", relabelConfig))}
+		return &e2eobs.Observable{Runnable: e2e.NewFailedRunnable(name, errors.Wrapf(err, "generate store relabel file: %v", relabelConfig))}
 	}
 
 	args := append(e2e.BuildArgs(map[string]string{
@@ -896,7 +895,7 @@ func NewStoreGW(e e2e.Environment, name string, bucketConfig client.BucketConfig
 		args = append(args, "--index-cache.config", indexCacheConfig)
 	}
 
-	return e2emon.AsInstrumented(f.Init(wrapWithDefaults(e2e.StartOptions{
+	return e2eobs.AsObservable(f.Init(wrapWithDefaults(e2e.StartOptions{
 		Image:     DefaultImage(),
 		Command:   e2e.NewCommand("store", args...),
 		Readiness: e2e.NewHTTPReadinessProbe("http", "/-/ready", 200, 200),
@@ -918,22 +917,22 @@ func NewCompactorBuilder(e e2e.Environment, name string) *CompactorBuilder {
 	}
 }
 
-func (c *CompactorBuilder) Init(bucketConfig client.BucketConfig, relabelConfig []relabel.Config, extArgs ...string) *e2emon.InstrumentedRunnable {
+func (c *CompactorBuilder) Init(bucketConfig client.BucketConfig, relabelConfig []relabel.Config, extArgs ...string) *e2eobs.Observable {
 	if err := os.MkdirAll(c.Dir(), 0750); err != nil {
-		return &e2emon.InstrumentedRunnable{Runnable: e2e.NewFailedRunnable(c.Name(), errors.Wrap(err, "create compact dir"))}
+		return &e2eobs.Observable{Runnable: e2e.NewFailedRunnable(c.Name(), errors.Wrap(err, "create compact dir"))}
 	}
 
 	bktConfigBytes, err := yaml.Marshal(bucketConfig)
 	if err != nil {
-		return &e2emon.InstrumentedRunnable{Runnable: e2e.NewFailedRunnable(c.Name(), errors.Wrapf(err, "generate compact config file: %v", bucketConfig))}
+		return &e2eobs.Observable{Runnable: e2e.NewFailedRunnable(c.Name(), errors.Wrapf(err, "generate compact config file: %v", bucketConfig))}
 	}
 
 	relabelConfigBytes, err := yaml.Marshal(relabelConfig)
 	if err != nil {
-		return &e2emon.InstrumentedRunnable{Runnable: e2e.NewFailedRunnable(c.Name(), errors.Wrapf(err, "generate compact relabel file: %v", relabelConfig))}
+		return &e2eobs.Observable{Runnable: e2e.NewFailedRunnable(c.Name(), errors.Wrapf(err, "generate compact relabel file: %v", relabelConfig))}
 	}
 
-	return e2emon.AsInstrumented(c.f.Init(wrapWithDefaults(e2e.StartOptions{
+	return e2eobs.AsObservable(c.f.Init(wrapWithDefaults(e2e.StartOptions{
 		Image: DefaultImage(),
 		Command: e2e.NewCommand("compact", append(e2e.BuildArgs(map[string]string{
 			"--debug.name":               c.Name(),
@@ -996,7 +995,7 @@ func NewQueryFrontend(e e2e.Environment, name, downstreamURL string, config quer
 		}), "http")
 }
 
-func NewReverseProxy(e e2e.Environment, name, tenantID, target string) *e2emon.InstrumentedRunnable {
+func NewReverseProxy(e e2e.Environment, name, tenantID, target string) *e2eobs.Observable {
 	conf := fmt.Sprintf(`
 events {
 	worker_connections  1024;
@@ -1020,22 +1019,22 @@ http {
 		Future()
 
 	if err := os.MkdirAll(f.Dir(), 0750); err != nil {
-		return &e2emon.InstrumentedRunnable{Runnable: e2e.NewFailedRunnable(name, errors.Wrap(err, "create store dir"))}
+		return &e2eobs.Observable{Runnable: e2e.NewFailedRunnable(name, errors.Wrap(err, "create store dir"))}
 	}
 
 	if err := os.WriteFile(filepath.Join(f.Dir(), "nginx.conf"), []byte(conf), 0600); err != nil {
-		return &e2emon.InstrumentedRunnable{Runnable: e2e.NewFailedRunnable(name, errors.Wrap(err, "creating nginx config file failed"))}
+		return &e2eobs.Observable{Runnable: e2e.NewFailedRunnable(name, errors.Wrap(err, "creating nginx config file failed"))}
 	}
 
-	return e2emon.AsInstrumented(f.Init(e2e.StartOptions{
+	return e2eobs.AsObservable(f.Init(e2e.StartOptions{
 		Image:            "docker.io/nginx:1.21.1-alpine",
 		Volumes:          []string{filepath.Join(f.Dir(), "/nginx.conf") + ":/etc/nginx/nginx.conf:ro"},
 		WaitReadyBackoff: &defaultBackoffConfig,
 	}), "http")
 }
 
-func NewMemcached(e e2e.Environment, name string) *e2emon.InstrumentedRunnable {
-	return e2emon.AsInstrumented(e.Runnable(fmt.Sprintf("memcached-%s", name)).
+func NewMemcached(e e2e.Environment, name string) *e2eobs.Observable {
+	return e2eobs.AsObservable(e.Runnable(fmt.Sprintf("memcached-%s", name)).
 		WithPorts(map[string]int{"memcached": 11211}).
 		Init(e2e.StartOptions{
 			Image:            "docker.io/memcached:1.6.3-alpine",
@@ -1054,10 +1053,10 @@ func NewToolsBucketWeb(
 	minTime string,
 	maxTime string,
 	relabelConfig string,
-) *e2emon.InstrumentedRunnable {
+) *e2eobs.Observable {
 	bktConfigBytes, err := yaml.Marshal(bucketConfig)
 	if err != nil {
-		return &e2emon.InstrumentedRunnable{Runnable: e2e.NewFailedRunnable(name, errors.Wrapf(err, "generate tools bucket web config file: %v", bucketConfig))}
+		return &e2eobs.Observable{Runnable: e2e.NewFailedRunnable(name, errors.Wrapf(err, "generate tools bucket web config file: %v", bucketConfig))}
 	}
 
 	f := e.Runnable(fmt.Sprintf("toolsBucketWeb-%s", name)).
@@ -1092,7 +1091,7 @@ func NewToolsBucketWeb(
 
 	args = append([]string{"bucket", "web"}, args...)
 
-	return e2emon.AsInstrumented(f.Init(wrapWithDefaults(e2e.StartOptions{
+	return e2eobs.AsObservable(f.Init(wrapWithDefaults(e2e.StartOptions{
 		Image:     DefaultImage(),
 		Command:   e2e.NewCommand("tools", args...),
 		Readiness: e2e.NewHTTPReadinessProbe("http", "/-/ready", 200, 200),

--- a/test/e2e/exemplars_api_test.go
+++ b/test/e2e/exemplars_api_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/efficientgo/e2e"
 	e2emon "github.com/efficientgo/e2e/monitoring"
+	e2eobs "github.com/efficientgo/e2e/observable"
 	"github.com/pkg/errors"
 	"github.com/prometheus/prometheus/model/timestamp"
 
@@ -27,8 +28,8 @@ const (
 func TestExemplarsAPI_Fanout(t *testing.T) {
 	t.Parallel()
 	var (
-		prom1, prom2       *e2emon.InstrumentedRunnable
-		sidecar1, sidecar2 *e2emon.InstrumentedRunnable
+		prom1, prom2       *e2eobs.Observable
+		sidecar1, sidecar2 *e2eobs.Observable
 		err                error
 		e                  *e2e.DockerEnvironment
 	)

--- a/test/e2e/query_test.go
+++ b/test/e2e/query_test.go
@@ -2402,7 +2402,7 @@ func TestTenantHTTPMetrics(t *testing.T) {
 	tenant1Matcher, err := matchers.NewMatcher(matchers.MatchEqual, "tenant", "test-tenant-1")
 	testutil.Ok(t, err)
 	testutil.Ok(t, q.WaitSumMetricsWithOptions(
-		e2emon.Equals(3),
+		e2emon.GreaterOrEqual(3),
 		[]string{"http_requests_total"}, e2emon.WithLabelMatchers(
 			tenant1Matcher,
 		),

--- a/test/e2e/query_test.go
+++ b/test/e2e/query_test.go
@@ -27,6 +27,7 @@ import (
 	e2edb "github.com/efficientgo/e2e/db"
 	e2emon "github.com/efficientgo/e2e/monitoring"
 	"github.com/efficientgo/e2e/monitoring/matchers"
+	e2eobs "github.com/efficientgo/e2e/observable"
 	"github.com/go-kit/log"
 	"github.com/gogo/protobuf/proto"
 	"github.com/golang/snappy"
@@ -95,7 +96,7 @@ func TestQueryServiceAttribute(t *testing.T) {
 			Image:     "jaegertracing/all-in-one:1.33",
 			Readiness: e2e.NewHTTPReadinessProbe("http.admin", "/", 200, 200),
 		})
-	newJaeger := e2emon.AsInstrumented(newJaegerRunnable, "http.admin")
+	newJaeger := e2eobs.AsObservable(newJaegerRunnable, "http.admin")
 	testutil.Ok(t, e2e.StartAndWaitReady(newJaeger))
 
 	otelcolConfig := fmt.Sprintf(`---
@@ -1739,7 +1740,7 @@ func queryExemplars(t *testing.T, ctx context.Context, addr, q string, start, en
 	}))
 }
 
-func synthesizeFakeMetricSamples(ctx context.Context, prometheus *e2emon.InstrumentedRunnable, testSamples []fakeMetricSample) error {
+func synthesizeFakeMetricSamples(ctx context.Context, prometheus *e2eobs.Observable, testSamples []fakeMetricSample) error {
 	samples := make([]model.Sample, len(testSamples))
 	for i, s := range testSamples {
 		samples[i] = newSample(s)
@@ -1748,7 +1749,7 @@ func synthesizeFakeMetricSamples(ctx context.Context, prometheus *e2emon.Instrum
 	return synthesizeSamples(ctx, prometheus, samples)
 }
 
-func synthesizeSamples(ctx context.Context, prometheus *e2emon.InstrumentedRunnable, samples []model.Sample) error {
+func synthesizeSamples(ctx context.Context, prometheus *e2eobs.Observable, samples []model.Sample) error {
 	rawRemoteWriteURL := "http://" + prometheus.Endpoint("http") + "/api/v1/write"
 
 	samplespb := make([]prompb.TimeSeries, 0, len(samples))
@@ -1778,7 +1779,7 @@ func synthesizeSamples(ctx context.Context, prometheus *e2emon.InstrumentedRunna
 	return storeWriteRequest(ctx, rawRemoteWriteURL, writeRequest)
 }
 
-func remoteWriteSeriesWithLabels(ctx context.Context, prometheus *e2emon.InstrumentedRunnable, series []seriesWithLabels) error {
+func remoteWriteSeriesWithLabels(ctx context.Context, prometheus *e2eobs.Observable, series []seriesWithLabels) error {
 	rawRemoteWriteURL := "http://" + prometheus.Endpoint("http") + "/api/v1/write"
 
 	samplespb := make([]prompb.TimeSeries, 0, len(series))

--- a/test/e2e/rule_test.go
+++ b/test/e2e/rule_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/efficientgo/e2e"
 	e2emon "github.com/efficientgo/e2e/monitoring"
+	e2eobs "github.com/efficientgo/e2e/observable"
 	common_cfg "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/config"
@@ -171,7 +172,7 @@ func reloadRulesHTTP(t *testing.T, ctx context.Context, endpoint string) {
 	testutil.Equals(t, 200, resp.StatusCode)
 }
 
-func reloadRulesSignal(t *testing.T, r *e2emon.InstrumentedRunnable) {
+func reloadRulesSignal(t *testing.T, r *e2eobs.Observable) {
 	c := e2e.NewCommand("kill", "-1", "1")
 	testutil.Ok(t, r.Exec(c))
 }
@@ -623,7 +624,7 @@ func TestStatelessRulerAlertStateRestore(t *testing.T) {
 		WithReplicaLabels("replica", "receive").Init()
 	testutil.Ok(t, e2e.StartAndWaitReady(q))
 	rulesSubDir := "rules"
-	var rulers []*e2emon.InstrumentedRunnable
+	var rulers []*e2eobs.Observable
 	for i := 1; i <= 2; i++ {
 		rFuture := e2ethanos.NewRulerBuilder(e, fmt.Sprintf("%d", i))
 		rulesPath := filepath.Join(rFuture.Dir(), rulesSubDir)

--- a/test/e2e/store_gateway_test.go
+++ b/test/e2e/store_gateway_test.go
@@ -1217,6 +1217,6 @@ func TestStoreGatewayLazyExpandedPostingsEnabled(t *testing.T) {
 	})
 
 	// Use greater or equal to handle flakiness.
-	testutil.Ok(t, s1.WaitSumMetrics(e2emon.GreaterOrEqual(1), "thanos_bucket_store_lazy_expanded_postings_total"))
-	testutil.Ok(t, s2.WaitSumMetrics(e2emon.Equals(0), "thanos_bucket_store_lazy_expanded_postings_total"))
+	testutil.Ok(t, s1.WaitSumMetrics(e2emon.GreaterOrEqual(1), "thanos_bucket_store_lazy_expanded_postings_total"), e2emon.WaitMissingMetrics())
+	testutil.Ok(t, s2.WaitSumMetrics(e2emon.Equals(0), "thanos_bucket_store_lazy_expanded_postings_total"), e2emon.WaitMissingMetrics())
 }

--- a/test/e2e/store_gateway_test.go
+++ b/test/e2e/store_gateway_test.go
@@ -21,6 +21,7 @@ import (
 	e2edb "github.com/efficientgo/e2e/db"
 	e2emon "github.com/efficientgo/e2e/monitoring"
 	"github.com/efficientgo/e2e/monitoring/matchers"
+	e2eobs "github.com/efficientgo/e2e/observable"
 	"github.com/go-kit/log"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
@@ -768,7 +769,7 @@ metafile_content_ttl: 0s`
 
 	// Wait for store to sync blocks.
 	// thanos_blocks_meta_synced: 1x loadedMeta 0x labelExcludedMeta 0x TooFreshMeta.
-	for _, st := range []*e2emon.InstrumentedRunnable{store1, store2, store3} {
+	for _, st := range []*e2eobs.Observable{store1, store2, store3} {
 		t.Run(st.Name(), func(t *testing.T) {
 			testutil.Ok(t, st.WaitSumMetrics(e2emon.Equals(1), "thanos_blocks_meta_synced"))
 			testutil.Ok(t, st.WaitSumMetrics(e2emon.Equals(0), "thanos_blocks_meta_sync_failures_total"))
@@ -794,7 +795,7 @@ metafile_content_ttl: 0s`
 			},
 		)
 
-		for _, st := range []*e2emon.InstrumentedRunnable{store1, store2, store3} {
+		for _, st := range []*e2eobs.Observable{store1, store2, store3} {
 			testutil.Ok(t, st.WaitSumMetricsWithOptions(e2emon.Greater(0), []string{`thanos_cache_groupcache_loads_total`}))
 			testutil.Ok(t, st.WaitSumMetricsWithOptions(e2emon.Greater(0), []string{`thanos_store_bucket_cache_operation_hits_total`}, e2emon.WithLabelMatchers(matchers.MustNewMatcher(matchers.MatchEqual, "config", "chunks"))))
 		}

--- a/test/e2e/tracing_test.go
+++ b/test/e2e/tracing_test.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/efficientgo/core/testutil"
 	"github.com/efficientgo/e2e"
-	e2emon "github.com/efficientgo/e2e/monitoring"
+	e2eobs "github.com/efficientgo/e2e/observable"
 	"gopkg.in/yaml.v2"
 )
 
@@ -44,7 +44,7 @@ func TestJaegerTracing(t *testing.T) {
 			Image:     "jaegertracing/all-in-one:1.33",
 			Readiness: e2e.NewHTTPReadinessProbe("http.admin", "/", 200, 200),
 		})
-	newJaeger := e2emon.AsInstrumented(newJaegerRunnable, "http.admin")
+	newJaeger := e2eobs.AsObservable(newJaegerRunnable, "http.admin")
 	testutil.Ok(t, e2e.StartAndWaitReady(newJaeger))
 
 	jaegerConfig, err := yaml.Marshal(client.TracingConfig{


### PR DESCRIPTION

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

Move tests to `e2eobs.Observable` API to make profiling tests easier and enable profiling for interactive tests.
Also, add certain interactive test dirs to .gitignore

## Verification

<!-- How you tested it? How do you know it works? -->
