### PR TITLE
Allow setting concurrency for bucket replicate

### DIFF
--- a/cmd/thanos/tools_bucket.go
+++ b/cmd/thanos/tools_bucket.go
@@ -129,6 +129,7 @@ type bucketReplicateConfig struct {
 	compactMin  int
 	compactMax  int
 	compactions []int
+	concurrency int
 	matcherStrs string
 	singleRun   bool
 }
@@ -224,6 +225,8 @@ func (tbc *bucketReplicateConfig) registerBucketReplicateFlag(cmd extkingpin.Fla
 	cmd.Flag("compaction-max", "Only blocks up to a maximum of this compaction level will be replicated.").Default("4").IntVar(&tbc.compactMax)
 
 	cmd.Flag("compaction", "Only blocks with these compaction levels will be replicated. Repeated flag. Overrides compaction-min and compaction-max if set.").Default().IntsVar(&tbc.compactions)
+
+	cmd.Flag("concurrency", "The concurrency with which to replicate blocks from the source to the destination bucket.").Default("1").IntVar(&tbc.concurrency)
 
 	cmd.Flag("matcher", "blocks whose external labels match this matcher will be replicated. All Prometheus matchers are supported, including =, !=, =~ and !~.").StringVar(&tbc.matcherStrs)
 
@@ -779,6 +782,7 @@ func registerBucketReplicate(app extkingpin.AppClause, objStoreConfig *extflag.P
 			matchers,
 			resolutionLevels,
 			tbc.compactions,
+			tbc.concurrency,
 			objStoreConfig,
 			toObjStoreConfig,
 			tbc.singleRun,

--- a/docs/components/tools.md
+++ b/docs/components/tools.md
@@ -588,6 +588,8 @@ Flags:
                                 level will be replicated.
       --compaction-min=1        Only blocks with at least this compaction level
                                 will be replicated.
+      --concurrency=1           The concurrency with which to replicate blocks
+                                from the source to the destination bucket.
       --enable-auto-gomemlimit  Enable go runtime to automatically limit memory
                                 consumption.
   -h, --help                    Show context-sensitive help (also try

--- a/pkg/replicate/replicator.go
+++ b/pkg/replicate/replicator.go
@@ -70,6 +70,7 @@ func RunReplicate(
 	labelSelector labels.Selector,
 	resolutions []compact.ResolutionLevel,
 	compactions []int,
+	concurrency int,
 	fromObjStoreConfig *extflag.PathOrContent,
 	toObjStoreConfig *extflag.PathOrContent,
 	singleRun bool,
@@ -188,7 +189,7 @@ func RunReplicate(
 		logger := log.With(logger, "replication-run-id", runID.String())
 		level.Info(logger).Log("msg", "running replication attempt")
 
-		if err := newReplicationScheme(logger, metrics, blockFilter, fetcher, fromBkt, toBkt, reg).execute(ctx); err != nil {
+		if err := newReplicationScheme(logger, metrics, blockFilter, fetcher, fromBkt, toBkt, concurrency, reg).execute(ctx); err != nil {
 			return errors.Wrap(err, "replication execute")
 		}
 


### PR DESCRIPTION
This commit allows setting the block copy concurrency for the bucket replicate command.

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
