### PR TITLE
Optimize empty posting check in lazy posting

### DIFF
--- a/pkg/store/lazy_postings_test.go
+++ b/pkg/store/lazy_postings_test.go
@@ -353,6 +353,21 @@ func TestOptimizePostingsFetchByDownloadedBytes(t *testing.T) {
 			},
 		},
 		{
+			name: "posting group label with add keys exist but no matching value, expect empty posting",
+			inputPostings: map[string]map[string]index.Range{
+				"foo": {"bar": index.Range{End: 8}},
+				"bar": {"baz": index.Range{Start: 8, End: 16}},
+			},
+			seriesMaxSize:    1000,
+			seriesMatchRatio: 0.5,
+			postingGroups: []*postingGroup{
+				{name: "foo", addKeys: []string{"bar"}},
+				{name: "bar", addKeys: []string{"foo"}},
+			},
+			expectedPostingGroups: nil,
+			expectedEmptyPosting:  true,
+		},
+		{
 			name: "posting group label with remove keys exist but no matching value, noop",
 			inputPostings: map[string]map[string]index.Range{
 				"foo": {"bar": index.Range{End: 8}},


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

Fix the logic of checking empty posting when lazy posting is enabled.

This is the previous logic. It checks the number of returned index range. This is actually not working because `indexHeaderReader.PostingsOffsets` actually returns `{start: -1, end: -1}` for label value that doesn't exist in Index.
 
`len(rngs) == 0` is only possible when the label name doesn't exist in index. https://github.com/thanos-io/thanos/blob/main/pkg/block/indexheader/binary_reader.go#L839

```
		// If the posting group adds keys, no posting ranges found means empty posting.
		if len(pg.addKeys) > 0 && len(rngs) == 0 {
			return nil, true, nil
		}
		// If the posting group removes keys, no posting ranges found is fine. It means
		// that the posting group is a noop. {job != "some_non_existent_value"}
		if len(pg.removeKeys) > 0 && len(rngs) == 0 {
			continue
		}
```

This is current logic which checks the actual cardinality inspected, which should cover both cases. 0 cardinality for add keys means no matching posting.

```
		if len(pg.addKeys) > 0 && pg.cardinality == 0 {
			return nil, true, nil
		}
```

This issue shouldn't impact correctness because eventually no postings is fetched when cardinality is 0. That's why it was caught in the correctness tests.
However, it does extra amount of work of fetching postings from cache and object storage.

## Verification

Added a unit test. Without this change, the test case doesn't return empty postings. Instead it returns those posting groups but with 0 cardinality. 
