### PR TITLE
store: label_values: fetch less postings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#7658](https://github.com/thanos-io/thanos/pull/7658) Store: Fix panic because too small buffer in pool.
 - [#7643](https://github.com/thanos-io/thanos/pull/7643) Receive: fix thanos_receive_write_{timeseries,samples} stats
 - [#7644](https://github.com/thanos-io/thanos/pull/7644) fix(ui): add null check to find overlapping blocks logic
-- [#7814](https://github.com/thanos-io/thanos/pull/7814) Store: label_values: fetch less postings.
+- [#7814](https://github.com/thanos-io/thanos/pull/7814) Store: label_values: if matchers contain __name__=="something", do not add <labelName> != "" to fetch less postings.
 - [#7679](https://github.com/thanos-io/thanos/pull/7679) Query: respect store.limit.* flags when evaluating queries
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#7658](https://github.com/thanos-io/thanos/pull/7658) Store: Fix panic because too small buffer in pool.
 - [#7643](https://github.com/thanos-io/thanos/pull/7643) Receive: fix thanos_receive_write_{timeseries,samples} stats
 - [#7644](https://github.com/thanos-io/thanos/pull/7644) fix(ui): add null check to find overlapping blocks logic
+- [#7814](https://github.com/thanos-io/thanos/pull/7814) Store: label_values: fetch less postings.
 - [#7679](https://github.com/thanos-io/thanos/pull/7679) Query: respect store.limit.* flags when evaluating queries
 
 ### Added

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -2145,7 +2145,7 @@ func (s *BucketStore) LabelValues(ctx context.Context, req *storepb.LabelValuesR
 					}
 
 					val := labelpb.ZLabelsToPromLabels(ls.GetSeries().Labels).Get(req.Label)
-					if val != "" { // Should never be empty since we added labelName!="" matcher to the list of matchers.
+					if val != "" {
 						values[val] = struct{}{}
 					}
 				}

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -1992,10 +1992,10 @@ func (s *BucketStore) LabelValues(ctx context.Context, req *storepb.LabelValuesR
 
 	resHints := &hintspb.LabelValuesResponseHints{}
 
-	var hasMetricNameMatcher = false
+	var hasMetricNameEqMatcher = false
 	for _, m := range reqSeriesMatchers {
-		if m.Name == labels.MetricName {
-			hasMetricNameMatcher = true
+		if m.Name == labels.MetricName && m.Type == labels.MatchEqual {
+			hasMetricNameEqMatcher = true
 			break
 		}
 	}
@@ -2042,8 +2042,8 @@ func (s *BucketStore) LabelValues(ctx context.Context, req *storepb.LabelValuesR
 
 		// If we have series matchers and the Label is not an external one, add <labelName> != "" matcher
 		// to only select series that have given label name.
-		// We don't need such matcher if matchers already contain __name__ matcher.
-		if !hasMetricNameMatcher && len(reqSeriesMatchersNoExtLabels) > 0 && !b.extLset.Has(req.Label) {
+		// We don't need such matcher if matchers already contain __name__=="something" matcher.
+		if !hasMetricNameEqMatcher && len(reqSeriesMatchersNoExtLabels) > 0 && !b.extLset.Has(req.Label) {
 			m, err := labels.NewMatcher(labels.MatchNotEqual, req.Label, "")
 			if err != nil {
 				return nil, status.Error(codes.InvalidArgument, err.Error())


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

This change optimizes `label_values` request to store.

Grafana lets you define template variables. You can define `pod` variable with query like this: `label_values(kube_pod_info{}, pod)`.

In older versions of grafana this query will lead to `series` request to store. In newer versions and with particular datasource settings this query will lead to `label_values` request. End result will be the same, but it considerably differs in data being downloaded from object storage.

Investigations show that in case of `label_values` thanos store fetches alot of postings. This is due to matcher `<labelName> != ""` being added in `label_values` request.

Analyzing debug logs of query stat we can see, that after the change we can download considerably less data from object storage.

![label_values_patch](https://github.com/user-attachments/assets/b635e6a9-b878-476e-a9c4-2e4fff404022)

This change checks, if matchers contain `__name__` matcher. This matcher, if present, lessens the number of data needed to be downloaded from storage. Because matchers are evalueated separately during `blockClient.ExpandPostings()` call, matcher `<labelName> != ""` will select all references to series which have the label. In case of popular labels such as `pod` in example above this will selecet alot of references.

The change won't affect queries like `label_values(pod)` or `label_values({some_label="some_value"}, pod)`, where `__name__` matcher isn't specified.


## Verification

<!-- How you tested it? How do you know it works? -->
