### PR TITLE
Don't halt compaction due to overlapping sources when vertical compac…

### DIFF
--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -807,14 +807,17 @@ type CompactionLifecycleCallback interface {
 type DefaultCompactionLifecycleCallback struct {
 }
 
-func (c DefaultCompactionLifecycleCallback) PreCompactionCallback(_ context.Context, _ log.Logger, _ *Group, toCompactBlocks []*metadata.Meta) error {
+func (c DefaultCompactionLifecycleCallback) PreCompactionCallback(_ context.Context, logger log.Logger, cg *Group, toCompactBlocks []*metadata.Meta) error {
 	// Due to #183 we verify that none of the blocks in the plan have overlapping sources.
 	// This is one potential source of how we could end up with duplicated chunks.
 	uniqueSources := map[ulid.ULID]struct{}{}
 	for _, m := range toCompactBlocks {
 		for _, s := range m.Compaction.Sources {
 			if _, ok := uniqueSources[s]; ok {
-				return halt(errors.Errorf("overlapping sources detected for plan %v", toCompactBlocks))
+				if !cg.enableVerticalCompaction {
+					return halt(errors.Errorf("overlapping sources detected for plan %v", toCompactBlocks))
+				}
+				level.Warn(logger).Log("msg", "overlapping sources detected for plan", "duplicated_block", s, "to_compact_blocks", fmt.Sprintf("%v", toCompactBlocks))
 			}
 			uniqueSources[s] = struct{}{}
 		}


### PR DESCRIPTION
…tion is enabled

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

When vertical compaction is enabled, there is no need to halt compaction when overlapping sources are detected. Instead of  halting, log it as a warning instead.

## Verification

<!-- How you tested it? How do you know it works? -->
