### PR TITLE
Adding new method on BucketedBytes to expose used memory

### DIFF
--- a/pkg/pool/pool.go
+++ b/pkg/pool/pool.go
@@ -17,6 +17,12 @@ type Bytes interface {
 	Put(b *[]byte)
 }
 
+type UsageAwareBytes interface {
+	Bytes
+	// UsedBytes returns the number of bytes currently in use.
+	UsedBytes() uint64
+}
+
 // NoopBytes is pool that always allocated required slice on heap and ignore puts.
 type NoopBytes struct{}
 
@@ -38,6 +44,12 @@ type BucketedBytes struct {
 	mtx       sync.Mutex
 
 	new func(s int) *[]byte
+}
+
+func (p *BucketedBytes) UsedBytes() uint64 {
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
+	return p.usedTotal
 }
 
 // MustNewBucketedBytes is like NewBucketedBytes but panics if construction fails.


### PR DESCRIPTION
## Summary

I am using Thanos as a library and want to expose a metric on how much of the Byte pool I am using, right now the `usedTotal` struct property is not exported, so I am adding a method to expose that information.

* [X] Change is not relevant to the end user.

## Changes

* Adds new method to `pkg/pool/BucketedBytes` to expose `usedTotal` property.

## Verification

N/A, API change.
