### PR TITLE
Disable chunk trimming in Receivers

### DIFF
--- a/docs/components/receive.md
+++ b/docs/components/receive.md
@@ -94,6 +94,7 @@ config:
       server_name: ""
       insecure_skip_verify: false
     disable_compression: false
+  chunk_size_bytes: 0
 prefix: ""
 ```
 

--- a/docs/components/sidecar.md
+++ b/docs/components/sidecar.md
@@ -74,6 +74,7 @@ config:
       server_name: ""
       insecure_skip_verify: false
     disable_compression: false
+  chunk_size_bytes: 0
 prefix: ""
 ```
 

--- a/docs/components/store.md
+++ b/docs/components/store.md
@@ -33,6 +33,7 @@ config:
       server_name: ""
       insecure_skip_verify: false
     disable_compression: false
+  chunk_size_bytes: 0
 prefix: ""
 ```
 

--- a/docs/components/tools.md
+++ b/docs/components/tools.md
@@ -128,6 +128,7 @@ config:
       server_name: ""
       insecure_skip_verify: false
     disable_compression: false
+  chunk_size_bytes: 0
 prefix: ""
 ```
 
@@ -698,6 +699,7 @@ config:
       server_name: ""
       insecure_skip_verify: false
     disable_compression: false
+  chunk_size_bytes: 0
 prefix: ""
 ```
 
@@ -800,6 +802,7 @@ config:
       server_name: ""
       insecure_skip_verify: false
     disable_compression: false
+  chunk_size_bytes: 0
 prefix: ""
 ```
 

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -304,6 +304,7 @@ config:
       server_name: ""
       insecure_skip_verify: false
     disable_compression: false
+  chunk_size_bytes: 0
 prefix: ""
 ```
 

--- a/pkg/store/storepb/rpc.pb.go
+++ b/pkg/store/storepb/rpc.pb.go
@@ -824,6 +824,9 @@ type StoreClient interface {
 	///
 	/// There is no requirements on chunk sorting, however it is recommended to have chunk sorted by chunk min time.
 	/// This heavily optimizes the resource usage on Querier / Federated Queries.
+	///
+	/// Chunks can span a range larger than the requested min and max time and it is up to the query engine to discard samples
+	/// which fall outside of the query range.
 	Series(ctx context.Context, in *SeriesRequest, opts ...grpc.CallOption) (Store_SeriesClient, error)
 	/// LabelNames returns all label names constrained by the given matchers.
 	LabelNames(ctx context.Context, in *LabelNamesRequest, opts ...grpc.CallOption) (*LabelNamesResponse, error)
@@ -900,6 +903,9 @@ type StoreServer interface {
 	///
 	/// There is no requirements on chunk sorting, however it is recommended to have chunk sorted by chunk min time.
 	/// This heavily optimizes the resource usage on Querier / Federated Queries.
+	///
+	/// Chunks can span a range larger than the requested min and max time and it is up to the query engine to discard samples
+	/// which fall outside of the query range.
 	Series(*SeriesRequest, Store_SeriesServer) error
 	/// LabelNames returns all label names constrained by the given matchers.
 	LabelNames(context.Context, *LabelNamesRequest) (*LabelNamesResponse, error)

--- a/pkg/store/storepb/rpc.proto
+++ b/pkg/store/storepb/rpc.proto
@@ -33,6 +33,9 @@ service Store {
   ///
   /// There is no requirements on chunk sorting, however it is recommended to have chunk sorted by chunk min time.
   /// This heavily optimizes the resource usage on Querier / Federated Queries.
+  ///
+  /// Chunks can span a range larger than the requested min and max time and it is up to the query engine to discard samples
+  /// which fall outside of the query range.
   rpc Series(SeriesRequest) returns (stream SeriesResponse);
 
   /// LabelNames returns all label names constrained by the given matchers.

--- a/pkg/store/tsdb.go
+++ b/pkg/store/tsdb.go
@@ -272,9 +272,10 @@ func (s *TSDBStore) Series(r *storepb.SeriesRequest, seriesSrv storepb.Store_Ser
 	}
 
 	hints := &storage.SelectHints{
-		Start: r.MinTime,
-		End:   r.MaxTime,
-		Limit: int(r.Limit),
+		Start:           r.MinTime,
+		End:             r.MaxTime,
+		Limit:           int(r.Limit),
+		DisableTrimming: true,
 	}
 	set := q.Select(srv.Context(), true, hints, matchers...)
 

--- a/pkg/store/tsdb_test.go
+++ b/pkg/store/tsdb_test.go
@@ -124,7 +124,7 @@ func TestTSDBStore_Series(t *testing.T) {
 			expectedSeries: []rawSeries{
 				{
 					lset:   labels.FromStrings("a", "1", "region", "eu-west"),
-					chunks: [][]sample{{{1, 1}, {2, 2}}},
+					chunks: [][]sample{{{1, 1}, {2, 2}, {3, 3}}},
 				},
 			},
 		},


### PR DESCRIPTION
This change is motivated by the following Slack discussion: https://cloud-native.slack.com/archives/C02KR205UMU/p1728575718863519

When trimming is not disabled, receivers end up recoding all chunks
in order to drop samples that are outside of the range.
This ends up being very expensive and causes ingestion problems during high
query load.

Trimming will be triggered in the following case:
```
|-------------| chunk
   |-------|        requested range
```

This commit disables trimming which should reduce CPU usage in receivers.
The engine already skips samples outside of the query range, so correctness will not be affected.



<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
