### PR TITLE
Proxy: Query goroutine leak when `store.response-timeout` is set

### DIFF
--- a/pkg/store/proxy_merge.go
+++ b/pkg/store/proxy_merge.go
@@ -361,7 +361,9 @@ func newLazyRespSet(
 				var rerr error
 				// If timer is already stopped
 				if t != nil && !t.Stop() {
-					<-t.C // Drain the channel if it was already stopped.
+					if t.C != nil {
+						<-t.C // Drain the channel if it was already stopped.
+					}
 					rerr = errors.Wrapf(err, "failed to receive any data in %s from %s", l.frameTimeout, st)
 				} else {
 					rerr = errors.Wrapf(err, "receive series from %s", st)
@@ -614,7 +616,9 @@ func newEagerRespSet(
 				var rerr error
 				// If timer is already stopped
 				if t != nil && !t.Stop() {
-					<-t.C // Drain the channel if it was already stopped.
+					if t.C != nil {
+						<-t.C // Drain the channel if it was already stopped.
+					}
 					rerr = errors.Wrapf(err, "failed to receive any data in %s from %s", l.frameTimeout, storeName)
 				} else {
 					rerr = errors.Wrapf(err, "receive series from %s", storeName)


### PR DESCRIPTION
`time.AfterFunc()` returns a `time.Timer` object whose `C` field is nil, accroding to the documentation. A goroutine blocks forever on reading from a `nil` channel, leading to a goroutine leak on random slow queries for Thanos.

This goroutine leak would be most apparent for busy services with `query.promql-engine=thanos`, when grouroutins tend to stuck in batches, thanks to the wide usage of `sync.Once` by the engine.

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
