### PR TITLE
thanos component/sidecar metrics

### DIFF
--- a/docs/components/sidecar.md
+++ b/docs/components/sidecar.md
@@ -264,3 +264,20 @@ transport_config:
   disable_compression: false
   tls_handshake_timeout: 0
 ```
+
+## Metrics
+
+### List of Metrics Exported By Sidecar
+
+| Metric Name         | Type | Description          | 
+| ------------ | -------------- | ----------- |
+| thanos_sidecar_prometheus_up | gauge | Boolean indicator whether the sidecar can reach its Prometheus peer. |
+| thanos_sidecar_reloader_config_apply_operations | counter | Total number of config apply operations. |
+| thanos_sidecar_reloader_config_apply_operations_failed | counter | Total number of config apply operations that failed. |
+| thanos_sidecar_reloader_last_reload_success_timestamp_seconds | gauge | Timestamp of the last successful reload. |
+| thanos_sidecar_reloader_last_reload_successful | gauge | Whether the last reload attempt was successful. |
+| thanos_sidecar_reloader_reloads | counter | Total number of reload requests. |
+| thanos_sidecar_reloader_reloads_failed | counter | Total number of reload requests that failed. |
+| thanos_sidecar_reloader_watch_errors | counter | Total number of errors received by the reloader from the watcher. |
+| thanos_sidecar_reloader_watch_events | counter | Total number of events received by the reloader from the watcher. |
+| thanos_sidecar_reloader_watches | gauge | Number of resources watched by the reloader. |

--- a/docs/components/sidecar.md
+++ b/docs/components/sidecar.md
@@ -269,15 +269,15 @@ transport_config:
 
 ### List of Metrics Exported By Sidecar
 
-| Metric Name         | Type | Description          | 
-| ------------ | -------------- | ----------- |
-| thanos_sidecar_prometheus_up | gauge | Boolean indicator whether the sidecar can reach its Prometheus peer. |
-| thanos_sidecar_reloader_config_apply_operations | counter | Total number of config apply operations. |
-| thanos_sidecar_reloader_config_apply_operations_failed | counter | Total number of config apply operations that failed. |
-| thanos_sidecar_reloader_last_reload_success_timestamp_seconds | gauge | Timestamp of the last successful reload. |
-| thanos_sidecar_reloader_last_reload_successful | gauge | Whether the last reload attempt was successful. |
-| thanos_sidecar_reloader_reloads | counter | Total number of reload requests. |
-| thanos_sidecar_reloader_reloads_failed | counter | Total number of reload requests that failed. |
-| thanos_sidecar_reloader_watch_errors | counter | Total number of errors received by the reloader from the watcher. |
-| thanos_sidecar_reloader_watch_events | counter | Total number of events received by the reloader from the watcher. |
-| thanos_sidecar_reloader_watches | gauge | Number of resources watched by the reloader. |
+| Metric Name                                                   | Type    | Description                                                          |
+|---------------------------------------------------------------|---------|----------------------------------------------------------------------|
+| thanos_sidecar_prometheus_up                                  | gauge   | Boolean indicator whether the sidecar can reach its Prometheus peer. |
+| thanos_sidecar_reloader_config_apply_operations               | counter | Total number of config apply operations.                             |
+| thanos_sidecar_reloader_config_apply_operations_failed        | counter | Total number of config apply operations that failed.                 |
+| thanos_sidecar_reloader_last_reload_success_timestamp_seconds | gauge   | Timestamp of the last successful reload.                             |
+| thanos_sidecar_reloader_last_reload_successful                | gauge   | Whether the last reload attempt was successful.                      |
+| thanos_sidecar_reloader_reloads                               | counter | Total number of reload requests.                                     |
+| thanos_sidecar_reloader_reloads_failed                        | counter | Total number of reload requests that failed.                         |
+| thanos_sidecar_reloader_watch_errors                          | counter | Total number of errors received by the reloader from the watcher.    |
+| thanos_sidecar_reloader_watch_events                          | counter | Total number of events received by the reloader from the watcher.    |
+| thanos_sidecar_reloader_watches                               | gauge   | Number of resources watched by the reloader.                         |


### PR DESCRIPTION
Updated Thanos sidecar component exported metrics in its documentation based on this [issue](https://github.com/thanos-io/thanos/issues/5758), kindly review @douglascamata @bill3tt @hanjm.  
