### PR TITLE
Receive: stop relying on grpc server config to set grpc client secure/skipVerify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#7200](https://github.com/thanos-io/thanos/pull/7175): Query: Add `--selector.relabel-config` and `--selector.relabel-config-file` flags which allows scoping the Querier to a subset of matched TSDBs.
 - [#7233](https://github.com/thanos-io/thanos/pull/7233): UI: Showing Block Size Stats
 - [#7280](https://github.com/thanos-io/thanos/pull/7281): Adding User-Agent to request logs
+- [#7219](https://github.com/thanos-io/thanos/pull/7219): Receive: add `--remote-write.client-tls-secure` and `--remote-write.client-tls-skip-verify` flags to stop relying on grpc server config to determine grpc client secure/skipVerify.
 
 ### Changed
 

--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -144,8 +144,8 @@ func runReceive(
 		logger,
 		reg,
 		tracer,
-		conf.grpcConfig.tlsSrvCert != "",
-		conf.grpcConfig.tlsSrvClientCA == "",
+		conf.rwClientSecure,
+		conf.rwClientSkipVerify,
 		conf.rwClientCert,
 		conf.rwClientKey,
 		conf.rwClientServerCA,
@@ -781,8 +781,10 @@ type receiveConfig struct {
 	rwServerClientCA   string
 	rwClientCert       string
 	rwClientKey        string
+	rwClientSecure     bool
 	rwClientServerCA   string
 	rwClientServerName string
+	rwClientSkipVerify bool
 
 	dataDir   string
 	labelStrs []string
@@ -855,6 +857,10 @@ func (rc *receiveConfig) registerFlag(cmd extkingpin.FlagClause) {
 	cmd.Flag("remote-write.client-tls-cert", "TLS Certificates to use to identify this client to the server.").Default("").StringVar(&rc.rwClientCert)
 
 	cmd.Flag("remote-write.client-tls-key", "TLS Key for the client's certificate.").Default("").StringVar(&rc.rwClientKey)
+
+	cmd.Flag("remote-write.client-tls-secure", "Use TLS when talking to the other receivers.").Default("false").BoolVar(&rc.rwClientSecure)
+
+	cmd.Flag("remote-write.client-tls-skip-verify", "Disable TLS certificate verification when talking to the other receivers i.e self signed, signed by fake CA.").Default("false").BoolVar(&rc.rwClientSkipVerify)
 
 	cmd.Flag("remote-write.client-tls-ca", "TLS CA Certificates to use to verify servers.").Default("").StringVar(&rc.rwClientServerCA)
 

--- a/docs/components/receive.md
+++ b/docs/components/receive.md
@@ -444,6 +444,12 @@ Flags:
                                  to the server.
       --remote-write.client-tls-key=""
                                  TLS Key for the client's certificate.
+      --remote-write.client-tls-secure
+                                 Use TLS when talking to the other receivers.
+      --remote-write.client-tls-skip-verify
+                                 Disable TLS certificate verification when
+                                 talking to the other receivers i.e self signed,
+                                 signed by fake CA.
       --remote-write.server-tls-cert=""
                                  TLS Certificate for HTTP server, leave blank to
                                  disable TLS.


### PR DESCRIPTION
* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

I'm using a thanos receive HA cluster on ECS Fargate, with 3 endpoints in the hashring, with one dedicated listener + grpc target group per endpoint.

The TLS termination is done at the listener level (so out of thanos). Therefore the thanos receive containers are configured **with no TLS**.

When testing, I ended up with `error reading server preface: http2: frame too large` errors.

After debugging, I found that the receive grpc client is configured in secure mode only if the receive grpc server has TLS enabled.
This breaks the inter-endpoint communication between our hashring members.

To fix this problem, I introduce 2 new flags `--remote-write.client-tls-secure` and `--remote-write.client-tls-skip-verify` to mimic what is done in the [grpc client configuration of thanos query.](https://github.com/thanos-io/thanos/blob/v0.34.1/cmd/thanos/query.go#L450).

## Verification

Everything is now working on our cluster.