### PR TITLE
sidecar: Allow customizing the shipper metadata file name

### DIFF
--- a/cmd/thanos/config.go
+++ b/cmd/thanos/config.go
@@ -15,6 +15,7 @@ import (
 	"github.com/prometheus/common/model"
 
 	"github.com/thanos-io/thanos/pkg/extkingpin"
+	"github.com/thanos-io/thanos/pkg/shipper"
 )
 
 type grpcConfig struct {
@@ -140,6 +141,7 @@ type shipperConfig struct {
 	ignoreBlockSize       bool
 	allowOutOfOrderUpload bool
 	hashFunc              string
+	metaFileName          string
 }
 
 func (sc *shipperConfig) registerFlag(cmd extkingpin.FlagClause) *shipperConfig {
@@ -156,6 +158,7 @@ func (sc *shipperConfig) registerFlag(cmd extkingpin.FlagClause) *shipperConfig 
 		Default("false").Hidden().BoolVar(&sc.allowOutOfOrderUpload)
 	cmd.Flag("hash-func", "Specify which hash function to use when calculating the hashes of produced files. If no function has been specified, it does not happen. This permits avoiding downloading some files twice albeit at some performance cost. Possible values are: \"\", \"SHA256\".").
 		Default("").EnumVar(&sc.hashFunc, "SHA256", "")
+	cmd.Flag("shipper.meta-file-name", "the file to store shipper metadata in").Default(shipper.DefaultMetaFilename).StringVar(&sc.metaFileName)
 	return sc
 }
 

--- a/cmd/thanos/rule.go
+++ b/cmd/thanos/rule.go
@@ -745,7 +745,7 @@ func runRule(
 			}
 		}()
 
-		s := shipper.New(logger, reg, conf.dataDir, bkt, func() labels.Labels { return conf.lset }, metadata.RulerSource, nil, conf.shipper.allowOutOfOrderUpload, metadata.HashFunc(conf.shipper.hashFunc))
+		s := shipper.New(logger, reg, conf.dataDir, bkt, func() labels.Labels { return conf.lset }, metadata.RulerSource, nil, conf.shipper.allowOutOfOrderUpload, metadata.HashFunc(conf.shipper.hashFunc), conf.shipper.metaFileName)
 
 		ctx, cancel := context.WithCancel(context.Background())
 

--- a/cmd/thanos/sidecar.go
+++ b/cmd/thanos/sidecar.go
@@ -347,7 +347,7 @@ func runSidecar(
 
 			uploadCompactedFunc := func() bool { return conf.shipper.uploadCompacted }
 			s := shipper.New(logger, reg, conf.tsdb.path, bkt, m.Labels, metadata.SidecarSource,
-				uploadCompactedFunc, conf.shipper.allowOutOfOrderUpload, metadata.HashFunc(conf.shipper.hashFunc))
+				uploadCompactedFunc, conf.shipper.allowOutOfOrderUpload, metadata.HashFunc(conf.shipper.hashFunc), conf.shipper.metaFileName)
 
 			return runutil.Repeat(30*time.Second, ctx.Done(), func() error {
 				if uploaded, err := s.Sync(ctx); err != nil {

--- a/docs/components/rule.md
+++ b/docs/components/rule.md
@@ -445,6 +445,8 @@ Flags:
                                  Note that rules are not automatically detected,
                                  use SIGHUP or do HTTP POST /-/reload to re-read
                                  them.
+      --shipper.meta-file-name="thanos.shipper.json"
+                                 the file to store shipper metadata in
       --shipper.upload-compacted
                                  If true shipper will try to upload compacted
                                  blocks as well. Useful for migration purposes.

--- a/docs/components/sidecar.md
+++ b/docs/components/sidecar.md
@@ -172,6 +172,8 @@ Flags:
                                  Path to YAML file with request logging
                                  configuration. See format details:
                                  https://thanos.io/tip/thanos/logging.md/#configuration
+      --shipper.meta-file-name="thanos.shipper.json"
+                                 the file to store shipper metadata in
       --shipper.upload-compacted
                                  If true shipper will try to upload compacted
                                  blocks as well. Useful for migration purposes.

--- a/pkg/receive/multitsdb.go
+++ b/pkg/receive/multitsdb.go
@@ -607,6 +607,7 @@ func (t *MultiTSDB) startTSDB(logger log.Logger, tenantID string, tenant *tenant
 			nil,
 			t.allowOutOfOrderUpload,
 			t.hashFunc,
+			shipper.DefaultMetaFilename,
 		)
 	}
 	tenant.set(store.NewTSDBStore(logger, s, component.Receive, lset), s, ship, exemplars.NewTSDB(s, lset))

--- a/pkg/shipper/shipper.go
+++ b/pkg/shipper/shipper.go
@@ -69,11 +69,12 @@ func newMetrics(reg prometheus.Registerer) *metrics {
 // Shipper watches a directory for matching files and directories and uploads
 // them to a remote data store.
 type Shipper struct {
-	logger  log.Logger
-	dir     string
-	metrics *metrics
-	bucket  objstore.Bucket
-	source  metadata.SourceType
+	logger           log.Logger
+	dir              string
+	metrics          *metrics
+	bucket           objstore.Bucket
+	source           metadata.SourceType
+	metadataFilePath string
 
 	uploadCompactedFunc    func() bool
 	allowOutOfOrderUploads bool
@@ -96,12 +97,17 @@ func New(
 	uploadCompactedFunc func() bool,
 	allowOutOfOrderUploads bool,
 	hashFunc metadata.HashFunc,
+	metaFileName string,
 ) *Shipper {
 	if logger == nil {
 		logger = log.NewNopLogger()
 	}
 	if lbls == nil {
 		lbls = func() labels.Labels { return labels.EmptyLabels() }
+	}
+
+	if metaFileName == "" {
+		metaFileName = DefaultMetaFilename
 	}
 
 	if uploadCompactedFunc == nil {
@@ -119,6 +125,7 @@ func New(
 		allowOutOfOrderUploads: allowOutOfOrderUploads,
 		uploadCompactedFunc:    uploadCompactedFunc,
 		hashFunc:               hashFunc,
+		metadataFilePath:       filepath.Join(dir, filepath.Clean(metaFileName)),
 	}
 }
 
@@ -139,7 +146,7 @@ func (s *Shipper) getLabels() labels.Labels {
 // Timestamps returns the minimum timestamp for which data is available and the highest timestamp
 // of blocks that were successfully uploaded.
 func (s *Shipper) Timestamps() (minTime, maxSyncTime int64, err error) {
-	meta, err := ReadMetaFile(s.dir)
+	meta, err := ReadMetaFile(s.metadataFilePath)
 	if err != nil {
 		return 0, 0, errors.Wrap(err, "read shipper meta file")
 	}
@@ -247,7 +254,7 @@ func (c *lazyOverlapChecker) IsOverlapping(ctx context.Context, newMeta tsdb.Blo
 //
 // It is not concurrency-safe, however it is compactor-safe (running concurrently with compactor is ok).
 func (s *Shipper) Sync(ctx context.Context) (uploaded int, err error) {
-	meta, err := ReadMetaFile(s.dir)
+	meta, err := ReadMetaFile(s.metadataFilePath)
 	if err != nil {
 		// If we encounter any error, proceed with an empty meta file and overwrite it later.
 		// The meta file is only used to avoid unnecessary bucket.Exists call,
@@ -330,7 +337,7 @@ func (s *Shipper) Sync(ctx context.Context) (uploaded int, err error) {
 		uploaded++
 		s.metrics.uploads.Inc()
 	}
-	if err := WriteMetaFile(s.logger, s.dir, meta); err != nil {
+	if err := WriteMetaFile(s.logger, s.metadataFilePath, meta); err != nil {
 		level.Warn(s.logger).Log("msg", "updating meta file failed", "err", err)
 	}
 
@@ -457,17 +464,16 @@ type Meta struct {
 }
 
 const (
-	// MetaFilename is the known JSON filename for meta information.
-	MetaFilename = "thanos.shipper.json"
+	// DefaultMetaFilename is the default JSON filename for meta information.
+	DefaultMetaFilename = "thanos.shipper.json"
 
 	// MetaVersion1 represents 1 version of meta.
 	MetaVersion1 = 1
 )
 
 // WriteMetaFile writes the given meta into <dir>/thanos.shipper.json.
-func WriteMetaFile(logger log.Logger, dir string, meta *Meta) error {
+func WriteMetaFile(logger log.Logger, path string, meta *Meta) error {
 	// Make any changes to the file appear atomic.
-	path := filepath.Join(dir, MetaFilename)
 	tmp := path + ".tmp"
 
 	f, err := os.Create(tmp)
@@ -489,16 +495,15 @@ func WriteMetaFile(logger log.Logger, dir string, meta *Meta) error {
 }
 
 // ReadMetaFile reads the given meta from <dir>/thanos.shipper.json.
-func ReadMetaFile(dir string) (*Meta, error) {
-	fpath := filepath.Join(dir, filepath.Clean(MetaFilename))
-	b, err := os.ReadFile(fpath)
+func ReadMetaFile(path string) (*Meta, error) {
+	b, err := os.ReadFile(path)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to read %s", fpath)
+		return nil, errors.Wrapf(err, "failed to read %s", path)
 	}
 
 	var m Meta
 	if err := json.Unmarshal(b, &m); err != nil {
-		return nil, errors.Wrapf(err, "failed to parse %s as JSON: %q", fpath, string(b))
+		return nil, errors.Wrapf(err, "failed to parse %s as JSON: %q", path, string(b))
 	}
 	if m.Version != MetaVersion1 {
 		return nil, errors.Errorf("unexpected meta file version %d", m.Version)

--- a/pkg/shipper/shipper_e2e_test.go
+++ b/pkg/shipper/shipper_e2e_test.go
@@ -44,7 +44,7 @@ func TestShipper_SyncBlocks_e2e(t *testing.T) {
 		dir := t.TempDir()
 
 		extLset := labels.FromStrings("prometheus", "prom-1")
-		shipper := New(log.NewLogfmtLogger(os.Stderr), nil, dir, metricsBucket, func() labels.Labels { return extLset }, metadata.TestSource, nil, false, metadata.NoneFunc)
+		shipper := New(log.NewLogfmtLogger(os.Stderr), nil, dir, metricsBucket, func() labels.Labels { return extLset }, metadata.TestSource, nil, false, metadata.NoneFunc, DefaultMetaFilename)
 
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -101,7 +101,7 @@ func TestShipper_SyncBlocks_e2e(t *testing.T) {
 			testutil.Ok(t, err)
 			testutil.Equals(t, 0, b)
 
-			shipMeta, err := ReadMetaFile(dir)
+			shipMeta, err := ReadMetaFile(shipper.metadataFilePath)
 			testutil.Ok(t, err)
 			if len(shipMeta.Uploaded) == 0 {
 				shipMeta.Uploaded = []ulid.ULID{}
@@ -164,7 +164,7 @@ func TestShipper_SyncBlocks_e2e(t *testing.T) {
 				testutil.Ok(t, block.Delete(ctx, log.NewNopLogger(), bkt, ids[4]))
 			}
 			// The shipper meta file should show all blocks as uploaded except the compacted one.
-			shipMeta, err = ReadMetaFile(dir)
+			shipMeta, err = ReadMetaFile(shipper.metadataFilePath)
 			testutil.Ok(t, err)
 			testutil.Equals(t, &Meta{Version: MetaVersion1, Uploaded: ids}, shipMeta)
 
@@ -212,7 +212,7 @@ func TestShipper_SyncBlocksWithMigrating_e2e(t *testing.T) {
 		testutil.Ok(t, p.Restart(context.Background(), logger))
 
 		uploadCompactedFunc := func() bool { return true }
-		shipper := New(log.NewLogfmtLogger(os.Stderr), nil, dir, bkt, func() labels.Labels { return extLset }, metadata.TestSource, uploadCompactedFunc, false, metadata.NoneFunc)
+		shipper := New(log.NewLogfmtLogger(os.Stderr), nil, dir, bkt, func() labels.Labels { return extLset }, metadata.TestSource, uploadCompactedFunc, false, metadata.NoneFunc, DefaultMetaFilename)
 
 		// Create 10 new blocks. 9 of them (non compacted) should be actually uploaded.
 		var (
@@ -265,7 +265,7 @@ func TestShipper_SyncBlocksWithMigrating_e2e(t *testing.T) {
 			testutil.Ok(t, err)
 			testutil.Equals(t, 0, b)
 
-			shipMeta, err := ReadMetaFile(dir)
+			shipMeta, err := ReadMetaFile(shipper.metadataFilePath)
 			testutil.Ok(t, err)
 			if len(shipMeta.Uploaded) == 0 {
 				shipMeta.Uploaded = []ulid.ULID{}
@@ -310,7 +310,7 @@ func TestShipper_SyncBlocksWithMigrating_e2e(t *testing.T) {
 				testutil.Ok(t, block.Delete(ctx, log.NewNopLogger(), bkt, ids[4]))
 			}
 			// The shipper meta file should show all blocks as uploaded except the compacted one.
-			shipMeta, err = ReadMetaFile(dir)
+			shipMeta, err = ReadMetaFile(shipper.metadataFilePath)
 			testutil.Ok(t, err)
 			testutil.Equals(t, &Meta{Version: MetaVersion1, Uploaded: ids}, shipMeta)
 
@@ -361,7 +361,7 @@ func TestShipper_SyncOverlapBlocks_e2e(t *testing.T) {
 
 	uploadCompactedFunc := func() bool { return true }
 	// Here, the allowOutOfOrderUploads flag is set to true, which allows blocks with overlaps to be uploaded.
-	shipper := New(log.NewLogfmtLogger(os.Stderr), nil, dir, bkt, func() labels.Labels { return extLset }, metadata.TestSource, uploadCompactedFunc, true, metadata.NoneFunc)
+	shipper := New(log.NewLogfmtLogger(os.Stderr), nil, dir, bkt, func() labels.Labels { return extLset }, metadata.TestSource, uploadCompactedFunc, true, metadata.NoneFunc, DefaultMetaFilename)
 
 	// Creating 2 overlapping blocks - both uploaded when OOO uploads allowed.
 	var (
@@ -421,7 +421,7 @@ func TestShipper_SyncOverlapBlocks_e2e(t *testing.T) {
 		testutil.Ok(t, err)
 		testutil.Equals(t, 0, b)
 
-		shipMeta, err := ReadMetaFile(dir)
+		shipMeta, err := ReadMetaFile(shipper.metadataFilePath)
 		testutil.Ok(t, err)
 		if len(shipMeta.Uploaded) == 0 {
 			shipMeta.Uploaded = []ulid.ULID{}
@@ -460,7 +460,7 @@ func TestShipper_SyncOverlapBlocks_e2e(t *testing.T) {
 		expFiles[id[i].String()+"/chunks/0002"] = []byte("chunkcontents2")
 
 		// The shipper meta file should show all blocks as uploaded except the compacted one.
-		shipMeta, err = ReadMetaFile(dir)
+		shipMeta, err = ReadMetaFile(shipper.metadataFilePath)
 		testutil.Ok(t, err)
 		testutil.Equals(t, &Meta{Version: MetaVersion1, Uploaded: ids}, shipMeta)
 	}

--- a/pkg/shipper/shipper_test.go
+++ b/pkg/shipper/shipper_test.go
@@ -29,14 +29,14 @@ import (
 func TestShipperTimestamps(t *testing.T) {
 	dir := t.TempDir()
 
-	s := New(nil, nil, dir, nil, nil, metadata.TestSource, nil, false, metadata.NoneFunc)
+	s := New(nil, nil, dir, nil, nil, metadata.TestSource, nil, false, metadata.NoneFunc, DefaultMetaFilename)
 
 	// Missing thanos meta file.
 	_, _, err := s.Timestamps()
 	testutil.NotOk(t, err)
 
 	meta := &Meta{Version: MetaVersion1}
-	testutil.Ok(t, WriteMetaFile(log.NewNopLogger(), dir, meta))
+	testutil.Ok(t, WriteMetaFile(log.NewNopLogger(), s.metadataFilePath, meta))
 
 	// Nothing uploaded, nothing in the filesystem. We assume that
 	// we are still waiting for TSDB to dump first TSDB block.
@@ -79,7 +79,7 @@ func TestShipperTimestamps(t *testing.T) {
 		Version:  MetaVersion1,
 		Uploaded: []ulid.ULID{id1},
 	}
-	testutil.Ok(t, WriteMetaFile(log.NewNopLogger(), dir, meta))
+	testutil.Ok(t, WriteMetaFile(log.NewNopLogger(), s.metadataFilePath, meta))
 	mint, maxt, err = s.Timestamps()
 	testutil.Ok(t, err)
 	testutil.Equals(t, int64(1000), mint)
@@ -122,7 +122,7 @@ func TestIterBlockMetas(t *testing.T) {
 		},
 	}.WriteToDir(log.NewNopLogger(), path.Join(dir, id3.String())))
 
-	shipper := New(nil, nil, dir, nil, nil, metadata.TestSource, nil, false, metadata.NoneFunc)
+	shipper := New(nil, nil, dir, nil, nil, metadata.TestSource, nil, false, metadata.NoneFunc, DefaultMetaFilename)
 	metas, err := shipper.blockMetasFromOldest()
 	testutil.Ok(t, err)
 	testutil.Equals(t, sort.SliceIsSorted(metas, func(i, j int) bool {
@@ -153,7 +153,7 @@ func BenchmarkIterBlockMetas(b *testing.B) {
 	})
 	b.ResetTimer()
 
-	shipper := New(nil, nil, dir, nil, nil, metadata.TestSource, nil, false, metadata.NoneFunc)
+	shipper := New(nil, nil, dir, nil, nil, metadata.TestSource, nil, false, metadata.NoneFunc, DefaultMetaFilename)
 
 	_, err := shipper.blockMetasFromOldest()
 	testutil.Ok(b, err)
@@ -165,7 +165,7 @@ func TestShipperAddsSegmentFiles(t *testing.T) {
 	inmemory := objstore.NewInMemBucket()
 
 	lbls := labels.FromStrings("test", "test")
-	s := New(nil, nil, dir, inmemory, func() labels.Labels { return lbls }, metadata.TestSource, nil, false, metadata.NoneFunc)
+	s := New(nil, nil, dir, inmemory, func() labels.Labels { return lbls }, metadata.TestSource, nil, false, metadata.NoneFunc, DefaultMetaFilename)
 
 	id := ulid.MustNew(1, nil)
 	blockDir := path.Join(dir, id.String())
@@ -202,28 +202,29 @@ func TestReadMetaFile(t *testing.T) {
 	t.Run("Missing meta file", func(t *testing.T) {
 		// Create TSDB directory without meta file
 		dpath := t.TempDir()
+		fpath := filepath.Join(dpath, DefaultMetaFilename)
 
-		_, err := ReadMetaFile(dpath)
-		fpath := filepath.Join(dpath, MetaFilename)
+		_, err := ReadMetaFile(fpath)
 		testutil.Equals(t, fmt.Sprintf(`failed to read %s: open %s: no such file or directory`, fpath, fpath), err.Error())
 	})
 
 	t.Run("Non-JSON meta file", func(t *testing.T) {
 		dpath := t.TempDir()
-		fpath := filepath.Join(dpath, MetaFilename)
+		fpath := filepath.Join(dpath, DefaultMetaFilename)
+
 		// Make an invalid JSON file
 		testutil.Ok(t, os.WriteFile(fpath, []byte("{"), 0600))
 
-		_, err := ReadMetaFile(dpath)
+		_, err := ReadMetaFile(fpath)
 		testutil.Equals(t, fmt.Sprintf(`failed to parse %s as JSON: "{": unexpected end of JSON input`, fpath), err.Error())
 	})
 
 	t.Run("Wrongly versioned meta file", func(t *testing.T) {
 		dpath := t.TempDir()
-		fpath := filepath.Join(dpath, MetaFilename)
+		fpath := filepath.Join(dpath, DefaultMetaFilename)
 		testutil.Ok(t, os.WriteFile(fpath, []byte(`{"version": 2}`), 0600))
 
-		_, err := ReadMetaFile(dpath)
+		_, err := ReadMetaFile(fpath)
 		testutil.Equals(t, "unexpected meta file version 2", err.Error())
 	})
 }


### PR DESCRIPTION
Currently, the shipper metadata file is always called `thanos.shipper.json` in the Prometheus data directory. This precludes running multiple sidecars that upload to different object stores, as they will overwrite each other's metadata file.

This commit allows the metadata file name to be customized via a flag. The default is unchanged, but it can be overridden with the `--shipper.meta-file-name` flag.

As part of this, we update the signatures of `WriteMetaFile` and `ReadMetaFile` to take the full path of the metadata file, rather than just the directory, and updates the tests that go along with this.

The previous guidance on doing this was to run a single sidecar to upload to one object storage, and then sync that across to a second. In our case our sidecars run outside the clouds that store our data, so doing this becomes cost prohibitive as we have to pay egress fees from one cloud to the other. Uploading to both from our Prometheus is much cheaper as ingress is orders  or magnitude less expensive.

A few questions on the implementation here:

- This ties the `Read`/`Write` methods pretty closely to the shipper itself. Does it make sense to move them under it?
- This changes the metadata file, but two sidecars still share an /upload directory. From my testing this doesn't seem to have _much_ of an effect, but I can imagine issues where two sidecars are uploading the same block, and one removes it from the upload directory before the other is done. Does it make sense to  allow customizing that as well, or somehow derive it from the shipper file?

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

- Add a `shipper.meta-file-name` flag, allowing customizing the shipper meta file path, and allowing sidecars to co-exist

## Verification

Mostly submitting this to get comments on the approach for now. We run a variant of this at Cloudflare, but less formal. I'm testing this patch precisely next week. For now, I'll a test one to test the customization 