### PR TITLE
Proxy: fix response set panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 
 - [#7326](https://github.com/thanos-io/thanos/pull/7326) Query: fixing exemplars proxy when querying stores with multiple tenants.
 - [#7403](https://github.com/thanos-io/thanos/pull/7403) Sidecar: fix startup sequence
+- [#7484](https://github.com/thanos-io/thanos/pull/7484) Proxy: fix panic in lazy response set
 
 ### Added
 

--- a/pkg/store/proxy_merge.go
+++ b/pkg/store/proxy_merge.go
@@ -349,7 +349,6 @@ func newLazyRespSet(
 			}
 
 			resp, err := cl.Recv()
-
 			if err != nil {
 				if err == io.EOF {
 					l.bufferedResponsesMtx.Lock()
@@ -362,10 +361,8 @@ func newLazyRespSet(
 				var rerr error
 				// If timer is already stopped
 				if t != nil && !t.Stop() {
-					if errors.Is(err, context.Canceled) {
-						// The per-Recv timeout has been reached.
-						rerr = errors.Wrapf(err, "failed to receive any data in %s from %s", l.frameTimeout, st)
-					}
+					<-t.C // Drain the channel if it was already stopped.
+					rerr = errors.Wrapf(err, "failed to receive any data in %s from %s", l.frameTimeout, st)
 				} else {
 					rerr = errors.Wrapf(err, "receive series from %s", st)
 				}
@@ -609,7 +606,6 @@ func newEagerRespSet(
 			}
 
 			resp, err := cl.Recv()
-
 			if err != nil {
 				if err == io.EOF {
 					return false
@@ -619,10 +615,7 @@ func newEagerRespSet(
 				// If timer is already stopped
 				if t != nil && !t.Stop() {
 					<-t.C // Drain the channel if it was already stopped.
-					if errors.Is(err, context.Canceled) {
-						// The per-Recv timeout has been reached.
-						rerr = errors.Wrapf(err, "failed to receive any data in %s from %s", l.frameTimeout, storeName)
-					}
+					rerr = errors.Wrapf(err, "failed to receive any data in %s from %s", l.frameTimeout, storeName)
 				} else {
 					rerr = errors.Wrapf(err, "receive series from %s", storeName)
 				}


### PR DESCRIPTION
* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Adding the error tag panics in my prod with a nil pointer dereference. We can reach this if the error we face is not a context exceeded error but the timer has expired. I think we also forgot to receive from the timer channel in the lazy response set.

## Verification

Existing tests.
