### PR TITLE
add ability to run rule with remote write AND tsdb (statelessMode flag)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#7886](https://github.com/thanos-io/thanos/pull/7886) Discovery: Preserve results from other resolve calls
 - [#7745](https://github.com/thanos-io/thanos/pull/7745) *: Build with Prometheus stringlabels tags
 - [#7669](https://github.com/thanos-io/thanos/pull/7669) Receive: Change quorum calculation for rf=2
+- [#7875](https://github.com/thanos-io/thanos/pull/7875) Ruler: add ability to run rule with remote write AND tsdb (statelessMode flag)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,7 +101,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#7886](https://github.com/thanos-io/thanos/pull/7886) Discovery: Preserve results from other resolve calls
 - [#7745](https://github.com/thanos-io/thanos/pull/7745) *: Build with Prometheus stringlabels tags
 - [#7669](https://github.com/thanos-io/thanos/pull/7669) Receive: Change quorum calculation for rf=2
-- [#7875](https://github.com/thanos-io/thanos/pull/7875) Ruler: add ability to run rule with remote write AND tsdb (statelessMode flag)
+- [#7813](https://github.com/thanos-io/thanos/pull/7813) Receiver: enable initial TSDB compaction time randomization
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -937,11 +937,11 @@ The binaries published with this release are built with Go1.17.8 to avoid [CVE-2
 
 ### Changed
 
--
+- 
 
 ### Removed
 
--
+- 
 
 ## [v0.20.0](https://github.com/thanos-io/thanos/releases/tag/v0.20.0) - 2021.04.28
 

--- a/docs/components/compact.md
+++ b/docs/components/compact.md
@@ -279,10 +279,10 @@ usage: thanos compact [<flags>]
 Continuously compacts blocks in an object store bucket.
 
 Flags:
-      --auto-gomemlimit.ratio=0.9
+      --auto-gomemlimit.ratio=0.9  
                                 The ratio of reserved GOMEMLIMIT memory to the
                                 detected maximum container or system memory.
-      --block-discovery-strategy="concurrent"
+      --block-discovery-strategy="concurrent"  
                                 One of concurrent, recursive. When set to
                                 concurrent, stores will concurrently issue
                                 one call per directory to discover active
@@ -291,28 +291,28 @@ Flags:
                                 recursively traversing into each directory.
                                 This avoids N+1 calls at the expense of having
                                 slower bucket iterations.
-      --block-files-concurrency=1
+      --block-files-concurrency=1  
                                 Number of goroutines to use when
                                 fetching/uploading block files from object
                                 storage.
-      --block-meta-fetch-concurrency=32
+      --block-meta-fetch-concurrency=32  
                                 Number of goroutines to use when fetching block
                                 metadata from object storage.
-      --block-viewer.global.sync-block-interval=1m
+      --block-viewer.global.sync-block-interval=1m  
                                 Repeat interval for syncing the blocks between
                                 local and remote view for /global Block Viewer
                                 UI.
-      --block-viewer.global.sync-block-timeout=5m
+      --block-viewer.global.sync-block-timeout=5m  
                                 Maximum time for syncing the blocks between
                                 local and remote view for /global Block Viewer
                                 UI.
-      --bucket-web-label=BUCKET-WEB-LABEL
+      --bucket-web-label=BUCKET-WEB-LABEL  
                                 External block label to use as group title in
                                 the bucket web UI
-      --compact.blocks-fetch-concurrency=1
+      --compact.blocks-fetch-concurrency=1  
                                 Number of goroutines to use when download block
                                 during compaction.
-      --compact.cleanup-interval=5m
+      --compact.cleanup-interval=5m  
                                 How often we should clean up partially uploaded
                                 blocks and blocks with deletion mark in the
                                 background when --wait has been enabled. Setting
@@ -320,7 +320,7 @@ Flags:
                                 happen at the end of an iteration.
       --compact.concurrency=1   Number of goroutines to use when compacting
                                 groups.
-      --compact.progress-interval=5m
+      --compact.progress-interval=5m  
                                 Frequency of calculating the compaction progress
                                 in the background when --wait has been enabled.
                                 Setting it to "0s" disables it. Now compaction,
@@ -341,7 +341,7 @@ Flags:
                                 based deduplication algorithm will be used.
                                 At least one replica label has to be set via
                                 --deduplication.replica-label flag.
-      --deduplication.replica-label=DEDUPLICATION.REPLICA-LABEL ...
+      --deduplication.replica-label=DEDUPLICATION.REPLICA-LABEL ...  
                                 Experimental. Label to treat as a replica
                                 indicator of blocks that can be deduplicated
                                 (repeated flag). This will merge multiple
@@ -369,10 +369,10 @@ Flags:
                                 block loaded, or compactor is ignoring the
                                 deletion because it's compacting the block at
                                 the same time.
-      --disable-admin-operations
+      --disable-admin-operations  
                                 Disable UI/API admin operations like marking
                                 blocks for deletion and no compaction.
-      --downsample.concurrency=1
+      --downsample.concurrency=1  
                                 Number of goroutines to use when downsampling
                                 blocks.
       --downsampling.disable    Disables downsampling. This is not recommended
@@ -390,7 +390,7 @@ Flags:
                                 Possible values are: "", "SHA256".
   -h, --help                    Show context-sensitive help (also try
                                 --help-long and --help-man).
-      --http-address="0.0.0.0:10902"
+      --http-address="0.0.0.0:10902"  
                                 Listen host:port for HTTP endpoints.
       --http-grace-period=2m    Time to wait after an interrupt received for
                                 HTTP Server.
@@ -400,7 +400,7 @@ Flags:
       --log.format=logfmt       Log format to use. Possible options: logfmt or
                                 json.
       --log.level=info          Log filtering level.
-      --max-time=9999-12-31T23:59:59Z
+      --max-time=9999-12-31T23:59:59Z  
                                 End of time range limit to compact.
                                 Thanos Compactor will compact only blocks,
                                 which happened earlier than this value. Option
@@ -408,36 +408,36 @@ Flags:
                                 duration relative to current time, such as -1d
                                 or 2h45m. Valid duration units are ms, s, m, h,
                                 d, w, y.
-      --min-time=0000-01-01T00:00:00Z
+      --min-time=0000-01-01T00:00:00Z  
                                 Start of time range limit to compact.
                                 Thanos Compactor will compact only blocks, which
                                 happened later than this value. Option can be a
                                 constant time in RFC3339 format or time duration
                                 relative to current time, such as -1d or 2h45m.
                                 Valid duration units are ms, s, m, h, d, w, y.
-      --objstore.config=<content>
+      --objstore.config=<content>  
                                 Alternative to 'objstore.config-file'
                                 flag (mutually exclusive). Content of
                                 YAML file that contains object store
                                 configuration. See format details:
                                 https://thanos.io/tip/thanos/storage.md/#configuration
-      --objstore.config-file=<file-path>
+      --objstore.config-file=<file-path>  
                                 Path to YAML file that contains object
                                 store configuration. See format details:
                                 https://thanos.io/tip/thanos/storage.md/#configuration
-      --retention.resolution-1h=0d
+      --retention.resolution-1h=0d  
                                 How long to retain samples of resolution 2 (1
                                 hour) in bucket. Setting this to 0d will retain
                                 samples of this resolution forever
-      --retention.resolution-5m=0d
+      --retention.resolution-5m=0d  
                                 How long to retain samples of resolution 1 (5
                                 minutes) in bucket. Setting this to 0d will
                                 retain samples of this resolution forever
-      --retention.resolution-raw=0d
+      --retention.resolution-raw=0d  
                                 How long to retain raw samples in bucket.
                                 Setting this to 0d will retain samples of this
                                 resolution forever
-      --selector.relabel-config=<content>
+      --selector.relabel-config=<content>  
                                 Alternative to 'selector.relabel-config-file'
                                 flag (mutually exclusive). Content of YAML
                                 file with relabeling configuration that allows
@@ -445,19 +445,19 @@ Flags:
                                 external labels. It follows thanos sharding
                                 relabel-config syntax. For format details see:
                                 https://thanos.io/tip/thanos/sharding.md/#relabelling
-      --selector.relabel-config-file=<file-path>
+      --selector.relabel-config-file=<file-path>  
                                 Path to YAML file with relabeling
                                 configuration that allows selecting blocks
                                 to act on based on their external labels.
                                 It follows thanos sharding relabel-config
                                 syntax. For format details see:
                                 https://thanos.io/tip/thanos/sharding.md/#relabelling
-      --tracing.config=<content>
+      --tracing.config=<content>  
                                 Alternative to 'tracing.config-file' flag
                                 (mutually exclusive). Content of YAML file
                                 with tracing configuration. See format details:
                                 https://thanos.io/tip/thanos/tracing.md/#configuration
-      --tracing.config-file=<file-path>
+      --tracing.config-file=<file-path>  
                                 Path to YAML file with tracing
                                 configuration. See format details:
                                 https://thanos.io/tip/thanos/tracing.md/#configuration

--- a/docs/components/query-frontend.md
+++ b/docs/components/query-frontend.md
@@ -278,10 +278,6 @@ Flags:
                                  functions in query-frontend.
                                  --no-query-frontend.enable-x-functions for
                                  disabling.
-      --query-frontend.force-query-stats
-                                 Enables query statistics for all queries and
-                                 will export statistics as logs and service
-                                 headers.
       --query-frontend.forward-header=<http-header-name> ...
                                  List of headers forwarded by the query-frontend
                                  to downstream queriers, default is empty

--- a/docs/components/query-frontend.md
+++ b/docs/components/query-frontend.md
@@ -47,6 +47,8 @@ Query Frontend supports caching query results and reuses them on subsequent quer
 #### In-memory
 
 ```yaml mdox-exec="go run scripts/cfggen/main.go --name=queryfrontend.InMemoryResponseCacheConfig"
+# command-line-arguments
+ld: warning: ignoring duplicate libraries: '-lproc'
 type: IN-MEMORY
 config:
   max_size: ""
@@ -65,6 +67,8 @@ Example configuration: [kube-thanos](https://github.com/thanos-io/kube-thanos/bl
 #### Memcached
 
 ```yaml mdox-exec="go run scripts/cfggen/main.go --name=queryfrontend.MemcachedResponseCacheConfig"
+# command-line-arguments
+ld: warning: ignoring duplicate libraries: '-lproc'
 type: MEMCACHED
 config:
   addresses: []
@@ -115,6 +119,8 @@ config:
 The default redis config is:
 
 ```yaml mdox-exec="go run scripts/cfggen/main.go --name=queryfrontend.RedisResponseCacheConfig"
+# command-line-arguments
+ld: warning: ignoring duplicate libraries: '-lproc'
 type: REDIS
 config:
   addr: ""
@@ -201,10 +207,10 @@ Query frontend command implements a service deployed in front of queriers to
 improve query parallelization and caching.
 
 Flags:
-      --auto-gomemlimit.ratio=0.9
+      --auto-gomemlimit.ratio=0.9  
                                  The ratio of reserved GOMEMLIMIT memory to the
                                  detected maximum container or system memory.
-      --cache-compression-type=""
+      --cache-compression-type=""  
                                  Use compression in results cache.
                                  Supported values are: 'snappy' and ” (disable
                                  compression).
@@ -212,40 +218,40 @@ Flags:
                                  consumption.
   -h, --help                     Show context-sensitive help (also try
                                  --help-long and --help-man).
-      --http-address="0.0.0.0:10902"
+      --http-address="0.0.0.0:10902"  
                                  Listen host:port for HTTP endpoints.
       --http-grace-period=2m     Time to wait after an interrupt received for
                                  HTTP Server.
       --http.config=""           [EXPERIMENTAL] Path to the configuration file
                                  that can enable TLS or authentication for all
                                  HTTP endpoints.
-      --labels.default-time-range=24h
+      --labels.default-time-range=24h  
                                  The default metadata time range duration for
                                  retrieving labels through Labels and Series API
                                  when the range parameters are not specified.
-      --labels.max-query-parallelism=14
+      --labels.max-query-parallelism=14  
                                  Maximum number of labels requests will be
                                  scheduled in parallel by the Frontend.
-      --labels.max-retries-per-request=5
+      --labels.max-retries-per-request=5  
                                  Maximum number of retries for a single
                                  label/series API request; beyond this,
                                  the downstream error is returned.
       --labels.partial-response  Enable partial response for labels requests
                                  if no partial_response param is specified.
                                  --no-labels.partial-response for disabling.
-      --labels.response-cache-config=<content>
+      --labels.response-cache-config=<content>  
                                  Alternative to
                                  'labels.response-cache-config-file' flag
                                  (mutually exclusive). Content of YAML file that
                                  contains response cache configuration.
-      --labels.response-cache-config-file=<file-path>
+      --labels.response-cache-config-file=<file-path>  
                                  Path to YAML file that contains response cache
                                  configuration.
-      --labels.response-cache-max-freshness=1m
+      --labels.response-cache-max-freshness=1m  
                                  Most recent allowed cacheable result for
                                  labels requests, to prevent caching very recent
                                  results that might still be in flux.
-      --labels.split-interval=24h
+      --labels.split-interval=24h  
                                  Split labels requests by an interval and
                                  execute in parallel, it should be greater
                                  than 0 when labels.response-cache-config is
@@ -253,9 +259,9 @@ Flags:
       --log.format=logfmt        Log format to use. Possible options: logfmt or
                                  json.
       --log.level=info           Log filtering level.
-      --query-frontend.compress-responses
+      --query-frontend.compress-responses  
                                  Compress HTTP responses.
-      --query-frontend.downstream-tripper-config=<content>
+      --query-frontend.downstream-tripper-config=<content>  
                                  Alternative to
                                  'query-frontend.downstream-tripper-config-file'
                                  flag (mutually exclusive). Content of YAML file
@@ -264,28 +270,28 @@ Flags:
                                  127.0.0.1 then it is highly recommended to
                                  increase max_idle_conns_per_host to at least
                                  100.
-      --query-frontend.downstream-tripper-config-file=<file-path>
+      --query-frontend.downstream-tripper-config-file=<file-path>  
                                  Path to YAML file that contains downstream
                                  tripper configuration. If your downstream URL
                                  is localhost or 127.0.0.1 then it is highly
                                  recommended to increase max_idle_conns_per_host
                                  to at least 100.
-      --query-frontend.downstream-url="http://localhost:9090"
+      --query-frontend.downstream-url="http://localhost:9090"  
                                  URL of downstream Prometheus Query compatible
                                  API.
-      --query-frontend.enable-x-functions
+      --query-frontend.enable-x-functions  
                                  Enable experimental x-
                                  functions in query-frontend.
                                  --no-query-frontend.enable-x-functions for
                                  disabling.
-      --query-frontend.forward-header=<http-header-name> ...
+      --query-frontend.forward-header=<http-header-name> ...  
                                  List of headers forwarded by the query-frontend
                                  to downstream queriers, default is empty
-      --query-frontend.log-queries-longer-than=0
+      --query-frontend.log-queries-longer-than=0  
                                  Log queries that are slower than the specified
                                  duration. Set to 0 to disable. Set to < 0 to
                                  enable on all queries.
-      --query-frontend.org-id-header=<http-header-name> ...
+      --query-frontend.org-id-header=<http-header-name> ...  
                                  Deprecation Warning - This flag
                                  will be soon deprecated in favor of
                                  query-frontend.tenant-header and both flags
@@ -297,42 +303,42 @@ Flags:
                                  the request, the first matching arg specified
                                  will take precedence. If no headers match
                                  'anonymous' will be used.
-      --query-frontend.slow-query-logs-user-header=<http-header-name>
+      --query-frontend.slow-query-logs-user-header=<http-header-name>  
                                  Set the value of the field remote_user in the
                                  slow query logs to the value of the given HTTP
                                  header. Falls back to reading the user from the
                                  basic auth header.
-      --query-frontend.vertical-shards=QUERY-FRONTEND.VERTICAL-SHARDS
+      --query-frontend.vertical-shards=QUERY-FRONTEND.VERTICAL-SHARDS  
                                  Number of shards to use when
                                  distributing shardable PromQL queries.
                                  For more details, you can refer to
                                  the Vertical query sharding proposal:
                                  https://thanos.io/tip/proposals-accepted/202205-vertical-query-sharding.md
-      --query-range.align-range-with-step
+      --query-range.align-range-with-step  
                                  Mutate incoming queries to align their
                                  start and end with their step for better
                                  cache-ability. Note: Grafana dashboards do that
                                  by default.
-      --query-range.horizontal-shards=0
+      --query-range.horizontal-shards=0  
                                  Split queries in this many requests
                                  when query duration is below
                                  query-range.max-split-interval.
-      --query-range.max-query-length=0
+      --query-range.max-query-length=0  
                                  Limit the query time range (end - start time)
                                  in the query-frontend, 0 disables it.
-      --query-range.max-query-parallelism=14
+      --query-range.max-query-parallelism=14  
                                  Maximum number of query range requests will be
                                  scheduled in parallel by the Frontend.
-      --query-range.max-retries-per-request=5
+      --query-range.max-retries-per-request=5  
                                  Maximum number of retries for a single query
                                  range request; beyond this, the downstream
                                  error is returned.
-      --query-range.max-split-interval=0
+      --query-range.max-split-interval=0  
                                  Split query range below this interval in
                                  query-range.horizontal-shards. Queries with a
                                  range longer than this value will be split in
                                  multiple requests of this length.
-      --query-range.min-split-interval=0
+      --query-range.min-split-interval=0  
                                  Split query range requests above this
                                  interval in query-range.horizontal-shards
                                  requests of equal range. Using
@@ -340,48 +346,48 @@ Flags:
                                  query-range.split-interval. One should also set
                                  query-range.split-min-horizontal-shards to a
                                  value greater than 1 to enable splitting.
-      --query-range.partial-response
+      --query-range.partial-response  
                                  Enable partial response for query range
                                  requests if no partial_response param is
                                  specified. --no-query-range.partial-response
                                  for disabling.
-      --query-range.request-downsampled
+      --query-range.request-downsampled  
                                  Make additional query for downsampled data in
                                  case of empty or incomplete response to range
                                  request.
-      --query-range.response-cache-config=<content>
+      --query-range.response-cache-config=<content>  
                                  Alternative to
                                  'query-range.response-cache-config-file' flag
                                  (mutually exclusive). Content of YAML file that
                                  contains response cache configuration.
-      --query-range.response-cache-config-file=<file-path>
+      --query-range.response-cache-config-file=<file-path>  
                                  Path to YAML file that contains response cache
                                  configuration.
-      --query-range.response-cache-max-freshness=1m
+      --query-range.response-cache-max-freshness=1m  
                                  Most recent allowed cacheable result for query
                                  range requests, to prevent caching very recent
                                  results that might still be in flux.
-      --query-range.split-interval=24h
+      --query-range.split-interval=24h  
                                  Split query range requests by an interval and
                                  execute in parallel, it should be greater than
                                  0 when query-range.response-cache-config is
                                  configured.
-      --request.logging-config=<content>
+      --request.logging-config=<content>  
                                  Alternative to 'request.logging-config-file'
                                  flag (mutually exclusive). Content
                                  of YAML file with request logging
                                  configuration. See format details:
                                  https://thanos.io/tip/thanos/logging.md/#configuration
-      --request.logging-config-file=<file-path>
+      --request.logging-config-file=<file-path>  
                                  Path to YAML file with request logging
                                  configuration. See format details:
                                  https://thanos.io/tip/thanos/logging.md/#configuration
-      --tracing.config=<content>
+      --tracing.config=<content>  
                                  Alternative to 'tracing.config-file' flag
                                  (mutually exclusive). Content of YAML file
                                  with tracing configuration. See format details:
                                  https://thanos.io/tip/thanos/tracing.md/#configuration
-      --tracing.config-file=<file-path>
+      --tracing.config-file=<file-path>  
                                  Path to YAML file with tracing
                                  configuration. See format details:
                                  https://thanos.io/tip/thanos/tracing.md/#configuration

--- a/docs/components/query.md
+++ b/docs/components/query.md
@@ -291,10 +291,10 @@ Query node exposing PromQL enabled Query API with data retrieved from multiple
 store nodes.
 
 Flags:
-      --alert.query-url=ALERT.QUERY-URL
+      --alert.query-url=ALERT.QUERY-URL  
                                  The external Thanos Query URL that would be set
                                  in all alerts 'Source' field.
-      --auto-gomemlimit.ratio=0.9
+      --auto-gomemlimit.ratio=0.9  
                                  The ratio of reserved GOMEMLIMIT memory to the
                                  detected maximum container or system memory.
       --enable-auto-gomemlimit   Enable go runtime to automatically limit memory
@@ -304,27 +304,27 @@ Flags:
                                  prefixed with 'dns+' or 'dnssrv+' to detect
                                  Thanos API servers through respective DNS
                                  lookups.
-      --endpoint-group=<endpoint-group> ...
+      --endpoint-group=<endpoint-group> ...  
                                  Experimental: DNS name of statically configured
                                  Thanos API server groups (repeatable). Targets
                                  resolved from the DNS name will be queried in
                                  a round-robin, instead of a fanout manner.
                                  This flag should be used when connecting a
                                  Thanos Query to HA groups of Thanos components.
-      --endpoint-group-strict=<endpoint-group-strict> ...
+      --endpoint-group-strict=<endpoint-group-strict> ...  
                                  Experimental: DNS name of statically configured
                                  Thanos API server groups (repeatable) that are
                                  always used, even if the health check fails.
-      --endpoint-strict=<staticendpoint> ...
+      --endpoint-strict=<staticendpoint> ...  
                                  Addresses of only statically configured Thanos
                                  API servers that are always used, even if
                                  the health check fails. Useful if you have a
                                  caching layer on top.
-      --grpc-address="0.0.0.0:10901"
+      --grpc-address="0.0.0.0:10901"  
                                  Listen ip:port address for gRPC endpoints
                                  (StoreAPI). Make sure this address is routable
                                  from other components.
-      --grpc-client-server-name=""
+      --grpc-client-server-name=""  
                                  Server name to verify the hostname on
                                  the returned gRPC certificates. See
                                  https://tools.ietf.org/html/rfc4366#section-3.1
@@ -334,33 +334,33 @@ Flags:
                                  to the server
       --grpc-client-tls-key=""   TLS Key for the client's certificate
       --grpc-client-tls-secure   Use TLS when talking to the gRPC server
-      --grpc-client-tls-skip-verify
+      --grpc-client-tls-skip-verify  
                                  Disable TLS certificate verification i.e self
                                  signed, signed by fake CA
       --grpc-compression=none    Compression algorithm to use for gRPC requests
                                  to other clients. Must be one of: snappy, none
       --grpc-grace-period=2m     Time to wait after an interrupt received for
                                  GRPC Server.
-      --grpc-server-max-connection-age=60m
+      --grpc-server-max-connection-age=60m  
                                  The grpc server max connection age. This
                                  controls how often to re-establish connections
                                  and redo TLS handshakes.
       --grpc-server-tls-cert=""  TLS Certificate for gRPC server, leave blank to
                                  disable TLS
-      --grpc-server-tls-client-ca=""
+      --grpc-server-tls-client-ca=""  
                                  TLS CA to verify clients against. If no
                                  client CA is specified, there is no client
                                  verification on server side. (tls.NoClientCert)
       --grpc-server-tls-key=""   TLS Key for the gRPC server, leave blank to
                                  disable TLS
-      --grpc-server-tls-min-version="1.3"
+      --grpc-server-tls-min-version="1.3"  
                                  TLS supported minimum version for gRPC server.
                                  If no version is specified, it'll default to
                                  1.3. Allowed values: ["1.0", "1.1", "1.2",
                                  "1.3"]
   -h, --help                     Show context-sensitive help (also try
                                  --help-long and --help-man).
-      --http-address="0.0.0.0:10902"
+      --http-address="0.0.0.0:10902"  
                                  Listen host:port for HTTP endpoints.
       --http-grace-period=2m     Time to wait after an interrupt received for
                                  HTTP Server.
@@ -370,16 +370,16 @@ Flags:
       --log.format=logfmt        Log format to use. Possible options: logfmt or
                                  json.
       --log.level=info           Log filtering level.
-      --query.active-query-path=""
+      --query.active-query-path=""  
                                  Directory to log currently active queries in
                                  the queries.active file.
       --query.auto-downsampling  Enable automatic adjustment (step / 5) to what
                                  source of data should be used in store gateways
                                  if no max_source_resolution param is specified.
-      --query.conn-metric.label=external_labels... ...
+      --query.conn-metric.label=external_labels... ...  
                                  Optional selection of query connection metric
                                  labels to be collected from endpoint set
-      --query.default-evaluation-interval=1m
+      --query.default-evaluation-interval=1m  
                                  Set default evaluation interval for sub
                                  queries.
       --query.default-step=1s    Set default step for range queries. Default
@@ -389,10 +389,10 @@ Flags:
                                  = max(rangeSeconds / 250, defaultStep)).
                                  This will not work from Grafana, but Grafana
                                  has __step variable which can be used.
-      --query.default-tenant-id="default-tenant"
+      --query.default-tenant-id="default-tenant"  
                                  Default tenant ID to use if tenant header is
                                  not present
-      --query.enable-x-functions
+      --query.enable-x-functions  
                                  Whether to enable extended rate functions
                                  (xrate, xincrease and xdelta). Only has effect
                                  when used with Thanos engine.
@@ -400,7 +400,7 @@ Flags:
                                  are returned only if the label value of the
                                  configured tenant-label-name and the value of
                                  the tenant header matches.
-      --query.lookback-delta=QUERY.LOOKBACK-DELTA
+      --query.lookback-delta=QUERY.LOOKBACK-DELTA  
                                  The maximum lookback duration for retrieving
                                  metrics during expression evaluations.
                                  PromQL always evaluates the query for the
@@ -415,10 +415,10 @@ Flags:
                                  If unset it will use the promql default of 5m.
       --query.max-concurrent=20  Maximum number of queries processed
                                  concurrently by query node.
-      --query.max-concurrent-select=4
+      --query.max-concurrent-select=4  
                                  Maximum number of select requests made
                                  concurrently per a query.
-      --query.metadata.default-time-range=0s
+      --query.metadata.default-time-range=0s  
                                  The default metadata time range duration for
                                  retrieving labels through Labels and Series API
                                  when the range parameters are not specified.
@@ -428,7 +428,7 @@ Flags:
       --query.partial-response   Enable partial response for queries if
                                  no partial_response param is specified.
                                  --no-query.partial-response for disabling.
-      --query.partition-label=QUERY.PARTITION-LABEL ...
+      --query.partition-label=QUERY.PARTITION-LABEL ...  
                                  Labels that partition the leaf queriers. This
                                  is used to scope down the labelsets of leaf
                                  queriers when using the distributed query mode.
@@ -441,9 +441,9 @@ Flags:
                                  it allows the distributed engine to ignore them
                                  for some optimizations. If this is empty then
                                  all labels are used as partition labels.
-      --query.promql-engine=prometheus
+      --query.promql-engine=prometheus  
                                  Default PromQL engine to use.
-      --query.replica-label=QUERY.REPLICA-LABEL ...
+      --query.replica-label=QUERY.REPLICA-LABEL ...  
                                  Labels to treat as a replica indicator along
                                  which data is deduplicated. Still you will
                                  be able to query without deduplication using
@@ -451,41 +451,41 @@ Flags:
                                  series, recording rules, and alerting rules.
                                  Flag may be specified multiple times as well as
                                  a comma separated list of labels.
-      --query.telemetry.request-duration-seconds-quantiles=0.1... ...
+      --query.telemetry.request-duration-seconds-quantiles=0.1... ...  
                                  The quantiles for exporting metrics about the
                                  request duration quantiles.
-      --query.telemetry.request-samples-quantiles=100... ...
+      --query.telemetry.request-samples-quantiles=100... ...  
                                  The quantiles for exporting metrics about the
                                  samples count quantiles.
-      --query.telemetry.request-series-seconds-quantiles=10... ...
+      --query.telemetry.request-series-seconds-quantiles=10... ...  
                                  The quantiles for exporting metrics about the
                                  series count quantiles.
-      --query.tenant-certificate-field=
+      --query.tenant-certificate-field=  
                                  Use TLS client's certificate field to determine
                                  tenant for write requests. Must be one of
                                  organization, organizationalUnit or commonName.
                                  This setting will cause the query.tenant-header
                                  flag value to be ignored.
-      --query.tenant-header="THANOS-TENANT"
+      --query.tenant-header="THANOS-TENANT"  
                                  HTTP header to determine tenant.
-      --query.tenant-label-name="tenant_id"
+      --query.tenant-label-name="tenant_id"  
                                  Label name to use when enforcing tenancy (if
                                  --query.enforce-tenancy is enabled).
       --query.timeout=2m         Maximum time to process query by query node.
-      --request.logging-config=<content>
+      --request.logging-config=<content>  
                                  Alternative to 'request.logging-config-file'
                                  flag (mutually exclusive). Content
                                  of YAML file with request logging
                                  configuration. See format details:
                                  https://thanos.io/tip/thanos/logging.md/#configuration
-      --request.logging-config-file=<file-path>
+      --request.logging-config-file=<file-path>  
                                  Path to YAML file with request logging
                                  configuration. See format details:
                                  https://thanos.io/tip/thanos/logging.md/#configuration
-      --selector-label=<name>="<value>" ...
+      --selector-label=<name>="<value>" ...  
                                  Query selector labels that will be exposed in
                                  info endpoint (repeated).
-      --selector.relabel-config=<content>
+      --selector.relabel-config=<content>  
                                  Alternative to 'selector.relabel-config-file'
                                  flag (mutually exclusive). Content of YAML
                                  file with relabeling configuration that allows
@@ -493,7 +493,7 @@ Flags:
                                  external labels. It follows the Thanos sharding
                                  relabel-config syntax. For format details see:
                                  https://thanos.io/tip/thanos/sharding.md/#relabelling
-      --selector.relabel-config-file=<file-path>
+      --selector.relabel-config-file=<file-path>  
                                  Path to YAML file with relabeling
                                  configuration that allows selecting blocks
                                  to query based on their external labels.
@@ -506,46 +506,46 @@ Flags:
                                  (repeatable). The scheme may be prefixed with
                                  'dns+' or 'dnssrv+' to detect store API servers
                                  through respective DNS lookups.
-      --store-strict=<staticstore> ...
+      --store-strict=<staticstore> ...  
                                  Deprecation Warning - This flag is deprecated
                                  and replaced with `endpoint-strict`. Addresses
                                  of only statically configured store API servers
                                  that are always used, even if the health check
                                  fails. Useful if you have a caching layer on
                                  top.
-      --store.limits.request-samples=0
+      --store.limits.request-samples=0  
                                  The maximum samples allowed for a single
                                  Series request, The Series call fails if
                                  this limit is exceeded. 0 means no limit.
                                  NOTE: For efficiency the limit is internally
                                  implemented as 'chunks limit' considering each
                                  chunk contains a maximum of 120 samples.
-      --store.limits.request-series=0
+      --store.limits.request-series=0  
                                  The maximum series allowed for a single Series
                                  request. The Series call fails if this limit is
                                  exceeded. 0 means no limit.
-      --store.response-timeout=0ms
+      --store.response-timeout=0ms  
                                  If a Store doesn't send any data in this
                                  specified duration then a Store will be ignored
                                  and partial data will be returned if it's
                                  enabled. 0 disables timeout.
-      --store.sd-dns-interval=30s
+      --store.sd-dns-interval=30s  
                                  Interval between DNS resolutions.
-      --store.sd-files=<path> ...
+      --store.sd-files=<path> ...  
                                  Path to files that contain addresses of store
                                  API servers. The path can be a glob pattern
                                  (repeatable).
       --store.sd-interval=5m     Refresh interval to re-read file SD files.
                                  It is used as a resync fallback.
-      --store.unhealthy-timeout=5m
+      --store.unhealthy-timeout=5m  
                                  Timeout before an unhealthy store is cleaned
                                  from the store UI page.
-      --tracing.config=<content>
+      --tracing.config=<content>  
                                  Alternative to 'tracing.config-file' flag
                                  (mutually exclusive). Content of YAML file
                                  with tracing configuration. See format details:
                                  https://thanos.io/tip/thanos/tracing.md/#configuration
-      --tracing.config-file=<file-path>
+      --tracing.config-file=<file-path>  
                                  Path to YAML file with tracing
                                  configuration. See format details:
                                  https://thanos.io/tip/thanos/tracing.md/#configuration

--- a/docs/components/receive.md
+++ b/docs/components/receive.md
@@ -90,6 +90,8 @@ where `<thanos-receive-containter-ip>` is an IP address reachable by Prometheus 
 The example content of `bucket.yml`:
 
 ```yaml mdox-exec="go run scripts/cfggen/main.go --name=gcs.Config"
+# command-line-arguments
+ld: warning: ignoring duplicate libraries: '-lproc'
 type: GCS
 config:
   bucket: ""
@@ -113,6 +115,7 @@ config:
       insecure_skip_verify: false
     disable_compression: false
   chunk_size_bytes: 0
+  max_retries: 0
 prefix: ""
 ```
 
@@ -354,7 +357,7 @@ usage: thanos receive [<flags>]
 Accept Prometheus remote write API requests and write to local tsdb.
 
 Flags:
-      --auto-gomemlimit.ratio=0.9
+      --auto-gomemlimit.ratio=0.9  
                                  The ratio of reserved GOMEMLIMIT memory to the
                                  detected maximum container or system memory.
       --enable-auto-gomemlimit   Enable go runtime to automatically limit memory
@@ -362,25 +365,25 @@ Flags:
       --enable-feature= ...      Comma separated experimental feature names
                                  to enable. The current list of features is
                                  metric-names-filter.
-      --grpc-address="0.0.0.0:10901"
+      --grpc-address="0.0.0.0:10901"  
                                  Listen ip:port address for gRPC endpoints
                                  (StoreAPI). Make sure this address is routable
                                  from other components.
       --grpc-grace-period=2m     Time to wait after an interrupt received for
                                  GRPC Server.
-      --grpc-server-max-connection-age=60m
+      --grpc-server-max-connection-age=60m  
                                  The grpc server max connection age. This
                                  controls how often to re-establish connections
                                  and redo TLS handshakes.
       --grpc-server-tls-cert=""  TLS Certificate for gRPC server, leave blank to
                                  disable TLS
-      --grpc-server-tls-client-ca=""
+      --grpc-server-tls-client-ca=""  
                                  TLS CA to verify clients against. If no
                                  client CA is specified, there is no client
                                  verification on server side. (tls.NoClientCert)
       --grpc-server-tls-key=""   TLS Key for the gRPC server, leave blank to
                                  disable TLS
-      --grpc-server-tls-min-version="1.3"
+      --grpc-server-tls-min-version="1.3"  
                                  TLS supported minimum version for gRPC server.
                                  If no version is specified, it'll default to
                                  1.3. Allowed values: ["1.0", "1.1", "1.2",
@@ -393,7 +396,7 @@ Flags:
                                  Possible values are: "", "SHA256".
   -h, --help                     Show context-sensitive help (also try
                                  --help-long and --help-man).
-      --http-address="0.0.0.0:10902"
+      --http-address="0.0.0.0:10902"  
                                  Listen host:port for HTTP endpoints.
       --http-grace-period=2m     Time to wait after an interrupt received for
                                  HTTP Server.
@@ -406,148 +409,148 @@ Flags:
       --log.format=logfmt        Log format to use. Possible options: logfmt or
                                  json.
       --log.level=info           Log filtering level.
-      --objstore.config=<content>
+      --objstore.config=<content>  
                                  Alternative to 'objstore.config-file'
                                  flag (mutually exclusive). Content of
                                  YAML file that contains object store
                                  configuration. See format details:
                                  https://thanos.io/tip/thanos/storage.md/#configuration
-      --objstore.config-file=<file-path>
+      --objstore.config-file=<file-path>  
                                  Path to YAML file that contains object
                                  store configuration. See format details:
                                  https://thanos.io/tip/thanos/storage.md/#configuration
-      --receive.capnproto-address="0.0.0.0:19391"
+      --receive.capnproto-address="0.0.0.0:19391"  
                                  Address for the Cap'n Proto server.
-      --receive.default-tenant-id="default-tenant"
+      --receive.default-tenant-id="default-tenant"  
                                  Default tenant ID to use when none is provided
                                  via a header.
-      --receive.forward.async-workers=5
+      --receive.forward.async-workers=5  
                                  Number of concurrent workers processing
                                  forwarding of remote-write requests.
-      --receive.grpc-compression=snappy
+      --receive.grpc-compression=snappy  
                                  Compression algorithm to use for gRPC requests
                                  to other receivers. Must be one of: snappy,
                                  none
-      --receive.hashrings=<content>
+      --receive.hashrings=<content>  
                                  Alternative to 'receive.hashrings-file' flag
                                  (lower priority). Content of file that contains
                                  the hashring configuration.
-      --receive.hashrings-algorithm=hashmod
+      --receive.hashrings-algorithm=hashmod  
                                  The algorithm used when distributing series in
                                  the hashrings. Must be one of hashmod, ketama.
                                  Will be overwritten by the tenant-specific
                                  algorithm in the hashring config.
-      --receive.hashrings-file=<path>
+      --receive.hashrings-file=<path>  
                                  Path to file that contains the hashring
                                  configuration. A watcher is initialized
                                  to watch changes and update the hashring
                                  dynamically.
-      --receive.hashrings-file-refresh-interval=5m
+      --receive.hashrings-file-refresh-interval=5m  
                                  Refresh interval to re-read the hashring
                                  configuration file. (used as a fallback)
-      --receive.local-endpoint=RECEIVE.LOCAL-ENDPOINT
+      --receive.local-endpoint=RECEIVE.LOCAL-ENDPOINT  
                                  Endpoint of local receive node. Used to
                                  identify the local node in the hashring
                                  configuration. If it's empty AND hashring
                                  configuration was provided, it means that
                                  receive will run in RoutingOnly mode.
-      --receive.relabel-config=<content>
+      --receive.relabel-config=<content>  
                                  Alternative to 'receive.relabel-config-file'
                                  flag (mutually exclusive). Content of YAML file
                                  that contains relabeling configuration.
-      --receive.relabel-config-file=<file-path>
+      --receive.relabel-config-file=<file-path>  
                                  Path to YAML file that contains relabeling
                                  configuration.
-      --receive.replica-header="THANOS-REPLICA"
+      --receive.replica-header="THANOS-REPLICA"  
                                  HTTP header specifying the replica number of a
                                  write request.
-      --receive.replication-factor=1
+      --receive.replication-factor=1  
                                  How many times to replicate incoming write
                                  requests.
-      --receive.replication-protocol=protobuf
+      --receive.replication-protocol=protobuf  
                                  The protocol to use for replicating
                                  remote-write requests. One of protobuf,
                                  capnproto
-      --receive.split-tenant-label-name=""
+      --receive.split-tenant-label-name=""  
                                  Label name through which the request will
                                  be split into multiple tenants. This takes
                                  precedence over the HTTP header.
-      --receive.tenant-certificate-field=
+      --receive.tenant-certificate-field=  
                                  Use TLS client's certificate field to
                                  determine tenant for write requests.
                                  Must be one of organization, organizationalUnit
                                  or commonName. This setting will cause the
                                  receive.tenant-header flag value to be ignored.
-      --receive.tenant-header="THANOS-TENANT"
+      --receive.tenant-header="THANOS-TENANT"  
                                  HTTP header to determine tenant for write
                                  requests.
-      --receive.tenant-label-name="tenant_id"
+      --receive.tenant-label-name="tenant_id"  
                                  Label name through which the tenant will be
                                  announced.
-      --remote-write.address="0.0.0.0:19291"
+      --remote-write.address="0.0.0.0:19291"  
                                  Address to listen on for remote write requests.
-      --remote-write.client-server-name=""
+      --remote-write.client-server-name=""  
                                  Server name to verify the hostname
                                  on the returned TLS certificates. See
                                  https://tools.ietf.org/html/rfc4366#section-3.1
-      --remote-write.client-tls-ca=""
+      --remote-write.client-tls-ca=""  
                                  TLS CA Certificates to use to verify servers.
-      --remote-write.client-tls-cert=""
+      --remote-write.client-tls-cert=""  
                                  TLS Certificates to use to identify this client
                                  to the server.
-      --remote-write.client-tls-key=""
+      --remote-write.client-tls-key=""  
                                  TLS Key for the client's certificate.
-      --remote-write.client-tls-secure
+      --remote-write.client-tls-secure  
                                  Use TLS when talking to the other receivers.
-      --remote-write.client-tls-skip-verify
+      --remote-write.client-tls-skip-verify  
                                  Disable TLS certificate verification when
                                  talking to the other receivers i.e self signed,
                                  signed by fake CA.
-      --remote-write.server-tls-cert=""
+      --remote-write.server-tls-cert=""  
                                  TLS Certificate for HTTP server, leave blank to
                                  disable TLS.
-      --remote-write.server-tls-client-ca=""
+      --remote-write.server-tls-client-ca=""  
                                  TLS CA to verify clients against. If no
                                  client CA is specified, there is no client
                                  verification on server side. (tls.NoClientCert)
-      --remote-write.server-tls-key=""
+      --remote-write.server-tls-key=""  
                                  TLS Key for the HTTP server, leave blank to
                                  disable TLS.
-      --remote-write.server-tls-min-version="1.3"
+      --remote-write.server-tls-min-version="1.3"  
                                  TLS version for the gRPC server, leave blank
                                  to default to TLS 1.3, allow values: ["1.0",
                                  "1.1", "1.2", "1.3"]
-      --request.logging-config=<content>
+      --request.logging-config=<content>  
                                  Alternative to 'request.logging-config-file'
                                  flag (mutually exclusive). Content
                                  of YAML file with request logging
                                  configuration. See format details:
                                  https://thanos.io/tip/thanos/logging.md/#configuration
-      --request.logging-config-file=<file-path>
+      --request.logging-config-file=<file-path>  
                                  Path to YAML file with request logging
                                  configuration. See format details:
                                  https://thanos.io/tip/thanos/logging.md/#configuration
-      --store.limits.request-samples=0
+      --store.limits.request-samples=0  
                                  The maximum samples allowed for a single
                                  Series request, The Series call fails if
                                  this limit is exceeded. 0 means no limit.
                                  NOTE: For efficiency the limit is internally
                                  implemented as 'chunks limit' considering each
                                  chunk contains a maximum of 120 samples.
-      --store.limits.request-series=0
+      --store.limits.request-series=0  
                                  The maximum series allowed for a single Series
                                  request. The Series call fails if this limit is
                                  exceeded. 0 means no limit.
-      --tracing.config=<content>
+      --tracing.config=<content>  
                                  Alternative to 'tracing.config-file' flag
                                  (mutually exclusive). Content of YAML file
                                  with tracing configuration. See format details:
                                  https://thanos.io/tip/thanos/tracing.md/#configuration
-      --tracing.config-file=<file-path>
+      --tracing.config-file=<file-path>  
                                  Path to YAML file with tracing
                                  configuration. See format details:
                                  https://thanos.io/tip/thanos/tracing.md/#configuration
-      --tsdb.allow-overlapping-blocks
+      --tsdb.allow-overlapping-blocks  
                                  Allow overlapping blocks, which in turn enables
                                  vertical compaction and vertical query merge.
                                  Does not do anything, enabled all the time.
@@ -559,7 +562,7 @@ Flags:
                                  ingesting a new exemplar will evict the oldest
                                  exemplar from storage. 0 (or less) value of
                                  this flag disables exemplars storage.
-      --tsdb.max-retention-bytes=0
+      --tsdb.max-retention-bytes=0  
                                  Maximum number of bytes that can be stored for
                                  blocks. A unit is required, supported units: B,
                                  KB, MB, GB, TB, PB, EB. Ex: "512MB". Based on
@@ -576,7 +579,7 @@ Flags:
                                  refer to the Tenant lifecycle management
                                  section in the Receive documentation:
                                  https://thanos.io/tip/components/receive.md/#tenant-lifecycle-management
-      --tsdb.too-far-in-future.time-window=0s
+      --tsdb.too-far-in-future.time-window=0s  
                                  Configures the allowed time window for
                                  ingesting samples too far in the future.
                                  Disabled (0s) by defaultPlease note enable

--- a/docs/components/receive.md
+++ b/docs/components/receive.md
@@ -113,7 +113,6 @@ config:
       insecure_skip_verify: false
     disable_compression: false
   chunk_size_bytes: 0
-  max_retries: 0
 prefix: ""
 ```
 
@@ -429,10 +428,6 @@ Flags:
                                  Compression algorithm to use for gRPC requests
                                  to other receivers. Must be one of: snappy,
                                  none
-      --receive.grpc-service-config=<content>
-                                 gRPC service configuration file
-                                 or content in JSON format. See
-                                 https://github.com/grpc/grpc/blob/master/doc/service_config.md
       --receive.hashrings=<content>
                                  Alternative to 'receive.hashrings-file' flag
                                  (lower priority). Content of file that contains
@@ -556,12 +551,6 @@ Flags:
                                  Allow overlapping blocks, which in turn enables
                                  vertical compaction and vertical query merge.
                                  Does not do anything, enabled all the time.
-      --tsdb.block.expanded-postings-cache-size=0
-                                 [EXPERIMENTAL] If non-zero, enables expanded
-                                 postings cache for compacted blocks.
-      --tsdb.head.expanded-postings-cache-size=0
-                                 [EXPERIMENTAL] If non-zero, enables expanded
-                                 postings cache for the head block.
       --tsdb.max-exemplars=0     Enables support for ingesting exemplars and
                                  sets the maximum number of exemplars that will
                                  be stored per tenant. In case the exemplar

--- a/docs/components/rule.md
+++ b/docs/components/rule.md
@@ -266,25 +266,25 @@ Ruler evaluating Prometheus rules against given Query nodes, exposing Store API
 and storing old blocks in bucket.
 
 Flags:
-      --alert.label-drop=ALERT.LABEL-DROP ...
+      --alert.label-drop=ALERT.LABEL-DROP ...  
                                  Labels by name to drop before sending
                                  to alertmanager. This allows alert to be
                                  deduplicated on replica label (repeated).
                                  Similar Prometheus alert relabelling
-      --alert.query-template="/graph?g0.expr={{.Expr}}&g0.tab=1"
+      --alert.query-template="/graph?g0.expr={{.Expr}}&g0.tab=1"  
                                  Template to use in alerts source field.
                                  Need only include {{.Expr}} parameter
-      --alert.query-url=ALERT.QUERY-URL
+      --alert.query-url=ALERT.QUERY-URL  
                                  The external Thanos Query URL that would be set
                                  in all alerts 'Source' field
-      --alert.relabel-config=<content>
+      --alert.relabel-config=<content>  
                                  Alternative to 'alert.relabel-config-file' flag
                                  (mutually exclusive). Content of YAML file that
                                  contains alert relabelling configuration.
-      --alert.relabel-config-file=<file-path>
+      --alert.relabel-config-file=<file-path>  
                                  Path to YAML file that contains alert
                                  relabelling configuration.
-      --alertmanagers.config=<content>
+      --alertmanagers.config=<content>  
                                  Alternative to 'alertmanagers.config-file'
                                  flag (mutually exclusive). Content
                                  of YAML file that contains alerting
@@ -293,19 +293,19 @@ Flags:
                                  If defined, it takes precedence
                                  over the '--alertmanagers.url' and
                                  '--alertmanagers.send-timeout' flags.
-      --alertmanagers.config-file=<file-path>
+      --alertmanagers.config-file=<file-path>  
                                  Path to YAML file that contains alerting
                                  configuration. See format details:
                                  https://thanos.io/tip/components/rule.md/#configuration.
                                  If defined, it takes precedence
                                  over the '--alertmanagers.url' and
                                  '--alertmanagers.send-timeout' flags.
-      --alertmanagers.sd-dns-interval=30s
+      --alertmanagers.sd-dns-interval=30s  
                                  Interval between DNS resolutions of
                                  Alertmanager hosts.
-      --alertmanagers.send-timeout=10s
+      --alertmanagers.send-timeout=10s  
                                  Timeout for sending alerts to Alertmanager
-      --alertmanagers.url=ALERTMANAGERS.URL ...
+      --alertmanagers.url=ALERTMANAGERS.URL ...  
                                  Alertmanager replica URLs to push firing
                                  alerts. Ruler claims success if push to
                                  at least one alertmanager from discovered
@@ -316,7 +316,7 @@ Flags:
                                  lookups. The port defaults to 9093 or the
                                  SRV record's value. The URL path is used as a
                                  prefix for the regular Alertmanager API path.
-      --auto-gomemlimit.ratio=0.9
+      --auto-gomemlimit.ratio=0.9  
                                  The ratio of reserved GOMEMLIMIT memory to the
                                  detected maximum container or system memory.
       --data-dir="data/"         data directory
@@ -329,30 +329,30 @@ Flags:
                                  period.
       --for-outage-tolerance=1h  Max time to tolerate prometheus outage for
                                  restoring "for" state of alert.
-      --grpc-address="0.0.0.0:10901"
+      --grpc-address="0.0.0.0:10901"  
                                  Listen ip:port address for gRPC endpoints
                                  (StoreAPI). Make sure this address is routable
                                  from other components.
       --grpc-grace-period=2m     Time to wait after an interrupt received for
                                  GRPC Server.
-      --grpc-query-endpoint=<endpoint> ...
+      --grpc-query-endpoint=<endpoint> ...  
                                  Addresses of Thanos gRPC query API servers
                                  (repeatable). The scheme may be prefixed
                                  with 'dns+' or 'dnssrv+' to detect Thanos API
                                  servers through respective DNS lookups.
-      --grpc-server-max-connection-age=60m
+      --grpc-server-max-connection-age=60m  
                                  The grpc server max connection age. This
                                  controls how often to re-establish connections
                                  and redo TLS handshakes.
       --grpc-server-tls-cert=""  TLS Certificate for gRPC server, leave blank to
                                  disable TLS
-      --grpc-server-tls-client-ca=""
+      --grpc-server-tls-client-ca=""  
                                  TLS CA to verify clients against. If no
                                  client CA is specified, there is no client
                                  verification on server side. (tls.NoClientCert)
       --grpc-server-tls-key=""   TLS Key for the gRPC server, leave blank to
                                  disable TLS
-      --grpc-server-tls-min-version="1.3"
+      --grpc-server-tls-min-version="1.3"  
                                  TLS supported minimum version for gRPC server.
                                  If no version is specified, it'll default to
                                  1.3. Allowed values: ["1.0", "1.1", "1.2",
@@ -365,14 +365,14 @@ Flags:
                                  Possible values are: "", "SHA256".
   -h, --help                     Show context-sensitive help (also try
                                  --help-long and --help-man).
-      --http-address="0.0.0.0:10902"
+      --http-address="0.0.0.0:10902"  
                                  Listen host:port for HTTP endpoints.
       --http-grace-period=2m     Time to wait after an interrupt received for
                                  HTTP Server.
       --http.config=""           [EXPERIMENTAL] Path to the configuration file
                                  that can enable TLS or authentication for all
                                  HTTP endpoints.
-      --label=<name>="<value>" ...
+      --label=<name>="<value>" ...  
                                  Labels to be applied to all generated metrics
                                  (repeated). Similar to external labels for
                                  Prometheus, used to identify ruler and its
@@ -380,13 +380,13 @@ Flags:
       --log.format=logfmt        Log format to use. Possible options: logfmt or
                                  json.
       --log.level=info           Log filtering level.
-      --objstore.config=<content>
+      --objstore.config=<content>  
                                  Alternative to 'objstore.config-file'
                                  flag (mutually exclusive). Content of
                                  YAML file that contains object store
                                  configuration. See format details:
                                  https://thanos.io/tip/thanos/storage.md/#configuration
-      --objstore.config-file=<file-path>
+      --objstore.config-file=<file-path>  
                                  Path to YAML file that contains object
                                  store configuration. See format details:
                                  https://thanos.io/tip/thanos/storage.md/#configuration
@@ -402,7 +402,7 @@ Flags:
                                  https://thanos.io/tip/components/rule.md/#configuration.
                                  If defined, it takes precedence over the
                                  '--query' and '--query.sd-files' flags.
-      --query.config-file=<file-path>
+      --query.config-file=<file-path>  
                                  Path to YAML file that contains query API
                                  servers configuration. See format details:
                                  https://thanos.io/tip/components/rule.md/#configuration.
@@ -411,59 +411,55 @@ Flags:
       --query.default-step=1s    Default range query step to use. This is
                                  only used in stateless Ruler and alert state
                                  restoration.
-      --query.enable-x-functions
+      --query.enable-x-functions  
                                  Whether to enable extended rate functions
                                  (xrate, xincrease and xdelta). Only has effect
                                  when used with Thanos engine.
       --query.http-method=POST   HTTP method to use when sending queries.
                                  Possible options: [GET, POST]
-      --query.sd-dns-interval=30s
+      --query.sd-dns-interval=30s  
                                  Interval between DNS resolutions.
-      --query.sd-files=<path> ...
+      --query.sd-files=<path> ...  
                                  Path to file that contains addresses of query
                                  API servers. The path can be a glob pattern
                                  (repeatable).
       --query.sd-interval=5m     Refresh interval to re-read file SD files.
                                  (used as a fallback)
-      --remote-write.config=<content>
+      --remote-write.config=<content>  
                                  Alternative to 'remote-write.config-file'
                                  flag (mutually exclusive). Content
                                  of YAML config for the remote-write
                                  configurations, that specify servers
                                  where samples should be sent to (see
                                  https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_write).
-                                 This automatically enables stateless mode
-                                 for ruler and no series will be stored in the
-                                 ruler's TSDB. If an empty config (or file) is
-                                 provided, the flag is ignored and ruler is run
-                                 with its own TSDB.
-      --remote-write.config-file=<file-path>
+                                 If an empty config (or file) is provided,
+                                 the flag is ignored and ruler is run with its
+                                 own TSDB.
+      --remote-write.config-file=<file-path>  
                                  Path to YAML config for the remote-write
                                  configurations, that specify servers
                                  where samples should be sent to (see
                                  https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_write).
-                                 This automatically enables stateless mode
-                                 for ruler and no series will be stored in the
-                                 ruler's TSDB. If an empty config (or file) is
-                                 provided, the flag is ignored and ruler is run
-                                 with its own TSDB.
-      --request.logging-config=<content>
+                                 If an empty config (or file) is provided,
+                                 the flag is ignored and ruler is run with its
+                                 own TSDB.
+      --request.logging-config=<content>  
                                  Alternative to 'request.logging-config-file'
                                  flag (mutually exclusive). Content
                                  of YAML file with request logging
                                  configuration. See format details:
                                  https://thanos.io/tip/thanos/logging.md/#configuration
-      --request.logging-config-file=<file-path>
+      --request.logging-config-file=<file-path>  
                                  Path to YAML file with request logging
                                  configuration. See format details:
                                  https://thanos.io/tip/thanos/logging.md/#configuration
       --resend-delay=1m          Minimum amount of time to wait before resending
                                  an alert to Alertmanager.
-      --restore-ignored-label=RESTORE-IGNORED-LABEL ...
+      --restore-ignored-label=RESTORE-IGNORED-LABEL ...  
                                  Label names to be ignored when restoring alerts
                                  from the remote storage. This is only used in
                                  stateless mode.
-      --rule-concurrent-evaluation=1
+      --rule-concurrent-evaluation=1  
                                  How many rules can be evaluated concurrently.
                                  Default is 1.
       --rule-file=rules/ ...     Rule files that should be used by rule
@@ -471,31 +467,32 @@ Flags:
                                  Note that rules are not automatically detected,
                                  use SIGHUP or do HTTP POST /-/reload to re-read
                                  them.
-      --shipper.meta-file-name="thanos.shipper.json"
+      --shipper.meta-file-name="thanos.shipper.json"  
                                  the file to store shipper metadata in
-      --shipper.upload-compacted
+      --shipper.upload-compacted  
                                  If true shipper will try to upload compacted
                                  blocks as well. Useful for migration purposes.
                                  Works only if compaction is disabled on
                                  Prometheus. Do it once and then disable the
                                  flag when done.
-      --store.limits.request-samples=0
+      --stateless                Enable stateless mode for the ruler
+      --store.limits.request-samples=0  
                                  The maximum samples allowed for a single
                                  Series request, The Series call fails if
                                  this limit is exceeded. 0 means no limit.
                                  NOTE: For efficiency the limit is internally
                                  implemented as 'chunks limit' considering each
                                  chunk contains a maximum of 120 samples.
-      --store.limits.request-series=0
+      --store.limits.request-series=0  
                                  The maximum series allowed for a single Series
                                  request. The Series call fails if this limit is
                                  exceeded. 0 means no limit.
-      --tracing.config=<content>
+      --tracing.config=<content>  
                                  Alternative to 'tracing.config-file' flag
                                  (mutually exclusive). Content of YAML file
                                  with tracing configuration. See format details:
                                  https://thanos.io/tip/thanos/tracing.md/#configuration
-      --tracing.config-file=<file-path>
+      --tracing.config-file=<file-path>  
                                  Path to YAML file with tracing
                                  configuration. See format details:
                                  https://thanos.io/tip/thanos/tracing.md/#configuration

--- a/docs/components/rule.md
+++ b/docs/components/rule.md
@@ -266,25 +266,25 @@ Ruler evaluating Prometheus rules against given Query nodes, exposing Store API
 and storing old blocks in bucket.
 
 Flags:
-      --alert.label-drop=ALERT.LABEL-DROP ...  
+      --alert.label-drop=ALERT.LABEL-DROP ...
                                  Labels by name to drop before sending
                                  to alertmanager. This allows alert to be
                                  deduplicated on replica label (repeated).
                                  Similar Prometheus alert relabelling
-      --alert.query-template="/graph?g0.expr={{.Expr}}&g0.tab=1"  
+      --alert.query-template="/graph?g0.expr={{.Expr}}&g0.tab=1"
                                  Template to use in alerts source field.
                                  Need only include {{.Expr}} parameter
-      --alert.query-url=ALERT.QUERY-URL  
+      --alert.query-url=ALERT.QUERY-URL
                                  The external Thanos Query URL that would be set
                                  in all alerts 'Source' field
-      --alert.relabel-config=<content>  
+      --alert.relabel-config=<content>
                                  Alternative to 'alert.relabel-config-file' flag
                                  (mutually exclusive). Content of YAML file that
                                  contains alert relabelling configuration.
-      --alert.relabel-config-file=<file-path>  
+      --alert.relabel-config-file=<file-path>
                                  Path to YAML file that contains alert
                                  relabelling configuration.
-      --alertmanagers.config=<content>  
+      --alertmanagers.config=<content>
                                  Alternative to 'alertmanagers.config-file'
                                  flag (mutually exclusive). Content
                                  of YAML file that contains alerting
@@ -293,19 +293,19 @@ Flags:
                                  If defined, it takes precedence
                                  over the '--alertmanagers.url' and
                                  '--alertmanagers.send-timeout' flags.
-      --alertmanagers.config-file=<file-path>  
+      --alertmanagers.config-file=<file-path>
                                  Path to YAML file that contains alerting
                                  configuration. See format details:
                                  https://thanos.io/tip/components/rule.md/#configuration.
                                  If defined, it takes precedence
                                  over the '--alertmanagers.url' and
                                  '--alertmanagers.send-timeout' flags.
-      --alertmanagers.sd-dns-interval=30s  
+      --alertmanagers.sd-dns-interval=30s
                                  Interval between DNS resolutions of
                                  Alertmanager hosts.
-      --alertmanagers.send-timeout=10s  
+      --alertmanagers.send-timeout=10s
                                  Timeout for sending alerts to Alertmanager
-      --alertmanagers.url=ALERTMANAGERS.URL ...  
+      --alertmanagers.url=ALERTMANAGERS.URL ...
                                  Alertmanager replica URLs to push firing
                                  alerts. Ruler claims success if push to
                                  at least one alertmanager from discovered
@@ -316,7 +316,7 @@ Flags:
                                  lookups. The port defaults to 9093 or the
                                  SRV record's value. The URL path is used as a
                                  prefix for the regular Alertmanager API path.
-      --auto-gomemlimit.ratio=0.9  
+      --auto-gomemlimit.ratio=0.9
                                  The ratio of reserved GOMEMLIMIT memory to the
                                  detected maximum container or system memory.
       --data-dir="data/"         data directory
@@ -329,30 +329,30 @@ Flags:
                                  period.
       --for-outage-tolerance=1h  Max time to tolerate prometheus outage for
                                  restoring "for" state of alert.
-      --grpc-address="0.0.0.0:10901"  
+      --grpc-address="0.0.0.0:10901"
                                  Listen ip:port address for gRPC endpoints
                                  (StoreAPI). Make sure this address is routable
                                  from other components.
       --grpc-grace-period=2m     Time to wait after an interrupt received for
                                  GRPC Server.
-      --grpc-query-endpoint=<endpoint> ...  
+      --grpc-query-endpoint=<endpoint> ...
                                  Addresses of Thanos gRPC query API servers
                                  (repeatable). The scheme may be prefixed
                                  with 'dns+' or 'dnssrv+' to detect Thanos API
                                  servers through respective DNS lookups.
-      --grpc-server-max-connection-age=60m  
+      --grpc-server-max-connection-age=60m
                                  The grpc server max connection age. This
                                  controls how often to re-establish connections
                                  and redo TLS handshakes.
       --grpc-server-tls-cert=""  TLS Certificate for gRPC server, leave blank to
                                  disable TLS
-      --grpc-server-tls-client-ca=""  
+      --grpc-server-tls-client-ca=""
                                  TLS CA to verify clients against. If no
                                  client CA is specified, there is no client
                                  verification on server side. (tls.NoClientCert)
       --grpc-server-tls-key=""   TLS Key for the gRPC server, leave blank to
                                  disable TLS
-      --grpc-server-tls-min-version="1.3"  
+      --grpc-server-tls-min-version="1.3"
                                  TLS supported minimum version for gRPC server.
                                  If no version is specified, it'll default to
                                  1.3. Allowed values: ["1.0", "1.1", "1.2",
@@ -365,14 +365,14 @@ Flags:
                                  Possible values are: "", "SHA256".
   -h, --help                     Show context-sensitive help (also try
                                  --help-long and --help-man).
-      --http-address="0.0.0.0:10902"  
+      --http-address="0.0.0.0:10902"
                                  Listen host:port for HTTP endpoints.
       --http-grace-period=2m     Time to wait after an interrupt received for
                                  HTTP Server.
       --http.config=""           [EXPERIMENTAL] Path to the configuration file
                                  that can enable TLS or authentication for all
                                  HTTP endpoints.
-      --label=<name>="<value>" ...  
+      --label=<name>="<value>" ...
                                  Labels to be applied to all generated metrics
                                  (repeated). Similar to external labels for
                                  Prometheus, used to identify ruler and its
@@ -380,13 +380,13 @@ Flags:
       --log.format=logfmt        Log format to use. Possible options: logfmt or
                                  json.
       --log.level=info           Log filtering level.
-      --objstore.config=<content>  
+      --objstore.config=<content>
                                  Alternative to 'objstore.config-file'
                                  flag (mutually exclusive). Content of
                                  YAML file that contains object store
                                  configuration. See format details:
                                  https://thanos.io/tip/thanos/storage.md/#configuration
-      --objstore.config-file=<file-path>  
+      --objstore.config-file=<file-path>
                                  Path to YAML file that contains object
                                  store configuration. See format details:
                                  https://thanos.io/tip/thanos/storage.md/#configuration
@@ -402,7 +402,7 @@ Flags:
                                  https://thanos.io/tip/components/rule.md/#configuration.
                                  If defined, it takes precedence over the
                                  '--query' and '--query.sd-files' flags.
-      --query.config-file=<file-path>  
+      --query.config-file=<file-path>
                                  Path to YAML file that contains query API
                                  servers configuration. See format details:
                                  https://thanos.io/tip/components/rule.md/#configuration.
@@ -411,55 +411,59 @@ Flags:
       --query.default-step=1s    Default range query step to use. This is
                                  only used in stateless Ruler and alert state
                                  restoration.
-      --query.enable-x-functions  
+      --query.enable-x-functions
                                  Whether to enable extended rate functions
                                  (xrate, xincrease and xdelta). Only has effect
                                  when used with Thanos engine.
       --query.http-method=POST   HTTP method to use when sending queries.
                                  Possible options: [GET, POST]
-      --query.sd-dns-interval=30s  
+      --query.sd-dns-interval=30s
                                  Interval between DNS resolutions.
-      --query.sd-files=<path> ...  
+      --query.sd-files=<path> ...
                                  Path to file that contains addresses of query
                                  API servers. The path can be a glob pattern
                                  (repeatable).
       --query.sd-interval=5m     Refresh interval to re-read file SD files.
                                  (used as a fallback)
-      --remote-write.config=<content>  
+      --remote-write.config=<content>
                                  Alternative to 'remote-write.config-file'
                                  flag (mutually exclusive). Content
                                  of YAML config for the remote-write
                                  configurations, that specify servers
                                  where samples should be sent to (see
                                  https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_write).
-                                 If an empty config (or file) is provided,
-                                 the flag is ignored and ruler is run with its
-                                 own TSDB.
-      --remote-write.config-file=<file-path>  
+                                 This automatically enables stateless mode
+                                 for ruler and no series will be stored in the
+                                 ruler's TSDB. If an empty config (or file) is
+                                 provided, the flag is ignored and ruler is run
+                                 with its own TSDB.
+      --remote-write.config-file=<file-path>
                                  Path to YAML config for the remote-write
                                  configurations, that specify servers
                                  where samples should be sent to (see
                                  https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_write).
-                                 If an empty config (or file) is provided,
-                                 the flag is ignored and ruler is run with its
-                                 own TSDB.
-      --request.logging-config=<content>  
+                                 This automatically enables stateless mode
+                                 for ruler and no series will be stored in the
+                                 ruler's TSDB. If an empty config (or file) is
+                                 provided, the flag is ignored and ruler is run
+                                 with its own TSDB.
+      --request.logging-config=<content>
                                  Alternative to 'request.logging-config-file'
                                  flag (mutually exclusive). Content
                                  of YAML file with request logging
                                  configuration. See format details:
                                  https://thanos.io/tip/thanos/logging.md/#configuration
-      --request.logging-config-file=<file-path>  
+      --request.logging-config-file=<file-path>
                                  Path to YAML file with request logging
                                  configuration. See format details:
                                  https://thanos.io/tip/thanos/logging.md/#configuration
       --resend-delay=1m          Minimum amount of time to wait before resending
                                  an alert to Alertmanager.
-      --restore-ignored-label=RESTORE-IGNORED-LABEL ...  
+      --restore-ignored-label=RESTORE-IGNORED-LABEL ...
                                  Label names to be ignored when restoring alerts
                                  from the remote storage. This is only used in
                                  stateless mode.
-      --rule-concurrent-evaluation=1  
+      --rule-concurrent-evaluation=1
                                  How many rules can be evaluated concurrently.
                                  Default is 1.
       --rule-file=rules/ ...     Rule files that should be used by rule
@@ -467,32 +471,31 @@ Flags:
                                  Note that rules are not automatically detected,
                                  use SIGHUP or do HTTP POST /-/reload to re-read
                                  them.
-      --shipper.meta-file-name="thanos.shipper.json"  
+      --shipper.meta-file-name="thanos.shipper.json"
                                  the file to store shipper metadata in
-      --shipper.upload-compacted  
+      --shipper.upload-compacted
                                  If true shipper will try to upload compacted
                                  blocks as well. Useful for migration purposes.
                                  Works only if compaction is disabled on
                                  Prometheus. Do it once and then disable the
                                  flag when done.
-      --stateless                Enable stateless mode for the ruler
-      --store.limits.request-samples=0  
+      --store.limits.request-samples=0
                                  The maximum samples allowed for a single
                                  Series request, The Series call fails if
                                  this limit is exceeded. 0 means no limit.
                                  NOTE: For efficiency the limit is internally
                                  implemented as 'chunks limit' considering each
                                  chunk contains a maximum of 120 samples.
-      --store.limits.request-series=0  
+      --store.limits.request-series=0
                                  The maximum series allowed for a single Series
                                  request. The Series call fails if this limit is
                                  exceeded. 0 means no limit.
-      --tracing.config=<content>  
+      --tracing.config=<content>
                                  Alternative to 'tracing.config-file' flag
                                  (mutually exclusive). Content of YAML file
                                  with tracing configuration. See format details:
                                  https://thanos.io/tip/thanos/tracing.md/#configuration
-      --tracing.config-file=<file-path>  
+      --tracing.config-file=<file-path>
                                  Path to YAML file with tracing
                                  configuration. See format details:
                                  https://thanos.io/tip/thanos/tracing.md/#configuration

--- a/docs/components/sidecar.md
+++ b/docs/components/sidecar.md
@@ -75,7 +75,6 @@ config:
       insecure_skip_verify: false
     disable_compression: false
   chunk_size_bytes: 0
-  max_retries: 0
 prefix: ""
 ```
 

--- a/docs/components/sidecar.md
+++ b/docs/components/sidecar.md
@@ -52,6 +52,8 @@ thanos sidecar \
 The example content of `bucket.yml`:
 
 ```yaml mdox-exec="go run scripts/cfggen/main.go --name=gcs.Config"
+# command-line-arguments
+ld: warning: ignoring duplicate libraries: '-lproc'
 type: GCS
 config:
   bucket: ""
@@ -75,6 +77,7 @@ config:
       insecure_skip_verify: false
     disable_compression: false
   chunk_size_bytes: 0
+  max_retries: 0
 prefix: ""
 ```
 
@@ -95,30 +98,30 @@ usage: thanos sidecar [<flags>]
 Sidecar for Prometheus server.
 
 Flags:
-      --auto-gomemlimit.ratio=0.9
+      --auto-gomemlimit.ratio=0.9  
                                  The ratio of reserved GOMEMLIMIT memory to the
                                  detected maximum container or system memory.
       --enable-auto-gomemlimit   Enable go runtime to automatically limit memory
                                  consumption.
-      --grpc-address="0.0.0.0:10901"
+      --grpc-address="0.0.0.0:10901"  
                                  Listen ip:port address for gRPC endpoints
                                  (StoreAPI). Make sure this address is routable
                                  from other components.
       --grpc-grace-period=2m     Time to wait after an interrupt received for
                                  GRPC Server.
-      --grpc-server-max-connection-age=60m
+      --grpc-server-max-connection-age=60m  
                                  The grpc server max connection age. This
                                  controls how often to re-establish connections
                                  and redo TLS handshakes.
       --grpc-server-tls-cert=""  TLS Certificate for gRPC server, leave blank to
                                  disable TLS
-      --grpc-server-tls-client-ca=""
+      --grpc-server-tls-client-ca=""  
                                  TLS CA to verify clients against. If no
                                  client CA is specified, there is no client
                                  verification on server side. (tls.NoClientCert)
       --grpc-server-tls-key=""   TLS Key for the gRPC server, leave blank to
                                  disable TLS
-      --grpc-server-tls-min-version="1.3"
+      --grpc-server-tls-min-version="1.3"  
                                  TLS supported minimum version for gRPC server.
                                  If no version is specified, it'll default to
                                  1.3. Allowed values: ["1.0", "1.1", "1.2",
@@ -131,7 +134,7 @@ Flags:
                                  Possible values are: "", "SHA256".
   -h, --help                     Show context-sensitive help (also try
                                  --help-long and --help-man).
-      --http-address="0.0.0.0:10902"
+      --http-address="0.0.0.0:10902"  
                                  Listen host:port for HTTP endpoints.
       --http-grace-period=2m     Time to wait after an interrupt received for
                                  HTTP Server.
@@ -141,95 +144,95 @@ Flags:
       --log.format=logfmt        Log format to use. Possible options: logfmt or
                                  json.
       --log.level=info           Log filtering level.
-      --min-time=0000-01-01T00:00:00Z
+      --min-time=0000-01-01T00:00:00Z  
                                  Start of time range limit to serve. Thanos
                                  sidecar will serve only metrics, which happened
                                  later than this value. Option can be a constant
                                  time in RFC3339 format or time duration
                                  relative to current time, such as -1d or 2h45m.
                                  Valid duration units are ms, s, m, h, d, w, y.
-      --objstore.config=<content>
+      --objstore.config=<content>  
                                  Alternative to 'objstore.config-file'
                                  flag (mutually exclusive). Content of
                                  YAML file that contains object store
                                  configuration. See format details:
                                  https://thanos.io/tip/thanos/storage.md/#configuration
-      --objstore.config-file=<file-path>
+      --objstore.config-file=<file-path>  
                                  Path to YAML file that contains object
                                  store configuration. See format details:
                                  https://thanos.io/tip/thanos/storage.md/#configuration
-      --prometheus.get_config_interval=30s
+      --prometheus.get_config_interval=30s  
                                  How often to get Prometheus config
-      --prometheus.get_config_timeout=5s
+      --prometheus.get_config_timeout=5s  
                                  Timeout for getting Prometheus config
-      --prometheus.http-client=<content>
+      --prometheus.http-client=<content>  
                                  Alternative to 'prometheus.http-client-file'
                                  flag (mutually exclusive). Content
                                  of YAML file or string with http
                                  client configs. See Format details:
                                  https://thanos.io/tip/components/sidecar.md/#configuration.
-      --prometheus.http-client-file=<file-path>
+      --prometheus.http-client-file=<file-path>  
                                  Path to YAML file or string with http
                                  client configs. See Format details:
                                  https://thanos.io/tip/components/sidecar.md/#configuration.
-      --prometheus.ready_timeout=10m
+      --prometheus.ready_timeout=10m  
                                  Maximum time to wait for the Prometheus
                                  instance to start up
-      --prometheus.url=http://localhost:9090
+      --prometheus.url=http://localhost:9090  
                                  URL at which to reach Prometheus's API.
                                  For better performance use local network.
-      --reloader.config-envsubst-file=""
+      --reloader.config-envsubst-file=""  
                                  Output file for environment variable
                                  substituted config file.
       --reloader.config-file=""  Config file watched by the reloader.
       --reloader.method=http     Method used to reload the configuration.
-      --reloader.process-name="prometheus"
+      --reloader.process-name="prometheus"  
                                  Executable name used to match the process being
                                  reloaded when using the signal method.
-      --reloader.retry-interval=5s
+      --reloader.retry-interval=5s  
                                  Controls how often reloader retries config
                                  reload in case of error.
-      --reloader.rule-dir=RELOADER.RULE-DIR ...
+      --reloader.rule-dir=RELOADER.RULE-DIR ...  
                                  Rule directories for the reloader to refresh
                                  (repeated field).
-      --reloader.watch-interval=3m
+      --reloader.watch-interval=3m  
                                  Controls how often reloader re-reads config and
                                  rules.
-      --request.logging-config=<content>
+      --request.logging-config=<content>  
                                  Alternative to 'request.logging-config-file'
                                  flag (mutually exclusive). Content
                                  of YAML file with request logging
                                  configuration. See format details:
                                  https://thanos.io/tip/thanos/logging.md/#configuration
-      --request.logging-config-file=<file-path>
+      --request.logging-config-file=<file-path>  
                                  Path to YAML file with request logging
                                  configuration. See format details:
                                  https://thanos.io/tip/thanos/logging.md/#configuration
-      --shipper.meta-file-name="thanos.shipper.json"
+      --shipper.meta-file-name="thanos.shipper.json"  
                                  the file to store shipper metadata in
-      --shipper.upload-compacted
+      --shipper.upload-compacted  
                                  If true shipper will try to upload compacted
                                  blocks as well. Useful for migration purposes.
                                  Works only if compaction is disabled on
                                  Prometheus. Do it once and then disable the
                                  flag when done.
-      --store.limits.request-samples=0
+      --store.limits.request-samples=0  
                                  The maximum samples allowed for a single
                                  Series request, The Series call fails if
                                  this limit is exceeded. 0 means no limit.
                                  NOTE: For efficiency the limit is internally
                                  implemented as 'chunks limit' considering each
                                  chunk contains a maximum of 120 samples.
-      --store.limits.request-series=0
+      --store.limits.request-series=0  
                                  The maximum series allowed for a single Series
                                  request. The Series call fails if this limit is
                                  exceeded. 0 means no limit.
-      --tracing.config=<content>
+      --tracing.config=<content>  
                                  Alternative to 'tracing.config-file' flag
                                  (mutually exclusive). Content of YAML file
                                  with tracing configuration. See format details:
                                  https://thanos.io/tip/thanos/tracing.md/#configuration
-      --tracing.config-file=<file-path>
+      --tracing.config-file=<file-path>  
                                  Path to YAML file with tracing
                                  configuration. See format details:
                                  https://thanos.io/tip/thanos/tracing.md/#configuration

--- a/docs/components/store.md
+++ b/docs/components/store.md
@@ -11,6 +11,8 @@ thanos store \
 The content of `bucket.yml`:
 
 ```yaml mdox-exec="go run scripts/cfggen/main.go --name=gcs.Config"
+# command-line-arguments
+ld: warning: ignoring duplicate libraries: '-lproc'
 type: GCS
 config:
   bucket: ""
@@ -34,6 +36,7 @@ config:
       insecure_skip_verify: false
     disable_compression: false
   chunk_size_bytes: 0
+  max_retries: 0
 prefix: ""
 ```
 
@@ -48,10 +51,10 @@ Store node giving access to blocks in a bucket provider. Now supported GCS, S3,
 Azure, Swift, Tencent COS and Aliyun OSS.
 
 Flags:
-      --auto-gomemlimit.ratio=0.9
+      --auto-gomemlimit.ratio=0.9  
                                  The ratio of reserved GOMEMLIMIT memory to the
                                  detected maximum container or system memory.
-      --block-discovery-strategy="concurrent"
+      --block-discovery-strategy="concurrent"  
                                  One of concurrent, recursive. When set to
                                  concurrent, stores will concurrently issue
                                  one call per directory to discover active
@@ -60,14 +63,14 @@ Flags:
                                  recursively traversing into each directory.
                                  This avoids N+1 calls at the expense of having
                                  slower bucket iterations.
-      --block-meta-fetch-concurrency=32
+      --block-meta-fetch-concurrency=32  
                                  Number of goroutines to use when fetching block
                                  metadata from object storage.
-      --block-sync-concurrency=20
+      --block-sync-concurrency=20  
                                  Number of goroutines to use when constructing
                                  index-cache.json blocks from object storage.
                                  Must be equal or greater than 1.
-      --bucket-web-label=BUCKET-WEB-LABEL
+      --bucket-web-label=BUCKET-WEB-LABEL  
                                  External block label to use as group title in
                                  the bucket web UI
       --cache-index-header       Cache TSDB index-headers on disk to reduce
@@ -93,39 +96,39 @@ Flags:
                                  --no-cache-index-header option is specified.
       --enable-auto-gomemlimit   Enable go runtime to automatically limit memory
                                  consumption.
-      --grpc-address="0.0.0.0:10901"
+      --grpc-address="0.0.0.0:10901"  
                                  Listen ip:port address for gRPC endpoints
                                  (StoreAPI). Make sure this address is routable
                                  from other components.
       --grpc-grace-period=2m     Time to wait after an interrupt received for
                                  GRPC Server.
-      --grpc-server-max-connection-age=60m
+      --grpc-server-max-connection-age=60m  
                                  The grpc server max connection age. This
                                  controls how often to re-establish connections
                                  and redo TLS handshakes.
       --grpc-server-tls-cert=""  TLS Certificate for gRPC server, leave blank to
                                  disable TLS
-      --grpc-server-tls-client-ca=""
+      --grpc-server-tls-client-ca=""  
                                  TLS CA to verify clients against. If no
                                  client CA is specified, there is no client
                                  verification on server side. (tls.NoClientCert)
       --grpc-server-tls-key=""   TLS Key for the gRPC server, leave blank to
                                  disable TLS
-      --grpc-server-tls-min-version="1.3"
+      --grpc-server-tls-min-version="1.3"  
                                  TLS supported minimum version for gRPC server.
                                  If no version is specified, it'll default to
                                  1.3. Allowed values: ["1.0", "1.1", "1.2",
                                  "1.3"]
   -h, --help                     Show context-sensitive help (also try
                                  --help-long and --help-man).
-      --http-address="0.0.0.0:10902"
+      --http-address="0.0.0.0:10902"  
                                  Listen host:port for HTTP endpoints.
       --http-grace-period=2m     Time to wait after an interrupt received for
                                  HTTP Server.
       --http.config=""           [EXPERIMENTAL] Path to the configuration file
                                  that can enable TLS or authentication for all
                                  HTTP endpoints.
-      --ignore-deletion-marks-delay=24h
+      --ignore-deletion-marks-delay=24h  
                                  Duration after which the blocks marked for
                                  deletion will be filtered out while fetching
                                  blocks. The idea of ignore-deletion-marks-delay
@@ -149,54 +152,54 @@ Flags:
       --index-cache-size=250MB   Maximum size of items held in the in-memory
                                  index cache. Ignored if --index-cache.config or
                                  --index-cache.config-file option is specified.
-      --index-cache.config=<content>
+      --index-cache.config=<content>  
                                  Alternative to 'index-cache.config-file'
                                  flag (mutually exclusive). Content of
                                  YAML file that contains index cache
                                  configuration. See format details:
                                  https://thanos.io/tip/components/store.md/#index-cache
-      --index-cache.config-file=<file-path>
+      --index-cache.config-file=<file-path>  
                                  Path to YAML file that contains index
                                  cache configuration. See format details:
                                  https://thanos.io/tip/components/store.md/#index-cache
       --log.format=logfmt        Log format to use. Possible options: logfmt or
                                  json.
       --log.level=info           Log filtering level.
-      --max-time=9999-12-31T23:59:59Z
+      --max-time=9999-12-31T23:59:59Z  
                                  End of time range limit to serve. Thanos Store
                                  will serve only blocks, which happened earlier
                                  than this value. Option can be a constant time
                                  in RFC3339 format or time duration relative
                                  to current time, such as -1d or 2h45m. Valid
                                  duration units are ms, s, m, h, d, w, y.
-      --min-time=0000-01-01T00:00:00Z
+      --min-time=0000-01-01T00:00:00Z  
                                  Start of time range limit to serve. Thanos
                                  Store will serve only metrics, which happened
                                  later than this value. Option can be a constant
                                  time in RFC3339 format or time duration
                                  relative to current time, such as -1d or 2h45m.
                                  Valid duration units are ms, s, m, h, d, w, y.
-      --objstore.config=<content>
+      --objstore.config=<content>  
                                  Alternative to 'objstore.config-file'
                                  flag (mutually exclusive). Content of
                                  YAML file that contains object store
                                  configuration. See format details:
                                  https://thanos.io/tip/thanos/storage.md/#configuration
-      --objstore.config-file=<file-path>
+      --objstore.config-file=<file-path>  
                                  Path to YAML file that contains object
                                  store configuration. See format details:
                                  https://thanos.io/tip/thanos/storage.md/#configuration
-      --request.logging-config=<content>
+      --request.logging-config=<content>  
                                  Alternative to 'request.logging-config-file'
                                  flag (mutually exclusive). Content
                                  of YAML file with request logging
                                  configuration. See format details:
                                  https://thanos.io/tip/thanos/logging.md/#configuration
-      --request.logging-config-file=<file-path>
+      --request.logging-config-file=<file-path>  
                                  Path to YAML file with request logging
                                  configuration. See format details:
                                  https://thanos.io/tip/thanos/logging.md/#configuration
-      --selector.relabel-config=<content>
+      --selector.relabel-config=<content>  
                                  Alternative to 'selector.relabel-config-file'
                                  flag (mutually exclusive). Content of YAML
                                  file with relabeling configuration that allows
@@ -204,59 +207,59 @@ Flags:
                                  external labels. It follows thanos sharding
                                  relabel-config syntax. For format details see:
                                  https://thanos.io/tip/thanos/sharding.md/#relabelling
-      --selector.relabel-config-file=<file-path>
+      --selector.relabel-config-file=<file-path>  
                                  Path to YAML file with relabeling
                                  configuration that allows selecting blocks
                                  to act on based on their external labels.
                                  It follows thanos sharding relabel-config
                                  syntax. For format details see:
                                  https://thanos.io/tip/thanos/sharding.md/#relabelling
-      --store.enable-index-header-lazy-reader
+      --store.enable-index-header-lazy-reader  
                                  If true, Store Gateway will lazy memory map
                                  index-header only once the block is required by
                                  a query.
-      --store.enable-lazy-expanded-postings
+      --store.enable-lazy-expanded-postings  
                                  If true, Store Gateway will estimate postings
                                  size and try to lazily expand postings if
                                  it downloads less data than expanding all
                                  postings.
-      --store.grpc.downloaded-bytes-limit=0
+      --store.grpc.downloaded-bytes-limit=0  
                                  Maximum amount of downloaded (either
                                  fetched or touched) bytes in a single
                                  Series/LabelNames/LabelValues call. The Series
                                  call fails if this limit is exceeded. 0 means
                                  no limit.
-      --store.grpc.series-max-concurrency=20
+      --store.grpc.series-max-concurrency=20  
                                  Maximum number of concurrent Series calls.
-      --store.grpc.series-sample-limit=0
+      --store.grpc.series-sample-limit=0  
                                  DEPRECATED: use store.limits.request-samples.
-      --store.grpc.touched-series-limit=0
+      --store.grpc.touched-series-limit=0  
                                  DEPRECATED: use store.limits.request-series.
-      --store.index-header-lazy-download-strategy=eager
+      --store.index-header-lazy-download-strategy=eager  
                                  Strategy of how to download index headers
                                  lazily. Supported values: eager, lazy.
                                  If eager, always download index header during
                                  initial load. If lazy, download index header
                                  during query time.
-      --store.limits.request-samples=0
+      --store.limits.request-samples=0  
                                  The maximum samples allowed for a single
                                  Series request, The Series call fails if
                                  this limit is exceeded. 0 means no limit.
                                  NOTE: For efficiency the limit is internally
                                  implemented as 'chunks limit' considering each
                                  chunk contains a maximum of 120 samples.
-      --store.limits.request-series=0
+      --store.limits.request-series=0  
                                  The maximum series allowed for a single Series
                                  request. The Series call fails if this limit is
                                  exceeded. 0 means no limit.
       --sync-block-duration=15m  Repeat interval for syncing the blocks between
                                  local and remote view.
-      --tracing.config=<content>
+      --tracing.config=<content>  
                                  Alternative to 'tracing.config-file' flag
                                  (mutually exclusive). Content of YAML file
                                  with tracing configuration. See format details:
                                  https://thanos.io/tip/thanos/tracing.md/#configuration
-      --tracing.config-file=<file-path>
+      --tracing.config-file=<file-path>  
                                  Path to YAML file with tracing
                                  configuration. See format details:
                                  https://thanos.io/tip/thanos/tracing.md/#configuration
@@ -332,6 +335,8 @@ The `in-memory` index cache is enabled by default and its max size can be config
 Alternatively, the `in-memory` index cache can also be configured using `--index-cache.config-file` to reference the configuration file or `--index-cache.config` to put yaml config directly:
 
 ```yaml mdox-exec="go run scripts/cfggen/main.go --name=storecache.InMemoryIndexCacheConfig"
+# command-line-arguments
+ld: warning: ignoring duplicate libraries: '-lproc'
 type: IN-MEMORY
 config:
   max_size: 0
@@ -352,6 +357,8 @@ All the settings are **optional**:
 The `memcached` index cache allows to use [Memcached](https://memcached.org) as cache backend. This cache type is configured using `--index-cache.config-file` to reference the configuration file or `--index-cache.config` to put yaml config directly:
 
 ```yaml mdox-exec="go run scripts/cfggen/main.go --name=cacheutil.MemcachedClientConfig"
+# command-line-arguments
+ld: warning: ignoring duplicate libraries: '-lproc'
 type: MEMCACHED
 config:
   addresses: []
@@ -411,6 +418,8 @@ While the remaining settings are **optional**:
 The `redis` index cache allows to use [Redis](https://redis.io) as cache backend. This cache type is configured using `--index-cache.config-file` to reference the configuration file or `--index-cache.config` to put yaml config directly:
 
 ```yaml mdox-exec="go run scripts/cfggen/main.go --name=cacheutil.RedisClientConfig"
+# command-line-arguments
+ld: warning: ignoring duplicate libraries: '-lproc'
 type: REDIS
 config:
   addr: ""

--- a/docs/components/tools.md
+++ b/docs/components/tools.md
@@ -12,7 +12,7 @@ usage: thanos tools <command> [<args> ...]
 Tools utility commands
 
 Flags:
-      --auto-gomemlimit.ratio=0.9
+      --auto-gomemlimit.ratio=0.9  
                                 The ratio of reserved GOMEMLIMIT memory to the
                                 detected maximum container or system memory.
       --enable-auto-gomemlimit  Enable go runtime to automatically limit memory
@@ -22,12 +22,12 @@ Flags:
       --log.format=logfmt       Log format to use. Possible options: logfmt or
                                 json.
       --log.level=info          Log filtering level.
-      --tracing.config=<content>
+      --tracing.config=<content>  
                                 Alternative to 'tracing.config-file' flag
                                 (mutually exclusive). Content of YAML file
                                 with tracing configuration. See format details:
                                 https://thanos.io/tip/thanos/tracing.md/#configuration
-      --tracing.config-file=<file-path>
+      --tracing.config-file=<file-path>  
                                 Path to YAML file with tracing
                                 configuration. See format details:
                                 https://thanos.io/tip/thanos/tracing.md/#configuration
@@ -106,6 +106,8 @@ thanos tools bucket verify --objstore.config-file=bucket.yml
 The content of `bucket.yml`:
 
 ```yaml mdox-exec="go run scripts/cfggen/main.go --name=gcs.Config"
+# command-line-arguments
+ld: warning: ignoring duplicate libraries: '-lproc'
 type: GCS
 config:
   bucket: ""
@@ -129,6 +131,7 @@ config:
       insecure_skip_verify: false
     disable_compression: false
   chunk_size_bytes: 0
+  max_retries: 0
 prefix: ""
 ```
 
@@ -140,7 +143,7 @@ usage: thanos tools bucket [<flags>] <command> [<args> ...]
 Bucket utility commands
 
 Flags:
-      --auto-gomemlimit.ratio=0.9
+      --auto-gomemlimit.ratio=0.9  
                                 The ratio of reserved GOMEMLIMIT memory to the
                                 detected maximum container or system memory.
       --enable-auto-gomemlimit  Enable go runtime to automatically limit memory
@@ -150,22 +153,22 @@ Flags:
       --log.format=logfmt       Log format to use. Possible options: logfmt or
                                 json.
       --log.level=info          Log filtering level.
-      --objstore.config=<content>
+      --objstore.config=<content>  
                                 Alternative to 'objstore.config-file'
                                 flag (mutually exclusive). Content of
                                 YAML file that contains object store
                                 configuration. See format details:
                                 https://thanos.io/tip/thanos/storage.md/#configuration
-      --objstore.config-file=<file-path>
+      --objstore.config-file=<file-path>  
                                 Path to YAML file that contains object
                                 store configuration. See format details:
                                 https://thanos.io/tip/thanos/storage.md/#configuration
-      --tracing.config=<content>
+      --tracing.config=<content>  
                                 Alternative to 'tracing.config-file' flag
                                 (mutually exclusive). Content of YAML file
                                 with tracing configuration. See format details:
                                 https://thanos.io/tip/thanos/tracing.md/#configuration
-      --tracing.config-file=<file-path>
+      --tracing.config-file=<file-path>  
                                 Path to YAML file with tracing
                                 configuration. See format details:
                                 https://thanos.io/tip/thanos/tracing.md/#configuration
@@ -248,17 +251,17 @@ usage: thanos tools bucket web [<flags>]
 Web interface for remote storage bucket.
 
 Flags:
-      --auto-gomemlimit.ratio=0.9
+      --auto-gomemlimit.ratio=0.9  
                                 The ratio of reserved GOMEMLIMIT memory to the
                                 detected maximum container or system memory.
-      --disable-admin-operations
+      --disable-admin-operations  
                                 Disable UI/API admin operations like marking
                                 blocks for deletion and no compaction.
       --enable-auto-gomemlimit  Enable go runtime to automatically limit memory
                                 consumption.
   -h, --help                    Show context-sensitive help (also try
                                 --help-long and --help-man).
-      --http-address="0.0.0.0:10902"
+      --http-address="0.0.0.0:10902"  
                                 Listen host:port for HTTP endpoints.
       --http-grace-period=2m    Time to wait after an interrupt received for
                                 HTTP Server.
@@ -269,7 +272,7 @@ Flags:
       --log.format=logfmt       Log format to use. Possible options: logfmt or
                                 json.
       --log.level=info          Log filtering level.
-      --max-time=9999-12-31T23:59:59Z
+      --max-time=9999-12-31T23:59:59Z  
                                 End of time range limit to serve. Thanos
                                 tool bucket web will serve only blocks,
                                 which happened earlier than this value. Option
@@ -277,26 +280,26 @@ Flags:
                                 duration relative to current time, such as -1d
                                 or 2h45m. Valid duration units are ms, s, m, h,
                                 d, w, y.
-      --min-time=0000-01-01T00:00:00Z
+      --min-time=0000-01-01T00:00:00Z  
                                 Start of time range limit to serve. Thanos
                                 tool bucket web will serve only blocks, which
                                 happened later than this value. Option can be a
                                 constant time in RFC3339 format or time duration
                                 relative to current time, such as -1d or 2h45m.
                                 Valid duration units are ms, s, m, h, d, w, y.
-      --objstore.config=<content>
+      --objstore.config=<content>  
                                 Alternative to 'objstore.config-file'
                                 flag (mutually exclusive). Content of
                                 YAML file that contains object store
                                 configuration. See format details:
                                 https://thanos.io/tip/thanos/storage.md/#configuration
-      --objstore.config-file=<file-path>
+      --objstore.config-file=<file-path>  
                                 Path to YAML file that contains object
                                 store configuration. See format details:
                                 https://thanos.io/tip/thanos/storage.md/#configuration
       --refresh=30m             Refresh interval to download metadata from
                                 remote storage
-      --selector.relabel-config=<content>
+      --selector.relabel-config=<content>  
                                 Alternative to 'selector.relabel-config-file'
                                 flag (mutually exclusive). Content of YAML
                                 file with relabeling configuration that allows
@@ -304,7 +307,7 @@ Flags:
                                 external labels. It follows thanos sharding
                                 relabel-config syntax. For format details see:
                                 https://thanos.io/tip/thanos/sharding.md/#relabelling
-      --selector.relabel-config-file=<file-path>
+      --selector.relabel-config-file=<file-path>  
                                 Path to YAML file with relabeling
                                 configuration that allows selecting blocks
                                 to act on based on their external labels.
@@ -312,12 +315,12 @@ Flags:
                                 syntax. For format details see:
                                 https://thanos.io/tip/thanos/sharding.md/#relabelling
       --timeout=5m              Timeout to download metadata from remote storage
-      --tracing.config=<content>
+      --tracing.config=<content>  
                                 Alternative to 'tracing.config-file' flag
                                 (mutually exclusive). Content of YAML file
                                 with tracing configuration. See format details:
                                 https://thanos.io/tip/thanos/tracing.md/#configuration
-      --tracing.config-file=<file-path>
+      --tracing.config-file=<file-path>  
                                 Path to YAML file with tracing
                                 configuration. See format details:
                                 https://thanos.io/tip/thanos/tracing.md/#configuration
@@ -372,7 +375,7 @@ issue this might take time and will need downloading all specified blocks to
 disk.
 
 Flags:
-      --auto-gomemlimit.ratio=0.9
+      --auto-gomemlimit.ratio=0.9  
                                 The ratio of reserved GOMEMLIMIT memory to the
                                 detected maximum container or system memory.
       --delete-delay=0s         Duration after which blocks marked for deletion
@@ -395,7 +398,7 @@ Flags:
       --id=ID ...               Block IDs to verify (and optionally repair)
                                 only. If none is specified, all blocks will be
                                 verified. Repeated field
-  -i, --issues=index_known_issues... ...
+  -i, --issues=index_known_issues... ...  
                                 Issues to verify (and optionally repair).
                                 Possible issue to verify, without repair:
                                 [overlapped_blocks]; Possible issue to
@@ -404,7 +407,7 @@ Flags:
       --log.format=logfmt       Log format to use. Possible options: logfmt or
                                 json.
       --log.level=info          Log filtering level.
-      --objstore-backup.config=<content>
+      --objstore-backup.config=<content>  
                                 Alternative to 'objstore-backup.config-file'
                                 flag (mutually exclusive). Content of YAML
                                 file that contains object store-backup
@@ -412,30 +415,30 @@ Flags:
                                 https://thanos.io/tip/thanos/storage.md/#configuration
                                 Used for repair logic to backup blocks before
                                 removal.
-      --objstore-backup.config-file=<file-path>
+      --objstore-backup.config-file=<file-path>  
                                 Path to YAML file that contains object
                                 store-backup configuration. See format details:
                                 https://thanos.io/tip/thanos/storage.md/#configuration
                                 Used for repair logic to backup blocks before
                                 removal.
-      --objstore.config=<content>
+      --objstore.config=<content>  
                                 Alternative to 'objstore.config-file'
                                 flag (mutually exclusive). Content of
                                 YAML file that contains object store
                                 configuration. See format details:
                                 https://thanos.io/tip/thanos/storage.md/#configuration
-      --objstore.config-file=<file-path>
+      --objstore.config-file=<file-path>  
                                 Path to YAML file that contains object
                                 store configuration. See format details:
                                 https://thanos.io/tip/thanos/storage.md/#configuration
   -r, --repair                  Attempt to repair blocks for which issues were
                                 detected
-      --tracing.config=<content>
+      --tracing.config=<content>  
                                 Alternative to 'tracing.config-file' flag
                                 (mutually exclusive). Content of YAML file
                                 with tracing configuration. See format details:
                                 https://thanos.io/tip/thanos/tracing.md/#configuration
-      --tracing.config-file=<file-path>
+      --tracing.config-file=<file-path>  
                                 Path to YAML file with tracing
                                 configuration. See format details:
                                 https://thanos.io/tip/thanos/tracing.md/#configuration
@@ -459,7 +462,7 @@ usage: thanos tools bucket ls [<flags>]
 List all blocks in the bucket.
 
 Flags:
-      --auto-gomemlimit.ratio=0.9
+      --auto-gomemlimit.ratio=0.9  
                                 The ratio of reserved GOMEMLIMIT memory to the
                                 detected maximum container or system memory.
       --enable-auto-gomemlimit  Enable go runtime to automatically limit memory
@@ -470,25 +473,25 @@ Flags:
       --log.format=logfmt       Log format to use. Possible options: logfmt or
                                 json.
       --log.level=info          Log filtering level.
-      --objstore.config=<content>
+      --objstore.config=<content>  
                                 Alternative to 'objstore.config-file'
                                 flag (mutually exclusive). Content of
                                 YAML file that contains object store
                                 configuration. See format details:
                                 https://thanos.io/tip/thanos/storage.md/#configuration
-      --objstore.config-file=<file-path>
+      --objstore.config-file=<file-path>  
                                 Path to YAML file that contains object
                                 store configuration. See format details:
                                 https://thanos.io/tip/thanos/storage.md/#configuration
   -o, --output=""               Optional format in which to print each block's
                                 information. Options are 'json', 'wide' or a
                                 custom template.
-      --tracing.config=<content>
+      --tracing.config=<content>  
                                 Alternative to 'tracing.config-file' flag
                                 (mutually exclusive). Content of YAML file
                                 with tracing configuration. See format details:
                                 https://thanos.io/tip/thanos/tracing.md/#configuration
-      --tracing.config-file=<file-path>
+      --tracing.config-file=<file-path>  
                                 Path to YAML file with tracing
                                 configuration. See format details:
                                 https://thanos.io/tip/thanos/tracing.md/#configuration
@@ -512,7 +515,7 @@ usage: thanos tools bucket inspect [<flags>]
 Inspect all blocks in the bucket in detailed, table-like way.
 
 Flags:
-      --auto-gomemlimit.ratio=0.9
+      --auto-gomemlimit.ratio=0.9  
                                 The ratio of reserved GOMEMLIMIT memory to the
                                 detected maximum container or system memory.
       --enable-auto-gomemlimit  Enable go runtime to automatically limit memory
@@ -522,19 +525,19 @@ Flags:
       --log.format=logfmt       Log format to use. Possible options: logfmt or
                                 json.
       --log.level=info          Log filtering level.
-      --objstore.config=<content>
+      --objstore.config=<content>  
                                 Alternative to 'objstore.config-file'
                                 flag (mutually exclusive). Content of
                                 YAML file that contains object store
                                 configuration. See format details:
                                 https://thanos.io/tip/thanos/storage.md/#configuration
-      --objstore.config-file=<file-path>
+      --objstore.config-file=<file-path>  
                                 Path to YAML file that contains object
                                 store configuration. See format details:
                                 https://thanos.io/tip/thanos/storage.md/#configuration
       --output=table            Output format for result. Currently supports
                                 table, cvs, tsv.
-  -l, --selector=<name>=\"<value>\" ...
+  -l, --selector=<name>=\"<value>\" ...  
                                 Selects blocks based on label, e.g. '-l
                                 key1=\"value1\" -l key2=\"value2\"'. All key
                                 value pairs must match.
@@ -544,12 +547,12 @@ Flags:
                                 rows are then further sorted by the 'UNTIL'
                                 value.
       --timeout=5m              Timeout to download metadata from remote storage
-      --tracing.config=<content>
+      --tracing.config=<content>  
                                 Alternative to 'tracing.config-file' flag
                                 (mutually exclusive). Content of YAML file
                                 with tracing configuration. See format details:
                                 https://thanos.io/tip/thanos/tracing.md/#configuration
-      --tracing.config-file=<file-path>
+      --tracing.config-file=<file-path>  
                                 Path to YAML file with tracing
                                 configuration. See format details:
                                 https://thanos.io/tip/thanos/tracing.md/#configuration
@@ -576,10 +579,10 @@ Replicate data from one object storage to another. NOTE: Currently it works only
 with Thanos blocks (meta.json has to have Thanos metadata).
 
 Flags:
-      --auto-gomemlimit.ratio=0.9
+      --auto-gomemlimit.ratio=0.9  
                                 The ratio of reserved GOMEMLIMIT memory to the
                                 detected maximum container or system memory.
-      --compaction=COMPACTION ...
+      --compaction=COMPACTION ...  
                                 Only blocks with these compaction levels
                                 will be replicated. Repeated flag. Overrides
                                 compaction-min and compaction-max if set.
@@ -591,7 +594,7 @@ Flags:
                                 consumption.
   -h, --help                    Show context-sensitive help (also try
                                 --help-long and --help-man).
-      --http-address="0.0.0.0:10902"
+      --http-address="0.0.0.0:10902"  
                                 Listen host:port for HTTP endpoints.
       --http-grace-period=2m    Time to wait after an interrupt received for
                                 HTTP Server.
@@ -603,7 +606,7 @@ Flags:
                                 other matchers will be ignored. When specified,
                                 this command will be run only once after
                                 successful replication. Repeated field
-      --ignore-marked-for-deletion
+      --ignore-marked-for-deletion  
                                 Do not replicate blocks that have deletion mark.
       --log.format=logfmt       Log format to use. Possible options: logfmt or
                                 json.
@@ -611,7 +614,7 @@ Flags:
       --matcher=MATCHER         blocks whose external labels match this matcher
                                 will be replicated. All Prometheus matchers are
                                 supported, including =, !=, =~ and !~.
-      --max-time=9999-12-31T23:59:59Z
+      --max-time=9999-12-31T23:59:59Z  
                                 End of time range limit to replicate.
                                 Thanos Replicate will replicate only metrics,
                                 which happened earlier than this value. Option
@@ -619,44 +622,44 @@ Flags:
                                 duration relative to current time, such as -1d
                                 or 2h45m. Valid duration units are ms, s, m, h,
                                 d, w, y.
-      --min-time=0000-01-01T00:00:00Z
+      --min-time=0000-01-01T00:00:00Z  
                                 Start of time range limit to replicate. Thanos
                                 Replicate will replicate only metrics, which
                                 happened later than this value. Option can be a
                                 constant time in RFC3339 format or time duration
                                 relative to current time, such as -1d or 2h45m.
                                 Valid duration units are ms, s, m, h, d, w, y.
-      --objstore-to.config=<content>
+      --objstore-to.config=<content>  
                                 Alternative to 'objstore-to.config-file'
                                 flag (mutually exclusive). Content of
                                 YAML file that contains object store-to
                                 configuration. See format details:
                                 https://thanos.io/tip/thanos/storage.md/#configuration
                                 The object storage which replicate data to.
-      --objstore-to.config-file=<file-path>
+      --objstore-to.config-file=<file-path>  
                                 Path to YAML file that contains object
                                 store-to configuration. See format details:
                                 https://thanos.io/tip/thanos/storage.md/#configuration
                                 The object storage which replicate data to.
-      --objstore.config=<content>
+      --objstore.config=<content>  
                                 Alternative to 'objstore.config-file'
                                 flag (mutually exclusive). Content of
                                 YAML file that contains object store
                                 configuration. See format details:
                                 https://thanos.io/tip/thanos/storage.md/#configuration
-      --objstore.config-file=<file-path>
+      --objstore.config-file=<file-path>  
                                 Path to YAML file that contains object
                                 store configuration. See format details:
                                 https://thanos.io/tip/thanos/storage.md/#configuration
       --resolution=0s... ...    Only blocks with these resolutions will be
                                 replicated. Repeated flag.
       --single-run              Run replication only one time, then exit.
-      --tracing.config=<content>
+      --tracing.config=<content>  
                                 Alternative to 'tracing.config-file' flag
                                 (mutually exclusive). Content of YAML file
                                 with tracing configuration. See format details:
                                 https://thanos.io/tip/thanos/tracing.md/#configuration
-      --tracing.config-file=<file-path>
+      --tracing.config-file=<file-path>  
                                 Path to YAML file with tracing
                                 configuration. See format details:
                                 https://thanos.io/tip/thanos/tracing.md/#configuration
@@ -677,6 +680,8 @@ thanos tools bucket downsample \
 The content of `bucket.yml`:
 
 ```yaml mdox-exec="go run scripts/cfggen/main.go --name=gcs.Config"
+# command-line-arguments
+ld: warning: ignoring duplicate libraries: '-lproc'
 type: GCS
 config:
   bucket: ""
@@ -700,6 +705,7 @@ config:
       insecure_skip_verify: false
     disable_compression: false
   chunk_size_bytes: 0
+  max_retries: 0
 prefix: ""
 ```
 
@@ -709,16 +715,16 @@ usage: thanos tools bucket downsample [<flags>]
 Continuously downsamples blocks in an object store bucket.
 
 Flags:
-      --auto-gomemlimit.ratio=0.9
+      --auto-gomemlimit.ratio=0.9  
                                 The ratio of reserved GOMEMLIMIT memory to the
                                 detected maximum container or system memory.
-      --block-files-concurrency=1
+      --block-files-concurrency=1  
                                 Number of goroutines to use when
                                 fetching/uploading block files from object
                                 storage.
       --data-dir="./data"       Data directory in which to cache blocks and
                                 process downsamplings.
-      --downsample.concurrency=1
+      --downsample.concurrency=1  
                                 Number of goroutines to use when downsampling
                                 blocks.
       --enable-auto-gomemlimit  Enable go runtime to automatically limit memory
@@ -731,7 +737,7 @@ Flags:
                                 Possible values are: "", "SHA256".
   -h, --help                    Show context-sensitive help (also try
                                 --help-long and --help-man).
-      --http-address="0.0.0.0:10902"
+      --http-address="0.0.0.0:10902"  
                                 Listen host:port for HTTP endpoints.
       --http-grace-period=2m    Time to wait after an interrupt received for
                                 HTTP Server.
@@ -741,22 +747,22 @@ Flags:
       --log.format=logfmt       Log format to use. Possible options: logfmt or
                                 json.
       --log.level=info          Log filtering level.
-      --objstore.config=<content>
+      --objstore.config=<content>  
                                 Alternative to 'objstore.config-file'
                                 flag (mutually exclusive). Content of
                                 YAML file that contains object store
                                 configuration. See format details:
                                 https://thanos.io/tip/thanos/storage.md/#configuration
-      --objstore.config-file=<file-path>
+      --objstore.config-file=<file-path>  
                                 Path to YAML file that contains object
                                 store configuration. See format details:
                                 https://thanos.io/tip/thanos/storage.md/#configuration
-      --tracing.config=<content>
+      --tracing.config=<content>  
                                 Alternative to 'tracing.config-file' flag
                                 (mutually exclusive). Content of YAML file
                                 with tracing configuration. See format details:
                                 https://thanos.io/tip/thanos/tracing.md/#configuration
-      --tracing.config-file=<file-path>
+      --tracing.config-file=<file-path>  
                                 Path to YAML file with tracing
                                 configuration. See format details:
                                 https://thanos.io/tip/thanos/tracing.md/#configuration
@@ -780,6 +786,8 @@ thanos tools bucket mark \
 The example content of `bucket.yml`:
 
 ```yaml mdox-exec="go run scripts/cfggen/main.go --name=gcs.Config"
+# command-line-arguments
+ld: warning: ignoring duplicate libraries: '-lproc'
 type: GCS
 config:
   bucket: ""
@@ -803,6 +811,7 @@ config:
       insecure_skip_verify: false
     disable_compression: false
   chunk_size_bytes: 0
+  max_retries: 0
 prefix: ""
 ```
 
@@ -814,7 +823,7 @@ currently running compacting same block, this operation would be potentially a
 noop.
 
 Flags:
-      --auto-gomemlimit.ratio=0.9
+      --auto-gomemlimit.ratio=0.9  
                                 The ratio of reserved GOMEMLIMIT memory to the
                                 detected maximum container or system memory.
       --details=DETAILS         Human readable details to be put into marker.
@@ -828,23 +837,23 @@ Flags:
                                 json.
       --log.level=info          Log filtering level.
       --marker=MARKER           Marker to be put.
-      --objstore.config=<content>
+      --objstore.config=<content>  
                                 Alternative to 'objstore.config-file'
                                 flag (mutually exclusive). Content of
                                 YAML file that contains object store
                                 configuration. See format details:
                                 https://thanos.io/tip/thanos/storage.md/#configuration
-      --objstore.config-file=<file-path>
+      --objstore.config-file=<file-path>  
                                 Path to YAML file that contains object
                                 store configuration. See format details:
                                 https://thanos.io/tip/thanos/storage.md/#configuration
       --remove                  Remove the marker.
-      --tracing.config=<content>
+      --tracing.config=<content>  
                                 Alternative to 'tracing.config-file' flag
                                 (mutually exclusive). Content of YAML file
                                 with tracing configuration. See format details:
                                 https://thanos.io/tip/thanos/tracing.md/#configuration
-      --tracing.config-file=<file-path>
+      --tracing.config-file=<file-path>  
                                 Path to YAML file with tracing
                                 configuration. See format details:
                                 https://thanos.io/tip/thanos/tracing.md/#configuration
@@ -896,7 +905,7 @@ block for deletion to avoid overlaps. WARNING: This procedure is *IRREVERSIBLE*
 after certain time (delete delay), so do backup your blocks first.
 
 Flags:
-      --auto-gomemlimit.ratio=0.9
+      --auto-gomemlimit.ratio=0.9  
                                 The ratio of reserved GOMEMLIMIT memory to the
                                 detected maximum container or system memory.
       --delete-blocks           Whether to delete the original blocks after
@@ -920,13 +929,13 @@ Flags:
       --log.format=logfmt       Log format to use. Possible options: logfmt or
                                 json.
       --log.level=info          Log filtering level.
-      --objstore.config=<content>
+      --objstore.config=<content>  
                                 Alternative to 'objstore.config-file'
                                 flag (mutually exclusive). Content of
                                 YAML file that contains object store
                                 configuration. See format details:
                                 https://thanos.io/tip/thanos/storage.md/#configuration
-      --objstore.config-file=<file-path>
+      --objstore.config-file=<file-path>  
                                 Path to YAML file that contains object
                                 store configuration. See format details:
                                 https://thanos.io/tip/thanos/storage.md/#configuration
@@ -936,31 +945,31 @@ Flags:
       --rewrite.add-change-log  If specified, all modifications are written to
                                 new block directory. Disable if latency is to
                                 high.
-      --rewrite.to-delete-config=<content>
+      --rewrite.to-delete-config=<content>  
                                 Alternative to 'rewrite.to-delete-config-file'
                                 flag (mutually exclusive). Content of YAML file
                                 that contains []metadata.DeletionRequest that
                                 will be applied to blocks
-      --rewrite.to-delete-config-file=<file-path>
+      --rewrite.to-delete-config-file=<file-path>  
                                 Path to YAML file that contains
                                 []metadata.DeletionRequest that will be applied
                                 to blocks
-      --rewrite.to-relabel-config=<content>
+      --rewrite.to-relabel-config=<content>  
                                 Alternative to 'rewrite.to-relabel-config-file'
                                 flag (mutually exclusive). Content of YAML
                                 file that contains relabel configs that will be
                                 applied to blocks
-      --rewrite.to-relabel-config-file=<file-path>
+      --rewrite.to-relabel-config-file=<file-path>  
                                 Path to YAML file that contains relabel configs
                                 that will be applied to blocks
-      --tmp.dir="/tmp/thanos-rewrite"
+      --tmp.dir="/var/folders/vm/59g86g4n7t35531zxplgc8r40000gp/T/thanos-rewrite"  
                                 Working directory for temporary files
-      --tracing.config=<content>
+      --tracing.config=<content>  
                                 Alternative to 'tracing.config-file' flag
                                 (mutually exclusive). Content of YAML file
                                 with tracing configuration. See format details:
                                 https://thanos.io/tip/thanos/tracing.md/#configuration
-      --tracing.config-file=<file-path>
+      --tracing.config-file=<file-path>  
                                 Path to YAML file with tracing
                                 configuration. See format details:
                                 https://thanos.io/tip/thanos/tracing.md/#configuration
@@ -978,7 +987,7 @@ usage: thanos tools bucket upload-blocks [<flags>]
 Upload blocks push blocks from the provided path to the object storage.
 
 Flags:
-      --auto-gomemlimit.ratio=0.9
+      --auto-gomemlimit.ratio=0.9  
                                 The ratio of reserved GOMEMLIMIT memory to the
                                 detected maximum container or system memory.
       --enable-auto-gomemlimit  Enable go runtime to automatically limit memory
@@ -990,24 +999,24 @@ Flags:
       --log.format=logfmt       Log format to use. Possible options: logfmt or
                                 json.
       --log.level=info          Log filtering level.
-      --objstore.config=<content>
+      --objstore.config=<content>  
                                 Alternative to 'objstore.config-file'
                                 flag (mutually exclusive). Content of
                                 YAML file that contains object store
                                 configuration. See format details:
                                 https://thanos.io/tip/thanos/storage.md/#configuration
-      --objstore.config-file=<file-path>
+      --objstore.config-file=<file-path>  
                                 Path to YAML file that contains object
                                 store configuration. See format details:
                                 https://thanos.io/tip/thanos/storage.md/#configuration
       --path="./data"           Path to the directory containing blocks to
                                 upload.
-      --tracing.config=<content>
+      --tracing.config=<content>  
                                 Alternative to 'tracing.config-file' flag
                                 (mutually exclusive). Content of YAML file
                                 with tracing configuration. See format details:
                                 https://thanos.io/tip/thanos/tracing.md/#configuration
-      --tracing.config-file=<file-path>
+      --tracing.config-file=<file-path>  
                                 Path to YAML file with tracing
                                 configuration. See format details:
                                 https://thanos.io/tip/thanos/tracing.md/#configuration
@@ -1037,7 +1046,7 @@ usage: thanos tools rules-check --rules=RULES
 Check if the rule files are valid or not.
 
 Flags:
-      --auto-gomemlimit.ratio=0.9
+      --auto-gomemlimit.ratio=0.9  
                                 The ratio of reserved GOMEMLIMIT memory to the
                                 detected maximum container or system memory.
       --enable-auto-gomemlimit  Enable go runtime to automatically limit memory
@@ -1048,12 +1057,12 @@ Flags:
                                 json.
       --log.level=info          Log filtering level.
       --rules=RULES ...         The rule files glob to check (repeated).
-      --tracing.config=<content>
+      --tracing.config=<content>  
                                 Alternative to 'tracing.config-file' flag
                                 (mutually exclusive). Content of YAML file
                                 with tracing configuration. See format details:
                                 https://thanos.io/tip/thanos/tracing.md/#configuration
-      --tracing.config-file=<file-path>
+      --tracing.config-file=<file-path>  
                                 Path to YAML file with tracing
                                 configuration. See format details:
                                 https://thanos.io/tip/thanos/tracing.md/#configuration

--- a/docs/components/tools.md
+++ b/docs/components/tools.md
@@ -129,7 +129,6 @@ config:
       insecure_skip_verify: false
     disable_compression: false
   chunk_size_bytes: 0
-  max_retries: 0
 prefix: ""
 ```
 
@@ -701,7 +700,6 @@ config:
       insecure_skip_verify: false
     disable_compression: false
   chunk_size_bytes: 0
-  max_retries: 0
 prefix: ""
 ```
 
@@ -805,7 +803,6 @@ config:
       insecure_skip_verify: false
     disable_compression: false
   chunk_size_bytes: 0
-  max_retries: 0
 prefix: ""
 ```
 

--- a/docs/sharding.md
+++ b/docs/sharding.md
@@ -18,7 +18,7 @@ Queries against store gateway which are touching large number of blocks (no matt
 
 # Relabelling
 
-Similar to [promtail](https://grafana.com/docs/loki/latest/clients/promtail/configuration/#relabel_configs) this config follows native [Prometheus relabel-config](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config) syntax.
+Similar to [promtail](https://grafana.com/docs/loki/latest/send-data/promtail/configuration/#relabel_configs) this config follows native [Prometheus relabel-config](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config) syntax.
 
 Currently, thanos only supports the following relabel actions:
 

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -61,6 +61,8 @@ You can configure an S3 bucket as an object store with YAML, either by passing t
 NOTE: Minio client was mainly for AWS S3, but it can be configured against other S3-compatible object storages e.g Ceph
 
 ```yaml mdox-exec="go run scripts/cfggen/main.go --name=s3.Config"
+# command-line-arguments
+ld: warning: ignoring duplicate libraries: '-lproc'
 type: S3
 config:
   bucket: ""
@@ -103,6 +105,7 @@ config:
     kms_encryption_context: {}
     encryption_key: ""
   sts_endpoint: ""
+  max_retries: 0
 prefix: ""
 ```
 
@@ -282,6 +285,8 @@ To configure Google Cloud Storage bucket as an object store you need to set `buc
 For example:
 
 ```yaml mdox-exec="go run scripts/cfggen/main.go --name=gcs.Config"
+# command-line-arguments
+ld: warning: ignoring duplicate libraries: '-lproc'
 type: GCS
 config:
   bucket: ""
@@ -305,6 +310,7 @@ config:
       insecure_skip_verify: false
     disable_compression: false
   chunk_size_bytes: 0
+  max_retries: 0
 prefix: ""
 ```
 
@@ -375,6 +381,8 @@ To configure Azure Storage account as an object store you need to provide a path
 Config file format is the following:
 
 ```yaml mdox-exec="go run scripts/cfggen/main.go --name=azure.Config"
+# command-line-arguments
+ld: warning: ignoring duplicate libraries: '-lproc'
 type: AZURE
 config:
   storage_account: ""
@@ -435,6 +443,8 @@ Below is an example configuration file for thanos to use OpenStack swift contain
 By default, OpenStack Swift has a limit for maximum file size of 5 GiB. Thanos index files are often larger than that. To resolve this issue, Thanos uses [Static Large Objects (SLO)](https://docs.openstack.org/swift/latest/overview_large_objects.html) which are uploaded as segments. These are by default put into the `segments` directory of the same container. The default limit for using SLO is 1 GiB which is also the maximum size of the segment. If you don't want to use the same container for the segments (best practise is to use `<container_name>_segments` to avoid polluting listing of the container objects) you can use the `large_file_segments_container_name` option to override the default and put the segments to other container. *In rare cases you can switch to [Dynamic Large Objects (DLO)](https://docs.openstack.org/swift/latest/overview_large_objects.html) by setting the `use_dynamic_large_objects` to true, but use it with caution since it even more relies on eventual consistency.*
 
 ```yaml mdox-exec="go run scripts/cfggen/main.go --name=swift.Config"
+# command-line-arguments
+ld: warning: ignoring duplicate libraries: '-lproc'
 type: SWIFT
 config:
   auth_version: 0
@@ -487,6 +497,8 @@ To use Tencent COS as storage store, you should apply a Tencent Account to creat
 To configure Tencent Account to use COS as storage store you need to set these parameters in yaml format stored in a file:
 
 ```yaml mdox-exec="go run scripts/cfggen/main.go --name=cos.Config"
+# command-line-arguments
+ld: warning: ignoring duplicate libraries: '-lproc'
 type: COS
 config:
   bucket: ""
@@ -495,6 +507,7 @@ config:
   endpoint: ""
   secret_key: ""
   secret_id: ""
+  max_retries: 0
   http_config:
     idle_conn_timeout: 1m30s
     response_header_timeout: 2m
@@ -527,6 +540,8 @@ In order to use AliYun OSS object storage, you should first create a bucket with
 To use AliYun OSS object storage, please specify following yaml configuration file in `objstore.config*` flag.
 
 ```yaml mdox-exec="go run scripts/cfggen/main.go --name=oss.Config"
+# command-line-arguments
+ld: warning: ignoring duplicate libraries: '-lproc'
 type: ALIYUNOSS
 config:
   endpoint: ""
@@ -543,6 +558,8 @@ Use --objstore.config-file to reference to this configuration file.
 In order to use Baidu BOS object storage, you should apply for a Baidu Account and create an object storage bucket first. Refer to [Baidu Cloud Documents](https://cloud.baidu.com/doc/BOS/index.html) for more details. To use Baidu BOS object storage, please specify the following yaml configuration file in `--objstore.config*` flag.
 
 ```yaml mdox-exec="go run scripts/cfggen/main.go --name=bos.Config"
+# command-line-arguments
+ld: warning: ignoring duplicate libraries: '-lproc'
 type: BOS
 config:
   bucket: ""
@@ -559,6 +576,8 @@ This storage type is used when user wants to store and access the bucket in the 
 NOTE: This storage type is experimental and might be inefficient. It is NOT advised to use it as the main storage for metrics in production environment. Particularly there is no planned support for distributed filesystems like NFS. This is mainly useful for testing and demos.
 
 ```yaml mdox-exec="go run scripts/cfggen/main.go --name=filesystem.Config"
+# command-line-arguments
+ld: warning: ignoring duplicate libraries: '-lproc'
 type: FILESYSTEM
 config:
   directory: ""

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -103,7 +103,6 @@ config:
     kms_encryption_context: {}
     encryption_key: ""
   sts_endpoint: ""
-  max_retries: 0
 prefix: ""
 ```
 
@@ -306,7 +305,6 @@ config:
       insecure_skip_verify: false
     disable_compression: false
   chunk_size_bytes: 0
-  max_retries: 0
 prefix: ""
 ```
 
@@ -497,7 +495,6 @@ config:
   endpoint: ""
   secret_key: ""
   secret_id: ""
-  max_retries: 0
   http_config:
     idle_conn_timeout: 1m30s
     response_header_timeout: 2m

--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -75,6 +75,8 @@ Currently supported tracing backends:
 Thanos supports exporting traces in the OpenTelemetry Protocol (OTLP). Both gRPC and HTTP clients are supported. Options can be provided also via environment variables. For more details see the [exporter specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#configuration-options).
 
 ```yaml mdox-exec="go run scripts/cfggen/main.go --name=otlp.Config"
+# command-line-arguments
+ld: warning: ignoring duplicate libraries: '-lproc'
 type: OTLP
 config:
   client_type: ""
@@ -109,6 +111,8 @@ Client for https://github.com/jaegertracing/jaeger tracing. Options can be provi
 *WARNING: Options `RPC Metrics`, `Gen128Bit` and `Disabled` are now deprecated and won't have any effect when set*
 
 ```yaml mdox-exec="go run scripts/cfggen/main.go --name=jaeger.Config"
+# command-line-arguments
+ld: warning: ignoring duplicate libraries: '-lproc'
 type: JAEGER
 config:
   service_name: ""
@@ -148,6 +152,8 @@ You will also need to ensure that the authentication with the API is working, fo
 *Note:* The `type` in the configuration below can have either value `GOOGLE_CLOUD` or `STACKDRIVER` - this is to ensure backwards compatibility.
 
 ```yaml mdox-exec="go run scripts/cfggen/main.go --name=google_cloud.Config"
+# command-line-arguments
+ld: warning: ignoring duplicate libraries: '-lproc'
 type: GOOGLE_CLOUD
 config:
   service_name: ""
@@ -160,6 +166,8 @@ config:
 Client for https://www.elastic.co/products/apm tracing.
 
 ```yaml mdox-exec="go run scripts/cfggen/main.go --name=elasticapm.Config"
+# command-line-arguments
+ld: warning: ignoring duplicate libraries: '-lproc'
 type: ELASTIC_APM
 config:
   service_name: ""
@@ -175,6 +183,8 @@ Client for [Lightstep](https://www.servicenow.com/products/observability.html).
 In order to configure Thanos to interact with Lightstep you need to provide at least an [access token](https://docs.lightstep.com/docs/create-and-use-access-tokens) in the configuration file. The `collector` key is optional and used when you have on-premise satellites.
 
 ```yaml mdox-exec="go run scripts/cfggen/main.go --name=lightstep.Config"
+# command-line-arguments
+ld: warning: ignoring duplicate libraries: '-lproc'
 type: LIGHTSTEP
 config:
   access_token: ""


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

- updated `rule.go` to add a statelessMode flag to potentially enable both the local tsdb and remote write

## Verification

<!-- How you tested it? How do you know it works? -->
Verified locally with the quickstart script (edited for enabling remote write to a different endpoint then thanos receive)


Fixes https://github.com/thanos-io/thanos/issues/6469 