### PR TITLE
e2e: fix compactor test

### DIFF
--- a/test/e2e/compact_test.go
+++ b/test/e2e/compact_test.go
@@ -778,7 +778,12 @@ func testCompactWithStoreGateway(t *testing.T, penaltyDedup bool) {
 		testutil.Ok(t, c.WaitSumMetricsWithOptions(e2emon.Equals(0), []string{"thanos_compact_downsample_total"}, e2emon.WaitMissingMetrics()))
 		testutil.Ok(t, c.WaitSumMetricsWithOptions(e2emon.Equals(0), []string{"thanos_compact_downsample_failures_total"}, e2emon.WaitMissingMetrics()))
 
-		testutil.Ok(t, str.WaitSumMetricsWithOptions(e2emon.Equals(float64(len(rawBlockIDs)+8+6-18-2+2)), []string{"thanos_blocks_meta_synced"}, e2emon.WaitMissingMetrics()))
+		testutil.Ok(t, str.WaitSumMetricsWithOptions(
+			e2emon.Equals(21),
+			[]string{"thanos_blocks_meta_synced"},
+			e2emon.WaitMissingMetrics(),
+			e2emon.WithLabelMatchers(matchers.MustNewMatcher(matchers.MatchEqual, "state", "loaded")),
+		))
 		testutil.Ok(t, str.WaitSumMetricsWithOptions(e2emon.Equals(0), []string{"thanos_blocks_meta_sync_failures_total"}, e2emon.WaitMissingMetrics()))
 
 		testutil.Ok(t, c.WaitSumMetricsWithOptions(e2emon.Equals(0), []string{"thanos_compact_halted"}, e2emon.WaitMissingMetrics()))
@@ -801,7 +806,12 @@ func testCompactWithStoreGateway(t *testing.T, penaltyDedup bool) {
 		)
 
 		// Store view:
-		testutil.Ok(t, str.WaitSumMetrics(e2emon.Equals(float64(len(rawBlockIDs)+8-18+6-2+2)), "thanos_blocks_meta_synced"))
+		testutil.Ok(t, str.WaitSumMetricsWithOptions(
+			e2emon.Equals(21),
+			[]string{"thanos_blocks_meta_synced"},
+			e2emon.WaitMissingMetrics(),
+			e2emon.WithLabelMatchers(matchers.MustNewMatcher(matchers.MatchEqual, "state", "loaded")),
+		))
 		testutil.Ok(t, str.WaitSumMetrics(e2emon.Equals(0), "thanos_blocks_meta_sync_failures_total"))
 		testutil.Ok(t, str.WaitSumMetrics(e2emon.Equals(0), "thanos_blocks_meta_modified"))
 	}
@@ -835,7 +845,12 @@ func testCompactWithStoreGateway(t *testing.T, penaltyDedup bool) {
 		testutil.Ok(t, str.Stop())
 		testutil.Ok(t, e2e.StartAndWaitReady(str))
 		testutil.Ok(t, runutil.Retry(time.Second, ctx.Done(), func() error {
-			return str.WaitSumMetrics(e2emon.Equals(float64(len(rawBlockIDs)+8-18+6-2+2-1)), "thanos_blocks_meta_synced")
+			return str.WaitSumMetricsWithOptions(
+				e2emon.Equals(20),
+				[]string{"thanos_blocks_meta_synced"},
+				e2emon.WaitMissingMetrics(),
+				e2emon.WithLabelMatchers(matchers.MustNewMatcher(matchers.MatchEqual, "state", "loaded")),
+			)
 		}))
 		testutil.Ok(t, q.WaitSumMetricsWithOptions(e2emon.Equals(1), []string{"thanos_store_nodes_grpc_connections"}, e2emon.WaitMissingMetrics(), e2emon.WithLabelMatchers(
 			matchers.MustNewMatcher(matchers.MatchEqual, "store_type", "store"),


### PR DESCRIPTION
Spotted some randomness in the compactor test -
`thanos_blocks_meta_synced` includes cached blocks. Depending on luck, Store might or might not see those blocks leading to inconsistent results. Thus, only check the loaded metas count because that's what matters.
