### PR TITLE
*: fix server grpc histograms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 
 ### Fixed
 
+- [#7493](https://github.com/thanos-io/thanos/pull/7493) *: fix server grpc histograms
+
 ### Added
 
 ### Changed

--- a/pkg/server/grpc/grpc.go
+++ b/pkg/server/grpc/grpc.go
@@ -59,10 +59,10 @@ func New(logger log.Logger, reg prometheus.Registerer, tracer opentracing.Tracer
 
 	met := grpc_prometheus.NewServerMetrics(
 		grpc_prometheus.WithServerHandlingTimeHistogram(
-			grpc_prometheus.WithHistogramBuckets([]float64{0.001, 0.01, 0.1, 0.3, 0.6, 1, 3, 6, 9, 20, 30, 60, 90, 120}),
 			grpc_prometheus.WithHistogramOpts(&prometheus.HistogramOpts{
-				NativeHistogramBucketFactor:    1.1,
+				Buckets:                        []float64{0.001, 0.01, 0.1, 0.3, 0.6, 1, 3, 6, 9, 20, 30, 60, 90, 120},
 				NativeHistogramMaxBucketNumber: 256,
+				NativeHistogramBucketFactor:    1.1,
 			}),
 		),
 	)


### PR DESCRIPTION
* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Setting histogram options after setting buckets overrides the buckets from the previous option.

## Verification

Didnt test.
