### PR TITLE
store: compare labels directly

### DIFF
--- a/pkg/store/proxy_merge.go
+++ b/pkg/store/proxy_merge.go
@@ -173,10 +173,7 @@ func NewProxyResponseLoserTree(seriesSets ...respSet) *losertree.Tree[*storepb.S
 			return true
 		}
 		if a.GetSeries() != nil && b.GetSeries() != nil {
-			iLbls := labelpb.LabelpbLabelsToPromLabels(a.GetSeries().Labels)
-			jLbls := labelpb.LabelpbLabelsToPromLabels(b.GetSeries().Labels)
-
-			return labels.Compare(iLbls, jLbls) < 0
+			return labelpb.CompareLabels(a.GetSeries().Labels, b.GetSeries().Labels) < 0
 		} else if a.GetSeries() == nil && b.GetSeries() != nil {
 			return true
 		} else if a.GetSeries() != nil && b.GetSeries() == nil {


### PR DESCRIPTION
Do not create intermediate prometheus labels and compare the labels directly.
