### PR TITLE
Align tenant pruning according to wall clock

### DIFF
--- a/pkg/receive/multitsdb.go
+++ b/pkg/receive/multitsdb.go
@@ -6,7 +6,6 @@ package receive
 import (
 	"context"
 	"fmt"
-	"math"
 	"os"
 	"path"
 	"path/filepath"
@@ -440,11 +439,7 @@ func (t *MultiTSDB) pruneTSDB(ctx context.Context, logger log.Logger, tenantInst
 		return false, err
 	}
 
-	var tenantMinTimeMillis int64 = math.MaxInt64
-	for _, b := range tdb.Blocks() {
-		tenantMinTimeMillis = min(b.MinTime(), tenantMinTimeMillis)
-	}
-	if time.Since(time.UnixMilli(tenantMinTimeMillis)).Milliseconds() <= t.tsdbOpts.RetentionDuration {
+	if sinceLastAppendMillis <= t.tsdbOpts.RetentionDuration {
 		return false, nil
 	}
 

--- a/pkg/receive/multitsdb_test.go
+++ b/pkg/receive/multitsdb_test.go
@@ -454,10 +454,10 @@ func TestMultiTSDBPrune(t *testing.T) {
 			)
 			defer func() { testutil.Ok(t, m.Close()) }()
 
-			for i := 0; i < 100; i++ {
-				testutil.Ok(t, appendSample(m, "deleted-tenant", time.Now().Add(-10*time.Hour)))
-				testutil.Ok(t, appendSample(m, "compacted-tenant", time.Now().Add(-4*time.Hour)))
-				testutil.Ok(t, appendSample(m, "active-tenant", time.Now().Add(time.Duration(i)*time.Second)))
+			for step := time.Duration(0); step <= 2*time.Hour; step += time.Minute {
+				testutil.Ok(t, appendSample(m, "deleted-tenant", time.Now().Add(-9*time.Hour+step)))
+				testutil.Ok(t, appendSample(m, "compacted-tenant", time.Now().Add(-4*time.Hour+step)))
+				testutil.Ok(t, appendSample(m, "active-tenant", time.Now().Add(step)))
 			}
 			testutil.Equals(t, 3, len(m.TSDBLocalClients()))
 

--- a/pkg/receive/multitsdb_test.go
+++ b/pkg/receive/multitsdb_test.go
@@ -455,7 +455,7 @@ func TestMultiTSDBPrune(t *testing.T) {
 			defer func() { testutil.Ok(t, m.Close()) }()
 
 			for i := 0; i < 100; i++ {
-				testutil.Ok(t, appendSample(m, "deleted-tenant", time.UnixMilli(int64(10+i))))
+				testutil.Ok(t, appendSample(m, "deleted-tenant", time.Now().Add(-10*time.Hour)))
 				testutil.Ok(t, appendSample(m, "compacted-tenant", time.Now().Add(-4*time.Hour)))
 				testutil.Ok(t, appendSample(m, "active-tenant", time.Now().Add(time.Duration(i)*time.Second)))
 			}


### PR DESCRIPTION
Pruning a tenant currently acquires a lock on the tenant's TSDB, which blocks reads from incoming queries. We have noticed spikes in query latency when tenants get decomissioned since each receiver will prune the tenant at a different time.

To reduce the window where queries get degraded, this commit makes sure that pruning happens at predictable intervals by aligning it to the wall clock, similar to how head compaction is aligned.

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
