### PR TITLE
codespell: check `pkg` folder

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -107,8 +107,8 @@ jobs:
         with:
           check_filenames: false
           check_hidden: true
-          skip: ./pkg/*,./internal/*,./mixin/vendor/*,./.bingo/*,go.mod,go.sum
-          ignore_words_list: re-use,intrumentation,mmaped,nd,serie
+          skip: ./pkg/ui/*,./pkg/store/6545postingsrepro,./internal/*,./mixin/vendor/*,./.bingo/*,go.mod,go.sum
+          ignore_words_list: intrumentation,mmaped,nd,ot,re-use,ser,serie,sme,sudu,tast,te
 
   e2e:
     strategy:

--- a/pkg/block/indexheader/reader_pool.go
+++ b/pkg/block/indexheader/reader_pool.go
@@ -32,7 +32,7 @@ func NewReaderPoolMetrics(reg prometheus.Registerer) *ReaderPoolMetrics {
 	}
 }
 
-// ReaderPool is used to istantiate new index-header readers and keep track of them.
+// ReaderPool is used to instantiate new index-header readers and keep track of them.
 // When the lazy reader is enabled, the pool keeps track of all instantiated readers
 // and automatically close them once the idle timeout is reached. A closed lazy reader
 // will be automatically re-opened upon next usage.
@@ -73,7 +73,7 @@ func (s IndexHeaderLazyDownloadStrategy) StrategyToDownloadFunc() LazyDownloadIn
 	}
 }
 
-// LazyDownloadIndexHeaderFunc is used to determinte whether to download the index header lazily
+// LazyDownloadIndexHeaderFunc is used to determine whether to download the index header lazily
 // or not by checking its block metadata. Usecase can be by time or by index file size.
 type LazyDownloadIndexHeaderFunc func(meta *metadata.Meta) bool
 

--- a/pkg/cacheutil/memcached_client.go
+++ b/pkg/cacheutil/memcached_client.go
@@ -134,7 +134,7 @@ type MemcachedClientConfig struct {
 	MaxItemSize model.Bytes `yaml:"max_item_size"`
 
 	// MaxGetMultiBatchSize specifies the maximum number of keys a single underlying
-	// GetMulti() should run. If more keys are specified, internally keys are splitted
+	// GetMulti() should run. If more keys are specified, internally keys are split
 	// into multiple batches and fetched concurrently, honoring MaxGetMultiConcurrency parallelism.
 	// If set to 0, the max batch size is unlimited.
 	MaxGetMultiBatchSize int `yaml:"max_get_multi_batch_size"`

--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -894,7 +894,7 @@ func (cg *Group) Compact(ctx context.Context, dir string, planner Planner, comp 
 					_, _ = sb.WriteString(",")
 				}
 			}
-			rerr = fmt.Errorf("paniced while compacting %s: %v", sb.String(), p)
+			rerr = fmt.Errorf("panicked while compacting %s: %v", sb.String(), p)
 		}
 	}()
 

--- a/pkg/compact/compact_e2e_test.go
+++ b/pkg/compact/compact_e2e_test.go
@@ -258,7 +258,7 @@ func testGroupCompactE2e(t *testing.T, mergeFunc storage.VerticalChunkSeriesMerg
 			},
 			// Mix order to make sure compactor is able to deduct min time / max time.
 			// Currently TSDB does not produces empty blocks (see: https://github.com/prometheus/tsdb/pull/374). However before v2.7.0 it was
-			// so we still want to mimick this case as close as possible.
+			// so we still want to mimic this case as close as possible.
 			{
 				mint: 1000, maxt: 2000, extLset: extLabels, res: 124,
 				// Empty block.

--- a/pkg/compact/downsample/downsample.go
+++ b/pkg/compact/downsample/downsample.go
@@ -149,7 +149,7 @@ func Downsample(
 		// Raw and already downsampled data need different processing.
 		if origMeta.Thanos.Downsample.Resolution == 0 {
 			for _, c := range chks {
-				// TODO(bwplotka): We can optimze this further by using in WriteSeries iterators of each chunk instead of
+				// TODO(bwplotka): We can optimize this further by using in WriteSeries iterators of each chunk instead of
 				// samples. Also ensure 120 sample limit, otherwise we have gigantic chunks.
 				// https://github.com/thanos-io/thanos/issues/2542.
 				if err := expandChunkIterator(c.Chunk.Iterator(reuseIt), &all); err != nil {

--- a/pkg/compact/downsample/downsample_test.go
+++ b/pkg/compact/downsample/downsample_test.go
@@ -1437,7 +1437,7 @@ func TestApplyCounterResetsIterator(t *testing.T) {
 			name: "series with stale marker",
 			chunks: [][]sample{
 				{{100, 10}, {200, 20}, {300, 10}, {400, 20}, {400, 5}},
-				{{500, 10}, {600, 20}, {700, 30}, {800, 40}, {800, 10}},                // No reset, just downsampling addded sample at the end.
+				{{500, 10}, {600, 20}, {700, 30}, {800, 40}, {800, 10}},                // No reset, just downsampling added sample at the end.
 				{{900, 5}, {1000, 10}, {1100, 15}},                                     // Actual reset.
 				{{1200, 20}, {1250, math.Float64frombits(value.StaleNaN)}, {1300, 40}}, // No special last sample, no reset.
 				{{1400, 30}, {1500, 30}, {1600, 50}},                                   // No special last sample, reset.

--- a/pkg/compact/planner.go
+++ b/pkg/compact/planner.go
@@ -68,7 +68,7 @@ func (p *tsdbBasedPlanner) plan(noCompactMarked map[ulid.ULID]*metadata.NoCompac
 	}
 	// No overlapping blocks, do compaction the usual way.
 
-	// We do not include a recently producted block with max(minTime), so the block which was just uploaded to bucket.
+	// We do not include a recently produced block with max(minTime), so the block which was just uploaded to bucket.
 	// This gives users a window of a full block size maintenance if needed.
 	if _, excluded := noCompactMarked[metasByMinTime[len(metasByMinTime)-1].ULID]; !excluded {
 		notExcludedMetasByMinTime = notExcludedMetasByMinTime[:len(notExcludedMetasByMinTime)-1]
@@ -200,7 +200,7 @@ func splitByRange(metasByMinTime []*metadata.Meta, tr int64) [][]*metadata.Meta 
 			t0 = tr * ((m.MinTime - tr + 1) / tr)
 		}
 
-		// Skip blocks that don't fall into the range. This can happen via mis-alignment or
+		// Skip blocks that don't fall into the range. This can happen via misalignment or
 		// by being the multiple of the intended range.
 		if m.MaxTime > t0+tr {
 			i++

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -118,7 +118,7 @@ func formatErrorChain(err error) string {
 // The functions `Is`, `As` & `Unwrap` provides a thin wrapper around the builtin errors
 // package in go. Just for sake of completeness and correct autocompletion behaviors from
 // IDEs they have been wrapped using functions instead of using variable to reference them
-// as first class functions (eg: var Is = errros.Is ).
+// as first class functions (eg: var Is = errors.Is ).
 
 // Is is a wrapper of built-in errors.Is. It reports whether any error in err's
 // chain matches target. The chain consists of err itself followed by the sequence

--- a/pkg/prober/grpc.go
+++ b/pkg/prober/grpc.go
@@ -13,7 +13,7 @@ type GRPCProbe struct {
 	h *health.Server
 }
 
-// NewGRPC creates a Probe that wrapped around grpc/healt.Server which reflects status of server.
+// NewGRPC creates a Probe that wrapped around grpc/health.Server which reflects status of server.
 func NewGRPC() *GRPCProbe {
 	h := health.NewServer()
 	h.SetServingStatus("", grpc_health.HealthCheckResponse_NOT_SERVING)

--- a/pkg/query/endpointset.go
+++ b/pkg/query/endpointset.go
@@ -717,7 +717,7 @@ func (er *endpointRef) updateMetadata(metadata *endpointMetadata, err error) {
 }
 
 // isQueryable returns true if an endpointRef should be used for querying.
-// A strict endpointRef is always queriable. A non-strict endpointRef
+// A strict endpointRef is always queryable. A non-strict endpointRef
 // is queryable if the last health check (info call) succeeded.
 func (er *endpointRef) isQueryable() bool {
 	er.mtx.RLock()

--- a/pkg/query/endpointset_test.go
+++ b/pkg/query/endpointset_test.go
@@ -1430,40 +1430,40 @@ func TestEndpointSet_APIs_Discovery(t *testing.T) {
 					t,
 					tc.states[currentState].expectedStores,
 					gotStores,
-					"unexepected discovered storeAPIs in state %q",
+					"unexpected discovered storeAPIs in state %q",
 					tc.states[currentState].name)
 				testutil.Equals(
 					t,
 					tc.states[currentState].expectedRules,
 					gotRules,
-					"unexepected discovered rulesAPIs in state %q",
+					"unexpected discovered rulesAPIs in state %q",
 					tc.states[currentState].name)
 				testutil.Equals(
 					t,
 					tc.states[currentState].expectedTarget,
 					gotTarget,
-					"unexepected discovered targetAPIs in state %q",
+					"unexpected discovered targetAPIs in state %q",
 					tc.states[currentState].name,
 				)
 				testutil.Equals(
 					t,
 					tc.states[currentState].expectedMetricMetadata,
 					gotMetricMetadata,
-					"unexepected discovered metricMetadataAPIs in state %q",
+					"unexpected discovered metricMetadataAPIs in state %q",
 					tc.states[currentState].name,
 				)
 				testutil.Equals(
 					t,
 					tc.states[currentState].expectedExemplars,
 					gotExemplars,
-					"unexepected discovered ExemplarsAPIs in state %q",
+					"unexpected discovered ExemplarsAPIs in state %q",
 					tc.states[currentState].name,
 				)
 				testutil.Equals(
 					t,
 					tc.states[currentState].expectedQueryAPIs,
 					gotQueryAPIs,
-					"unexepected discovered QueryAPIs in state %q",
+					"unexpected discovered QueryAPIs in state %q",
 					tc.states[currentState].name,
 				)
 

--- a/pkg/query/querier_test.go
+++ b/pkg/query/querier_test.go
@@ -388,7 +388,7 @@ func TestQuerier_Select_AfterPromQL(t *testing.T) {
 				resolution := time.Duration(tcase.hints.Step) * time.Millisecond
 				t.Run(fmt.Sprintf("dedup=%v, resolution=%v", sc.dedup, resolution.String()), func(t *testing.T) {
 					var actual []series
-					// Boostrap a local store and pass the data through promql.
+					// Bootstrap a local store and pass the data through promql.
 					{
 						g := gate.New(2)
 						mq := &mockedQueryable{

--- a/pkg/query/testdata/promql/prometheus/functions.test
+++ b/pkg/query/testdata/promql/prometheus/functions.test
@@ -745,10 +745,10 @@ clear
 eval instant at 50m absent(sum(nonexistent{job="testjob", instance="testinstance"}))
 	{} 1
 
-eval instant at 50m absent(max(nonexistant))
+eval instant at 50m absent(max(nonexistent))
 	{} 1
 
-eval instant at 50m absent(nonexistant > 1)
+eval instant at 50m absent(nonexistent > 1)
 	{} 1
 
 eval instant at 50m absent(a + b)
@@ -757,7 +757,7 @@ eval instant at 50m absent(a + b)
 eval instant at 50m absent(a and b)
 	{} 1
 
-eval instant at 50m absent(rate(nonexistant[5m]))
+eval instant at 50m absent(rate(nonexistent[5m]))
 	{} 1
 
 clear
@@ -775,7 +775,7 @@ eval instant at 1m absent_over_time(http_requests{handler!="/foo"}[5m])
 eval instant at 1m absent_over_time(http_requests{handler="/foo", handler="/bar", handler="/foobar"}[5m])
     {} 1
 
-eval instant at 1m absent_over_time(rate(nonexistant[5m])[5m:])
+eval instant at 1m absent_over_time(rate(nonexistent[5m])[5m:])
     {} 1
 
 eval instant at 1m absent_over_time(http_requests{handler="/foo", handler="/bar", instance="127.0.0.1"}[5m])

--- a/pkg/receive/handler.go
+++ b/pkg/receive/handler.go
@@ -936,7 +936,7 @@ func (h *Handler) sendLocalWrite(
 
 }
 
-// sendRemoteWrite sends a write request to the remote node. It takes care of checking wether the endpoint is up or not
+// sendRemoteWrite sends a write request to the remote node. It takes care of checking whether the endpoint is up or not
 // in the peerGroup, correctly marking them as up or down when appropriate.
 // The responses are sent to the responses channel.
 func (h *Handler) sendRemoteWrite(

--- a/pkg/receive/writer.go
+++ b/pkg/receive/writer.go
@@ -201,7 +201,7 @@ func (r *Writer) Write(ctx context.Context, tenantID string, wreq *prompb.WriteR
 			}
 		}
 
-		// Current implemetation of app.AppendExemplar doesn't create a new series, so it must be already present.
+		// Current implementation of app.AppendExemplar doesn't create a new series, so it must be already present.
 		// We drop the exemplars in case the series doesn't exist.
 		if ref != 0 && len(t.Exemplars) > 0 {
 			for _, ex := range t.Exemplars {

--- a/pkg/rules/manager.go
+++ b/pkg/rules/manager.go
@@ -282,7 +282,7 @@ func (g configRuleAdapter) validate() (errs []error) {
 	return errs
 }
 
-// ValidateAndCount validates all rules in the rule groups and return overal number of rules in all groups.
+// ValidateAndCount validates all rules in the rule groups and return overall number of rules in all groups.
 // TODO(bwplotka): Replace this with upstream implementation after https://github.com/prometheus/prometheus/issues/7128 is fixed.
 func ValidateAndCount(group io.Reader) (numRules int, errs errutil.MultiError) {
 	var rgs configGroups

--- a/pkg/rules/proxy_test.go
+++ b/pkg/rules/proxy_test.go
@@ -113,27 +113,27 @@ func TestProxy(t *testing.T) {
 			wantResponse: rulespb.NewWarningRulesResponse(errors.New("warning from client")),
 		},
 		{
-			name: "warn: retreiving rules client failed",
+			name: "warn: retrieving rules client failed",
 			request: &rulespb.RulesRequest{
 				Type:                    rulespb.RulesRequest_ALL,
 				PartialResponseStrategy: storepb.PartialResponseStrategy_WARN,
 			},
 			client: &testRulesClient{
 				response: nil,
-				rulesErr: errors.New("retreiving rules failed"),
+				rulesErr: errors.New("retrieving rules failed"),
 			},
 			server:       &testRulesServer{},
-			wantResponse: rulespb.NewWarningRulesResponse(errors.New("fetching rules from rules client test: retreiving rules failed")),
+			wantResponse: rulespb.NewWarningRulesResponse(errors.New("fetching rules from rules client test: retrieving rules failed")),
 		},
 		{
-			name: "warn: retreiving rules client failed, forward warning failed",
+			name: "warn: retrieving rules client failed, forward warning failed",
 			request: &rulespb.RulesRequest{
 				Type:                    rulespb.RulesRequest_ALL,
 				PartialResponseStrategy: storepb.PartialResponseStrategy_WARN,
 			},
 			client: &testRulesClient{
 				response: nil,
-				rulesErr: errors.New("retreiving rules failed"),
+				rulesErr: errors.New("retrieving rules failed"),
 			},
 			server: &testRulesServer{
 				sendErr: errors.New("forwarding warning response failed"),
@@ -141,17 +141,17 @@ func TestProxy(t *testing.T) {
 			wantError: errors.New("forwarding warning response failed"),
 		},
 		{
-			name: "abort: retreiving rules client failed",
+			name: "abort: retrieving rules client failed",
 			request: &rulespb.RulesRequest{
 				Type:                    rulespb.RulesRequest_ALL,
 				PartialResponseStrategy: storepb.PartialResponseStrategy_ABORT,
 			},
 			client: &testRulesClient{
 				response: nil,
-				rulesErr: errors.New("retreiving rules failed"),
+				rulesErr: errors.New("retrieving rules failed"),
 			},
 			server:    &testRulesServer{},
-			wantError: errors.New("fetching rules from rules client test: retreiving rules failed"),
+			wantError: errors.New("fetching rules from rules client test: retrieving rules failed"),
 		},
 		{
 			name: "warn: receive failed",

--- a/pkg/runutil/runutil.go
+++ b/pkg/runutil/runutil.go
@@ -3,7 +3,7 @@
 
 // Package runutil provides helpers to advanced function scheduling control like repeat or retry.
 //
-// It's very often the case when you need to excutes some code every fixed intervals or have it retried automatically.
+// It's very often the case when you need to executes some code every fixed intervals or have it retried automatically.
 // To make it reliably with proper timeout, you need to carefully arrange some boilerplate for this.
 // Below function does it for you.
 //

--- a/pkg/store/bucket_test.go
+++ b/pkg/store/bucket_test.go
@@ -601,7 +601,7 @@ func TestGapBasedPartitioner_Partition(t *testing.T) {
 		},
 		{
 			input: [][2]int{
-				// Mimick AllPostingsKey, where range specified whole range.
+				// Mimic AllPostingsKey, where range specified whole range.
 				{1, 15},
 				{1, maxGapSize + 100},
 				{maxGapSize + 31, maxGapSize + 40},
@@ -1238,7 +1238,7 @@ func appendTestData(t testing.TB, app storage.Appender, series int) {
 	testutil.Ok(t, app.Commit())
 }
 
-// Very similar benchmark to ths: https://github.com/prometheus/prometheus/blob/1d1732bc25cc4b47f513cb98009a4eb91879f175/tsdb/querier_bench_test.go#L82,
+// Very similar benchmark to this: https://github.com/prometheus/prometheus/blob/1d1732bc25cc4b47f513cb98009a4eb91879f175/tsdb/querier_bench_test.go#L82,
 // but with postings results check when run as test.
 func benchmarkExpandedPostings(
 	t testutil.TB,

--- a/pkg/store/cache/tracing_index_cache.go
+++ b/pkg/store/cache/tracing_index_cache.go
@@ -66,8 +66,8 @@ func (c *TracingIndexCache) FetchExpandedPostings(ctx context.Context, blockID u
 	return data, exists
 }
 
-// StoreSeries stores a single series. Skip intrumenting this method
-// excessive spans as a single request can store millions of serieses.
+// StoreSeries stores a single series. Skip instrumenting this method
+// excessive spans as a single request can store millions of series.
 func (c *TracingIndexCache) StoreSeries(blockID ulid.ULID, id storage.SeriesRef, v []byte, tenant string) {
 	c.cache.StoreSeries(blockID, id, v, tenant)
 }

--- a/pkg/store/io.go
+++ b/pkg/store/io.go
@@ -109,7 +109,7 @@ func readByteRanges(src io.Reader, dst []byte, byteRanges byteRanges) ([]byte, e
 		if err != nil {
 			// We get an ErrUnexpectedEOF if EOF is reached before we fill the slice.
 			// Due to how the reading logic works in the bucket store, we may try to overread
-			// the last byte range so, if the error occurrs on the last one, we consider it legit.
+			// the last byte range so, if the error occurs on the last one, we consider it legit.
 			if err == io.ErrUnexpectedEOF && idx == len(byteRanges)-1 {
 				return dst, nil
 			}

--- a/pkg/store/limiter_test.go
+++ b/pkg/store/limiter_test.go
@@ -56,7 +56,7 @@ func TestRateLimitedServer(t *testing.T) {
 			series: series,
 		},
 		{
-			name: "series bellow limit",
+			name: "series below limit",
 			limits: SeriesSelectLimits{
 				SeriesPerRequest:  3,
 				SamplesPerRequest: 0,
@@ -73,7 +73,7 @@ func TestRateLimitedServer(t *testing.T) {
 			err:    "failed to send series: limit 2 violated (got 3)",
 		},
 		{
-			name: "chunks bellow limit",
+			name: "chunks below limit",
 			limits: SeriesSelectLimits{
 				SeriesPerRequest:  0,
 				SamplesPerRequest: uint64(3 * numSamples * MaxSamplesPerChunk),

--- a/pkg/store/proxy.go
+++ b/pkg/store/proxy.go
@@ -286,7 +286,7 @@ func (s *ProxyStore) TSDBInfos() []infopb.TSDBInfo {
 
 func (s *ProxyStore) Series(originalRequest *storepb.SeriesRequest, srv storepb.Store_SeriesServer) error {
 	// TODO(bwplotka): This should be part of request logger, otherwise it does not make much sense. Also, could be
-	// tiggered by tracing span to reduce cognitive load.
+	// triggered by tracing span to reduce cognitive load.
 	reqLogger := log.With(s.logger, "component", "proxy")
 	if s.debugLogging {
 		reqLogger = log.With(reqLogger, "request", originalRequest.String())
@@ -381,7 +381,7 @@ func (s *ProxyStore) Series(originalRequest *storepb.SeriesRequest, srv storepb.
 // LabelNames returns all known label names.
 func (s *ProxyStore) LabelNames(ctx context.Context, originalRequest *storepb.LabelNamesRequest) (*storepb.LabelNamesResponse, error) {
 	// TODO(bwplotka): This should be part of request logger, otherwise it does not make much sense. Also, could be
-	// tiggered by tracing span to reduce cognitive load.
+	// triggered by tracing span to reduce cognitive load.
 	reqLogger := log.With(s.logger, "component", "proxy")
 	if s.debugLogging {
 		reqLogger = log.With(reqLogger, "request", originalRequest.String())
@@ -476,7 +476,7 @@ func (s *ProxyStore) LabelValues(ctx context.Context, originalRequest *storepb.L
 	*storepb.LabelValuesResponse, error,
 ) {
 	// TODO(bwplotka): This should be part of request logger, otherwise it does not make much sense. Also, could be
-	// tiggered by tracing span to reduce cognitive load.
+	// triggered by tracing span to reduce cognitive load.
 	reqLogger := log.With(s.logger, "component", "proxy")
 	if s.debugLogging {
 		reqLogger = log.With(reqLogger, "request", originalRequest.String())

--- a/pkg/store/proxy_test.go
+++ b/pkg/store/proxy_test.go
@@ -2155,7 +2155,7 @@ func TestProxyStore_NotLeakingOnPrematureFinish(t *testing.T) {
 		tsdbSelector:      DefaultSelector,
 	}
 
-	t.Run("failling send", func(t *testing.T) {
+	t.Run("failing send", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		// We mimic failing series server, but practically context cancel will do the same.
 		testutil.NotOk(t, p.Series(&storepb.SeriesRequest{Matchers: []storepb.LabelMatcher{{}}, PartialResponseStrategy: storepb.PartialResponseStrategy_ABORT}, &mockedSeriesServer{

--- a/pkg/store/storepb/prompb/samples.go
+++ b/pkg/store/storepb/prompb/samples.go
@@ -61,7 +61,7 @@ func SamplesFromPromqlSeries(series promql.Series) ([]Sample, []Histogram) {
 
 // HistogramProtoToHistogram extracts a (normal integer) Histogram from the
 // provided proto message. The caller has to make sure that the proto message
-// represents an interger histogram and not a float histogram.
+// represents an integer histogram and not a float histogram.
 // Copied from https://github.com/prometheus/prometheus/blob/0ab95536115adfe50af249d36d73674be694ca3f/storage/remote/codec.go#L626-L645
 func HistogramProtoToHistogram(hp Histogram) *histogram.Histogram {
 	if hp.IsFloatHistogram() {

--- a/pkg/store/tsdb_test.go
+++ b/pkg/store/tsdb_test.go
@@ -163,7 +163,7 @@ func TestTSDBStore_Series(t *testing.T) {
 			},
 		},
 		{
-			title: "dont't match time range series",
+			title: "don't match time range series",
 			req: &storepb.SeriesRequest{
 				MinTime: 4,
 				MaxTime: 6,
@@ -185,7 +185,7 @@ func TestTSDBStore_Series(t *testing.T) {
 			expectedError: "rpc error: code = InvalidArgument desc = no matchers specified (excluding external labels)",
 		},
 		{
-			title: "dont't match labels",
+			title: "don't match labels",
 			req: &storepb.SeriesRequest{
 				MinTime: 1,
 				MaxTime: 3,

--- a/pkg/tracing/util/metautils/nicemd_test.go
+++ b/pkg/tracing/util/metautils/nicemd_test.go
@@ -40,7 +40,7 @@ func TestNiceMD_Get(t *testing.T) {
 func TestNiceMD_Del(t *testing.T) {
 	nmd := metautils.NiceMD(metadata.Pairs(testPairs...))
 	assert.Equal(t, "uno", nmd.Get("singlekey"), "for present single-key value it should return it")
-	nmd.Del("singlekey").Del("doesnt exist")
+	nmd.Del("singlekey").Del("doesn't exist")
 	assert.Empty(t, nmd.Get("singlekey"), "after deletion singlekey shouldn't exist")
 }
 

--- a/pkg/verifier/duplicated_compaction.go
+++ b/pkg/verifier/duplicated_compaction.go
@@ -90,7 +90,7 @@ func (DuplicatedCompactionBlocks) VerifyRepair(ctx Context, idMatcher func(ulid.
 }
 
 // duplicatedBlocks returns duplicated blocks that have exactly same range, sources and stats.
-// If block is unique it is not included in the resulted blocs.
+// If block is unique it is not included in the resulted blocks.
 func duplicatedBlocks(blocks []tsdb.BlockMeta) (res [][]tsdb.BlockMeta) {
 	var dups [][]tsdb.BlockMeta
 	for _, b := range blocks {


### PR DESCRIPTION
Hi,

This is a trivial PR and a follow-up of #7646. It fixes some of the remaining spelling issues in the `pkg` folder. 

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [X] Change is not relevant to the end user.

## Changes

* codespell: Adjust CI job to exclude some pkg exceptions
* pkg: Fix all spelling issues discovered by codespell.
* pkg/rules: Fix all spelling issues discovered by codespell.
* pkg/query: Fix all spelling issues discovered by codespell.
* pkg/block: Fix all spelling issues discovered by codespell.
* pkg/store: Fix all spelling issues discovered by codespell.

## Verification

This is verified via the adjusted `codespell` CI job.