### PR TITLE
extprom: fix tg_gauge With* race

### DIFF
--- a/pkg/extprom/tx_gauge.go
+++ b/pkg/extprom/tx_gauge.go
@@ -81,6 +81,9 @@ func (tx *TxGaugeVec) Collect(ch chan<- prometheus.Metric) {
 //
 //	myVec.With(prometheus.Labels{"code": "404", "method": "GET"}).Add(42)
 func (tx *TxGaugeVec) With(labels prometheus.Labels) prometheus.Gauge {
+	tx.mtx.Lock()
+	defer tx.mtx.Unlock()
+
 	if tx.tx == nil {
 		tx.ResetTx()
 	}
@@ -93,6 +96,9 @@ func (tx *TxGaugeVec) With(labels prometheus.Labels) prometheus.Gauge {
 //
 //	myVec.WithLabelValues("404", "GET").Add(42)
 func (tx *TxGaugeVec) WithLabelValues(lvs ...string) prometheus.Gauge {
+	tx.mtx.Lock()
+	defer tx.mtx.Unlock()
+
 	if tx.tx == nil {
 		tx.ResetTx()
 	}


### PR DESCRIPTION
Fix the following race:
```
Read at 0x00c000645ac0 by goroutine 43:
  github.com/prometheus/client_golang/prometheus.(*MetricVec).hashLabelValues()
      /home/giedrius/go/pkg/mod/github.com/prometheus/client_golang@v1.16.0/prometheus/vec.go:279 +0x3a4
  github.com/prometheus/client_golang/prometheus.(*MetricVec).GetMetricWithLabelValues()
      /home/giedrius/go/pkg/mod/github.com/prometheus/client_golang@v1.16.0/prometheus/vec.go:228 +0x109
  github.com/prometheus/client_golang/prometheus.(*GaugeVec).GetMetricWithLabelValues()
      /home/giedrius/go/pkg/mod/github.com/prometheus/client_golang@v1.16.0/prometheus/gauge.go:203 +0x57
  github.com/prometheus/client_golang/prometheus.(*GaugeVec).WithLabelValues()
      /home/giedrius/go/pkg/mod/github.com/prometheus/client_golang@v1.16.0/prometheus/gauge.go:236 +0xe4
  github.com/thanos-io/thanos/pkg/extprom.(*TxGaugeVec).WithLabelValues()
      /home/giedrius/dev/thanos/pkg/extprom/tx_gauge.go:105 +0xb8
  github.com/thanos-io/thanos/pkg/compact.(*GatherNoCompactionMarkFilter).Filter.func1()
      /home/giedrius/dev/thanos/pkg/compact/compact.go:1603 +0x78d
  golang.org/x/sync/errgroup.(*Group).Go.func1()
      /home/giedrius/go/pkg/mod/golang.org/x/sync@v0.3.0/errgroup/errgroup.go:75 +0x76

Previous write at 0x00c000645ac0 by goroutine 41:
  github.com/prometheus/client_golang/prometheus.NewMetricVec()
      /home/giedrius/go/pkg/mod/github.com/prometheus/client_golang@v1.16.0/prometheus/vec.go:66 +0xfe
  github.com/prometheus/client_golang/prometheus.v2.NewGaugeVec()
      /home/giedrius/go/pkg/mod/github.com/prometheus/client_golang@v1.16.0/prometheus/gauge.go:168 +0x80
  github.com/prometheus/client_golang/prometheus.NewGaugeVec()
      /home/giedrius/go/pkg/mod/github.com/prometheus/client_golang@v1.16.0/prometheus/gauge.go:153 +0x197
  github.com/prometheus/client_golang/prometheus/promauto.Factory.NewGaugeVec()
      /home/giedrius/go/pkg/mod/github.com/prometheus/client_golang@v1.16.0/prometheus/promauto/auto.go:306 +0x5c
  github.com/thanos-io/thanos/pkg/extprom.NewTxGaugeVec.func1()
      /home/giedrius/dev/thanos/pkg/extprom/tx_gauge.go:31 +0x124
  github.com/thanos-io/thanos/pkg/extprom.(*TxGaugeVec).ResetTx()
      /home/giedrius/dev/thanos/pkg/extprom/tx_gauge.go:49 +0x72
  github.com/thanos-io/thanos/pkg/extprom.(*TxGaugeVec).WithLabelValues()
      /home/giedrius/dev/thanos/pkg/extprom/tx_gauge.go:103 +0x58
  github.com/thanos-io/thanos/pkg/compact.(*GatherNoCompactionMarkFilter).Filter.func1()
      /home/giedrius/dev/thanos/pkg/compact/compact.go:1603 +0x78d
  golang.org/x/sync/errgroup.(*Group).Go.func1()
      /home/giedrius/go/pkg/mod/golang.org/x/sync@v0.3.0/errgroup/errgroup.go:75 +0x76
```

During `TestNoMarkFilterAtomic`, Filter() is called concurrently thus leading to this situation. This can happen during regular operation too.