### PR TITLE
Close endpoints after the gRPC server has terminated

### DIFF
--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -826,6 +826,7 @@ func runQuery(
 		}, func(error) {
 			statusProber.NotReady(err)
 			s.Shutdown(err)
+			endpoints.Close()
 		})
 	}
 
@@ -919,7 +920,6 @@ func prepareEndpointSet(
 			})
 		}, func(error) {
 			cancel()
-			endpointSet.Close()
 		})
 	}
 


### PR DESCRIPTION
Endpoints are currently closed as soon as we receive a SIGTERM or SIGINT. This causes in-flight queries to get cancelled since outgoing connections get closed instantly.

This commit moves the endpoints.Close call after the grpc server shutdown to make sure connections are available as long as the server is running.

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
