### PR TITLE
chore: Optimize docker image size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 ### Changed
 
 - [#6539](https://github.com/thanos-io/thanos/pull/6539) Store: *breaking :warning:* Changed `--sync-block-duration` default 3m to 15m.
+- [#7040](https://github.com/thanos-io/thanos/pull/7040) Optimize docker image size. Note that this changed the default user in container image from 1001(thanos) to 65534(nobody), which is unified with prometheus and alertmanager images.
 
 ### Removed
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,6 @@ LABEL maintainer="The Thanos Authors"
 
 COPY /thanos_tmp_for_docker /bin/thanos
 
-RUN adduser \
-    -D `#Dont assign a password` \
-    -H `#Dont create home directory` \
-    -u 1001 `#User id`\
-    thanos && \
-    chown thanos /bin/thanos
-USER 1001
+USER       nobody
+WORKDIR    /thanos
 ENTRYPOINT [ "/bin/thanos" ]

--- a/Dockerfile.multi-arch
+++ b/Dockerfile.multi-arch
@@ -9,11 +9,6 @@ ARG OS="linux"
 
 COPY .build/${OS}-${ARCH}/thanos /bin/thanos
 
-RUN adduser \
-    -D `#Dont assign a password` \
-    -H `#Dont create home directory` \
-    -u 1001 `#User id`\
-    thanos && \
-    chown thanos /bin/thanos
-USER 1001
+USER       nobody
+WORKDIR    /thanos
 ENTRYPOINT [ "/bin/thanos" ]

--- a/Dockerfile.multi-stage
+++ b/Dockerfile.multi-stage
@@ -21,11 +21,6 @@ LABEL maintainer="The Thanos Authors"
 
 COPY --from=builder /go/bin/thanos /bin/thanos
 
-RUN adduser \
-    -D `#Dont assign a password` \
-    -H `#Dont create home directory` \
-    -u 1001 `#User id`\
-    thanos && \
-    chown thanos /bin/thanos
-USER 1001
+USER       nobody
+WORKDIR    /thanos
 ENTRYPOINT [ "/bin/thanos" ]


### PR DESCRIPTION
* Remove RUN after COPY instruction.
* Use the nobody user directly.
* Set /thanos as the working directory.

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Before (179MB):
```
➜  thanos git:(main) docker history 93159880a2d9
IMAGE          CREATED          CREATED BY                                       SIZE      COMMENT
93159880a2d9   14 seconds ago   ENTRYPOINT ["/bin/thanos"]                       0B        buildkit.dockerfile.v0
<missing>      14 seconds ago   USER 1001                                        0B        buildkit.dockerfile.v0
<missing>      14 seconds ago   RUN |2 ARCH=arm64 OS=linux /bin/sh -c adduse…   87.8MB    buildkit.dockerfile.v0
<missing>      18 minutes ago   COPY .build/linux-arm64/thanos /bin/thanos #…   87.8MB    buildkit.dockerfile.v0
<missing>      18 minutes ago   ARG OS=linux                                     0B        buildkit.dockerfile.v0
<missing>      18 minutes ago   ARG ARCH=amd64                                   0B        buildkit.dockerfile.v0
<missing>      18 minutes ago   LABEL maintainer=The Thanos Authors              0B        buildkit.dockerfile.v0
<missing>      3 weeks ago      COPY /rootfs / # buildkit                        1.54MB    buildkit.dockerfile.v0
<missing>      3 weeks ago      MAINTAINER The Prometheus Authors <prometheu…   0B        buildkit.dockerfile.v0
<missing>      4 weeks ago      /bin/sh -c #(nop)  CMD ["sh"]                    0B
<missing>      4 weeks ago      /bin/sh -c #(nop) ADD file:1582deb90400e4ba7…   1.46MB
```
After (90.8MB):
```
➜  thanos git:(main) docker history b429a5714aa0
IMAGE          CREATED          CREATED BY                                       SIZE      COMMENT
b429a5714aa0   18 minutes ago   ENTRYPOINT ["/bin/thanos"]                       0B        buildkit.dockerfile.v0
<missing>      18 minutes ago   WORKDIR /thanos                                  0B        buildkit.dockerfile.v0
<missing>      18 minutes ago   USER nobody                                      0B        buildkit.dockerfile.v0
<missing>      18 minutes ago   COPY .build/linux-arm64/thanos /bin/thanos #…   87.8MB    buildkit.dockerfile.v0
<missing>      18 minutes ago   ARG OS=linux                                     0B        buildkit.dockerfile.v0
<missing>      18 minutes ago   ARG ARCH=amd64                                   0B        buildkit.dockerfile.v0
<missing>      18 minutes ago   LABEL maintainer=The Thanos Authors              0B        buildkit.dockerfile.v0
<missing>      3 weeks ago      COPY /rootfs / # buildkit                        1.54MB    buildkit.dockerfile.v0
<missing>      3 weeks ago      MAINTAINER The Prometheus Authors <prometheu…   0B        buildkit.dockerfile.v0
<missing>      4 weeks ago      /bin/sh -c #(nop)  CMD ["sh"]                    0B
<missing>      4 weeks ago      /bin/sh -c #(nop) ADD file:1582deb90400e4ba7…   1.46MB
```

This changed the default user in container image from 1001(thanos) to 65534(nobody), which is unified with prometheus and alertmanager images.
<!-- Enumerate changes you made -->

## Verification

Tested thanos-query in k8s cluster
<!-- How you tested it? How do you know it works? -->
