### PR TITLE
Add block lifecycle callback

### DIFF
--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -451,6 +451,8 @@ type BucketStore struct {
 	indexHeaderLazyDownloadStrategy indexheader.LazyDownloadIndexHeaderFunc
 
 	requestLoggerFunc RequestLoggerFunc
+
+	blockLifecycleCallback BlockLifecycleCallback
 }
 
 func (s *BucketStore) validate() error {
@@ -598,6 +600,24 @@ func WithIndexHeaderLazyDownloadStrategy(strategy indexheader.LazyDownloadIndexH
 	}
 }
 
+// BlockLifecycleCallback specifies callbacks that will be called during the lifecycle of a block.
+type BlockLifecycleCallback interface {
+	// PreAdd is called before adding a block to indicate if the block needs to be added.
+	// A non nil error means the block should not be added.
+	PreAdd(meta metadata.Meta) error
+}
+
+type noopBlockLifecycleCallback struct{}
+
+func (c noopBlockLifecycleCallback) PreAdd(meta metadata.Meta) error { return nil }
+
+// WithBlockLifecycleCallback allows customizing callbacks of block lifecycle.
+func WithBlockLifecycleCallback(c BlockLifecycleCallback) BucketStoreOption {
+	return func(s *BucketStore) {
+		s.blockLifecycleCallback = c
+	}
+}
+
 // NewBucketStore creates a new bucket backed store that implements the store API against
 // an object store bucket. It is optimized to work against high latency backends.
 func NewBucketStore(
@@ -643,6 +663,7 @@ func NewBucketStore(
 		sortingStrategy:                 sortingStrategyStore,
 		indexHeaderLazyDownloadStrategy: indexheader.AlwaysEagerDownloadIndexHeader,
 		requestLoggerFunc:               NoopRequestLoggerFunc,
+		blockLifecycleCallback:          &noopBlockLifecycleCallback{},
 	}
 
 	for _, option := range options {
@@ -698,6 +719,9 @@ func (s *BucketStore) SyncBlocks(ctx context.Context) error {
 		wg.Add(1)
 		go func() {
 			for meta := range blockc {
+				if preAddErr := s.blockLifecycleCallback.PreAdd(*meta); preAddErr != nil {
+					continue
+				}
 				if err := s.addBlock(ctx, meta); err != nil {
 					continue
 				}


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

Fixes #8029

This PR adds a new interface called `BlockLifecycleCallback` which only has 1 method `PreAdd` now. `PreAdd` can be used to customize the logic to see if a block needs to be added by the current store gateway instance

## Verification

<!-- How you tested it? How do you know it works? -->
