### PR TITLE
Improve filtered index cache filtering

### DIFF
--- a/pkg/store/cache/filter_cache.go
+++ b/pkg/store/cache/filter_cache.go
@@ -14,22 +14,31 @@ import (
 )
 
 type FilteredIndexCache struct {
-	cache        IndexCache
-	enabledItems []string
+	cache                   IndexCache
+	postingsEnabled         bool
+	seriesEnabled           bool
+	expandedPostingsEnabled bool
 }
 
 // NewFilteredIndexCache creates a filtered index cache based on enabled items.
 func NewFilteredIndexCache(cache IndexCache, enabledItems []string) *FilteredIndexCache {
-	return &FilteredIndexCache{
-		cache:        cache,
-		enabledItems: enabledItems,
+	c := &FilteredIndexCache{cache: cache}
+	if len(enabledItems) == 0 || slices.Contains(enabledItems, CacheTypePostings) {
+		c.postingsEnabled = true
 	}
+	if len(enabledItems) == 0 || slices.Contains(enabledItems, CacheTypeExpandedPostings) {
+		c.expandedPostingsEnabled = true
+	}
+	if len(enabledItems) == 0 || slices.Contains(enabledItems, CacheTypeSeries) {
+		c.seriesEnabled = true
+	}
+	return c
 }
 
 // StorePostings sets the postings identified by the ulid and label to the value v,
 // if the postings already exists in the cache it is not mutated.
 func (c *FilteredIndexCache) StorePostings(blockID ulid.ULID, l labels.Label, v []byte, tenant string) {
-	if len(c.enabledItems) == 0 || slices.Contains(c.enabledItems, CacheTypePostings) {
+	if c.postingsEnabled {
 		c.cache.StorePostings(blockID, l, v, tenant)
 	}
 }
@@ -37,7 +46,7 @@ func (c *FilteredIndexCache) StorePostings(blockID ulid.ULID, l labels.Label, v 
 // FetchMultiPostings fetches multiple postings - each identified by a label -
 // and returns a map containing cache hits, along with a list of missing keys.
 func (c *FilteredIndexCache) FetchMultiPostings(ctx context.Context, blockID ulid.ULID, keys []labels.Label, tenant string) (hits map[labels.Label][]byte, misses []labels.Label) {
-	if len(c.enabledItems) == 0 || slices.Contains(c.enabledItems, CacheTypePostings) {
+	if c.postingsEnabled {
 		return c.cache.FetchMultiPostings(ctx, blockID, keys, tenant)
 	}
 	return nil, keys
@@ -45,14 +54,14 @@ func (c *FilteredIndexCache) FetchMultiPostings(ctx context.Context, blockID uli
 
 // StoreExpandedPostings stores expanded postings for a set of label matchers.
 func (c *FilteredIndexCache) StoreExpandedPostings(blockID ulid.ULID, matchers []*labels.Matcher, v []byte, tenant string) {
-	if len(c.enabledItems) == 0 || slices.Contains(c.enabledItems, CacheTypeExpandedPostings) {
+	if c.expandedPostingsEnabled {
 		c.cache.StoreExpandedPostings(blockID, matchers, v, tenant)
 	}
 }
 
 // FetchExpandedPostings fetches expanded postings and returns cached data and a boolean value representing whether it is a cache hit or not.
 func (c *FilteredIndexCache) FetchExpandedPostings(ctx context.Context, blockID ulid.ULID, matchers []*labels.Matcher, tenant string) ([]byte, bool) {
-	if len(c.enabledItems) == 0 || slices.Contains(c.enabledItems, CacheTypeExpandedPostings) {
+	if c.expandedPostingsEnabled {
 		return c.cache.FetchExpandedPostings(ctx, blockID, matchers, tenant)
 	}
 	return nil, false
@@ -61,7 +70,7 @@ func (c *FilteredIndexCache) FetchExpandedPostings(ctx context.Context, blockID 
 // StoreSeries sets the series identified by the ulid and id to the value v,
 // if the series already exists in the cache it is not mutated.
 func (c *FilteredIndexCache) StoreSeries(blockID ulid.ULID, id storage.SeriesRef, v []byte, tenant string) {
-	if len(c.enabledItems) == 0 || slices.Contains(c.enabledItems, CacheTypeSeries) {
+	if c.seriesEnabled {
 		c.cache.StoreSeries(blockID, id, v, tenant)
 	}
 }
@@ -69,7 +78,7 @@ func (c *FilteredIndexCache) StoreSeries(blockID ulid.ULID, id storage.SeriesRef
 // FetchMultiSeries fetches multiple series - each identified by ID - from the cache
 // and returns a map containing cache hits, along with a list of missing IDs.
 func (c *FilteredIndexCache) FetchMultiSeries(ctx context.Context, blockID ulid.ULID, ids []storage.SeriesRef, tenant string) (hits map[storage.SeriesRef][]byte, misses []storage.SeriesRef) {
-	if len(c.enabledItems) == 0 || slices.Contains(c.enabledItems, CacheTypeSeries) {
+	if c.seriesEnabled {
 		return c.cache.FetchMultiSeries(ctx, blockID, ids, tenant)
 	}
 	return nil, ids

--- a/pkg/store/cache/filter_cache.go
+++ b/pkg/store/cache/filter_cache.go
@@ -23,15 +23,9 @@ type FilteredIndexCache struct {
 // NewFilteredIndexCache creates a filtered index cache based on enabled items.
 func NewFilteredIndexCache(cache IndexCache, enabledItems []string) *FilteredIndexCache {
 	c := &FilteredIndexCache{cache: cache}
-	if len(enabledItems) == 0 || slices.Contains(enabledItems, CacheTypePostings) {
-		c.postingsEnabled = true
-	}
-	if len(enabledItems) == 0 || slices.Contains(enabledItems, CacheTypeExpandedPostings) {
-		c.expandedPostingsEnabled = true
-	}
-	if len(enabledItems) == 0 || slices.Contains(enabledItems, CacheTypeSeries) {
-		c.seriesEnabled = true
-	}
+	c.postingsEnabled = len(enabledItems) == 0 || slices.Contains(enabledItems, CacheTypePostings)
+	c.expandedPostingsEnabled = len(enabledItems) == 0 || slices.Contains(enabledItems, CacheTypeExpandedPostings)
+	c.seriesEnabled = len(enabledItems) == 0 || slices.Contains(enabledItems, CacheTypeSeries)
 	return c
 }
 


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

Improved the filtered index cache code a little bit to avoid checking whether one item is supported or not during query time, but doing it at initialization time instead

## Verification

<!-- How you tested it? How do you know it works? -->
