### PR TITLE
QFE: disable double compression middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 ### Fixed
 
 - [#7493](https://github.com/thanos-io/thanos/pull/7493) *: fix server grpc histograms
+* [#7511](https://github.com/thanos-io/thanos/pull/7511) Query Frontend: fix doubled gzip compression for response body.
 
 ### Added
 

--- a/cmd/thanos/query_frontend.go
+++ b/cmd/thanos/query_frontend.go
@@ -359,9 +359,7 @@ func runQueryFrontend(
 						logger,
 						ins.NewHandler(
 							name,
-							gzhttp.GzipHandler(
-								logMiddleware.HTTPMiddleware(name, f),
-							),
+							logMiddleware.HTTPMiddleware(name, f),
 						),
 						// Cortex frontend middlewares require orgID.
 					),


### PR DESCRIPTION
* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Remove the Zip middleware from the main setup of the QFE, since we already have a compression middleware controlled by the flag `query-frontend.compress-responses`.

The other gzip middleware is added here: https://github.com/pedro-stanaka/thanos/blob/21dbac558b3f011f530e31fca2dc0607af8ab122/cmd/thanos/query_frontend.go#L324-L328


## Verification

Ran the QFE locally, but we are running this on our staging environment and it still returns gzipped responses.


