### PR TITLE
Store: fix returned labels on external label conflict when skipping chunks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 
 ### Fixed
 
+- [#6874](https://github.com/thanos-io/thanos/pull/6874) Sidecar: fix labels returned by 'api/v1/series' in presence of conflicting external and inner labels.
+
 ### Added
 
 ### Changed

--- a/pkg/store/acceptance_test.go
+++ b/pkg/store/acceptance_test.go
@@ -53,9 +53,10 @@ type labelValuesCallCase struct {
 }
 
 type seriesCallCase struct {
-	matchers []storepb.LabelMatcher
-	start    int64
-	end      int64
+	matchers   []storepb.LabelMatcher
+	start      int64
+	end        int64
+	skipChunks bool
 
 	expectedLabels []labels.Labels
 	expectErr      error
@@ -216,6 +217,28 @@ func testStoreAPIsAcceptance(t *testing.T, startStore func(t *testing.T, extLset
 					end:      timestamp.FromTime(maxTime),
 					label:    "bar",
 					matchers: []storepb.LabelMatcher{{Type: storepb.LabelMatcher_EQ, Name: "region", Value: "different"}},
+				},
+			},
+		},
+		{
+			desc: "conflicting internal and external labels when skipping chunks",
+			appendFn: func(app storage.Appender) {
+				_, err := app.Append(0, labels.FromStrings("foo", "bar", "region", "somewhere"), 0, 0)
+				testutil.Ok(t, err)
+
+				testutil.Ok(t, app.Commit())
+			},
+			seriesCalls: []seriesCallCase{
+				{
+					start: timestamp.FromTime(minTime),
+					end:   timestamp.FromTime(maxTime),
+					matchers: []storepb.LabelMatcher{
+						{Type: storepb.LabelMatcher_EQ, Name: "foo", Value: "bar"},
+					},
+					skipChunks: true,
+					expectedLabels: []labels.Labels{
+						labels.FromStrings("foo", "bar", "region", "eu-west"),
+					},
 				},
 			},
 		},
@@ -701,9 +724,10 @@ func testStoreAPIsAcceptance(t *testing.T, startStore func(t *testing.T, extLset
 				t.Run("series", func(t *testing.T) {
 					srv := newStoreSeriesServer(context.Background())
 					err := store.Series(&storepb.SeriesRequest{
-						MinTime:  c.start,
-						MaxTime:  c.end,
-						Matchers: c.matchers,
+						MinTime:    c.start,
+						MaxTime:    c.end,
+						Matchers:   c.matchers,
+						SkipChunks: c.skipChunks,
 					}, srv)
 					if c.expectErr != nil {
 						testutil.NotOk(t, err)


### PR DESCRIPTION
* [x] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

When skipping chunks we would send invalid labelsets in prometheus store if external and inner labels conflicted

## Verification

Added a acceptance testcase


Fixes #6844 
