### PR TITLE
[Issue-8106] Fix tenant hashring glob with multiple tenant match patterns

### DIFF
--- a/pkg/receive/hashring.go
+++ b/pkg/receive/hashring.go
@@ -241,13 +241,42 @@ func (c ketamaHashring) GetN(tenant string, ts *prompb.TimeSeries, n uint64) (En
 	return c.endpoints[endpointIndex], nil
 }
 
+type tenantSet map[string]tenantMatcher
+
+func (t tenantSet) match(tenant string) (bool, error) {
+	// Fast path for the common case of direct match.
+	if mt, ok := t[tenant]; ok && isExactMatcher(mt) {
+		return true, nil
+	} else {
+		for tenantPattern, matcherType := range t {
+			switch matcherType {
+			case TenantMatcherGlob:
+				matches, err := filepath.Match(tenantPattern, tenant)
+				if err != nil {
+					return false, fmt.Errorf("error matching tenant pattern %s (tenant %s): %w", tenantPattern, tenant, err)
+				}
+				if matches {
+					return true, nil
+				}
+			case TenantMatcherTypeExact:
+				// Already checked above, skipping.
+				fallthrough
+			default:
+				continue
+			}
+
+		}
+	}
+	return false, nil
+}
+
 // multiHashring represents a set of hashrings.
 // Which hashring to use for a tenant is determined
 // by the tenants field of the hashring configuration.
 type multiHashring struct {
 	cache      map[string]Hashring
 	hashrings  []Hashring
-	tenantSets []map[string]tenantMatcher
+	tenantSets []tenantSet
 
 	// We need a mutex to guard concurrent access
 	// to the cache map, as this is both written to
@@ -284,21 +313,9 @@ func (m *multiHashring) GetN(tenant string, ts *prompb.TimeSeries, n uint64) (En
 			if mt, ok := t[tenant]; ok && isExactMatcher(mt) {
 				found = true
 			} else {
-				for tenantPattern, matcherType := range t {
-					switch matcherType {
-					case TenantMatcherGlob:
-						matches, err := filepath.Match(tenantPattern, tenant)
-						if err != nil {
-							return Endpoint{}, fmt.Errorf("error matching tenant pattern %s (tenant %s): %w", tenantPattern, tenant, err)
-						}
-						found = matches
-					case TenantMatcherTypeExact:
-						// Already checked above, skipping.
-						fallthrough
-					default:
-						continue
-					}
-
+				var err error
+				if found, err = t.match(tenant); err != nil {
+					return Endpoint{}, err
 				}
 			}
 

--- a/pkg/receive/hashring_test.go
+++ b/pkg/receive/hashring_test.go
@@ -140,6 +140,63 @@ func TestHashringGet(t *testing.T) {
 				"node6": {},
 			},
 		},
+		{
+			name: "glob hashring match",
+			cfg: []HashringConfig{
+				{
+					Endpoints:         []Endpoint{{Address: "node1"}, {Address: "node2"}, {Address: "node3"}},
+					Tenants:           []string{"prefix*"},
+					TenantMatcherType: TenantMatcherGlob,
+				},
+				{
+					Endpoints: []Endpoint{{Address: "node4"}, {Address: "node5"}, {Address: "node6"}},
+				},
+			},
+			nodes: map[string]struct{}{
+				"node1": {},
+				"node2": {},
+				"node3": {},
+			},
+			tenant: "prefix-1",
+		},
+		{
+			name: "glob hashring not match",
+			cfg: []HashringConfig{
+				{
+					Endpoints:         []Endpoint{{Address: "node1"}, {Address: "node2"}, {Address: "node3"}},
+					Tenants:           []string{"prefix*"},
+					TenantMatcherType: TenantMatcherGlob,
+				},
+				{
+					Endpoints: []Endpoint{{Address: "node4"}, {Address: "node5"}, {Address: "node6"}},
+				},
+			},
+			nodes: map[string]struct{}{
+				"node4": {},
+				"node5": {},
+				"node6": {},
+			},
+			tenant: "suffix-1",
+		},
+		{
+			name: "glob hashring multiple matches",
+			cfg: []HashringConfig{
+				{
+					Endpoints:         []Endpoint{{Address: "node1"}, {Address: "node2"}, {Address: "node3"}},
+					Tenants:           []string{"t1-*", "t2", "t3-*"},
+					TenantMatcherType: TenantMatcherGlob,
+				},
+				{
+					Endpoints: []Endpoint{{Address: "node4"}, {Address: "node5"}, {Address: "node6"}},
+				},
+			},
+			nodes: map[string]struct{}{
+				"node1": {},
+				"node2": {},
+				"node3": {},
+			},
+			tenant: "t2",
+		},
 	} {
 		hs, err := NewMultiHashring(AlgorithmHashmod, 3, tc.cfg)
 		require.NoError(t, err)


### PR DESCRIPTION
see https://github.com/thanos-io/thanos/issues/8106

Without this change, unit test "glob hashring multiple matches" will fail
<img width="1199" alt="Screenshot 2025-02-14 at 12 53 53 PM" src="https://github.com/user-attachments/assets/b5cebcd1-2b5e-4fd1-8f2b-27a6586155c0" />

it passes after the fix

<img width="897" alt="Screenshot 2025-02-14 at 12 54 06 PM" src="https://github.com/user-attachments/assets/59d9f407-ca9b-4153-ab2a-b017a0e1ee99" />

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
