### PR TITLE
fixing thanos querier dedup issue causing incorrect/high values when …

### DIFF
--- a/pkg/dedup/iter.go
+++ b/pkg/dedup/iter.go
@@ -5,6 +5,7 @@ package dedup
 
 import (
 	"math"
+	"strings"
 
 	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
@@ -83,13 +84,46 @@ chunksLoop:
 		currMinTime := chunks[i].MinTime
 		for ri := range o.replicas {
 			if len(o.replicas[ri]) == 0 || o.replicas[ri][len(o.replicas[ri])-1].MaxTime < currMinTime {
-				o.replicas[ri] = append(o.replicas[ri], chunks[i])
+				//Approach 1, Just comment below line to not pick sample causing issue
+				//o.replicas[ri] = append(o.replicas[ri], chunks[i])
+
+				//Approach 2, whenever lower timestamps has higher values don't pick it if it is a counter metric, not filtering it is causing incorrect/
+				//higher values over rate/increase functions which is causing false alerts
+				if len(o.replicas[ri]) != 0 && (strings.HasSuffix(o.currLabels[0].Value, "count") ||
+					strings.HasSuffix(o.currLabels[0].Value, "sum") ||
+					strings.HasSuffix(o.currLabels[0].Value, "total")) {
+
+					chk, _ := chunkenc.FromData(chunkenc.EncXOR, o.replicas[ri][len(o.replicas[ri])-1].Raw.Data)
+					chk2, _ := chunkenc.FromData(chunkenc.EncXOR, chunks[i].Raw.Data)
+					samples := expandChunk(chk.Iterator(nil))
+					samples2 := expandChunk(chk2.Iterator(nil))
+
+					if samples[len(samples)-1].t < samples2[len(samples2)-1].t && samples[len(samples)-1].v < samples2[len(samples2)-1].v {
+						o.replicas[ri] = append(o.replicas[ri], chunks[i])
+					}
+				} else {
+					o.replicas[ri] = append(o.replicas[ri], chunks[i])
+				}
+
 				continue chunksLoop
 			}
 		}
 		o.replicas = append(o.replicas, []storepb.AggrChunk{chunks[i]}) // Not found, add to a new "fake" series.
 	}
 	return true
+}
+
+type dupSample struct {
+	t int64
+	v float64
+}
+
+func expandChunk(cit chunkenc.Iterator) (res []dupSample) {
+	for cit.Next() != chunkenc.ValNone {
+		t, v := cit.At()
+		res = append(res, dupSample{t, v})
+	}
+	return res
 }
 
 func (o *overlapSplitSet) At() (labels.Labels, []storepb.AggrChunk) {


### PR DESCRIPTION
Thanos querier rate/increase function creating huge spikes/incorrect results when deduplication is enabled

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Changes are made in overlapSplitSet Next function to filter out the prometheus replica/instance counter metric value whenever lower timestamps has higher values. The issue is explained in detail in https://github.com/thanos-io/thanos/issues/7623 

Most of the chunks from different replicas are merged and few leftover separate chunks are returned from loser tree and the separate non merged chunks when fed to dedup.NewSeriesSet in querier.go doesn't have any effect. Hence the changes are made in dedup.NewOverlapSplit to filter out samples which has higher values at lower timestamps 

Note: Current dedup bug was resulting in many false alerts breaching the treshold and hence it is very important to fix the dedup bug ASAP

## Verification

Tests are being performed. Before this change rate function was returning result of 1200 for below samples. When the fix is applied rate function only result in 0.46 which is accurate

Dedup issue

304528 @1731358720.447
304530 @1731358725.97
304532 @1731358750.447
304536 @1731358780.447
304540 @1731358810.447
304543 @1731358816.021 -- This sample has been filtered after fix
304542 @1731358816.028 


replica 0
304531 @1731358726.028
304535 @1731358756.028
304539 @1731358786.028
304542 @1731358816.028

replica 1
304530 @1731358725.97
304534 @1731358755.97
304538 @1731358785.97
304543 @1731358816.021

replica 2
304528 @1731358720.447
304532 @1731358750.447
304536 @1731358780.447
304540 @1731358810.447

Please review the changes
