### PR TITLE
docs: update helm installation instruction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 
 - [#7083](https://github.com/thanos-io/thanos/pull/7083) Store Gateway: Fix lazy expanded postings with 0 length failed to be cached.
 - [#7080](https://github.com/thanos-io/thanos/pull/7080) Receive: race condition in handler Close() when stopped early
+- [#7132](https://github.com/thanos-io/thanos/pull/7132) Documentation: fix broken helm installation instruction
 
 ### Added
 

--- a/tutorials/kubernetes-helm/README.md
+++ b/tutorials/kubernetes-helm/README.md
@@ -1,10 +1,14 @@
-To deploy thanos sidecar along with Prometheus using official helm chart - just run the next command, putting the values to a file `values.yaml` and changing `--namespace` value beforehand:
+To deploy thanos sidecar along with Prometheus using [community helm chart](https://prometheus-community.github.io/helm-charts) - just run the next command, putting the values to a file `values.yaml` and changing `--namespace` value beforehand:
 
 ```
-helm upgrade --version="8.6.0" --install --namespace="my-lovely-namespace" --values values.yaml  prometheus-thanos-sidecar stable/prometheus
+helm upgrade --version="25.11.0" --install --namespace="my-lovely-namespace" --values values.yaml  prometheus-thanos-sidecar prometheus-community/prometheus
 ```
 
-Take a note that you need to replace two placeholders in the values: `BUCKET_REPLACE_ME` and `CLUSTER_NAME`. Also adjust all the other values according to your infrastructure requirements.
+Please note that you need to replace the two placeholders in the values: `BUCKET_REPLACE_ME` and `CLUSTER_NAME`.
+It's also mandatory to create a secret for the sidecar to access the object storage bucket. 
+In the example below, `GCS` is used and for that a secret with name `thanos-storage-secret` got manually created and used in here.
+
+A more detailed documentation about the different values can be found on the [helm chart repository](https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus).
 
 An example of the `values.yaml` file:
 ```yaml
@@ -14,13 +18,13 @@ rbac:
 alertmanager:
   enabled: false
 
-pushgateway:
+prometheus-pushgateway:
   enabled: false
 
-nodeExporter:
+prometheus-node-exporter:
   enabled: false
 
-kubeStateMetrics:
+kube-state-metrics:
   enabled: false
 
 initChownData:
@@ -35,91 +39,67 @@ initChownData:
 server:
   extraArgs:
     log.level: debug
-    storage.tsdb.min-block-duration: 2h  # Don't change this, see docs/components/sidecar.md
-    storage.tsdb.max-block-duration: 2h  # Don't change this, see docs/components/sidecar.md
+    storage.tsdb.min-block-duration: 2h # Don't change this, see docs/components/sidecar.md
+    storage.tsdb.max-block-duration: 2h # Don't change this, see docs/components/sidecar.md
   retention: 4h
   service:
     annotations:
-       prometheus.io/scrape: "true"
-       prometheus.io/port: "9090"
+      prometheus.io/scrape: "true"
+      prometheus.io/port: "9090"
   statefulSet:
     enabled: true
   podAnnotations:
     prometheus.io/scrape: "true"
     prometheus.io/port: "10902"
-  affinity:
-    podAntiAffinity:
-      requiredDuringSchedulingIgnoredDuringExecution:
-      - labelSelector:
-          matchExpressions:
-          - key: app
-            operator: In
-            values:
-            - prometheus
-          - key: component
-            operator: In
-            values:
-            - server
-        topologyKey: "kubernetes.io/hostname"
   sidecarContainers:
-  - name: thanos-sidecar
-    # Always use explicit image tags (release or main-<date>-sha) instead of ambigous `latest` or `main`.
-    # Check https://quay.io/repository/thanos/thanos?tab=tags to get latest tag.
-    image: quay.io/thanos/thanos:main-2021-03-01-1bbad3b5
-    resources:
-      requests:
-        memory: "4Gi"
-        cpu: "2"
-      limits:
-        memory: "4Gi"
-        cpu: "2"
-    env:
-    - name: GOOGLE_APPLICATION_CREDENTIALS
-      value: /etc/secret/sa
-    args:
-    - "sidecar"
-    - "--log.level=debug"
-    - "--tsdb.path=/data/"
-    - "--prometheus.url=http://127.0.0.1:9090"
-    - "--objstore.config={type: GCS, config: {bucket: BUCKET_REPLACE_ME}}"
-    - "--reloader.config-file=/etc/prometheus-config/prometheus.yml"
-    - "--reloader.config-envsubst-file=/etc/prometheus-shared/prometheus.yml"
-    - "--reloader.rule-dir=/etc/prometheus-config/rules"
-    ports:
-    - name: sidecar-http
-      containerPort: 10902
-    - name: grpc
-      containerPort: 10901
-    - name: cluster
-      containerPort: 10900
-    volumeMounts:
-    - name: storage-volume
-      mountPath: /data
-    - name: thanos-storage-secret
-      mountPath: /etc/secret
-    - name: config-volume
-      mountPath: /etc/prometheus-config
-      readOnly: false
+    thanos-sidecar:
+      image: quay.io/thanos/thanos:v0.34.0
+      resources:
+        requests:
+          memory: "512Mi"
+      env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/secret/sa
+      args:
+        - "sidecar"
+        - "--log.level=debug"
+        - "--tsdb.path=/data/"
+        - "--prometheus.url=http://127.0.0.1:9090"
+        - "--objstore.config={type: GCS, config: {bucket: BUCKET_REPLACE_ME}}"
+        - "--reloader.config-file=/etc/prometheus-config/prometheus.yml"
+        - "--reloader.config-envsubst-file=/etc/prometheus-shared/prometheus.yml"
+        - "--reloader.rule-dir=/etc/prometheus-config/rules"
+      ports:
+        - name: sidecar-http
+          containerPort: 10902
+        - name: grpc
+          containerPort: 10901
+        - name: cluster
+          containerPort: 10900
+      volumeMounts:
+        - name: storage-volume
+          mountPath: /data
+        - name: thanos-storage-secret
+          mountPath: /etc/secret
+        - name: config-volume
+          mountPath: /etc/prometheus-config
+          readOnly: false
+        - name: prometheus-config-shared
+          mountPath: /etc/prometheus-shared/
+          readOnly: false
+  configPath: /etc/prometheus-shared/prometheus.yml
+  replicaCount: 1
+  persistentVolume:
+    size: 20Gi
+  extraVolumes: # spec.template.spec.volumes
+    - name: prometheus-config-shared
+      emptyDir: {}
+  extraVolumeMounts: # spec.template.spec.containers.volumeMounts for prometheus container
     - name: prometheus-config-shared
       mountPath: /etc/prometheus-shared/
-      readOnly: false
-  configPath: /etc/prometheus-shared/prometheus.yml
-  replicaCount: 2
-  persistentVolume:
-    size: 100Gi
-  extraVolumes:
-  - name: prometheus-config-shared
-    emptyDir: {}
-  extraVolumeMounts:
-  - name: prometheus-config-shared
-    mountPath: /etc/prometheus-shared/
   resources:
-    limits:
-      cpu: 4
-      memory: 20Gi
     requests:
-      cpu: 4
-      memory: 20Gi
+      memory: 1Gi
   global:
     scrape_interval: 5s
     scrape_timeout: 4s
@@ -128,27 +108,19 @@ server:
       prometheus_replica: '$(HOSTNAME)'
     evaluation_interval: 5s
   extraSecretMounts:
-  - name: thanos-storage-secret
-    mountPath: /etc/secret/
-    subPath: sa
-    readOnly: false
-    secretName: thanos-storage-secret
+    - name: thanos-storage-secret
+      mountPath: /etc/secret/
+      subPath: sa
+      readOnly: false
+      secretName: thanos-storage-secret
 
+# as thanos sidecar is taking care of the config reload
+# we can disable the prometheus configmap reload
 configmapReload:
-  image:
-    repository: gcr.io/google-containers/pause-amd64 # This image changed to just pause since there's no option to disable configmapReload container in chart, but thanos-sidecar overtakes this functionality. So basically we don't need another reloader
-    tag: 3.1
-  resources:
-    limits:
-      cpu: 20m
-      memory: 20Mi
-    requests:
-      cpu: 20m
-      memory: 20Mi
-
+  prometheus:
+    enabled: false
 
 serverFiles:
   alerts: {}
   rules: {}
-
 ```

--- a/tutorials/kubernetes-helm/README.md
+++ b/tutorials/kubernetes-helm/README.md
@@ -5,7 +5,7 @@ helm upgrade --version="25.11.0" --install --namespace="my-lovely-namespace" --v
 ```
 
 Please note that you need to replace the two placeholders in the values: `BUCKET_REPLACE_ME` and `CLUSTER_NAME`.
-It's also mandatory to create a secret for the sidecar to access the object storage bucket. 
+It's also mandatory to create a secret for the sidecar to access the object storage bucket.
 In the example below, `GCS` is used and for that a secret with name `thanos-storage-secret` got manually created and used in here.
 
 A more detailed documentation about the different values can be found on the [helm chart repository](https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus).


### PR DESCRIPTION
the prometheus helm chart is a community maintained chart since a few years. With that, the old example pointed to an old chart and the provided example values aren't also working anymore.

This update the documentation.

Fixes https://github.com/thanos-io/thanos/issues/6301

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->

```bash
helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
helm template --version="25.11.0" --namespace="prometheus" --values dev-thanos.yaml prometheus prometheus-community/prometheus
```
