### PR TITLE
Query-frontend: fix missing redis username config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#7132](https://github.com/thanos-io/thanos/pull/7132) Documentation: fix broken helm installation instruction
 - [#7134](https://github.com/thanos-io/thanos/pull/7134) Store, Compact: Revert the recursive block listing mechanism introduced in https://github.com/thanos-io/thanos/pull/6474 and use the same strategy as in 0.31. Introduce a `--block-discovery-strategy` flag to control the listing strategy so that a recursive lister can still be used if the tradeoff of slower but cheaper discovery is preferred.
 - [#7122](https://github.com/thanos-io/thanos/pull/7122) Store Gateway: Fix lazy expanded postings estimate base cardinality using posting group with remove keys.
+- [#7224](https://github.com/thanos-io/thanos/pull/7224) Query-frontend: Add Redis username to the client configuration.
 
 ### Added
 - [#7194](https://github.com/thanos-io/thanos/pull/7194) Downsample: retry objstore related errors

--- a/internal/cortex/chunk/cache/redis_client.go
+++ b/internal/cortex/chunk/cache/redis_client.go
@@ -25,6 +25,7 @@ type RedisConfig struct {
 	Timeout            time.Duration  `yaml:"timeout"`
 	Expiration         time.Duration  `yaml:"expiration"`
 	DB                 int            `yaml:"db"`
+	Username           string         `yaml:"username"`
 	Password           flagext.Secret `yaml:"password"`
 	EnableTLS          bool           `yaml:"tls_enabled"`
 	InsecureSkipVerify bool           `yaml:"tls_insecure_skip_verify"`
@@ -54,6 +55,7 @@ func NewRedisClient(cfg *RedisConfig) (*RedisClient, error) {
 		InitAddress:      strings.Split(cfg.Endpoint, ","),
 		ShuffleInit:      true,
 		Password:         cfg.Password.Value,
+		Username:         cfg.Username,
 		SelectDB:         cfg.DB,
 		Dialer:           net.Dialer{Timeout: cfg.Timeout},
 		ConnWriteTimeout: cfg.Timeout,

--- a/pkg/queryfrontend/config.go
+++ b/pkg/queryfrontend/config.go
@@ -168,6 +168,7 @@ func NewCacheConfig(logger log.Logger, confContentYaml []byte) (*cortexcache.Con
 				Expiration: config.Expiration,
 				DB:         config.Redis.DB,
 				Password:   flagext.Secret{Value: config.Redis.Password},
+				Username:   config.Redis.Username,
 			},
 			Background: cortexcache.BackgroundConfig{
 				WriteBackBuffer:     config.Redis.MaxSetMultiConcurrency * config.Redis.SetMultiBatchSize,


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->
This PR forwards the Redis username configured in the Thanos Cache to the redis client configuration.
It fixes https://github.com/thanos-io/thanos/issues/7103

## Verification

<!-- How you tested it? How do you know it works? -->
Tested with following Redis configuration:
```
bind 0.0.0.0 
port 6379

user default nopass ~* -@all
user thanosuser on allcommands allkeys >thanospassword 
```

And following query-frontend configuration:
```
--query-range.response-cache-config=type: REDIS
          config:
            addr: redis.thanos.svc.cluster.local:6379
            username: thanosuser
            password: thanospassword
```
