### PR TITLE
fix(ui/blocks): fixing overlapping blocks for empty poolArrays

### DIFF
--- a/pkg/ui/react-app/src/thanos/pages/blocks/helpers.ts
+++ b/pkg/ui/react-app/src/thanos/pages/blocks/helpers.ts
@@ -156,7 +156,7 @@ export const getFilteredBlockPools = (
     const poolArrayIndex = blockPools[key];
     const poolArray = poolArrayIndex[Object.keys(poolArrayIndex)[0]];
     for (let i = 0; i < filteredBlocks.length; i++) {
-      if (JSON.stringify(filteredBlocks[i].thanos.labels) === JSON.stringify(poolArray[0][0].thanos.labels)) {
+      if (JSON.stringify(filteredBlocks[i]?.thanos.labels) === JSON.stringify(poolArray[0][0]?.thanos.labels)) {
         Object.assign(newblockPools, { [key]: blockPools[key] });
         break;
       }


### PR DESCRIPTION
It appears that `poolArray[0][0]` can return `undefined`, resulting in an error when trying to read `.thanos`.

I haven't dug deeper into why it's undefined, so there is a root cause that should be fixed instead?

* [ ] I added CHANGELOG entry for this change.

Fixes #7216 

## Changes

Using `?.` to catch undefined poolArrays.

## Verification
If have only tested this with my Thanos deployment, which hasn't any overlapping blocks - can someone check if this works also when there are overlapping blocks present?
