### PR TITLE
Website: remove ThanosCon banner

### DIFF
--- a/website/layouts/index.html
+++ b/website/layouts/index.html
@@ -49,11 +49,6 @@
     or
     <a class="color-yellow" target="_blank" href="https://care-in-action.org/en/pages/please-fund-emergency-aid-for-ukraine">Care in Action</a> to provide relief.
 </div>
-<div class="bg-info text-white py-3 font-weight-bold container-fluid text-center">
-    📢
-    <a target="_blank" href="{{ "/blog/2023-20-11-thanoscon" | relURL }}">ThanosCon</a>
-    is happening on 19th March as a co-located half-day on KubeCon EU in Paris. Join us there! 🤗 CFP is open until 3rd December!
-</div>
 <div class="container-fluid bg-light">
     <div class="row">
         <div class="col-12 col-md-6 col-lg text-center py-5">


### PR DESCRIPTION
## Changes

Even though it was great, ThanosCon is long over. I am removing the banner for CFP from the main website.

## Verification

![image](https://github.com/user-attachments/assets/07a72410-c524-4423-b1d1-072da6eadb0a)

