### PR TITLE
receive/multitsdb: do not delete not uploaded blocks

### DIFF
--- a/pkg/receive/multitsdb.go
+++ b/pkg/receive/multitsdb.go
@@ -416,8 +416,8 @@ func (t *MultiTSDB) pruneTSDB(ctx context.Context, logger log.Logger, tenantInst
 	tenantInstance.mtx.Lock()
 	shipper := tenantInstance.ship
 	tenantInstance.ship = nil
-	tenantInstance.mtx.Unlock()
 	shipper.DisableWait()
+	tenantInstance.mtx.Unlock()
 
 	defer func() {
 		if pruned {

--- a/pkg/receive/multitsdb.go
+++ b/pkg/receive/multitsdb.go
@@ -416,7 +416,6 @@ func (t *MultiTSDB) pruneTSDB(ctx context.Context, logger log.Logger, tenantInst
 	tenantInstance.mtx.Lock()
 	shipper := tenantInstance.ship
 	tenantInstance.ship = nil
-	shipper.DisableWait()
 	tenantInstance.mtx.Unlock()
 
 	defer func() {
@@ -426,7 +425,6 @@ func (t *MultiTSDB) pruneTSDB(ctx context.Context, logger log.Logger, tenantInst
 		// If the tenant was not pruned, re-enable the shipper.
 		tenantInstance.mtx.Lock()
 		tenantInstance.ship = shipper
-		shipper.Enable()
 		tenantInstance.mtx.Unlock()
 	}()
 
@@ -447,7 +445,6 @@ func (t *MultiTSDB) pruneTSDB(ctx context.Context, logger log.Logger, tenantInst
 	level.Info(logger).Log("msg", "Pruning tenant")
 	if shipper != nil {
 		// No other code can reach this shipper anymore so enable it again to be able to sync manually.
-		shipper.Enable()
 		uploaded, err := shipper.Sync(ctx)
 		if err != nil {
 			return false, err

--- a/pkg/receive/writer.go
+++ b/pkg/receive/writer.go
@@ -225,9 +225,7 @@ func (r *Writer) Write(ctx context.Context, tenantID string, wreq *prompb.WriteR
 						numExemplarsLabelLength++
 						level.Debug(exLogger).Log("msg", "Label length for exemplar exceeds max limit", "limit", exemplar.ExemplarMaxLabelSetLength)
 					default:
-						if err != nil {
-							level.Debug(exLogger).Log("msg", "Error ingesting exemplar", "err", err)
-						}
+						level.Debug(exLogger).Log("msg", "Error ingesting exemplar", "err", err)
 					}
 				}
 			}


### PR DESCRIPTION
If a block hasn't been uploaded yet then tell the TSDB layer not to delete them. This prevents a nasty race where the TSDB layer can delete a block before the shipper gets to it. I saw this happen with a very small block.

Similar code in Cortex https://github.com/cortexproject/cortex/blob/c03317017ac0d60e16ae644ab4d3332717450bcd/pkg/ingester/ingester.go#L438. I don't get the point of caching the reading because the file is typically very small.
