### PR TITLE
test(tools_test.go/Test_CheckRules_Glob): take into consideration RO current dirs while changing files permissions.

### DIFF
--- a/cmd/thanos/tools_test.go
+++ b/cmd/thanos/tools_test.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"os"
+	"path"
 	"testing"
 
 	"github.com/go-kit/log"
@@ -47,9 +48,12 @@ func Test_CheckRules_Glob(t *testing.T) {
 	testutil.NotOk(t, checkRulesFiles(logger, files), "expected err for file %s", files)
 
 	// Unreadble path
-	files = &[]string{"./testdata/rules-files/unreadable_valid.yaml"}
-	filename := (*files)[0]
-	testutil.Ok(t, os.Chmod(filename, 0000), "failed to change file permissions of %s to 0000", filename)
+	// Move the initial file to a temp dir and make it unreadble there, in case the process cannot chmod the file in the current dir.
+	filename := "./testdata/rules-files/unreadable_valid.yaml"
+	bytesRead, err := os.ReadFile(filename)
+	testutil.Ok(t, err)
+	filename = path.Join(t.TempDir(), "file.yaml")
+	testutil.Ok(t, os.WriteFile(filename, bytesRead, 0000))
+	files = &[]string{filename}
 	testutil.NotOk(t, checkRulesFiles(logger, files), "expected err for file %s", files)
-	testutil.Ok(t, os.Chmod(filename, 0777), "failed to change file permissions of %s to 0777", filename)
 }


### PR DESCRIPTION
The process may not have the needed permissions on the file (not the owner, not root or doesn't have the CAP_FOWNER capability) to chmod it.

tests failures don't seem to be related, some other tests are flaky https://github.com/thanos-io/thanos/issues/8015

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
