### PR TITLE
util: Pass limit to strutil.MergeSlices

### DIFF
--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -1858,7 +1858,7 @@ func (s *BucketStore) LabelNames(ctx context.Context, req *storepb.LabelNamesReq
 					}
 				})
 
-				result = strutil.MergeSlices(res, extRes)
+				result = strutil.MergeSlices(int(req.Limit), res, extRes)
 			} else {
 				seriesReq := &storepb.SeriesRequest{
 					MinTime:              req.Start,
@@ -1953,10 +1953,7 @@ func (s *BucketStore) LabelNames(ctx context.Context, req *storepb.LabelNamesReq
 		return nil, status.Error(codes.Unknown, errors.Wrap(err, "marshal label names response hints").Error())
 	}
 
-	names := strutil.MergeSlices(sets...)
-	if req.Limit > 0 && len(names) > int(req.Limit) {
-		names = names[:req.Limit]
-	}
+	names := strutil.MergeSlices(int(req.Limit), sets...)
 
 	return &storepb.LabelNamesResponse{
 		Names: names,
@@ -2075,7 +2072,7 @@ func (s *BucketStore) LabelValues(ctx context.Context, req *storepb.LabelValuesR
 
 				// Add the external label value as well.
 				if extLabelValue := b.extLset.Get(req.Label); extLabelValue != "" {
-					res = strutil.MergeSlices(res, []string{extLabelValue})
+					res = strutil.MergeSlices(int(req.Limit), res, []string{extLabelValue})
 				}
 				result = res
 			} else {
@@ -2173,10 +2170,7 @@ func (s *BucketStore) LabelValues(ctx context.Context, req *storepb.LabelValuesR
 		return nil, status.Error(codes.Unknown, errors.Wrap(err, "marshal label values response hints").Error())
 	}
 
-	vals := strutil.MergeSlices(sets...)
-	if req.Limit > 0 && len(vals) > int(req.Limit) {
-		vals = vals[:req.Limit]
-	}
+	vals := strutil.MergeSlices(int(req.Limit), sets...)
 
 	return &storepb.LabelValuesResponse{
 		Values: vals,

--- a/pkg/store/proxy.go
+++ b/pkg/store/proxy.go
@@ -421,10 +421,7 @@ func (s *ProxyStore) LabelNames(ctx context.Context, originalRequest *storepb.La
 		return nil, err
 	}
 
-	result := strutil.MergeUnsortedSlices(names...)
-	if originalRequest.Limit > 0 && len(result) > int(originalRequest.Limit) {
-		result = result[:originalRequest.Limit]
-	}
+	result := strutil.MergeUnsortedSlices(int(originalRequest.Limit), names...)
 
 	return &storepb.LabelNamesResponse{
 		Names:    result,
@@ -529,10 +526,7 @@ func (s *ProxyStore) LabelValues(ctx context.Context, originalRequest *storepb.L
 		return nil, err
 	}
 
-	vals := strutil.MergeUnsortedSlices(all...)
-	if originalRequest.Limit > 0 && len(vals) > int(originalRequest.Limit) {
-		vals = vals[:originalRequest.Limit]
-	}
+	vals := strutil.MergeUnsortedSlices(int(originalRequest.Limit), all...)
 
 	return &storepb.LabelValuesResponse{
 		Values:   vals,

--- a/pkg/strutil/merge.go
+++ b/pkg/strutil/merge.go
@@ -10,33 +10,39 @@ import (
 
 // MergeSlices merges a set of sorted string slices into a single ones
 // while removing all duplicates.
-func MergeSlices(a ...[]string) []string {
+// If limit is set, only the first limit results will be returned. 0 to disable.
+func MergeSlices(limit int, a ...[]string) []string {
 	if len(a) == 0 {
 		return nil
 	}
 	if len(a) == 1 {
-		return a[0]
+		return truncateToLimit(limit, a[0])
 	}
 	l := len(a) / 2
-	return mergeTwoStringSlices(MergeSlices(a[:l]...), MergeSlices(a[l:]...))
+	return mergeTwoStringSlices(limit, MergeSlices(limit, a[:l]...), MergeSlices(limit, a[l:]...))
 }
 
 // MergeUnsortedSlices behaves like StringSlices but input slices are validated
 // for sortedness and are sorted if they are not ordered yet.
-func MergeUnsortedSlices(a ...[]string) []string {
+// If limit is set, only the first limit results will be returned. 0 to disable.
+func MergeUnsortedSlices(limit int, a ...[]string) []string {
 	for _, s := range a {
 		if !sort.StringsAreSorted(s) {
 			sort.Strings(s)
 		}
 	}
-	return MergeSlices(a...)
+	return MergeSlices(limit, a...)
 }
 
-func mergeTwoStringSlices(a, b []string) []string {
+func mergeTwoStringSlices(limit int, a, b []string) []string {
+	a = truncateToLimit(limit, a)
+	b = truncateToLimit(limit, b)
+
 	maxl := len(a)
 	if len(b) > len(a) {
 		maxl = len(b)
 	}
+
 	res := make([]string, 0, maxl*10/9)
 
 	for len(a) > 0 && len(b) > 0 {
@@ -56,5 +62,13 @@ func mergeTwoStringSlices(a, b []string) []string {
 	// Append all remaining elements.
 	res = append(res, a...)
 	res = append(res, b...)
+	res = truncateToLimit(limit, res)
 	return res
+}
+
+func truncateToLimit(limit int, a []string) []string {
+	if limit > 0 && len(a) > limit {
+		return a[:limit]
+	}
+	return a
 }

--- a/pkg/strutil/merge_test.go
+++ b/pkg/strutil/merge_test.go
@@ -1,0 +1,111 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package strutil
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/efficientgo/core/testutil"
+)
+
+func TestMergeSlices(t *testing.T) {
+	testCases := map[string]struct {
+		slices   [][]string
+		limit    int
+		expected []string
+	}{
+		"empty slice": {
+			slices: [][]string{
+				{},
+			},
+			expected: []string{},
+		},
+		"single slice with limit": {
+			slices: [][]string{
+				{"a", "b", "c", "d"},
+			},
+			limit:    2,
+			expected: []string{"a", "b"},
+		},
+		"multiple slices with limit": {
+			slices: [][]string{
+				{"a", "b", "d", "f"},
+				{"c", "e", "g"},
+				{"r", "s", "t"},
+			},
+			limit:    4,
+			expected: []string{"a", "b", "c", "d"},
+		},
+		"multiple slices without limit": {
+			slices: [][]string{
+				{"a", "b", "d", "f"},
+				{"c", "e", "g"},
+				{"r", "s"},
+			},
+			expected: []string{"a", "b", "c", "d", "e", "f", "g", "r", "s"},
+		},
+	}
+
+	for tcName, tc := range testCases {
+		t.Run(tcName, func(t *testing.T) {
+			res := MergeSlices(tc.limit, tc.slices...)
+			testutil.Equals(t, tc.expected, res)
+		})
+	}
+}
+
+func TestMergeUnsortedSlices(t *testing.T) {
+	testCases := map[string]struct {
+		slices   [][]string
+		limit    int
+		expected []string
+	}{
+		"empty slice": {
+			slices: [][]string{
+				{},
+			},
+			expected: []string{},
+		},
+		"multiple slices without limit": {
+			slices: [][]string{
+				{"d", "c", "b", "a"},
+				{"f", "g", "c"},
+				{"s", "r", "e"},
+			},
+			expected: []string{"a", "b", "c", "d", "e", "f", "g", "r", "s"},
+		},
+		"multiple slices with limit": {
+			slices: [][]string{
+				{"d", "c", "b", "a"},
+				{"f", "g", "c"},
+				{"s", "r", "e"},
+			},
+			limit:    5,
+			expected: []string{"a", "b", "c", "d", "e"},
+		},
+	}
+
+	for tcName, tc := range testCases {
+		t.Run(tcName, func(t *testing.T) {
+			res := MergeUnsortedSlices(tc.limit, tc.slices...)
+			testutil.Equals(t, tc.expected, res)
+		})
+	}
+}
+
+func BenchmarkMergeSlices(b *testing.B) {
+	var slices [][]string
+	for i := 0; i < 10; i++ {
+		var slice []string
+		for j := 0; j < 10000; j++ {
+			slice = append(slice, fmt.Sprintf("str_%d_%d", i, j))
+		}
+		slices = append(slices, slice)
+	}
+
+	b.Run("benchmark", func(b *testing.B) {
+		MergeSlices(1000, slices...)
+	})
+}


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [X] Change is not relevant to the end user.

## Changes
`MergeSlices` and `MergeUnsortedSlices` now accepts a limit param which will make the merge faster when a lmit is passed.

## Benchmark
```
(base) ➜  thanos git:(merge_slices_with_limit) ✗ benchstat old.txt new.txt
goos: darwin
goarch: arm64
pkg: github.com/thanos-io/thanos/pkg/strutil
cpu: Apple M1 Pro
                         │      old.txt      │                  new.txt                  │
                         │      sec/op       │      sec/op        vs base                │
MergeSlices/benchmark-10   0.00275000n ± 13%   0.00006540n ± 16%  -97.62% (p=0.000 n=10)

                         │  old.txt   │            new.txt             │
                         │    B/op    │    B/op     vs base            │
MergeSlices/benchmark-10   0.000 ± 0%   0.000 ± 0%  ~ (p=1.000 n=10) ¹
¹ all samples are equal

                         │  old.txt   │            new.txt             │
                         │ allocs/op  │ allocs/op   vs base            │
MergeSlices/benchmark-10   0.000 ± 0%   0.000 ± 0%  ~ (p=1.000 n=10) ¹
¹ all samples are equal
```

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
- Added unit tests
- Added benchmarks
