### PR TITLE
reloader: don't fail on envvar expansion errors

### DIFF
--- a/.mdox.validate.yaml
+++ b/.mdox.validate.yaml
@@ -42,6 +42,5 @@ validators:
     type: 'ignore'
   - regex: 'twitter\.com'
     type: 'ignore'
-  # 500 when requested my mdox in GH actions.
-  - regex: 'outshift\.cisco\.com'
+  - regex: 'outshift\.cisco\.com\/blog\/multi-cluster-monitoring'
     type: 'ignore'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 
 ### Added
 
+- [#7429](https://github.com/thanos-io/thanos/pull/7429): Reloader: introduce `TolerateEnvVarExpansionErrors` to allow suppressing errors when expanding environment variables in the configuration file. When set, this will ensure that the reloader won't consider the operation to fail when an unset environment variable is encountered. Note that all unset environment variables are left as is, whereas all set environment variables are expanded as usual.
 - [#7317](https://github.com/thanos-io/thanos/pull/7317) Tracing: allow specifying resource attributes for the OTLP configuration.
 - [#7367](https://github.com/thanos-io/thanos/pull/7367) Store Gateway: log request ID in request logs.
 - [#7361](https://github.com/thanos-io/thanos/pull/7361) Query: *breaking :warning:* pass query stats from remote execution from server to client. We changed the protobuf of the QueryAPI, if you use `query.mode=distributed` you need to update your client (upper level Queriers) first, before updating leaf Queriers (servers).


### PR DESCRIPTION
Don't fail the reloader on environment variable expansion errors.

Refer: https://github.com/prometheus-operator/prometheus-operator/issues/6136

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

- Reloader: do not fail on environment variable expansion errors.

## Verification

<!-- How you tested it? How do you know it works? -->

- Modified the tests to cover the changes.