### PR TITLE
Lazy downloaded index header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#6954](https://github.com/thanos-io/thanos/pull/6954) Index Cache: Support tracing for fetch APIs.
 - [#6943](https://github.com/thanos-io/thanos/pull/6943) Ruler: Added `keep_firing_for` field in alerting rule.
 - [#6972](https://github.com/thanos-io/thanos/pull/6972) Store Gateway: Apply series limit when streaming series for series actually matched if lazy postings is enabled.
+- [#6984](https://github.com/thanos-io/thanos/pull/6984) Store Gateway: Added `--store.index-header-lazy-download-strategy` to specify how to lazily download index headers when lazy mmap is enabled.
 
 ### Changed
 

--- a/docs/components/store.md
+++ b/docs/components/store.md
@@ -193,6 +193,12 @@ Flags:
                                  DEPRECATED: use store.limits.request-samples.
       --store.grpc.touched-series-limit=0
                                  DEPRECATED: use store.limits.request-series.
+      --store.index-header-lazy-download-strategy=eager
+                                 Strategy of how to download index headers
+                                 lazily. Supported values: eager, lazy.
+                                 If eager, always download index header during
+                                 initial load. If lazy, download index header
+                                 during query time.
       --store.limits.request-samples=0
                                  The maximum samples allowed for a single
                                  Series request, The Series call fails if

--- a/pkg/block/indexheader/header_test.go
+++ b/pkg/block/indexheader/header_test.go
@@ -206,7 +206,7 @@ func TestReaders(t *testing.T) {
 				_, err := WriteBinary(ctx, bkt, id, fn)
 				testutil.Ok(t, err)
 
-				br, err := NewLazyBinaryReader(ctx, log.NewNopLogger(), nil, tmpDir, id, 3, NewLazyBinaryReaderMetrics(nil), NewBinaryReaderMetrics(nil), nil)
+				br, err := NewLazyBinaryReader(ctx, log.NewNopLogger(), nil, tmpDir, id, 3, NewLazyBinaryReaderMetrics(nil), NewBinaryReaderMetrics(nil), nil, false)
 				testutil.Ok(t, err)
 
 				defer func() { testutil.Ok(t, br.Close()) }()

--- a/pkg/block/indexheader/lazy_binary_reader.go
+++ b/pkg/block/indexheader/lazy_binary_reader.go
@@ -83,6 +83,8 @@ type LazyBinaryReader struct {
 
 	// Keep track of the last time it was used.
 	usedAt *atomic.Int64
+
+	lazyDownload bool
 }
 
 // NewLazyBinaryReader makes a new LazyBinaryReader. If the index-header does not exist
@@ -99,8 +101,9 @@ func NewLazyBinaryReader(
 	metrics *LazyBinaryReaderMetrics,
 	binaryReaderMetrics *BinaryReaderMetrics,
 	onClosed func(*LazyBinaryReader),
+	lazyDownload bool,
 ) (*LazyBinaryReader, error) {
-	if dir != "" {
+	if dir != "" && !lazyDownload {
 		indexHeaderFile := filepath.Join(dir, id.String(), block.IndexHeaderFilename)
 		// If the index-header doesn't exist we should download it.
 		if _, err := os.Stat(indexHeaderFile); err != nil {
@@ -131,6 +134,7 @@ func NewLazyBinaryReader(
 		binaryReaderMetrics:         binaryReaderMetrics,
 		usedAt:                      atomic.NewInt64(time.Now().UnixNano()),
 		onClosed:                    onClosed,
+		lazyDownload:                lazyDownload,
 	}, nil
 }
 

--- a/pkg/block/indexheader/lazy_binary_reader.go
+++ b/pkg/block/indexheader/lazy_binary_reader.go
@@ -84,6 +84,7 @@ type LazyBinaryReader struct {
 	// Keep track of the last time it was used.
 	usedAt *atomic.Int64
 
+	// If true, index header will be downloaded at query time rather than initialization time.
 	lazyDownload bool
 }
 

--- a/pkg/block/indexheader/lazy_binary_reader_test.go
+++ b/pkg/block/indexheader/lazy_binary_reader_test.go
@@ -5,6 +5,7 @@ package indexheader
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"sync"
@@ -56,45 +57,47 @@ func TestNewLazyBinaryReader_ShouldBuildIndexHeaderFromBucket(t *testing.T) {
 	testutil.Ok(t, err)
 	defer func() { testutil.Ok(t, bkt.Close()) }()
 
-	// Create block.
-	blockID, err := e2eutil.CreateBlock(ctx, tmpDir, []labels.Labels{
-		{{Name: "a", Value: "1"}},
-		{{Name: "a", Value: "2"}},
-	}, 100, 0, 1000, labels.Labels{{Name: "ext1", Value: "1"}}, 124, metadata.NoneFunc)
-	testutil.Ok(t, err)
-	testutil.Ok(t, block.Upload(ctx, log.NewNopLogger(), bkt, filepath.Join(tmpDir, blockID.String()), metadata.NoneFunc))
-
-	for _, lazyDownload := range []bool{true} {
-		m := NewLazyBinaryReaderMetrics(nil)
-		bm := NewBinaryReaderMetrics(nil)
-		r, err := NewLazyBinaryReader(ctx, log.NewNopLogger(), bkt, tmpDir, blockID, 3, m, bm, nil, lazyDownload)
-		testutil.Ok(t, err)
-		testutil.Assert(t, r.reader == nil)
-		testutil.Equals(t, float64(0), promtestutil.ToFloat64(m.loadCount))
-		testutil.Equals(t, float64(0), promtestutil.ToFloat64(m.unloadCount))
-
-		_, err = os.Stat(filepath.Join(r.dir, blockID.String(), block.IndexHeaderFilename))
-		// Index file shouldn't exist.
-		if lazyDownload {
-			testutil.Equals(t, true, os.IsNotExist(err))
-		}
-		// Should lazy load the index upon first usage.
-		v, err := r.IndexVersion()
-		testutil.Ok(t, err)
-		if lazyDownload {
-			_, err = os.Stat(filepath.Join(r.dir, blockID.String(), block.IndexHeaderFilename))
+	for _, lazyDownload := range []bool{false, true} {
+		t.Run(fmt.Sprintf("lazyDownload=%v", lazyDownload), func(t *testing.T) {
+			// Create block.
+			blockID, err := e2eutil.CreateBlock(ctx, tmpDir, []labels.Labels{
+				{{Name: "a", Value: "1"}},
+				{{Name: "a", Value: "2"}},
+			}, 100, 0, 1000, labels.Labels{{Name: "ext1", Value: "1"}}, 124, metadata.NoneFunc)
 			testutil.Ok(t, err)
-		}
-		testutil.Equals(t, 2, v)
-		testutil.Assert(t, r.reader != nil)
-		testutil.Equals(t, float64(1), promtestutil.ToFloat64(m.loadCount))
-		testutil.Equals(t, float64(0), promtestutil.ToFloat64(m.unloadCount))
+			testutil.Ok(t, block.Upload(ctx, log.NewNopLogger(), bkt, filepath.Join(tmpDir, blockID.String()), metadata.NoneFunc))
 
-		labelNames, err := r.LabelNames()
-		testutil.Ok(t, err)
-		testutil.Equals(t, []string{"a"}, labelNames)
-		testutil.Equals(t, float64(1), promtestutil.ToFloat64(m.loadCount))
-		testutil.Equals(t, float64(0), promtestutil.ToFloat64(m.unloadCount))
+			m := NewLazyBinaryReaderMetrics(nil)
+			bm := NewBinaryReaderMetrics(nil)
+			r, err := NewLazyBinaryReader(ctx, log.NewNopLogger(), bkt, tmpDir, blockID, 3, m, bm, nil, lazyDownload)
+			testutil.Ok(t, err)
+			testutil.Assert(t, r.reader == nil)
+			testutil.Equals(t, float64(0), promtestutil.ToFloat64(m.loadCount))
+			testutil.Equals(t, float64(0), promtestutil.ToFloat64(m.unloadCount))
+
+			_, err = os.Stat(filepath.Join(r.dir, blockID.String(), block.IndexHeaderFilename))
+			// Index file shouldn't exist.
+			if lazyDownload {
+				testutil.Equals(t, true, os.IsNotExist(err))
+			}
+			// Should lazy load the index upon first usage.
+			v, err := r.IndexVersion()
+			testutil.Ok(t, err)
+			if lazyDownload {
+				_, err = os.Stat(filepath.Join(r.dir, blockID.String(), block.IndexHeaderFilename))
+				testutil.Ok(t, err)
+			}
+			testutil.Equals(t, 2, v)
+			testutil.Assert(t, r.reader != nil)
+			testutil.Equals(t, float64(1), promtestutil.ToFloat64(m.loadCount))
+			testutil.Equals(t, float64(0), promtestutil.ToFloat64(m.unloadCount))
+
+			labelNames, err := r.LabelNames()
+			testutil.Ok(t, err)
+			testutil.Equals(t, []string{"a"}, labelNames)
+			testutil.Equals(t, float64(1), promtestutil.ToFloat64(m.loadCount))
+			testutil.Equals(t, float64(0), promtestutil.ToFloat64(m.unloadCount))
+		})
 	}
 }
 
@@ -120,22 +123,24 @@ func TestNewLazyBinaryReader_ShouldRebuildCorruptedIndexHeader(t *testing.T) {
 	testutil.Ok(t, os.WriteFile(headerFilename, []byte("xxx"), os.ModePerm))
 
 	for _, lazyDownload := range []bool{false, true} {
-		m := NewLazyBinaryReaderMetrics(nil)
-		bm := NewBinaryReaderMetrics(nil)
-		r, err := NewLazyBinaryReader(ctx, log.NewNopLogger(), bkt, tmpDir, blockID, 3, m, bm, nil, lazyDownload)
-		testutil.Ok(t, err)
-		testutil.Assert(t, r.reader == nil)
-		testutil.Equals(t, float64(0), promtestutil.ToFloat64(m.loadCount))
-		testutil.Equals(t, float64(0), promtestutil.ToFloat64(m.loadFailedCount))
-		testutil.Equals(t, float64(0), promtestutil.ToFloat64(m.unloadCount))
+		t.Run(fmt.Sprintf("lazyDownload=%v", lazyDownload), func(t *testing.T) {
+			m := NewLazyBinaryReaderMetrics(nil)
+			bm := NewBinaryReaderMetrics(nil)
+			r, err := NewLazyBinaryReader(ctx, log.NewNopLogger(), bkt, tmpDir, blockID, 3, m, bm, nil, lazyDownload)
+			testutil.Ok(t, err)
+			testutil.Assert(t, r.reader == nil)
+			testutil.Equals(t, float64(0), promtestutil.ToFloat64(m.loadCount))
+			testutil.Equals(t, float64(0), promtestutil.ToFloat64(m.loadFailedCount))
+			testutil.Equals(t, float64(0), promtestutil.ToFloat64(m.unloadCount))
 
-		// Ensure it can read data.
-		labelNames, err := r.LabelNames()
-		testutil.Ok(t, err)
-		testutil.Equals(t, []string{"a"}, labelNames)
-		testutil.Equals(t, float64(1), promtestutil.ToFloat64(m.loadCount))
-		testutil.Equals(t, float64(0), promtestutil.ToFloat64(m.loadFailedCount))
-		testutil.Equals(t, float64(0), promtestutil.ToFloat64(m.unloadCount))
+			// Ensure it can read data.
+			labelNames, err := r.LabelNames()
+			testutil.Ok(t, err)
+			testutil.Equals(t, []string{"a"}, labelNames)
+			testutil.Equals(t, float64(1), promtestutil.ToFloat64(m.loadCount))
+			testutil.Equals(t, float64(0), promtestutil.ToFloat64(m.loadFailedCount))
+			testutil.Equals(t, float64(0), promtestutil.ToFloat64(m.unloadCount))
+		})
 	}
 }
 
@@ -157,38 +162,40 @@ func TestLazyBinaryReader_ShouldReopenOnUsageAfterClose(t *testing.T) {
 	testutil.Ok(t, block.Upload(ctx, log.NewNopLogger(), bkt, filepath.Join(tmpDir, blockID.String()), metadata.NoneFunc))
 
 	for _, lazyDownload := range []bool{false, true} {
-		m := NewLazyBinaryReaderMetrics(nil)
-		bm := NewBinaryReaderMetrics(nil)
-		r, err := NewLazyBinaryReader(ctx, log.NewNopLogger(), bkt, tmpDir, blockID, 3, m, bm, nil, lazyDownload)
-		testutil.Ok(t, err)
-		testutil.Assert(t, r.reader == nil)
+		t.Run(fmt.Sprintf("lazyDownload=%v", lazyDownload), func(t *testing.T) {
+			m := NewLazyBinaryReaderMetrics(nil)
+			bm := NewBinaryReaderMetrics(nil)
+			r, err := NewLazyBinaryReader(ctx, log.NewNopLogger(), bkt, tmpDir, blockID, 3, m, bm, nil, lazyDownload)
+			testutil.Ok(t, err)
+			testutil.Assert(t, r.reader == nil)
 
-		// Should lazy load the index upon first usage.
-		labelNames, err := r.LabelNames()
-		testutil.Ok(t, err)
-		testutil.Equals(t, []string{"a"}, labelNames)
-		testutil.Equals(t, float64(1), promtestutil.ToFloat64(m.loadCount))
-		testutil.Equals(t, float64(0), promtestutil.ToFloat64(m.loadFailedCount))
+			// Should lazy load the index upon first usage.
+			labelNames, err := r.LabelNames()
+			testutil.Ok(t, err)
+			testutil.Equals(t, []string{"a"}, labelNames)
+			testutil.Equals(t, float64(1), promtestutil.ToFloat64(m.loadCount))
+			testutil.Equals(t, float64(0), promtestutil.ToFloat64(m.loadFailedCount))
 
-		// Close it.
-		testutil.Ok(t, r.Close())
-		testutil.Assert(t, r.reader == nil)
-		testutil.Equals(t, float64(1), promtestutil.ToFloat64(m.unloadCount))
-		testutil.Equals(t, float64(0), promtestutil.ToFloat64(m.unloadFailedCount))
-
-		// Should lazy load again upon next usage.
-		labelNames, err = r.LabelNames()
-		testutil.Ok(t, err)
-		testutil.Equals(t, []string{"a"}, labelNames)
-		testutil.Equals(t, float64(2), promtestutil.ToFloat64(m.loadCount))
-		testutil.Equals(t, float64(0), promtestutil.ToFloat64(m.loadFailedCount))
-
-		// Closing an already closed lazy reader should be a no-op.
-		for i := 0; i < 2; i++ {
+			// Close it.
 			testutil.Ok(t, r.Close())
-			testutil.Equals(t, float64(2), promtestutil.ToFloat64(m.unloadCount))
+			testutil.Assert(t, r.reader == nil)
+			testutil.Equals(t, float64(1), promtestutil.ToFloat64(m.unloadCount))
 			testutil.Equals(t, float64(0), promtestutil.ToFloat64(m.unloadFailedCount))
-		}
+
+			// Should lazy load again upon next usage.
+			labelNames, err = r.LabelNames()
+			testutil.Ok(t, err)
+			testutil.Equals(t, []string{"a"}, labelNames)
+			testutil.Equals(t, float64(2), promtestutil.ToFloat64(m.loadCount))
+			testutil.Equals(t, float64(0), promtestutil.ToFloat64(m.loadFailedCount))
+
+			// Closing an already closed lazy reader should be a no-op.
+			for i := 0; i < 2; i++ {
+				testutil.Ok(t, r.Close())
+				testutil.Equals(t, float64(2), promtestutil.ToFloat64(m.unloadCount))
+				testutil.Equals(t, float64(0), promtestutil.ToFloat64(m.unloadFailedCount))
+			}
+		})
 	}
 }
 
@@ -210,34 +217,36 @@ func TestLazyBinaryReader_unload_ShouldReturnErrorIfNotIdle(t *testing.T) {
 	testutil.Ok(t, block.Upload(ctx, log.NewNopLogger(), bkt, filepath.Join(tmpDir, blockID.String()), metadata.NoneFunc))
 
 	for _, lazyDownload := range []bool{false, true} {
-		m := NewLazyBinaryReaderMetrics(nil)
-		bm := NewBinaryReaderMetrics(nil)
-		r, err := NewLazyBinaryReader(ctx, log.NewNopLogger(), bkt, tmpDir, blockID, 3, m, bm, nil, lazyDownload)
-		testutil.Ok(t, err)
-		testutil.Assert(t, r.reader == nil)
+		t.Run(fmt.Sprintf("lazyDownload=%v", lazyDownload), func(t *testing.T) {
+			m := NewLazyBinaryReaderMetrics(nil)
+			bm := NewBinaryReaderMetrics(nil)
+			r, err := NewLazyBinaryReader(ctx, log.NewNopLogger(), bkt, tmpDir, blockID, 3, m, bm, nil, lazyDownload)
+			testutil.Ok(t, err)
+			testutil.Assert(t, r.reader == nil)
 
-		// Should lazy load the index upon first usage.
-		labelNames, err := r.LabelNames()
-		testutil.Ok(t, err)
-		testutil.Equals(t, []string{"a"}, labelNames)
-		testutil.Equals(t, float64(1), promtestutil.ToFloat64(m.loadCount))
-		testutil.Equals(t, float64(0), promtestutil.ToFloat64(m.loadFailedCount))
-		testutil.Equals(t, float64(0), promtestutil.ToFloat64(m.unloadCount))
-		testutil.Equals(t, float64(0), promtestutil.ToFloat64(m.unloadFailedCount))
+			// Should lazy load the index upon first usage.
+			labelNames, err := r.LabelNames()
+			testutil.Ok(t, err)
+			testutil.Equals(t, []string{"a"}, labelNames)
+			testutil.Equals(t, float64(1), promtestutil.ToFloat64(m.loadCount))
+			testutil.Equals(t, float64(0), promtestutil.ToFloat64(m.loadFailedCount))
+			testutil.Equals(t, float64(0), promtestutil.ToFloat64(m.unloadCount))
+			testutil.Equals(t, float64(0), promtestutil.ToFloat64(m.unloadFailedCount))
 
-		// Try to unload but not idle since enough time.
-		testutil.Equals(t, errNotIdle, r.unloadIfIdleSince(time.Now().Add(-time.Minute).UnixNano()))
-		testutil.Equals(t, float64(1), promtestutil.ToFloat64(m.loadCount))
-		testutil.Equals(t, float64(0), promtestutil.ToFloat64(m.loadFailedCount))
-		testutil.Equals(t, float64(0), promtestutil.ToFloat64(m.unloadCount))
-		testutil.Equals(t, float64(0), promtestutil.ToFloat64(m.unloadFailedCount))
+			// Try to unload but not idle since enough time.
+			testutil.Equals(t, errNotIdle, r.unloadIfIdleSince(time.Now().Add(-time.Minute).UnixNano()))
+			testutil.Equals(t, float64(1), promtestutil.ToFloat64(m.loadCount))
+			testutil.Equals(t, float64(0), promtestutil.ToFloat64(m.loadFailedCount))
+			testutil.Equals(t, float64(0), promtestutil.ToFloat64(m.unloadCount))
+			testutil.Equals(t, float64(0), promtestutil.ToFloat64(m.unloadFailedCount))
 
-		// Try to unload and idle since enough time.
-		testutil.Ok(t, r.unloadIfIdleSince(time.Now().UnixNano()))
-		testutil.Equals(t, float64(1), promtestutil.ToFloat64(m.loadCount))
-		testutil.Equals(t, float64(0), promtestutil.ToFloat64(m.loadFailedCount))
-		testutil.Equals(t, float64(1), promtestutil.ToFloat64(m.unloadCount))
-		testutil.Equals(t, float64(0), promtestutil.ToFloat64(m.unloadFailedCount))
+			// Try to unload and idle since enough time.
+			testutil.Ok(t, r.unloadIfIdleSince(time.Now().UnixNano()))
+			testutil.Equals(t, float64(1), promtestutil.ToFloat64(m.loadCount))
+			testutil.Equals(t, float64(0), promtestutil.ToFloat64(m.loadFailedCount))
+			testutil.Equals(t, float64(1), promtestutil.ToFloat64(m.unloadCount))
+			testutil.Equals(t, float64(0), promtestutil.ToFloat64(m.unloadFailedCount))
+		})
 	}
 }
 
@@ -262,50 +271,52 @@ func TestLazyBinaryReader_LoadUnloadRaceCondition(t *testing.T) {
 	testutil.Ok(t, block.Upload(ctx, log.NewNopLogger(), bkt, filepath.Join(tmpDir, blockID.String()), metadata.NoneFunc))
 
 	for _, lazyDownload := range []bool{false, true} {
-		m := NewLazyBinaryReaderMetrics(nil)
-		bm := NewBinaryReaderMetrics(nil)
-		r, err := NewLazyBinaryReader(ctx, log.NewNopLogger(), bkt, tmpDir, blockID, 3, m, bm, nil, lazyDownload)
-		testutil.Ok(t, err)
-		testutil.Assert(t, r.reader == nil)
-		t.Cleanup(func() {
-			testutil.Ok(t, r.Close())
+		t.Run(fmt.Sprintf("lazyDownload=%v", lazyDownload), func(t *testing.T) {
+			m := NewLazyBinaryReaderMetrics(nil)
+			bm := NewBinaryReaderMetrics(nil)
+			r, err := NewLazyBinaryReader(ctx, log.NewNopLogger(), bkt, tmpDir, blockID, 3, m, bm, nil, lazyDownload)
+			testutil.Ok(t, err)
+			testutil.Assert(t, r.reader == nil)
+			t.Cleanup(func() {
+				testutil.Ok(t, r.Close())
+			})
+
+			done := make(chan struct{})
+			time.AfterFunc(runDuration, func() { close(done) })
+			wg := sync.WaitGroup{}
+			wg.Add(2)
+
+			// Start a goroutine which continuously try to unload the reader.
+			go func() {
+				defer wg.Done()
+
+				for {
+					select {
+					case <-done:
+						return
+					default:
+						testutil.Ok(t, r.unloadIfIdleSince(0))
+					}
+				}
+			}()
+
+			// Try to read multiple times, while the other goroutine continuously try to unload it.
+			go func() {
+				defer wg.Done()
+
+				for {
+					select {
+					case <-done:
+						return
+					default:
+						_, err := r.PostingsOffset("a", "1")
+						testutil.Assert(t, err == nil || err == errUnloadedWhileLoading)
+					}
+				}
+			}()
+
+			// Wait until both goroutines have done.
+			wg.Wait()
 		})
-
-		done := make(chan struct{})
-		time.AfterFunc(runDuration, func() { close(done) })
-		wg := sync.WaitGroup{}
-		wg.Add(2)
-
-		// Start a goroutine which continuously try to unload the reader.
-		go func() {
-			defer wg.Done()
-
-			for {
-				select {
-				case <-done:
-					return
-				default:
-					testutil.Ok(t, r.unloadIfIdleSince(0))
-				}
-			}
-		}()
-
-		// Try to read multiple times, while the other goroutine continuously try to unload it.
-		go func() {
-			defer wg.Done()
-
-			for {
-				select {
-				case <-done:
-					return
-				default:
-					_, err := r.PostingsOffset("a", "1")
-					testutil.Assert(t, err == nil || err == errUnloadedWhileLoading)
-				}
-			}
-		}()
-
-		// Wait until both goroutines have done.
-		wg.Wait()
 	}
 }

--- a/pkg/block/indexheader/lazy_binary_reader_test.go
+++ b/pkg/block/indexheader/lazy_binary_reader_test.go
@@ -31,7 +31,7 @@ func TestNewLazyBinaryReader_ShouldFailIfUnableToBuildIndexHeader(t *testing.T) 
 	bkt, err := filesystem.NewBucket(filepath.Join(tmpDir, "bkt"))
 	testutil.Ok(t, err)
 	defer func() { testutil.Ok(t, bkt.Close()) }()
-	_, err = NewLazyBinaryReader(ctx, log.NewNopLogger(), bkt, tmpDir, ulid.MustNew(0, nil), 3, NewLazyBinaryReaderMetrics(nil), NewBinaryReaderMetrics(nil), nil)
+	_, err = NewLazyBinaryReader(ctx, log.NewNopLogger(), bkt, tmpDir, ulid.MustNew(0, nil), 3, NewLazyBinaryReaderMetrics(nil), NewBinaryReaderMetrics(nil), nil, false)
 	testutil.NotOk(t, err)
 }
 
@@ -54,7 +54,7 @@ func TestNewLazyBinaryReader_ShouldBuildIndexHeaderFromBucket(t *testing.T) {
 
 	m := NewLazyBinaryReaderMetrics(nil)
 	bm := NewBinaryReaderMetrics(nil)
-	r, err := NewLazyBinaryReader(ctx, log.NewNopLogger(), bkt, tmpDir, blockID, 3, m, bm, nil)
+	r, err := NewLazyBinaryReader(ctx, log.NewNopLogger(), bkt, tmpDir, blockID, 3, m, bm, nil, false)
 	testutil.Ok(t, err)
 	testutil.Assert(t, r.reader == nil)
 	testutil.Equals(t, float64(0), promtestutil.ToFloat64(m.loadCount))
@@ -98,7 +98,7 @@ func TestNewLazyBinaryReader_ShouldRebuildCorruptedIndexHeader(t *testing.T) {
 
 	m := NewLazyBinaryReaderMetrics(nil)
 	bm := NewBinaryReaderMetrics(nil)
-	r, err := NewLazyBinaryReader(ctx, log.NewNopLogger(), bkt, tmpDir, blockID, 3, m, bm, nil)
+	r, err := NewLazyBinaryReader(ctx, log.NewNopLogger(), bkt, tmpDir, blockID, 3, m, bm, nil, false)
 	testutil.Ok(t, err)
 	testutil.Assert(t, r.reader == nil)
 	testutil.Equals(t, float64(0), promtestutil.ToFloat64(m.loadCount))
@@ -133,7 +133,7 @@ func TestLazyBinaryReader_ShouldReopenOnUsageAfterClose(t *testing.T) {
 
 	m := NewLazyBinaryReaderMetrics(nil)
 	bm := NewBinaryReaderMetrics(nil)
-	r, err := NewLazyBinaryReader(ctx, log.NewNopLogger(), bkt, tmpDir, blockID, 3, m, bm, nil)
+	r, err := NewLazyBinaryReader(ctx, log.NewNopLogger(), bkt, tmpDir, blockID, 3, m, bm, nil, false)
 	testutil.Ok(t, err)
 	testutil.Assert(t, r.reader == nil)
 
@@ -184,7 +184,7 @@ func TestLazyBinaryReader_unload_ShouldReturnErrorIfNotIdle(t *testing.T) {
 
 	m := NewLazyBinaryReaderMetrics(nil)
 	bm := NewBinaryReaderMetrics(nil)
-	r, err := NewLazyBinaryReader(ctx, log.NewNopLogger(), bkt, tmpDir, blockID, 3, m, bm, nil)
+	r, err := NewLazyBinaryReader(ctx, log.NewNopLogger(), bkt, tmpDir, blockID, 3, m, bm, nil, false)
 	testutil.Ok(t, err)
 	testutil.Assert(t, r.reader == nil)
 
@@ -234,7 +234,7 @@ func TestLazyBinaryReader_LoadUnloadRaceCondition(t *testing.T) {
 
 	m := NewLazyBinaryReaderMetrics(nil)
 	bm := NewBinaryReaderMetrics(nil)
-	r, err := NewLazyBinaryReader(ctx, log.NewNopLogger(), bkt, tmpDir, blockID, 3, m, bm, nil)
+	r, err := NewLazyBinaryReader(ctx, log.NewNopLogger(), bkt, tmpDir, blockID, 3, m, bm, nil, false)
 	testutil.Ok(t, err)
 	testutil.Assert(t, r.reader == nil)
 	t.Cleanup(func() {

--- a/pkg/block/indexheader/reader_pool.go
+++ b/pkg/block/indexheader/reader_pool.go
@@ -52,13 +52,39 @@ type ReaderPool struct {
 	lazyDownloadFunc LazyDownloadIndexHeaderFunc
 }
 
+// IndexHeaderLazyDownloadStrategy specifies how to download index headers
+// lazily. Only used when lazy mmap is enabled.
+type IndexHeaderLazyDownloadStrategy string
+
+const (
+	// EagerDownloadStrategy always disables lazy downloading index headers.
+	EagerDownloadStrategy IndexHeaderLazyDownloadStrategy = "eager"
+	// LazyDownloadStrategy always lazily download index headers.
+	LazyDownloadStrategy IndexHeaderLazyDownloadStrategy = "lazy"
+)
+
+func (s IndexHeaderLazyDownloadStrategy) StrategyToDownloadFunc() LazyDownloadIndexHeaderFunc {
+	switch s {
+	case LazyDownloadStrategy:
+		return AlwaysLazyDownloadIndexHeader
+	default:
+		// Always fallback to eager download index header.
+		return AlwaysEagerDownloadIndexHeader
+	}
+}
+
 // LazyDownloadIndexHeaderFunc is used to determinte whether to download the index header lazily
 // or not by checking its block metadata. Usecase can be by time or by index file size.
 type LazyDownloadIndexHeaderFunc func(meta *metadata.Meta) bool
 
-// DisableLazyDownloadIndexHeader disables lazy downloaded index header.
-func DisableLazyDownloadIndexHeader(meta *metadata.Meta) bool {
+// AlwaysEagerDownloadIndexHeader always eagerly download index header.
+func AlwaysEagerDownloadIndexHeader(meta *metadata.Meta) bool {
 	return false
+}
+
+// AlwaysLazyDownloadIndexHeader always lazily download index header.
+func AlwaysLazyDownloadIndexHeader(meta *metadata.Meta) bool {
+	return true
 }
 
 // NewReaderPool makes a new ReaderPool.

--- a/pkg/block/indexheader/reader_pool.go
+++ b/pkg/block/indexheader/reader_pool.go
@@ -52,8 +52,11 @@ type ReaderPool struct {
 	lazyDownloadFunc LazyDownloadIndexHeaderFunc
 }
 
+// LazyDownloadIndexHeaderFunc is used to determinte whether to download the index header lazily
+// or not by checking its block metadata. Usecase can be by time or by index file size.
 type LazyDownloadIndexHeaderFunc func(meta *metadata.Meta) bool
 
+// DisableLazyDownloadIndexHeader disables lazy downloaded index header.
 func DisableLazyDownloadIndexHeader(meta *metadata.Meta) bool {
 	return false
 }

--- a/pkg/block/indexheader/reader_pool_test.go
+++ b/pkg/block/indexheader/reader_pool_test.go
@@ -59,7 +59,7 @@ func TestReaderPool_NewBinaryReader(t *testing.T) {
 
 	for testName, testData := range tests {
 		t.Run(testName, func(t *testing.T) {
-			pool := NewReaderPool(log.NewNopLogger(), testData.lazyReaderEnabled, testData.lazyReaderIdleTimeout, NewReaderPoolMetrics(nil), DisableLazyDownloadIndexHeader)
+			pool := NewReaderPool(log.NewNopLogger(), testData.lazyReaderEnabled, testData.lazyReaderIdleTimeout, NewReaderPoolMetrics(nil), AlwaysEagerDownloadIndexHeader)
 			defer pool.Close()
 
 			r, err := pool.NewBinaryReader(ctx, log.NewNopLogger(), bkt, tmpDir, blockID, 3, meta)
@@ -96,7 +96,7 @@ func TestReaderPool_ShouldCloseIdleLazyReaders(t *testing.T) {
 	testutil.Ok(t, err)
 
 	metrics := NewReaderPoolMetrics(nil)
-	pool := NewReaderPool(log.NewNopLogger(), true, idleTimeout, metrics, DisableLazyDownloadIndexHeader)
+	pool := NewReaderPool(log.NewNopLogger(), true, idleTimeout, metrics, AlwaysEagerDownloadIndexHeader)
 	defer pool.Close()
 
 	r, err := pool.NewBinaryReader(ctx, log.NewNopLogger(), bkt, tmpDir, blockID, 3, meta)

--- a/pkg/block/indexheader/reader_pool_test.go
+++ b/pkg/block/indexheader/reader_pool_test.go
@@ -54,12 +54,15 @@ func TestReaderPool_NewBinaryReader(t *testing.T) {
 	testutil.Ok(t, err)
 	testutil.Ok(t, block.Upload(ctx, log.NewNopLogger(), bkt, filepath.Join(tmpDir, blockID.String()), metadata.NoneFunc))
 
+	meta, err := metadata.ReadFromDir(filepath.Join(tmpDir, blockID.String()))
+	testutil.Ok(t, err)
+
 	for testName, testData := range tests {
 		t.Run(testName, func(t *testing.T) {
-			pool := NewReaderPool(log.NewNopLogger(), testData.lazyReaderEnabled, testData.lazyReaderIdleTimeout, NewReaderPoolMetrics(nil))
+			pool := NewReaderPool(log.NewNopLogger(), testData.lazyReaderEnabled, testData.lazyReaderIdleTimeout, NewReaderPoolMetrics(nil), DisableLazyDownloadIndexHeader)
 			defer pool.Close()
 
-			r, err := pool.NewBinaryReader(ctx, log.NewNopLogger(), bkt, tmpDir, blockID, 3)
+			r, err := pool.NewBinaryReader(ctx, log.NewNopLogger(), bkt, tmpDir, blockID, 3, meta)
 			testutil.Ok(t, err)
 			defer func() { testutil.Ok(t, r.Close()) }()
 
@@ -89,12 +92,14 @@ func TestReaderPool_ShouldCloseIdleLazyReaders(t *testing.T) {
 	}, 100, 0, 1000, labels.Labels{{Name: "ext1", Value: "1"}}, 124, metadata.NoneFunc)
 	testutil.Ok(t, err)
 	testutil.Ok(t, block.Upload(ctx, log.NewNopLogger(), bkt, filepath.Join(tmpDir, blockID.String()), metadata.NoneFunc))
+	meta, err := metadata.ReadFromDir(filepath.Join(tmpDir, blockID.String()))
+	testutil.Ok(t, err)
 
 	metrics := NewReaderPoolMetrics(nil)
-	pool := NewReaderPool(log.NewNopLogger(), true, idleTimeout, metrics)
+	pool := NewReaderPool(log.NewNopLogger(), true, idleTimeout, metrics, DisableLazyDownloadIndexHeader)
 	defer pool.Close()
 
-	r, err := pool.NewBinaryReader(ctx, log.NewNopLogger(), bkt, tmpDir, blockID, 3)
+	r, err := pool.NewBinaryReader(ctx, log.NewNopLogger(), bkt, tmpDir, blockID, 3, meta)
 	testutil.Ok(t, err)
 	defer func() { testutil.Ok(t, r.Close()) }()
 

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -533,6 +533,8 @@ func WithDontResort(true bool) BucketStoreOption {
 	}
 }
 
+// WithLazyDownloadIndexHeaderFunc specifies what block to lazy download its index header.
+// Only used when lazy mmap is enabled at the same time.
 func WithLazyDownloadIndexHeaderFunc(f indexheader.LazyDownloadIndexHeaderFunc) BucketStoreOption {
 	return func(s *BucketStore) {
 		s.lazyDownloadIndexHeaderFunc = f

--- a/pkg/store/bucket_test.go
+++ b/pkg/store/bucket_test.go
@@ -1658,7 +1658,7 @@ func TestBucketSeries_OneBlock_InMemIndexCacheSegfault(t *testing.T) {
 		bkt:             objstore.WithNoopInstr(bkt),
 		logger:          logger,
 		indexCache:      indexCache,
-		indexReaderPool: indexheader.NewReaderPool(log.NewNopLogger(), false, 0, indexheader.NewReaderPoolMetrics(nil)),
+		indexReaderPool: indexheader.NewReaderPool(log.NewNopLogger(), false, 0, indexheader.NewReaderPoolMetrics(nil), indexheader.DisableLazyDownloadIndexHeader),
 		metrics:         newBucketStoreMetrics(nil),
 		blockSets: map[uint64]*bucketBlockSet{
 			labels.Labels{{Name: "ext1", Value: "1"}}.Hash(): {blocks: [][]*bucketBlock{{b1, b2}}},

--- a/pkg/store/bucket_test.go
+++ b/pkg/store/bucket_test.go
@@ -1658,7 +1658,7 @@ func TestBucketSeries_OneBlock_InMemIndexCacheSegfault(t *testing.T) {
 		bkt:             objstore.WithNoopInstr(bkt),
 		logger:          logger,
 		indexCache:      indexCache,
-		indexReaderPool: indexheader.NewReaderPool(log.NewNopLogger(), false, 0, indexheader.NewReaderPoolMetrics(nil), indexheader.DisableLazyDownloadIndexHeader),
+		indexReaderPool: indexheader.NewReaderPool(log.NewNopLogger(), false, 0, indexheader.NewReaderPoolMetrics(nil), indexheader.AlwaysEagerDownloadIndexHeader),
 		metrics:         newBucketStoreMetrics(nil),
 		blockSets: map[uint64]*bucketBlockSet{
 			labels.Labels{{Name: "ext1", Value: "1"}}.Hash(): {blocks: [][]*bucketBlock{{b1, b2}}},


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

This pr allows index header to be lazily downloaded by checking block metadata info when lazy mmap is enabled.
Currently, it is set to always disable lazy download. But in the future we can utilize it to lazy download indexes if needed.

This can be useful if we know block size is small and it is fast to download index headers. Or we don't need to eagerly download blocks that are one year old at startup time since they might be never queried.

## Verification

<!-- How you tested it? How do you know it works? -->
