### PR TITLE
Thanos is not able to read redis password passed as environment variable

### DIFF
--- a/pkg/cacheutil/redis_client.go
+++ b/pkg/cacheutil/redis_client.go
@@ -207,7 +207,7 @@ func NewRedisClientWithConfig(logger log.Logger, name string, config RedisClient
 		InitAddress:       strings.Split(config.Addr, ","),
 		ShuffleInit:       true,
 		Username:          config.Username,
-		Password:          config.Password,
+		Password:          config.Password.String(),
 		SelectDB:          config.DB,
 		CacheSizeEachConn: int(config.CacheSize),
 		Dialer:            net.Dialer{Timeout: config.DialTimeout},


### PR DESCRIPTION
we don't have that problem with loki, and I think the reason is they use different redis package (go-redis), and also the interpretation of Password
Ref: https://github.com/grafana/loki/blob/main/pkg/storage/chunk/cache/redis_client.go#L69 


with below config

```
    indexCacheConfig: |
      type: REDIS
      config:
        addr: ${THANOS_CACHE_REDIS_ENDPOINT}:6379
        password: ${THANOS_CACHE_REDIS_PASSWORD}
        ....
```
and 
```
      - name: THANOS_CACHE_REDIS_PASSWORD
        valueFrom:
          secretKeyRef:
            name: thanos-metrics-redis
            key: password
```
we face
```
WRONGPASS invalid username-password pair or user is disabled.\ncreate REDIS index cache
```
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
