### PR TITLE
Proxy: unify store filtering

### DIFF
--- a/pkg/store/proxy_merge.go
+++ b/pkg/store/proxy_merge.go
@@ -459,16 +459,10 @@ func newAsyncRespSet(
 	var span opentracing.Span
 	var closeSeries context.CancelFunc
 
-	storeAddr, isLocalStore := st.Addr()
-	storeID := labelpb.PromLabelSetsToString(st.LabelSets())
-	if storeID == "" {
-		storeID = "Store Gateway"
-	}
-
+	storeID, storeAddr, isLocalStore := storeInfo(st)
 	seriesCtx := grpc_opentracing.ClientAddContextTags(ctx, opentracing.Tags{
 		"target": storeAddr,
 	})
-
 	span, seriesCtx = tracing.StartSpan(seriesCtx, "proxy.series", tracing.Tags{
 		"store.id":       storeID,
 		"store.is_local": isLocalStore,

--- a/pkg/store/proxy_test.go
+++ b/pkg/store/proxy_test.go
@@ -1842,7 +1842,7 @@ func TestStoreMatches(t *testing.T) {
 		},
 	} {
 		t.Run("", func(t *testing.T) {
-			ok, reason := storeMatches(context.TODO(), c.s, true, c.mint, c.maxt, c.ms...)
+			ok, reason := storeMatches(context.TODO(), c.s, c.mint, c.maxt, c.ms...)
 			testutil.Equals(t, c.expectedMatch, ok)
 			testutil.Equals(t, c.expectedReason, reason)
 


### PR DESCRIPTION
* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

In LabelNames and LabelValues gRPC calls were not pruned properly. While results are not wrong, this leads to inefficient fan-out for setups with many endpoints.
We took the opportunity to unify the store filtering and generally also the larger layout of the gRPC methods, including logging and tracing.

## Verification

Existing unittests.
