### PR TITLE
Query: set keepalive for store grpc client

### DIFF
--- a/pkg/extgrpc/client.go
+++ b/pkg/extgrpc/client.go
@@ -71,6 +71,7 @@ func StoreClientGRPCOpts(logger log.Logger, reg prometheus.Registerer, tracer op
 				tracing.StreamClientInterceptor(tracer),
 			),
 		),
+		grpc.WithKeepaliveParams(keepalive.ClientParameters{Time: 10 * time.Second, Timeout: 5 * time.Second}),
 	}
 	if reg != nil {
 		reg.MustRegister(grpcMets)


### PR DESCRIPTION
* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Added keepalive to grpc dial options for store clients.

## Verification

<!-- How you tested it? How do you know it works? -->
