### PR TITLE
Mark posting group lazy if it has a lot of keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 ### Added
 
 - [#7907](https://github.com/thanos-io/thanos/pull/7907) Receive: Add `--receive.grpc-service-config` flag to configure gRPC service config for the receivers.
+- [#7961](https://github.com/thanos-io/thanos/pull/7961) Store Gateway: Add `--store.posting-group-max-keys` flag to mark posting group as lazy if it exceeds number of keys limit. Added `thanos_bucket_store_lazy_expanded_posting_groups_total` for total number of lazy posting groups and corresponding reasons.
 
 ### Changed
 

--- a/cmd/thanos/store.go
+++ b/cmd/thanos/store.go
@@ -101,6 +101,7 @@ type storeConfig struct {
 	lazyIndexReaderEnabled      bool
 	lazyIndexReaderIdleTimeout  time.Duration
 	lazyExpandedPostingsEnabled bool
+	PostingGroupMaxKeys         int
 
 	indexHeaderLazyDownloadStrategy string
 }
@@ -203,6 +204,9 @@ func (sc *storeConfig) registerFlag(cmd extkingpin.FlagClause) {
 
 	cmd.Flag("store.enable-lazy-expanded-postings", "If true, Store Gateway will estimate postings size and try to lazily expand postings if it downloads less data than expanding all postings.").
 		Default("false").BoolVar(&sc.lazyExpandedPostingsEnabled)
+
+	cmd.Flag("store.posting-group-max-keys", "Mark posting group as lazy if it fetches more keys than the configured number. Only valid if lazy expanded posting is enabled. 0 disables the limit.").
+		Default("0").IntVar(&sc.PostingGroupMaxKeys)
 
 	cmd.Flag("store.index-header-lazy-download-strategy", "Strategy of how to download index headers lazily. Supported values: eager, lazy. If eager, always download index header during initial load. If lazy, download index header during query time.").
 		Default(string(indexheader.EagerDownloadStrategy)).
@@ -429,6 +433,7 @@ func runStore(
 			return conf.estimatedMaxChunkSize
 		}),
 		store.WithLazyExpandedPostings(conf.lazyExpandedPostingsEnabled),
+		store.WithPostingGroupMaxKeys(conf.PostingGroupMaxKeys),
 		store.WithIndexHeaderLazyDownloadStrategy(
 			indexheader.IndexHeaderLazyDownloadStrategy(conf.indexHeaderLazyDownloadStrategy).StrategyToDownloadFunc(),
 		),

--- a/cmd/thanos/store.go
+++ b/cmd/thanos/store.go
@@ -205,7 +205,7 @@ func (sc *storeConfig) registerFlag(cmd extkingpin.FlagClause) {
 	cmd.Flag("store.enable-lazy-expanded-postings", "If true, Store Gateway will estimate postings size and try to lazily expand postings if it downloads less data than expanding all postings.").
 		Default("false").BoolVar(&sc.lazyExpandedPostingsEnabled)
 
-	cmd.Flag("store.posting-group-max-key-series-ratio", "Mark posting group as lazy if it fetches more keys than R * max series the query should fetch. With R set to 100, a posting group which fetches 100K keys will be marked as lazy if the current query only fetches 1000 series. This config is only valid if lazy expanded posting is enabled. 0 disables the limit.").
+	cmd.Flag("store.posting-group-max-key-series-ratio", "Mark posting group as lazy if it fetches more keys than R * max series the query should fetch. With R set to 100, a posting group which fetches 100K keys will be marked as lazy if the current query only fetches 1000 series. thanos_bucket_store_lazy_expanded_posting_groups_total shows lazy expanded postings groups with reasons and you can tune this config accordingly. This config is only valid if lazy expanded posting is enabled. 0 disables the limit.").
 		Default("100").Float64Var(&sc.postingGroupMaxKeySeriesRatio)
 
 	cmd.Flag("store.index-header-lazy-download-strategy", "Strategy of how to download index headers lazily. Supported values: eager, lazy. If eager, always download index header during initial load. If lazy, download index header during query time.").

--- a/docs/components/store.md
+++ b/docs/components/store.md
@@ -256,8 +256,12 @@ Flags:
                                  fetch. With R set to 100, a posting group which
                                  fetches 100K keys will be marked as lazy if
                                  the current query only fetches 1000 series.
-                                 This config is only valid if lazy expanded
-                                 posting is enabled. 0 disables the limit.
+                                 thanos_bucket_store_lazy_expanded_posting_groups_total
+                                 shows lazy expanded postings groups with
+                                 reasons and you can tune this config
+                                 accordingly. This config is only valid if lazy
+                                 expanded posting is enabled. 0 disables the
+                                 limit.
       --sync-block-duration=15m  Repeat interval for syncing the blocks between
                                  local and remote view.
       --tracing.config=<content>

--- a/docs/components/store.md
+++ b/docs/components/store.md
@@ -250,6 +250,11 @@ Flags:
                                  The maximum series allowed for a single Series
                                  request. The Series call fails if this limit is
                                  exceeded. 0 means no limit.
+      --store.posting-group-max-keys=0
+                                 Mark posting group as lazy if it fetches more
+                                 keys than the configured number. Only valid if
+                                 lazy expanded posting is enabled. 0 disables
+                                 the limit.
       --sync-block-duration=15m  Repeat interval for syncing the blocks between
                                  local and remote view.
       --tracing.config=<content>

--- a/docs/components/store.md
+++ b/docs/components/store.md
@@ -250,11 +250,14 @@ Flags:
                                  The maximum series allowed for a single Series
                                  request. The Series call fails if this limit is
                                  exceeded. 0 means no limit.
-      --store.posting-group-max-keys=0
+      --store.posting-group-max-key-series-ratio=100
                                  Mark posting group as lazy if it fetches more
-                                 keys than the configured number. Only valid if
-                                 lazy expanded posting is enabled. 0 disables
-                                 the limit.
+                                 keys than R * max series the query should
+                                 fetch. With R set to 100, a posting group which
+                                 fetches 100K keys will be marked as lazy if
+                                 the current query only fetches 1000 series.
+                                 This config is only valid if lazy expanded
+                                 posting is enabled. 0 disables the limit.
       --sync-block-duration=15m  Repeat interval for syncing the blocks between
                                  local and remote view.
       --tracing.config=<content>

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -151,6 +151,7 @@ type bucketStoreMetrics struct {
 	emptyPostingCount     *prometheus.CounterVec
 
 	lazyExpandedPostingsCount                     prometheus.Counter
+	lazyExpandedPostingGroupsByReason             *prometheus.CounterVec
 	lazyExpandedPostingSizeBytes                  prometheus.Counter
 	lazyExpandedPostingSeriesOverfetchedSizeBytes prometheus.Counter
 
@@ -345,6 +346,11 @@ func newBucketStoreMetrics(reg prometheus.Registerer) *bucketStoreMetrics {
 		Help: "Total number of times when lazy expanded posting optimization applies.",
 	})
 
+	m.lazyExpandedPostingGroupsByReason = promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+		Name: "thanos_bucket_store_lazy_expanded_posting_groups_total",
+		Help: "Total number of posting groups that are marked as lazy and corresponding reason",
+	}, []string{"reason"})
+
 	m.lazyExpandedPostingSizeBytes = promauto.With(reg).NewCounter(prometheus.CounterOpts{
 		Name: "thanos_bucket_store_lazy_expanded_posting_size_bytes_total",
 		Help: "Total number of lazy posting group size in bytes.",
@@ -420,6 +426,7 @@ type BucketStore struct {
 	enableChunkHashCalculation bool
 
 	enabledLazyExpandedPostings bool
+	postingGroupMaxKeys         int
 
 	sortingStrategy sortingStrategy
 
@@ -549,6 +556,13 @@ func WithBlockEstimatedMaxChunkFunc(f BlockEstimator) BucketStoreOption {
 func WithLazyExpandedPostings(enabled bool) BucketStoreOption {
 	return func(s *BucketStore) {
 		s.enabledLazyExpandedPostings = enabled
+	}
+}
+
+// WithPostingGroupMaxKeys configures a threshold to mark a posting group as lazy if it has more add keys.
+func WithPostingGroupMaxKeys(postingGroupMaxKeys int) BucketStoreOption {
+	return func(s *BucketStore) {
+		s.postingGroupMaxKeys = postingGroupMaxKeys
 	}
 }
 
@@ -1002,8 +1016,11 @@ type blockSeriesClient struct {
 	chunksLimiter ChunksLimiter
 	bytesLimiter  BytesLimiter
 
-	lazyExpandedPostingEnabled                    bool
+	lazyExpandedPostingEnabled bool
+	// Mark posting group as lazy if it adds too many keys. 0 to disable.
+	postingGroupMaxKeys                           int
 	lazyExpandedPostingsCount                     prometheus.Counter
+	lazyExpandedPostingGroupByReason              *prometheus.CounterVec
 	lazyExpandedPostingSizeBytes                  prometheus.Counter
 	lazyExpandedPostingSeriesOverfetchedSizeBytes prometheus.Counter
 
@@ -1046,7 +1063,9 @@ func newBlockSeriesClient(
 	chunkFetchDurationSum *prometheus.HistogramVec,
 	extLsetToRemove map[string]struct{},
 	lazyExpandedPostingEnabled bool,
+	postingGroupMaxKeys int,
 	lazyExpandedPostingsCount prometheus.Counter,
+	lazyExpandedPostingByReason *prometheus.CounterVec,
 	lazyExpandedPostingSizeBytes prometheus.Counter,
 	lazyExpandedPostingSeriesOverfetchedSizeBytes prometheus.Counter,
 	tenant string,
@@ -1081,7 +1100,9 @@ func newBlockSeriesClient(
 		chunkFetchDurationSum:  chunkFetchDurationSum,
 
 		lazyExpandedPostingEnabled:                    lazyExpandedPostingEnabled,
+		postingGroupMaxKeys:                           postingGroupMaxKeys,
 		lazyExpandedPostingsCount:                     lazyExpandedPostingsCount,
+		lazyExpandedPostingGroupByReason:              lazyExpandedPostingByReason,
 		lazyExpandedPostingSizeBytes:                  lazyExpandedPostingSizeBytes,
 		lazyExpandedPostingSeriesOverfetchedSizeBytes: lazyExpandedPostingSeriesOverfetchedSizeBytes,
 
@@ -1133,7 +1154,7 @@ func (b *blockSeriesClient) ExpandPostings(
 	matchers sortedMatchers,
 	seriesLimiter SeriesLimiter,
 ) error {
-	ps, err := b.indexr.ExpandedPostings(b.ctx, matchers, b.bytesLimiter, b.lazyExpandedPostingEnabled, b.lazyExpandedPostingSizeBytes, b.tenant)
+	ps, err := b.indexr.ExpandedPostings(b.ctx, matchers, b.bytesLimiter, b.lazyExpandedPostingEnabled, b.postingGroupMaxKeys, b.lazyExpandedPostingSizeBytes, b.lazyExpandedPostingGroupByReason, b.tenant)
 	if err != nil {
 		return errors.Wrap(err, "expanded matching posting")
 	}
@@ -1566,7 +1587,9 @@ func (s *BucketStore) Series(req *storepb.SeriesRequest, seriesSrv storepb.Store
 				s.metrics.chunkFetchDurationSum,
 				extLsetToRemove,
 				s.enabledLazyExpandedPostings,
+				s.postingGroupMaxKeys,
 				s.metrics.lazyExpandedPostingsCount,
+				s.metrics.lazyExpandedPostingGroupsByReason,
 				s.metrics.lazyExpandedPostingSizeBytes,
 				s.metrics.lazyExpandedPostingSeriesOverfetchedSizeBytes,
 				tenant,
@@ -1880,7 +1903,9 @@ func (s *BucketStore) LabelNames(ctx context.Context, req *storepb.LabelNamesReq
 					nil,
 					extLsetToRemove,
 					s.enabledLazyExpandedPostings,
+					s.postingGroupMaxKeys,
 					s.metrics.lazyExpandedPostingsCount,
+					s.metrics.lazyExpandedPostingGroupsByReason,
 					s.metrics.lazyExpandedPostingSizeBytes,
 					s.metrics.lazyExpandedPostingSeriesOverfetchedSizeBytes,
 					tenant,
@@ -2106,7 +2131,9 @@ func (s *BucketStore) LabelValues(ctx context.Context, req *storepb.LabelValuesR
 					nil,
 					nil,
 					s.enabledLazyExpandedPostings,
+					s.postingGroupMaxKeys,
 					s.metrics.lazyExpandedPostingsCount,
+					s.metrics.lazyExpandedPostingGroupsByReason,
 					s.metrics.lazyExpandedPostingSizeBytes,
 					s.metrics.lazyExpandedPostingSeriesOverfetchedSizeBytes,
 					tenant,
@@ -2563,7 +2590,16 @@ func (r *bucketIndexReader) reset(size int) {
 // Reminder: A posting is a reference (represented as a uint64) to a series reference, which in turn points to the first
 // chunk where the series contains the matching label-value pair for a given block of data. Postings can be fetched by
 // single label name=value.
-func (r *bucketIndexReader) ExpandedPostings(ctx context.Context, ms sortedMatchers, bytesLimiter BytesLimiter, lazyExpandedPostingEnabled bool, lazyExpandedPostingSizeBytes prometheus.Counter, tenant string) (*lazyExpandedPostings, error) {
+func (r *bucketIndexReader) ExpandedPostings(
+	ctx context.Context,
+	ms sortedMatchers,
+	bytesLimiter BytesLimiter,
+	lazyExpandedPostingEnabled bool,
+	postingGroupMaxKeys int,
+	lazyExpandedPostingSizeBytes prometheus.Counter,
+	lazyExpandedPostingGroupsByReason *prometheus.CounterVec,
+	tenant string,
+) (*lazyExpandedPostings, error) {
 	// Shortcut the case of `len(postingGroups) == 0`. It will only happen when no
 	// matchers specified, and we don't need to fetch expanded postings from cache.
 	if len(ms) == 0 {
@@ -2615,7 +2651,7 @@ func (r *bucketIndexReader) ExpandedPostings(ctx context.Context, ms sortedMatch
 		postingGroups = append(postingGroups, newPostingGroup(true, name, []string{value}, nil))
 	}
 
-	ps, err := fetchLazyExpandedPostings(ctx, postingGroups, r, bytesLimiter, addAllPostings, lazyExpandedPostingEnabled, lazyExpandedPostingSizeBytes, tenant)
+	ps, err := fetchLazyExpandedPostings(ctx, postingGroups, r, bytesLimiter, addAllPostings, lazyExpandedPostingEnabled, postingGroupMaxKeys, lazyExpandedPostingSizeBytes, lazyExpandedPostingGroupsByReason, tenant)
 	if err != nil {
 		return nil, errors.Wrap(err, "fetch and expand postings")
 	}
@@ -2661,13 +2697,14 @@ func ExpandPostingsWithContext(ctx context.Context, p index.Postings) ([]storage
 // If addAll is not set: Merge of postings for "addKeys" labels minus postings for removeKeys labels
 // This computation happens in ExpandedPostings.
 type postingGroup struct {
-	addAll      bool
-	name        string
-	matchers    []*labels.Matcher
-	addKeys     []string
-	removeKeys  []string
-	cardinality int64
-	lazy        bool
+	addAll       bool
+	name         string
+	matchers     []*labels.Matcher
+	addKeys      []string
+	removeKeys   []string
+	cardinality  int64
+	existentKeys int
+	lazy         bool
 }
 
 func newPostingGroup(addAll bool, name string, addKeys, removeKeys []string) *postingGroup {

--- a/pkg/store/lazy_postings.go
+++ b/pkg/store/lazy_postings.go
@@ -178,7 +178,8 @@ func optimizePostingsFetchByDownloadedBytes(
 			underfetchedSeriesSize = underfetchedSeries * seriesMaxSize
 		} else {
 			// Only mark posting group as lazy due to too many keys when those keys are known to be existent.
-			if postingGroupMaxKeySeriesRatio > 0 && float64(pg.existentKeys)/float64(maxSeriesMatched) > postingGroupMaxKeySeriesRatio {
+			if postingGroupMaxKeySeriesRatio > 0 && maxSeriesMatched > 0 &&
+				float64(pg.existentKeys)/float64(maxSeriesMatched) > postingGroupMaxKeySeriesRatio {
 				markPostingGroupLazy(pg, "keys_limit", lazyExpandedPostingSizeBytes, lazyExpandedPostingGroupsByReason)
 				i++
 				continue

--- a/pkg/store/lazy_postings.go
+++ b/pkg/store/lazy_postings.go
@@ -39,7 +39,15 @@ func (p *lazyExpandedPostings) lazyExpanded() bool {
 	return p != nil && len(p.matchers) > 0
 }
 
-func optimizePostingsFetchByDownloadedBytes(r *bucketIndexReader, postingGroups []*postingGroup, seriesMaxSize int64, seriesMatchRatio float64, lazyExpandedPostingSizeBytes prometheus.Counter) ([]*postingGroup, bool, error) {
+func optimizePostingsFetchByDownloadedBytes(
+	r *bucketIndexReader,
+	postingGroups []*postingGroup,
+	seriesMaxSize int64,
+	seriesMatchRatio float64,
+	postingGroupMaxKeys int,
+	lazyExpandedPostingSizeBytes prometheus.Counter,
+	lazyExpandedPostingGroupsByReason *prometheus.CounterVec,
+) ([]*postingGroup, bool, error) {
 	if len(postingGroups) <= 1 {
 		return postingGroups, false, nil
 	}
@@ -55,6 +63,7 @@ func optimizePostingsFetchByDownloadedBytes(r *bucketIndexReader, postingGroups 
 			return nil, false, errors.Wrapf(err, "postings offsets for %s", pg.name)
 		}
 
+		existentKeys := 0
 		for _, rng := range rngs {
 			if rng == indexheader.NotFoundRange {
 				continue
@@ -63,14 +72,16 @@ func optimizePostingsFetchByDownloadedBytes(r *bucketIndexReader, postingGroups 
 				level.Error(r.logger).Log("msg", "invalid index range, fallback to non lazy posting optimization")
 				return postingGroups, false, nil
 			}
+			existentKeys++
 			// Each range starts from the #entries field which is 4 bytes.
 			// Need to subtract it when calculating number of postings.
 			// https://github.com/prometheus/prometheus/blob/v2.46.0/tsdb/docs/format/index.md.
 			pg.cardinality += (rng.End - rng.Start - 4) / 4
 		}
+		pg.existentKeys = existentKeys
 		// If the posting group adds keys, 0 cardinality means the posting doesn't exist.
 		// If the posting group removes keys, no posting ranges found is fine as it is a noop.
-		if len(pg.addKeys) > 0 && pg.cardinality == 0 {
+		if len(pg.addKeys) > 0 && pg.existentKeys == 0 {
 			return nil, true, nil
 		}
 	}
@@ -165,6 +176,12 @@ func optimizePostingsFetchByDownloadedBytes(r *bucketIndexReader, postingGroups 
 			seriesMatched -= underfetchedSeries
 			underfetchedSeriesSize = underfetchedSeries * seriesMaxSize
 		} else {
+			// Only mark posting group as lazy due to too many keys when those keys are known to be existent.
+			if postingGroupMaxKeys > 0 && pg.existentKeys > postingGroupMaxKeys {
+				markPostingGroupLazy(pg, "too_many_keys", lazyExpandedPostingSizeBytes, lazyExpandedPostingGroupsByReason)
+				i++
+				continue
+			}
 			underfetchedSeriesSize = seriesMaxSize * int64(math.Ceil(float64(seriesMatched)*(1-seriesMatchRatio)))
 			seriesMatched = int64(math.Ceil(float64(seriesMatched) * seriesMatchRatio))
 		}
@@ -176,11 +193,16 @@ func optimizePostingsFetchByDownloadedBytes(r *bucketIndexReader, postingGroups 
 		i++
 	}
 	for i < len(postingGroups) {
-		postingGroups[i].lazy = true
-		lazyExpandedPostingSizeBytes.Add(float64(4 * postingGroups[i].cardinality))
+		markPostingGroupLazy(postingGroups[i], "postings_size", lazyExpandedPostingSizeBytes, lazyExpandedPostingGroupsByReason)
 		i++
 	}
 	return postingGroups, false, nil
+}
+
+func markPostingGroupLazy(pg *postingGroup, reason string, lazyExpandedPostingSizeBytes prometheus.Counter, lazyExpandedPostingGroupsByReason *prometheus.CounterVec) {
+	pg.lazy = true
+	lazyExpandedPostingSizeBytes.Add(float64(4 * pg.cardinality))
+	lazyExpandedPostingGroupsByReason.WithLabelValues(reason).Inc()
 }
 
 func fetchLazyExpandedPostings(
@@ -190,7 +212,9 @@ func fetchLazyExpandedPostings(
 	bytesLimiter BytesLimiter,
 	addAllPostings bool,
 	lazyExpandedPostingEnabled bool,
+	postingGroupMaxKeys int,
 	lazyExpandedPostingSizeBytes prometheus.Counter,
+	lazyExpandedPostingGroupsByReason *prometheus.CounterVec,
 	tenant string,
 ) (*lazyExpandedPostings, error) {
 	var (
@@ -212,7 +236,9 @@ func fetchLazyExpandedPostings(
 			postingGroups,
 			int64(r.block.estimatedMaxSeriesSize),
 			0.5, // TODO(yeya24): Expose this as a flag.
+			postingGroupMaxKeys,
 			lazyExpandedPostingSizeBytes,
+			lazyExpandedPostingGroupsByReason,
 		)
 		if err != nil {
 			return nil, err
@@ -243,27 +269,25 @@ func keysToFetchFromPostingGroups(postingGroups []*postingGroup) ([]labels.Label
 	for i < len(postingGroups) {
 		pg := postingGroups[i]
 		if pg.lazy {
-			break
+			if len(lazyMatchers) == 0 {
+				lazyMatchers = make([]*labels.Matcher, 0)
+			}
+			lazyMatchers = append(lazyMatchers, postingGroups[i].matchers...)
+		} else {
+			// Postings returned by fetchPostings will be in the same order as keys
+			// so it's important that we iterate them in the same order later.
+			// We don't have any other way of pairing keys and fetched postings.
+			for _, key := range pg.addKeys {
+				keys = append(keys, labels.Label{Name: pg.name, Value: key})
+			}
+			for _, key := range pg.removeKeys {
+				keys = append(keys, labels.Label{Name: pg.name, Value: key})
+			}
 		}
 
-		// Postings returned by fetchPostings will be in the same order as keys
-		// so it's important that we iterate them in the same order later.
-		// We don't have any other way of pairing keys and fetched postings.
-		for _, key := range pg.addKeys {
-			keys = append(keys, labels.Label{Name: pg.name, Value: key})
-		}
-		for _, key := range pg.removeKeys {
-			keys = append(keys, labels.Label{Name: pg.name, Value: key})
-		}
 		i++
 	}
-	if i < len(postingGroups) {
-		lazyMatchers = make([]*labels.Matcher, 0)
-		for i < len(postingGroups) {
-			lazyMatchers = append(lazyMatchers, postingGroups[i].matchers...)
-			i++
-		}
-	}
+
 	return keys, lazyMatchers
 }
 

--- a/pkg/store/lazy_postings.go
+++ b/pkg/store/lazy_postings.go
@@ -178,7 +178,7 @@ func optimizePostingsFetchByDownloadedBytes(
 		} else {
 			// Only mark posting group as lazy due to too many keys when those keys are known to be existent.
 			if postingGroupMaxKeys > 0 && pg.existentKeys > postingGroupMaxKeys {
-				markPostingGroupLazy(pg, "too_many_keys", lazyExpandedPostingSizeBytes, lazyExpandedPostingGroupsByReason)
+				markPostingGroupLazy(pg, "keys_limit", lazyExpandedPostingSizeBytes, lazyExpandedPostingGroupsByReason)
 				i++
 				continue
 			}

--- a/pkg/store/lazy_postings_test.go
+++ b/pkg/store/lazy_postings_test.go
@@ -206,6 +206,38 @@ func TestKeysToFetchFromPostingGroups(t *testing.T) {
 				labels.MustNewMatcher(labels.MatchRegexp, "job", "prometheus.*"),
 			},
 		},
+		{
+			name: "multiple non lazy and lazy posting groups with lazy posting groups in the middle",
+			pgs: []*postingGroup{
+				{
+					name:     "test",
+					addKeys:  []string{"foo", "bar"},
+					matchers: []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "foo", "bar")},
+				},
+				{
+					name:     "cluster",
+					addKeys:  []string{"bar"},
+					matchers: []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "cluster", "bar")},
+					lazy:     true,
+				},
+				{
+					name:     "env",
+					addKeys:  []string{"beta", "gamma", "prod"},
+					matchers: []*labels.Matcher{labels.MustNewMatcher(labels.MatchRegexp, "env", "beta|gamma|prod")},
+					lazy:     true,
+				},
+				{
+					name:     "job",
+					addKeys:  []string{"prometheus"},
+					matchers: []*labels.Matcher{labels.MustNewMatcher(labels.MatchRegexp, "job", "prometheus.*")},
+				},
+			},
+			expectedLabels: []labels.Label{{Name: "test", Value: "foo"}, {Name: "test", Value: "bar"}, {Name: "job", Value: "prometheus"}},
+			expectedMatchers: []*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchEqual, "cluster", "bar"),
+				labels.MustNewMatcher(labels.MatchRegexp, "env", "beta|gamma|prod"),
+			},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			keys, matchers := keysToFetchFromPostingGroups(tc.pgs)
@@ -282,6 +314,7 @@ func TestOptimizePostingsFetchByDownloadedBytes(t *testing.T) {
 		postingGroups         []*postingGroup
 		seriesMaxSize         int64
 		seriesMatchRatio      float64
+		minAddKeysToMarkLazy  int
 		expectedPostingGroups []*postingGroup
 		expectedEmptyPosting  bool
 		expectedError         string
@@ -353,7 +386,7 @@ func TestOptimizePostingsFetchByDownloadedBytes(t *testing.T) {
 			},
 			expectedPostingGroups: []*postingGroup{
 				{name: "bar", removeKeys: []string{"foo"}, cardinality: 0, addAll: true},
-				{name: "foo", addKeys: []string{"bar"}, cardinality: 1},
+				{name: "foo", addKeys: []string{"bar"}, cardinality: 1, existentKeys: 1},
 			},
 		},
 		{
@@ -385,7 +418,7 @@ func TestOptimizePostingsFetchByDownloadedBytes(t *testing.T) {
 			},
 			expectedPostingGroups: []*postingGroup{
 				{name: "bar", removeKeys: []string{"foo"}, cardinality: 0, addAll: true},
-				{name: "foo", addKeys: []string{"bar"}, cardinality: 1},
+				{name: "foo", addKeys: []string{"bar"}, cardinality: 1, existentKeys: 1},
 			},
 		},
 		{
@@ -401,8 +434,8 @@ func TestOptimizePostingsFetchByDownloadedBytes(t *testing.T) {
 				{name: "bar", addKeys: []string{"foo", "buz"}},
 			},
 			expectedPostingGroups: []*postingGroup{
-				{name: "bar", addKeys: []string{"foo", "buz"}, cardinality: 1},
-				{name: "foo", addKeys: []string{"bar"}, cardinality: 1},
+				{name: "bar", addKeys: []string{"foo", "buz"}, cardinality: 1, existentKeys: 1},
+				{name: "foo", addKeys: []string{"bar"}, cardinality: 1, existentKeys: 1},
 			},
 		},
 		{
@@ -418,8 +451,79 @@ func TestOptimizePostingsFetchByDownloadedBytes(t *testing.T) {
 				{name: "bar", addKeys: []string{"foo"}},
 			},
 			expectedPostingGroups: []*postingGroup{
-				{name: "bar", addKeys: []string{"foo"}, cardinality: 1},
-				{name: "foo", addKeys: []string{"bar"}, cardinality: 1},
+				{name: "bar", addKeys: []string{"foo"}, cardinality: 1, existentKeys: 1},
+				{name: "foo", addKeys: []string{"bar"}, cardinality: 1, existentKeys: 1},
+			},
+		},
+		{
+			name: "two posting groups with add keys, posting group not marked as lazy due to some add keys don't exist",
+			inputPostings: map[string]map[string]index.Range{
+				"foo": {"bar": index.Range{End: 8}},
+				"bar": {"foo": index.Range{Start: 8, End: 16}},
+			},
+			seriesMaxSize:    1000,
+			seriesMatchRatio: 0.5,
+			postingGroups: []*postingGroup{
+				{name: "foo", addKeys: []string{"bar"}},
+				{name: "bar", addKeys: []string{"baz", "foo"}},
+			},
+			minAddKeysToMarkLazy: 1,
+			expectedPostingGroups: []*postingGroup{
+				{name: "bar", addKeys: []string{"baz", "foo"}, cardinality: 1, existentKeys: 1},
+				{name: "foo", addKeys: []string{"bar"}, cardinality: 1, existentKeys: 1},
+			},
+		},
+		{
+			name: "two posting groups with add keys, first posting group not marked as lazy even though exceeding 2 keys due to we always mark first posting group as non lazy",
+			inputPostings: map[string]map[string]index.Range{
+				"foo": {"bar": index.Range{End: 108}},
+				"bar": {"foo": index.Range{Start: 108, End: 116}, "baz": index.Range{Start: 116, End: 124}},
+			},
+			seriesMaxSize:    1000,
+			seriesMatchRatio: 0.5,
+			postingGroups: []*postingGroup{
+				{name: "foo", addKeys: []string{"bar"}},
+				{name: "bar", addKeys: []string{"baz", "foo"}},
+			},
+			minAddKeysToMarkLazy: 1,
+			expectedPostingGroups: []*postingGroup{
+				{name: "bar", addKeys: []string{"baz", "foo"}, cardinality: 2, existentKeys: 2},
+				{name: "foo", addKeys: []string{"bar"}, cardinality: 26, existentKeys: 1},
+			},
+		},
+		{
+			name: "two posting groups with add keys, one posting group marked as lazy due to exceeding minAddKeysToMarkLazy",
+			inputPostings: map[string]map[string]index.Range{
+				"foo": {"bar": index.Range{End: 8}},
+				"bar": {"foo": index.Range{Start: 8, End: 16}, "baz": index.Range{Start: 16, End: 24}},
+			},
+			seriesMaxSize:    1000,
+			seriesMatchRatio: 0.5,
+			postingGroups: []*postingGroup{
+				{name: "foo", addKeys: []string{"bar"}},
+				{name: "bar", addKeys: []string{"baz", "foo"}},
+			},
+			minAddKeysToMarkLazy: 1,
+			expectedPostingGroups: []*postingGroup{
+				{name: "foo", addKeys: []string{"bar"}, cardinality: 1, existentKeys: 1},
+				{name: "bar", addKeys: []string{"baz", "foo"}, cardinality: 2, existentKeys: 2, lazy: true},
+			},
+		},
+		{
+			name: "two posting groups with remove keys, minAddKeysToMarkLazy won't be applied",
+			inputPostings: map[string]map[string]index.Range{
+				"foo": {"bar": index.Range{End: 8}},
+				"bar": {"foo": index.Range{Start: 8, End: 16}, "baz": index.Range{Start: 16, End: 24}},
+			},
+			seriesMaxSize:    1000,
+			seriesMatchRatio: 0.5,
+			postingGroups: []*postingGroup{
+				{addAll: true, name: "foo", removeKeys: []string{"bar"}},
+				{addAll: true, name: "bar", removeKeys: []string{"baz", "foo"}},
+			},
+			expectedPostingGroups: []*postingGroup{
+				{addAll: true, name: "foo", removeKeys: []string{"bar"}, cardinality: 1, existentKeys: 1},
+				{addAll: true, name: "bar", removeKeys: []string{"baz", "foo"}, cardinality: 2, existentKeys: 2},
 			},
 		},
 		{
@@ -437,8 +541,8 @@ func TestOptimizePostingsFetchByDownloadedBytes(t *testing.T) {
 				{addAll: true, name: "bar", removeKeys: []string{"foo"}},
 			},
 			expectedPostingGroups: []*postingGroup{
-				{addAll: true, name: "bar", removeKeys: []string{"foo"}, cardinality: 1},
-				{addAll: true, name: "foo", removeKeys: []string{"bar"}, cardinality: 1},
+				{addAll: true, name: "bar", removeKeys: []string{"foo"}, cardinality: 1, existentKeys: 1},
+				{addAll: true, name: "foo", removeKeys: []string{"bar"}, cardinality: 1, existentKeys: 1},
 			},
 		},
 		{
@@ -454,8 +558,8 @@ func TestOptimizePostingsFetchByDownloadedBytes(t *testing.T) {
 				{name: "bar", addKeys: []string{"foo"}},
 			},
 			expectedPostingGroups: []*postingGroup{
-				{addAll: true, name: "foo", removeKeys: []string{"bar"}, cardinality: 1},
-				{name: "bar", addKeys: []string{"foo"}, cardinality: 250000},
+				{addAll: true, name: "foo", removeKeys: []string{"bar"}, cardinality: 1, existentKeys: 1},
+				{name: "bar", addKeys: []string{"foo"}, cardinality: 250000, existentKeys: 1},
 			},
 		},
 		{
@@ -471,8 +575,8 @@ func TestOptimizePostingsFetchByDownloadedBytes(t *testing.T) {
 				{name: "bar", addKeys: []string{"foo"}},
 			},
 			expectedPostingGroups: []*postingGroup{
-				{name: "bar", addKeys: []string{"foo"}, cardinality: 1},
-				{name: "foo", addKeys: []string{"bar"}, cardinality: 1, lazy: true},
+				{name: "bar", addKeys: []string{"foo"}, cardinality: 1, existentKeys: 1},
+				{name: "foo", addKeys: []string{"bar"}, cardinality: 1, existentKeys: 1, lazy: true},
 			},
 		},
 		{
@@ -488,8 +592,8 @@ func TestOptimizePostingsFetchByDownloadedBytes(t *testing.T) {
 				{name: "bar", addKeys: []string{"foo"}},
 			},
 			expectedPostingGroups: []*postingGroup{
-				{name: "foo", addKeys: []string{"bar"}, cardinality: 1},
-				{name: "bar", addKeys: []string{"foo"}, cardinality: 250000, lazy: true},
+				{name: "foo", addKeys: []string{"bar"}, cardinality: 1, existentKeys: 1},
+				{name: "bar", addKeys: []string{"foo"}, cardinality: 250000, existentKeys: 1, lazy: true},
 			},
 		},
 		{
@@ -507,9 +611,51 @@ func TestOptimizePostingsFetchByDownloadedBytes(t *testing.T) {
 				{name: "cluster", addKeys: []string{"us"}},
 			},
 			expectedPostingGroups: []*postingGroup{
-				{name: "cluster", addKeys: []string{"us"}, cardinality: 1},
-				{name: "foo", addKeys: []string{"bar"}, cardinality: 1},
-				{name: "bar", addKeys: []string{"foo"}, cardinality: 250000, lazy: true},
+				{name: "cluster", addKeys: []string{"us"}, cardinality: 1, existentKeys: 1},
+				{name: "foo", addKeys: []string{"bar"}, cardinality: 1, existentKeys: 1},
+				{name: "bar", addKeys: []string{"foo"}, cardinality: 250000, existentKeys: 1, lazy: true},
+			},
+		},
+		{
+			name: "three posting groups with add keys, middle posting group marked as lazy due to too many add keys",
+			inputPostings: map[string]map[string]index.Range{
+				"foo":     {"bar": index.Range{End: 8}},
+				"bar":     {"baz": index.Range{Start: 8, End: 16}, "foo": index.Range{Start: 16, End: 24}},
+				"cluster": {"us": index.Range{Start: 24, End: 100}},
+			},
+			seriesMaxSize:        1000,
+			seriesMatchRatio:     0.5,
+			minAddKeysToMarkLazy: 1,
+			postingGroups: []*postingGroup{
+				{name: "foo", addKeys: []string{"bar"}},
+				{name: "bar", addKeys: []string{"baz", "foo"}},
+				{name: "cluster", addKeys: []string{"us"}},
+			},
+			expectedPostingGroups: []*postingGroup{
+				{name: "foo", addKeys: []string{"bar"}, cardinality: 1, existentKeys: 1},
+				{name: "bar", addKeys: []string{"baz", "foo"}, cardinality: 2, existentKeys: 2, lazy: true},
+				{name: "cluster", addKeys: []string{"us"}, cardinality: 18, existentKeys: 1},
+			},
+		},
+		{
+			name: "three posting groups with add keys, bar not marked as lazy even though too many add keys due to first positive posting group sorted by cardinality",
+			inputPostings: map[string]map[string]index.Range{
+				"foo":     {"bar": index.Range{End: 8}},
+				"bar":     {"baz": index.Range{Start: 8, End: 16}, "foo": index.Range{Start: 16, End: 24}},
+				"cluster": {"us": index.Range{Start: 24, End: 100}},
+			},
+			seriesMaxSize:        1000,
+			seriesMatchRatio:     0.5,
+			minAddKeysToMarkLazy: 1,
+			postingGroups: []*postingGroup{
+				{addAll: true, name: "foo", removeKeys: []string{"bar"}},
+				{name: "bar", addKeys: []string{"baz", "foo"}},
+				{name: "cluster", addKeys: []string{"us"}},
+			},
+			expectedPostingGroups: []*postingGroup{
+				{addAll: true, name: "foo", removeKeys: []string{"bar"}, cardinality: 1, existentKeys: 1},
+				{name: "bar", addKeys: []string{"baz", "foo"}, cardinality: 2, existentKeys: 2},
+				{name: "cluster", addKeys: []string{"us"}, cardinality: 18, existentKeys: 1},
 			},
 		},
 		{
@@ -527,9 +673,9 @@ func TestOptimizePostingsFetchByDownloadedBytes(t *testing.T) {
 				{name: "cluster", addKeys: []string{"us"}},
 			},
 			expectedPostingGroups: []*postingGroup{
-				{name: "cluster", addKeys: []string{"us"}, cardinality: 1},
-				{addAll: true, name: "foo", removeKeys: []string{"bar"}, cardinality: 1},
-				{addAll: true, name: "bar", removeKeys: []string{"foo"}, cardinality: 250000, lazy: true},
+				{name: "cluster", addKeys: []string{"us"}, cardinality: 1, existentKeys: 1},
+				{addAll: true, name: "foo", removeKeys: []string{"bar"}, cardinality: 1, existentKeys: 1},
+				{addAll: true, name: "bar", removeKeys: []string{"foo"}, cardinality: 250000, existentKeys: 1, lazy: true},
 			},
 		},
 		{
@@ -549,10 +695,10 @@ func TestOptimizePostingsFetchByDownloadedBytes(t *testing.T) {
 				{name: "cluster", addKeys: []string{"us"}},
 			},
 			expectedPostingGroups: []*postingGroup{
-				{addAll: true, name: "foo", removeKeys: []string{"bar"}, cardinality: 1},
-				{name: "bar", addKeys: []string{"foo"}, cardinality: 500},
-				{name: "baz", addKeys: []string{"foo"}, cardinality: 501},
-				{name: "cluster", addKeys: []string{"us"}, cardinality: 250000, lazy: true},
+				{addAll: true, name: "foo", removeKeys: []string{"bar"}, cardinality: 1, existentKeys: 1},
+				{name: "bar", addKeys: []string{"foo"}, cardinality: 500, existentKeys: 1},
+				{name: "baz", addKeys: []string{"foo"}, cardinality: 501, existentKeys: 1},
+				{name: "cluster", addKeys: []string{"us"}, cardinality: 250000, existentKeys: 1, lazy: true},
 			},
 		},
 	} {
@@ -563,7 +709,8 @@ func TestOptimizePostingsFetchByDownloadedBytes(t *testing.T) {
 			testutil.Ok(t, err)
 			ir := newBucketIndexReader(block, logger)
 			dummyCounter := promauto.With(registry).NewCounter(prometheus.CounterOpts{Name: "test"})
-			pgs, emptyPosting, err := optimizePostingsFetchByDownloadedBytes(ir, tc.postingGroups, tc.seriesMaxSize, tc.seriesMatchRatio, dummyCounter)
+			dummyCounterVec := promauto.With(registry).NewCounterVec(prometheus.CounterOpts{Name: "test_counter_vec"}, []string{"reason"})
+			pgs, emptyPosting, err := optimizePostingsFetchByDownloadedBytes(ir, tc.postingGroups, tc.seriesMaxSize, tc.seriesMatchRatio, tc.minAddKeysToMarkLazy, dummyCounter, dummyCounterVec)
 			if err != nil {
 				testutil.Equals(t, tc.expectedError, err.Error())
 				return


### PR DESCRIPTION
Signed-off-by: Ben Ye <benye@amazon.com><!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

Fixes https://github.com/thanos-io/thanos/issues/7956

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

- Introduce a new Store Gateway flag `store.posting-group-max-keys` to mark a posting group as lazy if it tries to fetch too many keys. 0 disables the limit. This is only effective if lazy expanded posting is enabled.
- Introduce a new metric `thanos_bucket_store_lazy_expanded_posting_groups_total` to track total number of posting groups that are marked to lazy for different reasons

## Verification

- Updated unit tests
