### PR TITLE
Reuse bounded series iterator

### DIFF
--- a/pkg/dedup/iter.go
+++ b/pkg/dedup/iter.go
@@ -443,8 +443,18 @@ type boundedSeriesIterator struct {
 	mint, maxt int64
 }
 
-func NewBoundedSeriesIterator(it chunkenc.Iterator, mint, maxt int64) *boundedSeriesIterator {
+func NewBoundedSeriesIterator(reuseIt chunkenc.Iterator, it chunkenc.Iterator, mint, maxt int64) *boundedSeriesIterator {
+	if seriesIter, ok := reuseIt.(*boundedSeriesIterator); ok {
+		seriesIter.reset(it, mint, maxt)
+		return seriesIter
+	}
 	return &boundedSeriesIterator{it: it, mint: mint, maxt: maxt}
+}
+
+func (it *boundedSeriesIterator) reset(cit chunkenc.Iterator, mint, maxt int64) {
+	it.it = cit
+	it.mint = mint
+	it.maxt = maxt
 }
 
 func (it *boundedSeriesIterator) Seek(t int64) chunkenc.ValueType {

--- a/pkg/query/iter.go
+++ b/pkg/query/iter.go
@@ -109,7 +109,7 @@ func (s *chunkSeries) Labels() labels.Labels {
 	return s.lset
 }
 
-func (s *chunkSeries) Iterator(_ chunkenc.Iterator) chunkenc.Iterator {
+func (s *chunkSeries) Iterator(it chunkenc.Iterator) chunkenc.Iterator {
 	var sit chunkenc.Iterator
 	its := make([]chunkenc.Iterator, 0, len(s.chunks))
 
@@ -144,7 +144,7 @@ func (s *chunkSeries) Iterator(_ chunkenc.Iterator) chunkenc.Iterator {
 		default:
 			return errSeriesIterator{err: errors.Errorf("unexpected result aggregate type %v", s.aggrs)}
 		}
-		return dedup.NewBoundedSeriesIterator(sit, s.mint, s.maxt)
+		return dedup.NewBoundedSeriesIterator(it, sit, s.mint, s.maxt)
 	}
 
 	if len(s.aggrs) != 2 {
@@ -167,7 +167,7 @@ func (s *chunkSeries) Iterator(_ chunkenc.Iterator) chunkenc.Iterator {
 	default:
 		return errSeriesIterator{err: errors.Errorf("unexpected result aggregate type %v", s.aggrs)}
 	}
-	return dedup.NewBoundedSeriesIterator(sit, s.mint, s.maxt)
+	return dedup.NewBoundedSeriesIterator(it, sit, s.mint, s.maxt)
 }
 
 func getFirstIterator(cs ...*storepb.Chunk) chunkenc.Iterator {


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

Allow `NewBoundedSeriesIterator` to be reused.

## Changes

Change `NewBoundedSeriesIterator` function to take an additional iterator and reuse it.

## Verification

<!-- How you tested it? How do you know it works? -->
