### PR TITLE
cache/caching_bucket: add path to hash

### DIFF
--- a/cmd/thanos/store.go
+++ b/cmd/thanos/store.go
@@ -309,7 +309,7 @@ func runStore(
 	r := route.New()
 
 	if len(cachingBucketConfigYaml) > 0 {
-		insBkt, err = storecache.NewCachingBucketFromYaml(cachingBucketConfigYaml, insBkt, logger, reg, r)
+		insBkt, err = storecache.NewCachingBucketFromYaml(cachingBucketConfigYaml, insBkt, logger, reg, r, conf.cachingBucketConfig.Path())
 		if err != nil {
 			return errors.Wrap(err, "create caching bucket")
 		}


### PR DESCRIPTION
Add path to the hash. This allows identifying difference instances by different config paths.
