### PR TITLE
Use registerer for gRPC opts and endpoints

### DIFF
--- a/pkg/extgrpc/client.go
+++ b/pkg/extgrpc/client.go
@@ -45,7 +45,7 @@ func EndpointGroupGRPCOpts() []grpc.DialOption {
 }
 
 // StoreClientGRPCOpts creates gRPC dial options for connecting to a store client.
-func StoreClientGRPCOpts(logger log.Logger, reg *prometheus.Registry, tracer opentracing.Tracer, secure, skipVerify bool, cert, key, caCert, serverName string) ([]grpc.DialOption, error) {
+func StoreClientGRPCOpts(logger log.Logger, reg prometheus.Registerer, tracer opentracing.Tracer, secure, skipVerify bool, cert, key, caCert, serverName string) ([]grpc.DialOption, error) {
 	grpcMets := grpc_prometheus.NewClientMetrics()
 	grpcMets.EnableClientHandlingTimeHistogram(
 		grpc_prometheus.WithHistogramBuckets([]float64{0.001, 0.01, 0.1, 0.3, 0.6, 1, 3, 6, 9, 20, 30, 60, 90, 120, 240, 360, 720}),

--- a/pkg/query/endpointset.go
+++ b/pkg/query/endpointset.go
@@ -307,7 +307,7 @@ type nowFunc func() time.Time
 func NewEndpointSet(
 	now nowFunc,
 	logger log.Logger,
-	reg *prometheus.Registry,
+	reg prometheus.Registerer,
 	endpointSpecs func() []*GRPCEndpointSpec,
 	dialOpts []grpc.DialOption,
 	unhealthyEndpointTimeout time.Duration,


### PR DESCRIPTION
The EndpointSet and StoreGRPC options accept concrete *prometheus.Registry type. This makes it hard to create multiple instances of them because they will try to register the same metrics and the registry will panic.

This commit changes the type to a prometheus.Registerer which allows clients to inject a prefixed registry and get metrics for each instance.

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
