### PR TITLE
Add request ID to client grpc spans

### DIFF
--- a/cmd/thanos/query_frontend.go
+++ b/cmd/thanos/query_frontend.go
@@ -350,19 +350,19 @@ func runQueryFrontend(
 				if !cfg.webDisableCORS {
 					api.SetCORS(w)
 				}
-				tracing.HTTPMiddleware(
-					tracer,
-					name,
-					logger,
-					ins.NewHandler(
+				middleware.RequestID(
+					tracing.HTTPMiddleware(
+						tracer,
 						name,
-						gzhttp.GzipHandler(
-							middleware.RequestID(
+						logger,
+						ins.NewHandler(
+							name,
+							gzhttp.GzipHandler(
 								logMiddleware.HTTPMiddleware(name, f),
 							),
 						),
+						// Cortex frontend middlewares require orgID.
 					),
-					// Cortex frontend middlewares require orgID.
 				).ServeHTTP(w, r.WithContext(user.InjectOrgID(r.Context(), orgId)))
 			})
 			return hf

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -221,10 +221,10 @@ func GetInstr(
 			}
 		})
 
-		return tracing.HTTPMiddleware(tracer, name, logger,
-			ins.NewHandler(name,
-				gzhttp.GzipHandler(
-					middleware.RequestID(
+		return middleware.RequestID(
+			tracing.HTTPMiddleware(tracer, name, logger,
+				ins.NewHandler(name,
+					gzhttp.GzipHandler(
 						logMiddleware.HTTPMiddleware(name, hf),
 					),
 				),

--- a/pkg/tracing/http.go
+++ b/pkg/tracing/http.go
@@ -14,6 +14,8 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
+
+	"github.com/thanos-io/thanos/pkg/server/http/middleware"
 	"github.com/thanos-io/thanos/pkg/tracing/migration"
 )
 
@@ -32,6 +34,9 @@ func HTTPMiddleware(tracer opentracing.Tracer, name string, logger log.Logger, n
 		}
 
 		opts := []opentracing.StartSpanOption{ext.RPCServerOption(wireContext)}
+		if requestID, ok := middleware.RequestIDFromContext(r.Context()); ok {
+			opts = append(opts, opentracing.Tag{Key: "request_id", Value: requestID})
+		}
 		// Check for force tracing header and add it as a tag at the start of span.
 		// This is required for the OpenTelemetry sampler to force tracing.
 		if r.Header.Get(ForceTracingBaggageKey) != "" {


### PR DESCRIPTION
This commit adds the request ID as a span tag to outgoing gRPC and incoming HTTP requests. This would allow easier correlation of traces and logs using the request ID. I still need to figure out how to attach this information to incoming gRPC tags.

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
