### PR TITLE
Extend posting-group-max-key-series-ratio for add all posting group

### DIFF
--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -585,7 +585,7 @@ func WithLazyExpandedPostings(enabled bool) BucketStoreOption {
 	}
 }
 
-// WithPostingGroupMaxKeySeriesRatio configures a threshold to mark a posting group as lazy if it has more add keys.
+// WithPostingGroupMaxKeySeriesRatio configures a threshold to mark a posting group as lazy if it has more add keys or remove keys.
 func WithPostingGroupMaxKeySeriesRatio(postingGroupMaxKeySeriesRatio float64) BucketStoreOption {
 	return func(s *BucketStore) {
 		s.postingGroupMaxKeySeriesRatio = postingGroupMaxKeySeriesRatio
@@ -1076,7 +1076,7 @@ type blockSeriesClient struct {
 
 	lazyExpandedPostingEnabled bool
 	seriesMatchRatio           float64
-	// Mark posting group as lazy if it adds too many keys. 0 to disable.
+	// Mark posting group as lazy if it adds or removes too many keys. 0 to disable.
 	postingGroupMaxKeySeriesRatio                 float64
 	lazyExpandedPostingsCount                     prometheus.Counter
 	lazyExpandedPostingGroupByReason              *prometheus.CounterVec

--- a/pkg/store/lazy_postings.go
+++ b/pkg/store/lazy_postings.go
@@ -166,6 +166,13 @@ func optimizePostingsFetchByDownloadedBytes(
 		if seriesMatched <= 0 {
 			break
 		}
+		// Only mark posting group as lazy due to too many keys when those keys are known to be existent.
+		if postingGroupMaxKeySeriesRatio > 0 && maxSeriesMatched > 0 &&
+			float64(pg.existentKeys)/float64(maxSeriesMatched) > postingGroupMaxKeySeriesRatio {
+			markPostingGroupLazy(pg, "keys_limit", lazyExpandedPostingSizeBytes, lazyExpandedPostingGroupsByReason)
+			i++
+			continue
+		}
 		if pg.addAll {
 			// For posting group that has negative matchers, we assume we can underfetch
 			// min(pg.cardinality, current_series_matched) * match ratio series.
@@ -177,13 +184,6 @@ func optimizePostingsFetchByDownloadedBytes(
 			seriesMatched -= underfetchedSeries
 			underfetchedSeriesSize = underfetchedSeries * seriesMaxSize
 		} else {
-			// Only mark posting group as lazy due to too many keys when those keys are known to be existent.
-			if postingGroupMaxKeySeriesRatio > 0 && maxSeriesMatched > 0 &&
-				float64(pg.existentKeys)/float64(maxSeriesMatched) > postingGroupMaxKeySeriesRatio {
-				markPostingGroupLazy(pg, "keys_limit", lazyExpandedPostingSizeBytes, lazyExpandedPostingGroupsByReason)
-				i++
-				continue
-			}
 			underfetchedSeriesSize = seriesMaxSize * int64(math.Ceil(float64(seriesMatched)*(1-seriesMatchRatio)))
 			seriesMatched = int64(math.Ceil(float64(seriesMatched) * seriesMatchRatio))
 		}


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

We introduced `posting-group-max-key-series-ratio` in https://github.com/thanos-io/thanos/pull/7961 to mark a posting group as lazy if it fetches a lot of keys. But at that time, it was only applied for posting group with add keys for example `=~".+"` or `!=""`.

The same problem of fetching a lot of postings and unable to be optimized can also occur for posting groups with remove keys. We had an issue with matcher `pod=~""` which ended up becoming an add all posting group with removing all postings for `pod` label. This requires fetching a lot of keys and unable to be optimized. This PR should apply the same optimization and solve the issue here.

## Verification

<!-- How you tested it? How do you know it works? -->
