### PR TITLE
Use the default dependabot labeling

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,15 +5,12 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    labels: ["dependencies"]
     open-pull-requests-limit: 20
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
       interval: "weekly"
-    labels: ["dependencies"]
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule: 
       interval: weekly
-    labels: ["dependencies"]


### PR DESCRIPTION

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

Dependabot already includes `dependencies` on PRs. Removing the config will cause it to also include an ecosystem label like `go`.

## Verification

This is the same config we use in Prometheus.