### PR TITLE
receive/handler: implement tenant label splitting

### DIFF
--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -887,7 +887,7 @@ func (rc *receiveConfig) registerFlag(cmd extkingpin.FlagClause) {
 
 	cmd.Flag("receive.default-tenant-id", "Default tenant ID to use when none is provided via a header.").Default(tenancy.DefaultTenant).StringVar(&rc.defaultTenantID)
 
-	cmd.Flag("receive.split-tenant-label-name", "Label name through which the request will be split into multiple tenants. This takes precendence over the HTTP header.").Default("").StringVar(&rc.splitTenantLabelName)
+	cmd.Flag("receive.split-tenant-label-name", "Label name through which the request will be split into multiple tenants. This takes precedence over the HTTP header.").Default("").StringVar(&rc.splitTenantLabelName)
 
 	cmd.Flag("receive.tenant-label-name", "Label name through which the tenant will be announced.").Default(tenancy.DefaultTenantLabel).StringVar(&rc.tenantLabelName)
 

--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -237,24 +237,25 @@ func runReceive(
 	}
 
 	webHandler := receive.NewHandler(log.With(logger, "component", "receive-handler"), &receive.Options{
-		Writer:            writer,
-		ListenAddress:     conf.rwAddress,
-		Registry:          reg,
-		Endpoint:          conf.endpoint,
-		TenantHeader:      conf.tenantHeader,
-		TenantField:       conf.tenantField,
-		DefaultTenantID:   conf.defaultTenantID,
-		ReplicaHeader:     conf.replicaHeader,
-		ReplicationFactor: conf.replicationFactor,
-		RelabelConfigs:    relabelConfig,
-		ReceiverMode:      receiveMode,
-		Tracer:            tracer,
-		TLSConfig:         rwTLSConfig,
-		DialOpts:          dialOpts,
-		ForwardTimeout:    time.Duration(*conf.forwardTimeout),
-		MaxBackoff:        time.Duration(*conf.maxBackoff),
-		TSDBStats:         dbs,
-		Limiter:           limiter,
+		Writer:               writer,
+		ListenAddress:        conf.rwAddress,
+		Registry:             reg,
+		Endpoint:             conf.endpoint,
+		TenantHeader:         conf.tenantHeader,
+		TenantField:          conf.tenantField,
+		DefaultTenantID:      conf.defaultTenantID,
+		ReplicaHeader:        conf.replicaHeader,
+		ReplicationFactor:    conf.replicationFactor,
+		RelabelConfigs:       relabelConfig,
+		ReceiverMode:         receiveMode,
+		Tracer:               tracer,
+		TLSConfig:            rwTLSConfig,
+		SplitTenantLabelName: conf.splitTenantLabelName,
+		DialOpts:             dialOpts,
+		ForwardTimeout:       time.Duration(*conf.forwardTimeout),
+		MaxBackoff:           time.Duration(*conf.maxBackoff),
+		TSDBStats:            dbs,
+		Limiter:              limiter,
 	})
 
 	grpcProbe := prober.NewGRPC()
@@ -815,9 +816,10 @@ type receiveConfig struct {
 	tsdbMemorySnapshotOnShutdown bool
 	tsdbEnableNativeHistograms   bool
 
-	walCompression  bool
-	noLockFile      bool
-	writerInterning bool
+	walCompression       bool
+	noLockFile           bool
+	writerInterning      bool
+	splitTenantLabelName string
 
 	hashFunc string
 
@@ -884,6 +886,8 @@ func (rc *receiveConfig) registerFlag(cmd extkingpin.FlagClause) {
 	cmd.Flag("receive.tenant-certificate-field", "Use TLS client's certificate field to determine tenant for write requests. Must be one of "+tenancy.CertificateFieldOrganization+", "+tenancy.CertificateFieldOrganizationalUnit+" or "+tenancy.CertificateFieldCommonName+". This setting will cause the receive.tenant-header flag value to be ignored.").Default("").EnumVar(&rc.tenantField, "", tenancy.CertificateFieldOrganization, tenancy.CertificateFieldOrganizationalUnit, tenancy.CertificateFieldCommonName)
 
 	cmd.Flag("receive.default-tenant-id", "Default tenant ID to use when none is provided via a header.").Default(tenancy.DefaultTenant).StringVar(&rc.defaultTenantID)
+
+	cmd.Flag("receive.split-tenant-label-name", "Label name through which the request will be split into multiple tenants.").Default("").StringVar(&rc.splitTenantLabelName)
 
 	cmd.Flag("receive.tenant-label-name", "Label name through which the tenant will be announced.").Default(tenancy.DefaultTenantLabel).StringVar(&rc.tenantLabelName)
 

--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -887,7 +887,7 @@ func (rc *receiveConfig) registerFlag(cmd extkingpin.FlagClause) {
 
 	cmd.Flag("receive.default-tenant-id", "Default tenant ID to use when none is provided via a header.").Default(tenancy.DefaultTenant).StringVar(&rc.defaultTenantID)
 
-	cmd.Flag("receive.split-tenant-label-name", "Label name through which the request will be split into multiple tenants.").Default("").StringVar(&rc.splitTenantLabelName)
+	cmd.Flag("receive.split-tenant-label-name", "Label name through which the request will be split into multiple tenants. This takes precendence over the HTTP header.").Default("").StringVar(&rc.splitTenantLabelName)
 
 	cmd.Flag("receive.tenant-label-name", "Label name through which the tenant will be announced.").Default(tenancy.DefaultTenantLabel).StringVar(&rc.tenantLabelName)
 

--- a/docs/components/receive.md
+++ b/docs/components/receive.md
@@ -415,6 +415,10 @@ Flags:
       --receive.replication-factor=1
                                  How many times to replicate incoming write
                                  requests.
+      --receive.split-tenant-label-name=""
+                                 Label name through which the request will
+                                 be split into multiple tenants. This takes
+                                 precendence over the HTTP header.
       --receive.tenant-certificate-field=
                                  Use TLS client's certificate field to
                                  determine tenant for write requests.

--- a/docs/components/receive.md
+++ b/docs/components/receive.md
@@ -418,7 +418,7 @@ Flags:
       --receive.split-tenant-label-name=""
                                  Label name through which the request will
                                  be split into multiple tenants. This takes
-                                 precendence over the HTTP header.
+                                 precedence over the HTTP header.
       --receive.tenant-certificate-field=
                                  Use TLS client's certificate field to
                                  determine tenant for write requests.

--- a/pkg/receive/handler.go
+++ b/pkg/receive/handler.go
@@ -29,6 +29,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/common/route"
+	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/relabel"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb"
@@ -92,6 +93,7 @@ type Options struct {
 	ReplicaHeader           string
 	Endpoint                string
 	ReplicationFactor       uint64
+	SplitTenantLabelName    string
 	ReceiverMode            ReceiverMode
 	Tracer                  opentracing.Tracer
 	TLSConfig               *tls.Config
@@ -106,11 +108,12 @@ type Options struct {
 
 // Handler serves a Prometheus remote write receiving HTTP endpoint.
 type Handler struct {
-	logger  log.Logger
-	writer  *Writer
-	router  *route.Router
-	options *Options
-	httpSrv *http.Server
+	logger               log.Logger
+	writer               *Writer
+	router               *route.Router
+	options              *Options
+	splitTenantLabelName string
+	httpSrv              *http.Server
 
 	mtx          sync.RWMutex
 	hashring     Hashring
@@ -143,10 +146,11 @@ func NewHandler(logger log.Logger, o *Options) *Handler {
 	}
 
 	h := &Handler{
-		logger:  logger,
-		writer:  o.Writer,
-		router:  route.New(),
-		options: o,
+		logger:               logger,
+		writer:               o.Writer,
+		router:               route.New(),
+		options:              o,
+		splitTenantLabelName: o.SplitTenantLabelName,
 		peers: newPeerGroup(
 			backoff.Backoff{
 				Factor: 2,
@@ -458,15 +462,15 @@ func (h *Handler) receiveHTTP(w http.ResponseWriter, r *http.Request) {
 	span.SetTag("receiver.mode", string(h.receiverMode))
 	defer span.Finish()
 
-	tenant, err := tenancy.GetTenantFromHTTP(r, h.options.TenantHeader, h.options.DefaultTenantID, h.options.TenantField)
+	tenantHTTP, err := tenancy.GetTenantFromHTTP(r, h.options.TenantHeader, h.options.DefaultTenantID, h.options.TenantField)
 	if err != nil {
 		level.Error(h.logger).Log("msg", "error getting tenant from HTTP", "err", err)
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 
-	tLogger := log.With(h.logger, "tenant", tenant)
-	span.SetTag("tenant", tenant)
+	tLogger := log.With(h.logger, "tenant", tenantHTTP)
+	span.SetTag("tenant", tenantHTTP)
 
 	writeGate := h.Limiter.WriteGate()
 	tracing.DoInSpan(r.Context(), "receive_write_gate_ismyturn", func(ctx context.Context) {
@@ -479,7 +483,7 @@ func (h *Handler) receiveHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	under, err := h.Limiter.HeadSeriesLimiter().isUnderLimit(tenant)
+	under, err := h.Limiter.HeadSeriesLimiter().isUnderLimit(tenantHTTP)
 	if err != nil {
 		level.Error(tLogger).Log("msg", "error while limiting", "err", err.Error())
 	}
@@ -495,7 +499,7 @@ func (h *Handler) receiveHTTP(w http.ResponseWriter, r *http.Request) {
 	// Since this is receive hot path, grow upfront saving allocations and CPU time.
 	compressed := bytes.Buffer{}
 	if r.ContentLength >= 0 {
-		if !requestLimiter.AllowSizeBytes(tenant, r.ContentLength) {
+		if !requestLimiter.AllowSizeBytes(tenantHTTP, r.ContentLength) {
 			http.Error(w, "write request too large", http.StatusRequestEntityTooLarge)
 			return
 		}
@@ -515,7 +519,7 @@ func (h *Handler) receiveHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !requestLimiter.AllowSizeBytes(tenant, int64(len(reqBuf))) {
+	if !requestLimiter.AllowSizeBytes(tenantHTTP, int64(len(reqBuf))) {
 		http.Error(w, "write request too large", http.StatusRequestEntityTooLarge)
 		return
 	}
@@ -551,7 +555,7 @@ func (h *Handler) receiveHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !requestLimiter.AllowSeries(tenant, int64(len(wreq.Timeseries))) {
+	if !requestLimiter.AllowSeries(tenantHTTP, int64(len(wreq.Timeseries))) {
 		http.Error(w, "too many timeseries", http.StatusRequestEntityTooLarge)
 		return
 	}
@@ -560,7 +564,7 @@ func (h *Handler) receiveHTTP(w http.ResponseWriter, r *http.Request) {
 	for _, timeseries := range wreq.Timeseries {
 		totalSamples += len(timeseries.Samples)
 	}
-	if !requestLimiter.AllowSamples(tenant, int64(totalSamples)) {
+	if !requestLimiter.AllowSamples(tenantHTTP, int64(totalSamples)) {
 		http.Error(w, "too many samples", http.StatusRequestEntityTooLarge)
 		return
 	}
@@ -573,7 +577,8 @@ func (h *Handler) receiveHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	responseStatusCode := http.StatusOK
-	if err := h.handleRequest(ctx, rep, tenant, &wreq); err != nil {
+	tenantStats, err := h.handleRequest(ctx, rep, tenantHTTP, &wreq)
+	if err != nil {
 		level.Debug(tLogger).Log("msg", "failed to handle request", "err", err.Error())
 		switch errors.Cause(err) {
 		case errNotReady:
@@ -590,12 +595,22 @@ func (h *Handler) receiveHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 		http.Error(w, err.Error(), responseStatusCode)
 	}
-	h.writeTimeseriesTotal.WithLabelValues(strconv.Itoa(responseStatusCode), tenant).Observe(float64(len(wreq.Timeseries)))
-	h.writeSamplesTotal.WithLabelValues(strconv.Itoa(responseStatusCode), tenant).Observe(float64(totalSamples))
+
+	for tenant, stats := range tenantStats {
+		h.writeTimeseriesTotal.WithLabelValues(strconv.Itoa(responseStatusCode), tenant).Observe(float64(stats.timeseries))
+		h.writeSamplesTotal.WithLabelValues(strconv.Itoa(responseStatusCode), tenant).Observe(float64(stats.totalSamples))
+	}
 }
 
-func (h *Handler) handleRequest(ctx context.Context, rep uint64, tenant string, wreq *prompb.WriteRequest) error {
-	tLogger := log.With(h.logger, "tenant", tenant)
+type requestStats struct {
+	timeseries   int
+	totalSamples int
+}
+
+type tenantRequestStats map[string]requestStats
+
+func (h *Handler) handleRequest(ctx context.Context, rep uint64, tenantHTTP string, wreq *prompb.WriteRequest) (tenantRequestStats, error) {
+	tLogger := log.With(h.logger, "tenantHTTP", tenantHTTP)
 
 	// This replica value is used to detect cycles in cyclic topologies.
 	// A non-zero value indicates that the request has already been replicated by a previous receive instance.
@@ -610,7 +625,7 @@ func (h *Handler) handleRequest(ctx context.Context, rep uint64, tenant string, 
 	if rep > h.options.ReplicationFactor {
 		level.Error(tLogger).Log("err", errBadReplica, "msg", "write request rejected",
 			"request_replica", rep, "replication_factor", h.options.ReplicationFactor)
-		return errBadReplica
+		return tenantRequestStats{}, errBadReplica
 	}
 
 	r := replica{n: rep, replicated: rep != 0}
@@ -623,7 +638,7 @@ func (h *Handler) handleRequest(ctx context.Context, rep uint64, tenant string, 
 	// Forward any time series as necessary. All time series
 	// destined for the local node will be written to the receiver.
 	// Time series will be replicated as necessary.
-	return h.forward(ctx, tenant, r, wreq)
+	return h.forward(ctx, tenantHTTP, r, wreq)
 }
 
 // forward accepts a write request, batches its time series by
@@ -634,7 +649,7 @@ func (h *Handler) handleRequest(ctx context.Context, rep uint64, tenant string, 
 // unless the request needs to be replicated.
 // The function only returns when all requests have finished
 // or the context is canceled.
-func (h *Handler) forward(ctx context.Context, tenant string, r replica, wreq *prompb.WriteRequest) error {
+func (h *Handler) forward(ctx context.Context, tenantHTTP string, r replica, wreq *prompb.WriteRequest) (tenantRequestStats, error) {
 	span, ctx := tracing.StartSpan(ctx, "receive_fanout_forward")
 	defer span.Finish()
 
@@ -648,7 +663,7 @@ func (h *Handler) forward(ctx context.Context, tenant string, r replica, wreq *p
 	}
 
 	params := remoteWriteParams{
-		tenant:            tenant,
+		tenant:            tenantHTTP,
 		writeRequest:      wreq,
 		replicas:          replicas,
 		alreadyReplicated: r.replicated,
@@ -664,10 +679,43 @@ type remoteWriteParams struct {
 	alreadyReplicated bool
 }
 
-func (h *Handler) fanoutForward(ctx context.Context, params remoteWriteParams) error {
+func (h *Handler) gatherWriteStats(writes ...map[endpointReplica]map[string]trackedSeries) tenantRequestStats {
+	var stats tenantRequestStats = make(tenantRequestStats)
+
+	for _, write := range writes {
+		for er := range write {
+			for tenant, series := range write[er] {
+				samples := 0
+
+				for _, ts := range series.timeSeries {
+					samples += len(ts.Samples)
+				}
+
+				if st, ok := stats[tenant]; ok {
+					st.timeseries += len(series.timeSeries)
+					st.totalSamples += samples
+
+					stats[tenant] = st
+				} else {
+					stats[tenant] = requestStats{
+						timeseries:   len(series.timeSeries),
+						totalSamples: samples,
+					}
+				}
+			}
+		}
+	}
+
+	return stats
+
+}
+
+func (h *Handler) fanoutForward(ctx context.Context, params remoteWriteParams) (tenantRequestStats, error) {
 	ctx, cancel := context.WithTimeout(tracing.CopyTraceContext(context.Background(), ctx), h.options.ForwardTimeout)
 
 	var writeErrors writeErrors
+	var stats tenantRequestStats = make(tenantRequestStats)
+
 	defer func() {
 		if writeErrors.ErrOrNil() != nil {
 			// NOTICE: The cancel function is not used on all paths intentionally,
@@ -686,15 +734,20 @@ func (h *Handler) fanoutForward(ctx context.Context, params remoteWriteParams) e
 	localWrites, remoteWrites, err := h.distributeTimeseriesToReplicas(params.tenant, params.replicas, params.writeRequest.Timeseries)
 	if err != nil {
 		level.Error(requestLogger).Log("msg", "failed to distribute timeseries to replicas", "err", err)
-		return err
+		return stats, err
 	}
+
+	stats = h.gatherWriteStats(localWrites, remoteWrites)
 
 	// Prepare a buffered channel to receive the responses from the local and remote writes. Remote writes will all go
 	// asynchronously and with this capacity we will never block on writing to the channel.
-	maxBufferedResponses := len(localWrites) + len(remoteWrites)
+	maxBufferedResponses := len(localWrites)
+	for er := range remoteWrites {
+		maxBufferedResponses += len(remoteWrites[er])
+	}
+
 	responses := make(chan writeResponse, maxBufferedResponses)
 	wg := sync.WaitGroup{}
-	wg.Add(len(remoteWrites))
 
 	h.sendWrites(ctx, &wg, params, localWrites, remoteWrites, responses)
 
@@ -724,13 +777,13 @@ func (h *Handler) fanoutForward(ctx context.Context, params remoteWriteParams) e
 	for {
 		select {
 		case <-ctx.Done():
-			return ctx.Err()
+			return stats, ctx.Err()
 		case resp, hasMore := <-responses:
 			if !hasMore {
 				for _, seriesErr := range seriesErrs {
 					writeErrors.Add(seriesErr)
 				}
-				return writeErrors.ErrOrNil()
+				return stats, writeErrors.ErrOrNil()
 			}
 
 			if resp.err != nil {
@@ -746,7 +799,7 @@ func (h *Handler) fanoutForward(ctx context.Context, params remoteWriteParams) e
 				successes[seriesID]++
 			}
 			if quorumReached(successes, quorum) {
-				return nil
+				return stats, nil
 			}
 		}
 	}
@@ -757,15 +810,33 @@ func (h *Handler) fanoutForward(ctx context.Context, params remoteWriteParams) e
 // The first return value are the series that should be written to the local node. The second return value are the
 // series that should be written to remote nodes.
 func (h *Handler) distributeTimeseriesToReplicas(
-	tenant string,
+	tenantHTTP string,
 	replicas []uint64,
 	timeseries []prompb.TimeSeries,
-) (map[endpointReplica]trackedSeries, map[endpointReplica]trackedSeries, error) {
+) (map[endpointReplica]map[string]trackedSeries, map[endpointReplica]map[string]trackedSeries, error) {
 	h.mtx.RLock()
 	defer h.mtx.RUnlock()
-	remoteWrites := make(map[endpointReplica]trackedSeries)
-	localWrites := make(map[endpointReplica]trackedSeries)
+	remoteWrites := make(map[endpointReplica]map[string]trackedSeries)
+	localWrites := make(map[endpointReplica]map[string]trackedSeries)
 	for tsIndex, ts := range timeseries {
+		var tenant = tenantHTTP
+
+		if h.splitTenantLabelName != "" {
+			lbls := labelpb.ZLabelsToPromLabels(ts.Labels)
+
+			tenantLabel := lbls.Get(h.splitTenantLabelName)
+			if tenantLabel != "" {
+				tenant = tenantLabel
+
+				newLabels := labels.NewBuilder(lbls)
+				newLabels.Del(h.splitTenantLabelName)
+
+				ts.Labels = labelpb.ZLabelsFromPromLabels(
+					newLabels.Labels(),
+				)
+			}
+		}
+
 		for _, rn := range replicas {
 			endpoint, err := h.hashring.GetN(tenant, &ts, rn)
 			if err != nil {
@@ -778,14 +849,19 @@ func (h *Handler) distributeTimeseriesToReplicas(
 			}
 			writeableSeries, ok := writeDestination[endpointReplica]
 			if !ok {
-				writeableSeries = trackedSeries{
-					seriesIDs:  make([]int, 0),
-					timeSeries: make([]prompb.TimeSeries, 0),
+				writeDestination[endpointReplica] = map[string]trackedSeries{
+					tenant: {
+						seriesIDs:  make([]int, 0),
+						timeSeries: make([]prompb.TimeSeries, 0),
+					},
 				}
 			}
-			writeableSeries.timeSeries = append(writeDestination[endpointReplica].timeSeries, ts)
-			writeableSeries.seriesIDs = append(writeDestination[endpointReplica].seriesIDs, tsIndex)
-			writeDestination[endpointReplica] = writeableSeries
+			tenantSeries := writeableSeries[tenant]
+
+			tenantSeries.timeSeries = append(tenantSeries.timeSeries, ts)
+			tenantSeries.seriesIDs = append(tenantSeries.seriesIDs, tsIndex)
+
+			writeDestination[endpointReplica][tenant] = tenantSeries
 		}
 	}
 	return localWrites, remoteWrites, nil
@@ -797,20 +873,26 @@ func (h *Handler) sendWrites(
 	ctx context.Context,
 	wg *sync.WaitGroup,
 	params remoteWriteParams,
-	localWrites map[endpointReplica]trackedSeries,
-	remoteWrites map[endpointReplica]trackedSeries,
+	localWrites map[endpointReplica]map[string]trackedSeries,
+	remoteWrites map[endpointReplica]map[string]trackedSeries,
 	responses chan writeResponse,
 ) {
 	// Do the writes to the local node first. This should be easy and fast.
 	for writeDestination := range localWrites {
 		func(writeDestination endpointReplica) {
-			h.sendLocalWrite(ctx, writeDestination, params.tenant, localWrites[writeDestination], responses)
+			for tenant, trackedSeries := range localWrites[writeDestination] {
+				h.sendLocalWrite(ctx, writeDestination, tenant, trackedSeries, responses)
+			}
 		}(writeDestination)
 	}
 
 	// Do the writes to remote nodes. Run them all in parallel.
 	for writeDestination := range remoteWrites {
-		h.sendRemoteWrite(ctx, params.tenant, writeDestination, remoteWrites[writeDestination], params.alreadyReplicated, responses, wg)
+		for tenant, trackedSeries := range remoteWrites[writeDestination] {
+			wg.Add(1)
+
+			h.sendRemoteWrite(ctx, tenant, writeDestination, trackedSeries, params.alreadyReplicated, responses, wg)
+		}
 	}
 }
 
@@ -819,7 +901,7 @@ func (h *Handler) sendWrites(
 func (h *Handler) sendLocalWrite(
 	ctx context.Context,
 	writeDestination endpointReplica,
-	tenant string,
+	tenantHTTP string,
 	trackedSeries trackedSeries,
 	responses chan<- writeResponse,
 ) {
@@ -827,16 +909,32 @@ func (h *Handler) sendLocalWrite(
 	defer span.Finish()
 	span.SetTag("endpoint", writeDestination.endpoint)
 	span.SetTag("replica", writeDestination.replica)
-	err := h.writer.Write(tracingCtx, tenant, &prompb.WriteRequest{
-		Timeseries: trackedSeries.timeSeries,
-	})
-	if err != nil {
-		span.SetTag("error", true)
-		span.SetTag("error.msg", err.Error())
-		responses <- newWriteResponse(trackedSeries.seriesIDs, err, writeDestination)
-		return
+
+	tenantSeriesMapping := map[string][]prompb.TimeSeries{}
+	for _, ts := range trackedSeries.timeSeries {
+		var tenant = tenantHTTP
+		if h.splitTenantLabelName != "" {
+			lbls := labelpb.ZLabelsToPromLabels(ts.Labels)
+			if tnt := lbls.Get(h.splitTenantLabelName); tnt != "" {
+				tenant = tnt
+			}
+		}
+		tenantSeriesMapping[tenant] = append(tenantSeriesMapping[tenant], ts)
+	}
+
+	for tenant, series := range tenantSeriesMapping {
+		err := h.writer.Write(tracingCtx, tenant, &prompb.WriteRequest{
+			Timeseries: series,
+		})
+		if err != nil {
+			span.SetTag("error", true)
+			span.SetTag("error.msg", err.Error())
+			responses <- newWriteResponse(trackedSeries.seriesIDs, err, writeDestination)
+			return
+		}
 	}
 	responses <- newWriteResponse(trackedSeries.seriesIDs, nil, writeDestination)
+
 }
 
 // sendRemoteWrite sends a write request to the remote node. It takes care of checking wether the endpoint is up or not
@@ -909,7 +1007,7 @@ func (h *Handler) RemoteWrite(ctx context.Context, r *storepb.WriteRequest) (*st
 	span, ctx := tracing.StartSpan(ctx, "receive_grpc")
 	defer span.Finish()
 
-	err := h.handleRequest(ctx, uint64(r.Replica), r.Tenant, &prompb.WriteRequest{Timeseries: r.Timeseries})
+	_, err := h.handleRequest(ctx, uint64(r.Replica), r.Tenant, &prompb.WriteRequest{Timeseries: r.Timeseries})
 	if err != nil {
 		level.Debug(h.logger).Log("msg", "failed to handle request", "err", err)
 	}

--- a/pkg/receive/handler_test.go
+++ b/pkg/receive/handler_test.go
@@ -1660,6 +1660,57 @@ func TestHandlerEarlyStop(t *testing.T) {
 	testutil.Equals(t, "http: Server closed", err.Error())
 }
 
+type hashringSeenTenants struct {
+	Hashring
+
+	seenTenants map[string]struct{}
+}
+
+func (h *hashringSeenTenants) GetN(tenant string, ts *prompb.TimeSeries, n uint64) (string, error) {
+	if h.seenTenants == nil {
+		h.seenTenants = map[string]struct{}{}
+	}
+	h.seenTenants[tenant] = struct{}{}
+	return h.Hashring.GetN(tenant, ts, n)
+}
+
+func TestDistributeSeries(t *testing.T) {
+	const tenantIDLabelName = "thanos_tenant_id"
+	h := NewHandler(nil, &Options{
+		SplitTenantLabelName: tenantIDLabelName,
+	})
+
+	hashring, err := newSimpleHashring([]Endpoint{
+		{
+			Address: "http://localhost:9090",
+		},
+	})
+	require.NoError(t, err)
+	hr := &hashringSeenTenants{Hashring: hashring}
+	h.Hashring(hr)
+
+	_, remote, err := h.distributeTimeseriesToReplicas(
+		"foo",
+		[]uint64{0},
+		[]prompb.TimeSeries{
+			{
+				Labels: labelpb.ZLabelsFromPromLabels(labels.FromStrings("a", "b", tenantIDLabelName, "bar")),
+			},
+			{
+				Labels: labelpb.ZLabelsFromPromLabels(labels.FromStrings("b", "a", tenantIDLabelName, "boo")),
+			},
+		},
+	)
+	require.NoError(t, err)
+	require.Len(t, remote, 1)
+	require.Len(t, remote[endpointReplica{endpoint: "http://localhost:9090", replica: 0}]["bar"].timeSeries, 1)
+	require.Len(t, remote[endpointReplica{endpoint: "http://localhost:9090", replica: 0}]["boo"].timeSeries, 1)
+
+	require.Equal(t, 1, labelpb.ZLabelsToPromLabels(remote[endpointReplica{endpoint: "http://localhost:9090", replica: 0}]["bar"].timeSeries[0].Labels).Len())
+	require.Equal(t, 1, labelpb.ZLabelsToPromLabels(remote[endpointReplica{endpoint: "http://localhost:9090", replica: 0}]["boo"].timeSeries[0].Labels).Len())
+	require.Equal(t, map[string]struct{}{"bar": {}, "boo": {}}, hr.seenTenants)
+}
+
 func TestHandlerFlippingHashrings(t *testing.T) {
 	h := NewHandler(log.NewLogfmtLogger(os.Stderr), &Options{})
 	t.Cleanup(h.Close)
@@ -1695,7 +1746,7 @@ func TestHandlerFlippingHashrings(t *testing.T) {
 				return
 			}
 
-			err := h.handleRequest(ctx, 0, "test", &prompb.WriteRequest{
+			_, err := h.handleRequest(ctx, 0, "test", &prompb.WriteRequest{
 				Timeseries: []prompb.TimeSeries{
 					{
 						Labels: labelpb.ZLabelsFromPromLabels(labels.FromStrings("foo", "bar")),

--- a/pkg/receive/writer.go
+++ b/pkg/receive/writer.go
@@ -225,9 +225,7 @@ func (r *Writer) Write(ctx context.Context, tenantID string, wreq *prompb.WriteR
 						numExemplarsLabelLength++
 						level.Debug(exLogger).Log("msg", "Label length for exemplar exceeds max limit", "limit", exemplar.ExemplarMaxLabelSetLength)
 					default:
-						if err != nil {
-							level.Debug(exLogger).Log("msg", "Error ingesting exemplar", "err", err)
-						}
+						level.Debug(exLogger).Log("msg", "Error ingesting exemplar", "err", err)
 					}
 				}
 			}

--- a/test/e2e/e2ethanos/services.go
+++ b/test/e2e/e2ethanos/services.go
@@ -547,6 +547,7 @@ type ReceiveBuilder struct {
 	image               string
 	nativeHistograms    bool
 	labels              []string
+	tenantSplitLabel    string
 }
 
 func NewReceiveBuilder(e e2e.Environment, name string) *ReceiveBuilder {
@@ -585,6 +586,11 @@ func (r *ReceiveBuilder) WithLabel(name, value string) *ReceiveBuilder {
 func (r *ReceiveBuilder) WithRouting(replication int, hashringConfigs ...receive.HashringConfig) *ReceiveBuilder {
 	r.hashringConfigs = hashringConfigs
 	r.replication = replication
+	return r
+}
+
+func (r *ReceiveBuilder) WithTenantSplitLabel(splitLabel string) *ReceiveBuilder {
+	r.tenantSplitLabel = splitLabel
 	return r
 }
 
@@ -627,6 +633,10 @@ func (r *ReceiveBuilder) Init() *e2eobs.Observable {
 		"--tsdb.path":            filepath.Join(r.InternalDir(), "data"),
 		"--log.level":            infoLogLevel,
 		"--tsdb.max-exemplars":   fmt.Sprintf("%v", r.maxExemplars),
+	}
+
+	if r.tenantSplitLabel != "" {
+		args["--receive.split-tenant-label-name"] = r.tenantSplitLabel
 	}
 
 	if len(r.labels) > 0 {

--- a/test/e2e/store_gateway_test.go
+++ b/test/e2e/store_gateway_test.go
@@ -974,9 +974,7 @@ config:
 
 		testutil.Ok(t, runutil.RetryWithLog(log.NewLogfmtLogger(os.Stdout), 5*time.Second, ctx.Done(), func() error {
 			if _, _, _, err := promclient.NewDefaultClient().QueryInstant(ctx, urlParse(t, "http://"+q3.Endpoint("http")), testQuery, now, opts); err != nil {
-				if err != nil {
-					t.Logf("got error: %s", err)
-				}
+				t.Logf("got error: %s", err)
 				e := err.Error()
 				if strings.Contains(e, "load chunks") && strings.Contains(e, "exceeded bytes limit while fetching chunks: limit 310176 violated") {
 					return nil


### PR DESCRIPTION
Implement splitting incoming HTTP requests along some label inside of the timeseries themselves. This functionality is useful when you have one big application exposing lots of series and, for instance, you have a label `team` that identifies different owners of metrics in that application. Then using this you can use that `team` label to have different tenants in Thanos.

Only negative thing that I could spot is that if after splitting one of the requests fails then that code is used for all tenants and that skews the Receiver metrics a little bit. I think that can be left as a TODO task.
