### PR TITLE
Compact : parameter to control warnings for empty chunks

### DIFF
--- a/pkg/compact/downsample/downsample.go
+++ b/pkg/compact/downsample/downsample.go
@@ -98,7 +98,7 @@ func Downsample(
 
 	// Writes downsampled chunks right into the files, avoiding excess memory allocation.
 	// Flushes index and meta data after aggregations.
-	streamedBlockWriter, err := NewStreamedBlockWriter(blockDir, indexr, logger, newMeta)
+	streamedBlockWriter, err := NewStreamedBlockWriter(blockDir, indexr, logger, newMeta, true)
 	if err != nil {
 		return id, errors.Wrap(err, "get streamed block writer")
 	}


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->
#7182 
added a parameter  `logEmptyChunks` which helps in controlling warnings when prometheus creates empty check which can be configured by `NewStreamedBlockWriter` function 

## Verification

<!-- How you tested it? How do you know it works? -->
