### PR TITLE
Feature: Added CI to verify the format of PR titles.

### DIFF
--- a/.github/workflows/pr-title-check.yaml
+++ b/.github/workflows/pr-title-check.yaml
@@ -1,0 +1,37 @@
+name: Verify PR Title
+
+on:
+  pull_request:
+    types: [opened, edited, reopened]
+
+jobs:
+  verify-title:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v2
+
+      - name: Verify PR Title
+        id: verify
+        run: |
+          PREFIXES="query|compactor|query-frontend|receiver|rule|sidecar|store|tools|\.\*"
+
+          IFS=',' read -ra PREFIX_ARRAY <<< "${PREFIXES}"
+          VALID=0
+
+          for PREFIX in "${PREFIX_ARRAY[@]}"; do
+            PREFIX="${PREFIX}:"
+            if [[ "${{ github.event.pull_request.title }}" =~ ^(${PREFIXES}):.* ]]; then
+              VALID=1
+              break
+            fi
+          done
+
+          if [[ $VALID -eq 0 ]]; then
+            echo "PR title does not follow the required format: 'prefix: description'"
+            echo "::error::PR title must start with one or more of the following prefixes: query:, compactor:, query-frontend:, receiver:, rule:, sidecar:, store:, tools:, .*:"
+            exit 1
+          else
+            echo "PR title is valid."
+          fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -185,6 +185,34 @@ It is a good practice to keep your branch updated by rebasing your branch to mai
 * If you feel like your PR is waiting too long for a review, feel free to ping the [`#thanos-dev`](https://slack.cncf.io/) channel on our slack for a review!
 * If you are a new contributor with no write access, you can tag in the respective maintainer for the changes, but be patient enough for the reviews. *Remember, good things take time :)*
 
+### Pull Request Title Format
+
+When submitting a pull request (PR), please ensure that the title follows the specified format:
+
+#### Prefixes
+
+PR titles must start with one of the following prefixes:
+- `query:`
+- `compactor:`
+- `query-frontend:`
+- `receiver:`
+- `rule:`
+- `sidecar:`
+- `store:`
+- `tools:`
+- `.*:` (any string followed by a colon)
+
+Or combinations of components:
+- `query,store: Enhance data retrieval efficiency`
+
+#### Examples of Valid PR Titles
+
+- `query: Improve query performance`
+- `receiver: Fix bug in data processing`
+- `feature: Add new logging functionality`
+
+PR titles that do not adhere to this format will not pass the automated title verification and may be rejected.
+
 ### Dependency management
 
 The Thanos project uses [Go modules](https://golang.org/cmd/go/#hdr-Modules__module_versions__and_more) to manage dependencies on external packages. This requires a working Go environment with version 1.11 or greater and git installed.


### PR DESCRIPTION
##Feature : This PR adds the functionality to automatically verifies the titles of pull request.

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Added one Github workflow which automates the verification of PR titles, and updated CONTRIBUTING.md file for users.

## Verification

make test
