### PR TITLE
Query|Receiver: Do not log full request on ProxyStore by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#7123](https://github.com/thanos-io/thanos/pull/7123) Rule: Change default Alertmanager API version to v2.
 - [#7223](https://github.com/thanos-io/thanos/pull/7223) Automatic detection of memory limits and configure GOMEMLIMIT to match.
 - [#7283](https://github.com/thanos-io/thanos/pull/7283) Compact: *breaking :warning:* Replace group with resolution in compact downsample metrics to avoid cardinality explosion with large numbers of groups.
+- [#7305](https://github.com/thanos-io/thanos/pull/7305) Query|Receiver: Do not log full request on ProxyStore by default.
 
 ### Removed
 

--- a/pkg/store/proxy.go
+++ b/pkg/store/proxy.go
@@ -283,7 +283,10 @@ func (s *ProxyStore) TSDBInfos() []infopb.TSDBInfo {
 func (s *ProxyStore) Series(originalRequest *storepb.SeriesRequest, srv storepb.Store_SeriesServer) error {
 	// TODO(bwplotka): This should be part of request logger, otherwise it does not make much sense. Also, could be
 	// tiggered by tracing span to reduce cognitive load.
-	reqLogger := log.With(s.logger, "component", "proxy", "request", originalRequest.String())
+	reqLogger := log.With(s.logger, "component", "proxy")
+	if s.debugLogging {
+		reqLogger = log.With(reqLogger, "request", originalRequest.String())
+	}
 
 	match, matchers, err := matchesExternalLabels(originalRequest.Matchers, s.selectorLabels)
 	if err != nil {


### PR DESCRIPTION
We had a problem on our production where a sudden increase in requests with long matchers was putting our receivers under a lot of pressure. Upon checking profiles we saw that the problem was calls to Log(). 
We want to avoid Log calls with really heavy requests to avoid allocating memory.

As an alternative we could also create a "safe" version of the String() method for the request that would not serialize the whole matchers if their values are too long.

Original PromQL in our case was something like:

`sum(rate(http_request_total{foo=~"looongvalueA|looongvalueB|looongvalueC|looongvalueD|looongvalueE...<lots of other values>"}))`

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Only log the full request on ProxyStore when using debug logging.


## Verification

Ran the locally without debug logging to check that the request is not logged.
