### PR TITLE
receive/store: use Client.String()

### DIFF
--- a/pkg/receive/multitsdb.go
+++ b/pkg/receive/multitsdb.go
@@ -97,12 +97,18 @@ func NewMultiTSDB(
 type localClient struct {
 	storepb.StoreClient
 	store *store.TSDBStore
+	desc  string
 }
 
 func newLocalClient(c storepb.StoreClient, store *store.TSDBStore) *localClient {
+	mint, maxt := store.TimeRange()
 	return &localClient{
 		StoreClient: c,
 		store:       store,
+		desc: fmt.Sprintf(
+			"LabelSets: %v MinTime: %d MaxTime: %d",
+			labelpb.PromLabelSetsToString(labelpb.ZLabelSetsToPromLabelSets(store.LabelSet()...)), mint, maxt,
+		),
 	}
 }
 
@@ -131,11 +137,7 @@ func (l *localClient) TSDBInfos() []infopb.TSDBInfo {
 }
 
 func (l *localClient) String() string {
-	mint, maxt := l.store.TimeRange()
-	return fmt.Sprintf(
-		"LabelSets: %v MinTime: %d MaxTime: %d",
-		labelpb.PromLabelSetsToString(l.LabelSets()), mint, maxt,
-	)
+	return l.desc
 }
 
 func (l *localClient) Addr() (string, bool) {

--- a/pkg/store/proxy.go
+++ b/pkg/store/proxy.go
@@ -575,7 +575,7 @@ func (s *ProxyStore) LabelValues(ctx context.Context, originalRequest *storepb.L
 
 func storeInfo(st Client) (storeID string, storeAddr string, isLocalStore bool) {
 	storeAddr, isLocalStore = st.Addr()
-	storeID = labelpb.PromLabelSetsToString(st.LabelSets())
+	storeID = st.String()
 	if storeID == "" {
 		storeID = "Store Gateway"
 	}


### PR DESCRIPTION
Use Client.String() instead of allocating a new string each time. With 15-20k req/s I have noticed that a lot of time is spent on allocating a new string here.
