### PR TITLE
store: fix stringlabel build errors for prometheus store api

### DIFF
--- a/pkg/store/prometheus_test.go
+++ b/pkg/store/prometheus_test.go
@@ -169,9 +169,9 @@ func testPrometheusStoreSeriesE2e(t *testing.T, prefix string) {
 		testutil.Equals(t, 1, len(srv.SeriesSet))
 
 		testutil.Equals(t, []labelpb.ZLabel{
+			{Name: "__thanos_pushed_down", Value: "true"},
 			{Name: "a", Value: "b"},
 			{Name: "region", Value: "eu-west"},
-			{Name: "__thanos_pushed_down", Value: "true"},
 		}, srv.SeriesSet[0].Labels)
 		testutil.Equals(t, []string(nil), srv.Warnings)
 		testutil.Equals(t, 1, len(srv.SeriesSet[0].Chunks))

--- a/pkg/testutil/e2eutil/prometheus.go
+++ b/pkg/testutil/e2eutil/prometheus.go
@@ -509,10 +509,6 @@ func createBlock(
 				app := h.Appender(ctx)
 
 				for _, lset := range batch {
-					sort.Slice(lset, func(i, j int) bool {
-						return lset[i].Name < lset[j].Name
-					})
-
 					var err error
 					if sampleType == chunkenc.ValFloat {
 						randMutex.Lock()


### PR DESCRIPTION
* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

* Make PrometheusStore compatible with stringlabels by removing its dependency on slice labels

## Verification

* Existing tests still pass
