### PR TITLE
Make RetryError and HaltError able to be fetched for root cause

### DIFF
--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -941,7 +941,7 @@ func (e HaltError) Error() string {
 	return e.err.Error()
 }
 
-func (e HaltError) Cause() error {
+func (e HaltError) Unwrap() error {
 	return errors.Cause(e.err)
 }
 
@@ -978,7 +978,7 @@ func (e RetryError) Error() string {
 	return e.err.Error()
 }
 
-func (e RetryError) Cause() error {
+func (e RetryError) Unwrap() error {
 	return errors.Cause(e.err)
 }
 

--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -941,10 +941,14 @@ func (e HaltError) Error() string {
 	return e.err.Error()
 }
 
+func (e HaltError) Cause() error {
+	return errors.Cause(e.err)
+}
+
 // IsHaltError returns true if the base error is a HaltError.
 // If a multierror is passed, any halt error will return true.
 func IsHaltError(err error) bool {
-	if multiErr, ok := errors.Cause(err).(errutil.NonNilMultiError); ok {
+	if multiErr, ok := errors.Cause(err).(errutil.NonNilMultiRootError); ok {
 		for _, err := range multiErr {
 			if _, ok := errors.Cause(err).(HaltError); ok {
 				return true
@@ -974,10 +978,14 @@ func (e RetryError) Error() string {
 	return e.err.Error()
 }
 
+func (e RetryError) Cause() error {
+	return errors.Cause(e.err)
+}
+
 // IsRetryError returns true if the base error is a RetryError.
 // If a multierror is passed, all errors must be retriable.
 func IsRetryError(err error) bool {
-	if multiErr, ok := errors.Cause(err).(errutil.NonNilMultiError); ok {
+	if multiErr, ok := errors.Cause(err).(errutil.NonNilMultiRootError); ok {
 		for _, err := range multiErr {
 			if _, ok := errors.Cause(err).(RetryError); !ok {
 				return false

--- a/pkg/errutil/multierror.go
+++ b/pkg/errutil/multierror.go
@@ -80,7 +80,7 @@ func (es NonNilMultiError) getCause() NonNilMultiRootError {
 			causes = append(causes, errors.Cause(err))
 		}
 	}
-	return NonNilMultiRootError(causes)
+	return causes
 }
 
 type NonNilMultiRootError MultiError

--- a/pkg/errutil/multierror.go
+++ b/pkg/errutil/multierror.go
@@ -7,6 +7,8 @@ import (
 	"bytes"
 	"fmt"
 	"sync"
+
+	"github.com/pkg/errors"
 )
 
 // The MultiError type implements the error interface, and contains the
@@ -62,6 +64,33 @@ type NonNilMultiError MultiError
 
 // Returns a concatenated string of the contained errors.
 func (es NonNilMultiError) Error() string {
+	return multiErrorString(es)
+}
+
+func (es NonNilMultiError) Cause() error {
+	return es.getCause()
+}
+
+func (es NonNilMultiError) getCause() NonNilMultiRootError {
+	var causes []error
+	for _, err := range es {
+		if multiErr, ok := errors.Cause(err).(NonNilMultiError); ok {
+			causes = append(causes, multiErr.getCause()...)
+		} else {
+			causes = append(causes, errors.Cause(err))
+		}
+	}
+	return NonNilMultiRootError(causes)
+}
+
+type NonNilMultiRootError MultiError
+
+// Returns a concatenated string of the contained errors.
+func (es NonNilMultiRootError) Error() string {
+	return multiErrorString(es)
+}
+
+func multiErrorString(es []error) string {
 	var buf bytes.Buffer
 
 	if len(es) > 1 {

--- a/pkg/errutil/multierror_test.go
+++ b/pkg/errutil/multierror_test.go
@@ -5,10 +5,56 @@ package errutil
 
 import (
 	"fmt"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
 	"testing"
 )
 
 func TestMultiSyncErrorAdd(t *testing.T) {
 	sme := &SyncMultiError{}
 	sme.Add(fmt.Errorf("test"))
+}
+
+func TestNonNilMultiErrorCause_SingleCause(t *testing.T) {
+	rootCause := fmt.Errorf("test root cause")
+	me := MultiError{}
+	me.Add(errors.Wrap(rootCause, "wrapped error"))
+	causes, ok := errors.Cause(NonNilMultiError(me)).(NonNilMultiRootError)
+	require.True(t, ok)
+	require.Equal(t, 1, len(causes))
+	require.Equal(t, rootCause, causes[0])
+}
+
+func TestNonNilMultiErrorCause_MultipleCauses(t *testing.T) {
+	rootCause1 := fmt.Errorf("test root cause 1")
+	rootCause2 := fmt.Errorf("test root cause 2")
+	rootCause3 := fmt.Errorf("test root cause 3")
+	me := MultiError{}
+	me.Add(errors.Wrap(rootCause1, "wrapped error 1"))
+	me.Add(errors.Wrap(errors.Wrap(rootCause2, "wrapped error 2"), "wrapped error 2 again"))
+	me.Add(rootCause3)
+	causes, ok := errors.Cause(NonNilMultiError(me)).(NonNilMultiRootError)
+	require.True(t, ok)
+	require.Equal(t, 3, len(causes))
+	require.Contains(t, causes, rootCause1)
+	require.Contains(t, causes, rootCause2)
+	require.Contains(t, causes, rootCause3)
+}
+
+func TestNonNilMultiErrorCause_MultipleCausesWithNestedNonNilMultiError(t *testing.T) {
+	rootCause1 := fmt.Errorf("test root cause 1")
+	rootCause2 := fmt.Errorf("test root cause 2")
+	rootCause3 := fmt.Errorf("test root cause 3")
+	me1 := MultiError{}
+	me1.Add(errors.Wrap(rootCause1, "wrapped error 1"))
+	me1.Add(errors.Wrap(rootCause2, "wrapped error 2"))
+	me := MultiError{}
+	me.Add(errors.Wrap(rootCause3, "wrapped error 3"))
+	me.Add(NonNilMultiError(me1))
+	causes, ok := errors.Cause(NonNilMultiError(me)).(NonNilMultiRootError)
+	require.True(t, ok)
+	require.Equal(t, 3, len(causes))
+	require.Contains(t, causes, rootCause1)
+	require.Contains(t, causes, rootCause2)
+	require.Contains(t, causes, rootCause3)
 }

--- a/pkg/errutil/multierror_test.go
+++ b/pkg/errutil/multierror_test.go
@@ -5,9 +5,10 @@ package errutil
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestMultiSyncErrorAdd(t *testing.T) {


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

Implemented `Cause` function for `NonNilMultiRootError` to return a list of root cause errors. This could simplify `Unwrap` function for `RetryError` and `HaltError`. With this change, project depending on Thanos (ie. Cortex) could evaluate the root cause of `RetryError` and `HaltError` and have special handling logic for particular root causes.

## Verification

Created unit tests for `NonNilMultiRootError`
