### PR TITLE
[draft; not-ready] receive: Sloppy quorum implementation

### DIFF
--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -531,7 +531,7 @@ func setupHashring(g *run.Group,
 					webHandler.Hashring(receive.SingleNodeHashring(conf.endpoint))
 					level.Info(logger).Log("msg", "Empty hashring config. Set up single node hashring.")
 				} else {
-					h, err := receive.NewMultiHashring(algorithm, conf.replicationFactor, c)
+					h, err := receive.NewMultiHashring(algorithm, conf.replicationFactor, c, conf.sloppyRetriesLimit)
 					if err != nil {
 						return errors.Wrap(err, "unable to create new hashring from config")
 					}

--- a/pkg/receive/handler_test.go
+++ b/pkg/receive/handler_test.go
@@ -234,7 +234,7 @@ func newTestHandlerHashring(appendables []*fakeAppendable, replicationFactor uin
 		hashringAlgo = AlgorithmHashmod
 	}
 
-	hashring, err := NewMultiHashring(hashringAlgo, replicationFactor, cfg)
+	hashring, err := NewMultiHashring(hashringAlgo, replicationFactor, cfg, 0)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/receive/hashring.go
+++ b/pkg/receive/hashring.go
@@ -60,6 +60,45 @@ type Hashring interface {
 	Nodes() []string
 }
 
+type NodesIter struct {
+	nodes        map[int]string
+	currentNode  string
+	currentIndex int
+}
+
+func NewNodesIter(nodes []string, self string) *NodesIter {
+	nl := &NodesIter{
+		nodes: make(map[int]string, len(nodes)),
+	}
+	for i, node := range nodes {
+		if node == self {
+			continue
+		}
+		nl.nodes[i] = node
+	}
+	return nl
+}
+
+func (nl *NodesIter) StartFrom(node string) bool {
+	for i, n := range nl.nodes {
+		if n == node {
+			nl.currentNode = node
+			nl.currentIndex = i
+			return true
+		}
+	}
+	return false
+}
+
+func (nl *NodesIter) Next() string {
+	nl.currentIndex++
+	if nl.currentIndex >= len(nl.nodes) {
+		nl.currentIndex = 0
+	}
+	nl.currentNode = nl.nodes[nl.currentIndex]
+	return nl.currentNode
+}
+
 // SingleNodeHashring always returns the same node.
 type SingleNodeHashring string
 

--- a/pkg/receive/hashring.go
+++ b/pkg/receive/hashring.go
@@ -60,14 +60,17 @@ type Hashring interface {
 	Nodes() []string
 }
 
-type NodesIter struct {
+// sloppyQuorumIterator is an iterator over the nodes in a hashring.
+// It excludes the node that is passed in to the constructor.
+type sloppyQuorumIterator struct {
 	nodes        map[int]string
 	currentNode  string
 	currentIndex int
 }
 
-func NewNodesIter(nodes []string, self string) *NodesIter {
-	nl := &NodesIter{
+// newSloppyQuorumIterator returns a new sloppyQuorumIterator.
+func newSloppyQuorumIterator(nodes []string, self string) *sloppyQuorumIterator {
+	nl := &sloppyQuorumIterator{
 		nodes: make(map[int]string, len(nodes)),
 	}
 	for i, node := range nodes {
@@ -79,7 +82,8 @@ func NewNodesIter(nodes []string, self string) *NodesIter {
 	return nl
 }
 
-func (nl *NodesIter) StartFrom(node string) bool {
+// seek sets the current node in the iterator to the given node.
+func (nl *sloppyQuorumIterator) seek(node string) bool {
 	for i, n := range nl.nodes {
 		if n == node {
 			nl.currentNode = node
@@ -90,7 +94,8 @@ func (nl *NodesIter) StartFrom(node string) bool {
 	return false
 }
 
-func (nl *NodesIter) Next() string {
+// next returns the next node in the iterator.
+func (nl *sloppyQuorumIterator) next() string {
 	nl.currentIndex++
 	if nl.currentIndex >= len(nl.nodes) {
 		nl.currentIndex = 0

--- a/pkg/receive/hashring_test.go
+++ b/pkg/receive/hashring_test.go
@@ -139,7 +139,7 @@ func TestHashringGet(t *testing.T) {
 			},
 		},
 	} {
-		hs, err := NewMultiHashring(AlgorithmHashmod, 3, tc.cfg)
+		hs, err := NewMultiHashring(AlgorithmHashmod, 3, tc.cfg, 0)
 		require.NoError(t, err)
 
 		h, err := hs.Get(tc.tenant, ts)
@@ -231,7 +231,7 @@ func TestKetamaHashringGet(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			hashRing, err := newKetamaHashring(test.endpoints, 10, test.n+1)
+			hashRing, err := newKetamaHashring(test.endpoints, 10, test.n+1, 0)
 			require.NoError(t, err)
 
 			result, err := hashRing.GetN("tenant", test.ts, test.n)
@@ -242,7 +242,7 @@ func TestKetamaHashringGet(t *testing.T) {
 }
 
 func TestKetamaHashringBadConfigIsRejected(t *testing.T) {
-	_, err := newKetamaHashring([]Endpoint{{Address: "node-1"}}, 1, 2)
+	_, err := newKetamaHashring([]Endpoint{{Address: "node-1"}}, 1, 2, 0)
 	require.Error(t, err)
 }
 
@@ -445,7 +445,7 @@ func TestKetamaHashringEvenAZSpread(t *testing.T) {
 		},
 	} {
 		t.Run("", func(t *testing.T) {
-			hashRing, err := newKetamaHashring(tt.nodes, SectionsPerNode, tt.replicas)
+			hashRing, err := newKetamaHashring(tt.nodes, SectionsPerNode, tt.replicas, 0)
 			testutil.Ok(t, err)
 
 			availableAzs := make(map[string]int64)
@@ -548,7 +548,7 @@ func TestKetamaHashringEvenNodeSpread(t *testing.T) {
 		},
 	} {
 		t.Run("", func(t *testing.T) {
-			hashRing, err := newKetamaHashring(tt.nodes, SectionsPerNode, tt.replicas)
+			hashRing, err := newKetamaHashring(tt.nodes, SectionsPerNode, tt.replicas, 0)
 			testutil.Ok(t, err)
 			optimalSpread := int(tt.numSeries*tt.replicas) / len(tt.nodes)
 			nodeSpread := make(map[string]int)
@@ -586,7 +586,7 @@ func TestInvalidAZHashringCfg(t *testing.T) {
 		},
 	} {
 		t.Run("", func(t *testing.T) {
-			_, err := NewMultiHashring(tt.algorithm, tt.replicas, tt.cfg)
+			_, err := NewMultiHashring(tt.algorithm, tt.replicas, tt.cfg, 0)
 			require.EqualError(t, err, tt.expectedError)
 		})
 	}
@@ -625,7 +625,7 @@ func assignSeries(series []prompb.TimeSeries, nodes []Endpoint) (map[string][]pr
 }
 
 func assignReplicatedSeries(series []prompb.TimeSeries, nodes []Endpoint, replicas uint64) (map[string][]prompb.TimeSeries, error) {
-	hashRing, err := newKetamaHashring(nodes, SectionsPerNode, replicas)
+	hashRing, err := newKetamaHashring(nodes, SectionsPerNode, replicas, 0)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/runutil/runutil.go
+++ b/pkg/runutil/runutil.go
@@ -215,3 +215,36 @@ func DeleteAll(dir string, ignoreDirs ...string) error {
 	}
 	return nil
 }
+
+// RetryFunc is the type for the function to retry.
+// It returns a value of generic type T and an error.
+type RetryFunc[T any] func() (T, error)
+
+// RetryWithReturn executes the given function up to maxRetries times until it succeeds.
+// It returns the result of the function and any error encountered.
+func RetryWithReturn[T any](logger log.Logger, maxRetries int, interval time.Duration, stopc <-chan struct{}, fn RetryFunc[T]) (T, error) {
+	var result T
+
+	if interval <= 0 {
+		interval = 1 * time.Millisecond
+	}
+	if maxRetries <= 0 {
+		maxRetries = 1
+	}
+	tick := time.NewTicker(interval)
+	defer tick.Stop()
+
+	var err error
+	for i := 0; i < maxRetries; i++ {
+		if result, err = fn(); err == nil {
+			return result, nil
+		}
+		level.Error(logger).Log("msg", "function failed. Retrying in next tick", "err", err)
+		select {
+		case <-stopc:
+			return *new(T), err
+		case <-tick.C:
+		}
+	}
+	return *new(T), err
+}


### PR DESCRIPTION
* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

* Adds a simple sloppy quorum implementation based on #5809. The feature can be enabled with the CLI flag `--receive.sloppy-quorum`. The control of the amount of times the algorithm looks for a new node to replicate the request to is done using the `--receive.sloppy-retries-limit` flag. Currently the sloppy quorum logic happens in two places: when finding a peer connection and when writing, with independent retries counters. 

One important detail is that **there's no implementation of what's known as "hinted handoff"**. This means that writes that end up "slipping" will **never** be sent back to the original place where they should be. The reasons for this are:

- Receive's sensitive to the metrics timestamp. It's not easy to write data that's not "from this instant in time" into a node. This requires enabling out-of-order features that are still experimental, adding a system to keep track of these, attempt the handoff periodically and (maybe?) delete this data from the temporary owning node's TSDB. It's a lot of complication and complexity.
- Thanos' query path doesn't really care where the data is. If there's no requirement for such complicated system as mentioned above we are better off avoiding it.

## Verification

<!-- How you tested it? How do you know it works? -->
