### PR TITLE
Check context cancellation every 128 iterations

### DIFF
--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -2619,7 +2619,6 @@ func ExpandPostingsWithContext(ctx context.Context, p index.Postings) ([]storage
 			}
 		}
 		res = append(res, p.At())
-		i++
 	}
 	return res, p.Err()
 }

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -117,6 +117,9 @@ const (
 
 	// SeriesBatchSize is the default batch size when fetching series from object storage.
 	SeriesBatchSize = 10000
+
+	// checkContextEveryNIterations is used in some tight loops to check if the context is done.
+	checkContextEveryNIterations = 128
 )
 
 var (
@@ -2605,12 +2608,18 @@ func (r *bucketIndexReader) ExpandedPostings(ctx context.Context, ms sortedMatch
 }
 
 // ExpandPostingsWithContext returns the postings expanded as a slice and considers context.
-func ExpandPostingsWithContext(ctx context.Context, p index.Postings) (res []storage.SeriesRef, err error) {
+func ExpandPostingsWithContext(ctx context.Context, p index.Postings) ([]storage.SeriesRef, error) {
+	res := make([]storage.SeriesRef, 0, 1024) // Pre-allocate slice with initial capacity
+	i := 0
 	for p.Next() {
-		if ctx.Err() != nil {
-			return nil, ctx.Err()
+		i++
+		if i%checkContextEveryNIterations == 0 {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
 		}
 		res = append(res, p.At())
+		i++
 	}
 	return res, p.Err()
 }
@@ -2831,8 +2840,8 @@ func toPostingGroup(ctx context.Context, lvalsFn func(name string) ([]string, er
 			return nil, nil, err
 		}
 
-		for _, val := range vals {
-			if ctx.Err() != nil {
+		for i, val := range vals {
+			if (i+1)%checkContextEveryNIterations == 0 && ctx.Err() != nil {
 				return nil, nil, ctx.Err()
 			}
 			if !m.Matches(val) {
@@ -2860,8 +2869,8 @@ func toPostingGroup(ctx context.Context, lvalsFn func(name string) ([]string, er
 	}
 
 	var toAdd []string
-	for _, val := range vals {
-		if ctx.Err() != nil {
+	for i, val := range vals {
+		if (i+1)%checkContextEveryNIterations == 0 && ctx.Err() != nil {
 			return nil, nil, ctx.Err()
 		}
 		if m.Matches(val) {
@@ -2964,8 +2973,10 @@ func (r *bucketIndexReader) fetchPostings(ctx context.Context, keys []labels.Lab
 	// If we have a miss, mark key to be fetched in `ptrs` slice.
 	// Overlaps are well handled by partitioner, so we don't need to deduplicate keys.
 	for ix, key := range keys {
-		if err := ctx.Err(); err != nil {
-			return nil, closeFns, err
+		if (ix+1)%checkContextEveryNIterations == 0 {
+			if err := ctx.Err(); err != nil {
+				return nil, closeFns, err
+			}
 		}
 		// Get postings for the given key from cache first.
 		if b, ok := fromCache[key]; ok {

--- a/pkg/store/bucket_test.go
+++ b/pkg/store/bucket_test.go
@@ -2932,8 +2932,20 @@ func BenchmarkDownsampledBlockSeries(b *testing.B) {
 }
 
 func TestExpandPostingsWithContextCancel(t *testing.T) {
+	// Not enough number of postings to check context cancellation.
 	p := index.NewListPostings([]storage.SeriesRef{1, 2, 3, 4, 5, 6, 7, 8})
 	ctx, cancel := context.WithCancel(context.Background())
+
+	cancel()
+	_, err := ExpandPostingsWithContext(ctx, p)
+	testutil.Ok(t, err)
+
+	refs := make([]storage.SeriesRef, 0)
+	for i := 0; i < 128; i++ {
+		refs = append(refs, storage.SeriesRef(i))
+	}
+	p = index.NewListPostings(refs)
+	ctx, cancel = context.WithCancel(context.Background())
 
 	cancel()
 	res, err := ExpandPostingsWithContext(ctx, p)

--- a/pkg/store/lazy_postings.go
+++ b/pkg/store/lazy_postings.go
@@ -308,8 +308,8 @@ func fetchAndExpandPostingGroups(ctx context.Context, r *bucketIndexReader, post
 
 	result := index.Without(index.Intersect(groupAdds...), index.Merge(ctx, groupRemovals...))
 
-	if ctx.Err() != nil {
-		return nil, nil, ctx.Err()
+	if err := ctx.Err(); err != nil {
+		return nil, nil, err
 	}
 	ps, err := ExpandPostingsWithContext(ctx, result)
 	if err != nil {


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

Apply the same as https://github.com/prometheus/prometheus/pull/14118 to only check context cancellation every 128 iterations. This should help with the performance a bit but overall it is just a small portion of the CPU profile.

## Verification

<!-- How you tested it? How do you know it works? -->
