### PR TITLE
Sidecar Flag: Random delay before upload blocks on sidecar

### DIFF
--- a/cmd/thanos/config.go
+++ b/cmd/thanos/config.go
@@ -164,6 +164,7 @@ type shipperConfig struct {
 	allowOutOfOrderUpload bool
 	hashFunc              string
 	metaFileName          string
+	uploadJitter          time.Duration
 }
 
 func (sc *shipperConfig) registerFlag(cmd extkingpin.FlagClause) *shipperConfig {

--- a/docs/components/sidecar.md
+++ b/docs/components/sidecar.md
@@ -228,6 +228,7 @@ Flags:
                                  configuration. See format details:
                                  https://thanos.io/tip/thanos/tracing.md/#configuration
       --tsdb.path="./data"       Data directory of TSDB.
+      --upload-jitter=0s         Maximum random delay before uploading blocks.
       --version                  Show application version.
 
 ```


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->
Implemented the logic to sleep for a random time between 0 and the specified jitter before uploading blocks.

## Verification

<!-- How you tested it? How do you know it works? -->
