### PR TITLE
Change order of log for finished compacting blocks

### DIFF
--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -1286,8 +1286,8 @@ func (cg *Group) compact(ctx context.Context, dir string, planner Planner, comp 
 	}
 	level.Info(cg.logger).Log("msg", "finished running post compaction callback", "result_block", compID)
 
-	level.Info(cg.logger).Log("msg", "finished compacting blocks", "result_block", compID, "source_blocks", sourceBlockStr,
-		"duration", time.Since(groupCompactionBegin), "duration_ms", time.Since(groupCompactionBegin).Milliseconds())
+	level.Info(cg.logger).Log("msg", "finished compacting blocks", "duration", time.Since(groupCompactionBegin),
+		"duration_ms", time.Since(groupCompactionBegin).Milliseconds(), "result_block", compID, "source_blocks", sourceBlockStr)
 	return true, compID, nil
 }
 


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [X] Change is not relevant to the end user.

## Changes

Continuation of https://github.com/thanos-io/thanos/pull/6850

One line was missed at previous PR where we are putting info before the sourceBlock list as it can be extense

## Verification

None

<!-- How you tested it? How do you know it works? -->
