### PR TITLE
Query-range.timeout : Global timeout for range queries

### DIFF
--- a/cmd/thanos/query_frontend.go
+++ b/cmd/thanos/query_frontend.go
@@ -70,6 +70,9 @@ func registerQueryFrontend(app *extkingpin.App) {
 	cmd.Flag("web.disable-cors", "Whether to disable CORS headers to be set by Thanos. By default Thanos sets CORS headers to be allowed by all.").
 		Default("false").BoolVar(&cfg.webDisableCORS)
 
+	cmd.Flag("query-range.timeout", "Global timeout for range queries in the query frontend. Queries exceeding this duration will be aborted.").
+		Default("5m").DurationVar(&cfg.QueryRangeConfig.Timeout)
+
 	// Query range tripperware flags.
 	cmd.Flag("query-range.align-range-with-step", "Mutate incoming queries to align their start and end with their step for better cache-ability. Note: Grafana dashboards do that by default.").
 		Default("true").BoolVar(&cfg.QueryRangeConfig.AlignRangeWithStep)

--- a/docs/components/query-frontend.md
+++ b/docs/components/query-frontend.md
@@ -340,6 +340,9 @@ Flags:
                                  execute in parallel, it should be greater than
                                  0 when query-range.response-cache-config is
                                  configured.
+      --query-range.timeout=5m   Global timeout for range queries in the query
+                                 frontend. Queries exceeding this duration will
+                                 be aborted.
       --request.logging-config=<content>
                                  Alternative to 'request.logging-config-file'
                                  flag (mutually exclusive). Content

--- a/pkg/queryfrontend/config.go
+++ b/pkg/queryfrontend/config.go
@@ -229,6 +229,7 @@ type QueryRangeConfig struct {
 	HorizontalShards       int64
 	MaxRetries             int
 	Limits                 *cortexvalidation.Limits
+	Timeout                time.Duration `yaml:"timeout"`
 }
 
 // LabelsConfig holds the config for labels tripperware.
@@ -244,7 +245,8 @@ type LabelsConfig struct {
 	SplitQueriesByInterval time.Duration
 	MaxRetries             int
 
-	Limits *cortexvalidation.Limits
+	Limits  *cortexvalidation.Limits
+	Timeout time.Duration `yaml:"timeout"`
 }
 
 // Validate a fully initialized config.


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#7052](https://github.com/thanos-io/thanos/pull/7052) Thanos query-frontend ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->
With reference to the issue #7046 . I have added the new flag `query-range.timeout` for Global timeout for range queries in the query frontend. 