### PR TITLE
QFE: Fix @ modifier not being applied correctly on subqueries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 ### Fixed
 
 - [#7978](https://github.com/thanos-io/thanos/pull/7978) Receive: Fix deadlock during local writes when `split-tenant-label-name` is used
+- [#8016](https://github.com/thanos-io/thanos/pull/8016) Query Frontend: Fix @ modifier not being applied correctly on sub queries.
 
 ### Added
 

--- a/internal/cortex/querier/queryrange/split_by_interval.go
+++ b/internal/cortex/querier/queryrange/split_by_interval.go
@@ -5,9 +5,10 @@ package queryrange
 
 import (
 	"context"
-	"github.com/thanos-io/thanos/pkg/extpromql"
 	"net/http"
 	"time"
+
+	"github.com/thanos-io/thanos/pkg/extpromql"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -104,6 +105,15 @@ func EvaluateAtModifierFunction(query string, start, end int64) (string, error) 
 	}
 	parser.Inspect(expr, func(n parser.Node, _ []parser.Node) error {
 		if selector, ok := n.(*parser.VectorSelector); ok {
+			switch selector.StartOrEnd {
+			case parser.START:
+				selector.Timestamp = &start
+			case parser.END:
+				selector.Timestamp = &end
+			}
+			selector.StartOrEnd = 0
+		}
+		if selector, ok := n.(*parser.SubqueryExpr); ok {
 			switch selector.StartOrEnd {
 			case parser.START:
 				selector.Timestamp = &start

--- a/internal/cortex/querier/queryrange/split_by_interval_test.go
+++ b/internal/cortex/querier/queryrange/split_by_interval_test.go
@@ -375,6 +375,14 @@ func Test_evaluateAtModifier(t *testing.T) {
 			[10m:])`,
 		},
 		{
+			in:       `irate(kube_pod_info{namespace="test"}[1h:1m] @ start())`,
+			expected: `irate(kube_pod_info{namespace="test"}[1h:1m] @ 1546300.800)`,
+		},
+		{
+			in:       `irate(kube_pod_info{namespace="test"} @ end()[1h:1m] @ start())`,
+			expected: `irate(kube_pod_info{namespace="test"} @ 1646300.800 [1h:1m] @ 1546300.800)`,
+		},
+		{
 			// parse error: @ modifier must be preceded by an instant vector selector or range vector selector or a subquery
 			in:                "sum(http_requests_total[5m]) @ 10.001",
 			expectedErrorCode: http.StatusBadRequest,


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [X] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes
- QFE doesn't correctly apply the @ modifier for subqueries before splitting the query.
- Related: https://github.com/cortexproject/cortex/pull/6450

## Verification
- Added tests
<!-- How you tested it? How do you know it works? -->
