### PR TITLE
receive: add mode set

### DIFF
--- a/pkg/receive/handler.go
+++ b/pkg/receive/handler.go
@@ -837,9 +837,17 @@ func (h *Handler) distributeTimeseriesToReplicas(
 		}
 
 		for _, rn := range replicas {
-			endpoint, err := h.hashring.GetN(tenant, &ts, rn)
-			if err != nil {
-				return nil, nil, err
+			var endpoint string
+			if h.options.ReceiverMode != IngestorOnly {
+				var err error
+				endpoint, err = h.hashring.GetN(tenant, &ts, rn)
+				if err != nil {
+					return nil, nil, err
+				}
+			} else {
+				// In IngestorOnly mode, directly use the h.options.endpoint,
+				// and then we still can use other config in the hashring such as tenant-specific external labels.
+				endpoint = h.options.Endpoint
 			}
 			endpointReplica := endpointReplica{endpoint: endpoint, replica: rn}
 			var writeDestination = remoteWrites


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

Add `receive.mode` flag to set run mode for Receive component, so we can make Receive run in `IngestorOnly` mode even if it started with a hashring configuration flag.

Then it will also support specifying tenant-specific external labels in `IngestorOnly` mode for https://github.com/thanos-io/thanos/issues/5434 by following configurations:
```yaml
args:
- --receive.mode=IngesterOnly
- --receive.local-endpoint=<local-endpoint>
- |
  --receive.hashring=[
	{
		"tenants": ["tenant1"],
                "external_labels": {
                    "cluster": "host"
                }
	}
  ]
```


## Verification

<!-- How you tested it? How do you know it works? -->
