### PR TITLE
Matcher cache/series

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#7907](https://github.com/thanos-io/thanos/pull/7907) Receive: Add `--receive.grpc-service-config` flag to configure gRPC service config for the receivers.
 - [#7961](https://github.com/thanos-io/thanos/pull/7961) Store Gateway: Add `--store.posting-group-max-keys` flag to mark posting group as lazy if it exceeds number of keys limit. Added `thanos_bucket_store_lazy_expanded_posting_groups_total` for total number of lazy posting groups and corresponding reasons.
 - [#8000](https://github.com/thanos-io/thanos/pull/8000) Query: Bump promql-engine, pass partial response through options
-- [#7353](https://github.com/thanos-io/thanos/pull/7353) Receiver: introduce optional cache for matchers in series calls.
+- [#7353](https://github.com/thanos-io/thanos/pull/7353) [#8045](https://github.com/thanos-io/thanos/pull/8045) Receiver/StoreGateway: Add `--matcher-cache-size` option to enable caching for regex matchers in series calls.
 - [#8017](https://github.com/thanos-io/thanos/pull/8017) Store Gateway: Use native histogram for binary reader load and download duration and fixed download duration metric. #8017
 
 ### Changed

--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -1058,7 +1058,7 @@ func (rc *receiveConfig) registerFlag(cmd extkingpin.FlagClause) {
 			"about order.").
 		Default("false").Hidden().BoolVar(&rc.allowOutOfOrderUpload)
 
-	cmd.Flag("matcher-cache-size", "The size of the cache used for matching against external labels. Using 0 disables caching.").Default("0").IntVar(&rc.matcherCacheSize)
+	cmd.Flag("matcher-cache-size", "The size of the cache used for caching matchers. Using 0 disables caching.").Default("0").IntVar(&rc.matcherCacheSize)
 
 	rc.reqLogConfig = extkingpin.RegisterRequestLoggingFlags(cmd)
 

--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -225,7 +225,7 @@ func runReceive(
 		return errors.Wrap(err, "parse relabel configuration")
 	}
 
-	var cache = storecache.NewNoopMatcherCache()
+	var cache = storecache.NoopMatchersCache
 	if conf.matcherCacheSize > 0 {
 		cache, err = storecache.NewMatchersCache(storecache.WithSize(conf.matcherCacheSize), storecache.WithPromRegistry(reg))
 		if err != nil {

--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -1058,7 +1058,7 @@ func (rc *receiveConfig) registerFlag(cmd extkingpin.FlagClause) {
 			"about order.").
 		Default("false").Hidden().BoolVar(&rc.allowOutOfOrderUpload)
 
-	cmd.Flag("matcher-cache-size", "The size of the cache used for caching matchers. Using 0 disables caching.").Default("0").IntVar(&rc.matcherCacheSize)
+	cmd.Flag("matcher-cache-size", "Max number of cached matchers items. Using 0 disables caching.").Default("0").IntVar(&rc.matcherCacheSize)
 
 	rc.reqLogConfig = extkingpin.RegisterRequestLoggingFlags(cmd)
 

--- a/cmd/thanos/store.go
+++ b/cmd/thanos/store.go
@@ -227,7 +227,7 @@ func (sc *storeConfig) registerFlag(cmd extkingpin.FlagClause) {
 
 	cmd.Flag("bucket-web-label", "External block label to use as group title in the bucket web UI").StringVar(&sc.label)
 
-	cmd.Flag("matcher-cache-size", "The size of the cache used for matching against external labels. Using 0 disables caching.").Default("0").IntVar(&sc.matcherCacheSize)
+	cmd.Flag("matcher-cache-size", "The size of the cache used for caching matchers. Using 0 disables caching.").Default("0").IntVar(&sc.matcherCacheSize)
 
 	sc.reqLogConfig = extkingpin.RegisterRequestLoggingFlags(cmd)
 }

--- a/cmd/thanos/store.go
+++ b/cmd/thanos/store.go
@@ -227,7 +227,7 @@ func (sc *storeConfig) registerFlag(cmd extkingpin.FlagClause) {
 
 	cmd.Flag("bucket-web-label", "External block label to use as group title in the bucket web UI").StringVar(&sc.label)
 
-	cmd.Flag("matcher-cache-size", "The size of the cache used for caching matchers. Using 0 disables caching.").Default("0").IntVar(&sc.matcherCacheSize)
+	cmd.Flag("matcher-cache-size", "Max number of cached matchers items. Using 0 disables caching.").Default("0").IntVar(&sc.matcherCacheSize)
 
 	sc.reqLogConfig = extkingpin.RegisterRequestLoggingFlags(cmd)
 }

--- a/cmd/thanos/store.go
+++ b/cmd/thanos/store.go
@@ -104,6 +104,8 @@ type storeConfig struct {
 	postingGroupMaxKeySeriesRatio float64
 
 	indexHeaderLazyDownloadStrategy string
+
+	matcherCacheSize int
 }
 
 func (sc *storeConfig) registerFlag(cmd extkingpin.FlagClause) {
@@ -224,6 +226,8 @@ func (sc *storeConfig) registerFlag(cmd extkingpin.FlagClause) {
 		Default("false").BoolVar(&sc.webConfig.disableCORS)
 
 	cmd.Flag("bucket-web-label", "External block label to use as group title in the bucket web UI").StringVar(&sc.label)
+
+	cmd.Flag("matcher-cache-size", "The size of the cache used for matching against external labels. Using 0 disables caching.").Default("0").IntVar(&sc.matcherCacheSize)
 
 	sc.reqLogConfig = extkingpin.RegisterRequestLoggingFlags(cmd)
 }
@@ -368,6 +372,14 @@ func runStore(
 		return errors.Wrap(err, "create index cache")
 	}
 
+	var matchersCache = storecache.NoopMatchersCache
+	if conf.matcherCacheSize > 0 {
+		matchersCache, err = storecache.NewMatchersCache(storecache.WithSize(conf.matcherCacheSize), storecache.WithPromRegistry(reg))
+		if err != nil {
+			return errors.Wrap(err, "failed to create matchers cache")
+		}
+	}
+
 	var blockLister block.Lister
 	switch syncStrategy(conf.blockListStrategy) {
 	case concurrentDiscovery:
@@ -413,6 +425,7 @@ func runStore(
 		}),
 		store.WithRegistry(reg),
 		store.WithIndexCache(indexCache),
+		store.WithMatchersCache(matchersCache),
 		store.WithQueryGate(queriesGate),
 		store.WithChunkPool(chunkPool),
 		store.WithFilterConfig(conf.filterConf),

--- a/docs/components/receive.md
+++ b/docs/components/receive.md
@@ -407,8 +407,8 @@ Flags:
       --log.format=logfmt        Log format to use. Possible options: logfmt or
                                  json.
       --log.level=info           Log filtering level.
-      --matcher-cache-size=0     The size of the cache used for matching against
-                                 external labels. Using 0 disables caching.
+      --matcher-cache-size=0     Max number of cached matchers items. Using 0
+                                 disables caching.
       --objstore.config=<content>
                                  Alternative to 'objstore.config-file'
                                  flag (mutually exclusive). Content of

--- a/docs/components/store.md
+++ b/docs/components/store.md
@@ -163,8 +163,8 @@ Flags:
       --log.format=logfmt        Log format to use. Possible options: logfmt or
                                  json.
       --log.level=info           Log filtering level.
-      --matcher-cache-size=0     The size of the cache used for matching against
-                                 external labels. Using 0 disables caching.
+      --matcher-cache-size=0     Max number of cached matchers items. Using 0
+                                 disables caching.
       --max-time=9999-12-31T23:59:59Z
                                  End of time range limit to serve. Thanos Store
                                  will serve only blocks, which happened earlier

--- a/docs/components/store.md
+++ b/docs/components/store.md
@@ -163,6 +163,8 @@ Flags:
       --log.format=logfmt        Log format to use. Possible options: logfmt or
                                  json.
       --log.level=info           Log filtering level.
+      --matcher-cache-size=0     The size of the cache used for matching against
+                                 external labels. Using 0 disables caching.
       --max-time=9999-12-31T23:59:59Z
                                  End of time range limit to serve. Thanos Store
                                  will serve only blocks, which happened earlier

--- a/pkg/receive/multitsdb.go
+++ b/pkg/receive/multitsdb.go
@@ -134,7 +134,7 @@ func NewMultiTSDB(
 		bucket:                bucket,
 		allowOutOfOrderUpload: allowOutOfOrderUpload,
 		hashFunc:              hashFunc,
-		matcherCache:          storecache.NewNoopMatcherCache(),
+		matcherCache:          storecache.NoopMatchersCache,
 	}
 
 	for _, option := range options {

--- a/pkg/store/bucket_test.go
+++ b/pkg/store/bucket_test.go
@@ -1682,6 +1682,8 @@ func TestBucketSeries_OneBlock_InMemIndexCacheSegfault(t *testing.T) {
 		MaxSize: 8889,
 	})
 	testutil.Ok(t, err)
+	matcherCache, err := storecache.NewMatchersCache(storecache.WithSize(10000))
+	testutil.Ok(t, err)
 
 	var b1 *bucketBlock
 
@@ -1775,6 +1777,7 @@ func TestBucketSeries_OneBlock_InMemIndexCacheSegfault(t *testing.T) {
 	store := &BucketStore{
 		bkt:             objstore.WithNoopInstr(bkt),
 		logger:          logger,
+		matcherCache:    matcherCache,
 		indexCache:      indexCache,
 		indexReaderPool: indexheader.NewReaderPool(log.NewNopLogger(), false, 0, indexheader.NewReaderPoolMetrics(nil), indexheader.AlwaysEagerDownloadIndexHeader),
 		metrics:         newBucketStoreMetrics(nil),

--- a/pkg/store/bucket_test.go
+++ b/pkg/store/bucket_test.go
@@ -2080,6 +2080,9 @@ func TestSeries_BlockWithMultipleChunks(t *testing.T) {
 	indexCache, err := storecache.NewInMemoryIndexCacheWithConfig(logger, nil, nil, storecache.InMemoryIndexCacheConfig{})
 	testutil.Ok(tb, err)
 
+	matcherCache, err := storecache.NewMatchersCache(storecache.WithSize(1024))
+	testutil.Ok(tb, err)
+
 	store, err := NewBucketStore(
 		instrBkt,
 		fetcher,
@@ -2096,6 +2099,7 @@ func TestSeries_BlockWithMultipleChunks(t *testing.T) {
 		0,
 		WithLogger(logger),
 		WithIndexCache(indexCache),
+		WithMatchersCache(matcherCache),
 	)
 	testutil.Ok(tb, err)
 	testutil.Ok(tb, store.SyncBlocks(context.Background()))

--- a/pkg/store/cache/matchers_cache.go
+++ b/pkg/store/cache/matchers_cache.go
@@ -31,10 +31,6 @@ var (
 
 type noopMatcherCache struct{}
 
-func newNoopMatcherCache() MatchersCache {
-	return &noopMatcherCache{}
-}
-
 // GetOrSet implements MatchersCache by always creating a new matcher without caching.
 func (n *noopMatcherCache) GetOrSet(_ string, newItem NewItemFunc) (*labels.Matcher, error) {
 	return newItem()

--- a/pkg/store/cache/matchers_cache_test.go
+++ b/pkg/store/cache/matchers_cache_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) The Thanos Authors.
 // Licensed under the Apache License 2.0.
 
-package storecache_test
+package storecache
 
 import (
 	"testing"
@@ -9,87 +9,106 @@ import (
 	"github.com/efficientgo/core/testutil"
 	"github.com/prometheus/prometheus/model/labels"
 
-	storecache "github.com/thanos-io/thanos/pkg/store/cache"
 	"github.com/thanos-io/thanos/pkg/store/storepb"
 )
 
 func TestMatchersCache(t *testing.T) {
-	cache, err := storecache.NewMatchersCache(storecache.WithSize(2))
-	testutil.Ok(t, err)
-
-	matcher := &storepb.LabelMatcher{
-		Type:  storepb.LabelMatcher_EQ,
-		Name:  "key",
-		Value: "val",
+	testCases := map[string]struct {
+		isCacheable func(matcher ConversionLabelMatcher) bool
+	}{
+		"default": {
+			isCacheable: defaultIsCacheableFunc,
+		},
+		"cache all items": {
+			isCacheable: func(matcher ConversionLabelMatcher) bool {
+				return true
+			},
+		},
 	}
 
-	matcher2 := &storepb.LabelMatcher{
-		Type:  storepb.LabelMatcher_RE,
-		Name:  "key2",
-		Value: "val2|val3",
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			cache, err := NewMatchersCache(
+				WithSize(2),
+				WithIsCacheableFunc(tc.isCacheable),
+			)
+			testutil.Ok(t, err)
+
+			matcher := &storepb.LabelMatcher{
+				Type:  storepb.LabelMatcher_EQ,
+				Name:  "key",
+				Value: "val",
+			}
+
+			matcher2 := &storepb.LabelMatcher{
+				Type:  storepb.LabelMatcher_RE,
+				Name:  "key2",
+				Value: "val2|val3",
+			}
+
+			matcher3 := &storepb.LabelMatcher{
+				Type:  storepb.LabelMatcher_EQ,
+				Name:  "key3",
+				Value: "val3",
+			}
+
+			var cacheHit bool
+			newItem := func(matcher *storepb.LabelMatcher) func() (*labels.Matcher, error) {
+				return func() (*labels.Matcher, error) {
+					cacheHit = false
+					return storepb.MatcherToPromMatcher(*matcher)
+				}
+			}
+			expected := labels.MustNewMatcher(labels.MatchEqual, "key", "val")
+			expected2 := labels.MustNewMatcher(labels.MatchRegexp, "key2", "val2|val3")
+			expected3 := labels.MustNewMatcher(labels.MatchEqual, "key3", "val3")
+
+			item, err := cache.GetOrSet(matcher, newItem(matcher))
+			testutil.Ok(t, err)
+			testutil.Equals(t, false, cacheHit)
+			testutil.Equals(t, expected.String(), item.String())
+
+			cacheHit = true
+			item, err = cache.GetOrSet(matcher, newItem(matcher))
+			testutil.Ok(t, err)
+			testutil.Equals(t, tc.isCacheable(matcher), cacheHit)
+			testutil.Equals(t, expected.String(), item.String())
+
+			cacheHit = true
+			item, err = cache.GetOrSet(matcher2, newItem(matcher2))
+			testutil.Ok(t, err)
+			testutil.Equals(t, false, cacheHit)
+			testutil.Equals(t, expected2.String(), item.String())
+
+			cacheHit = true
+			item, err = cache.GetOrSet(matcher2, newItem(matcher2))
+			testutil.Ok(t, err)
+			testutil.Equals(t, tc.isCacheable(matcher2), cacheHit)
+			testutil.Equals(t, expected2.String(), item.String())
+
+			cacheHit = true
+			item, err = cache.GetOrSet(matcher, newItem(matcher))
+			testutil.Ok(t, err)
+			testutil.Equals(t, tc.isCacheable(matcher), cacheHit)
+			testutil.Equals(t, expected, item)
+
+			cacheHit = true
+			item, err = cache.GetOrSet(matcher3, newItem(matcher3))
+			testutil.Ok(t, err)
+			testutil.Equals(t, false, cacheHit)
+			testutil.Equals(t, expected3, item)
+
+			cacheHit = true
+			item, err = cache.GetOrSet(matcher2, newItem(matcher2))
+			testutil.Ok(t, err)
+			testutil.Equals(t, tc.isCacheable(matcher2) && cache.cache.Len() < 2, cacheHit)
+			testutil.Equals(t, expected2.String(), item.String())
+		})
 	}
-
-	matcher3 := &storepb.LabelMatcher{
-		Type:  storepb.LabelMatcher_EQ,
-		Name:  "key3",
-		Value: "val3",
-	}
-
-	var cacheHit bool
-	newItem := func(matcher *storepb.LabelMatcher) func() (*labels.Matcher, error) {
-		return func() (*labels.Matcher, error) {
-			cacheHit = false
-			return storepb.MatcherToPromMatcher(*matcher)
-		}
-	}
-	expected := labels.MustNewMatcher(labels.MatchEqual, "key", "val")
-	expected2 := labels.MustNewMatcher(labels.MatchRegexp, "key2", "val2|val3")
-	expected3 := labels.MustNewMatcher(labels.MatchEqual, "key3", "val3")
-
-	item, err := cache.GetOrSet(matcher.String(), newItem(matcher))
-	testutil.Ok(t, err)
-	testutil.Equals(t, false, cacheHit)
-	testutil.Equals(t, expected.String(), item.String())
-
-	cacheHit = true
-	item, err = cache.GetOrSet(matcher.String(), newItem(matcher))
-	testutil.Ok(t, err)
-	testutil.Equals(t, true, cacheHit)
-	testutil.Equals(t, expected.String(), item.String())
-
-	cacheHit = true
-	item, err = cache.GetOrSet(matcher2.String(), newItem(matcher2))
-	testutil.Ok(t, err)
-	testutil.Equals(t, false, cacheHit)
-	testutil.Equals(t, expected2.String(), item.String())
-
-	cacheHit = true
-	item, err = cache.GetOrSet(matcher2.String(), newItem(matcher2))
-	testutil.Ok(t, err)
-	testutil.Equals(t, true, cacheHit)
-	testutil.Equals(t, expected2.String(), item.String())
-
-	cacheHit = true
-	item, err = cache.GetOrSet(matcher.String(), newItem(matcher))
-	testutil.Ok(t, err)
-	testutil.Equals(t, true, cacheHit)
-	testutil.Equals(t, expected, item)
-
-	cacheHit = true
-	item, err = cache.GetOrSet(matcher3.String(), newItem(matcher3))
-	testutil.Ok(t, err)
-	testutil.Equals(t, false, cacheHit)
-	testutil.Equals(t, expected3, item)
-
-	cacheHit = true
-	item, err = cache.GetOrSet(matcher2.String(), newItem(matcher2))
-	testutil.Ok(t, err)
-	testutil.Equals(t, false, cacheHit)
-	testutil.Equals(t, expected2.String(), item.String())
 }
 
 func BenchmarkMatchersCache(b *testing.B) {
-	cache, err := storecache.NewMatchersCache(storecache.WithSize(100))
+	cache, err := NewMatchersCache(WithSize(100))
 	if err != nil {
 		b.Fatalf("failed to create cache: %v", err)
 	}
@@ -106,7 +125,7 @@ func BenchmarkMatchersCache(b *testing.B) {
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		matcher := matchers[i%len(matchers)]
-		_, err := cache.GetOrSet(matcher.String(), func() (*labels.Matcher, error) {
+		_, err := cache.GetOrSet(matcher, func() (*labels.Matcher, error) {
 			return storepb.MatcherToPromMatcher(*matcher)
 		})
 		if err != nil {

--- a/pkg/store/local.go
+++ b/pkg/store/local.go
@@ -131,7 +131,7 @@ func ScanGRPCCurlProtoStreamMessages(data []byte, atEOF bool) (advance int, toke
 // Series returns all series for a requested time range and label matcher. The returned data may
 // exceed the requested time bounds.
 func (s *LocalStore) Series(r *storepb.SeriesRequest, srv storepb.Store_SeriesServer) error {
-	match, matchers, err := matchesExternalLabels(r.Matchers, s.extLabels, storecache.NewNoopMatcherCache())
+	match, matchers, err := matchesExternalLabels(r.Matchers, s.extLabels, storecache.NoopMatchersCache)
 	if err != nil {
 		return status.Error(codes.InvalidArgument, err.Error())
 	}

--- a/pkg/store/prometheus.go
+++ b/pkg/store/prometheus.go
@@ -126,7 +126,7 @@ func (p *PrometheusStore) Series(r *storepb.SeriesRequest, seriesSrv storepb.Sto
 
 	extLset := p.externalLabelsFn()
 
-	match, matchers, err := matchesExternalLabels(r.Matchers, extLset, storecache.NewNoopMatcherCache())
+	match, matchers, err := matchesExternalLabels(r.Matchers, extLset, storecache.NoopMatchersCache)
 	if err != nil {
 		return status.Error(codes.InvalidArgument, err.Error())
 	}
@@ -543,7 +543,7 @@ func (p *PrometheusStore) encodeChunk(ss []prompb.Sample) (storepb.Chunk_Encodin
 func (p *PrometheusStore) LabelNames(ctx context.Context, r *storepb.LabelNamesRequest) (*storepb.LabelNamesResponse, error) {
 	extLset := p.externalLabelsFn()
 
-	match, matchers, err := matchesExternalLabels(r.Matchers, extLset, storecache.NewNoopMatcherCache())
+	match, matchers, err := matchesExternalLabels(r.Matchers, extLset, storecache.NoopMatchersCache)
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
@@ -606,7 +606,7 @@ func (p *PrometheusStore) LabelValues(ctx context.Context, r *storepb.LabelValue
 
 	extLset := p.externalLabelsFn()
 
-	match, matchers, err := matchesExternalLabels(r.Matchers, extLset, storecache.NewNoopMatcherCache())
+	match, matchers, err := matchesExternalLabels(r.Matchers, extLset, storecache.NoopMatchersCache)
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}

--- a/pkg/store/proxy.go
+++ b/pkg/store/proxy.go
@@ -177,7 +177,7 @@ func NewProxyStore(
 		retrievalStrategy: retrievalStrategy,
 		tsdbSelector:      DefaultSelector,
 		enableDedup:       true,
-		matcherCache:      storecache.NewNoopMatcherCache(),
+		matcherCache:      storecache.NoopMatchersCache,
 	}
 
 	for _, option := range options {

--- a/pkg/store/proxy_test.go
+++ b/pkg/store/proxy_test.go
@@ -2175,7 +2175,7 @@ func benchProxySeries(t testutil.TB, totalSamples, totalSeries int) {
 		responseTimeout:   5 * time.Second,
 		retrievalStrategy: EagerRetrieval,
 		tsdbSelector:      DefaultSelector,
-		matcherCache:      storecache.NewNoopMatcherCache(),
+		matcherCache:      storecache.NoopMatchersCache,
 	}
 
 	var allResps []*storepb.SeriesResponse
@@ -2312,7 +2312,7 @@ func TestProxyStore_NotLeakingOnPrematureFinish(t *testing.T) {
 					responseTimeout:   50 * time.Millisecond,
 					retrievalStrategy: respStrategy,
 					tsdbSelector:      DefaultSelector,
-					matcherCache:      storecache.NewNoopMatcherCache(),
+					matcherCache:      storecache.NoopMatchersCache,
 				}
 
 				ctx, cancel := context.WithCancel(context.Background())
@@ -2350,7 +2350,7 @@ func TestProxyStore_NotLeakingOnPrematureFinish(t *testing.T) {
 					responseTimeout:   50 * time.Millisecond,
 					retrievalStrategy: respStrategy,
 					tsdbSelector:      DefaultSelector,
-					matcherCache:      storecache.NewNoopMatcherCache(),
+					matcherCache:      storecache.NoopMatchersCache,
 				}
 
 				ctx := context.Background()

--- a/pkg/store/storepb/custom.go
+++ b/pkg/store/storepb/custom.go
@@ -552,3 +552,21 @@ func (c *SeriesStatsCounter) Count(series *Series) {
 func (m *SeriesRequest) ToPromQL() string {
 	return m.QueryHints.toPromQL(m.Matchers)
 }
+
+func (m *LabelMatcher) MatcherType() (labels.MatchType, error) {
+	var t labels.MatchType
+	switch m.Type {
+	case LabelMatcher_EQ:
+		t = labels.MatchEqual
+	case LabelMatcher_NEQ:
+		t = labels.MatchNotEqual
+	case LabelMatcher_RE:
+		t = labels.MatchRegexp
+	case LabelMatcher_NRE:
+		t = labels.MatchNotRegexp
+	default:
+		return 0, errors.Errorf("unrecognized label matcher type %d", m.Type)
+	}
+
+	return t, nil
+}

--- a/pkg/store/tsdb.go
+++ b/pkg/store/tsdb.go
@@ -120,7 +120,7 @@ func NewTSDBStore(
 			b := make([]byte, 0, initialBufSize)
 			return &b
 		}},
-		matcherCache: storecache.NewNoopMatcherCache(),
+		matcherCache: storecache.NoopMatchersCache,
 	}
 
 	for _, option := range options {


### PR DESCRIPTION

## Changes

Implementing the same matcher cache from https://github.com/thanos-io/thanos/pull/7353 but for store-gateways.

There also 2 small changes on the cr:
* Avoid creating the NoopCache struct for every call
* Fix maxItems metric

## Verification

Unit test was update to use the cache.
