### PR TITLE
fetcher: sanity check metas for common corruptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 
 - [#7123](https://github.com/thanos-io/thanos/pull/7123) Rule: Change default Alertmanager API version to v2.
 - [#7223](https://github.com/thanos-io/thanos/pull/7223) Automatic detection of memory limits and configure GOMEMLIMIT to match.
-- [#7282](https://github.com/thanos-io/thanos/pull/7282) Fetcher: mark metas with incomplete files as corrupted.
+- [#7282](https://github.com/thanos-io/thanos/pull/7282) Fetcher: mark metas with incomplete files as partial if configured.
 - [#7282](https://github.com/thanos-io/thanos/pull/7282) Compactor: add flag to disable cleanup of partial uploads
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 
 - [#7123](https://github.com/thanos-io/thanos/pull/7123) Rule: Change default Alertmanager API version to v2.
 - [#7223](https://github.com/thanos-io/thanos/pull/7223) Automatic detection of memory limits and configure GOMEMLIMIT to match.
+- [#7282](https://github.com/thanos-io/thanos/pull/7282) Fetcher: mark metas with incomplete files as corrupted.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#7123](https://github.com/thanos-io/thanos/pull/7123) Rule: Change default Alertmanager API version to v2.
 - [#7223](https://github.com/thanos-io/thanos/pull/7223) Automatic detection of memory limits and configure GOMEMLIMIT to match.
 - [#7282](https://github.com/thanos-io/thanos/pull/7282) Fetcher: mark metas with incomplete files as corrupted.
+- [#7282](https://github.com/thanos-io/thanos/pull/7282) Compactor: add flag to disable cleanup of partial uploads
 
 ### Removed
 

--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -419,7 +419,7 @@ func runCompact(
 	var cleanMtx sync.Mutex
 	// TODO(GiedriusS): we could also apply retention policies here but the logic would be a bit more complex.
 	cleanPartialMarked := func() error {
-		if !conf.cleanupPartialUploads {
+		if conf.disableCleanupPartialUploads {
 			level.Info(logger).Log("msg", "cleanup of partial uploads is disabled, skipping")
 			return nil
 		}
@@ -728,7 +728,7 @@ type compactConfig struct {
 	progressCalculateInterval                      time.Duration
 	filterConf                                     *store.FilterConfig
 	disableAdminOperations                         bool
-	cleanupPartialUploads                          bool
+	disableCleanupPartialUploads                   bool
 }
 
 func (cc *compactConfig) registerFlag(cmd extkingpin.FlagClause) {
@@ -842,6 +842,5 @@ func (cc *compactConfig) registerFlag(cmd extkingpin.FlagClause) {
 	cmd.Flag("bucket-web-label", "External block label to use as group title in the bucket web UI").StringVar(&cc.label)
 
 	cmd.Flag("disable-admin-operations", "Disable UI/API admin operations like marking blocks for deletion and no compaction.").Default("false").BoolVar(&cc.disableAdminOperations)
-	cmd.Flag("compact.cleanup-partial-uploads", "Enable cleanup of partial uploads").
-		Hidden().Default("true").BoolVar(&cc.cleanupPartialUploads)
+	cmd.Flag("compact.disable-cleanup-partial-uploads", "Disable cleanup of partial uploads.").Default("false").BoolVar(&cc.disableCleanupPartialUploads)
 }

--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -419,6 +419,10 @@ func runCompact(
 	var cleanMtx sync.Mutex
 	// TODO(GiedriusS): we could also apply retention policies here but the logic would be a bit more complex.
 	cleanPartialMarked := func() error {
+		if !conf.cleanupPartialUploads {
+			level.Info(logger).Log("msg", "cleanup of partial uploads is disabled, skipping")
+			return nil
+		}
 		cleanMtx.Lock()
 		defer cleanMtx.Unlock()
 
@@ -724,6 +728,7 @@ type compactConfig struct {
 	progressCalculateInterval                      time.Duration
 	filterConf                                     *store.FilterConfig
 	disableAdminOperations                         bool
+	cleanupPartialUploads                          bool
 }
 
 func (cc *compactConfig) registerFlag(cmd extkingpin.FlagClause) {
@@ -837,4 +842,6 @@ func (cc *compactConfig) registerFlag(cmd extkingpin.FlagClause) {
 	cmd.Flag("bucket-web-label", "External block label to use as group title in the bucket web UI").StringVar(&cc.label)
 
 	cmd.Flag("disable-admin-operations", "Disable UI/API admin operations like marking blocks for deletion and no compaction.").Default("false").BoolVar(&cc.disableAdminOperations)
+	cmd.Flag("compact.cleanup-partial-uploads", "Enable cleanup of partial uploads").
+		Hidden().Default("true").BoolVar(&cc.cleanupPartialUploads)
 }

--- a/pkg/shipper/shipper.go
+++ b/pkg/shipper/shipper.go
@@ -26,7 +26,6 @@ import (
 	"github.com/prometheus/prometheus/tsdb/fileutil"
 
 	"github.com/thanos-io/objstore"
-
 	"github.com/thanos-io/thanos/pkg/block"
 	"github.com/thanos-io/thanos/pkg/block/metadata"
 	"github.com/thanos-io/thanos/pkg/runutil"


### PR DESCRIPTION
* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Mark metas with incomplete files as corrupted. Once shipper uploads the meta, the block is considered complete. This should make it possible to use the "Files" field in meta for a cheap check if the block is valid if its already in object storage. Neither storage-gw nor compactor can handle incomplete blocks, so this should fix a couple runtime issues; produce metrics and automatically clean up this issue.

Added a flag to disable cleanup of partially uploaded blocks that defaults to true.

## Verification

Added unittests

Should solve #6328 
