### PR TITLE
adding colour code according to query

### DIFF
--- a/pkg/ui/react-app/src/thanos/pages/stores/StorePoolPanel.tsx
+++ b/pkg/ui/react-app/src/thanos/pages/stores/StorePoolPanel.tsx
@@ -36,6 +36,14 @@ export const storeTimeRangeMsg = (validMin: boolean, validMax: boolean): string 
   return '';
 };
 
+export const getColorTimeRangeMsg = (validMin: boolean, validMax: boolean): string => {
+  if (!validMin || !validMax) {
+    return 'yellow';
+  }
+
+  return validMin && validMax ? 'green' : 'red';
+};
+
 export const StorePoolPanel: FC<StorePoolPanelProps> = ({ title, storePool }) => {
   const [{ expanded }, setOptions] = useLocalStorage(`store-pool-${title}-expanded`, { expanded: true });
 
@@ -72,10 +80,18 @@ export const StorePoolPanel: FC<StorePoolPanelProps> = ({ title, storePool }) =>
                   <td data-testid="storeLabels">
                     <StoreLabels labelSets={labelSets} />
                   </td>
-                  <td data-testid="minTime" title={storeTimeRangeMsg(validMinTime, validMaxTime)}>
+                  <td
+                    data-testid="minTime"
+                    title={storeTimeRangeMsg(validMinTime, validMaxTime)}
+                    style={{ color: getColorTimeRangeMsg(validMinTime, validMaxTime) }}
+                  >
                     {validMinTime ? formatTime(minTime) : <FontAwesomeIcon icon={faMinus} />}
                   </td>
-                  <td data-testid="maxTime" title={storeTimeRangeMsg(validMinTime, validMaxTime)}>
+                  <td
+                    data-testid="maxTime"
+                    title={storeTimeRangeMsg(validMinTime, validMaxTime)}
+                    style={{ color: getColorTimeRangeMsg(validMinTime, validMaxTime) }}
+                  >
                     {validMaxTime ? formatTime(maxTime) : <FontAwesomeIcon icon={faMinus} />}
                   </td>
                   <td data-testid="lastCheck">


### PR DESCRIPTION
Signed-off-by: Harsh Pratap Singh <harshpratapsingh8210@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Fixes #5022 
by adding colour codes in UI

## Verification
<img width="1280" alt="Screenshot 2024-01-13 at 3 28 50 PM" src="https://github.com/thanos-io/thanos/assets/119954739/593f2cd7-dd0f-4df5-9a8f-c0141eb6d8ed">

