### PR TITLE
store: don't create intermediate labels

### DIFF
--- a/pkg/store/labelpb/custom.go
+++ b/pkg/store/labelpb/custom.go
@@ -1,0 +1,28 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package labelpb
+
+func CompareLabels(a, b []*Label) int {
+	l := len(a)
+	if len(b) < l {
+		l = len(b)
+	}
+
+	for i := 0; i < l; i++ {
+		if a[i].Name != b[i].Name {
+			if a[i].Name < b[i].Name {
+				return -1
+			}
+			return 1
+		}
+		if a[i].Value != b[i].Value {
+			if a[i].Value < b[i].Value {
+				return -1
+			}
+			return 1
+		}
+	}
+	// If all labels so far were in common, the set with fewer labels comes first.
+	return len(a) - len(b)
+}

--- a/pkg/store/proxy_merge.go
+++ b/pkg/store/proxy_merge.go
@@ -96,7 +96,7 @@ func (d *responseDeduplicator) Next() bool {
 		lbls := d.bufferedSameSeries[0].GetSeries().Labels
 		atLbls := s.GetSeries().Labels
 
-		if labels.Compare(labelpb.LabelpbLabelsToPromLabels(lbls), labelpb.LabelpbLabelsToPromLabels(atLbls)) == 0 {
+		if labelpb.CompareLabels(lbls, atLbls) == 0 {
 			d.bufferedSameSeries = append(d.bufferedSameSeries, s)
 			continue
 		}


### PR DESCRIPTION
Just compare labelpb.Label directly instead of creating promlabels from them.
