### PR TITLE
CI: increase e2e test parallelism

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -70,8 +70,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        parallelism: [4]
-        index: [0, 1, 2, 3]
+        parallelism: [8]
+        index: [0, 1, 2, 3, 4, 5, 6, 7]
     runs-on: ubuntu-latest
     name: Thanos end-to-end tests
     env:


### PR DESCRIPTION
E2E tests have been timing out more frequently lately; bumping parallelism should help with keeping the pipeline under 10min still.