### PR TITLE
fix query_test when --race enabled

### DIFF
--- a/pkg/query/query_test.go
+++ b/pkg/query/query_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -25,6 +26,31 @@ func TestMain(m *testing.M) {
 	custom.TolerantVerifyLeakMain(m)
 }
 
+type safeClients struct {
+	sync.RWMutex
+	clients []store.Client
+}
+
+func (sc *safeClients) get() []store.Client {
+	sc.RLock()
+	defer sc.RUnlock()
+	ret := make([]store.Client, len(sc.clients))
+	copy(ret, sc.clients)
+	return ret
+}
+
+func (sc *safeClients) reset() {
+	sc.Lock()
+	defer sc.Unlock()
+	sc.clients = sc.clients[:0]
+}
+
+func (sc *safeClients) append(c store.Client) {
+	sc.Lock()
+	defer sc.Unlock()
+	sc.clients = append(sc.clients, c)
+}
+
 func TestQuerier_Proxy(t *testing.T) {
 	files, err := filepath.Glob("testdata/promql/**/*.test")
 	testutil.Ok(t, err)
@@ -32,24 +58,23 @@ func TestQuerier_Proxy(t *testing.T) {
 
 	logger := log.NewLogfmtLogger(os.Stderr)
 	t.Run("proxy", func(t *testing.T) {
-		var clients []store.Client
+		var sc safeClients
 		q := NewQueryableCreator(
 			logger,
 			nil,
-			store.NewProxyStore(logger, nil, func() []store.Client { return clients },
+			store.NewProxyStore(logger, nil, func() []store.Client { return sc.get() },
 				component.Debug, nil, 5*time.Minute, store.EagerRetrieval),
 			1000000,
 			5*time.Minute,
 		)
 
 		createQueryableFn := func(stores []*testStore) storage.Queryable {
-			clients = clients[:0]
+			sc.reset()
 			for i, st := range stores {
 				m, err := storepb.PromMatchersToMatchers(st.matchers...)
 				testutil.Ok(t, err)
-
 				// TODO(bwplotka): Parse external labels.
-				clients = append(clients, &storetestutil.TestClient{
+				sc.append(&storetestutil.TestClient{
 					Name:        fmt.Sprintf("store number %v", i),
 					StoreClient: storepb.ServerAsClient(selectedStore(store.NewTSDBStore(logger, st.storage.DB, component.Debug, nil), m, st.mint, st.maxt)),
 					MinTime:     st.mint,


### PR DESCRIPTION
This is a simple pr to fix a data race when running thanos unit tests with `--race`:
```
/opt/homebrew/opt/go/libexec/bin/go test -c --race -o /Users/yi.jin/Library/Caches/JetBrains/IntelliJIdea2023.2/tmp/GoLand/___1TestQuerier_Proxy_in_github_com_thanos_io_thanos_pkg_query.test github.com/thanos-io/thanos/pkg/query #gosetup

```

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
