### PR TITLE
Rule: Fix URI encoding of strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 ### Fixed
 
 - [#6874](https://github.com/thanos-io/thanos/pull/6874) Sidecar: fix labels returned by 'api/v1/series' in presence of conflicting external and inner labels.
+- [#7009](https://github.com/thanos-io/thanos/pull/7009) Rule: Fix spacing error in URL.
 
 ### Added
 - [#6944](https://github.com/thanos-io/thanos/pull/6944) Receive: Added a new flag for maximum retention bytes.

--- a/cmd/thanos/rule.go
+++ b/cmd/thanos/rule.go
@@ -16,6 +16,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	texttemplate "text/template"
 	"time"
 
 	extflag "github.com/efficientgo/tools/extkingpin"
@@ -939,7 +940,7 @@ func tableLinkForExpression(tmpl string, expr string) (string, error) {
 	escapedExpression := url.QueryEscape(expr)
 
 	escapedExpr := Expression{Expr: escapedExpression}
-	t, err := template.New("url").Parse(tmpl)
+	t, err := texttemplate.New("url").Parse(tmpl)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to parse template")
 	}

--- a/cmd/thanos/rule_test.go
+++ b/cmd/thanos/rule_test.go
@@ -87,6 +87,12 @@ func Test_tableLinkForExpression(t *testing.T) {
 			expectErr: false,
 		},
 		{
+			template:  `/graph?g0.expr={{.Expr}}&g0.tab=1`,
+			expr:      `up{app="foo yoo"}`,
+			expectStr: `/graph?g0.expr=up%7Bapp%3D%22foo+yoo%22%7D&g0.tab=1`,
+			expectErr: false,
+		},
+		{
 			template:  `/graph?g0.expr={{.Expression}}&g0.tab=1`,
 			expr:      "test_expr",
 			expectErr: true,


### PR DESCRIPTION
* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Should fix #7002
Added how the URI should treat `+` as it is ignored by `url.QueryEscape`

[Reference](https://forum.golangbridge.org/t/html-template-may-invalidate-urls-encoded-using-url-queryescape/4219)