### PR TITLE
Add a func converting go-kit log to slog

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -117,6 +117,7 @@ require (
 )
 
 require (
+	github.com/tjhop/slog-gokit v0.1.2
 	go.opentelemetry.io/collector/pdata v1.14.1
 	go.opentelemetry.io/collector/semconv v0.108.1
 )

--- a/go.sum
+++ b/go.sum
@@ -2255,6 +2255,8 @@ github.com/themihai/gomemcache v0.0.0-20180902122335-24332e2d58ab h1:7ZR3hmisBWw
 github.com/themihai/gomemcache v0.0.0-20180902122335-24332e2d58ab/go.mod h1:eheTFp954zcWZXCU8d0AT76ftsQOTo4DTqkN/h3k1MY=
 github.com/tinylib/msgp v1.1.5 h1:2gXmtWueD2HefZHQe1QOy9HVzmFrLOVvsXwXBQ0ayy0=
 github.com/tinylib/msgp v1.1.5/go.mod h1:eQsjooMTnV42mHu917E26IogZ2930nFyBQdofk10Udg=
+github.com/tjhop/slog-gokit v0.1.2 h1:pmQI4SvU9h4gA0vIQsdhJQSqQg4mOmsPykG2/PM3j1I=
+github.com/tjhop/slog-gokit v0.1.2/go.mod h1:8fhlcp8C8ELbg3GCyKv06tgt4B5sDq2P1r2DQAu1HuM=
 github.com/tklauser/go-sysconf v0.3.4/go.mod h1:Cl2c8ZRWfHD5IrfHo9VN+FX9kCFjIOyVklgXycLB6ek=
 github.com/tklauser/go-sysconf v0.3.10 h1:IJ1AZGZRWbY8T5Vfk04D9WOA5WSejdflXxP03OUqALw=
 github.com/tklauser/go-sysconf v0.3.10/go.mod h1:C8XykCvCb+Gn0oNCWPIlcb0RuglQTYaQ2hGm7jmxEFk=

--- a/pkg/logging/logger.go
+++ b/pkg/logging/logger.go
@@ -15,6 +15,11 @@ const (
 	LogFormatJSON   = "json"
 )
 
+type LevelLogger struct {
+	log.Logger
+	LogLevel string
+}
+
 // NewLogger returns a log.Logger that prints in the provided format at the
 // provided level with a UTC timestamp and the caller of the log entry. If non
 // empty, the debug name is also appended as a field to all log lines. Panics
@@ -55,5 +60,8 @@ func NewLogger(logLevel, logFormat, debugName string) log.Logger {
 		logger = log.With(logger, "name", debugName)
 	}
 
-	return logger
+	return LevelLogger{
+		Logger:   logger,
+		LogLevel: logLevel,
+	}
 }

--- a/pkg/logutil/logutil.go
+++ b/pkg/logutil/logutil.go
@@ -1,0 +1,33 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package logutil
+
+import (
+	"log/slog"
+
+	"github.com/go-kit/log"
+	"github.com/thanos-io/thanos/pkg/logging"
+	sloggk "github.com/tjhop/slog-gokit"
+)
+
+// GoKitLogToSlog convert go-kit/log to slog.
+func GoKitLogToSlog(logger log.Logger) *slog.Logger {
+	levelVar := slog.LevelVar{}
+	levelLogger, ok := logger.(logging.LevelLogger)
+	if !ok {
+		levelVar.Set(slog.LevelDebug)
+	} else {
+		switch levelLogger.LogLevel {
+		case "debug":
+			levelVar.Set(slog.LevelDebug)
+		case "info":
+			levelVar.Set(slog.LevelInfo)
+		case "warn":
+			levelVar.Set(slog.LevelWarn)
+		case "error":
+			levelVar.Set(slog.LevelError)
+		}
+	}
+	return slog.New(sloggk.NewGoKitHandler(logger, &levelVar))
+}

--- a/pkg/logutil/logutil_test.go
+++ b/pkg/logutil/logutil_test.go
@@ -1,0 +1,52 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package logutil
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/go-kit/log/level"
+	"github.com/stretchr/testify/require"
+	"github.com/thanos-io/thanos/pkg/logging"
+)
+
+func Test_GoKitLogToSlog(t *testing.T) {
+	ctx := context.Background()
+	logLevels := []string{"debug", "info", "warn", "error"}
+	slogLevels := []slog.Level{slog.LevelDebug, slog.LevelInfo, slog.LevelWarn, slog.LevelError}
+
+	for _, logFormat := range []string{"logfmt", "json"} {
+		for i, lv := range logLevels {
+			logger := logging.NewLogger(lv, logFormat, "test")
+
+			slog := GoKitLogToSlog(logger)
+			for j, slogLv := range slogLevels {
+				if i <= j {
+					t.Logf("[logFormat: %v, go-kit log level: %v, slog level: %v] slog should be enabled", logFormat, lv, slogLv)
+					require.True(t, slog.Enabled(ctx, slogLv))
+				} else {
+					t.Logf("[logFormat: %v, go-kit log level: %v, slog level: %v] slog should be disabled", logFormat, lv, slogLv)
+					require.False(t, slog.Enabled(ctx, slogLv))
+				}
+
+				switch lv {
+				case "debug":
+					level.Debug(logger).Log("msg", "message", "debug", lv)
+					slog.Debug("message", "debug", lv)
+				case "info":
+					level.Info(logger).Log("msg", "message", "info", lv)
+					slog.Info("message", "info", lv)
+				case "warn":
+					level.Warn(logger).Log("msg", "message", "warn", lv)
+					slog.Warn("message", "warn", lv)
+				case "error":
+					level.Error(logger).Log("msg", "message", "error", lv)
+					slog.Error("message", "error", lv)
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

This PR adds a function `GoKitLogToSlog` to convert `go-kit/log` to `slog`.
Fixes https://github.com/thanos-io/thanos/issues/7949

## Verification

I added a test code to verify the converted `slog` level should conform to the initial `go-kit/log`.
