### PR TITLE
Fix store gateway tracing span name

### DIFF
--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -1726,7 +1726,7 @@ func (s *BucketStore) LabelNames(ctx context.Context, req *storepb.LabelNamesReq
 		indexr := b.indexReader()
 
 		g.Go(func() error {
-			span, newCtx := tracing.StartSpan(gctx, "bucket_store_block_series", tracing.Tags{
+			span, newCtx := tracing.StartSpan(gctx, "bucket_store_block_label_names", tracing.Tags{
 				"block.id":         b.meta.ULID,
 				"block.mint":       b.meta.MinTime,
 				"block.maxt":       b.meta.MaxTime,
@@ -1934,7 +1934,7 @@ func (s *BucketStore) LabelValues(ctx context.Context, req *storepb.LabelValuesR
 
 		indexr := b.indexReader()
 		g.Go(func() error {
-			span, newCtx := tracing.StartSpan(gctx, "bucket_store_block_series", tracing.Tags{
+			span, newCtx := tracing.StartSpan(gctx, "bucket_store_block_label_values", tracing.Tags{
 				"block.id":         b.meta.ULID,
 				"block.mint":       b.meta.MinTime,
 				"block.maxt":       b.meta.MaxTime,


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Rename the spans that have the incorrect span name

## Verification

<!-- How you tested it? How do you know it works? -->
