### PR TITLE
Docs: Remove quote from replica label

### DIFF
--- a/docs/components/compact.md
+++ b/docs/components/compact.md
@@ -106,7 +106,7 @@ external_labels: {cluster="us1", replica="1", receive="true", environment="produ
 external_labels: {cluster="us1", replica="1", receive="true", environment="staging"}
 ```
 
-and set `--deduplication.replica-label="replica"`, Compactor will assume those as:
+and set `--deduplication.replica-label=replica`, Compactor will assume those as:
 
 ```
 external_labels: {cluster="eu1", receive="true", environment="production"} (2 streams, resulted in one)


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

Remove quotes from the `--deduplication.replica-label` examples for the Thanos Compactor docs, this is misleading as the quotes end up being assumed to be part of the replica label, which is unintended. 

Also referenced and suggested in this issue: https://github.com/thanos-io/thanos/issues/6410

## Verification

Not verified. Could not get a go dev environment to work to run the `make docs` command, encountered several issues following CONTRIBUTING.md, though I don't know enough about go development to determine if it's just a case of PEBKAC. 

Hoping the build system will be able to validate it for me, if not can just bin this PR as I'm unable to commit further time to it, sorry! 