### PR TITLE
docs: fixed indentation level for insecure_skip_verify in storage.md for s3

### DIFF
--- a/docs/storage.md
+++ b/docs/storage.md
@@ -88,7 +88,7 @@ config:
       cert_file: ""
       key_file: ""
       server_name: ""
-      insecure_skip_verify: false
+    insecure_skip_verify: false
     disable_compression: false
   trace:
     enable: false


### PR DESCRIPTION
Fixed indentation level for insecure_skip_verify

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

Fixed indentation level for insecure_skip_verify in s3 docs

