### PR TITLE
query-frontend: Fix cache keys for dynamic split intervals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#7821](https://github.com/thanos-io/thanos/pull/7679) Query/Receive: Fix coroutine leak introduced in https://github.com/thanos-io/thanos/pull/7796.
 - [#7843](https://github.com/thanos-io/thanos/pull/7843) Query Frontend: fix slow query logging for non-query endpoints.
 - [#7852](https://github.com/thanos-io/thanos/pull/7852) Query Frontend: pass "stats" parameter forward to queriers and fix Prometheus stats merging.
+- [#7832](https://github.com/thanos-io/thanos/pull/7832) Query Frontend: Fix cache keys for dynamic split intervals.
 
 ### Added
 - [#7763](https://github.com/thanos-io/thanos/pull/7763) Ruler: use native histograms for client latency metrics.

--- a/pkg/queryfrontend/cache.go
+++ b/pkg/queryfrontend/cache.go
@@ -12,13 +12,11 @@ import (
 
 // thanosCacheKeyGenerator is a utility for using split interval when determining cache keys.
 type thanosCacheKeyGenerator struct {
-	interval    queryrange.IntervalFn
 	resolutions []int64
 }
 
-func newThanosCacheKeyGenerator(intervalFn queryrange.IntervalFn) thanosCacheKeyGenerator {
+func newThanosCacheKeyGenerator() thanosCacheKeyGenerator {
 	return thanosCacheKeyGenerator{
-		interval:    intervalFn,
 		resolutions: []int64{downsample.ResLevel2, downsample.ResLevel1, downsample.ResLevel0},
 	}
 }
@@ -26,20 +24,26 @@ func newThanosCacheKeyGenerator(intervalFn queryrange.IntervalFn) thanosCacheKey
 // GenerateCacheKey generates a cache key based on the Request and interval.
 // TODO(yeya24): Add other request params as request key.
 func (t thanosCacheKeyGenerator) GenerateCacheKey(userID string, r queryrange.Request) string {
-	currentInterval := r.GetStart() / t.interval(r).Milliseconds()
 	switch tr := r.(type) {
 	case *ThanosQueryRangeRequest:
 		i := 0
 		for ; i < len(t.resolutions) && t.resolutions[i] > tr.MaxSourceResolution; i++ {
 		}
 		shardInfoKey := generateShardInfoKey(tr)
-		return fmt.Sprintf("fe:%s:%s:%d:%d:%d:%s:%d:%s", userID, tr.Query, tr.Step, currentInterval, i, shardInfoKey, tr.LookbackDelta, tr.Engine)
+		splitInterval := tr.SplitInterval.Milliseconds()
+		currentInterval := r.GetStart() / splitInterval
+		return fmt.Sprintf("fe:%s:%s:%d:%d:%d:%d:%s:%d:%s", userID, tr.Query, tr.Step, splitInterval, currentInterval, i, shardInfoKey, tr.LookbackDelta, tr.Engine)
 	case *ThanosLabelsRequest:
-		return fmt.Sprintf("fe:%s:%s:%s:%d", userID, tr.Label, tr.Matchers, currentInterval)
+		splitInterval := tr.SplitInterval.Milliseconds()
+		currentInterval := r.GetStart() / splitInterval
+		return fmt.Sprintf("fe:%s:%s:%s:%d:%d", userID, tr.Label, tr.Matchers, splitInterval, currentInterval)
 	case *ThanosSeriesRequest:
-		return fmt.Sprintf("fe:%s:%s:%d", userID, tr.Matchers, currentInterval)
+		splitInterval := tr.SplitInterval.Milliseconds()
+		currentInterval := r.GetStart() / splitInterval
+		return fmt.Sprintf("fe:%s:%s:%d:%d", userID, tr.Matchers, splitInterval, currentInterval)
 	}
-	return fmt.Sprintf("fe:%s:%s:%d:%d", userID, r.GetQuery(), r.GetStep(), currentInterval)
+
+	return "request_type_not_supported"
 }
 
 func generateShardInfoKey(r *ThanosQueryRangeRequest) string {

--- a/pkg/queryfrontend/cache_test.go
+++ b/pkg/queryfrontend/cache_test.go
@@ -23,15 +23,6 @@ func TestGenerateCacheKey(t *testing.T) {
 		expected string
 	}{
 		{
-			name: "non thanos req",
-			req: &queryrange.PrometheusRequest{
-				Query: "up",
-				Start: 0,
-				Step:  60 * seconds,
-			},
-			expected: "request_type_not_supported",
-		},
-		{
 			name: "non downsampling resolution specified",
 			req: &ThanosQueryRangeRequest{
 				Query:         "up",
@@ -163,4 +154,24 @@ func TestGenerateCacheKey(t *testing.T) {
 			testutil.Equals(t, tc.expected, key)
 		})
 	}
+}
+
+func TestGenerateCacheKey_UnsupportedRequest(t *testing.T) {
+	splitter := newThanosCacheKeyGenerator()
+
+	req := &queryrange.PrometheusRequest{
+		Query: "up",
+		Start: 0,
+		Step:  60 * seconds,
+	}
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic")
+		} else {
+			testutil.Assert(t, r == "request type not supported", "unexpected panic: %v", r)
+		}
+	}()
+
+	splitter.GenerateCacheKey("", req)
 }

--- a/pkg/queryfrontend/request.go
+++ b/pkg/queryfrontend/request.go
@@ -27,6 +27,12 @@ type ShardedRequest interface {
 	WithShardInfo(info *storepb.ShardInfo) queryrange.Request
 }
 
+// SplitRequest interface represents a query request that can be split horizontally.
+type SplitRequest interface {
+	GetSplitInterval() time.Duration
+	WithSplitInterval(interval time.Duration) queryrange.Request
+}
+
 type RequestHeader struct {
 	Name   string
 	Values []string
@@ -57,6 +63,7 @@ type ThanosQueryRangeRequest struct {
 	LookbackDelta       int64
 	Analyze             bool
 	Engine              string
+	SplitInterval       time.Duration
 }
 
 // IsDedupEnabled returns true if deduplication is enabled.
@@ -83,6 +90,8 @@ func (r *ThanosQueryRangeRequest) GetCachingOptions() queryrange.CachingOptions 
 
 func (r *ThanosQueryRangeRequest) GetStats() string { return r.Stats }
 
+func (r *ThanosQueryRangeRequest) GetSplitInterval() time.Duration { return r.SplitInterval }
+
 func (r *ThanosQueryRangeRequest) WithStats(stats string) queryrange.Request {
 	q := *r
 	q.Stats = stats
@@ -108,6 +117,13 @@ func (r *ThanosQueryRangeRequest) WithQuery(query string) queryrange.Request {
 func (r *ThanosQueryRangeRequest) WithShardInfo(info *storepb.ShardInfo) queryrange.Request {
 	q := *r
 	q.ShardInfo = info
+	return &q
+}
+
+// WithSplitInterval clones the current request with a different split interval.
+func (r *ThanosQueryRangeRequest) WithSplitInterval(interval time.Duration) queryrange.Request {
+	q := *r
+	q.SplitInterval = interval
 	return &q
 }
 
@@ -246,6 +262,7 @@ type ThanosLabelsRequest struct {
 	CachingOptions  queryrange.CachingOptions
 	Headers         []*RequestHeader
 	Stats           string
+	SplitInterval   time.Duration
 }
 
 // GetStoreMatchers returns store matches.
@@ -268,6 +285,8 @@ func (r *ThanosLabelsRequest) GetCachingOptions() queryrange.CachingOptions { re
 
 func (r *ThanosLabelsRequest) GetStats() string { return r.Stats }
 
+func (r *ThanosLabelsRequest) GetSplitInterval() time.Duration { return r.SplitInterval }
+
 func (r *ThanosLabelsRequest) WithStats(stats string) queryrange.Request {
 	q := *r
 	q.Stats = stats
@@ -285,6 +304,13 @@ func (r *ThanosLabelsRequest) WithStartEnd(start, end int64) queryrange.Request 
 // WithQuery clone the current request with a different query.
 func (r *ThanosLabelsRequest) WithQuery(_ string) queryrange.Request {
 	q := *r
+	return &q
+}
+
+// WithSplitInterval clones the current request with a different split interval.
+func (r *ThanosLabelsRequest) WithSplitInterval(interval time.Duration) queryrange.Request {
+	q := *r
+	q.SplitInterval = interval
 	return &q
 }
 
@@ -328,6 +354,7 @@ type ThanosSeriesRequest struct {
 	CachingOptions  queryrange.CachingOptions
 	Headers         []*RequestHeader
 	Stats           string
+	SplitInterval   time.Duration
 }
 
 // IsDedupEnabled returns true if deduplication is enabled.
@@ -353,6 +380,8 @@ func (r *ThanosSeriesRequest) GetCachingOptions() queryrange.CachingOptions { re
 
 func (r *ThanosSeriesRequest) GetStats() string { return r.Stats }
 
+func (r *ThanosSeriesRequest) GetSplitInterval() time.Duration { return r.SplitInterval }
+
 func (r *ThanosSeriesRequest) WithStats(stats string) queryrange.Request {
 	q := *r
 	q.Stats = stats
@@ -370,6 +399,13 @@ func (r *ThanosSeriesRequest) WithStartEnd(start, end int64) queryrange.Request 
 // WithQuery clone the current request with a different query.
 func (r *ThanosSeriesRequest) WithQuery(_ string) queryrange.Request {
 	q := *r
+	return &q
+}
+
+// WithSplitInterval clones the current request with a different split interval.
+func (r *ThanosSeriesRequest) WithSplitInterval(interval time.Duration) queryrange.Request {
+	q := *r
+	q.SplitInterval = interval
 	return &q
 }
 

--- a/pkg/queryfrontend/roundtrip.go
+++ b/pkg/queryfrontend/roundtrip.go
@@ -216,7 +216,7 @@ func newQueryRangeTripperware(
 		queryCacheMiddleware, _, err := queryrange.NewResultsCacheMiddleware(
 			logger,
 			*config.ResultsCacheConfig,
-			newThanosCacheKeyGenerator(dynamicIntervalFn(config)),
+			newThanosCacheKeyGenerator(),
 			limits,
 			codec,
 			queryrange.PrometheusResponseExtractor{},
@@ -299,11 +299,10 @@ func newLabelsTripperware(
 	}
 
 	if config.ResultsCacheConfig != nil {
-		staticIntervalFn := func(_ queryrange.Request) time.Duration { return config.SplitQueriesByInterval }
 		queryCacheMiddleware, _, err := queryrange.NewResultsCacheMiddleware(
 			logger,
 			*config.ResultsCacheConfig,
-			newThanosCacheKeyGenerator(staticIntervalFn),
+			newThanosCacheKeyGenerator(),
 			limits,
 			codec,
 			ThanosResponseExtractor{},

--- a/pkg/queryfrontend/split_by_interval_test.go
+++ b/pkg/queryfrontend/split_by_interval_test.go
@@ -30,10 +30,11 @@ func TestSplitQuery(t *testing.T) {
 			},
 			expected: []queryrange.Request{
 				&ThanosQueryRangeRequest{
-					Start: 0,
-					End:   60 * 60 * seconds,
-					Step:  15 * seconds,
-					Query: "foo",
+					Start:         0,
+					End:           60 * 60 * seconds,
+					Step:          15 * seconds,
+					Query:         "foo",
+					SplitInterval: day,
 				},
 			},
 			interval: day,
@@ -47,10 +48,11 @@ func TestSplitQuery(t *testing.T) {
 			},
 			expected: []queryrange.Request{
 				&ThanosQueryRangeRequest{
-					Start: 60 * 60 * seconds,
-					End:   60 * 60 * seconds,
-					Step:  15 * seconds,
-					Query: "foo",
+					Start:         60 * 60 * seconds,
+					End:           60 * 60 * seconds,
+					Step:          15 * seconds,
+					Query:         "foo",
+					SplitInterval: day,
 				},
 			},
 			interval: day,
@@ -64,10 +66,11 @@ func TestSplitQuery(t *testing.T) {
 			},
 			expected: []queryrange.Request{
 				&ThanosQueryRangeRequest{
-					Start: 0,
-					End:   60 * 60 * seconds,
-					Step:  15 * seconds,
-					Query: "foo",
+					Start:         0,
+					End:           60 * 60 * seconds,
+					Step:          15 * seconds,
+					Query:         "foo",
+					SplitInterval: 3 * time.Hour,
 				},
 			},
 			interval: 3 * time.Hour,
@@ -81,10 +84,11 @@ func TestSplitQuery(t *testing.T) {
 			},
 			expected: []queryrange.Request{
 				&ThanosQueryRangeRequest{
-					Start: 0,
-					End:   24 * 3600 * seconds,
-					Step:  15 * seconds,
-					Query: "foo",
+					Start:         0,
+					End:           24 * 3600 * seconds,
+					Step:          15 * seconds,
+					Query:         "foo",
+					SplitInterval: day,
 				},
 			},
 			interval: day,
@@ -98,10 +102,11 @@ func TestSplitQuery(t *testing.T) {
 			},
 			expected: []queryrange.Request{
 				&ThanosQueryRangeRequest{
-					Start: 0,
-					End:   3 * 3600 * seconds,
-					Step:  15 * seconds,
-					Query: "foo",
+					Start:         0,
+					End:           3 * 3600 * seconds,
+					Step:          15 * seconds,
+					Query:         "foo",
+					SplitInterval: 3 * time.Hour,
 				},
 			},
 			interval: 3 * time.Hour,
@@ -115,16 +120,18 @@ func TestSplitQuery(t *testing.T) {
 			},
 			expected: []queryrange.Request{
 				&ThanosQueryRangeRequest{
-					Start: 0,
-					End:   (24 * 3600 * seconds) - (15 * seconds),
-					Step:  15 * seconds,
-					Query: "foo @ 0.000",
+					Start:         0,
+					End:           (24 * 3600 * seconds) - (15 * seconds),
+					Step:          15 * seconds,
+					Query:         "foo @ 0.000",
+					SplitInterval: day,
 				},
 				&ThanosQueryRangeRequest{
-					Start: 24 * 3600 * seconds,
-					End:   2 * 24 * 3600 * seconds,
-					Step:  15 * seconds,
-					Query: "foo @ 0.000",
+					Start:         24 * 3600 * seconds,
+					End:           2 * 24 * 3600 * seconds,
+					Step:          15 * seconds,
+					Query:         "foo @ 0.000",
+					SplitInterval: day,
 				},
 			},
 			interval: day,
@@ -138,16 +145,18 @@ func TestSplitQuery(t *testing.T) {
 			},
 			expected: []queryrange.Request{
 				&ThanosQueryRangeRequest{
-					Start: 0,
-					End:   (24 * 3600 * seconds) - (15 * seconds),
-					Step:  15 * seconds,
-					Query: "foo @ 172800.000",
+					Start:         0,
+					End:           (24 * 3600 * seconds) - (15 * seconds),
+					Step:          15 * seconds,
+					Query:         "foo @ 172800.000",
+					SplitInterval: day,
 				},
 				&ThanosQueryRangeRequest{
-					Start: 24 * 3600 * seconds,
-					End:   2 * 24 * 3600 * seconds,
-					Step:  15 * seconds,
-					Query: "foo @ 172800.000",
+					Start:         24 * 3600 * seconds,
+					End:           2 * 24 * 3600 * seconds,
+					Step:          15 * seconds,
+					Query:         "foo @ 172800.000",
+					SplitInterval: day,
 				},
 			},
 			interval: day,
@@ -161,16 +170,18 @@ func TestSplitQuery(t *testing.T) {
 			},
 			expected: []queryrange.Request{
 				&ThanosQueryRangeRequest{
-					Start: 0,
-					End:   (3 * 3600 * seconds) - (15 * seconds),
-					Step:  15 * seconds,
-					Query: "foo",
+					Start:         0,
+					End:           (3 * 3600 * seconds) - (15 * seconds),
+					Step:          15 * seconds,
+					Query:         "foo",
+					SplitInterval: 3 * time.Hour,
 				},
 				&ThanosQueryRangeRequest{
-					Start: 3 * 3600 * seconds,
-					End:   2 * 3 * 3600 * seconds,
-					Step:  15 * seconds,
-					Query: "foo",
+					Start:         3 * 3600 * seconds,
+					End:           2 * 3 * 3600 * seconds,
+					Step:          15 * seconds,
+					Query:         "foo",
+					SplitInterval: 3 * time.Hour,
 				},
 			},
 			interval: 3 * time.Hour,
@@ -184,22 +195,25 @@ func TestSplitQuery(t *testing.T) {
 			},
 			expected: []queryrange.Request{
 				&ThanosQueryRangeRequest{
-					Start: 3 * 3600 * seconds,
-					End:   (24 * 3600 * seconds) - (15 * seconds),
-					Step:  15 * seconds,
-					Query: "foo",
+					Start:         3 * 3600 * seconds,
+					End:           (24 * 3600 * seconds) - (15 * seconds),
+					Step:          15 * seconds,
+					Query:         "foo",
+					SplitInterval: day,
 				},
 				&ThanosQueryRangeRequest{
-					Start: 24 * 3600 * seconds,
-					End:   (2 * 24 * 3600 * seconds) - (15 * seconds),
-					Step:  15 * seconds,
-					Query: "foo",
+					Start:         24 * 3600 * seconds,
+					End:           (2 * 24 * 3600 * seconds) - (15 * seconds),
+					Step:          15 * seconds,
+					Query:         "foo",
+					SplitInterval: day,
 				},
 				&ThanosQueryRangeRequest{
-					Start: 2 * 24 * 3600 * seconds,
-					End:   3 * 24 * 3600 * seconds,
-					Step:  15 * seconds,
-					Query: "foo",
+					Start:         2 * 24 * 3600 * seconds,
+					End:           3 * 24 * 3600 * seconds,
+					Step:          15 * seconds,
+					Query:         "foo",
+					SplitInterval: day,
 				},
 			},
 			interval: day,
@@ -213,22 +227,25 @@ func TestSplitQuery(t *testing.T) {
 			},
 			expected: []queryrange.Request{
 				&ThanosQueryRangeRequest{
-					Start: 2 * 3600 * seconds,
-					End:   (3 * 3600 * seconds) - (15 * seconds),
-					Step:  15 * seconds,
-					Query: "foo",
+					Start:         2 * 3600 * seconds,
+					End:           (3 * 3600 * seconds) - (15 * seconds),
+					Step:          15 * seconds,
+					Query:         "foo",
+					SplitInterval: 3 * time.Hour,
 				},
 				&ThanosQueryRangeRequest{
-					Start: 3 * 3600 * seconds,
-					End:   (2 * 3 * 3600 * seconds) - (15 * seconds),
-					Step:  15 * seconds,
-					Query: "foo",
+					Start:         3 * 3600 * seconds,
+					End:           (2 * 3 * 3600 * seconds) - (15 * seconds),
+					Step:          15 * seconds,
+					Query:         "foo",
+					SplitInterval: 3 * time.Hour,
 				},
 				&ThanosQueryRangeRequest{
-					Start: 2 * 3 * 3600 * seconds,
-					End:   3 * 3 * 3600 * seconds,
-					Step:  15 * seconds,
-					Query: "foo",
+					Start:         2 * 3 * 3600 * seconds,
+					End:           3 * 3 * 3600 * seconds,
+					Step:          15 * seconds,
+					Query:         "foo",
+					SplitInterval: 3 * time.Hour,
 				},
 			},
 			interval: 3 * time.Hour,
@@ -248,6 +265,23 @@ func TestSplitQuery_PromQLErrorReturnsJson(t *testing.T) {
 		End:   3 * 3 * 3600 * seconds,
 		Step:  15 * seconds,
 		Query: "foo{",
+	}
+	queries, err := splitQuery(input, 1*time.Hour)
+	require.Error(t, err)
+	require.Nil(t, queries)
+
+	resp, ok := httpgrpc.HTTPResponseFromError(err)
+	require.True(t, ok, "could not assemble httpgrpc.HTTPResponse, is not status.Status")
+
+	require.True(t, json.Valid(resp.Body), "error message is not valid JSON: %s", resp.Body)
+}
+
+func TestSplitQuery_PrometheusRequest(t *testing.T) {
+	input := &queryrange.PrometheusRequest{
+		Start: 2 * 3600 * seconds,
+		End:   3 * 3 * 3600 * seconds,
+		Step:  15 * seconds,
+		Query: "foo",
 	}
 	queries, err := splitQuery(input, 1*time.Hour)
 	require.Error(t, err)

--- a/test/e2e/query_frontend_test.go
+++ b/test/e2e/query_frontend_test.go
@@ -764,7 +764,7 @@ func TestRangeQueryDynamicHorizontalSharding(t *testing.T) {
 	// make sure that we don't break cortex cache code.
 	testutil.Ok(t, queryFrontend.WaitSumMetrics(e2emon.Equals(4), "cortex_cache_fetched_keys_total"))
 	testutil.Ok(t, queryFrontend.WaitSumMetrics(e2emon.Equals(0), "cortex_cache_hits_total"))
-	testutil.Ok(t, queryFrontend.WaitSumMetrics(e2emon.Equals(2), "querier_cache_added_new_total"))
+	testutil.Ok(t, queryFrontend.WaitSumMetrics(e2emon.Equals(4), "querier_cache_added_new_total"))
 	testutil.Ok(t, queryFrontend.WaitSumMetrics(e2emon.Equals(4), "querier_cache_added_total"))
 	testutil.Ok(t, queryFrontend.WaitSumMetrics(e2emon.Equals(4), "querier_cache_misses_total"))
 


### PR DESCRIPTION
* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

The same interval is used for query splitting and cache key generation (the split interval is stored in requests created during the split).
Split interval has been added to cache keys to avoid overlaps for queries based on different intervals.
Support for caching generic PrometheusRequest has been removed - already PrometheusRequest was not been created by any configured decoder.

## Verification

Run local tests `make test`, run query-frontend on a test environment.
