### PR TITLE
Stores: convert tests to not rely on slice labels

### DIFF
--- a/pkg/store/acceptance_test.go
+++ b/pkg/store/acceptance_test.go
@@ -1011,7 +1011,7 @@ func TestProxyStore_Acceptance(t *testing.T) {
 			storetestutil.TestClient{StoreClient: storepb.ServerAsClient(p2, 0)},
 		}
 
-		return NewProxyStore(nil, nil, func() []Client { return clients }, component.Query, nil, 0*time.Second, RetrievalStrategy(EagerRetrieval))
+		return NewProxyStore(nil, nil, func() []Client { return clients }, component.Query, labels.EmptyLabels(), 0*time.Second, RetrievalStrategy(EagerRetrieval))
 	}
 
 	testStoreAPIsAcceptance(t, startStore)

--- a/pkg/store/proxy_heap_test.go
+++ b/pkg/store/proxy_heap_test.go
@@ -314,12 +314,12 @@ func labelsFromStrings(ss ...string) labels.Labels {
 	if len(ss)%2 != 0 {
 		panic("invalid number of strings")
 	}
-	res := make(labels.Labels, 0, len(ss)/2)
-	for i := 0; i < len(ss); i += 2 {
-		res = append(res, labels.Label{Name: ss[i], Value: ss[i+1]})
-	}
 
-	return res
+	b := labels.NewScratchBuilder(len(ss) / 2)
+	for i := 0; i < len(ss); i += 2 {
+		b.Add(ss[i], ss[i+1])
+	}
+	return b.Labels()
 }
 
 func BenchmarkSortWithoutLabels(b *testing.B) {

--- a/pkg/store/proxy_test.go
+++ b/pkg/store/proxy_test.go
@@ -67,7 +67,7 @@ func TestProxyStore_Info(t *testing.T) {
 		nil,
 		func() []Client { return nil },
 		component.Query,
-		nil, 0*time.Second, RetrievalStrategy(EagerRetrieval),
+		labels.EmptyLabels(), 0*time.Second, RetrievalStrategy(EagerRetrieval),
 	)
 
 	resp, err := q.Info(ctx, &storepb.InfoRequest{})
@@ -96,7 +96,7 @@ func TestProxyStore_TSDBInfos(t *testing.T) {
 	}
 	q := NewProxyStore(nil, nil,
 		func() []Client { return stores },
-		component.Query, nil, 0*time.Second, EagerRetrieval,
+		component.Query, labels.EmptyLabels(), 0*time.Second, EagerRetrieval,
 	)
 
 	expected := []infopb.TSDBInfo{
@@ -1227,7 +1227,7 @@ func TestProxyStore_Series_RequestParamsProxied(t *testing.T) {
 		nil,
 		func() []Client { return cls },
 		component.Query,
-		nil,
+		labels.EmptyLabels(),
 		1*time.Second, EagerRetrieval,
 	)
 
@@ -1335,7 +1335,7 @@ func TestProxyStore_LabelValues(t *testing.T) {
 		nil,
 		func() []Client { return cls },
 		component.Query,
-		nil,
+		labels.EmptyLabels(),
 		0*time.Second, EagerRetrieval,
 	)
 
@@ -1535,7 +1535,7 @@ func TestProxyStore_LabelNames(t *testing.T) {
 				nil,
 				func() []Client { return tc.storeAPIs },
 				component.Query,
-				nil,
+				labels.EmptyLabels(),
 				5*time.Second, EagerRetrieval,
 			)
 

--- a/pkg/store/tsdb_test.go
+++ b/pkg/store/tsdb_test.go
@@ -597,7 +597,7 @@ func benchTSDBStoreSeries(t testutil.TB, totalSamples, totalSeries int) {
 			// Add external labels & frame it.
 			s := r.GetSeries()
 			bytesLeftForChunks := store.maxBytesPerFrame
-			lbls := make([]labelpb.ZLabel, 0, len(s.Labels)+len(extLabels))
+			lbls := make([]labelpb.ZLabel, 0, len(s.Labels)+extLabels.Len())
 			for _, l := range s.Labels {
 				lbls = append(lbls, labelpb.ZLabel{
 					Name:  l.Name,
@@ -605,13 +605,13 @@ func benchTSDBStoreSeries(t testutil.TB, totalSamples, totalSeries int) {
 				})
 				bytesLeftForChunks -= lbls[len(lbls)-1].Size()
 			}
-			for _, l := range extLabels {
+			extLabels.Range(func(l labels.Label) {
 				lbls = append(lbls, labelpb.ZLabel{
 					Name:  l.Name,
 					Value: l.Value,
 				})
 				bytesLeftForChunks -= lbls[len(lbls)-1].Size()
-			}
+			})
 			sort.Slice(lbls, func(i, j int) bool {
 				return lbls[i].Name < lbls[j].Name
 			})


### PR DESCRIPTION
* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

Converted StoreAPI tests to not rely on slice labels anymore in preparation for stringlabels

## Verification

Was just a refactoring, previous tests shall still pass.
