### PR TITLE
API: Add limit param in metadata APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 * [#7592](https://github.com/thanos-io/thanos/pull/7592) Ruler: Only increment `thanos_rule_evaluation_with_warnings_total` metric for non PromQL warnings.
 
 ### Added
+* [7609](https://github.com/thanos-io/thanos/pull/7609) API: Add limit param to metadata APIs (series, label names, label values).
 
 ### Changed
 

--- a/pkg/api/query/v1_test.go
+++ b/pkg/api/query/v1_test.go
@@ -1378,7 +1378,7 @@ func TestMetadataEndpoints(t *testing.T) {
 			errType: baseAPI.ErrorBadData,
 			method:  http.MethodPost,
 		},
-		// With limit=2
+		// With limit
 		{
 			endpoint: api.series,
 			query: url.Values{
@@ -1391,7 +1391,7 @@ func TestMetadataEndpoints(t *testing.T) {
 			},
 			method: http.MethodPost,
 		},
-		// Without
+		// Without limit
 		{
 			endpoint: api.series,
 			query: url.Values{

--- a/pkg/api/query/v1_test.go
+++ b/pkg/api/query/v1_test.go
@@ -1038,6 +1038,15 @@ func TestMetadataEndpoints(t *testing.T) {
 			},
 			response: []string{"__name__", "foo", "replica1"},
 		},
+		// With limit
+		{
+			endpoint: api.labelNames,
+			query: url.Values{
+				"match[]": []string{`test_metric_replica2`},
+				"limit":   []string{"2"},
+			},
+			response: []string{"__name__", "foo"},
+		},
 		{
 			endpoint: api.labelValues,
 			query: url.Values{
@@ -1057,6 +1066,18 @@ func TestMetadataEndpoints(t *testing.T) {
 				"name": "__name__",
 			},
 			response: []string{"test_metric1", "test_metric2", "test_metric_replica1", "test_metric_replica2"},
+		},
+		// With limit
+		{
+			endpoint: api.labelValues,
+			query: url.Values{
+				"match[]": []string{`{foo="bar"}`, `{foo="boo"}`},
+				"limit":   []string{"3"},
+			},
+			params: map[string]string{
+				"name": "__name__",
+			},
+			response: []string{"test_metric1", "test_metric2", "test_metric_replica1"},
 		},
 		// No matched series.
 		{
@@ -1356,6 +1377,32 @@ func TestMetadataEndpoints(t *testing.T) {
 			},
 			errType: baseAPI.ErrorBadData,
 			method:  http.MethodPost,
+		},
+		// With limit=2
+		{
+			endpoint: api.series,
+			query: url.Values{
+				"match[]": []string{`{replica="", foo=~"b.+", replica1=""}`},
+				"limit":   []string{"2"},
+			},
+			response: []labels.Labels{
+				labels.FromStrings("__name__", "test_metric1", "foo", "bar"),
+				labels.FromStrings("__name__", "test_metric1", "foo", "boo"),
+			},
+			method: http.MethodPost,
+		},
+		// Without
+		{
+			endpoint: api.series,
+			query: url.Values{
+				"match[]": []string{`{replica="", foo=~"b.+", replica1=""}`},
+			},
+			response: []labels.Labels{
+				labels.FromStrings("__name__", "test_metric1", "foo", "bar"),
+				labels.FromStrings("__name__", "test_metric1", "foo", "boo"),
+				labels.FromStrings("__name__", "test_metric2", "foo", "boo"),
+			},
+			method: http.MethodPost,
 		},
 	}
 
@@ -1695,6 +1742,42 @@ func TestParseStoreDebugMatchersParam(t *testing.T) {
 				testutil.NotOk(t, err)
 			}
 		})
+	}
+}
+
+func TestParseLimitParam(t *testing.T) {
+	var tests = []struct {
+		input  string
+		fail   bool
+		result int
+	}{
+		{
+			input:  "",
+			fail:   false,
+			result: 0,
+		}, {
+			input: "abc",
+			fail:  true,
+		}, {
+			input:  "10",
+			fail:   false,
+			result: 10,
+		},
+	}
+
+	for _, test := range tests {
+		res, err := parseLimitParam(test.input)
+		if err != nil && !test.fail {
+			t.Errorf("Unexpected error for %q: %s", test.input, err)
+			continue
+		}
+		if err == nil && test.fail {
+			t.Errorf("Expected error for %q but got none", test.input)
+			continue
+		}
+		if !test.fail && res != test.result {
+			t.Errorf("Expected limit %v for input %q but got %v", test.result, test.input, res)
+		}
 	}
 }
 


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->
Prometheus recently introduced `limit` param in metadata APIs to allow users to opt for a limited number of results.
- https://github.com/prometheus/prometheus/pull/13396
- https://github.com/prometheus/prometheus/pull/14109

This PR implements the limit param in Thanos API.






## Verification

<!-- How you tested it? How do you know it works? -->
- Updated the unit tests to cover the case of when limit is passed.


## Related
- https://github.com/thanos-io/thanos/issues/7575
- https://github.com/prometheus/prometheus/issues/12795