### PR TITLE
Expose NewPromSeriesSet function

### DIFF
--- a/pkg/query/iter.go
+++ b/pkg/query/iter.go
@@ -27,6 +27,17 @@ type promSeriesSet struct {
 	warns annotations.Annotations
 }
 
+// NewPromSeriesSet constructs a promSeriesSet.
+func NewPromSeriesSet(seriesSet storepb.SeriesSet, mint, maxt int64, aggrs []storepb.Aggr, warns annotations.Annotations) storage.SeriesSet {
+	return &promSeriesSet{
+		set:   seriesSet,
+		mint:  mint,
+		maxt:  maxt,
+		aggrs: aggrs,
+		warns: warns,
+	}
+}
+
 func (s *promSeriesSet) Next() bool {
 	return s.set.Next()
 }


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

This PR exposes `promSeriesSet` by adding a new function `NewPromSeriesSet`.
This could help projects like Cortex that reuses Thanos code to be able to query store gateway.

By exposing this function, I can just get rid of https://github.com/cortexproject/cortex/blob/master/pkg/querier/block.go#L44 because they do almost the same thing.

`promSeriesSet` also handles downsampling so it is a plus and beneficial to Cortex when it adds downsampling in the future.

## Verification

<!-- How you tested it? How do you know it works? -->
