### PR TITLE
Tests: unique docker env name for tenant tests

### DIFF
--- a/test/e2e/query_frontend_test.go
+++ b/test/e2e/query_frontend_test.go
@@ -1034,12 +1034,12 @@ func (u tenantRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
 func TestTenantQFEHTTPMetrics(t *testing.T) {
 	t.Parallel()
 
-	e, err := e2e.NewDockerEnvironment("tenant-metrics")
+	e, err := e2e.NewDockerEnvironment("qfetenantmetrics")
 	testutil.Ok(t, err)
 	t.Cleanup(e2ethanos.CleanScenario(t, e))
 
 	// scrape the local prometheus, and our querier metrics
-	prom1, sidecar1 := e2ethanos.NewPrometheusWithSidecar(e, "alone", e2ethanos.DefaultPromConfig("prom-alone", 0, "", "", e2ethanos.LocalPrometheusTarget, "tenant-metrics-querier-1:8080"), "", e2ethanos.DefaultPrometheusImage(), "")
+	prom1, sidecar1 := e2ethanos.NewPrometheusWithSidecar(e, "alone", e2ethanos.DefaultPromConfig("prom-alone", 0, "", "", e2ethanos.LocalPrometheusTarget, "qfetenantmetrics-querier-1:8080"), "", e2ethanos.DefaultPrometheusImage(), "")
 
 	q := e2ethanos.NewQuerierBuilder(e, "1", sidecar1.InternalEndpoint("grpc")).Init()
 	testutil.Ok(t, e2e.StartAndWaitReady(q))

--- a/test/e2e/query_test.go
+++ b/test/e2e/query_test.go
@@ -2420,12 +2420,12 @@ func TestSidecarPrefersExtLabels(t *testing.T) {
 func TestTenantHTTPMetrics(t *testing.T) {
 	t.Parallel()
 
-	e, err := e2e.NewDockerEnvironment("tenant-metrics")
+	e, err := e2e.NewDockerEnvironment("q-tenant-metrics")
 	testutil.Ok(t, err)
 	t.Cleanup(e2ethanos.CleanScenario(t, e))
 
 	// scrape the local prometheus, and our querier metrics
-	prom1, sidecar1 := e2ethanos.NewPrometheusWithSidecar(e, "alone", e2ethanos.DefaultPromConfig("prom-alone", 0, "", "", e2ethanos.LocalPrometheusTarget, "tenant-metrics-querier-1:8080"), "", e2ethanos.DefaultPrometheusImage(), "")
+	prom1, sidecar1 := e2ethanos.NewPrometheusWithSidecar(e, "alone", e2ethanos.DefaultPromConfig("prom-alone", 0, "", "", e2ethanos.LocalPrometheusTarget, "q-tenant-metrics-querier-1:8080"), "", e2ethanos.DefaultPrometheusImage(), "")
 
 	q := e2ethanos.NewQuerierBuilder(e, "1", sidecar1.InternalEndpoint("grpc")).Init()
 	testutil.Ok(t, e2e.StartAndWaitReady(q))


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->
* The e2e tests would occasionally fail due to non-unqiue docker environment names. With this commit the tests are environments are given unique names to avoid these failures.

## Verification

<!-- How you tested it? How do you know it works? -->
