### PR TITLE
Optimize validateLabels

### DIFF
--- a/pkg/receive/capnproto_writer_bench_test.go
+++ b/pkg/receive/capnproto_writer_bench_test.go
@@ -1,10 +1,14 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
 package receive
 
 import (
-	"github.com/prometheus/prometheus/model/labels"
-	"github.com/stretchr/testify/require"
 	"strconv"
 	"testing"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/stretchr/testify/require"
 )
 
 func BenchmarkValidateLabels(b *testing.B) {

--- a/pkg/receive/capnproto_writer_bench_test.go
+++ b/pkg/receive/capnproto_writer_bench_test.go
@@ -1,0 +1,21 @@
+package receive
+
+import (
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/stretchr/testify/require"
+	"strconv"
+	"testing"
+)
+
+func BenchmarkValidateLabels(b *testing.B) {
+	const numLabels = 20
+	builder := labels.NewScratchBuilder(numLabels)
+	for i := 0; i < numLabels; i++ {
+		builder.Add("name-"+strconv.Itoa(i), "value-"+strconv.Itoa(i))
+	}
+	builder.Sort()
+	lbls := builder.Labels()
+	for i := 0; i < b.N; i++ {
+		require.NoError(b, validateLabels(lbls))
+	}
+}


### PR DESCRIPTION
Validating labels in the capnproto writer seems to use a notable amount of CPU, mostly because it needlessly allocates bytes for each labels validation.

This commit optimizes that function to have zero allocs.

```
benchstat main.out branch.out

name               old time/op    new time/op    delta
ValidateLabels-11     536ns ± 1%     201ns ± 2%   -62.47%  (p=0.000 n=9+9)

name               old alloc/op   new alloc/op   delta
ValidateLabels-11      640B ± 0%        0B       -100.00%  (p=0.000 n=10+10)

name               old allocs/op  new allocs/op  delta
ValidateLabels-11      20.0 ± 0%       0.0       -100.00%  (p=0.000 n=10+10)
```

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
