### PR TITLE
receive: randomize TSDB compaction start times

### DIFF
--- a/docs/components/receive.md
+++ b/docs/components/receive.md
@@ -94,6 +94,7 @@ config:
       server_name: ""
       insecure_skip_verify: false
     disable_compression: false
+  chunk_size_bytes: 0
 prefix: ""
 ```
 

--- a/docs/components/sidecar.md
+++ b/docs/components/sidecar.md
@@ -74,6 +74,7 @@ config:
       server_name: ""
       insecure_skip_verify: false
     disable_compression: false
+  chunk_size_bytes: 0
 prefix: ""
 ```
 

--- a/docs/components/store.md
+++ b/docs/components/store.md
@@ -33,6 +33,7 @@ config:
       server_name: ""
       insecure_skip_verify: false
     disable_compression: false
+  chunk_size_bytes: 0
 prefix: ""
 ```
 

--- a/docs/components/tools.md
+++ b/docs/components/tools.md
@@ -128,6 +128,7 @@ config:
       server_name: ""
       insecure_skip_verify: false
     disable_compression: false
+  chunk_size_bytes: 0
 prefix: ""
 ```
 
@@ -698,6 +699,7 @@ config:
       server_name: ""
       insecure_skip_verify: false
     disable_compression: false
+  chunk_size_bytes: 0
 prefix: ""
 ```
 
@@ -800,6 +802,7 @@ config:
       server_name: ""
       insecure_skip_verify: false
     disable_compression: false
+  chunk_size_bytes: 0
 prefix: ""
 ```
 

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -304,6 +304,7 @@ config:
       server_name: ""
       insecure_skip_verify: false
     disable_compression: false
+  chunk_size_bytes: 0
 prefix: ""
 ```
 


### PR DESCRIPTION
Don't compact all TSDBs at the same time because that leads to latency spikes. Add initial randomized latency (between 0 and 60 seconds) to spread out the load over time.
