### PR TITLE
Copy external labels in endpointset

### DIFF
--- a/pkg/query/endpointset.go
+++ b/pkg/query/endpointset.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"math"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 	"unicode/utf8"
@@ -710,11 +711,17 @@ func (er *endpointRef) labelSets() []labels.Labels {
 	}
 
 	labelSet := make([]labels.Labels, 0, len(er.metadata.LabelSets))
-	for _, ls := range labelpb.ZLabelSetsToPromLabelSets(er.metadata.LabelSets...) {
-		if ls.Len() == 0 {
+	builder := labels.NewScratchBuilder(8)
+	for _, lset := range er.metadata.LabelSets {
+		if len(lset.Labels) == 0 {
 			continue
 		}
-		labelSet = append(labelSet, ls.Copy())
+		builder.Reset()
+		for _, lbl := range lset.Labels {
+			builder.Add(strings.Clone(lbl.Name), strings.Clone(lbl.Value))
+		}
+		builder.Sort()
+		labelSet = append(labelSet, builder.Labels())
 	}
 	return labelSet
 }


### PR DESCRIPTION
We are trying to update grpc and are seeing panics because of the interaction between memory pooling and unsafe pointer casting.

This is a small step to remove those hacks where possible.

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
