### PR TITLE
Fix store debug matchers panic on regex matcher

### DIFF
--- a/pkg/api/query/v1_test.go
+++ b/pkg/api/query/v1_test.go
@@ -1722,6 +1722,11 @@ func TestParseStoreDebugMatchersParam(t *testing.T) {
 				labels.MustNewMatcher(labels.MatchEqual, "cluster", "test"),
 			}},
 		},
+		{
+			storeMatchers: `{__address__=~"localhost:.*"}`,
+			fail:          false,
+			result:        [][]*labels.Matcher{{labels.MustNewMatcher(labels.MatchRegexp, "__address__", "localhost:.*")}},
+		},
 	} {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
 			api := QueryAPI{
@@ -1736,7 +1741,13 @@ func TestParseStoreDebugMatchersParam(t *testing.T) {
 
 			storeMatchers, err := api.parseStoreDebugMatchersParam(r)
 			if !tc.fail {
-				testutil.Equals(t, tc.result, storeMatchers)
+				testutil.Equals(t, len(tc.result), len(storeMatchers))
+				for i, m := range tc.result {
+					testutil.Equals(t, len(m), len(storeMatchers[i]))
+					for j, n := range m {
+						testutil.Equals(t, n.String(), storeMatchers[i][j].String())
+					}
+				}
 				testutil.Equals(t, (*baseAPI.ApiError)(nil), err)
 			} else {
 				testutil.NotOk(t, err)

--- a/pkg/api/query/v1_test.go
+++ b/pkg/api/query/v1_test.go
@@ -1727,6 +1727,11 @@ func TestParseStoreDebugMatchersParam(t *testing.T) {
 			fail:          false,
 			result:        [][]*labels.Matcher{{labels.MustNewMatcher(labels.MatchRegexp, "__address__", "localhost:.*")}},
 		},
+		{
+			storeMatchers: `{__address__!~"localhost:.*"}`,
+			fail:          false,
+			result:        [][]*labels.Matcher{{labels.MustNewMatcher(labels.MatchNotRegexp, "__address__", "localhost:.*")}},
+		},
 	} {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
 			api := QueryAPI{
@@ -1751,6 +1756,13 @@ func TestParseStoreDebugMatchersParam(t *testing.T) {
 				testutil.Equals(t, (*baseAPI.ApiError)(nil), err)
 			} else {
 				testutil.NotOk(t, err)
+			}
+
+			// We don't care about results but checking for panic.
+			for _, matchers := range storeMatchers {
+				for _, matcher := range matchers {
+					_ = matcher.Matches("")
+				}
 			}
 		})
 	}

--- a/pkg/extpromql/parser.go
+++ b/pkg/extpromql/parser.go
@@ -43,16 +43,7 @@ func ParseMetricSelector(input string) ([]*labels.Matcher, error) {
 		return nil, fmt.Errorf("expected type *parser.VectorSelector, got %T", expr)
 	}
 
-	matchers := make([]*labels.Matcher, len(vs.LabelMatchers))
-	for i, lm := range vs.LabelMatchers {
-		matchers[i] = &labels.Matcher{
-			Type:  lm.Type,
-			Name:  lm.Name,
-			Value: lm.Value,
-		}
-	}
-
-	return matchers, nil
+	return vs.LabelMatchers, nil
 }
 
 func isEmptyNameMatcherErr(err error) bool {


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Fixes https://github.com/thanos-io/thanos/issues/7676

`ParseMetricSelector` tries to copy label matchers but there is a new field `re` for the underlying regex and it is not copied, causing panic when calling `Matches`.

```
	for i, lm := range vs.LabelMatchers {
		matchers[i] = &labels.Matcher{
			Type:  lm.Type,
			Name:  lm.Name,
			Value: lm.Value,
		}
	}
```

## Verification

Added a simple unit test. Without the change in this PR the test will panic when calling `Matches`.