### PR TITLE
query: fix selectStore hints race

### DIFF
--- a/pkg/query/query_test.go
+++ b/pkg/query/query_test.go
@@ -119,6 +119,11 @@ func (s *selectStore) Series(r *storepb.SeriesRequest, srv storepb.Store_SeriesS
 	if r.MaxTime > s.maxt {
 		r.MaxTime = s.maxt
 	}
-	r.Matchers = append(r.Matchers, s.matchers...)
-	return s.StoreServer.Series(r, srv)
+
+	matchers := make([]storepb.LabelMatcher, 0, len(r.Matchers))
+	matchers = append(matchers, r.Matchers...)
+
+	req := *r
+	req.Matchers = matchers
+	return s.StoreServer.Series(&req, srv)
 }


### PR DESCRIPTION
Appending to the hints slice modifies the original request and we have multiple of goroutines doing that at the same time. Hence, make a copy of the hints and append only then.
