### PR TITLE
making the tsdb.too-far-in-future.time-window flag stable

### DIFF
--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -925,7 +925,7 @@ func (rc *receiveConfig) registerFlag(cmd extkingpin.FlagClause) {
 	rc.tsdbMaxBlockDuration = extkingpin.ModelDuration(cmd.Flag("tsdb.max-block-duration", "Max duration for local TSDB blocks").Default("2h").Hidden())
 
 	rc.tsdbTooFarInFutureTimeWindow = extkingpin.ModelDuration(cmd.Flag("tsdb.too-far-in-future.time-window",
-		"[EXPERIMENTAL] Configures the allowed time window for ingesting samples too far in the future. Disabled (0s) by default"+
+		"Configures the allowed time window for ingesting samples too far in the future. Disabled (0s) by default"+
 			"Please note enable this flag will reject samples in the future of receive local NTP time + configured duration due to clock skew in remote write clients.",
 	).Default("0s"))
 

--- a/docs/components/receive.md
+++ b/docs/components/receive.md
@@ -540,7 +540,7 @@ Flags:
                                  section in the Receive documentation:
                                  https://thanos.io/tip/components/receive.md/#tenant-lifecycle-management
       --tsdb.too-far-in-future.time-window=0s
-                                 [EXPERIMENTAL] Configures the allowed time
+                                 Configures the allowed time
                                  window for ingesting samples too far in the
                                  future. Disabled (0s) by defaultPlease note
                                  enable this flag will reject samples in the


### PR DESCRIPTION
## Changes

 changed the docs to support the stability of the tsdb.too-far-in-future.time-window flag
