### PR TITLE
*: Ensure objstore flag values are masked & disable debug/pprof/cmdline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 ### Changed
 
 - [#7334](https://github.com/thanos-io/thanos/pull/7334) Compactor: do not vertically compact downsampled blocks. Such cases are now marked with `no-compact-mark.json`. Fixes panic `panic: unexpected seriesToChunkEncoder lack of iterations`.
+- [#7382](https://github.com/thanos-io/thanos/pull/7382) *: Ensure objstore flag values are masked & disable debug/pprof/cmdline
 
 ### Removed
 

--- a/cmd/thanos/main.go
+++ b/cmd/thanos/main.go
@@ -217,6 +217,7 @@ func getFlagsMap(flags []*kingpin.FlagModel) map[string]string {
 		// Mask inline objstore flag which can have credentials.
 		if f.Name == "objstore.config" || f.Name == "objstore.config-file" {
 			flagsMap[f.Name] = "<REDACTED>"
+			continue
 		}
 		flagsMap[f.Name] = f.Value.String()
 	}

--- a/cmd/thanos/main.go
+++ b/cmd/thanos/main.go
@@ -214,6 +214,10 @@ func getFlagsMap(flags []*kingpin.FlagModel) map[string]string {
 		if boilerplateFlags.GetFlag(f.Name) != nil {
 			continue
 		}
+		// Mask inline objstore flag which can have credentials.
+		if f.Name == "objstore.config" || f.Name == "objstore.config-file" {
+			flagsMap[f.Name] = "<REDACTED>"
+		}
 		flagsMap[f.Name] = f.Value.String()
 	}
 

--- a/pkg/server/http/http.go
+++ b/pkg/server/http/http.go
@@ -117,7 +117,6 @@ func (s *Server) Handle(pattern string, handler http.Handler) {
 
 func registerProfiler(mux *http.ServeMux) {
 	mux.HandleFunc("/debug/pprof/", pprof.Index)
-	mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
 	mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
 	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
 	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)


### PR DESCRIPTION
* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Redacts objstore flag values from UI/API and disables debug/pprof/cmdline args so that inlining objstore flag doesn't expose cloud credentials.

## Verification

<!-- How you tested it? How do you know it works? -->
