### PR TITLE
QFE: only log slow query, if it is a query endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#7814](https://github.com/thanos-io/thanos/pull/7814) Store: label_values: if matchers contain **name**=="something", do not add <labelname> != "" to fetch less postings.
 - [#7679](https://github.com/thanos-io/thanos/pull/7679) Query: respect store.limit.* flags when evaluating queries
 - [#7821](https://github.com/thanos-io/thanos/pull/7679) Query/Receive: Fix coroutine leak introduced in https://github.com/thanos-io/thanos/pull/7796.
+- [#7843](https://github.com/thanos-io/thanos/pull/7843) Query Frontend: fix slow query logging for non-query endpoints.
 
 ### Added
 - [#7763](https://github.com/thanos-io/thanos/pull/7763) Ruler: use native histograms for client latency metrics.

--- a/internal/cortex/frontend/transport/handler_test.go
+++ b/internal/cortex/frontend/transport/handler_test.go
@@ -1,0 +1,112 @@
+// Copyright (c) The Cortex Authors.
+// Licensed under the Apache License 2.0.
+
+package transport
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeRoundTripper struct {
+	response       *http.Response
+	err            error
+	requestLatency time.Duration
+}
+
+func (f *fakeRoundTripper) RoundTrip(_ *http.Request) (*http.Response, error) {
+	time.Sleep(f.requestLatency)
+	return f.response, f.err
+}
+
+func TestHandler_SlowQueryLog(t *testing.T) {
+	t.Parallel()
+
+	cfg := HandlerConfig{
+		QueryStatsEnabled:    true,
+		LogQueriesLongerThan: 1 * time.Microsecond,
+	}
+
+	tests := []struct {
+		name     string
+		url      string
+		logParts []string
+	}{
+		{
+			name: "Basic query",
+			url:  "/api/v1/query?query=absent(up)&start=1714262400&end=1714266000",
+			logParts: []string{
+				"slow query detected",
+				"time_taken=",
+				"path=/api/v1/query",
+				"param_query=absent(up)",
+				"param_start=1714262400",
+				"param_end=1714266000",
+			},
+		},
+		{
+			name: "Series call",
+			url:  "/api/v1/series?match[]={__name__=~\"up\"}",
+			logParts: []string{
+				"slow query detected",
+				"time_taken=",
+				"path=/api/v1/series",
+			},
+		},
+		{
+			name: "Query with different parameters",
+			url:  "/api/v1/query_range?query=rate(http_requests_total[5m])&start=1714262400&end=1714266000&step=15",
+			logParts: []string{
+				"slow query detected",
+				"time_taken=",
+				"path=/api/v1/query_range",
+				"param_query=rate(http_requests_total[5m])",
+				"param_start=1714262400",
+				"param_end=1714266000",
+				"param_step=15",
+			},
+		},
+		{
+			name: "Non-query endpoint",
+			url:  "/favicon.ico",
+			// No slow query log for non-query endpoints
+			logParts: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			fakeRoundTripper := &fakeRoundTripper{
+				requestLatency: 2 * time.Microsecond,
+				response: &http.Response{
+					StatusCode: http.StatusOK,
+					Header: http.Header{
+						"Content-Type":  []string{"application/json"},
+						"Server-Timing": []string{"querier;dur=1.23"},
+					},
+					Body: io.NopCloser(bytes.NewBufferString(`{}`)),
+				},
+			}
+
+			logWriter := &bytes.Buffer{}
+			logger := log.NewLogfmtLogger(log.NewSyncWriter(logWriter))
+
+			handler := NewHandler(cfg, fakeRoundTripper, logger, prometheus.NewRegistry())
+
+			handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", tt.url, nil))
+
+			for _, part := range tt.logParts {
+				require.Contains(t, logWriter.String(), part)
+			}
+		})
+	}
+}


### PR DESCRIPTION
In Query Frontend we log slow queries, but we don't differ from a call to `GET /favicon.ico` to a proper query call.
In this PR I am fixing this, by checking that the URL matches one of the Prometheus HTTP API prefixes for query via expression or query of metadata.

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

* Introduced a check for the URL that we are processing, to check if it is a query URL.

