### PR TITLE
sidecar: set to not ready when failing to fetch prometheus version

### DIFF
--- a/cmd/thanos/sidecar.go
+++ b/cmd/thanos/sidecar.go
@@ -189,6 +189,8 @@ func runSidecar(
 						"msg", "failed to fetch prometheus version. Is Prometheus running? Retrying",
 						"err", err,
 					)
+					promUp.Set(0)
+					statusProber.NotReady(err)
 					return err
 				}
 


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->
Update ready state in "fetch prometheus version" loop - Currently, if no ready Prometheus behind sidecar then this loops indefinitely and never sets sidecar as `not ready`. As a result, sidecar reports as `ready` if there was never a running Prometheus behind it.

## Verification

<!-- How you tested it? How do you know it works? -->
* Added end-to-end test