### PR TITLE
Add query bytes fetched along with other series stats in Query Response

### DIFF
--- a/pkg/api/query/v1.go
+++ b/pkg/api/query/v1.go
@@ -309,8 +309,9 @@ type queryData struct {
 	Result     parser.Value     `json:"result"`
 	Stats      stats.QueryStats `json:"stats,omitempty"`
 	// Additional Thanos Response field.
-	QueryAnalysis queryTelemetry `json:"analysis,omitempty"`
-	Warnings      []error        `json:"warnings,omitempty"`
+	QueryAnalysis      queryTelemetry             `json:"analysis,omitempty"`
+	Warnings           []error                    `json:"warnings,omitempty"`
+	SeriesStatsCounter storepb.SeriesStatsCounter `json:"seriesStatsCounter,omitempty"`
 }
 
 type queryTelemetry struct {
@@ -723,6 +724,7 @@ func (qapi *QueryAPI) query(r *http.Request) (interface{}, []error, *api.ApiErro
 	for i := range seriesStats {
 		aggregator.Aggregate(seriesStats[i])
 	}
+	seriesStatsCounter := aggregator.GetSeriesStatsCounter()
 	aggregator.Observe(time.Since(beforeRange).Seconds())
 
 	// Optional stats field in response if parameter "stats" is not empty.
@@ -731,10 +733,11 @@ func (qapi *QueryAPI) query(r *http.Request) (interface{}, []error, *api.ApiErro
 		qs = stats.NewQueryStats(qry.Stats())
 	}
 	return &queryData{
-		ResultType:    res.Value.Type(),
-		Result:        res.Value,
-		Stats:         qs,
-		QueryAnalysis: analysis,
+		ResultType:         res.Value.Type(),
+		Result:             res.Value,
+		Stats:              qs,
+		QueryAnalysis:      analysis,
+		SeriesStatsCounter: seriesStatsCounter,
 	}, res.Warnings.AsErrors(), nil, qry.Close
 }
 
@@ -1022,6 +1025,7 @@ func (qapi *QueryAPI) queryRange(r *http.Request) (interface{}, []error, *api.Ap
 	for i := range seriesStats {
 		aggregator.Aggregate(seriesStats[i])
 	}
+	seriesStatsCounter := aggregator.GetSeriesStatsCounter()
 	aggregator.Observe(time.Since(beforeRange).Seconds())
 
 	// Optional stats field in response if parameter "stats" is not empty.
@@ -1030,10 +1034,11 @@ func (qapi *QueryAPI) queryRange(r *http.Request) (interface{}, []error, *api.Ap
 		qs = stats.NewQueryStats(qry.Stats())
 	}
 	return &queryData{
-		ResultType:    res.Value.Type(),
-		Result:        res.Value,
-		Stats:         qs,
-		QueryAnalysis: analysis,
+		ResultType:         res.Value.Type(),
+		Result:             res.Value,
+		Stats:              qs,
+		QueryAnalysis:      analysis,
+		SeriesStatsCounter: seriesStatsCounter,
 	}, res.Warnings.AsErrors(), nil, qry.Close
 }
 

--- a/pkg/query/querier.go
+++ b/pkg/query/querier.go
@@ -206,7 +206,7 @@ func (s *seriesServer) Send(r *storepb.SeriesResponse) error {
 
 	if r.GetSeries() != nil {
 		s.seriesSet = append(s.seriesSet, *r.GetSeries())
-		s.seriesSetStats.Count(r.GetSeries())
+		s.seriesSetStats.Count(r)
 		return nil
 	}
 

--- a/pkg/store/storepb/custom.go
+++ b/pkg/store/storepb/custom.go
@@ -484,6 +484,7 @@ type SeriesStatsCounter struct {
 	Series  int
 	Chunks  int
 	Samples int
+	Bytes   int
 }
 
 func (c *SeriesStatsCounter) CountSeries(seriesLabels []labelpb.ZLabel) {
@@ -494,39 +495,43 @@ func (c *SeriesStatsCounter) CountSeries(seriesLabels []labelpb.ZLabel) {
 	}
 }
 
-func (c *SeriesStatsCounter) Count(series *Series) {
-	c.CountSeries(series.Labels)
-	for _, chk := range series.Chunks {
-		if chk.Raw != nil {
-			c.Chunks++
-			c.Samples += chk.Raw.XORNumSamples()
-		}
+func (c *SeriesStatsCounter) Count(r *SeriesResponse) {
+	if r.GetSeries() != nil {
+		series := r.GetSeries()
+		c.CountSeries(series.Labels)
+		for _, chk := range series.Chunks {
+			if chk.Raw != nil {
+				c.Chunks++
+				c.Samples += chk.Raw.XORNumSamples()
+			}
 
-		if chk.Count != nil {
-			c.Chunks++
-			c.Samples += chk.Count.XORNumSamples()
-		}
+			if chk.Count != nil {
+				c.Chunks++
+				c.Samples += chk.Count.XORNumSamples()
+			}
 
-		if chk.Counter != nil {
-			c.Chunks++
-			c.Samples += chk.Counter.XORNumSamples()
-		}
+			if chk.Counter != nil {
+				c.Chunks++
+				c.Samples += chk.Counter.XORNumSamples()
+			}
 
-		if chk.Max != nil {
-			c.Chunks++
-			c.Samples += chk.Max.XORNumSamples()
-		}
+			if chk.Max != nil {
+				c.Chunks++
+				c.Samples += chk.Max.XORNumSamples()
+			}
 
-		if chk.Min != nil {
-			c.Chunks++
-			c.Samples += chk.Min.XORNumSamples()
-		}
+			if chk.Min != nil {
+				c.Chunks++
+				c.Samples += chk.Min.XORNumSamples()
+			}
 
-		if chk.Sum != nil {
-			c.Chunks++
-			c.Samples += chk.Sum.XORNumSamples()
+			if chk.Sum != nil {
+				c.Chunks++
+				c.Samples += chk.Sum.XORNumSamples()
+			}
 		}
 	}
+	c.Bytes += r.Size()
 }
 
 func (m *SeriesRequest) ToPromQL() string {

--- a/pkg/store/telemetry.go
+++ b/pkg/store/telemetry.go
@@ -24,6 +24,10 @@ type seriesStatsAggregator struct {
 	seriesStats storepb.SeriesStatsCounter
 }
 
+func (s *seriesStatsAggregator) GetSeriesStatsCounter() storepb.SeriesStatsCounter {
+	return s.seriesStats
+}
+
 type seriesStatsAggregatorFactory struct {
 	queryDuration    *prometheus.HistogramVec
 	seriesLeBuckets  []float64
@@ -81,6 +85,7 @@ func (s *seriesStatsAggregator) Aggregate(stats storepb.SeriesStatsCounter) {
 	s.seriesStats.Series += stats.Series
 	s.seriesStats.Samples += stats.Samples
 	s.seriesStats.Chunks += stats.Chunks
+	s.seriesStats.Bytes += stats.Bytes
 }
 
 // Observe commits the aggregated SeriesStatsCounter as an observation.
@@ -124,10 +129,15 @@ type SeriesQueryPerformanceMetricsAggregatorFactory interface {
 type SeriesQueryPerformanceMetricsAggregator interface {
 	Aggregate(seriesStats storepb.SeriesStatsCounter)
 	Observe(duration float64)
+	GetSeriesStatsCounter() storepb.SeriesStatsCounter
 }
 
 // NoopSeriesStatsAggregator is a query performance series aggregator that does nothing.
 type NoopSeriesStatsAggregator struct{}
+
+func (s *NoopSeriesStatsAggregator) GetSeriesStatsCounter() storepb.SeriesStatsCounter {
+	return storepb.SeriesStatsCounter{}
+}
 
 func (s *NoopSeriesStatsAggregator) Aggregate(_ storepb.SeriesStatsCounter) {}
 


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->
Add query bytes fetched along with other series stats in Query Response
Want to seek approval before I added changelog
* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
curl http://localhost:10902/api/v1/query?query='COUNT(up)'
{"status":"success","data":{"resultType":"vector","result":[{"metric":{},"value":[1716515107.878,"173"]}],"analysis":{},"seriesStatsCounter":{"Series":174,"Chunks":174,"Samples":2248,"Bytes":101533}}}