### PR TITLE
Allow empty matcher at store gateway to fetch all postings

### DIFF
--- a/test/e2e/query_test.go
+++ b/test/e2e/query_test.go
@@ -2320,12 +2320,18 @@ func TestQueryTenancyEnforcement(t *testing.T) {
 		nil,
 	)
 
-	// default-tenant cannot attempt to view other tenants data, by setting the tenant id
+	// default-tenant cannot attempt to view other tenants data, by setting the tenant id.
+	// Query all data from `default-tenant` after enforcing tenancy.
 	queryAndAssertSeries(t, ctx, querierEnforce.Endpoint("http"), func() string { return "{tenant_id=\"tenant-01\"}" },
 		time.Now, promclient.QueryOptions{
 			Deduplicate: false,
 		},
-		nil,
+		[]model.Metric{
+			{
+				"c":         "3",
+				"tenant_id": "default-tenant",
+			},
+		},
 	)
 
 	rangeQuery(t, ctx, querierEnforce.Endpoint("http"), func() string { return testQueryA }, timestamp.FromTime(now.Add(-time.Hour)), timestamp.FromTime(now.Add(time.Hour)), 3600,


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

If a query only contains external labels, no matcher is left after matching external labels at store gateway and in this case store gateway fetches nothing. https://github.com/thanos-io/thanos/blob/main/pkg/store/bucket.go#L2471

This PR changes Store Gateway to add a matcher `""=""` to fetch all postings instead. This should match Prometheus behavior better.

This changes existing behavior. Current behavior all Stores will return nil. After that, Store Gateway will try to fetch all postings (series). This change is more compatible to Prometheus from what I understand. For example, `cluster` is just a normal label in Prometheus and users can do `count ({cluster="A"})` without issues. However, after they make `cluster` an external label, then there is no way to run `count ({cluster="A"})` anymore.

If there is concern about the behavior change, I can put this behavior under a FF and make it hidden to Thanos users.

## Verification

Updated E2E test case.
