### PR TITLE
docs: add Thanos store memcached deployment note

### DIFF
--- a/docs/components/store.md
+++ b/docs/components/store.md
@@ -374,6 +374,12 @@ The **required** settings are:
 
 - `addresses`: list of memcached addresses, that will get resolved with the [DNS service discovery](../service-discovery.md#dns-service-discovery) provider. If your cluster supports auto-discovery, you should use the flag `auto_discovery` instead and only point to *one of* the memcached servers. This typically means that there should be only one address specified that resolves to any of the alive memcached servers. Use this for Amazon ElastiCache and other similar services.
 
+**NOTE**: The Memcached client uses a jump hash algorithm to shard cached entries across a cluster of Memcached servers. For this reason, you should make sure memcached servers are not behind any kind of load balancer and their address is configured so that servers are added/removed to the end of the list whenever a scale up/down occurs. For example, if you’re running Memcached in Kubernetes, you may:
+
+1. Deploy your Memcached cluster using a [StatefulSet](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/)
+2. Create a [headless](https://kubernetes.io/docs/concepts/services-networking/service/#headless-services) service for Memcached StatefulSet
+3. Configure the Thanos's memcached `addresses` using the `dnssrvnoa+` [DNS service discovery](../service-discovery.md#dns-service-discovery)
+
 While the remaining settings are **optional**:
 
 - `timeout`: the socket read/write timeout.


### PR DESCRIPTION
Add Memcached deployment note, similar to Cortex [1].

[1] https://cortexmetrics.io/docs/blocks-storage/store-gateway/#memcached-index-cache
