### PR TITLE
Ruler: remove trailing period from SRV records returned by discovery `dnsnosrva` lookups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 
 ### Changed
 
+- [#7494](https://github.com/thanos-io/thanos/pull/7494) Ruler: remove trailing period from SRV records returned by discovery `dnsnosrva` lookups
+
 ### Removed
 
 ## [v0.36.0](https://github.com/thanos-io/thanos/tree/release-0.36) - in progress

--- a/pkg/discovery/dns/resolver.go
+++ b/pkg/discovery/dns/resolver.go
@@ -108,7 +108,9 @@ func (s *dnsSD) Resolve(ctx context.Context, name string, qtype QType) ([]string
 			}
 
 			if qtype == SRVNoA {
-				res = append(res, appendScheme(scheme, net.JoinHostPort(rec.Target, resPort)))
+				// Remove the final dot from rooted DNS names (this is for compatibility with Prometheus)
+				target := strings.TrimRight(rec.Target, ".")
+				res = append(res, appendScheme(scheme, net.JoinHostPort(target, resPort)))
 				continue
 			}
 			// Do A lookup for the domain in SRV answer.


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

This is a small change, that strips the trailing dot (.) on records returned by `dnssrvno` lookups. While the trailing dot is technically a valid URL, it causes "issues" for some tools (in my case Istio), This PR uses the [same approach as Prometheus](https://github.com/prometheus/prometheus/blob/main/discovery/dns/dns.go#L215-L216) to strip the trailing dot to look more "usual" so that third-party applications might not complain...

<!-- Enumerate changes you made -->

## Verification

I have had this running in our DEV environment since I opened the PR with no issues.
