### PR TITLE
Allow specifying OTLP resource attributes for traces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 
 ### Added
 
+- [#7317](https://github.com/thanos-io/thanos/pull/7317) Tracing: allow specifying resource attributes for the OTLP configuration.
+
 ### Changed
 
 ### Removed

--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -79,6 +79,7 @@ type: OTLP
 config:
   client_type: ""
   service_name: ""
+  resource_attributes: {}
   reconnection_period: 0s
   compression: ""
   insecure: false

--- a/pkg/tracing/otlp/config_yaml.go
+++ b/pkg/tracing/otlp/config_yaml.go
@@ -22,6 +22,7 @@ type retryConfig struct {
 type Config struct {
 	ClientType         string            `yaml:"client_type"`
 	ServiceName        string            `yaml:"service_name"`
+	ResourceAttributes map[string]string `yaml:"resource_attributes"`
 	ReconnectionPeriod time.Duration     `yaml:"reconnection_period"`
 	Compression        string            `yaml:"compression"`
 	Insecure           bool              `yaml:"insecure"`

--- a/pkg/tracing/otlp/otlp.go
+++ b/pkg/tracing/otlp/otlp.go
@@ -8,6 +8,8 @@ import (
 	"strconv"
 	"strings"
 
+	"go.opentelemetry.io/otel/attribute"
+
 	"github.com/thanos-io/thanos/pkg/tracing/migration"
 
 	"github.com/go-kit/log"
@@ -70,26 +72,27 @@ func NewTracerProvider(ctx context.Context, logger log.Logger, conf []byte) (*tr
 	if err != nil {
 		logger.Log(err)
 	}
-	tp := newTraceProvider(ctx, processor, logger, config.ServiceName, sampler)
+	tp := newTraceProvider(ctx, processor, logger, config.ServiceName, config.ResourceAttributes, sampler)
 
 	return tp, nil
 }
 
-func newTraceProvider(ctx context.Context, processor tracesdk.SpanProcessor, logger log.Logger, serviceName string, sampler tracesdk.Sampler) *tracesdk.TracerProvider {
-	var (
-		r   *resource.Resource
-		err error
-	)
+func newTraceProvider(
+	ctx context.Context,
+	processor tracesdk.SpanProcessor,
+	logger log.Logger,
+	serviceName string,
+	attrs map[string]string,
+	sampler tracesdk.Sampler,
+) *tracesdk.TracerProvider {
+	resourceAttrs := make([]attribute.KeyValue, 0, len(attrs)+1)
 	if serviceName != "" {
-		r, err = resource.New(
-			ctx,
-			resource.WithAttributes(semconv.ServiceNameKey.String(serviceName)),
-		)
-	} else {
-		r, err = resource.New(
-			ctx,
-		)
+		resourceAttrs = append(resourceAttrs, semconv.ServiceNameKey.String(serviceName))
 	}
+	for k, v := range attrs {
+		resourceAttrs = append(resourceAttrs, attribute.String(k, v))
+	}
+	r, err := resource.New(ctx, resource.WithAttributes(resourceAttrs...))
 	if err != nil {
 		level.Warn(logger).Log("msg", "jaeger: detecting resources for tracing provider failed", "err", err)
 	}

--- a/pkg/tracing/otlp/otlp_test.go
+++ b/pkg/tracing/otlp/otlp_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/efficientgo/core/testutil"
+
 	"github.com/thanos-io/thanos/pkg/tracing"
 	"github.com/thanos-io/thanos/pkg/tracing/migration"
 
@@ -20,12 +21,7 @@ import (
 func TestContextTracing_ClientEnablesTracing(t *testing.T) {
 	exp := tracetest.NewInMemoryExporter()
 
-	tracerOtel := newTraceProvider(
-		context.Background(),
-		tracesdk.NewSimpleSpanProcessor(exp),
-		log.NewNopLogger(),
-		"thanos",
-		tracesdk.AlwaysSample())
+	tracerOtel := newTraceProvider(context.Background(), tracesdk.NewSimpleSpanProcessor(exp), log.NewNopLogger(), "thanos", nil, tracesdk.AlwaysSample())
 	tracer, _ := migration.Bridge(tracerOtel, log.NewNopLogger())
 	clientRoot, _ := tracing.StartSpan(tracing.ContextWithTracer(context.Background(), tracer), "a")
 


### PR DESCRIPTION
This commit adds a resource_attributes field to the OTLP tracing configuration.

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
