### PR TITLE
sidecar: Add `/api/v1/flush` endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 
 ### Added
 
+- [#7358](https://github.com/thanos-io/thanos/pull/7358) Sidecar: Add HTTP flush endpoint for uploading what's in the head block
 - [#7317](https://github.com/thanos-io/thanos/pull/7317) Tracing: allow specifying resource attributes for the OTLP configuration.
 
 ### Changed

--- a/pkg/api/sidecar/v1.go
+++ b/pkg/api/sidecar/v1.go
@@ -1,0 +1,83 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package v1
+
+import (
+	"fmt"
+	"github.com/go-kit/log"
+	"github.com/opentracing/opentracing-go"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/route"
+	"github.com/thanos-io/thanos/pkg/promclient"
+	"github.com/thanos-io/thanos/pkg/shipper"
+	"net/http"
+	"net/url"
+	"os"
+
+	"github.com/thanos-io/thanos/pkg/api"
+	extpromhttp "github.com/thanos-io/thanos/pkg/extprom/http"
+	"github.com/thanos-io/thanos/pkg/logging"
+)
+
+// SidecarAPI is a very simple API used by Thanos Sidecar.
+type SidecarAPI struct {
+	baseAPI *api.BaseAPI
+	client  *promclient.Client
+	shipper *shipper.Shipper
+	promURL *url.URL
+	dataDir string
+	logger  log.Logger
+	reg     prometheus.Registerer
+}
+
+// NewSidecarAPI creates an Thanos Sidecar API.
+func NewSidecarAPI(
+	logger log.Logger,
+	reg prometheus.Registerer,
+	client *promclient.Client,
+	shipper *shipper.Shipper,
+	dataDir string,
+	promURL *url.URL,
+) *SidecarAPI {
+	return &SidecarAPI{
+		baseAPI: api.NewBaseAPI(logger, true, nil),
+		logger:  logger,
+		client:  client,
+		reg:     reg,
+		shipper: shipper,
+		dataDir: dataDir,
+		promURL: promURL,
+	}
+}
+
+func (s *SidecarAPI) Register(r *route.Router, tracer opentracing.Tracer, logger log.Logger, ins extpromhttp.InstrumentationMiddleware, logMiddleware *logging.HTTPServerMiddleware) {
+	s.baseAPI.Register(r, tracer, logger, ins, logMiddleware)
+
+	instr := api.GetInstr(tracer, logger, ins, logMiddleware, true)
+	r.Post("/flush", instr("flush", s.flush))
+}
+
+type flushResponse struct {
+	BlocksUploaded int `json:"blocksUploaded"`
+}
+
+func (s *SidecarAPI) flush(r *http.Request) (interface{}, []error, *api.ApiError, func()) {
+	dir, err := s.client.Snapshot(r.Context(), s.promURL, false)
+
+	if err != nil {
+		return nil, nil, &api.ApiError{Typ: api.ErrorInternal, Err: fmt.Errorf("failed to snapshot: %w", err)}, func() {}
+	}
+
+	snapshotDir := s.dataDir + "/" + dir
+
+	s.shipper.SetDirectoryToSync(snapshotDir)
+	uploaded, err := s.shipper.Sync(r.Context())
+	if err := os.RemoveAll(snapshotDir); err != nil {
+		s.logger.Log("failed to remove snapshot directory", err.Error())
+	}
+	if err != nil {
+		return nil, nil, &api.ApiError{Typ: api.ErrorInternal, Err: fmt.Errorf("failed to upload head block: %w", err)}, func() {}
+	}
+	return &flushResponse{BlocksUploaded: uploaded}, nil, nil, func() {}
+}

--- a/pkg/api/sidecar/v1_test.go
+++ b/pkg/api/sidecar/v1_test.go
@@ -1,0 +1,96 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package v1
+
+import (
+	"context"
+	"fmt"
+	"github.com/pkg/errors"
+	"github.com/thanos-io/thanos/pkg/clientconfig"
+	"github.com/thanos-io/thanos/pkg/promclient"
+	"github.com/thanos-io/thanos/pkg/runutil"
+	"github.com/thanos-io/thanos/pkg/shipper"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/thanos-io/objstore"
+
+	"github.com/efficientgo/core/testutil"
+	baseAPI "github.com/thanos-io/thanos/pkg/api"
+	"github.com/thanos-io/thanos/pkg/block/metadata"
+	"github.com/thanos-io/thanos/pkg/testutil/custom"
+	"github.com/thanos-io/thanos/pkg/testutil/e2eutil"
+)
+
+func TestMain(m *testing.M) {
+	custom.TolerantVerifyLeakMain(m)
+}
+
+func TestFlushEndpoint(t *testing.T) {
+	ctx := context.Background()
+
+	logger := log.NewNopLogger()
+
+	prom, err := e2eutil.NewPrometheus()
+	testutil.Ok(t, err)
+
+	prom.SetConfig(fmt.Sprintf(`
+global:
+  external_labels:
+    region: eu-west
+scrape_configs:
+- job_name: 'myself'
+  # Quick scrapes for test purposes.
+  scrape_interval: 1s
+  scrape_timeout: 1s
+  static_configs:
+  - targets: ['%s']
+`, prom.Addr()))
+	testutil.Ok(t, prom.Start(ctx, logger))
+	defer func() { testutil.Ok(t, prom.Stop()) }()
+
+	promURL, err := url.Parse("http://" + prom.Addr())
+	testutil.Ok(t, err)
+	httpClient, err := clientconfig.NewHTTPClient(clientconfig.NewDefaultHTTPClientConfig(), "thanos-sidecar")
+	testutil.Ok(t, err)
+	promClient := promclient.NewClient(httpClient, logger, "thanos-sidecar")
+
+	// Waits for targets to be present in prometheus, so we know there will be active chunks in the head block
+	// to snapshot
+	testutil.Ok(t, runutil.Retry(1*time.Second, ctx.Done(), func() error {
+		targets, err := promClient.TargetsInGRPC(ctx, promURL, "")
+		testutil.Ok(t, err)
+		if len(targets.ActiveTargets) > 0 {
+			return nil
+		}
+		return errors.New("empty targets response from Prometheus")
+	}))
+
+	bkt := objstore.WithNoopInstr(objstore.NewInMemBucket())
+	externalLabels := labels.FromStrings("external", "label")
+	s := shipper.New(logger, nil, prom.Dir(), bkt, func() labels.Labels { return externalLabels }, metadata.TestSource, nil, false, metadata.NoneFunc, shipper.DefaultMetaFilename)
+	now := time.Now()
+
+	api := &SidecarAPI{
+		baseAPI: &baseAPI.BaseAPI{
+			Now: func() time.Time { return now },
+		},
+		logger:  logger,
+		promURL: promURL,
+		dataDir: prom.Dir(),
+		client:  promClient,
+		shipper: s,
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "", nil)
+	testutil.Ok(t, err)
+
+	res, _, err, _ := api.flush(req)
+	r := res.(*flushResponse)
+	testutil.Assert(t, r.BlocksUploaded > 0)
+
+}

--- a/pkg/shipper/shipper.go
+++ b/pkg/shipper/shipper.go
@@ -351,6 +351,13 @@ func (s *Shipper) Sync(ctx context.Context) (uploaded int, err error) {
 	return uploaded, nil
 }
 
+func (s *Shipper) SetDirectoryToSync(dir string) {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+
+	s.dir = dir
+}
+
 func (s *Shipper) UploadedBlocks() map[ulid.ULID]struct{} {
 	meta, err := ReadMetaFile(s.metadataFilePath)
 	if err != nil {


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Adds a sidecar API with one endpoint: `/api/v1/flush` which calls the TSDB snapshot endpoint on the prometheus instance, then uploads all not-already-present blocks in the snapshot to object store.

There are a few issues that explain the motivation:
- https://github.com/thanos-io/thanos/issues/7295
- https://github.com/prometheus-operator/prometheus-operator/issues/6540

Essentially if this is the last time sidecar will be running (ie. cluster is being deleted, shard being removed, etc...) then without some flushing mechanism you will permanently lose up to 2 hours of data.

## Verification

Beside the unit tests, running prometheus locally and calling the endpoint works as expected. 

![image](https://github.com/thanos-io/thanos/assets/11613073/f3422026-db69-41a2-9a11-5719e9a3a47d)
