### PR TITLE
test: Fix flaky receive/multitsdb test

### DIFF
--- a/pkg/receive/multitsdb_test.go
+++ b/pkg/receive/multitsdb_test.go
@@ -462,10 +462,14 @@ func TestMultiTSDBPrune(t *testing.T) {
 			testutil.Equals(t, 3, len(m.TSDBLocalClients()))
 
 			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
+
+			g := sync.WaitGroup{}
+			defer func() { cancel(); g.Wait() }()
 
 			if test.bucket != nil {
+				g.Add(1)
 				go func() {
+					defer g.Done()
 					testutil.Ok(t, syncTSDBs(ctx, m, 10*time.Millisecond))
 				}()
 			}


### PR DESCRIPTION
There is race condition in `TestMultiTSDBPrune` due to a dangling goroutine which can fail outside of the test function's lifetime if the database object is closed before `Sync()` is finished.

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

Can be reliably reproduced with a simple change:
```diff
--- a/pkg/receive/multitsdb_test.go
+++ b/pkg/receive/multitsdb_test.go
@@ -502,6 +502,7 @@ func syncTSDBs(ctx context.Context, m *MultiTSDB, interval time.Duration) error
                case <-ctx.Done():
                        return nil
                case <-time.After(interval):
+                       time.Sleep(100 * time.Millisecond)
                        _, err := m.Sync(ctx)
                        if err != nil {
                                return err
``` 