### PR TITLE
optimize to posting group label value matching

### DIFF
--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -2803,9 +2803,9 @@ func toPostingGroup(ctx context.Context, lvalsFn func(name string) ([]string, er
 		if reuseValues {
 			toRemove = vals[:0]
 		}
-		// Only equal cases are left. Shortcut all values since label
+		// If equal matcher matches an empty string, shortcut all values since label
 		// values should always be non-empty string.
-		if m.Value == "" {
+		if m.Value == "" && (m.Type == labels.MatchRegexp || m.Type == labels.MatchEqual) {
 			toRemove = vals
 		} else {
 			for _, val := range vals {
@@ -2841,9 +2841,9 @@ func toPostingGroup(ctx context.Context, lvalsFn func(name string) ([]string, er
 	if reuseValues {
 		toAdd = vals[:0]
 	}
-	// Only non-equal cases are left. For regex not match, it is the same as
-	// matching a non-empty string, which is always true for label values.
-	if m.Value == "" {
+	// If non-equal matcher matches an empty string, shortcut all values since label
+	// values should always be non-empty string.
+	if m.Value == "" && (m.Type == labels.MatchNotRegexp || m.Type == labels.MatchNotEqual) {
 		toAdd = vals
 	} else {
 		for _, val := range vals {

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -2841,7 +2841,7 @@ func toPostingGroup(ctx context.Context, lvalsFn func(name string) ([]string, er
 	if reuseValues {
 		toAdd = vals[:0]
 	}
-	// If non-equal matcher matches an empty string, shortcut all values since label
+	// If non-equal matcher matches a non-empty string, shortcut all values since label
 	// values should always be non-empty string.
 	if m.Value == "" && (m.Type == labels.MatchNotRegexp || m.Type == labels.MatchNotEqual) {
 		toAdd = vals

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -2725,8 +2725,11 @@ func matchersToPostingGroups(ctx context.Context, lvalsFn func(name string) ([]s
 		matchers := make([]*labels.Matcher, 0, len(vals))
 		// Merge PostingGroups with the same matcher into 1 to
 		// avoid fetching duplicate postings.
+		cnt := 0
 		for _, val := range values {
-			pg, vals, err = toPostingGroup(ctx, lvalsFunc, val, len(values) == 1)
+			cnt++
+			// We can only reuse the values if the values won't be reused anymore.
+			pg, vals, err = toPostingGroup(ctx, lvalsFunc, val, cnt == len(values))
 			if err != nil {
 				return nil, errors.Wrap(err, "toPostingGroup")
 			}

--- a/pkg/store/bucket_test.go
+++ b/pkg/store/bucket_test.go
@@ -14,7 +14,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"reflect"
 	"regexp"
 	"sort"
 	"strconv"
@@ -2953,8 +2952,19 @@ func samePostingGroup(a, b *postingGroup) bool {
 		return false
 	}
 
-	if !reflect.DeepEqual(a.addKeys, b.addKeys) || !reflect.DeepEqual(a.removeKeys, b.removeKeys) {
+	if len(a.addKeys) != len(b.addKeys) || len(a.removeKeys) != len(b.removeKeys) {
 		return false
+	}
+	for i, key := range a.addKeys {
+		if key != b.addKeys[i] {
+			return false
+		}
+	}
+
+	for i, key := range a.removeKeys {
+		if key != b.removeKeys[i] {
+			return false
+		}
 	}
 
 	for i := 0; i < len(a.matchers); i++ {


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

The optimization comes from https://github.com/prometheus/prometheus/pull/13958 and  https://github.com/prometheus/prometheus/blob/main/tsdb/querier.go#L358.

With latest Prometheus regex matcher optimization, now empty value `""` is optimized into `emptyStringMatcher` which only checks the value length https://github.com/prometheus/prometheus/blob/main/model/labels/regexp.go#L325.

```
// emptyStringMatcher matches an empty string.
type emptyStringMatcher struct{}

func (m emptyStringMatcher) Matches(s string) bool {
	return len(s) == 0
}
```

Since label values should be always non empty, we can optimize some cases to not run matching at all.

## Verification

<!-- How you tested it? How do you know it works? -->
