### PR TITLE
receive: change quorum calculation for RF=2

### DIFF
--- a/docs/components/receive.md
+++ b/docs/components/receive.md
@@ -307,6 +307,25 @@ This number of workers is controlled by `--receive.forward.async-workers=`.
 
 Please see the metric `thanos_receive_forward_delay_seconds` to see if you need to increase the number of forwarding workers.
 
+## Quorum
+
+The following formula is used for calculating quorum:
+
+```go mdox-exec="sed -n '990,999p' pkg/receive/handler.go"
+func (h *Handler) writeQuorum() int {
+	// NOTE(GiedriusS): this is here because otherwise RF=2 doesn't make sense as all writes
+	// would need to succeed all the time. Another way to think about it is when migrating
+	// from a Sidecar based setup with 2 Prometheus nodes to a Receiver setup, we want to
+	// keep the same guarantees.
+	if h.options.ReplicationFactor == 2 {
+		return 1
+	}
+	return int((h.options.ReplicationFactor / 2) + 1)
+}
+```
+
+So, if the replication factor is 2 then at least one write must succeed. With RF=3, two writes must succeed, and so on.
+
 ## Flags
 
 ```$ mdox-exec="thanos receive --help"

--- a/pkg/receive/handler.go
+++ b/pkg/receive/handler.go
@@ -988,6 +988,13 @@ func (h *Handler) sendRemoteWrite(
 
 // writeQuorum returns minimum number of replicas that has to confirm write success before claiming replication success.
 func (h *Handler) writeQuorum() int {
+	// NOTE(GiedriusS): this is here because otherwise RF=2 doesn't make sense as all writes
+	// would need to succeed all the time. Another way to think about it is when migrating
+	// from a Sidecar based setup with 2 Prometheus nodes to a Receiver setup, we want to
+	// keep the same guarantees.
+	if h.options.ReplicationFactor == 2 {
+		return 1
+	}
 	return int((h.options.ReplicationFactor / 2) + 1)
 }
 


### PR DESCRIPTION
As discussed during ThanosCon, I am updating the handling for RF=2 to require only one successful write because requiring all writes to succeed all the time doesn't make sense and causes lots of confusion to users. The only other alternative is to forbid RF=2 but I think we shouldn't do that because people would be forced to add extra resources when moving from a Sidecar based setup.
