### PR TITLE
all: remove a bunch of internal spans

### DIFF
--- a/pkg/api/query/v1.go
+++ b/pkg/api/query/v1.go
@@ -684,10 +684,7 @@ func (qapi *QueryAPI) query(r *http.Request) (interface{}, []error, *api.ApiErro
 		return nil, nil, apiErr, func() {}
 	}
 
-	tracing.DoInSpan(ctx, "query_gate_ismyturn", func(ctx context.Context) {
-		err = qapi.gate.Start(ctx)
-	})
-	if err != nil {
+	if err := qapi.gate.Start(ctx); err != nil {
 		return nil, nil, &api.ApiError{Typ: api.ErrorExec, Err: err}, qry.Close
 	}
 	defer qapi.gate.Done()
@@ -989,10 +986,7 @@ func (qapi *QueryAPI) queryRange(r *http.Request) (interface{}, []error, *api.Ap
 		return nil, nil, apiErr, func() {}
 	}
 
-	tracing.DoInSpan(ctx, "query_gate_ismyturn", func(ctx context.Context) {
-		err = qapi.gate.Start(ctx)
-	})
-	if err != nil {
+	if err := qapi.gate.Start(ctx); err != nil {
 		return nil, nil, &api.ApiError{Typ: api.ErrorExec, Err: err}, qry.Close
 	}
 	defer qapi.gate.Done()
@@ -1356,9 +1350,7 @@ func NewAlertsHandler(client rules.UnaryClient, enablePartialResponse bool) func
 			Type:                    rulespb.RulesRequest_ALERT,
 			PartialResponseStrategy: ps,
 		}
-		tracing.DoInSpan(ctx, "retrieve_rules", func(ctx context.Context) {
-			groups, warnings, err = client.Rules(ctx, req)
-		})
+		groups, warnings, err = client.Rules(ctx, req)
 		if err != nil {
 			return nil, nil, &api.ApiError{Typ: api.ErrorInternal, Err: errors.Errorf("error retrieving rules: %v", err)}, func() {}
 		}
@@ -1416,9 +1408,7 @@ func NewRulesHandler(client rules.UnaryClient, enablePartialResponse bool) func(
 			PartialResponseStrategy: ps,
 			MatcherString:           r.Form[MatcherParam],
 		}
-		tracing.DoInSpan(ctx, "retrieve_rules", func(ctx context.Context) {
-			groups, warnings, err = client.Rules(ctx, req)
-		})
+		groups, warnings, err = client.Rules(ctx, req)
 		if err != nil {
 			return nil, nil, &api.ApiError{Typ: api.ErrorInternal, Err: errors.Errorf("error retrieving rules: %v", err)}, func() {}
 		}
@@ -1460,10 +1450,7 @@ func NewExemplarsHandler(client exemplars.UnaryClient, enablePartialResponse boo
 			PartialResponseStrategy: ps,
 		}
 
-		tracing.DoInSpan(ctx, "retrieve_exemplars", func(ctx context.Context) {
-			data, warnings, err = client.Exemplars(ctx, req)
-		})
-
+		data, warnings, err = client.Exemplars(ctx, req)
 		if err != nil {
 			return nil, nil, &api.ApiError{Typ: api.ErrorInternal, Err: errors.Wrap(err, "retrieving exemplars")}, func() {}
 		}
@@ -1578,9 +1565,7 @@ func NewMetricMetadataHandler(client metadata.UnaryClient, enablePartialResponse
 			req.Limit = int32(limit)
 		}
 
-		tracing.DoInSpan(ctx, "retrieve_metadata", func(ctx context.Context) {
-			t, warnings, err = client.MetricMetadata(ctx, req)
-		})
+		t, warnings, err = client.MetricMetadata(ctx, req)
 		if err != nil {
 			return nil, nil, &api.ApiError{Typ: api.ErrorInternal, Err: errors.Wrap(err, "retrieving metadata")}, func() {}
 		}

--- a/pkg/receive/handler.go
+++ b/pkg/receive/handler.go
@@ -433,15 +433,12 @@ func (h *Handler) receiveHTTP(w http.ResponseWriter, r *http.Request) {
 	tLogger := log.With(h.logger, "tenant", tenant)
 
 	writeGate := h.Limiter.WriteGate()
-	tracing.DoInSpan(r.Context(), "receive_write_gate_ismyturn", func(ctx context.Context) {
-		err = writeGate.Start(r.Context())
-	})
-	defer writeGate.Done()
-	if err != nil {
+	if err := writeGate.Start(r.Context()); err != nil {
 		level.Error(tLogger).Log("err", err, "msg", "internal server error")
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+	defer writeGate.Done()
 
 	under, err := h.Limiter.HeadSeriesLimiter().isUnderLimit(tenant)
 	if err != nil {
@@ -682,12 +679,9 @@ func (h *Handler) fanoutForward(pctx context.Context, tenant string, wreqs map[e
 		// can be ignored if the replication factor is met.
 		var err error
 
-		tracing.DoInSpan(fctx, "receive_tsdb_write", func(_ context.Context) {
-			err = h.writer.Write(fctx, tenant, &prompb.WriteRequest{
-				Timeseries: wreqs[writeTarget].timeSeries,
-			})
-		})
-		if err != nil {
+		if err = h.writer.Write(fctx, tenant, &prompb.WriteRequest{
+			Timeseries: wreqs[writeTarget].timeSeries,
+		}); err != nil {
 			level.Debug(tLogger).Log("msg", "local tsdb write failed", "err", err.Error())
 			responses <- newWriteResponse(wreqs[writeTarget].seriesIDs, errors.Wrapf(err, "store locally for endpoint %v", writeTarget.endpoint))
 			continue
@@ -740,17 +734,13 @@ func (h *Handler) fanoutForward(pctx context.Context, tenant string, wreqs map[e
 			}
 			h.mtx.RUnlock()
 
-			// Create a span to track the request made to another receive node.
-			tracing.DoInSpan(fctx, "receive_forward", func(ctx context.Context) {
-				// Actually make the request against the endpoint we determined should handle these time series.
-				_, err = cl.RemoteWrite(ctx, &storepb.WriteRequest{
-					Timeseries: wreqs[writeTarget].timeSeries,
-					Tenant:     tenant,
-					// Increment replica since on-the-wire format is 1-indexed and 0 indicates un-replicated.
-					Replica: int64(writeTarget.replica + 1),
-				})
-			})
-			if err != nil {
+			// Actually make the request against the endpoint we determined should handle these time series.
+			if _, err = cl.RemoteWrite(fctx, &storepb.WriteRequest{
+				Timeseries: wreqs[writeTarget].timeSeries,
+				Tenant:     tenant,
+				// Increment replica since on-the-wire format is 1-indexed and 0 indicates un-replicated.
+				Replica: int64(writeTarget.replica + 1),
+			}); err != nil {
 				// Check if peer connection is unavailable, don't attempt to send requests constantly.
 				if st, ok := status.FromError(err); ok {
 					if st.Code() == codes.Unavailable {


### PR DESCRIPTION
On big thanos deployments we can have queries that emit several thousand spans. This is clearly not feasible so I propose that we start cleaning up some internal ones and start relying on the spans that are generated at the boundaries by grpc or http middleware instead.

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

* removed a bunch of spans

## Verification

* previous tests
