### PR TITLE
Put query stats logging under s.debugLogging

### DIFF
--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -1660,10 +1660,12 @@ func (s *BucketStore) Series(req *storepb.SeriesRequest, seriesSrv storepb.Store
 		s.metrics.cachedPostingsCompressedSizeBytes.WithLabelValues(tenant).Add(float64(stats.CachedPostingsCompressedSizeSum))
 		s.metrics.postingsSizeBytes.WithLabelValues(tenant).Observe(float64(int(stats.PostingsFetchedSizeSum) + int(stats.PostingsTouchedSizeSum)))
 
-		level.Debug(logger).Log("msg", "stats query processed",
-			"request", req,
-			"tenant", tenant,
-			"stats", fmt.Sprintf("%+v", stats), "err", err)
+		if s.debugLogging {
+			level.Debug(logger).Log("msg", "stats query processed",
+				"request", req,
+				"tenant", tenant,
+				"stats", fmt.Sprintf("%+v", stats), "err", err)
+		}
 	}()
 
 	// Concurrently get data from all blocks.


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

The log line being changed in the PR uses `fmt.Sprintf("%+v", stats)` which is quite expensive and show up in our CPU profile.
We never enable debug level logging but it still evaluates `fmt.Sprintf`.

Put the log line under `debugLogging`. I think this makes no difference for Thanos users because when log level is set to `debug`, Store Gateway will set `debugLogging` to true as well.

## Verification

<!-- How you tested it? How do you know it works? -->
