### PR TITLE
store: added a log error print when proxy limit are violated

### DIFF
--- a/pkg/store/proxy.go
+++ b/pkg/store/proxy.go
@@ -371,6 +371,7 @@ func (s *ProxyStore) Series(originalRequest *storepb.SeriesRequest, srv storepb.
 		}
 
 		if err := srv.Send(resp); err != nil {
+			level.Error(reqLogger).Log("msg", errors.Wrap(err, "send series response").Error())
 			return status.Error(codes.Unknown, errors.Wrap(err, "send series response").Error())
 		}
 	}

--- a/pkg/store/proxy.go
+++ b/pkg/store/proxy.go
@@ -371,7 +371,7 @@ func (s *ProxyStore) Series(originalRequest *storepb.SeriesRequest, srv storepb.
 		}
 
 		if err := srv.Send(resp); err != nil {
-			level.Error(reqLogger).Log("msg", errors.Wrap(err, "send series response").Error())
+			level.Error(reqLogger).Log("msg", "failed to stream response", "error", err)
 			return status.Error(codes.Unknown, errors.Wrap(err, "send series response").Error())
 		}
 	}


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes
I added a log error when there are violations of the store's proxy limits.

<!-- Enumerate changes you made -->

## Verification
Tested locally and verified the message is printed to the log.
<!-- How you tested it? How do you know it works? -->
