### PR TITLE
Propagate warnings from instant queries

### DIFF
--- a/pkg/query/remote_engine_test.go
+++ b/pkg/query/remote_engine_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func TestRemoteEngine_Warnings(t *testing.T) {
-	client := NewClient(&queryWarnClient{}, "", nil)
+	client := NewClient(&warnClient{}, "", nil)
 	engine := NewRemoteEngine(log.NewNopLogger(), client, Opts{
 		Timeout: 1 * time.Second,
 	})
@@ -41,11 +41,23 @@ func TestRemoteEngine_Warnings(t *testing.T) {
 		Start: time.Now(),
 		End:   time.Now().Add(2 * time.Hour),
 	}, logicalplan.PlanOptions{})
-	qry, err := engine.NewRangeQuery(context.Background(), nil, plan.Root(), start, end, step)
-	testutil.Ok(t, err)
-	res := qry.Exec(context.Background())
-	testutil.Ok(t, res.Err)
-	testutil.Equals(t, 1, len(res.Warnings))
+
+	t.Run("instant_query", func(t *testing.T) {
+		qry, err := engine.NewInstantQuery(context.Background(), nil, plan.Root(), start)
+		testutil.Ok(t, err)
+		res := qry.Exec(context.Background())
+		testutil.Ok(t, res.Err)
+		testutil.Equals(t, 1, len(res.Warnings))
+	})
+
+	t.Run("range_query", func(t *testing.T) {
+		qry, err := engine.NewRangeQuery(context.Background(), nil, plan.Root(), start, end, step)
+		testutil.Ok(t, err)
+		res := qry.Exec(context.Background())
+		testutil.Ok(t, res.Err)
+		testutil.Equals(t, 1, len(res.Warnings))
+	})
+
 }
 
 func TestRemoteEngine_LabelSets(t *testing.T) {
@@ -198,11 +210,15 @@ func zLabelSetFromStrings(ss ...string) labelpb.ZLabelSet {
 	}
 }
 
-type queryWarnClient struct {
+type warnClient struct {
 	querypb.QueryClient
 }
 
-func (m queryWarnClient) QueryRange(ctx context.Context, in *querypb.QueryRangeRequest, opts ...grpc.CallOption) (querypb.Query_QueryRangeClient, error) {
+func (m warnClient) Query(ctx context.Context, in *querypb.QueryRequest, opts ...grpc.CallOption) (querypb.Query_QueryClient, error) {
+	return &queryWarnClient{}, nil
+}
+
+func (m warnClient) QueryRange(ctx context.Context, in *querypb.QueryRangeRequest, opts ...grpc.CallOption) (querypb.Query_QueryRangeClient, error) {
 	return &queryRangeWarnClient{}, nil
 }
 
@@ -217,4 +233,17 @@ func (m *queryRangeWarnClient) Recv() (*querypb.QueryRangeResponse, error) {
 	}
 	m.warnSent = true
 	return querypb.NewQueryRangeWarningsResponse(errors.New("warning")), nil
+}
+
+type queryWarnClient struct {
+	querypb.Query_QueryClient
+	warnSent bool
+}
+
+func (m *queryWarnClient) Recv() (*querypb.QueryResponse, error) {
+	if m.warnSent {
+		return nil, io.EOF
+	}
+	m.warnSent = true
+	return querypb.NewQueryWarningsResponse(errors.New("warning")), nil
 }


### PR DESCRIPTION
Warnings from remote instant queries get turned into errors, which is a bug. It should be up to the root client to decide whether warnings should be show as such, or converted to errors.

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
