### PR TITLE
Infer max query downsample resolution from promql query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 ### Fixed
 - [#8091](https://github.com/thanos-io/thanos/pull/8091) *: Add POST into allowed CORS methods header
 - [#8046](https://github.com/thanos-io/thanos/pull/8046) Query-Frontend: Fix query statistic reporting for range queries when caching is enabled.
-
 - [#7978](https://github.com/thanos-io/thanos/pull/7978) Receive: Fix deadlock during local writes when `split-tenant-label-name` is used
 - [#8016](https://github.com/thanos-io/thanos/pull/8016) Query Frontend: Fix @ modifier not being applied correctly on sub queries.
 
@@ -28,6 +27,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 ### Changed
 
 - [#7890](https://github.com/thanos-io/thanos/pull/7890) Query,Ruler: *breaking :warning:* deprecated `--store.sd-file` and `--store.sd-interval` to be replaced with `--endpoint.sd-config` and `--endpoint-sd-config-reload-interval`; removed legacy flags to pass endpoints `--store`, `--metadata`, `--rule`, `--exemplar`.
+- [#7012](https://github.com/thanos-io/thanos/pull/7012) Query: Automatically adjust `max_source_resolution` based on promql query to avoid querying data from higher resolution resulting empty results.
 
 ### Removed
 

--- a/pkg/query/querier.go
+++ b/pkg/query/querier.go
@@ -27,6 +27,18 @@ import (
 	"github.com/thanos-io/thanos/pkg/tracing"
 )
 
+var promqlFuncRequiresTwoSamples = map[string]struct{}{
+	"rate":                         {},
+	"irate":                        {},
+	"increase":                     {},
+	"delta":                        {},
+	"idelta":                       {},
+	"deriv":                        {},
+	"predict_linear":               {},
+	"holt_winters":                 {},
+	"double_exponential_smoothing": {},
+}
+
 type seriesStatsReporter func(seriesStats storepb.SeriesStatsCounter)
 
 var NoopSeriesStatsReporter seriesStatsReporter = func(_ storepb.SeriesStatsCounter) {}
@@ -320,6 +332,7 @@ func (q *querier) selectFn(ctx context.Context, hints *storage.SelectHints, ms .
 	}
 
 	aggrs := aggrsFromFunc(hints.Func)
+	maxResolutionMillis := maxResolutionFromSelectHints(q.maxResolutionMillis, *hints)
 
 	// TODO(bwplotka): Pass it using the SeriesRequest instead of relying on context.
 	ctx = context.WithValue(ctx, store.StoreMatcherKey, q.storeDebugMatchers)
@@ -333,7 +346,7 @@ func (q *querier) selectFn(ctx context.Context, hints *storage.SelectHints, ms .
 		MaxTime:                 hints.End,
 		Limit:                   int64(hints.Limit),
 		Matchers:                sms,
-		MaxResolutionWindow:     q.maxResolutionMillis,
+		MaxResolutionWindow:     maxResolutionMillis,
 		Aggregates:              aggrs,
 		ShardInfo:               q.shardInfo,
 		PartialResponseStrategy: q.partialResponseStrategy,
@@ -460,3 +473,13 @@ func (q *querier) LabelNames(ctx context.Context, hints *storage.LabelHints, mat
 }
 
 func (q *querier) Close() error { return nil }
+
+// maxResolutionFromSelectHints finds the max possible resolution by inferring from the promql query.
+func maxResolutionFromSelectHints(maxResolutionMillis int64, hints storage.SelectHints) int64 {
+	if hints.Range > 0 {
+		if _, ok := promqlFuncRequiresTwoSamples[hints.Func]; ok {
+			maxResolutionMillis = min(maxResolutionMillis, hints.Range/2)
+		}
+	}
+	return maxResolutionMillis
+}

--- a/pkg/query/querier.go
+++ b/pkg/query/querier.go
@@ -332,7 +332,7 @@ func (q *querier) selectFn(ctx context.Context, hints *storage.SelectHints, ms .
 	}
 
 	aggrs := aggrsFromFunc(hints.Func)
-	maxResolutionMillis := maxResolutionFromSelectHints(q.maxResolutionMillis, *hints)
+	maxResolutionMillis := maxResolutionFromSelectHints(q.maxResolutionMillis, hints.Range, hints.Func)
 
 	// TODO(bwplotka): Pass it using the SeriesRequest instead of relying on context.
 	ctx = context.WithValue(ctx, store.StoreMatcherKey, q.storeDebugMatchers)
@@ -475,10 +475,10 @@ func (q *querier) LabelNames(ctx context.Context, hints *storage.LabelHints, mat
 func (q *querier) Close() error { return nil }
 
 // maxResolutionFromSelectHints finds the max possible resolution by inferring from the promql query.
-func maxResolutionFromSelectHints(maxResolutionMillis int64, hints storage.SelectHints) int64 {
-	if hints.Range > 0 {
-		if _, ok := promqlFuncRequiresTwoSamples[hints.Func]; ok {
-			maxResolutionMillis = min(maxResolutionMillis, hints.Range/2)
+func maxResolutionFromSelectHints(maxResolutionMillis int64, hintsRange int64, hintsFunc string) int64 {
+	if hintsRange > 0 {
+		if _, ok := promqlFuncRequiresTwoSamples[hintsFunc]; ok {
+			maxResolutionMillis = min(maxResolutionMillis, hintsRange/2)
 		}
 	}
 	return maxResolutionMillis

--- a/pkg/query/querier_test.go
+++ b/pkg/query/querier_test.go
@@ -1406,7 +1406,7 @@ func TestMaxResolutionFromSelectHints(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			res := maxResolutionFromSelectHints(tc.maxResolutionMillis, tc.hints)
+			res := maxResolutionFromSelectHints(tc.maxResolutionMillis, tc.hints.Range, tc.hints.Func)
 			testutil.Equals(t, tc.expected, res)
 		})
 	}


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

This is useful to help with https://github.com/thanos-io/thanos/issues/6929.

No matter of auto downsample is enabled or not, always try to infer max allowed resolution based on promql query.

The main idea is from @fpetkovski to check `Range` and `Func` from hints to see if the promql function requires at least 2 samples in the range and then we adjust max allowed resolution accordingly.

For example I have a query like `rate[2m]`. Because `rate` function requires at least 2 samples to run so minimum resolution is 1m. This should avoid picking higher resolution like 5m or 1h. 

## Verification
Added unit test.
