### PR TITLE
Query: Support match filter in labels API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 
 - [#7317](https://github.com/thanos-io/thanos/pull/7317) Tracing: allow specifying resource attributes for the OTLP configuration.
 - [#7367](https://github.com/thanos-io/thanos/pull/7367) Store Gateway: log request ID in request logs.
+- [#7380](https://github.com/thanos-io/thanos/pull/7380) Query: Support match filter in labels API.
 
 ### Changed
 


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

The querier seems to ignore the `match` param in the labels API. Requests are sent to all the stores, even if their external labels don't match the values specified in the matchers.

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Add support for `match` param by passing the req matchers to `storeMatches`. I think it should have a similar implementation to Series, where the querier select labels are excluded. It also returns an empty result if the matchers don't match the selector labels.

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->

I added new tests and confirmed that the proxy ignored the matchers, and requests were fanning out to all the stores even if their external labels didn't match.
