### PR TITLE
Skip TestDistributedEngineWithDisjointTSDBs

### DIFF
--- a/test/e2e/query_test.go
+++ b/test/e2e/query_test.go
@@ -2378,6 +2378,7 @@ func TestDistributedEngineWithExtendedFunctions(t *testing.T) {
 }
 
 func TestDistributedEngineWithDisjointTSDBs(t *testing.T) {
+	t.Skip("skipping test as this replicates a bug")
 	e, err := e2e.New(e2e.WithName("dist-disj-tsdbs"))
 	testutil.Ok(t, err)
 	t.Cleanup(e2ethanos.CleanScenario(t, e))
@@ -2390,7 +2391,7 @@ func TestDistributedEngineWithDisjointTSDBs(t *testing.T) {
 	minio1 := e2edb.NewMinio(e, "1", bucket1, e2edb.WithMinioTLS())
 	testutil.Ok(t, e2e.StartAndWaitReady(minio1))
 
-	bkt1, err := s3.NewBucketWithConfig(l, e2ethanos.NewS3Config(bucket1, minio1.Endpoint("http"), minio1.Dir()), "test")
+	bkt1, err := s3.NewBucketWithConfig(l, e2ethanos.NewS3Config(bucket1, minio1.Endpoint("http"), minio1.Dir()), "test", nil)
 	testutil.Ok(t, err)
 
 	// Setup a storage GW with 2 blocks that have a gap to trigger distributed query MinT bug


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

The test documents a bug, so need to skip until bug is fixed cc: @MichaHoffmann 
Fixes main
## Verification

<!-- How you tested it? How do you know it works? -->
