### PR TITLE
Store: Fix LabelNames and LabelValues when using non-equal matchers

### DIFF
--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -1960,7 +1960,7 @@ func (b *bucketBlock) FilterExtLabelsMatchers(matchers []*labels.Matcher) ([]*la
 		// If value is empty string the matcher is a valid one since it's not part of external labels.
 		if v == "" {
 			result = append(result, m)
-		} else if v != "" && v != m.Value {
+		} else if v != "" && !m.Matches(v) {
 			// If matcher is external label but value is different we don't want to look in block anyway.
 			return []*labels.Matcher{}, false
 		}

--- a/pkg/store/bucket_test.go
+++ b/pkg/store/bucket_test.go
@@ -233,7 +233,7 @@ func TestBucketFilterExtLabelsMatchers(t *testing.T) {
 		{Type: labels.MatchNotEqual, Name: "a", Value: "a"},
 	}
 	_, ok := b.FilterExtLabelsMatchers(ms)
-	testutil.Equals(t, ok, false)
+	testutil.Equals(t, ok, true)
 
 	ms = []*labels.Matcher{
 		{Type: labels.MatchNotEqual, Name: "a", Value: "a"},
@@ -246,6 +246,18 @@ func TestBucketFilterExtLabelsMatchers(t *testing.T) {
 		{Type: labels.MatchNotEqual, Name: "a2", Value: "a"},
 	}
 	res, _ = b.FilterExtLabelsMatchers(ms)
+	testutil.Equals(t, len(res), 1)
+	testutil.Equals(t, res, ms)
+
+	// validate that it can filter out ext labels that match non-equal matchers
+	ext, err := labels.NewMatcher(labels.MatchRegexp, "a", ".*")
+	if err != nil {
+		t.Error(err)
+	}
+	ms = []*labels.Matcher{
+		{Type: labels.MatchNotEqual, Name: "a2", Value: "a"},
+	}
+	res, _ = b.FilterExtLabelsMatchers(append(ms, ext))
 	testutil.Equals(t, len(res), 1)
 	testutil.Equals(t, res, ms)
 }


### PR DESCRIPTION
The LabelNames and LabelValues API return empty when the only sources are stores and `match[]` is a non-equal matcher for an external label.

I see the error when sending a query that matches the store's external labels with a non-equal matcher—for example, sending `/api/v1/label/cluster/values?match[]=metricname{cluster=~".*"}` to a store with the external label `cluster="a"` returns empty, even though the label matches the matcher. However, `?match[]=metricname{cluster="a"}` returns the correct value, "a".

I added a few logs to a local deployment to follow the matchers, and the bug seems to be `bucket.FilterExtLabelsMatchers` filtering out matchers when their value isn't exactly equal to the external label value, which causes BucketStore to [skip blocks with data](https://github.com/thanos-io/thanos/blob/main/pkg/store/bucket.go#L2022-L2025).

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

I changed `bucketBlock.FilterExtLabelsMatchers` to use `Matcher.Matches()` instead of comparing if the matcher and ext label values are equal.

## Verification

I added and updated unit tests. I also deployed a patch to a test cluster and the change fixed the response.
