### PR TITLE
.circleci: cache tool deps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@
 version: 2.1
 
 orbs:
-  go: circleci/go@1.7.2
+  go: circleci/go@1.7.3
   git-shallow-clone: guitarrapc/git-shallow-clone@2.5.0
 
 executors:
@@ -21,7 +21,13 @@ jobs:
       GO111MODULE: "on"
     steps:
       - git-shallow-clone/checkout
-      - go/mod-download-cached
+      - go/load-cache
+      - go/mod-download
+      - run:
+          name: Download bingo modules
+          command: |
+            make install-tool-deps
+      - go/save-cache
       - setup_remote_docker:
           version: 20.10.12
       - run:


### PR DESCRIPTION
I have noticed that downloading tool deps takes ~5 min in CI each time. We should be able to also cache those tool deps.
