### PR TITLE
Fix failing e2e test

### DIFF
--- a/test/e2e/receive_test.go
+++ b/test/e2e/receive_test.go
@@ -848,9 +848,9 @@ test_metric{a="2", b="2"} 1`)
 			e2ethanos.AvalancheOptions{
 				MetricCount:    "10",
 				SeriesCount:    "1",
-				MetricInterval: "30",
-				SeriesInterval: "3600",
-				ValueInterval:  "3600",
+				MetricInterval: "3600",
+				SeriesInterval: "30",
+				ValueInterval:  "30",
 
 				RemoteURL:           e2ethanos.RemoteWriteEndpoint(ingestor1.InternalEndpoint("remote-write")),
 				RemoteWriteInterval: "30s",
@@ -886,9 +886,9 @@ test_metric{a="2", b="2"} 1`)
 			e2ethanos.AvalancheOptions{
 				MetricCount:    "10",
 				SeriesCount:    "1",
-				MetricInterval: "30",
-				SeriesInterval: "3600",
-				ValueInterval:  "3600",
+				MetricInterval: "3600",
+				SeriesInterval: "30",
+				ValueInterval:  "30",
 
 				RemoteURL:           e2ethanos.RemoteWriteEndpoint(ingestor1.InternalEndpoint("remote-write")),
 				RemoteWriteInterval: "30s",


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [X] Change is not relevant to the end user.

## Changes
There seems to be a bug in avalanche. When `--metric-interval` alone is set, no timeseries are returned and no write requests will be made by avalanche. See: [write.go#L143](https://github.com/prometheus-community/avalanche/blob/4b732e1a44668d1ed3fa6b503ee2c750d22990ff/metrics/write.go#L143)

Using `--series-interval` and `--sample-interval` seems to fix the test.

I haven't had a chance to look at avalanche bug in depth. But this PR should unblock Thanos e2e tests.
<!-- Enumerate changes you made -->

## Verification
- CI Workflows should pass
<!-- How you tested it? How do you know it works? -->
