### PR TITLE
Receive: fix issue-7248 with parallel receive_forward

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#7224](https://github.com/thanos-io/thanos/pull/7224) Query-frontend: Add Redis username to the client configuration.
 - [#7220](https://github.com/thanos-io/thanos/pull/7220) Store Gateway: Fix lazy expanded postings caching partial expanded postings and bug of estimating remove postings with non existent value. Added `PromQLSmith` based fuzz test to improve correctness.
 - [#7244](https://github.com/thanos-io/thanos/pull/7244) Query: Fix Internal Server Error unknown targetHealth: "unknown" when trying to open the targets page.
-- [#7248](https://github.com/thanos-io/thanos/pull/7248) Receive: Fix RemoteWriteAsync was sequentia     lly executed causing high latency in the ingestion path.
+- [#7248](https://github.com/thanos-io/thanos/pull/7248) Receive: Fix RemoteWriteAsync was sequentially executed causing high latency in the ingestion path.
 - [#7271](https://github.com/thanos-io/thanos/pull/7271) Query: fixing dedup iterator when working on mixed sample types.
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#7224](https://github.com/thanos-io/thanos/pull/7224) Query-frontend: Add Redis username to the client configuration.
 - [#7220](https://github.com/thanos-io/thanos/pull/7220) Store Gateway: Fix lazy expanded postings caching partial expanded postings and bug of estimating remove postings with non existent value. Added `PromQLSmith` based fuzz test to improve correctness.
 - [#7244](https://github.com/thanos-io/thanos/pull/7244) Query: Fix Internal Server Error unknown targetHealth: "unknown" when trying to open the targets page.
+- [#7248](https://github.com/thanos-io/thanos/pull/7248) Receive: Fix RemoteWriteAsync was sequentia     lly executed causing high latency in the ingestion path.
 - [#7271](https://github.com/thanos-io/thanos/pull/7271) Query: fixing dedup iterator when working on mixed sample types.
 
 ### Added

--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -256,6 +256,8 @@ func runReceive(
 		MaxBackoff:           time.Duration(*conf.maxBackoff),
 		TSDBStats:            dbs,
 		Limiter:              limiter,
+
+		AsyncForwardWorkerCount: conf.asyncForwardWorkerCount,
 	})
 
 	grpcProbe := prober.NewGRPC()

--- a/pkg/pool/worker_pool.go
+++ b/pkg/pool/worker_pool.go
@@ -28,26 +28,27 @@ type WorkerPool interface {
 
 type workerPool struct {
 	sync.Once
+	ctx    context.Context
 	workCh chan Work
 	cancel context.CancelFunc
 }
 
 func NewWorkerPool(workers uint) WorkerPool {
+	ctx, cancel := context.WithCancel(context.Background())
 	return &workerPool{
+		ctx:    ctx,
+		cancel: cancel,
 		workCh: make(chan Work, workers),
 	}
 }
 
 func (p *workerPool) Init() {
 	p.Do(func() {
-		ctx, cancel := context.WithCancel(context.Background())
-		p.cancel = cancel
-
 		for i := 0; i < p.Size(); i++ {
 			go func() {
 				for {
 					select {
-					case <-ctx.Done():
+					case <-p.ctx.Done():
 						// TODO: exhaust workCh before exit
 						return
 					case work := <-p.workCh:

--- a/pkg/pool/worker_pool.go
+++ b/pkg/pool/worker_pool.go
@@ -43,11 +43,12 @@ func (p *workerPool) Init() {
 		ctx, cancel := context.WithCancel(context.Background())
 		p.cancel = cancel
 
-		for i := 0; i < cap(p.workCh); i++ {
+		for i := 0; i < p.Size(); i++ {
 			go func() {
 				for {
 					select {
 					case <-ctx.Done():
+						// TODO: exhaust workCh before exit
 						return
 					case work := <-p.workCh:
 						work()

--- a/pkg/pool/worker_pool.go
+++ b/pkg/pool/worker_pool.go
@@ -1,0 +1,72 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package pool
+
+import (
+	"context"
+	"sync"
+)
+
+// Work is a unit of item to be worked on, like Java Runnable.
+type Work func()
+
+// WorkerPool is a pool of goroutines that are reusable, similar to Java ThreadPool.
+type WorkerPool interface {
+	// Init initializes the worker pool.
+	Init()
+
+	// Go waits until the next worker becomes available and executes the given work.
+	Go(work Work)
+
+	// Close cancels all workers and waits for them to finish.
+	Close()
+
+	// Size returns the number of workers in the pool.
+	Size() int
+}
+
+type workerPool struct {
+	sync.Once
+	workCh chan Work
+	cancel context.CancelFunc
+}
+
+func NewWorkerPool(workers uint) WorkerPool {
+	return &workerPool{
+		workCh: make(chan Work, workers),
+	}
+}
+
+func (p *workerPool) Init() {
+	p.Do(func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		p.cancel = cancel
+
+		for i := 0; i < cap(p.workCh); i++ {
+			go func() {
+				for {
+					select {
+					case <-ctx.Done():
+						return
+					case work := <-p.workCh:
+						work()
+					}
+				}
+			}()
+		}
+	})
+}
+
+func (p *workerPool) Go(work Work) {
+	p.Init()
+	p.workCh <- work
+}
+
+func (p *workerPool) Close() {
+	p.cancel()
+}
+
+func (p *workerPool) Size() int {
+	return cap(p.workCh)
+}

--- a/pkg/pool/worker_pool_test.go
+++ b/pkg/pool/worker_pool_test.go
@@ -1,0 +1,35 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package pool
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGo(t *testing.T) {
+	var expectedWorksDone uint32
+	var workerPoolSize uint
+	var mu sync.Mutex
+	workerPoolSize = 5
+	p := NewWorkerPool(workerPoolSize)
+	p.Init()
+	defer p.Close()
+
+	var wg sync.WaitGroup
+	for i := 0; i < int(workerPoolSize*3); i++ {
+		wg.Add(1)
+		p.Go(func() {
+			mu.Lock()
+			mu.Unlock()
+			expectedWorksDone++
+			wg.Done()
+		})
+	}
+	wg.Wait()
+	require.Equal(t, uint32(workerPoolSize*3), expectedWorksDone)
+	require.Equal(t, int(workerPoolSize), p.Size())
+}

--- a/pkg/pool/worker_pool_test.go
+++ b/pkg/pool/worker_pool_test.go
@@ -24,7 +24,7 @@ func TestGo(t *testing.T) {
 		wg.Add(1)
 		p.Go(func() {
 			mu.Lock()
-			mu.Unlock()
+			defer mu.Unlock()
 			expectedWorksDone++
 			wg.Done()
 		})

--- a/pkg/receive/handler.go
+++ b/pkg/receive/handler.go
@@ -145,6 +145,7 @@ func NewHandler(logger log.Logger, o *Options) *Handler {
 	if workers == 0 {
 		workers = 1
 	}
+	level.Info(logger).Log("msg", "Starting receive handler with async forward workers", "workers", workers)
 
 	h := &Handler{
 		logger:               logger,


### PR DESCRIPTION
Fix https://github.com/thanos-io/thanos/issues/7248. 

Basically the current RemoteWriteAsync method is a blocking operation and waits for remote write response to return, causing the http remote write to be sequentially executed. See this tracing:

<img width="1566" alt="Screenshot 2024-04-08 at 4 57 22 PM" src="https://github.com/thanos-io/thanos/assets/96499497/dde6abf8-ea66-4731-b5aa-a04711b70303">

This PR introduces a new building block called worker pool, similar to Java Thread Pool which spawns X goroutines and allow submit `Work` for available go routines to execute.

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification
We deployed this and verified it is working as expected, also found another bug which async worker CLI value isn't pass into handler:

<img width="1302" alt="Screenshot 2024-04-09 at 5 31 32 PM" src="https://github.com/thanos-io/thanos/assets/96499497/6d23d4ed-8a3a-45b8-8e67-51cb9b8551f1">

<img width="595" alt="Screenshot 2024-04-09 at 5 52 17 PM" src="https://github.com/thanos-io/thanos/assets/96499497/6dd40a73-dec5-41ba-9f91-e502ccbcb46d">


