### PR TITLE
api: use jsoniter

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -40,6 +40,9 @@ import (
 	"github.com/thanos-io/thanos/pkg/logging"
 	"github.com/thanos-io/thanos/pkg/server/http/middleware"
 	"github.com/thanos-io/thanos/pkg/tracing"
+
+	// NOTE(GiedriusS): to register jsoniter marshalers.
+	_ "github.com/prometheus/prometheus/web/api/v1"
 )
 
 type status string
@@ -218,10 +221,10 @@ func GetInstr(
 				SetCORS(w)
 			}
 			if data, warnings, err, releaseResources := f(r); err != nil {
-				RespondError(w, err, data)
+				RespondError(w, err, data, logger)
 				releaseResources()
 			} else if data != nil {
-				Respond(w, data, warnings)
+				Respond(w, data, warnings, logger)
 				releaseResources()
 			} else {
 				w.WriteHeader(http.StatusNoContent)
@@ -252,7 +255,7 @@ func shouldNotCacheBecauseOfWarnings(warnings []error) bool {
 	return false
 }
 
-func Respond(w http.ResponseWriter, data interface{}, warnings []error) {
+func Respond(w http.ResponseWriter, data interface{}, warnings []error, logger log.Logger) {
 	w.Header().Set("Content-Type", "application/json")
 	if shouldNotCacheBecauseOfWarnings(warnings) {
 		w.Header().Set("Cache-Control", "no-store")
@@ -266,10 +269,21 @@ func Respond(w http.ResponseWriter, data interface{}, warnings []error) {
 	for _, warn := range warnings {
 		resp.Warnings = append(resp.Warnings, warn.Error())
 	}
-	_ = json.NewEncoder(w).Encode(resp)
+
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	b, err := json.Marshal(resp)
+	if err != nil {
+		level.Error(logger).Log("msg", "error marshaling response", "err", err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	if n, err := w.Write(b); err != nil {
+		level.Error(logger).Log("msg", "error writing response", "bytesWritten", n, "err", err)
+	}
 }
 
-func RespondError(w http.ResponseWriter, apiErr *ApiError, data interface{}) {
+func RespondError(w http.ResponseWriter, apiErr *ApiError, data interface{}, logger log.Logger) {
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("Cache-Control", "no-store")
 
@@ -288,10 +302,20 @@ func RespondError(w http.ResponseWriter, apiErr *ApiError, data interface{}) {
 	}
 	w.WriteHeader(code)
 
-	_ = json.NewEncoder(w).Encode(&response{
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	b, err := json.Marshal(&response{
 		Status:    StatusError,
 		ErrorType: apiErr.Typ,
 		Error:     apiErr.Err.Error(),
 		Data:      data,
 	})
+	if err != nil {
+		level.Error(logger).Log("msg", "error marshaling response", "err", err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	if n, err := w.Write(b); err != nil {
+		level.Error(logger).Log("msg", "error writing response", "bytesWritten", n, "err", err)
+	}
 }

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	"github.com/prometheus/common/route"
+	promLabels "github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/promql/parser"
 	promApiV1 "github.com/prometheus/prometheus/web/api/v1"
@@ -71,7 +72,7 @@ func TestMarshallMatrixNull(t *testing.T) {
 
 func TestRespondSuccess(t *testing.T) {
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		Respond(w, "test", nil)
+		Respond(w, "test", nil, log.NewNopLogger())
 	}))
 	defer s.Close()
 
@@ -108,7 +109,7 @@ func TestRespondSuccess(t *testing.T) {
 
 func TestRespondError(t *testing.T) {
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		RespondError(w, &ApiError{ErrorTimeout, errors.New("message")}, "test")
+		RespondError(w, &ApiError{ErrorTimeout, errors.New("message")}, "test", log.NewNopLogger())
 	}))
 	defer s.Close()
 
@@ -172,5 +173,37 @@ func TestOptionsMethod(t *testing.T) {
 		if resp.Header.Get(h) != v {
 			t.Fatalf("Expected %q for header %q, got %q", v, h, resp.Header.Get(h))
 		}
+	}
+}
+
+type nilWriter struct{}
+
+var _ = http.ResponseWriter(&nilWriter{})
+
+func (nilWriter) Write(p []byte) (n int, err error) {
+	return 0, nil
+}
+
+func (nilWriter) Header() http.Header {
+	return http.Header{}
+}
+
+func (nilWriter) WriteHeader(statusCode int) {}
+
+func BenchmarkRespond(b *testing.B) {
+	floats := []promql.FPoint{}
+
+	for i := 0; i < 10000; i++ {
+		floats = append(floats, promql.FPoint{T: 1435781451 + int64(i), F: 1234.123 + float64(i)})
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		Respond(&nilWriter{}, promql.Matrix{
+			promql.Series{
+				Metric: promLabels.FromMap(map[string]string{"__name__": "up", "job": "prometheus"}),
+				Floats: floats,
+			},
+		}, nil, log.NewNopLogger())
 	}
 }


### PR DESCRIPTION
Use jsoniter for responding. Use Prometheus codecs for that. Benchmark:

```
goos: linux
goarch: amd64
pkg: github.com/thanos-io/thanos/pkg/api
cpu: Intel(R) Core(TM) i9-10885H CPU @ 2.40GHz
           │     old      │                newv2                 │
           │    sec/op    │    sec/op     vs base                │
Respond-16   1.497m ± 96%   1.208m ± 14%  -19.32% (p=0.000 n=10)

           │       old       │                newv2                 │
           │      B/op       │     B/op      vs base                │
Respond-16   1432.4Ki ± 227%   259.1Ki ± 1%  -81.91% (p=0.000 n=10)

           │     old     │               newv2                │
           │  allocs/op  │ allocs/op   vs base                │
Respond-16   30.000 ± 0%   8.000 ± 0%  -73.33% (p=0.000 n=10)
```

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
