### PR TITLE
Fix lazy postings with zero length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 
 ### Fixed
 
+- [#7083](https://github.com/thanos-io/thanos/pull/7083) Store Gateway: Fix lazy expanded postings with 0 length failed to be cached. 
+
 ### Added
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 
 ### Fixed
 
-- [#7083](https://github.com/thanos-io/thanos/pull/7083) Store Gateway: Fix lazy expanded postings with 0 length failed to be cached. 
+- [#7083](https://github.com/thanos-io/thanos/pull/7083) Store Gateway: Fix lazy expanded postings with 0 length failed to be cached.
 
 ### Added
 

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -1163,13 +1163,16 @@ func (b *blockSeriesClient) nextBatch(tenant string) error {
 	if len(postingsBatch) == 0 {
 		b.hasMorePostings = false
 		if b.lazyPostings.lazyExpanded() {
-			v, err := b.indexr.IndexVersion()
-			if err != nil {
-				return errors.Wrap(err, "get index version")
-			}
-			if v >= 2 {
-				for i := range b.expandedPostings {
-					b.expandedPostings[i] = b.expandedPostings[i] / 16
+			// No need to fetch index version again if lazy posting has 0 length.
+			if len(b.lazyPostings.postings) > 0 {
+				v, err := b.indexr.IndexVersion()
+				if err != nil {
+					return errors.Wrap(err, "get index version")
+				}
+				if v >= 2 {
+					for i := range b.expandedPostings {
+						b.expandedPostings[i] = b.expandedPostings[i] / 16
+					}
 				}
 			}
 			b.indexr.storeExpandedPostingsToCache(b.blockMatchers, index.NewListPostings(b.expandedPostings), len(b.expandedPostings), tenant)

--- a/pkg/store/lazy_postings.go
+++ b/pkg/store/lazy_postings.go
@@ -184,6 +184,9 @@ func fetchLazyExpandedPostings(
 	if err != nil {
 		return nil, err
 	}
+	if len(ps) == 0 {
+		return emptyLazyPostings, nil
+	}
 	return &lazyExpandedPostings{postings: ps, matchers: matchers}, nil
 }
 


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

When lazy expanded postings enabled, we will have expanded postings using partial matchers and matchers that will be evaluated lazily. However, it is possible that with partial matchers, the expanded postings already have 0 length then there is no need to evaluate lazy postings.

In this case, there is a bug that the expanded postings will not be cached. So add a check to return `emptyLazyPostings` if length is 0. Since `emtpyLazyPostings` doesn't have any matchers, it will be cached here https://github.com/thanos-io/thanos/blob/main/pkg/store/bucket.go#L2514

## Verification

<!-- How you tested it? How do you know it works? -->

Added unit tests
