### PR TITLE
Only increment ruler warning eval metric for non PromQL warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 ### Fixed
 
 * [#7511](https://github.com/thanos-io/thanos/pull/7511) Query Frontend: fix doubled gzip compression for response body.
+* [#7592](https://github.com/thanos-io/thanos/pull/7592) Ruler: Only increment `thanos_rule_evaluation_with_warnings_total` metric for non PromQL warnings.
 
 ### Added
 

--- a/cmd/thanos/rule.go
+++ b/cmd/thanos/rule.go
@@ -40,11 +40,12 @@ import (
 	"github.com/prometheus/prometheus/tsdb"
 	"github.com/prometheus/prometheus/tsdb/agent"
 	"github.com/prometheus/prometheus/tsdb/wlog"
+	"gopkg.in/yaml.v2"
+
 	"github.com/thanos-io/objstore"
 	"github.com/thanos-io/objstore/client"
 	objstoretracing "github.com/thanos-io/objstore/tracing/opentracing"
 	"github.com/thanos-io/promql-engine/execution/parse"
-	"gopkg.in/yaml.v2"
 
 	"github.com/thanos-io/thanos/pkg/alert"
 	v1 "github.com/thanos-io/thanos/pkg/api/rule"

--- a/cmd/thanos/rule.go
+++ b/cmd/thanos/rule.go
@@ -40,8 +40,6 @@ import (
 	"github.com/prometheus/prometheus/tsdb"
 	"github.com/prometheus/prometheus/tsdb/agent"
 	"github.com/prometheus/prometheus/tsdb/wlog"
-	"github.com/prometheus/prometheus/util/annotations"
-
 	"github.com/thanos-io/objstore"
 	"github.com/thanos-io/objstore/client"
 	objstoretracing "github.com/thanos-io/objstore/tracing/opentracing"
@@ -55,6 +53,7 @@ import (
 	"github.com/thanos-io/thanos/pkg/component"
 	"github.com/thanos-io/thanos/pkg/discovery/dns"
 	"github.com/thanos-io/thanos/pkg/errutil"
+	"github.com/thanos-io/thanos/pkg/extannotations"
 	"github.com/thanos-io/thanos/pkg/extgrpc"
 	"github.com/thanos-io/thanos/pkg/extkingpin"
 	"github.com/thanos-io/thanos/pkg/extprom"
@@ -80,11 +79,6 @@ import (
 )
 
 const dnsSDResolver = "miekgdns"
-
-var (
-	promQLInfo    = annotations.PromQLInfo.Error()
-	promQLWarning = annotations.PromQLWarning.Error()
-)
 
 type ruleConfig struct {
 	http    httpConfig
@@ -1095,7 +1089,7 @@ func validateTemplate(tmplStr string) error {
 func filterOutPromQLWarnings(warns []string, logger log.Logger, query string) []string {
 	storeWarnings := make([]string, 0, len(warns))
 	for _, warn := range warns {
-		if strings.Contains(warn, promQLInfo) || strings.Contains(warn, promQLWarning) {
+		if extannotations.IsPromQLAnnotation(warn) {
 			level.Warn(logger).Log("warning", warn, "query", query)
 			continue
 		}

--- a/cmd/thanos/rule_test.go
+++ b/cmd/thanos/rule_test.go
@@ -8,8 +8,9 @@ import (
 
 	"github.com/efficientgo/core/testutil"
 	"github.com/go-kit/log"
-	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/prometheus/prometheus/util/annotations"
+
+	"github.com/thanos-io/thanos/pkg/extpromql"
 )
 
 func Test_parseFlagLabels(t *testing.T) {
@@ -117,7 +118,7 @@ func Test_tableLinkForExpression(t *testing.T) {
 func TestFilterOutPromQLWarnings(t *testing.T) {
 	logger := log.NewNopLogger()
 	query := "foo"
-	expr, err := parser.ParseExpr(`rate(prometheus_build_info[5m])`)
+	expr, err := extpromql.ParseExpr(`rate(prometheus_build_info[5m])`)
 	testutil.Ok(t, err)
 	possibleCounterInfo := annotations.NewPossibleNonCounterInfo("foo", expr.PositionRange())
 	badBucketLabelWarning := annotations.NewBadBucketLabelWarning("foo", "0.99", expr.PositionRange())

--- a/cmd/thanos/rule_test.go
+++ b/cmd/thanos/rule_test.go
@@ -4,6 +4,9 @@
 package main
 
 import (
+	"github.com/go-kit/log"
+	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/prometheus/prometheus/util/annotations"
 	"testing"
 
 	"github.com/efficientgo/core/testutil"
@@ -108,5 +111,61 @@ func Test_tableLinkForExpression(t *testing.T) {
 		resStr, err := tableLinkForExpression(td.template, td.expr)
 		testutil.Equals(t, err != nil, td.expectErr)
 		testutil.Equals(t, resStr, td.expectStr)
+	}
+}
+
+func TestFilterOutPromQLWarnings(t *testing.T) {
+	logger := log.NewNopLogger()
+	query := "foo"
+	expr, err := parser.ParseExpr(`rate(prometheus_build_info[5m])`)
+	testutil.Ok(t, err)
+	possibleCounterInfo := annotations.NewPossibleNonCounterInfo("foo", expr.PositionRange())
+	badBucketLabelWarning := annotations.NewBadBucketLabelWarning("foo", "0.99", expr.PositionRange())
+	for _, tc := range []struct {
+		name     string
+		warnings []string
+		expected []string
+	}{
+		{
+			name:     "nil warning",
+			expected: make([]string, 0),
+		},
+		{
+			name:     "empty warning",
+			warnings: make([]string, 0),
+			expected: make([]string, 0),
+		},
+		{
+			name: "no PromQL warning",
+			warnings: []string{
+				"some_warning_message",
+			},
+			expected: []string{
+				"some_warning_message",
+			},
+		},
+		{
+			name: "PromQL warning",
+			warnings: []string{
+				possibleCounterInfo.Error(),
+			},
+			expected: make([]string, 0),
+		},
+		{
+			name: "filter out all PromQL warnings",
+			warnings: []string{
+				possibleCounterInfo.Error(),
+				badBucketLabelWarning.Error(),
+				"some_warning_message",
+			},
+			expected: []string{
+				"some_warning_message",
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			output := filterOutPromQLWarnings(tc.warnings, logger, query)
+			testutil.Equals(t, tc.expected, output)
+		})
 	}
 }

--- a/cmd/thanos/rule_test.go
+++ b/cmd/thanos/rule_test.go
@@ -4,12 +4,12 @@
 package main
 
 import (
-	"github.com/go-kit/log"
-	"github.com/prometheus/prometheus/promql/parser"
-	"github.com/prometheus/prometheus/util/annotations"
 	"testing"
 
 	"github.com/efficientgo/core/testutil"
+	"github.com/go-kit/log"
+	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/prometheus/prometheus/util/annotations"
 )
 
 func Test_parseFlagLabels(t *testing.T) {


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Fixes https://github.com/thanos-io/thanos/issues/7354

## Verification

Added a unit test. Also tested the behavior in my local Thanos Ruler
