### PR TITLE
Optimize sort keys by server in memcache client

### DIFF
--- a/pkg/cacheutil/memcached_client_test.go
+++ b/pkg/cacheutil/memcached_client_test.go
@@ -495,16 +495,6 @@ func TestMemcachedClient_sortKeysByServer(t *testing.T) {
 	testutil.ContainsStringSlice(t, sorted, []string{"key1", "key2", "key3", "key4", "key5", "key6"})
 }
 
-type mockAddr string
-
-func (m mockAddr) Network() string {
-	return "mock"
-}
-
-func (m mockAddr) String() string {
-	return string(m)
-}
-
 type mockServerSelector struct {
 	resp map[string][]string
 	err  error


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

When fetching a lot of keys from index cache using memcached, I see in our store gateway 13% CPU spent on `MemcachedJumpHashSelector.PickServer`. Among them most of the CPU spent on `Each` which is the function to get all the memcached server addresses.

<img width="1510" alt="image" src="https://github.com/user-attachments/assets/702250bc-de82-49a3-bc07-92c71536f7ce" />

For each key we call `PickServer` once and each `PickServer` call requires getting all memcached server addresses by calling `Each` function. https://github.com/thanos-io/thanos/blob/main/pkg/cacheutil/memcached_server_selector.go#L65

This is unnecessary because memcache server addresses update infrequently. When there are a lot of keys to fetch through memcached, it can be expensive to call `Each` every time.

This PR I try to cache server addresses in `SetServers` so that we don't have to call `Each` to get addresses every time. Instead we call `Each` once in the `sortKeysByServer` method to get all addresses and do jump hash using the fetched addresses to help reduce lock contention.

## Verification

<!-- How you tested it? How do you know it works? -->
