### PR TITLE
Receive: fix serverAsClient.Series goroutines leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#7323](https://github.com/thanos-io/thanos/pull/7323) Sidecar: wait for prometheus on startup
 - [#7326](https://github.com/thanos-io/thanos/pull/7326) Query: fixing exemplars proxy when querying stores with multiple tenants.
 - [#7335](https://github.com/thanos-io/thanos/pull/7335) Dependency: Update minio-go to v7.0.70 which includes support for EKS Pod Identity.
+- [#6948](https://github.com/thanos-io/thanos/pull/6948) Receive: fix goroutines leak during series requests to thanos store api.
 
 ### Added
 

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -1571,7 +1571,6 @@ func (s *BucketStore) Series(req *storepb.SeriesRequest, seriesSrv storepb.Store
 				var resp respSet
 				if s.sortingStrategy == sortingStrategyStore {
 					resp = newEagerRespSet(
-						srv.Context(),
 						span,
 						10*time.Minute,
 						blk.meta.ULID.String(),
@@ -1585,7 +1584,6 @@ func (s *BucketStore) Series(req *storepb.SeriesRequest, seriesSrv storepb.Store
 					)
 				} else {
 					resp = newLazyRespSet(
-						srv.Context(),
 						span,
 						10*time.Minute,
 						blk.meta.ULID.String(),

--- a/pkg/store/proxy_merge.go
+++ b/pkg/store/proxy_merge.go
@@ -210,8 +210,7 @@ func (l *lazyRespSet) StoreLabels() map[string]struct{} {
 // in Next().
 type lazyRespSet struct {
 	// Generic parameters.
-	span opentracing.Span
-	// cl             storepb.Store_SeriesClient
+	span           opentracing.Span
 	closeSeries    context.CancelFunc
 	storeName      string
 	storeLabelSets []labels.Labels

--- a/pkg/store/proxy_merge.go
+++ b/pkg/store/proxy_merge.go
@@ -217,7 +217,6 @@ type lazyRespSet struct {
 	storeLabelSets []labels.Labels
 	storeLabels    map[string]struct{}
 	frameTimeout   time.Duration
-	ctx            context.Context
 
 	// Internal bookkeeping.
 	dataOrFinishEvent    *sync.Cond
@@ -540,8 +539,6 @@ func (l *lazyRespSet) Close() {
 type eagerRespSet struct {
 	// Generic parameters.
 	span opentracing.Span
-	cl   storepb.Store_SeriesClient
-	ctx  context.Context
 
 	closeSeries  context.CancelFunc
 	frameTimeout time.Duration

--- a/pkg/store/proxy_merge.go
+++ b/pkg/store/proxy_merge.go
@@ -362,7 +362,6 @@ func newLazyRespSet(
 				var rerr error
 				// If timer is already stopped
 				if t != nil && !t.Stop() {
-					<-t.C // Drain the channel if it was already stopped.
 					if errors.Is(err, context.Canceled) {
 						// The per-Recv timeout has been reached.
 						rerr = errors.Wrapf(err, "failed to receive any data in %s from %s", l.frameTimeout, st)

--- a/pkg/store/proxy_merge.go
+++ b/pkg/store/proxy_merge.go
@@ -210,8 +210,8 @@ func (l *lazyRespSet) StoreLabels() map[string]struct{} {
 // in Next().
 type lazyRespSet struct {
 	// Generic parameters.
-	span           opentracing.Span
-	cl             storepb.Store_SeriesClient
+	span opentracing.Span
+	// cl             storepb.Store_SeriesClient
 	closeSeries    context.CancelFunc
 	storeName      string
 	storeLabelSets []labels.Labels
@@ -294,7 +294,6 @@ func (l *lazyRespSet) At() *storepb.SeriesResponse {
 }
 
 func newLazyRespSet(
-	ctx context.Context,
 	span opentracing.Span,
 	frameTimeout time.Duration,
 	storeName string,
@@ -311,12 +310,10 @@ func newLazyRespSet(
 
 	respSet := &lazyRespSet{
 		frameTimeout:         frameTimeout,
-		cl:                   cl,
 		storeName:            storeName,
 		storeLabelSets:       storeLabelSets,
 		closeSeries:          closeSeries,
 		span:                 span,
-		ctx:                  ctx,
 		dataOrFinishEvent:    dataAvailable,
 		bufferedResponsesMtx: bufferedResponsesMtx,
 		bufferedResponses:    bufferedResponses,
@@ -353,19 +350,9 @@ func newLazyRespSet(
 				defer t.Reset(frameTimeout)
 			}
 
-			select {
-			case <-l.ctx.Done():
-				err := errors.Wrapf(l.ctx.Err(), "failed to receive any data from %s", st)
-				l.span.SetTag("err", err.Error())
+			resp, err := cl.Recv()
 
-				l.bufferedResponsesMtx.Lock()
-				l.bufferedResponses = append(l.bufferedResponses, storepb.NewWarnSeriesResponse(err))
-				l.noMoreData = true
-				l.dataOrFinishEvent.Signal()
-				l.bufferedResponsesMtx.Unlock()
-				return false
-			default:
-				resp, err := cl.Recv()
+			if err != nil {
 				if err == io.EOF {
 					l.bufferedResponsesMtx.Lock()
 					l.noMoreData = true
@@ -374,45 +361,44 @@ func newLazyRespSet(
 					return false
 				}
 
-				if err != nil {
-					// TODO(bwplotka): Return early on error. Don't wait of dedup, merge and sort if partial response is disabled.
-					var rerr error
-					if t != nil && !t.Stop() && errors.Is(err, context.Canceled) {
-						// Most likely the per-Recv timeout has been reached.
-						// There's a small race between canceling and the Recv()
-						// but this is most likely true.
+				var rerr error
+				// If timer is already stopped
+				if t != nil && !t.Stop() {
+					<-t.C // Drain the channel if it was already stopped.
+					if errors.Is(err, context.Canceled) {
+						// The per-Recv timeout has been reached.
 						rerr = errors.Wrapf(err, "failed to receive any data in %s from %s", l.frameTimeout, st)
-					} else {
-						rerr = errors.Wrapf(err, "receive series from %s", st)
 					}
-
-					l.span.SetTag("err", rerr.Error())
-
-					l.bufferedResponsesMtx.Lock()
-					l.bufferedResponses = append(l.bufferedResponses, storepb.NewWarnSeriesResponse(rerr))
-					l.noMoreData = true
-					l.dataOrFinishEvent.Signal()
-					l.bufferedResponsesMtx.Unlock()
-					return false
+				} else {
+					rerr = errors.Wrapf(err, "receive series from %s", st)
 				}
 
-				numResponses++
-				bytesProcessed += resp.Size()
-
-				if resp.GetSeries() != nil && applySharding && !shardMatcher.MatchesZLabels(resp.GetSeries().Labels) {
-					return true
-				}
-
-				if resp.GetSeries() != nil {
-					seriesStats.Count(resp.GetSeries())
-				}
+				l.span.SetTag("err", rerr.Error())
 
 				l.bufferedResponsesMtx.Lock()
-				l.bufferedResponses = append(l.bufferedResponses, resp)
+				l.bufferedResponses = append(l.bufferedResponses, storepb.NewWarnSeriesResponse(rerr))
+				l.noMoreData = true
 				l.dataOrFinishEvent.Signal()
 				l.bufferedResponsesMtx.Unlock()
+				return false
+			}
+
+			numResponses++
+			bytesProcessed += resp.Size()
+
+			if resp.GetSeries() != nil && applySharding && !shardMatcher.MatchesZLabels(resp.GetSeries().Labels) {
 				return true
 			}
+
+			if resp.GetSeries() != nil {
+				seriesStats.Count(resp.GetSeries())
+			}
+
+			l.bufferedResponsesMtx.Lock()
+			l.bufferedResponses = append(l.bufferedResponses, resp)
+			l.dataOrFinishEvent.Signal()
+			l.bufferedResponsesMtx.Unlock()
+			return true
 		}
 
 		var t *time.Timer
@@ -509,7 +495,6 @@ func newAsyncRespSet(
 	switch retrievalStrategy {
 	case LazyRetrieval:
 		return newLazyRespSet(
-			seriesCtx,
 			span,
 			frameTimeout,
 			st.String(),
@@ -522,7 +507,6 @@ func newAsyncRespSet(
 		), nil
 	case EagerRetrieval:
 		return newEagerRespSet(
-			seriesCtx,
 			span,
 			frameTimeout,
 			st.String(),
@@ -576,7 +560,6 @@ type eagerRespSet struct {
 }
 
 func newEagerRespSet(
-	ctx context.Context,
 	span opentracing.Span,
 	frameTimeout time.Duration,
 	storeName string,
@@ -591,9 +574,7 @@ func newEagerRespSet(
 	ret := &eagerRespSet{
 		span:              span,
 		closeSeries:       closeSeries,
-		cl:                cl,
 		frameTimeout:      frameTimeout,
-		ctx:               ctx,
 		bufferedResponses: []*storepb.SeriesResponse{},
 		wg:                &sync.WaitGroup{},
 		shardMatcher:      shardMatcher,
@@ -638,48 +619,45 @@ func newEagerRespSet(
 				defer t.Reset(frameTimeout)
 			}
 
-			select {
-			case <-l.ctx.Done():
-				err := errors.Wrapf(l.ctx.Err(), "failed to receive any data from %s", storeName)
-				l.bufferedResponses = append(l.bufferedResponses, storepb.NewWarnSeriesResponse(err))
-				l.span.SetTag("err", err.Error())
-				return false
-			default:
-				resp, err := cl.Recv()
+			resp, err := cl.Recv()
+
+			if err != nil {
 				if err == io.EOF {
 					return false
 				}
-				if err != nil {
-					// TODO(bwplotka): Return early on error. Don't wait of dedup, merge and sort if partial response is disabled.
-					var rerr error
-					if t != nil && !t.Stop() && errors.Is(err, context.Canceled) {
-						// Most likely the per-Recv timeout has been reached.
-						// There's a small race between canceling and the Recv()
-						// but this is most likely true.
+
+				var rerr error
+				// If timer is already stopped
+				if t != nil && !t.Stop() {
+					<-t.C // Drain the channel if it was already stopped.
+					if errors.Is(err, context.Canceled) {
+						// The per-Recv timeout has been reached.
 						rerr = errors.Wrapf(err, "failed to receive any data in %s from %s", l.frameTimeout, storeName)
-					} else {
-						rerr = errors.Wrapf(err, "receive series from %s", storeName)
 					}
-					l.bufferedResponses = append(l.bufferedResponses, storepb.NewWarnSeriesResponse(rerr))
-					l.span.SetTag("err", rerr.Error())
-					return false
+				} else {
+					rerr = errors.Wrapf(err, "receive series from %s", storeName)
 				}
 
-				numResponses++
-				bytesProcessed += resp.Size()
+				l.bufferedResponses = append(l.bufferedResponses, storepb.NewWarnSeriesResponse(rerr))
+				l.span.SetTag("err", rerr.Error())
+				return false
+			}
 
-				if resp.GetSeries() != nil && applySharding && !shardMatcher.MatchesZLabels(resp.GetSeries().Labels) {
-					return true
-				}
+			numResponses++
+			bytesProcessed += resp.Size()
 
-				if resp.GetSeries() != nil {
-					seriesStats.Count(resp.GetSeries())
-				}
-
-				l.bufferedResponses = append(l.bufferedResponses, resp)
+			if resp.GetSeries() != nil && applySharding && !shardMatcher.MatchesZLabels(resp.GetSeries().Labels) {
 				return true
 			}
+
+			if resp.GetSeries() != nil {
+				seriesStats.Count(resp.GetSeries())
+			}
+
+			l.bufferedResponses = append(l.bufferedResponses, resp)
+			return true
 		}
+
 		var t *time.Timer
 		if frameTimeout > 0 {
 			t = time.AfterFunc(frameTimeout, closeSeries)

--- a/pkg/store/storepb/inprocess_test.go
+++ b/pkg/store/storepb/inprocess_test.go
@@ -7,9 +7,7 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"runtime"
 	"testing"
-	"time"
 
 	"github.com/efficientgo/core/testutil"
 	"github.com/pkg/errors"
@@ -186,41 +184,6 @@ func TestServerAsClient(t *testing.T) {
 						}
 						testutil.Equals(t, s.series[:len(s.series)/2], resps)
 						testutil.Equals(t, r, s.seriesLastReq)
-						s.seriesLastReq = nil
-					}
-				})
-				t.Run("context cancel", func(t *testing.T) {
-					for i := 0; i < 20; i++ {
-						r := &SeriesRequest{
-							MinTime:                 -214,
-							MaxTime:                 213,
-							Matchers:                []LabelMatcher{{Value: "wfsdfs", Name: "__name__", Type: LabelMatcher_EQ}},
-							PartialResponseStrategy: PartialResponseStrategy_ABORT,
-						}
-						before := runtime.NumGoroutine()
-						ctx, cancel := context.WithCancel(context.Background())
-						client, err := ServerAsClient(s, 0).Series(ctx, r)
-						cancel()
-						testutil.Ok(t, err)
-						// var resps []*SeriesResponse
-						for {
-							_, err := client.Recv()
-							if err == io.EOF {
-								break
-							}
-							if err != nil {
-								break
-							}
-							// testutil.Ok(t, err)
-							// resps = append(resps, resp)
-						}
-						time.Sleep(10 * time.Millisecond)
-						after := runtime.NumGoroutine()
-						if after > before {
-							t.Errorf("Possible goroutine leak detected. Before: %d, After: %d", before, after)
-						}
-						// testutil.Equals(t, s.series[:len(s.series)/2], resps)
-						// testutil.Equals(t, r, s.seriesLastReq)
 						s.seriesLastReq = nil
 					}
 				})


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

Series method in the serverAsClient struct incurs goroutines leak when the request is stopped due to a context cancellation.
When cancelling the context:

* [StoreServer.Series()](https://github.com/thanos-io/thanos/blob/463dd481cc740194cc9504cd6aeb48f342afe020/pkg/store/storepb/inprocess.go#L40-L41) returns an error of type `context.Canceled`
* This errors is sent on an [unbuffered channel](https://github.com/thanos-io/thanos/blob/463dd481cc740194cc9504cd6aeb48f342afe020/pkg/store/storepb/inprocess.go#L99)
* While at the same time, the same context's Done [channel is consumed](https://github.com/thanos-io/thanos/blob/463dd481cc740194cc9504cd6aeb48f342afe020/pkg/store/storepb/inprocess.go#L92)
* Probably in most cases, the context Done channel is first consumed by the [Recv()](https://github.com/thanos-io/thanos/blob/463dd481cc740194cc9504cd6aeb48f342afe020/pkg/store/storepb/inprocess.go#L90) function
* Having returned this error, Recv() is not called anymore, leaving a dangling [goroutine](https://github.com/thanos-io/thanos/blob/463dd481cc740194cc9504cd6aeb48f342afe020/pkg/store/storepb/inprocess.go#L39)

This also happens in proxy_heap `lazyRespSet` and `eagerRespSet` structures where the same [context Done channel](https://github.com/thanos-io/thanos/blob/463dd481cc740194cc9504cd6aeb48f342afe020/pkg/store/proxy_heap.go#L419) is again consumed in parallel to [Recv() calls](https://github.com/thanos-io/thanos/blob/463dd481cc740194cc9504cd6aeb48f342afe020/pkg/store/proxy_heap.go#L430)

I have removed parallel `Recv()` and `ctx.Done()` consumptions for the `storepb.SeriesResponse` types of clients.

I haven't included new tests because testing goroutines leaks in a deterministic manner is complicated, but don't hesitate if you have suggestions. However I validated this leak locally with a custom unit test.

This fix should reduce Receiver memory usage and unwanted crashes when OOMing.
<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
