### PR TITLE
Receive: race condition in handler Close() when stopped early

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#7011](https://github.com/thanos-io/thanos/pull/7011) Query Frontend: queries with negative offset should check whether it is cacheable or not.
 - [#6874](https://github.com/thanos-io/thanos/pull/6874) Sidecar: fix labels returned by 'api/v1/series' in presence of conflicting external and inner labels.
 - [#7009](https://github.com/thanos-io/thanos/pull/7009) Rule: Fix spacing error in URL.
+- [#7080](https://github.com/thanos-io/thanos/pull/7080) Receive: race condition in handler Close() when stopped early
 
 ### Added
 

--- a/pkg/receive/handler_test.go
+++ b/pkg/receive/handler_test.go
@@ -1645,3 +1645,12 @@ func TestHashringChangeCallsClose(t *testing.T) {
 	pg := allHandlers[0].peers.(*fakePeersGroup)
 	testutil.Assert(t, len(pg.closeCalled) > 0)
 }
+
+func TestHandlerEarlyStop(t *testing.T) {
+	h := NewHandler(nil, &Options{})
+	h.Close()
+
+	err := h.Run()
+	testutil.NotOk(t, err)
+	testutil.Equals(t, "http: Server closed", err.Error())
+}


### PR DESCRIPTION
Receiver hangs waiting for the HTTP Handler to shutdown if an error occurs before Handler is initialized. This might happen, for example, if the hashring is too small for a given replication factor.

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Fixes a race condition in `receive.Handler.Close()`.

## Verification

Before this change, the race condition could be reproduced with the script below. Eventually (in about 1-2 seconds) receiver would be able to start  "successfully" and the script would hang until killed with SIGKILL. Health checks would not work since the health check listener is already down.

```bash
#!/bin/bash

trap exit SIGINT SIGTERM

while :; do
    thanos receive \
        --tsdb.path=/tmp/data \
        --label='receive="1"' \
        --receive.hashrings-algorithm=ketama \
        --receive.hashrings='[{"endpoints": ["127.0.0.1:19291"]}]' \
        --receive.replication-factor=2
done
```
