### PR TITLE
Fix potential deadlock in hedging request

### DIFF
--- a/pkg/exthttp/hedging.go
+++ b/pkg/exthttp/hedging.go
@@ -48,11 +48,11 @@ func (hrt *hedgingRoundTripper) RoundTrip(req *http.Request) (*http.Response, er
 	}
 	duration := float64(time.Since(start).Milliseconds())
 	hrt.mu.Lock()
+	defer hrt.mu.Unlock()
 	err = hrt.TDigest.Add(duration)
 	if err != nil {
 		return nil, err
 	}
-	hrt.mu.Unlock()
 	return resp, err
 }
 


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

This PR fixes the potential deadlock situation when the `err = hrt.TDigest.Add(duration)` line gets an error.

## Verification

<!-- How you tested it? How do you know it works? -->
