### PR TITLE
storepb: make ServerAsClient channels unbuffered

### DIFF
--- a/pkg/api/query/v1_test.go
+++ b/pkg/api/query/v1_test.go
@@ -780,7 +780,7 @@ func TestQueryAnalyzeEndpoints(t *testing.T) {
 func newProxyStoreWithTSDBStore(db store.TSDBReader) *store.ProxyStore {
 	c := &storetestutil.TestClient{
 		Name:        "1",
-		StoreClient: storepb.ServerAsClient(store.NewTSDBStore(nil, db, component.Query, nil), 0),
+		StoreClient: storepb.ServerAsClient(store.NewTSDBStore(nil, db, component.Query, nil)),
 		MinTime:     math.MinInt64, MaxTime: math.MaxInt64,
 	}
 

--- a/pkg/query/querier_test.go
+++ b/pkg/query/querier_test.go
@@ -836,7 +836,7 @@ func newProxyStore(storeAPIs ...storepb.StoreServer) *store.ProxyStore {
 		}
 		cls[i] = &storetestutil.TestClient{
 			Name:        fmt.Sprintf("%v", i),
-			StoreClient: storepb.ServerAsClient(s, 0),
+			StoreClient: storepb.ServerAsClient(s),
 			MinTime:     math.MinInt64, MaxTime: math.MaxInt64,
 			WithoutReplicaLabelsEnabled: withoutReplicaLabelsEnabled,
 		}

--- a/pkg/query/query_test.go
+++ b/pkg/query/query_test.go
@@ -51,7 +51,7 @@ func TestQuerier_Proxy(t *testing.T) {
 				// TODO(bwplotka): Parse external labels.
 				clients = append(clients, &storetestutil.TestClient{
 					Name:        fmt.Sprintf("store number %v", i),
-					StoreClient: storepb.ServerAsClient(selectedStore(store.NewTSDBStore(logger, st.storage.DB, component.Debug, nil), m, st.mint, st.maxt), 0),
+					StoreClient: storepb.ServerAsClient(selectedStore(store.NewTSDBStore(logger, st.storage.DB, component.Debug, nil), m, st.mint, st.maxt)),
 					MinTime:     st.mint,
 					MaxTime:     st.maxt,
 				})

--- a/pkg/receive/multitsdb.go
+++ b/pkg/receive/multitsdb.go
@@ -183,7 +183,7 @@ func (t *tenant) client(logger log.Logger) store.Client {
 		return nil
 	}
 
-	client := storepb.ServerAsClient(store.NewRecoverableStoreServer(logger, tsdbStore), 0)
+	client := storepb.ServerAsClient(store.NewRecoverableStoreServer(logger, tsdbStore))
 	return newLocalClient(client, tsdbStore)
 }
 

--- a/pkg/store/acceptance_test.go
+++ b/pkg/store/acceptance_test.go
@@ -1008,8 +1008,8 @@ func TestProxyStore_Acceptance(t *testing.T) {
 		p2 := startNestedStore(tt, extLset, appendFn)
 
 		clients := []Client{
-			storetestutil.TestClient{StoreClient: storepb.ServerAsClient(p1, 0)},
-			storetestutil.TestClient{StoreClient: storepb.ServerAsClient(p2, 0)},
+			storetestutil.TestClient{StoreClient: storepb.ServerAsClient(p1)},
+			storetestutil.TestClient{StoreClient: storepb.ServerAsClient(p2)},
 		}
 
 		return NewProxyStore(nil, nil, func() []Client { return clients }, component.Query, labels.EmptyLabels(), 0*time.Second, RetrievalStrategy(EagerRetrieval))

--- a/pkg/store/storepb/inprocess_test.go
+++ b/pkg/store/storepb/inprocess_test.go
@@ -59,6 +59,7 @@ func (t *testStoreServer) LabelValues(_ context.Context, r *LabelValuesRequest) 
 }
 
 func TestServerAsClient(t *testing.T) {
+	ctx := context.Background()
 	for _, bufferSize := range []int{0, 1, 20, 100} {
 		t.Run(fmt.Sprintf("buffer=%v", bufferSize), func(t *testing.T) {
 			t.Run("Info", func(t *testing.T) {
@@ -72,7 +73,7 @@ func TestServerAsClient(t *testing.T) {
 				t.Run("ok", func(t *testing.T) {
 					for i := 0; i < 20; i++ {
 						r := &InfoRequest{}
-						resp, err := ServerAsClient(s, 0).Info(context.TODO(), r)
+						resp, err := ServerAsClient(s).Info(ctx, r)
 						testutil.Ok(t, err)
 						testutil.Equals(t, s.info, resp)
 						testutil.Equals(t, r, s.infoLastReq)
@@ -83,7 +84,7 @@ func TestServerAsClient(t *testing.T) {
 					s.err = errors.New("some error")
 					for i := 0; i < 20; i++ {
 						r := &InfoRequest{}
-						_, err := ServerAsClient(s, 0).Info(context.TODO(), r)
+						_, err := ServerAsClient(s).Info(ctx, r)
 						testutil.NotOk(t, err)
 						testutil.Equals(t, s.err, err)
 					}
@@ -114,7 +115,7 @@ func TestServerAsClient(t *testing.T) {
 							Matchers:                []LabelMatcher{{Value: "wfsdfs", Name: "__name__", Type: LabelMatcher_EQ}},
 							PartialResponseStrategy: PartialResponseStrategy_ABORT,
 						}
-						client, err := ServerAsClient(s, 0).Series(context.TODO(), r)
+						client, err := ServerAsClient(s).Series(ctx, r)
 						testutil.Ok(t, err)
 						var resps []*SeriesResponse
 						for {
@@ -139,7 +140,7 @@ func TestServerAsClient(t *testing.T) {
 							Matchers:                []LabelMatcher{{Value: "wfsdfs", Name: "__name__", Type: LabelMatcher_EQ}},
 							PartialResponseStrategy: PartialResponseStrategy_ABORT,
 						}
-						client, err := ServerAsClient(s, 0).Series(context.TODO(), r)
+						client, err := ServerAsClient(s).Series(ctx, r)
 						testutil.Ok(t, err)
 						var resps []*SeriesResponse
 						for {
@@ -167,7 +168,7 @@ func TestServerAsClient(t *testing.T) {
 							Matchers:                []LabelMatcher{{Value: "wfsdfs", Name: "__name__", Type: LabelMatcher_EQ}},
 							PartialResponseStrategy: PartialResponseStrategy_ABORT,
 						}
-						client, err := ServerAsClient(s, 0).Series(context.TODO(), r)
+						client, err := ServerAsClient(s).Series(ctx, r)
 						testutil.Ok(t, err)
 						var resps []*SeriesResponse
 						for {
@@ -202,7 +203,7 @@ func TestServerAsClient(t *testing.T) {
 							End:                     234,
 							PartialResponseStrategy: PartialResponseStrategy_ABORT,
 						}
-						resp, err := ServerAsClient(s, 0).LabelNames(context.TODO(), r)
+						resp, err := ServerAsClient(s).LabelNames(ctx, r)
 						testutil.Ok(t, err)
 						testutil.Equals(t, s.labelNames, resp)
 						testutil.Equals(t, r, s.labelNamesLastReq)
@@ -217,7 +218,7 @@ func TestServerAsClient(t *testing.T) {
 							End:                     234,
 							PartialResponseStrategy: PartialResponseStrategy_ABORT,
 						}
-						_, err := ServerAsClient(s, 0).LabelNames(context.TODO(), r)
+						_, err := ServerAsClient(s).LabelNames(ctx, r)
 						testutil.NotOk(t, err)
 						testutil.Equals(t, s.err, err)
 					}
@@ -238,7 +239,7 @@ func TestServerAsClient(t *testing.T) {
 							End:                     234,
 							PartialResponseStrategy: PartialResponseStrategy_ABORT,
 						}
-						resp, err := ServerAsClient(s, 0).LabelValues(context.TODO(), r)
+						resp, err := ServerAsClient(s).LabelValues(ctx, r)
 						testutil.Ok(t, err)
 						testutil.Equals(t, s.labelValues, resp)
 						testutil.Equals(t, r, s.labelValuesLastReq)
@@ -254,7 +255,7 @@ func TestServerAsClient(t *testing.T) {
 							End:                     234,
 							PartialResponseStrategy: PartialResponseStrategy_ABORT,
 						}
-						_, err := ServerAsClient(s, 0).LabelValues(context.TODO(), r)
+						_, err := ServerAsClient(s).LabelValues(ctx, r)
 						testutil.NotOk(t, err)
 						testutil.Equals(t, s.err, err)
 					}


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

Use unbuffered channels in ServerAsClient.

As far as i can tell all callsites of this function used 0 for their buffersize already. In a recent PR we found that using unbuffered channels causes ProxyStore to receive incomplete responses: https://app.circleci.com/pipelines/github/thanos-io/thanos/15685/workflows/ae306ee4-99e2-4eba-b76b-37bf906fc9b0/jobs/25975?invite=true#step-108-83819_118. 


## Verification

<!-- How you tested it? How do you know it works? -->
