### PR TITLE
disable parallel for TestEndpointSetUpdate_StrictEndpointMetadata

### DIFF
--- a/pkg/query/endpointset_test.go
+++ b/pkg/query/endpointset_test.go
@@ -464,8 +464,6 @@ func TestEndpointSetUpdate_EndpointComingOnline(t *testing.T) {
 }
 
 func TestEndpointSetUpdate_StrictEndpointMetadata(t *testing.T) {
-	t.Parallel()
-
 	info := sidecarInfo
 	info.Store.MinTime = 111
 	info.Store.MaxTime = 222


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Running this test in parallel with other tests seem caused a data race. https://github.com/thanos-io/thanos/pull/7353#issuecomment-2560372350



## Verification

<!-- How you tested it? How do you know it works? -->
