### PR TITLE
Fix coroutine leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#7643](https://github.com/thanos-io/thanos/pull/7643) Receive: fix thanos_receive_write_{timeseries,samples} stats
 - [#7644](https://github.com/thanos-io/thanos/pull/7644) fix(ui): add null check to find overlapping blocks logic
 - [#7679](https://github.com/thanos-io/thanos/pull/7679) Query: respect store.limit.* flags when evaluating queries
+- [#7821](https://github.com/thanos-io/thanos/pull/7679) Query/Receive: Fix coroutine leak introduced in https://github.com/thanos-io/thanos/pull/7796.
 
 ### Added
 - [#7763](https://github.com/thanos-io/thanos/pull/7763) Ruler: use native histograms for client latency metrics.

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -1574,8 +1574,6 @@ func (s *BucketStore) Series(req *storepb.SeriesRequest, seriesSrv storepb.Store
 				tenant,
 			)
 
-			defer blockClient.Close()
-
 			g.Go(func() error {
 
 				span, _ := tracing.StartSpan(gctx, "bucket_store_block_series", tracing.Tags{

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -3354,6 +3354,11 @@ func (r *bucketIndexReader) Close() error {
 	return nil
 }
 
+func (b *blockSeriesClient) CloseSend() error {
+	b.Close()
+	return nil
+}
+
 // LookupLabelsSymbols allows populates label set strings from symbolized label set.
 func (r *bucketIndexReader) LookupLabelsSymbols(ctx context.Context, symbolized []symbolizedLabel, b *labels.Builder) error {
 	b.Reset(labels.EmptyLabels())

--- a/pkg/store/proxy_merge_test.go
+++ b/pkg/store/proxy_merge_test.go
@@ -35,6 +35,7 @@ func TestProxyResponseTreeSort(t *testing.T) {
 			input: []respSet{
 				&eagerRespSet{
 					closeSeries: func() {},
+					cl:          nopClientSendCloser{},
 					wg:          &sync.WaitGroup{},
 					bufferedResponses: []*storepb.SeriesResponse{
 						storeSeriesResponse(t, labelsFromStrings("a", "1", "c", "3")),
@@ -43,6 +44,7 @@ func TestProxyResponseTreeSort(t *testing.T) {
 				},
 				&eagerRespSet{
 					closeSeries: func() {},
+					cl:          nopClientSendCloser{},
 					wg:          &sync.WaitGroup{},
 					bufferedResponses: []*storepb.SeriesResponse{
 						storeSeriesResponse(t, labelsFromStrings("a", "1", "c", "4", "e", "5")),
@@ -62,6 +64,7 @@ func TestProxyResponseTreeSort(t *testing.T) {
 			input: []respSet{
 				&eagerRespSet{
 					closeSeries: func() {},
+					cl:          nopClientSendCloser{},
 					wg:          &sync.WaitGroup{},
 					bufferedResponses: []*storepb.SeriesResponse{
 						storeSeriesResponse(t, labelsFromStrings("a", "1", "b", "2", "c", "3")),
@@ -71,6 +74,7 @@ func TestProxyResponseTreeSort(t *testing.T) {
 				},
 				&eagerRespSet{
 					closeSeries: func() {},
+					cl:          nopClientSendCloser{},
 					wg:          &sync.WaitGroup{},
 					bufferedResponses: []*storepb.SeriesResponse{
 						storeSeriesResponse(t, labelsFromStrings("d", "4", "e", "5")),
@@ -91,6 +95,7 @@ func TestProxyResponseTreeSort(t *testing.T) {
 			input: []respSet{
 				&eagerRespSet{
 					closeSeries: func() {},
+					cl:          nopClientSendCloser{},
 					wg:          &sync.WaitGroup{},
 					bufferedResponses: []*storepb.SeriesResponse{
 						storeSeriesResponse(t, labelsFromStrings("a", "1", "b", "2", "ext2", "9")),
@@ -100,6 +105,7 @@ func TestProxyResponseTreeSort(t *testing.T) {
 				},
 				&eagerRespSet{
 					closeSeries: func() {},
+					cl:          nopClientSendCloser{},
 					wg:          &sync.WaitGroup{},
 					bufferedResponses: []*storepb.SeriesResponse{
 						storeSeriesResponse(t, labelsFromStrings("a", "1", "b", "2", "ext1", "5", "ext2", "9")),
@@ -120,6 +126,7 @@ func TestProxyResponseTreeSort(t *testing.T) {
 			input: []respSet{
 				&eagerRespSet{
 					closeSeries: func() {},
+					cl:          nopClientSendCloser{},
 					wg:          &sync.WaitGroup{},
 					bufferedResponses: []*storepb.SeriesResponse{
 						storeSeriesResponse(t, labelsFromStrings("a", "1", "b", "2", "c", "3")),
@@ -129,6 +136,7 @@ func TestProxyResponseTreeSort(t *testing.T) {
 				},
 				&eagerRespSet{
 					closeSeries: func() {},
+					cl:          nopClientSendCloser{},
 					wg:          &sync.WaitGroup{},
 					bufferedResponses: []*storepb.SeriesResponse{
 						storeSeriesResponse(t, labelsFromStrings("a", "1", "b", "1", "c", "3")),
@@ -149,6 +157,7 @@ func TestProxyResponseTreeSort(t *testing.T) {
 			input: []respSet{
 				&eagerRespSet{
 					closeSeries: func() {},
+					cl:          nopClientSendCloser{},
 					wg:          &sync.WaitGroup{},
 					bufferedResponses: []*storepb.SeriesResponse{
 						storeSeriesResponse(t, labelsFromStrings("a", "1", "b", "2", "ext2", "9")),
@@ -158,6 +167,7 @@ func TestProxyResponseTreeSort(t *testing.T) {
 				},
 				&eagerRespSet{
 					closeSeries: func() {},
+					cl:          nopClientSendCloser{},
 					wg:          &sync.WaitGroup{},
 					bufferedResponses: []*storepb.SeriesResponse{
 						storeSeriesResponse(t, labelsFromStrings("a", "1", "b", "2", "ext1", "5", "ext2", "9")),
@@ -178,6 +188,7 @@ func TestProxyResponseTreeSort(t *testing.T) {
 			input: []respSet{
 				&eagerRespSet{
 					closeSeries: func() {},
+					cl:          nopClientSendCloser{},
 					wg:          &sync.WaitGroup{},
 					bufferedResponses: []*storepb.SeriesResponse{
 						storeSeriesResponse(t, labelsFromStrings("cluster", "beam-platform", "instance", "10.70.13.3:15692", "prometheus", "telemetry/observe-prometheus", "receive", "true", "tenant_id", "default-tenant")),
@@ -188,6 +199,7 @@ func TestProxyResponseTreeSort(t *testing.T) {
 				},
 				&eagerRespSet{
 					closeSeries: func() {},
+					cl:          nopClientSendCloser{},
 					wg:          &sync.WaitGroup{},
 					bufferedResponses: []*storepb.SeriesResponse{
 						storeSeriesResponse(t, labelsFromStrings("cluster", "beam-platform", "instance", "10.70.13.3:15692", "prometheus", "telemetry/observe-prometheus", "receive", "true", "tenant_id", "default-tenant")),
@@ -218,6 +230,12 @@ func TestProxyResponseTreeSort(t *testing.T) {
 		})
 	}
 }
+
+type nopClientSendCloser struct {
+	storepb.Store_SeriesClient
+}
+
+func (c nopClientSendCloser) CloseSend() error { return nil }
 
 func TestSortWithoutLabels(t *testing.T) {
 	for _, tcase := range []struct {
@@ -341,6 +359,7 @@ func BenchmarkKWayMerge(b *testing.B) {
 		for j := 0; j < 1000; j++ {
 			respSets = append(respSets, &eagerRespSet{
 				closeSeries: func() {},
+				cl:          nopClientSendCloser{},
 				wg:          &sync.WaitGroup{},
 				bufferedResponses: []*storepb.SeriesResponse{
 					storeSeriesResponse(b, labelsFromStrings("a", "1", "b", fmt.Sprintf("replica-%d", j), "c", "3")),

--- a/pkg/store/proxy_test.go
+++ b/pkg/store/proxy_test.go
@@ -6,6 +6,9 @@ package store
 import (
 	"context"
 	"fmt"
+	"strings"
+
+	"github.com/pkg/errors"
 
 	"math"
 	"math/rand"
@@ -19,7 +22,6 @@ import (
 	"github.com/go-kit/log"
 	"github.com/gogo/protobuf/proto"
 	"github.com/gogo/protobuf/types"
-	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/timestamp"
@@ -2213,69 +2215,58 @@ func benchProxySeries(t testutil.TB, totalSamples, totalSeries int) {
 func TestProxyStore_NotLeakingOnPrematureFinish(t *testing.T) {
 	defer custom.TolerantVerifyLeak(t)
 
-	clients := []Client{
-		&storetestutil.TestClient{
-			StoreClient: &mockedStoreAPI{
-				RespSeries: []*storepb.SeriesResponse{
-					// Ensure more than 10 (internal respCh channel).
-					storeSeriesResponse(t, labels.FromStrings("a", "a"), []sample{{0, 0}, {2, 1}, {3, 2}}),
-					storeSeriesResponse(t, labels.FromStrings("a", "b"), []sample{{0, 0}, {2, 1}, {3, 2}}),
-					storeSeriesResponse(t, labels.FromStrings("a", "c"), []sample{{0, 0}, {2, 1}, {3, 2}}),
-					storeSeriesResponse(t, labels.FromStrings("a", "d"), []sample{{0, 0}, {2, 1}, {3, 2}}),
-					storeSeriesResponse(t, labels.FromStrings("a", "e"), []sample{{0, 0}, {2, 1}, {3, 2}}),
-					storeSeriesResponse(t, labels.FromStrings("a", "f"), []sample{{0, 0}, {2, 1}, {3, 2}}),
-					storeSeriesResponse(t, labels.FromStrings("a", "g"), []sample{{0, 0}, {2, 1}, {3, 2}}),
-					storeSeriesResponse(t, labels.FromStrings("a", "h"), []sample{{0, 0}, {2, 1}, {3, 2}}),
-					storeSeriesResponse(t, labels.FromStrings("a", "i"), []sample{{0, 0}, {2, 1}, {3, 2}}),
-					storeSeriesResponse(t, labels.FromStrings("a", "j"), []sample{{0, 0}, {2, 1}, {3, 2}}),
-				},
-			},
-			MinTime: math.MinInt64,
-			MaxTime: math.MaxInt64,
-		},
-		&storetestutil.TestClient{
-			StoreClient: &mockedStoreAPI{
-				RespSeries: []*storepb.SeriesResponse{
-					storeSeriesResponse(t, labels.FromStrings("b", "a"), []sample{{0, 0}, {2, 1}, {3, 2}}),
-					storeSeriesResponse(t, labels.FromStrings("b", "b"), []sample{{0, 0}, {2, 1}, {3, 2}}),
-					storeSeriesResponse(t, labels.FromStrings("b", "c"), []sample{{0, 0}, {2, 1}, {3, 2}}),
-					storeSeriesResponse(t, labels.FromStrings("b", "d"), []sample{{0, 0}, {2, 1}, {3, 2}}),
-					storeSeriesResponse(t, labels.FromStrings("b", "e"), []sample{{0, 0}, {2, 1}, {3, 2}}),
-					storeSeriesResponse(t, labels.FromStrings("b", "f"), []sample{{0, 0}, {2, 1}, {3, 2}}),
-					storeSeriesResponse(t, labels.FromStrings("b", "g"), []sample{{0, 0}, {2, 1}, {3, 2}}),
-					storeSeriesResponse(t, labels.FromStrings("b", "h"), []sample{{0, 0}, {2, 1}, {3, 2}}),
-					storeSeriesResponse(t, labels.FromStrings("b", "i"), []sample{{0, 0}, {2, 1}, {3, 2}}),
-					storeSeriesResponse(t, labels.FromStrings("b", "j"), []sample{{0, 0}, {2, 1}, {3, 2}}),
-				},
-			},
-			MinTime: math.MinInt64,
-			MaxTime: math.MaxInt64,
-		},
-		&storetestutil.TestClient{
-			StoreClient: storepb.ServerAsClient(&storeServerStub{
-				delay: 50 * time.Millisecond,
-				responses: []*storepb.SeriesResponse{
-					storeSeriesResponse(t, labels.FromStrings("b", "a"), []sample{{0, 0}, {2, 1}, {3, 2}}),
-					storeSeriesResponse(t, labels.FromStrings("b", "b"), []sample{{0, 0}, {2, 1}, {3, 2}}),
-					storeSeriesResponse(t, labels.FromStrings("b", "c"), []sample{{0, 0}, {2, 1}, {3, 2}}),
-				},
-			}),
-			MinTime: math.MinInt64,
-			MaxTime: math.MaxInt64,
-		},
-	}
-
 	logger := log.NewNopLogger()
-	p := &ProxyStore{
-		logger:            logger,
-		stores:            func() []Client { return clients },
-		metrics:           newProxyStoreMetrics(nil),
-		responseTimeout:   50 * time.Millisecond,
-		retrievalStrategy: EagerRetrieval,
-		tsdbSelector:      DefaultSelector,
-	}
 
 	t.Run("failing send", func(t *testing.T) {
+		clients := []Client{
+			&storetestutil.TestClient{
+				StoreClient: &mockedStoreAPI{
+					RespSeries: []*storepb.SeriesResponse{
+						// Ensure more than 10 (internal respCh channel).
+						storeSeriesResponse(t, labels.FromStrings("a", "a"), []sample{{0, 0}, {2, 1}, {3, 2}}),
+						storeSeriesResponse(t, labels.FromStrings("a", "b"), []sample{{0, 0}, {2, 1}, {3, 2}}),
+						storeSeriesResponse(t, labels.FromStrings("a", "c"), []sample{{0, 0}, {2, 1}, {3, 2}}),
+						storeSeriesResponse(t, labels.FromStrings("a", "d"), []sample{{0, 0}, {2, 1}, {3, 2}}),
+						storeSeriesResponse(t, labels.FromStrings("a", "e"), []sample{{0, 0}, {2, 1}, {3, 2}}),
+						storeSeriesResponse(t, labels.FromStrings("a", "f"), []sample{{0, 0}, {2, 1}, {3, 2}}),
+						storeSeriesResponse(t, labels.FromStrings("a", "g"), []sample{{0, 0}, {2, 1}, {3, 2}}),
+						storeSeriesResponse(t, labels.FromStrings("a", "h"), []sample{{0, 0}, {2, 1}, {3, 2}}),
+						storeSeriesResponse(t, labels.FromStrings("a", "i"), []sample{{0, 0}, {2, 1}, {3, 2}}),
+						storeSeriesResponse(t, labels.FromStrings("a", "j"), []sample{{0, 0}, {2, 1}, {3, 2}}),
+					},
+				},
+				MinTime: math.MinInt64,
+				MaxTime: math.MaxInt64,
+			},
+			&storetestutil.TestClient{
+				StoreClient: &mockedStoreAPI{
+					RespSeries: []*storepb.SeriesResponse{
+						storeSeriesResponse(t, labels.FromStrings("b", "a"), []sample{{0, 0}, {2, 1}, {3, 2}}),
+						storeSeriesResponse(t, labels.FromStrings("b", "b"), []sample{{0, 0}, {2, 1}, {3, 2}}),
+						storeSeriesResponse(t, labels.FromStrings("b", "c"), []sample{{0, 0}, {2, 1}, {3, 2}}),
+						storeSeriesResponse(t, labels.FromStrings("b", "d"), []sample{{0, 0}, {2, 1}, {3, 2}}),
+						storeSeriesResponse(t, labels.FromStrings("b", "e"), []sample{{0, 0}, {2, 1}, {3, 2}}),
+						storeSeriesResponse(t, labels.FromStrings("b", "f"), []sample{{0, 0}, {2, 1}, {3, 2}}),
+						storeSeriesResponse(t, labels.FromStrings("b", "g"), []sample{{0, 0}, {2, 1}, {3, 2}}),
+						storeSeriesResponse(t, labels.FromStrings("b", "h"), []sample{{0, 0}, {2, 1}, {3, 2}}),
+						storeSeriesResponse(t, labels.FromStrings("b", "i"), []sample{{0, 0}, {2, 1}, {3, 2}}),
+						storeSeriesResponse(t, labels.FromStrings("b", "j"), []sample{{0, 0}, {2, 1}, {3, 2}}),
+					},
+				},
+				MinTime: math.MinInt64,
+				MaxTime: math.MaxInt64,
+			},
+		}
+
+		p := &ProxyStore{
+			logger:            logger,
+			stores:            func() []Client { return clients },
+			metrics:           newProxyStoreMetrics(nil),
+			responseTimeout:   50 * time.Millisecond,
+			retrievalStrategy: EagerRetrieval,
+			tsdbSelector:      DefaultSelector,
+		}
+
 		ctx, cancel := context.WithCancel(context.Background())
 		// We mimic failing series server, but practically context cancel will do the same.
 		testutil.NotOk(t, p.Series(&storepb.SeriesRequest{Matchers: []storepb.LabelMatcher{{}}, PartialResponseStrategy: storepb.PartialResponseStrategy_ABORT}, &mockedSeriesServer{
@@ -2287,14 +2278,45 @@ func TestProxyStore_NotLeakingOnPrematureFinish(t *testing.T) {
 		}))
 		testutil.NotOk(t, ctx.Err())
 	})
+
 	t.Run("client timeout", func(t *testing.T) {
-		ctx := context.Background()
-		testutil.NotOk(t, p.Series(&storepb.SeriesRequest{Matchers: []storepb.LabelMatcher{{}}, PartialResponseStrategy: storepb.PartialResponseStrategy_ABORT}, &mockedSeriesServer{
-			ctx: ctx,
-			send: func(*storepb.SeriesResponse) error {
-				return nil
+		clients := []Client{
+			&storetestutil.TestClient{
+				StoreClient: storepb.ServerAsClient(&storeServerStub{
+					delay: 50 * time.Millisecond,
+					responses: []*storepb.SeriesResponse{
+						storeSeriesResponse(t, labels.FromStrings("b", "a"), []sample{{0, 0}, {2, 1}, {3, 2}}),
+						storeSeriesResponse(t, labels.FromStrings("b", "b"), []sample{{0, 0}, {2, 1}, {3, 2}}),
+						storeSeriesResponse(t, labels.FromStrings("b", "c"), []sample{{0, 0}, {2, 1}, {3, 2}}),
+					},
+				}),
+				MinTime: math.MinInt64,
+				MaxTime: math.MaxInt64,
 			},
-		}))
+		}
+
+		for _, respStrategy := range []RetrievalStrategy{EagerRetrieval, LazyRetrieval} {
+			t.Run(fmt.Sprintf("strategy=%v", respStrategy), func(t *testing.T) {
+				p := &ProxyStore{
+					logger:            logger,
+					stores:            func() []Client { return clients },
+					metrics:           newProxyStoreMetrics(nil),
+					responseTimeout:   50 * time.Millisecond,
+					retrievalStrategy: respStrategy,
+					tsdbSelector:      DefaultSelector,
+				}
+
+				ctx := context.Background()
+				err := p.Series(&storepb.SeriesRequest{Matchers: []storepb.LabelMatcher{{}}, PartialResponseStrategy: storepb.PartialResponseStrategy_ABORT}, &mockedSeriesServer{
+					ctx: ctx,
+					send: func(*storepb.SeriesResponse) error {
+						return nil
+					},
+				})
+
+				testutil.Assert(t, strings.Contains(err.Error(), context.Canceled.Error()))
+			})
+		}
 	})
 }
 

--- a/pkg/store/proxy_test.go
+++ b/pkg/store/proxy_test.go
@@ -2217,86 +2217,86 @@ func TestProxyStore_NotLeakingOnPrematureFinish(t *testing.T) {
 
 	logger := log.NewNopLogger()
 
-	t.Run("failing send", func(t *testing.T) {
-		clients := []Client{
-			&storetestutil.TestClient{
-				StoreClient: &mockedStoreAPI{
-					RespSeries: []*storepb.SeriesResponse{
-						// Ensure more than 10 (internal respCh channel).
-						storeSeriesResponse(t, labels.FromStrings("a", "a"), []sample{{0, 0}, {2, 1}, {3, 2}}),
-						storeSeriesResponse(t, labels.FromStrings("a", "b"), []sample{{0, 0}, {2, 1}, {3, 2}}),
-						storeSeriesResponse(t, labels.FromStrings("a", "c"), []sample{{0, 0}, {2, 1}, {3, 2}}),
-						storeSeriesResponse(t, labels.FromStrings("a", "d"), []sample{{0, 0}, {2, 1}, {3, 2}}),
-						storeSeriesResponse(t, labels.FromStrings("a", "e"), []sample{{0, 0}, {2, 1}, {3, 2}}),
-						storeSeriesResponse(t, labels.FromStrings("a", "f"), []sample{{0, 0}, {2, 1}, {3, 2}}),
-						storeSeriesResponse(t, labels.FromStrings("a", "g"), []sample{{0, 0}, {2, 1}, {3, 2}}),
-						storeSeriesResponse(t, labels.FromStrings("a", "h"), []sample{{0, 0}, {2, 1}, {3, 2}}),
-						storeSeriesResponse(t, labels.FromStrings("a", "i"), []sample{{0, 0}, {2, 1}, {3, 2}}),
-						storeSeriesResponse(t, labels.FromStrings("a", "j"), []sample{{0, 0}, {2, 1}, {3, 2}}),
+	for _, respStrategy := range []RetrievalStrategy{EagerRetrieval, LazyRetrieval} {
+		t.Run(fmt.Sprintf("strategy=%v", respStrategy), func(t *testing.T) {
+			t.Run("failing send", func(t *testing.T) {
+				clients := []Client{
+					&storetestutil.TestClient{
+						StoreClient: &mockedStoreAPI{
+							RespSeries: []*storepb.SeriesResponse{
+								// Ensure more than 10 (internal respCh channel).
+								storeSeriesResponse(t, labels.FromStrings("a", "a"), []sample{{0, 0}, {2, 1}, {3, 2}}),
+								storeSeriesResponse(t, labels.FromStrings("a", "b"), []sample{{0, 0}, {2, 1}, {3, 2}}),
+								storeSeriesResponse(t, labels.FromStrings("a", "c"), []sample{{0, 0}, {2, 1}, {3, 2}}),
+								storeSeriesResponse(t, labels.FromStrings("a", "d"), []sample{{0, 0}, {2, 1}, {3, 2}}),
+								storeSeriesResponse(t, labels.FromStrings("a", "e"), []sample{{0, 0}, {2, 1}, {3, 2}}),
+								storeSeriesResponse(t, labels.FromStrings("a", "f"), []sample{{0, 0}, {2, 1}, {3, 2}}),
+								storeSeriesResponse(t, labels.FromStrings("a", "g"), []sample{{0, 0}, {2, 1}, {3, 2}}),
+								storeSeriesResponse(t, labels.FromStrings("a", "h"), []sample{{0, 0}, {2, 1}, {3, 2}}),
+								storeSeriesResponse(t, labels.FromStrings("a", "i"), []sample{{0, 0}, {2, 1}, {3, 2}}),
+								storeSeriesResponse(t, labels.FromStrings("a", "j"), []sample{{0, 0}, {2, 1}, {3, 2}}),
+							},
+						},
+						MinTime: math.MinInt64,
+						MaxTime: math.MaxInt64,
 					},
-				},
-				MinTime: math.MinInt64,
-				MaxTime: math.MaxInt64,
-			},
-			&storetestutil.TestClient{
-				StoreClient: &mockedStoreAPI{
-					RespSeries: []*storepb.SeriesResponse{
-						storeSeriesResponse(t, labels.FromStrings("b", "a"), []sample{{0, 0}, {2, 1}, {3, 2}}),
-						storeSeriesResponse(t, labels.FromStrings("b", "b"), []sample{{0, 0}, {2, 1}, {3, 2}}),
-						storeSeriesResponse(t, labels.FromStrings("b", "c"), []sample{{0, 0}, {2, 1}, {3, 2}}),
-						storeSeriesResponse(t, labels.FromStrings("b", "d"), []sample{{0, 0}, {2, 1}, {3, 2}}),
-						storeSeriesResponse(t, labels.FromStrings("b", "e"), []sample{{0, 0}, {2, 1}, {3, 2}}),
-						storeSeriesResponse(t, labels.FromStrings("b", "f"), []sample{{0, 0}, {2, 1}, {3, 2}}),
-						storeSeriesResponse(t, labels.FromStrings("b", "g"), []sample{{0, 0}, {2, 1}, {3, 2}}),
-						storeSeriesResponse(t, labels.FromStrings("b", "h"), []sample{{0, 0}, {2, 1}, {3, 2}}),
-						storeSeriesResponse(t, labels.FromStrings("b", "i"), []sample{{0, 0}, {2, 1}, {3, 2}}),
-						storeSeriesResponse(t, labels.FromStrings("b", "j"), []sample{{0, 0}, {2, 1}, {3, 2}}),
+					&storetestutil.TestClient{
+						StoreClient: &mockedStoreAPI{
+							RespSeries: []*storepb.SeriesResponse{
+								storeSeriesResponse(t, labels.FromStrings("b", "a"), []sample{{0, 0}, {2, 1}, {3, 2}}),
+								storeSeriesResponse(t, labels.FromStrings("b", "b"), []sample{{0, 0}, {2, 1}, {3, 2}}),
+								storeSeriesResponse(t, labels.FromStrings("b", "c"), []sample{{0, 0}, {2, 1}, {3, 2}}),
+								storeSeriesResponse(t, labels.FromStrings("b", "d"), []sample{{0, 0}, {2, 1}, {3, 2}}),
+								storeSeriesResponse(t, labels.FromStrings("b", "e"), []sample{{0, 0}, {2, 1}, {3, 2}}),
+								storeSeriesResponse(t, labels.FromStrings("b", "f"), []sample{{0, 0}, {2, 1}, {3, 2}}),
+								storeSeriesResponse(t, labels.FromStrings("b", "g"), []sample{{0, 0}, {2, 1}, {3, 2}}),
+								storeSeriesResponse(t, labels.FromStrings("b", "h"), []sample{{0, 0}, {2, 1}, {3, 2}}),
+								storeSeriesResponse(t, labels.FromStrings("b", "i"), []sample{{0, 0}, {2, 1}, {3, 2}}),
+								storeSeriesResponse(t, labels.FromStrings("b", "j"), []sample{{0, 0}, {2, 1}, {3, 2}}),
+							},
+						},
+						MinTime: math.MinInt64,
+						MaxTime: math.MaxInt64,
 					},
-				},
-				MinTime: math.MinInt64,
-				MaxTime: math.MaxInt64,
-			},
-		}
+				}
 
-		p := &ProxyStore{
-			logger:            logger,
-			stores:            func() []Client { return clients },
-			metrics:           newProxyStoreMetrics(nil),
-			responseTimeout:   50 * time.Millisecond,
-			retrievalStrategy: EagerRetrieval,
-			tsdbSelector:      DefaultSelector,
-		}
+				p := &ProxyStore{
+					logger:            logger,
+					stores:            func() []Client { return clients },
+					metrics:           newProxyStoreMetrics(nil),
+					responseTimeout:   50 * time.Millisecond,
+					retrievalStrategy: respStrategy,
+					tsdbSelector:      DefaultSelector,
+				}
 
-		ctx, cancel := context.WithCancel(context.Background())
-		// We mimic failing series server, but practically context cancel will do the same.
-		testutil.NotOk(t, p.Series(&storepb.SeriesRequest{Matchers: []storepb.LabelMatcher{{}}, PartialResponseStrategy: storepb.PartialResponseStrategy_ABORT}, &mockedSeriesServer{
-			ctx: ctx,
-			send: func(*storepb.SeriesResponse) error {
-				cancel()
-				return ctx.Err()
-			},
-		}))
-		testutil.NotOk(t, ctx.Err())
-	})
-
-	t.Run("client timeout", func(t *testing.T) {
-		clients := []Client{
-			&storetestutil.TestClient{
-				StoreClient: storepb.ServerAsClient(&storeServerStub{
-					delay: 50 * time.Millisecond,
-					responses: []*storepb.SeriesResponse{
-						storeSeriesResponse(t, labels.FromStrings("b", "a"), []sample{{0, 0}, {2, 1}, {3, 2}}),
-						storeSeriesResponse(t, labels.FromStrings("b", "b"), []sample{{0, 0}, {2, 1}, {3, 2}}),
-						storeSeriesResponse(t, labels.FromStrings("b", "c"), []sample{{0, 0}, {2, 1}, {3, 2}}),
+				ctx, cancel := context.WithCancel(context.Background())
+				// We mimic failing series server, but practically context cancel will do the same.
+				testutil.NotOk(t, p.Series(&storepb.SeriesRequest{Matchers: []storepb.LabelMatcher{{}}, PartialResponseStrategy: storepb.PartialResponseStrategy_ABORT}, &mockedSeriesServer{
+					ctx: ctx,
+					send: func(*storepb.SeriesResponse) error {
+						cancel()
+						return ctx.Err()
 					},
-				}),
-				MinTime: math.MinInt64,
-				MaxTime: math.MaxInt64,
-			},
-		}
+				}))
+				testutil.NotOk(t, ctx.Err())
+			})
 
-		for _, respStrategy := range []RetrievalStrategy{EagerRetrieval, LazyRetrieval} {
-			t.Run(fmt.Sprintf("strategy=%v", respStrategy), func(t *testing.T) {
+			t.Run("client timeout", func(t *testing.T) {
+				clients := []Client{
+					&storetestutil.TestClient{
+						StoreClient: storepb.ServerAsClient(&storeServerStub{
+							delay: 50 * time.Millisecond,
+							responses: []*storepb.SeriesResponse{
+								storeSeriesResponse(t, labels.FromStrings("b", "a"), []sample{{0, 0}, {2, 1}, {3, 2}}),
+								storeSeriesResponse(t, labels.FromStrings("b", "b"), []sample{{0, 0}, {2, 1}, {3, 2}}),
+								storeSeriesResponse(t, labels.FromStrings("b", "c"), []sample{{0, 0}, {2, 1}, {3, 2}}),
+							},
+						}),
+						MinTime: math.MinInt64,
+						MaxTime: math.MaxInt64,
+					},
+				}
+
 				p := &ProxyStore{
 					logger:            logger,
 					stores:            func() []Client { return clients },
@@ -2316,8 +2316,8 @@ func TestProxyStore_NotLeakingOnPrematureFinish(t *testing.T) {
 
 				testutil.Assert(t, strings.Contains(err.Error(), context.Canceled.Error()))
 			})
-		}
-	})
+		})
+	}
 }
 
 type storeServerStub struct {

--- a/pkg/store/proxy_test.go
+++ b/pkg/store/proxy_test.go
@@ -2454,6 +2454,7 @@ func TestDedupRespHeap_Deduplication(t *testing.T) {
 			h := NewResponseDeduplicator(NewProxyResponseLoserTree(
 				&eagerRespSet{
 					closeSeries:       func() {},
+					cl:                nopClientSendCloser{},
 					wg:                &sync.WaitGroup{},
 					bufferedResponses: tcase.responses,
 				},

--- a/pkg/store/storepb/inprocess.go
+++ b/pkg/store/storepb/inprocess.go
@@ -55,6 +55,9 @@ func (c *inProcessClient) Recv() (*SeriesResponse, error) {
 		return nil, err
 	}
 	if !ok {
+		if c.ctx.Err() != nil {
+			return nil, c.ctx.Err()
+		}
 		return nil, io.EOF
 	}
 	return resp, err

--- a/pkg/store/storepb/testutil/store_series_client.go
+++ b/pkg/store/storepb/testutil/store_series_client.go
@@ -50,3 +50,4 @@ func (c *StoreSeriesClient) Recv() (*storepb.SeriesResponse, error) {
 func (c *StoreSeriesClient) Context() context.Context {
 	return c.Ctx
 }
+func (c *StoreSeriesClient) CloseSend() error { return nil }


### PR DESCRIPTION
The in-process client uses a pull based iterator which needs to be closed, otherwise it will leak the underlying coroutine. When this happens, the tsdb reader will remain open which blocks head compaction indefinitely.

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
