### PR TITLE
e2e: remove chrome

### DIFF
--- a/test/e2e/tools_bucket_web_test.go
+++ b/test/e2e/tools_bucket_web_test.go
@@ -62,7 +62,7 @@ func TestToolsBucketWebExternalPrefixWithoutReverseProxy(t *testing.T) {
 	)
 	testutil.Ok(t, e2e.StartAndWaitReady(b))
 
-	checkNetworkRequests(t, "http://"+b.Endpoint("http")+"/"+externalPrefix+"/blocks")
+	checkRequestReturns200(t, "http://"+b.Endpoint("http")+"/"+externalPrefix+"/blocks")
 }
 
 func TestToolsBucketWebExternalPrefix(t *testing.T) {
@@ -99,7 +99,7 @@ func TestToolsBucketWebExternalPrefix(t *testing.T) {
 	toolsBucketWebProxy := httptest.NewServer(e2ethanos.NewSingleHostReverseProxy(toolsBucketWebURL, externalPrefix))
 	t.Cleanup(toolsBucketWebProxy.Close)
 
-	checkNetworkRequests(t, toolsBucketWebProxy.URL+"/"+externalPrefix+"/blocks")
+	checkRequestReturns200(t, toolsBucketWebProxy.URL+"/"+externalPrefix+"/blocks")
 }
 
 func TestToolsBucketWebExternalPrefixAndRoutePrefix(t *testing.T) {
@@ -138,7 +138,7 @@ func TestToolsBucketWebExternalPrefixAndRoutePrefix(t *testing.T) {
 	toolsBucketWebProxy := httptest.NewServer(e2ethanos.NewSingleHostReverseProxy(toolsBucketWebURL, externalPrefix))
 	t.Cleanup(toolsBucketWebProxy.Close)
 
-	checkNetworkRequests(t, toolsBucketWebProxy.URL+"/"+externalPrefix+"/blocks")
+	checkRequestReturns200(t, toolsBucketWebProxy.URL+"/"+externalPrefix+"/blocks")
 }
 
 func TestToolsBucketWebWithTimeAndRelabelFilter(t *testing.T) {


### PR DESCRIPTION
* chromedp has led to flakiness every now and then
* it was used to check that static assets dont return 404
* we can just use regular http GET to do the same check

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
