### PR TITLE
Fixing log line for remote engine in debug mode

### DIFF
--- a/pkg/query/remote_engine.go
+++ b/pkg/query/remote_engine.go
@@ -344,7 +344,7 @@ func (r *remoteQuery) Exec(ctx context.Context) *promql.Result {
 		}
 		result = append(result, series)
 	}
-	level.Debug(r.logger).Log("Executed query", "query", r.qs, "time", time.Since(start))
+	level.Debug(r.logger).Log("msg", "Executed query", "query", r.qs, "time", time.Since(start))
 
 	return &promql.Result{Value: result, Warnings: warnings}
 }


### PR DESCRIPTION
* [x] Change is not relevant to the end user.

## Changes

Just fixing a log call with wrong pair-value parameters.

## Verification

Executed a query in remote mode.
