### PR TITLE
*: bump Go version

### DIFF
--- a/Dockerfile.e2e-tests
+++ b/Dockerfile.e2e-tests
@@ -1,5 +1,5 @@
 # Taking a non-alpine image for e2e tests so that cgo can be enabled for the race detector.
-FROM golang:1.23.2 as builder
+FROM golang:1.23.3 as builder
 
 WORKDIR $GOPATH/src/github.com/thanos-io/thanos
 

--- a/Dockerfile.multi-stage
+++ b/Dockerfile.multi-stage
@@ -1,6 +1,6 @@
 # By default we pin to amd64 sha. Use make docker to automatically adjust for arm64 versions.
 ARG BASE_DOCKER_SHA="14d68ca3d69fceaa6224250c83d81d935c053fb13594c811038c461194599973"
-FROM golang:1.23.2-alpine3.20 as builder
+FROM golang:1.23.3-alpine3.20 as builder
 
 WORKDIR $GOPATH/src/github.com/thanos-io/thanos
 # Change in the docker context invalidates the cache so to leverage docker


### PR DESCRIPTION
Use 1.23.3 as it contains a critical fix: https://github.com/golang/go/issues/70001
