### PR TITLE
rule: default to alertmanager v2 api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 
 ### Changed
 
+- [#7123](https://github.com/thanos-io/thanos/pull/7123) Rule: Change default Alertmanager API version to v2.
+
 ### Removed
 
 ## [v0.34.0](https://github.com/thanos-io/thanos/tree/release-0.34) - 26.01.24

--- a/pkg/alert/config.go
+++ b/pkg/alert/config.go
@@ -67,7 +67,7 @@ func DefaultAlertmanagerConfig() AlertmanagerConfig {
 			FileSDConfigs:   []clientconfig.HTTPFileSDConfig{},
 		},
 		Timeout:    model.Duration(time.Second * 10),
-		APIVersion: APIv1,
+		APIVersion: APIv2,
 	}
 }
 
@@ -136,7 +136,7 @@ func BuildAlertmanagerConfig(address string, timeout time.Duration) (Alertmanage
 			StaticAddresses: []string{host},
 		},
 		Timeout:    model.Duration(timeout),
-		APIVersion: APIv1,
+		APIVersion: APIv2,
 	}, nil
 }
 

--- a/pkg/alert/config_test.go
+++ b/pkg/alert/config_test.go
@@ -58,7 +58,7 @@ func TestBuildAlertmanagerConfiguration(t *testing.T) {
 					StaticAddresses: []string{"localhost:9093"},
 					Scheme:          "http",
 				},
-				APIVersion: APIv1,
+				APIVersion: APIv2,
 			},
 		},
 		{
@@ -68,7 +68,7 @@ func TestBuildAlertmanagerConfiguration(t *testing.T) {
 					StaticAddresses: []string{"am.example.com"},
 					Scheme:          "https",
 				},
-				APIVersion: APIv1,
+				APIVersion: APIv2,
 			},
 		},
 		{
@@ -78,7 +78,7 @@ func TestBuildAlertmanagerConfiguration(t *testing.T) {
 					StaticAddresses: []string{"dns+localhost:9093"},
 					Scheme:          "http",
 				},
-				APIVersion: APIv1,
+				APIVersion: APIv2,
 			},
 		},
 		{
@@ -88,7 +88,7 @@ func TestBuildAlertmanagerConfiguration(t *testing.T) {
 					StaticAddresses: []string{"dnssrv+localhost"},
 					Scheme:          "http",
 				},
-				APIVersion: APIv1,
+				APIVersion: APIv2,
 			},
 		},
 		{
@@ -98,7 +98,7 @@ func TestBuildAlertmanagerConfiguration(t *testing.T) {
 					StaticAddresses: []string{"localhost"},
 					Scheme:          "ssh+http",
 				},
-				APIVersion: APIv1,
+				APIVersion: APIv2,
 			},
 		},
 		{
@@ -109,7 +109,7 @@ func TestBuildAlertmanagerConfiguration(t *testing.T) {
 					Scheme:          "https",
 					PathPrefix:      "/path/prefix/",
 				},
-				APIVersion: APIv1,
+				APIVersion: APIv2,
 			},
 		},
 		{
@@ -125,7 +125,7 @@ func TestBuildAlertmanagerConfiguration(t *testing.T) {
 					StaticAddresses: []string{"localhost:9093"},
 					Scheme:          "http",
 				},
-				APIVersion: APIv1,
+				APIVersion: APIv2,
 			},
 		},
 		{


### PR DESCRIPTION
the V1 alertmanager api has been deprecated since Jan 2019 with the `v0.16.0` release of alertmanager
the v1 apis are scheduled to be removed in `v0.28.0` and as of raising this PR we're at `v0.26.0`
that said the code changes to remove the v1 apis have been merged as of the Nov 2023
https://github.com/prometheus/alertmanager/pull/2970

we and i assume others just used the `--alertmanagers-url` which results in the v1 api being used by default
our upstream provider for alertmanager (grafana cloud) is currently ahead of the official releases and have already rolled out the above

this intent of this pr is to set the new default alertmanager api version to v2