### PR TITLE
Query: dont pass query hints to avoid triggering pushdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#7326](https://github.com/thanos-io/thanos/pull/7326) Query: fixing exemplars proxy when querying stores with multiple tenants.
 - [#7335](https://github.com/thanos-io/thanos/pull/7335) Dependency: Update minio-go to v7.0.70 which includes support for EKS Pod Identity.
 - [#6948](https://github.com/thanos-io/thanos/pull/6948) Receive: fix goroutines leak during series requests to thanos store api.
+- [#7392](https://github.com/thanos-io/thanos/pull/7392) Query: fix broken min, max for pre 0.34.1 sidecars
 
 ### Added
 

--- a/pkg/query/querier.go
+++ b/pkg/query/querier.go
@@ -241,20 +241,6 @@ func aggrsFromFunc(f string) []storepb.Aggr {
 	return []storepb.Aggr{storepb.Aggr_COUNT, storepb.Aggr_SUM}
 }
 
-func storeHintsFromPromHints(hints *storage.SelectHints) *storepb.QueryHints {
-	return &storepb.QueryHints{
-		StepMillis: hints.Step,
-		Func: &storepb.Func{
-			Name: hints.Func,
-		},
-		Grouping: &storepb.Grouping{
-			By:     hints.By,
-			Labels: hints.Grouping,
-		},
-		Range: &storepb.Range{Millis: hints.Range},
-	}
-}
-
 func (q *querier) Select(ctx context.Context, _ bool, hints *storage.SelectHints, ms ...*labels.Matcher) storage.SeriesSet {
 	if hints == nil {
 		hints = &storage.SelectHints{
@@ -351,7 +337,6 @@ func (q *querier) selectFn(ctx context.Context, hints *storage.SelectHints, ms .
 		ShardInfo:               q.shardInfo,
 		PartialResponseStrategy: q.partialResponseStrategy,
 		SkipChunks:              q.skipChunks,
-		QueryHints:              storeHintsFromPromHints(hints),
 	}
 	if q.isDedupEnabled() {
 		// Soft ask to sort without replica labels and push them at the end of labelset.

--- a/pkg/store/prometheus.go
+++ b/pkg/store/prometheus.go
@@ -163,19 +163,7 @@ func (p *PrometheusStore) Series(r *storepb.SeriesRequest, seriesSrv storepb.Sto
 	// Don't ask for more than available time. This includes potential `minTime` flag limit.
 	availableMinTime, _ := p.timestamps()
 	if r.MinTime < availableMinTime {
-		// Align min time with the step to avoid missing data when it gets retrieved by the upper layer's PromQL engine.
-		// This also is necessary when Sidecar uploads a block and then availableMinTime
-		// becomes a fixed timestamp.
-		if r.QueryHints != nil && r.QueryHints.StepMillis != 0 {
-			diff := availableMinTime - r.MinTime
-			r.MinTime += (diff / r.QueryHints.StepMillis) * r.QueryHints.StepMillis
-			// Add one more to strictly fit within --min-time -> infinity.
-			if r.MinTime != availableMinTime {
-				r.MinTime += r.QueryHints.StepMillis
-			}
-		} else {
-			r.MinTime = availableMinTime
-		}
+		r.MinTime = availableMinTime
 	}
 
 	extLsetToRemove := map[string]struct{}{}


### PR DESCRIPTION
If we have a new querier it will create query hints even without the pushdown feature being present anymore. Old sidecars will then trigger query pushdown which leads to broken max,min,max_over_time and min_over_time.

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Previously querier would only set query hints if pushdown was enabled. After f29b338cd9d885c17944a448419e3a58d5a573a7 we always set it which is not backwards compatible. This PR fixes that by not passing query hints anymore. Attempts to solve #7368 
