### PR TITLE
feat(sidecar): make external labels configurable

### DIFF
--- a/docs/components/sidecar.md
+++ b/docs/components/sidecar.md
@@ -133,6 +133,8 @@ Flags:
       --http.config=""           [EXPERIMENTAL] Path to the configuration file
                                  that can enable TLS or authentication for all
                                  HTTP endpoints.
+      --label=key="value" ...    External labels to announce. If not defined,
+                                 Prometheus external labels will used.
       --log.format=logfmt        Log format to use. Possible options: logfmt or
                                  json.
       --log.level=info           Log filtering level.

--- a/pkg/promclient/promclient.go
+++ b/pkg/promclient/promclient.go
@@ -208,6 +208,17 @@ func (c *Client) ExternalLabels(ctx context.Context, base *url.URL) (labels.Labe
 	return cfg.GlobalConfig.ExternalLabels, nil
 }
 
+func (c *Client) Health(ctx context.Context, base *url.URL) error {
+	u := *base
+	u.Path = path.Join(u.Path, "/-/healthy")
+
+	span, ctx := tracing.StartSpan(ctx, "/prom_health HTTP[client]")
+	defer span.Finish()
+
+	_, _, err := c.req2xx(ctx, &u, http.MethodHead, nil)
+	return err
+}
+
 type Flags struct {
 	TSDBPath           string         `json:"storage.tsdb.path"`
 	TSDBRetention      model.Duration `json:"storage.tsdb.retention"`


### PR DESCRIPTION
## Changes

Allow setting external labels via cmd flags to support using sidecar with other Prometheus speaking APIs, which do not have config API.
