### PR TITLE
pkg/cacheutil: Async op fix

### DIFF
--- a/pkg/cacheutil/async_op.go
+++ b/pkg/cacheutil/async_op.go
@@ -54,7 +54,14 @@ func (p *AsyncOperationProcessor) asyncQueueProcessLoop() {
 		case op := <-p.asyncQueue:
 			op()
 		case <-p.stop:
-			return
+			// Run all remaining operations before stopping
+			select {
+			case op := <-p.asyncQueue:
+				op()
+				continue
+			default:
+				return
+			}
 		}
 	}
 }

--- a/pkg/cacheutil/async_op_test.go
+++ b/pkg/cacheutil/async_op_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
 package cacheutil
 
 import (

--- a/pkg/cacheutil/async_op_test.go
+++ b/pkg/cacheutil/async_op_test.go
@@ -1,0 +1,33 @@
+package cacheutil
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/efficientgo/core/testutil"
+)
+
+// Ensure that the processor does not stop if there are still operations waiting in the queue.
+func TestAsyncOp(t *testing.T) {
+	for i := 0; i < 1000; i++ {
+		runTest(t)
+	}
+}
+
+func runTest(t *testing.T) {
+	p := NewAsyncOperationProcessor(100, 10)
+	mtx := sync.Mutex{}
+	var acc int = 0
+
+	for i := 0; i < 100; i++ {
+		err := p.EnqueueAsync(func() {
+			mtx.Lock()
+			defer mtx.Unlock()
+			acc += 1
+		})
+		testutil.Ok(t, err)
+	}
+
+	p.Stop()
+	testutil.Equals(t, 100, acc)
+}


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

This fixes the test in #8043. That separate PR was only to show that the test fails in CI.

The existing implementation sometimes drops existing operations that are
still on the queue when .stop() is called.

If multiple communications in a select statement can proceed, one is
chosen pseudo-randomly: https://go.dev/ref/spec#Select_statements

This means that sometimes a processor worker will process a remaining
operation, and sometimes it won't.

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->

I ran the test multiple times locally, switching between the old implementation of `asyncQueueProcessLoop()` and this new one.

Additionally, #8043 shows that the new test fails in CI with the old implementation.