### PR TITLE
Emit tracing span for remote queries

### DIFF
--- a/pkg/query/remote_engine.go
+++ b/pkg/query/remote_engine.go
@@ -226,7 +226,7 @@ type remoteQuery struct {
 
 func (r *remoteQuery) Exec(ctx context.Context) *promql.Result {
 	start := time.Now()
-	
+
 	qctx, cancel := context.WithCancel(ctx)
 	r.cancel = cancel
 	defer cancel()

--- a/pkg/query/remote_engine.go
+++ b/pkg/query/remote_engine.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql"
@@ -187,10 +188,11 @@ func (r *remoteEngine) NewRangeQuery(_ context.Context, _ promql.QueryOpts, plan
 		client: r.client,
 		opts:   r.opts,
 
-		plan:     plan,
-		start:    start,
-		end:      end,
-		interval: interval,
+		plan:       plan,
+		start:      start,
+		end:        end,
+		interval:   interval,
+		remoteAddr: r.client.GetAddress(),
 	}, nil
 }
 
@@ -200,10 +202,11 @@ func (r *remoteEngine) NewInstantQuery(_ context.Context, _ promql.QueryOpts, pl
 		client: r.client,
 		opts:   r.opts,
 
-		plan:     plan,
-		start:    ts,
-		end:      ts,
-		interval: 0,
+		plan:       plan,
+		start:      ts,
+		end:        ts,
+		interval:   0,
+		remoteAddr: r.client.GetAddress(),
 	}, nil
 }
 
@@ -212,20 +215,33 @@ type remoteQuery struct {
 	client Client
 	opts   Opts
 
-	plan     api.RemoteQuery
-	start    time.Time
-	end      time.Time
-	interval time.Duration
+	plan       api.RemoteQuery
+	start      time.Time
+	end        time.Time
+	interval   time.Duration
+	remoteAddr string
 
 	cancel context.CancelFunc
 }
 
 func (r *remoteQuery) Exec(ctx context.Context) *promql.Result {
 	start := time.Now()
-
+	
 	qctx, cancel := context.WithCancel(ctx)
 	r.cancel = cancel
 	defer cancel()
+
+	queryRange := r.end.Sub(r.start)
+	span, qctx := opentracing.StartSpanFromContext(qctx, "remote_query_exec", opentracing.Tags{
+		"query":            r.plan.String(),
+		"remote_address":   r.remoteAddr,
+		"start":            r.start.UTC().String(),
+		"end":              r.end.UTC().String(),
+		"interval_seconds": r.interval.Seconds(),
+		"range_seconds":    queryRange.Seconds(),
+		"range_human":      queryRange,
+	})
+	defer span.Finish()
 
 	var maxResolution int64
 	if r.opts.AutoDownsample {


### PR DESCRIPTION
This commit adds a new tracing span for remotely delegated queries with attributes related to the query and remote engine.

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
