### PR TITLE
receive/capnp: remove close

### DIFF
--- a/pkg/receive/capnp_server.go
+++ b/pkg/receive/capnp_server.go
@@ -14,7 +14,6 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/thanos-io/thanos/pkg/receive/writecapnp"
-	"github.com/thanos-io/thanos/pkg/runutil"
 )
 
 type CapNProtoServer struct {
@@ -39,7 +38,6 @@ func (c *CapNProtoServer) ListenAndServe() error {
 		}
 
 		go func() {
-			defer runutil.CloseWithLogOnErr(c.logger, conn, "receive capnp conn")
 			rpcConn := rpc.NewConn(rpc.NewPackedStreamTransport(conn), &rpc.Options{
 				// The BootstrapClient is the RPC interface that will be made available
 				// to the remote endpoint by default.


### PR DESCRIPTION
I always get this in logs:
```
err: receive capnp conn: close tcp ...: use of closed network connection
```

This is also visible in the e2e test.

After Done() returns, the connection is closed either way so no need to close it again.
