### PR TITLE
cache: implement the circuit breaker pattern for asynchronous set operations in the cache client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#6887](https://github.com/thanos-io/thanos/pull/6887) Query Frontend: *breaking :warning:* Add tenant label to relevant exported metrics. Note that this change may cause some pre-existing custom dashboard queries to be incorrect due to the added label.
 - [#7028](https://github.com/thanos-io/thanos/pull/7028) Query|Query Frontend: Add new `--query-frontend.enable-x-functions` flag to enable experimental extended functions.
 - [#6884](https://github.com/thanos-io/thanos/pull/6884) Tools: Add upload-block command to upload blocks to object storage.
+- [#7010](https://github.com/thanos-io/thanos/pull/7010) Cache: Added `set_async_circuit_breaker_*` to utilize the circuit breaker pattern for dynamically thresholding asynchronous set operations.
 
 ### Changed
 

--- a/docs/components/query-frontend.md
+++ b/docs/components/query-frontend.md
@@ -77,12 +77,13 @@ config:
   max_get_multi_batch_size: 0
   dns_provider_update_interval: 0s
   auto_discovery: false
-  set_async_circuit_breaker_enabled: false
-  set_async_circuit_breaker_half_open_max_requests: 0
-  set_async_circuit_breaker_open_duration: 0s
-  set_async_circuit_breaker_min_requests: 0
-  set_async_circuit_breaker_consecutive_failures: 0
-  set_async_circuit_breaker_failure_percent: 0
+  set_async_circuit_breaker_config:
+    enabled: false
+    half_open_max_requests: 0
+    open_duration: 0s
+    min_requests: 0
+    consecutive_failures: 0
+    failure_percent: 0
   expiration: 0s
 ```
 
@@ -138,12 +139,13 @@ config:
   master_name: ""
   max_async_buffer_size: 10000
   max_async_concurrency: 20
-  set_async_circuit_breaker_enabled: false
-  set_async_circuit_breaker_half_open_max_requests: 10
-  set_async_circuit_breaker_open_duration: 5s
-  set_async_circuit_breaker_min_requests: 50
-  set_async_circuit_breaker_consecutive_failures: 5
-  set_async_circuit_breaker_failure_percent: 0.05
+  set_async_circuit_breaker_config:
+    enabled: false
+    half_open_max_requests: 10
+    open_duration: 5s
+    min_requests: 50
+    consecutive_failures: 5
+    failure_percent: 0.05
   expiration: 24h0m0s
 ```
 

--- a/docs/components/query-frontend.md
+++ b/docs/components/query-frontend.md
@@ -77,6 +77,12 @@ config:
   max_get_multi_batch_size: 0
   dns_provider_update_interval: 0s
   auto_discovery: false
+  set_async_circuit_breaker_enabled: false
+  set_async_circuit_breaker_half_open_max_requests: 0
+  set_async_circuit_breaker_open_duration: 0s
+  set_async_circuit_breaker_min_requests: 0
+  set_async_circuit_breaker_consecutive_failures: 0
+  set_async_circuit_breaker_failure_percent: 0
   expiration: 0s
 ```
 
@@ -132,6 +138,12 @@ config:
   master_name: ""
   max_async_buffer_size: 10000
   max_async_concurrency: 20
+  set_async_circuit_breaker_enabled: false
+  set_async_circuit_breaker_half_open_max_requests: 10
+  set_async_circuit_breaker_open_duration: 5s
+  set_async_circuit_breaker_min_requests: 50
+  set_async_circuit_breaker_consecutive_failures: 5
+  set_async_circuit_breaker_failure_percent: 0.05
   expiration: 24h0m0s
 ```
 

--- a/docs/components/store.md
+++ b/docs/components/store.md
@@ -325,6 +325,12 @@ config:
   max_get_multi_batch_size: 0
   dns_provider_update_interval: 0s
   auto_discovery: false
+  set_async_circuit_breaker_enabled: false
+  set_async_circuit_breaker_half_open_max_requests: 0
+  set_async_circuit_breaker_open_duration: 0s
+  set_async_circuit_breaker_min_requests: 0
+  set_async_circuit_breaker_consecutive_failures: 0
+  set_async_circuit_breaker_failure_percent: 0
 enabled_items: []
 ttl: 0s
 ```
@@ -340,6 +346,12 @@ While the remaining settings are **optional**:
 - `max_async_concurrency`: maximum number of concurrent asynchronous operations can occur.
 - `max_async_buffer_size`: maximum number of enqueued asynchronous operations allowed.
 - `max_get_multi_concurrency`: maximum number of concurrent connections when fetching keys. If set to `0`, the concurrency is unlimited.
+- `set_async_circuit_breaker_enabled`: `true` to enable circuite breaker for asynchronous operations. The circuit breaker consists of three states: closed, half-open, and open. It begins in the closed state. When the total requests exceed `set_async_circuit_breaker_min_requests`, and either consecutive failures occur or the failure percentage is excessively high according to the configured values, the circuit breaker transitions to the open state. This results in the rejection of all asynchronous operations. After `set_async_circuit_breaker_open_duration`, the circuit breaker transitions to the half-open state, where it allows `set_async_circuit_breaker_half_open_max_requests` asynchronous operations to be processed in order to test if the conditions have improved. If they have not, the state transitions back to open; if they have, it transitions to the closed state. Following each 10 seconds interval in the closed state, the circuit breaker resets its metrics and repeats this cycle.
+- `set_async_circuit_breaker_half_open_max_requests`: maximum number of requests allowed to pass through when the circuit breaker is half-open. If set to 0, the circuit breaker allows only 1 request.
+- `set_async_circuit_breaker_open_duration`: the period of the open state after which the state of the circuit breaker becomes half-open. If set to 0, the circuit breaker resets it to 60 seconds.
+- `set_async_circuit_breaker_min_requests`: minimal requests to trigger the circuit breaker, 0 signifies no requirements.
+- `set_async_circuit_breaker_consecutive_failures`: consecutive failures based on `set_async_circuit_breaker_min_requests` to determine if the circuit breaker should open.
+- `set_async_circuit_breaker_failure_percent`: the failure percentage, which is based on `set_async_circuit_breaker_min_requests`, to determine if the circuit breaker should open.
 - `max_get_multi_batch_size`: maximum number of keys a single underlying operation should fetch. If more keys are specified, internally keys are splitted into multiple batches and fetched concurrently, honoring `max_get_multi_concurrency`. If set to `0`, the batch size is unlimited.
 - `max_item_size`: maximum size of an item to be stored in memcached. This option should be set to the same value of memcached `-I` flag (defaults to 1MB) in order to avoid wasting network round trips to store items larger than the max item size allowed in memcached. If set to `0`, the item size is unlimited.
 - `dns_provider_update_interval`: the DNS discovery update interval.
@@ -376,6 +388,12 @@ config:
   master_name: ""
   max_async_buffer_size: 10000
   max_async_concurrency: 20
+  set_async_circuit_breaker_enabled: false
+  set_async_circuit_breaker_half_open_max_requests: 10
+  set_async_circuit_breaker_open_duration: 5s
+  set_async_circuit_breaker_min_requests: 50
+  set_async_circuit_breaker_consecutive_failures: 5
+  set_async_circuit_breaker_failure_percent: 0.05
 enabled_items: []
 ttl: 0s
 ```

--- a/docs/components/store.md
+++ b/docs/components/store.md
@@ -325,12 +325,13 @@ config:
   max_get_multi_batch_size: 0
   dns_provider_update_interval: 0s
   auto_discovery: false
-  set_async_circuit_breaker_enabled: false
-  set_async_circuit_breaker_half_open_max_requests: 0
-  set_async_circuit_breaker_open_duration: 0s
-  set_async_circuit_breaker_min_requests: 0
-  set_async_circuit_breaker_consecutive_failures: 0
-  set_async_circuit_breaker_failure_percent: 0
+  set_async_circuit_breaker_config:
+    enabled: false
+    half_open_max_requests: 0
+    open_duration: 0s
+    min_requests: 0
+    consecutive_failures: 0
+    failure_percent: 0
 enabled_items: []
 ttl: 0s
 ```
@@ -346,16 +347,17 @@ While the remaining settings are **optional**:
 - `max_async_concurrency`: maximum number of concurrent asynchronous operations can occur.
 - `max_async_buffer_size`: maximum number of enqueued asynchronous operations allowed.
 - `max_get_multi_concurrency`: maximum number of concurrent connections when fetching keys. If set to `0`, the concurrency is unlimited.
-- `set_async_circuit_breaker_enabled`: `true` to enable circuite breaker for asynchronous operations. The circuit breaker consists of three states: closed, half-open, and open. It begins in the closed state. When the total requests exceed `set_async_circuit_breaker_min_requests`, and either consecutive failures occur or the failure percentage is excessively high according to the configured values, the circuit breaker transitions to the open state. This results in the rejection of all asynchronous operations. After `set_async_circuit_breaker_open_duration`, the circuit breaker transitions to the half-open state, where it allows `set_async_circuit_breaker_half_open_max_requests` asynchronous operations to be processed in order to test if the conditions have improved. If they have not, the state transitions back to open; if they have, it transitions to the closed state. Following each 10 seconds interval in the closed state, the circuit breaker resets its metrics and repeats this cycle.
-- `set_async_circuit_breaker_half_open_max_requests`: maximum number of requests allowed to pass through when the circuit breaker is half-open. If set to 0, the circuit breaker allows only 1 request.
-- `set_async_circuit_breaker_open_duration`: the period of the open state after which the state of the circuit breaker becomes half-open. If set to 0, the circuit breaker resets it to 60 seconds.
-- `set_async_circuit_breaker_min_requests`: minimal requests to trigger the circuit breaker, 0 signifies no requirements.
-- `set_async_circuit_breaker_consecutive_failures`: consecutive failures based on `set_async_circuit_breaker_min_requests` to determine if the circuit breaker should open.
-- `set_async_circuit_breaker_failure_percent`: the failure percentage, which is based on `set_async_circuit_breaker_min_requests`, to determine if the circuit breaker should open.
 - `max_get_multi_batch_size`: maximum number of keys a single underlying operation should fetch. If more keys are specified, internally keys are splitted into multiple batches and fetched concurrently, honoring `max_get_multi_concurrency`. If set to `0`, the batch size is unlimited.
 - `max_item_size`: maximum size of an item to be stored in memcached. This option should be set to the same value of memcached `-I` flag (defaults to 1MB) in order to avoid wasting network round trips to store items larger than the max item size allowed in memcached. If set to `0`, the item size is unlimited.
 - `dns_provider_update_interval`: the DNS discovery update interval.
 - `auto_discovery`: whether to use the auto-discovery mechanism for memcached.
+- `set_async_circuit_breaker_config`: the configuration for the circuit breaker for asynchronous set operations.
+  - `enabled`: `true` to enable circuite breaker for asynchronous operations. The circuit breaker consists of three states: closed, half-open, and open. It begins in the closed state. When the total requests exceed `min_requests`, and either consecutive failures occur or the failure percentage is excessively high according to the configured values, the circuit breaker transitions to the open state. This results in the rejection of all asynchronous operations. After `open_duration`, the circuit breaker transitions to the half-open state, where it allows `half_open_max_requests` asynchronous operations to be processed in order to test if the conditions have improved. If they have not, the state transitions back to open; if they have, it transitions to the closed state. Following each 10 seconds interval in the closed state, the circuit breaker resets its metrics and repeats this cycle.
+  - `half_open_max_requests`: maximum number of requests allowed to pass through when the circuit breaker is half-open. If set to 0, the circuit breaker allows only 1 request.
+  - `open_duration`: the period of the open state after which the state of the circuit breaker becomes half-open. If set to 0, the circuit breaker utilizes the default value of 60 seconds.
+  - `min_requests`: minimal requests to trigger the circuit breaker, 0 signifies no requirements.
+  - `consecutive_failures`: consecutive failures based on `min_requests` to determine if the circuit breaker should open.
+  - `failure_percent`: the failure percentage, which is based on `min_requests`, to determine if the circuit breaker should open.
 - `enabled_items`: selectively choose what types of items to cache. Supported values are `Postings`, `Series` and `ExpandedPostings`. By default, all items are cached.
 - `ttl`: ttl to store index cache items in memcached.
 
@@ -388,12 +390,13 @@ config:
   master_name: ""
   max_async_buffer_size: 10000
   max_async_concurrency: 20
-  set_async_circuit_breaker_enabled: false
-  set_async_circuit_breaker_half_open_max_requests: 10
-  set_async_circuit_breaker_open_duration: 5s
-  set_async_circuit_breaker_min_requests: 50
-  set_async_circuit_breaker_consecutive_failures: 5
-  set_async_circuit_breaker_failure_percent: 0.05
+  set_async_circuit_breaker_config:
+    enabled: false
+    half_open_max_requests: 10
+    open_duration: 5s
+    min_requests: 50
+    consecutive_failures: 5
+    failure_percent: 0.05
 enabled_items: []
 ttl: 0s
 ```

--- a/pkg/cacheutil/cacheutil.go
+++ b/pkg/cacheutil/cacheutil.go
@@ -5,12 +5,27 @@ package cacheutil
 
 import (
 	"context"
+	"time"
 
+	"github.com/pkg/errors"
+	"github.com/sony/gobreaker"
 	"golang.org/x/sync/errgroup"
 
-	"github.com/sony/gobreaker"
-
 	"github.com/thanos-io/thanos/pkg/gate"
+)
+
+var (
+	errCircuitBreakerConsecutiveFailuresNotPositive = errors.New("circuit breaker: consecutive failures must be greater than 0")
+	errCircuitBreakerFailurePercentInvalid          = errors.New("circuit breaker: failure percent must be in range (0,1]")
+
+	defaultCircuitBreakerConfig = CircuitBreakerConfig{
+		Enabled:             false,
+		HalfOpenMaxRequests: 10,
+		OpenDuration:        5 * time.Second,
+		MinRequests:         50,
+		ConsecutiveFailures: 5,
+		FailurePercent:      0.05,
+	}
 )
 
 // doWithBatch do func with batch and gate. batchSize==0 means one batch. gate==nil means no gate.
@@ -48,6 +63,39 @@ type CircuitBreaker interface {
 	Execute(func() error) error
 }
 
+// CircuitBreakerConfig is the config for the circuite breaker.
+type CircuitBreakerConfig struct {
+	// Enabled enables circuite breaker.
+	Enabled bool `yaml:"enabled"`
+
+	// HalfOpenMaxRequests is the maximum number of requests allowed to pass through
+	// when the circuit breaker is half-open.
+	// If set to 0, the circuit breaker allows only 1 request.
+	HalfOpenMaxRequests uint32 `yaml:"half_open_max_requests"`
+	// OpenDuration is the period of the open state after which the state of the circuit breaker becomes half-open.
+	// If set to 0, the circuit breaker utilizes the default value of 60 seconds.
+	OpenDuration time.Duration `yaml:"open_duration"`
+	// MinRequests is minimal requests to trigger the circuit breaker.
+	MinRequests uint32 `yaml:"min_requests"`
+	// ConsecutiveFailures represents consecutive failures based on CircuitBreakerMinRequests to determine if the circuit breaker should open.
+	ConsecutiveFailures uint32 `yaml:"consecutive_failures"`
+	// FailurePercent represents the failure percentage, which is based on CircuitBreakerMinRequests, to determine if the circuit breaker should open.
+	FailurePercent float64 `yaml:"failure_percent"`
+}
+
+func (c CircuitBreakerConfig) validate() error {
+	if !c.Enabled {
+		return nil
+	}
+	if c.ConsecutiveFailures == 0 {
+		return errCircuitBreakerConsecutiveFailuresNotPositive
+	}
+	if c.FailurePercent <= 0 || c.FailurePercent > 1 {
+		return errCircuitBreakerFailurePercentInvalid
+	}
+	return nil
+}
+
 type noopCircuitBreaker struct{}
 
 func (noopCircuitBreaker) Execute(f func() error) error { return f() }
@@ -61,4 +109,21 @@ func (cb gobreakerCircuitBreaker) Execute(f func() error) error {
 		return nil, f()
 	})
 	return err
+}
+
+func newCircuitBreaker(name string, config CircuitBreakerConfig) CircuitBreaker {
+	if !config.Enabled {
+		return noopCircuitBreaker{}
+	}
+	return gobreakerCircuitBreaker{gobreaker.NewCircuitBreaker(gobreaker.Settings{
+		Name:        name,
+		MaxRequests: config.HalfOpenMaxRequests,
+		Interval:    10 * time.Second,
+		Timeout:     config.OpenDuration,
+		ReadyToTrip: func(counts gobreaker.Counts) bool {
+			return counts.Requests >= config.MinRequests &&
+				(counts.ConsecutiveFailures >= uint32(config.ConsecutiveFailures) ||
+					float64(counts.TotalFailures)/float64(counts.Requests) >= config.FailurePercent)
+		},
+	})}
 }

--- a/pkg/cacheutil/memcached_client.go
+++ b/pkg/cacheutil/memcached_client.go
@@ -184,11 +184,13 @@ func (c *MemcachedClientConfig) validate() error {
 		return errMemcachedMaxAsyncConcurrencyNotPositive
 	}
 
-	if c.SetAsyncCircuitBreakerConsecutiveFailures == 0 {
-		return errCircuitBreakerConsecutiveFailuresNotPositive
-	}
-	if c.SetAsyncCircuitBreakerFailurePercent <= 0 || c.SetAsyncCircuitBreakerFailurePercent > 1 {
-		return errCircuitBreakerFailurePercentInvalid
+	if c.SetAsyncCircuitBreakerEnabled {
+		if c.SetAsyncCircuitBreakerConsecutiveFailures == 0 {
+			return errCircuitBreakerConsecutiveFailuresNotPositive
+		}
+		if c.SetAsyncCircuitBreakerFailurePercent <= 0 || c.SetAsyncCircuitBreakerFailurePercent > 1 {
+			return errCircuitBreakerFailurePercentInvalid
+		}
 	}
 	return nil
 }

--- a/pkg/cacheutil/memcached_client.go
+++ b/pkg/cacheutil/memcached_client.go
@@ -153,16 +153,6 @@ type MemcachedClientConfig struct {
 	AutoDiscovery bool `yaml:"auto_discovery"`
 
 	// SetAsyncCircuitBreakerEnabled enables circuite breaker for SetAsync operations.
-	//
-	// The circuit breaker consists of three states: closed, half-open, and open.
-	// It begins in the closed state. When the total requests exceed SetAsyncCircuitBreakerMinRequests,
-	// and either consecutive failures occur or the failure percentage is excessively high according
-	// to the configured values, the circuit breaker transitions to the open state.
-	// This results in the rejection of all SetAsync requests. After SetAsyncCircuitBreakerOpenDuration,
-	// the circuit breaker transitions to the half-open state, where it allows SetAsyncCircuitBreakerHalfOpenMaxRequests
-	// SetAsync requests to be processed in order to test if the conditions have improved. If they have not,
-	// the state transitions back to open; if they have, it transitions to the closed state. Following each 10 seconds
-	// interval in the closed state, the circuit breaker resets its metrics and repeats this cycle.
 	SetAsyncCircuitBreakerEnabled bool `yaml:"set_async_circuit_breaker_enabled"`
 	// SetAsyncCircuitBreakerHalfOpenMaxRequests is the maximum number of requests allowed to pass through
 	// when the circuit breaker is half-open.

--- a/pkg/cacheutil/memcached_client.go
+++ b/pkg/cacheutil/memcached_client.go
@@ -17,6 +17,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/sony/gobreaker"
 	"gopkg.in/yaml.v2"
 
 	"github.com/thanos-io/thanos/pkg/discovery/dns"
@@ -40,9 +41,11 @@ const (
 )
 
 var (
-	errMemcachedConfigNoAddrs                  = errors.New("no memcached addresses provided")
-	errMemcachedDNSUpdateIntervalNotPositive   = errors.New("DNS provider update interval must be positive")
-	errMemcachedMaxAsyncConcurrencyNotPositive = errors.New("max async concurrency must be positive")
+	errMemcachedConfigNoAddrs                       = errors.New("no memcached addresses provided")
+	errMemcachedDNSUpdateIntervalNotPositive        = errors.New("DNS provider update interval must be positive")
+	errMemcachedMaxAsyncConcurrencyNotPositive      = errors.New("max async concurrency must be positive")
+	errCircuitBreakerConsecutiveFailuresNotPositive = errors.New("set async circuit breaker: consecutive failures must be greater than 0")
+	errCircuitBreakerFailurePercentInvalid          = errors.New("set async circuit breaker: failure percent must be in range (0,1]")
 
 	defaultMemcachedClientConfig = MemcachedClientConfig{
 		Timeout:                   500 * time.Millisecond,
@@ -54,6 +57,11 @@ var (
 		MaxGetMultiBatchSize:      0,
 		DNSProviderUpdateInterval: 10 * time.Second,
 		AutoDiscovery:             false,
+		SetAsyncCircuitBreakerHalfOpenMaxRequests: 10,
+		SetAsyncCircuitBreakerOpenDuration:        5 * time.Second,
+		SetAsyncCircuitBreakerMinRequests:         50,
+		SetAsyncCircuitBreakerConsecutiveFailures: 5,
+		SetAsyncCircuitBreakerFailurePercent:      0.05,
 	}
 )
 
@@ -141,6 +149,20 @@ type MemcachedClientConfig struct {
 
 	// AutoDiscovery configures memached client to perform auto-discovery instead of DNS resolution
 	AutoDiscovery bool `yaml:"auto_discovery"`
+
+	// SetAsyncCircuitBreakerHalfOpenMaxRequests is the maximum number of requests allowed to pass through
+	// when the circuit breaker is half-open.
+	// If set to 0, the circuit breaker allows only 1 request.
+	SetAsyncCircuitBreakerHalfOpenMaxRequests uint32 `yaml:"set_async_circuit_breaker_half_open_max_requests"`
+	// SetAsyncCircuitBreakerOpenDuration is the period of the open state after which the state of the circuit breaker becomes half-open.
+	// If set to 0, the circuit breaker resets it to 60 seconds.
+	SetAsyncCircuitBreakerOpenDuration time.Duration `yaml:"set_async_circuit_breaker_open_duration"`
+	// SetAsyncCircuitBreakerMinRequests is minimal requests to trigger the circuit breaker.
+	SetAsyncCircuitBreakerMinRequests uint32 `yaml:"set_async_circuit_breaker_min_requests"`
+	// SetAsyncCircuitBreakerConsecutiveFailures represents consecutive failures based on CircuitBreakerMinRequests to determine if the circuit breaker should open.
+	SetAsyncCircuitBreakerConsecutiveFailures uint32 `yaml:"set_async_circuit_breaker_consecutive_failures"`
+	// SetAsyncCircuitBreakerFailurePercent represents the failure percentage, which is based on CircuitBreakerMinRequests, to determine if the circuit breaker should open.
+	SetAsyncCircuitBreakerFailurePercent float64 `yaml:"set_async_circuit_breaker_failure_percent"`
 }
 
 func (c *MemcachedClientConfig) validate() error {
@@ -158,6 +180,12 @@ func (c *MemcachedClientConfig) validate() error {
 		return errMemcachedMaxAsyncConcurrencyNotPositive
 	}
 
+	if c.SetAsyncCircuitBreakerConsecutiveFailures == 0 {
+		return errCircuitBreakerConsecutiveFailuresNotPositive
+	}
+	if c.SetAsyncCircuitBreakerFailurePercent <= 0 || c.SetAsyncCircuitBreakerFailurePercent > 1 {
+		return errCircuitBreakerFailurePercentInvalid
+	}
 	return nil
 }
 
@@ -195,6 +223,8 @@ type memcachedClient struct {
 	dataSize   *prometheus.HistogramVec
 
 	p *AsyncOperationProcessor
+
+	setAsyncCircuitBreaker *gobreaker.CircuitBreaker
 }
 
 // AddressProvider performs node address resolution given a list of clusters.
@@ -278,6 +308,17 @@ func newMemcachedClient(
 			gate.Gets,
 		),
 		p: NewAsyncOperationProcessor(config.MaxAsyncBufferSize, config.MaxAsyncConcurrency),
+		setAsyncCircuitBreaker: gobreaker.NewCircuitBreaker(gobreaker.Settings{
+			Name:        "memcached-set-async",
+			MaxRequests: config.SetAsyncCircuitBreakerHalfOpenMaxRequests,
+			Interval:    10 * time.Second,
+			Timeout:     config.SetAsyncCircuitBreakerOpenDuration,
+			ReadyToTrip: func(counts gobreaker.Counts) bool {
+				return counts.Requests >= config.SetAsyncCircuitBreakerMinRequests &&
+					(counts.ConsecutiveFailures >= uint32(config.SetAsyncCircuitBreakerConsecutiveFailures) ||
+						float64(counts.TotalFailures)/float64(counts.Requests) >= config.SetAsyncCircuitBreakerFailurePercent)
+			},
+		}),
 	}
 
 	c.clientInfo = promauto.With(reg).NewGaugeFunc(prometheus.GaugeOpts{
@@ -375,22 +416,31 @@ func (c *memcachedClient) SetAsync(key string, value []byte, ttl time.Duration) 
 		start := time.Now()
 		c.operations.WithLabelValues(opSet).Inc()
 
-		err := c.client.Set(&memcache.Item{
-			Key:        key,
-			Value:      value,
-			Expiration: int32(time.Now().Add(ttl).Unix()),
+		_, err := c.setAsyncCircuitBreaker.Execute(func() (any, error) {
+			return nil, c.client.Set(&memcache.Item{
+				Key:        key,
+				Value:      value,
+				Expiration: int32(time.Now().Add(ttl).Unix()),
+			})
 		})
 		if err != nil {
-			// If the PickServer will fail for any reason the server address will be nil
-			// and so missing in the logs. We're OK with that (it's a best effort).
-			serverAddr, _ := c.selector.PickServer(key)
-			level.Debug(c.logger).Log(
-				"msg", "failed to store item to memcached",
-				"key", key,
-				"sizeBytes", len(value),
-				"server", serverAddr,
-				"err", err,
-			)
+			if errors.Is(err, gobreaker.ErrOpenState) || errors.Is(err, gobreaker.ErrTooManyRequests) {
+				level.Warn(c.logger).Log(
+					"msg", "circuit breaker disallows storing item in memcached",
+					"key", key,
+					"err", err)
+			} else {
+				// If the PickServer will fail for any reason the server address will be nil
+				// and so missing in the logs. We're OK with that (it's a best effort).
+				serverAddr, _ := c.selector.PickServer(key)
+				level.Debug(c.logger).Log(
+					"msg", "failed to store item to memcached",
+					"key", key,
+					"sizeBytes", len(value),
+					"server", serverAddr,
+					"err", err,
+				)
+			}
 			c.trackError(opSet, err)
 			return
 		}

--- a/pkg/cacheutil/memcached_client.go
+++ b/pkg/cacheutil/memcached_client.go
@@ -41,11 +41,9 @@ const (
 )
 
 var (
-	errMemcachedConfigNoAddrs                       = errors.New("no memcached addresses provided")
-	errMemcachedDNSUpdateIntervalNotPositive        = errors.New("DNS provider update interval must be positive")
-	errMemcachedMaxAsyncConcurrencyNotPositive      = errors.New("max async concurrency must be positive")
-	errCircuitBreakerConsecutiveFailuresNotPositive = errors.New("set async circuit breaker: consecutive failures must be greater than 0")
-	errCircuitBreakerFailurePercentInvalid          = errors.New("set async circuit breaker: failure percent must be in range (0,1]")
+	errMemcachedConfigNoAddrs                  = errors.New("no memcached addresses provided")
+	errMemcachedDNSUpdateIntervalNotPositive   = errors.New("DNS provider update interval must be positive")
+	errMemcachedMaxAsyncConcurrencyNotPositive = errors.New("max async concurrency must be positive")
 
 	defaultMemcachedClientConfig = MemcachedClientConfig{
 		Timeout:                   500 * time.Millisecond,
@@ -58,12 +56,7 @@ var (
 		DNSProviderUpdateInterval: 10 * time.Second,
 		AutoDiscovery:             false,
 
-		SetAsyncCircuitBreakerEnabled:             false,
-		SetAsyncCircuitBreakerHalfOpenMaxRequests: 10,
-		SetAsyncCircuitBreakerOpenDuration:        5 * time.Second,
-		SetAsyncCircuitBreakerMinRequests:         50,
-		SetAsyncCircuitBreakerConsecutiveFailures: 5,
-		SetAsyncCircuitBreakerFailurePercent:      0.05,
+		SetAsyncCircuitBreaker: defaultCircuitBreakerConfig,
 	}
 )
 
@@ -152,21 +145,8 @@ type MemcachedClientConfig struct {
 	// AutoDiscovery configures memached client to perform auto-discovery instead of DNS resolution
 	AutoDiscovery bool `yaml:"auto_discovery"`
 
-	// SetAsyncCircuitBreakerEnabled enables circuite breaker for SetAsync operations.
-	SetAsyncCircuitBreakerEnabled bool `yaml:"set_async_circuit_breaker_enabled"`
-	// SetAsyncCircuitBreakerHalfOpenMaxRequests is the maximum number of requests allowed to pass through
-	// when the circuit breaker is half-open.
-	// If set to 0, the circuit breaker allows only 1 request.
-	SetAsyncCircuitBreakerHalfOpenMaxRequests uint32 `yaml:"set_async_circuit_breaker_half_open_max_requests"`
-	// SetAsyncCircuitBreakerOpenDuration is the period of the open state after which the state of the circuit breaker becomes half-open.
-	// If set to 0, the circuit breaker resets it to 60 seconds.
-	SetAsyncCircuitBreakerOpenDuration time.Duration `yaml:"set_async_circuit_breaker_open_duration"`
-	// SetAsyncCircuitBreakerMinRequests is minimal requests to trigger the circuit breaker.
-	SetAsyncCircuitBreakerMinRequests uint32 `yaml:"set_async_circuit_breaker_min_requests"`
-	// SetAsyncCircuitBreakerConsecutiveFailures represents consecutive failures based on CircuitBreakerMinRequests to determine if the circuit breaker should open.
-	SetAsyncCircuitBreakerConsecutiveFailures uint32 `yaml:"set_async_circuit_breaker_consecutive_failures"`
-	// SetAsyncCircuitBreakerFailurePercent represents the failure percentage, which is based on CircuitBreakerMinRequests, to determine if the circuit breaker should open.
-	SetAsyncCircuitBreakerFailurePercent float64 `yaml:"set_async_circuit_breaker_failure_percent"`
+	// SetAsyncCircuitBreaker configures the circuit breaker for SetAsync operations.
+	SetAsyncCircuitBreaker CircuitBreakerConfig `yaml:"set_async_circuit_breaker_config"`
 }
 
 func (c *MemcachedClientConfig) validate() error {
@@ -184,13 +164,8 @@ func (c *MemcachedClientConfig) validate() error {
 		return errMemcachedMaxAsyncConcurrencyNotPositive
 	}
 
-	if c.SetAsyncCircuitBreakerEnabled {
-		if c.SetAsyncCircuitBreakerConsecutiveFailures == 0 {
-			return errCircuitBreakerConsecutiveFailuresNotPositive
-		}
-		if c.SetAsyncCircuitBreakerFailurePercent <= 0 || c.SetAsyncCircuitBreakerFailurePercent > 1 {
-			return errCircuitBreakerFailurePercentInvalid
-		}
+	if err := c.SetAsyncCircuitBreaker.validate(); err != nil {
+		return err
 	}
 	return nil
 }
@@ -314,20 +289,7 @@ func newMemcachedClient(
 			gate.Gets,
 		),
 		p:                      NewAsyncOperationProcessor(config.MaxAsyncBufferSize, config.MaxAsyncConcurrency),
-		setAsyncCircuitBreaker: noopCircuitBreaker{},
-	}
-	if config.SetAsyncCircuitBreakerEnabled {
-		c.setAsyncCircuitBreaker = gobreakerCircuitBreaker{gobreaker.NewCircuitBreaker(gobreaker.Settings{
-			Name:        "memcached-set-async",
-			MaxRequests: config.SetAsyncCircuitBreakerHalfOpenMaxRequests,
-			Interval:    10 * time.Second,
-			Timeout:     config.SetAsyncCircuitBreakerOpenDuration,
-			ReadyToTrip: func(counts gobreaker.Counts) bool {
-				return counts.Requests >= config.SetAsyncCircuitBreakerMinRequests &&
-					(counts.ConsecutiveFailures >= uint32(config.SetAsyncCircuitBreakerConsecutiveFailures) ||
-						float64(counts.TotalFailures)/float64(counts.Requests) >= config.SetAsyncCircuitBreakerFailurePercent)
-			},
-		})}
+		setAsyncCircuitBreaker: newCircuitBreaker("memcached-set-async", config.SetAsyncCircuitBreaker),
 	}
 
 	c.clientInfo = promauto.With(reg).NewGaugeFunc(prometheus.GaugeOpts{

--- a/pkg/cacheutil/redis_client.go
+++ b/pkg/cacheutil/redis_client.go
@@ -155,11 +155,13 @@ func (c *RedisClientConfig) validate() error {
 		}
 	}
 
-	if c.SetAsyncCircuitBreakerConsecutiveFailures == 0 {
-		return errCircuitBreakerConsecutiveFailuresNotPositive
-	}
-	if c.SetAsyncCircuitBreakerFailurePercent <= 0 || c.SetAsyncCircuitBreakerFailurePercent > 1 {
-		return errCircuitBreakerFailurePercentInvalid
+	if c.SetAsyncCircuitBreakerEnabled {
+		if c.SetAsyncCircuitBreakerConsecutiveFailures == 0 {
+			return errCircuitBreakerConsecutiveFailuresNotPositive
+		}
+		if c.SetAsyncCircuitBreakerFailurePercent <= 0 || c.SetAsyncCircuitBreakerFailurePercent > 1 {
+			return errCircuitBreakerFailurePercentInvalid
+		}
 	}
 	return nil
 }

--- a/pkg/cacheutil/redis_client.go
+++ b/pkg/cacheutil/redis_client.go
@@ -40,6 +40,8 @@ var (
 		TLSConfig:              TLSConfig{},
 		MaxAsyncConcurrency:    20,
 		MaxAsyncBufferSize:     10000,
+
+		SetAsyncCircuitBreakerEnabled:             false,
 		SetAsyncCircuitBreakerHalfOpenMaxRequests: 10,
 		SetAsyncCircuitBreakerOpenDuration:        5 * time.Second,
 		SetAsyncCircuitBreakerMinRequests:         50,
@@ -126,16 +128,6 @@ type RedisClientConfig struct {
 	MaxAsyncConcurrency int `yaml:"max_async_concurrency"`
 
 	// SetAsyncCircuitBreakerEnabled enables circuite breaker for SetAsync operations.
-	//
-	// The circuit breaker consists of three states: closed, half-open, and open.
-	// It begins in the closed state. When the total requests exceed SetAsyncCircuitBreakerMinRequests,
-	// and either consecutive failures occur or the failure percentage is excessively high according
-	// to the configured values, the circuit breaker transitions to the open state.
-	// This results in the rejection of all SetAsync requests. After SetAsyncCircuitBreakerOpenDuration,
-	// the circuit breaker transitions to the half-open state, where it allows SetAsyncCircuitBreakerHalfOpenMaxRequests
-	// SetAsync requests to be processed in order to test if the conditions have improved. If they have not,
-	// the state transitions back to open; if they have, it transitions to the closed state. Following each 10 seconds
-	// interval in the closed state, the circuit breaker resets its metrics and repeats this cycle.
 	SetAsyncCircuitBreakerEnabled bool `yaml:"set_async_circuit_breaker_enabled"`
 	// SetAsyncCircuitBreakerHalfOpenMaxRequests is the maximum number of requests allowed to pass through
 	// when the circuit breaker is half-open.

--- a/pkg/cacheutil/redis_client_test.go
+++ b/pkg/cacheutil/redis_client_test.go
@@ -203,8 +203,8 @@ func TestValidateRedisConfig(t *testing.T) {
 			config: func() RedisClientConfig {
 				cfg := DefaultRedisClientConfig
 				cfg.Addr = addr
-				cfg.SetAsyncCircuitBreakerEnabled = false
-				cfg.SetAsyncCircuitBreakerConsecutiveFailures = 0
+				cfg.SetAsyncCircuitBreaker.Enabled = false
+				cfg.SetAsyncCircuitBreaker.ConsecutiveFailures = 0
 				return cfg
 			},
 			expect_err: false,
@@ -214,8 +214,8 @@ func TestValidateRedisConfig(t *testing.T) {
 			config: func() RedisClientConfig {
 				cfg := DefaultRedisClientConfig
 				cfg.Addr = addr
-				cfg.SetAsyncCircuitBreakerEnabled = true
-				cfg.SetAsyncCircuitBreakerConsecutiveFailures = 0
+				cfg.SetAsyncCircuitBreaker.Enabled = true
+				cfg.SetAsyncCircuitBreaker.ConsecutiveFailures = 0
 				return cfg
 			},
 			expect_err: true,
@@ -225,8 +225,8 @@ func TestValidateRedisConfig(t *testing.T) {
 			config: func() RedisClientConfig {
 				cfg := DefaultRedisClientConfig
 				cfg.Addr = addr
-				cfg.SetAsyncCircuitBreakerEnabled = true
-				cfg.SetAsyncCircuitBreakerFailurePercent = 0
+				cfg.SetAsyncCircuitBreaker.Enabled = true
+				cfg.SetAsyncCircuitBreaker.FailurePercent = 0
 				return cfg
 			},
 			expect_err: true,

--- a/pkg/cacheutil/redis_client_test.go
+++ b/pkg/cacheutil/redis_client_test.go
@@ -138,6 +138,7 @@ func TestRedisClient(t *testing.T) {
 }
 
 func TestValidateRedisConfig(t *testing.T) {
+	addr := "127.0.0.1:6789"
 	tests := []struct {
 		name       string
 		config     func() RedisClientConfig
@@ -147,7 +148,7 @@ func TestValidateRedisConfig(t *testing.T) {
 			name: "simpleConfig",
 			config: func() RedisClientConfig {
 				cfg := DefaultRedisClientConfig
-				cfg.Addr = "127.0.0.1:6789"
+				cfg.Addr = addr
 				cfg.Username = "user"
 				cfg.Password = "1234"
 				return cfg
@@ -158,7 +159,7 @@ func TestValidateRedisConfig(t *testing.T) {
 			name: "tlsConfigDefaults",
 			config: func() RedisClientConfig {
 				cfg := DefaultRedisClientConfig
-				cfg.Addr = "127.0.0.1:6789"
+				cfg.Addr = addr
 				cfg.Username = "user"
 				cfg.Password = "1234"
 				cfg.TLSEnabled = true
@@ -170,7 +171,7 @@ func TestValidateRedisConfig(t *testing.T) {
 			name: "tlsClientCertConfig",
 			config: func() RedisClientConfig {
 				cfg := DefaultRedisClientConfig
-				cfg.Addr = "127.0.0.1:6789"
+				cfg.Addr = addr
 				cfg.Username = "user"
 				cfg.Password = "1234"
 				cfg.TLSEnabled = true
@@ -186,7 +187,7 @@ func TestValidateRedisConfig(t *testing.T) {
 			name: "tlsInvalidClientCertConfig",
 			config: func() RedisClientConfig {
 				cfg := DefaultRedisClientConfig
-				cfg.Addr = "127.0.0.1:6789"
+				cfg.Addr = addr
 				cfg.Username = "user"
 				cfg.Password = "1234"
 				cfg.TLSEnabled = true
@@ -201,7 +202,7 @@ func TestValidateRedisConfig(t *testing.T) {
 			name: "SetAsyncCircuitBreakerDisabled",
 			config: func() RedisClientConfig {
 				cfg := DefaultRedisClientConfig
-				cfg.Addr = "127.0.0.1:6789"
+				cfg.Addr = addr
 				cfg.SetAsyncCircuitBreakerEnabled = false
 				cfg.SetAsyncCircuitBreakerConsecutiveFailures = 0
 				return cfg
@@ -212,7 +213,7 @@ func TestValidateRedisConfig(t *testing.T) {
 			name: "invalidCircuitBreakerFailurePercent",
 			config: func() RedisClientConfig {
 				cfg := DefaultRedisClientConfig
-				cfg.Addr = "127.0.0.1:6789"
+				cfg.Addr = addr
 				cfg.SetAsyncCircuitBreakerEnabled = true
 				cfg.SetAsyncCircuitBreakerConsecutiveFailures = 0
 				return cfg
@@ -223,7 +224,7 @@ func TestValidateRedisConfig(t *testing.T) {
 			name: "invalidCircuitBreakerFailurePercent",
 			config: func() RedisClientConfig {
 				cfg := DefaultRedisClientConfig
-				cfg.Addr = "127.0.0.1:6789"
+				cfg.Addr = addr
 				cfg.SetAsyncCircuitBreakerEnabled = true
 				cfg.SetAsyncCircuitBreakerFailurePercent = 0
 				return cfg

--- a/pkg/cacheutil/redis_client_test.go
+++ b/pkg/cacheutil/redis_client_test.go
@@ -197,6 +197,24 @@ func TestValidateRedisConfig(t *testing.T) {
 			},
 			expect_err: true,
 		},
+		{
+			name: "invalidCircuitBreakerFailurePercent",
+			config: func() RedisClientConfig {
+				cfg := DefaultRedisClientConfig
+				cfg.SetAsyncCircuitBreakerConsecutiveFailures = 0
+				return cfg
+			},
+			expect_err: true,
+		},
+		{
+			name: "invalidCircuitBreakerFailurePercent",
+			config: func() RedisClientConfig {
+				cfg := DefaultRedisClientConfig
+				cfg.SetAsyncCircuitBreakerFailurePercent = 0
+				return cfg
+			},
+			expect_err: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/cacheutil/redis_client_test.go
+++ b/pkg/cacheutil/redis_client_test.go
@@ -198,9 +198,22 @@ func TestValidateRedisConfig(t *testing.T) {
 			expect_err: true,
 		},
 		{
+			name: "SetAsyncCircuitBreakerDisabled",
+			config: func() RedisClientConfig {
+				cfg := DefaultRedisClientConfig
+				cfg.Addr = "127.0.0.1:6789"
+				cfg.SetAsyncCircuitBreakerEnabled = false
+				cfg.SetAsyncCircuitBreakerConsecutiveFailures = 0
+				return cfg
+			},
+			expect_err: false,
+		},
+		{
 			name: "invalidCircuitBreakerFailurePercent",
 			config: func() RedisClientConfig {
 				cfg := DefaultRedisClientConfig
+				cfg.Addr = "127.0.0.1:6789"
+				cfg.SetAsyncCircuitBreakerEnabled = true
 				cfg.SetAsyncCircuitBreakerConsecutiveFailures = 0
 				return cfg
 			},
@@ -210,6 +223,8 @@ func TestValidateRedisConfig(t *testing.T) {
 			name: "invalidCircuitBreakerFailurePercent",
 			config: func() RedisClientConfig {
 				cfg := DefaultRedisClientConfig
+				cfg.Addr = "127.0.0.1:6789"
+				cfg.SetAsyncCircuitBreakerEnabled = true
 				cfg.SetAsyncCircuitBreakerFailurePercent = 0
 				return cfg
 			},


### PR DESCRIPTION
Ref https://github.com/thanos-io/thanos/issues/6975

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

Wrap SetAsync with a circuit breaker to dynamically limit the cache backfilling requests. Both the memcached and redis clients have added the same circuit breaker configuration.


## Verification

<!-- How you tested it? How do you know it works? -->
Added some unit tests.
