### PR TITLE
Change shipper to not overwrite all external labels

### DIFF
--- a/pkg/shipper/shipper.go
+++ b/pkg/shipper/shipper.go
@@ -383,7 +383,9 @@ func (s *Shipper) upload(ctx context.Context, meta *metadata.Meta) error {
 	}
 	// Attach current labels and write a new meta file with Thanos extensions.
 	if lset := s.getLabels(); !lset.IsEmpty() {
-		meta.Thanos.Labels = lset.Map()
+		lset.Range(func(l labels.Label) {
+			meta.Thanos.Labels[l.Name] = l.Value
+		})
 	}
 	meta.Thanos.Source = s.source
 	meta.Thanos.SegmentFiles = block.GetSegmentFiles(updir)


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

At shipper, instead of using the provided external labels, only overwriting labels configured. If the block created by TSDB already has external labels attached, then there is no need to overwrite all labels again.

This shouldn't affect existing Thanos users.

## Verification

Add one test case.
