### PR TITLE
golangci-lint: Update deprecated linter configurations

### DIFF
--- a/.errcheck_excludes.txt
+++ b/.errcheck_excludes.txt
@@ -1,3 +1,0 @@
-(github.com/go-kit/log.Logger).Log
-fmt.Fprintln
-fmt.Fprint

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,7 +4,7 @@
 # options for analysis running
 run:
   # timeout for analysis, e.g. 30s, 5m, default is 1m
-  deadline: 5m
+  timeout: 5m
 
   # exit code when at least one issue was found, default is 1
   issues-exit-code: 1

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,16 +9,6 @@ run:
   # exit code when at least one issue was found, default is 1
   issues-exit-code: 1
 
-  # which dirs to skip: they won't be analyzed;
-  # can use regexp here: generated.*, regexp is applied on full path;
-  # default value is empty list, but next dirs are always skipped independently
-  # from this option's value:
-  #     vendor$, third_party$, testdata$, examples$, Godeps$, builtin$
-  skip-dirs:
-    - vendor
-    - internal/cortex
-
-
 # output configuration options
 output:
   # The formats used to render issues.
@@ -86,3 +76,7 @@ issues:
     - linters:
         - unused
       text: "ruleAndAssert"
+  # Which dirs to exclude: issues from them won't be reported.
+  exclude-dirs:
+    - vendor
+    - internal/cortex

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,8 +21,10 @@ run:
 
 # output configuration options
 output:
-  # colored-line-number|line-number|json|tab|checkstyle, default is "colored-line-number"
-  format: colored-line-number
+  # The formats used to render issues.
+  formats:
+    - format: colored-line-number
+      path: stdout
 
   # print lines of code with issue, default is true
   print-issued-lines: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -51,7 +51,11 @@ linters:
 
 linters-settings:
   errcheck:
-    exclude: ./.errcheck_excludes.txt
+    # List of functions to exclude from checking, where each entry is a single function to exclude.
+    exclude-functions:
+      - (github.com/go-kit/log.Logger).Log
+      - fmt.Fprintln
+      - fmt.Fprint
   misspell:
     locale: US
   goconst:


### PR DESCRIPTION
Hi,

This is a trivial PR, which fixes some configuration deprecation warnings reported by golangci-lint.
See [here](https://github.com/thanos-io/thanos/actions/runs/10399357185/job/28798102288#step:6:12).

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [X] Change is not relevant to the end user.

## Changes

* Replace deprecated `run.deadline` with `run.timeout`.
* Replace deprecated `run.skip-dirs` with `issues.exclude-dirs`.
* Fix output format configuration
* Fix errcheck configuration

## Verification

```console
make go-lint
```