### PR TITLE
Fix query: different results for rate function when not dedup or using implicit step interval #7341

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,10 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 ### Fixed
 
 - [#7493](https://github.com/thanos-io/thanos/pull/7493) *: fix server grpc histograms
+- [#7341] (https://github.com/thanos-io/thanos/issues/7341) *: fix query: different results for rate function when not dedup or using implicit step interval #7341
 
 ### Added
+- [#7341] (https://github.com/thanos-io/thanos/issues/7341) *: Query: Add `--query.dedup-penalty` flag to control the initial penalty value for deduplication in the query engine.
 
 ### Changed
 

--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -231,6 +231,7 @@ func registerQuery(app *extkingpin.App) {
 	tenantCertField := cmd.Flag("query.tenant-certificate-field", "Use TLS client's certificate field to determine tenant for write requests. Must be one of "+tenancy.CertificateFieldOrganization+", "+tenancy.CertificateFieldOrganizationalUnit+" or "+tenancy.CertificateFieldCommonName+". This setting will cause the query.tenant-header flag value to be ignored.").Default("").Enum("", tenancy.CertificateFieldOrganization, tenancy.CertificateFieldOrganizationalUnit, tenancy.CertificateFieldCommonName)
 	enforceTenancy := cmd.Flag("query.enforce-tenancy", "Enforce tenancy on Query APIs. Responses are returned only if the label value of the configured tenant-label-name and the value of the tenant header matches.").Default("false").Bool()
 	tenantLabel := cmd.Flag("query.tenant-label-name", "Label name to use when enforcing tenancy (if --query.enforce-tenancy is enabled).").Default(tenancy.DefaultTenantLabel).String()
+	dedupDefaultPenalty := extkingpin.ModelDuration(cmd.Flag("query.dedup-penalty", "Initial penalty for duplicate data. The penalty is added to the time of the duplicate data.").Default("5s"))
 
 	var storeRateLimits store.SeriesSelectLimits
 	storeRateLimits.RegisterFlags(cmd)
@@ -369,6 +370,7 @@ func registerQuery(app *extkingpin.App) {
 			*tenantCertField,
 			*enforceTenancy,
 			*tenantLabel,
+			time.Duration(*dedupDefaultPenalty),
 		)
 	})
 }
@@ -451,6 +453,7 @@ func runQuery(
 	tenantCertField string,
 	enforceTenancy bool,
 	tenantLabel string,
+	dedupDefaultPenalty time.Duration,
 ) error {
 	if alertQueryURL == "" {
 		lastColon := strings.LastIndex(httpBindAddr, ":")
@@ -562,6 +565,7 @@ func runQuery(
 			proxy,
 			maxConcurrentSelects,
 			queryTimeout,
+			dedupDefaultPenalty,
 		)
 	)
 

--- a/pkg/dedup/iter.go
+++ b/pkg/dedup/iter.go
@@ -15,6 +15,12 @@ import (
 	"github.com/thanos-io/thanos/pkg/store/storepb"
 )
 
+var initialPenalty int64 = 5000
+
+func InitialPenalty(value int64) {
+	initialPenalty = value
+}
+
 type dedupSeriesSet struct {
 	set       storage.SeriesSet
 	isCounter bool
@@ -345,7 +351,6 @@ func (it *dedupSeriesIterator) Next() chunkenc.ValueType {
 	// timestamp assignment.
 	// If we don't know a delta yet, we pick 5000 as a constant, which is based on the knowledge
 	// that timestamps are in milliseconds and sampling frequencies typically multiple seconds long.
-	const initialPenalty = 5000
 
 	if it.useA {
 		if it.lastT != math.MinInt64 {

--- a/pkg/query/querier.go
+++ b/pkg/query/querier.go
@@ -65,6 +65,7 @@ func NewQueryableCreator(
 	proxy storepb.StoreServer,
 	maxConcurrentSelects int,
 	selectTimeout time.Duration,
+	dedupDefaultPenalty time.Duration,
 ) QueryableCreator {
 	gf := gate.NewGateFactory(extprom.WrapRegistererWithPrefix("concurrent_selects_", reg), maxConcurrentSelects, gate.Selects)
 
@@ -78,6 +79,7 @@ func NewQueryableCreator(
 		shardInfo *storepb.ShardInfo,
 		seriesStatsReporter seriesStatsReporter,
 	) storage.Queryable {
+		dedup.InitialPenalty(dedupDefaultPenalty.Milliseconds())
 		return &queryable{
 			logger:              logger,
 			replicaLabels:       replicaLabels,


### PR DESCRIPTION
* [V ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

I added query.dedup-penalty to allow passing a different initial value for the default penalty of the deduplication algorithm.
see issue https://github.com/thanos-io/thanos/issues/7341

## Verification

added a unit test case for the usage of the new setting.
