### PR TITLE
change the reflect package to an unsafe package

### DIFF
--- a/pkg/store/cache/inmemory.go
+++ b/pkg/store/cache/inmemory.go
@@ -5,7 +5,6 @@ package storecache
 
 import (
 	"context"
-	"reflect"
 	"sync"
 	"unsafe"
 
@@ -277,12 +276,7 @@ func (c *InMemoryIndexCache) reset() {
 }
 
 func copyString(s string) string {
-	var b []byte
-	h := (*reflect.SliceHeader)(unsafe.Pointer(&b))
-	h.Data = (*reflect.StringHeader)(unsafe.Pointer(&s)).Data
-	h.Len = len(s)
-	h.Cap = len(s)
-	return string(b)
+	return string(unsafe.Slice(unsafe.StringData(s), len(s)))
 }
 
 // copyToKey is required as underlying strings might be mmaped.


### PR DESCRIPTION
- as 'reflect.StringHeader' is deprecated, it is replaced with an unsafe package.

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

In the 'pkg/store/cache/inmemory.go' file, the copyString() function that used relfect.StringHeader was replaced with the unsafe.StringData() and unsafe.Slice() functions.

## Verification

<!-- How you tested it? How do you know it works? -->
