### PR TITLE
compact: implement native histogram downsampling

### DIFF
--- a/cmd/thanos/main_test.go
+++ b/cmd/thanos/main_test.go
@@ -136,7 +136,7 @@ func TestRegression4960_Deadlock(t *testing.T) {
 			[]labels.Labels{{{Name: "a", Value: "1"}}},
 			1, 0, downsample.ResLevel1DownsampleRange+1, // Pass the minimum ResLevel1DownsampleRange check.
 			labels.Labels{{Name: "e1", Value: "1"}},
-			downsample.ResLevel0, metadata.NoneFunc)
+			downsample.ResLevel0, metadata.NoneFunc, nil)
 		testutil.Ok(t, err)
 		testutil.Ok(t, block.Upload(ctx, logger, bkt, path.Join(dir, id.String()), metadata.NoneFunc))
 	}
@@ -147,7 +147,7 @@ func TestRegression4960_Deadlock(t *testing.T) {
 			[]labels.Labels{{{Name: "a", Value: "2"}}},
 			1, 0, downsample.ResLevel1DownsampleRange+1, // Pass the minimum ResLevel1DownsampleRange check.
 			labels.Labels{{Name: "e1", Value: "2"}},
-			downsample.ResLevel0, metadata.NoneFunc)
+			downsample.ResLevel0, metadata.NoneFunc, nil)
 		testutil.Ok(t, err)
 		testutil.Ok(t, block.Upload(ctx, logger, bkt, path.Join(dir, id2.String()), metadata.NoneFunc))
 	}
@@ -158,7 +158,7 @@ func TestRegression4960_Deadlock(t *testing.T) {
 			[]labels.Labels{{{Name: "a", Value: "2"}}},
 			1, 0, downsample.ResLevel1DownsampleRange+1, // Pass the minimum ResLevel1DownsampleRange check.
 			labels.Labels{{Name: "e1", Value: "2"}},
-			downsample.ResLevel0, metadata.NoneFunc)
+			downsample.ResLevel0, metadata.NoneFunc, nil)
 		testutil.Ok(t, err)
 		testutil.Ok(t, block.Upload(ctx, logger, bkt, path.Join(dir, id3.String()), metadata.NoneFunc))
 	}
@@ -198,7 +198,7 @@ func TestCleanupDownsampleCacheFolder(t *testing.T) {
 			[]labels.Labels{{{Name: "a", Value: "1"}}},
 			1, 0, downsample.ResLevel1DownsampleRange+1, // Pass the minimum ResLevel1DownsampleRange check.
 			labels.Labels{{Name: "e1", Value: "1"}},
-			downsample.ResLevel0, metadata.NoneFunc)
+			downsample.ResLevel0, metadata.NoneFunc, nil)
 		testutil.Ok(t, err)
 		testutil.Ok(t, block.Upload(ctx, logger, bkt, path.Join(dir, id.String()), metadata.NoneFunc))
 	}

--- a/docs/components/compact.md
+++ b/docs/components/compact.md
@@ -152,9 +152,7 @@ message AggrChunk {
 
 This means that for each series we collect various aggregations with a given interval: 5m or 1h (depending on resolution). This allows us to keep precision on large duration queries, without fetching too many samples.
 
-Native histogram downsampling leverages the fact that one can aggregate & reduce schema i.e. downsample native histograms. Native histograms
-only store 3 aggregations - counter, count, and sum. Sum and count are used to produce "an average" native histogram. Counter is a counter
-that is used with functions irate, rate, increase, and resets.
+Native histogram downsampling leverages the fact that one can aggregate & reduce schema i.e. downsample native histograms. Native histograms only store 3 aggregations - counter, count, and sum. Sum and count are used to produce "an average" native histogram. Counter is a counter that is used with functions irate, rate, increase, and resets.
 
 ### ⚠ ️Downsampling: Note About Resolution and Retention ⚠️
 

--- a/docs/components/compact.md
+++ b/docs/components/compact.md
@@ -152,6 +152,10 @@ message AggrChunk {
 
 This means that for each series we collect various aggregations with a given interval: 5m or 1h (depending on resolution). This allows us to keep precision on large duration queries, without fetching too many samples.
 
+Native histogram downsampling leverages the fact that one can aggregate & reduce schema i.e. downsample native histograms. Native histograms
+only store 3 aggregations - counter, count, and sum. Sum and count are used to produce "an average" native histogram. Counter is a counter
+that is used with functions irate, rate, increase, and resets.
+
 ### ⚠ ️Downsampling: Note About Resolution and Retention ⚠️
 
 Resolution is a distance between data points on your graphs. E.g.

--- a/pkg/api/blocks/v1_test.go
+++ b/pkg/api/blocks/v1_test.go
@@ -104,7 +104,7 @@ func TestMarkBlockEndpoint(t *testing.T) {
 		labels.FromStrings("a", "3"),
 		labels.FromStrings("a", "4"),
 		labels.FromStrings("b", "1"),
-	}, 100, 0, 1000, labels.FromStrings("ext1", "val1"), 124, metadata.NoneFunc)
+	}, 100, 0, 1000, labels.FromStrings("ext1", "val1"), 124, metadata.NoneFunc, nil)
 	testutil.Ok(t, err)
 
 	// upload block

--- a/pkg/block/block_test.go
+++ b/pkg/block/block_test.go
@@ -92,7 +92,7 @@ func TestUpload(t *testing.T) {
 		labels.New(labels.Label{Name: "a", Value: "3"}),
 		labels.New(labels.Label{Name: "a", Value: "4"}),
 		labels.New(labels.Label{Name: "b", Value: "1"}),
-	}, 100, 0, 1000, labels.New(labels.Label{Name: "ext1", Value: "val1"}), 124, metadata.NoneFunc)
+	}, 100, 0, 1000, labels.New(labels.Label{Name: "ext1", Value: "val1"}), 124, metadata.NoneFunc, nil)
 	testutil.Ok(t, err)
 	testutil.Ok(t, os.MkdirAll(path.Join(tmpDir, "test", b1.String()), os.ModePerm))
 
@@ -207,7 +207,7 @@ func TestUpload(t *testing.T) {
 			labels.New(labels.Label{Name: "a", Value: "3"}),
 			labels.New(labels.Label{Name: "a", Value: "4"}),
 			labels.New(labels.Label{Name: "b", Value: "1"}),
-		}, 100, 0, 1000, labels.EmptyLabels(), 124, metadata.NoneFunc)
+		}, 100, 0, 1000, labels.EmptyLabels(), 124, metadata.NoneFunc, nil)
 		testutil.Ok(t, err)
 		err = Upload(ctx, log.NewNopLogger(), bkt, path.Join(tmpDir, b2.String()), metadata.NoneFunc)
 		testutil.NotOk(t, err)
@@ -222,7 +222,7 @@ func TestUpload(t *testing.T) {
 			labels.New(labels.Label{Name: "a", Value: "3"}),
 			labels.New(labels.Label{Name: "a", Value: "4"}),
 			labels.New(labels.Label{Name: "b", Value: "1"}),
-		}, 100, 0, 1000, labels.EmptyLabels(), 124, metadata.NoneFunc)
+		}, 100, 0, 1000, labels.EmptyLabels(), 124, metadata.NoneFunc, nil)
 		testutil.Ok(t, err)
 		err = UploadPromBlock(ctx, log.NewNopLogger(), bkt, path.Join(tmpDir, b2.String()), metadata.NoneFunc)
 		testutil.Ok(t, err)
@@ -247,7 +247,7 @@ func TestDelete(t *testing.T) {
 			labels.New(labels.Label{Name: "a", Value: "3"}),
 			labels.New(labels.Label{Name: "a", Value: "4"}),
 			labels.New(labels.Label{Name: "b", Value: "1"}),
-		}, 100, 0, 1000, labels.New(labels.Label{Name: "ext1", Value: "val1"}), 124, metadata.NoneFunc)
+		}, 100, 0, 1000, labels.New(labels.Label{Name: "ext1", Value: "val1"}), 124, metadata.NoneFunc, nil)
 		testutil.Ok(t, err)
 		testutil.Ok(t, Upload(ctx, log.NewNopLogger(), bkt, path.Join(tmpDir, b1.String()), metadata.NoneFunc))
 		testutil.Equals(t, 3, len(bkt.Objects()))
@@ -266,7 +266,7 @@ func TestDelete(t *testing.T) {
 			labels.New(labels.Label{Name: "a", Value: "3"}),
 			labels.New(labels.Label{Name: "a", Value: "4"}),
 			labels.New(labels.Label{Name: "b", Value: "1"}),
-		}, 100, 0, 1000, labels.New(labels.Label{Name: "ext1", Value: "val1"}), 124, metadata.NoneFunc)
+		}, 100, 0, 1000, labels.New(labels.Label{Name: "ext1", Value: "val1"}), 124, metadata.NoneFunc, nil)
 		testutil.Ok(t, err)
 		testutil.Ok(t, Upload(ctx, log.NewNopLogger(), bkt, path.Join(tmpDir, b2.String()), metadata.NoneFunc))
 		testutil.Equals(t, 3, len(bkt.Objects()))
@@ -317,7 +317,7 @@ func TestMarkForDeletion(t *testing.T) {
 				labels.New(labels.Label{Name: "a", Value: "3"}),
 				labels.New(labels.Label{Name: "a", Value: "4"}),
 				labels.New(labels.Label{Name: "b", Value: "1"}),
-			}, 100, 0, 1000, labels.New(labels.Label{Name: "ext1", Value: "val1"}), 124, metadata.NoneFunc)
+			}, 100, 0, 1000, labels.New(labels.Label{Name: "ext1", Value: "val1"}), 124, metadata.NoneFunc, nil)
 			testutil.Ok(t, err)
 
 			tcase.preUpload(t, id, bkt)
@@ -371,7 +371,7 @@ func TestMarkForNoCompact(t *testing.T) {
 				labels.New(labels.Label{Name: "a", Value: "3"}),
 				labels.New(labels.Label{Name: "a", Value: "4"}),
 				labels.New(labels.Label{Name: "b", Value: "1"}),
-			}, 100, 0, 1000, labels.New(labels.Label{Name: "ext1", Value: "val1"}), 124, metadata.NoneFunc)
+			}, 100, 0, 1000, labels.New(labels.Label{Name: "ext1", Value: "val1"}), 124, metadata.NoneFunc, nil)
 			testutil.Ok(t, err)
 
 			tcase.preUpload(t, id, bkt)
@@ -426,7 +426,7 @@ func TestMarkForNoDownsample(t *testing.T) {
 				labels.New(labels.Label{Name: "a", Value: "3"}),
 				labels.New(labels.Label{Name: "a", Value: "4"}),
 				labels.New(labels.Label{Name: "b", Value: "1"}),
-			}, 100, 0, 1000, labels.New(labels.Label{Name: "ext1", Value: "val1"}), 124, metadata.NoneFunc)
+			}, 100, 0, 1000, labels.New(labels.Label{Name: "ext1", Value: "val1"}), 124, metadata.NoneFunc, nil)
 			testutil.Ok(t, err)
 
 			tcase.preUpload(t, id, bkt)
@@ -457,7 +457,7 @@ func TestHashDownload(t *testing.T) {
 
 	b1, err := e2eutil.CreateBlockWithTombstone(ctx, tmpDir, []labels.Labels{
 		labels.New(labels.Label{Name: "a", Value: "1"}),
-	}, 100, 0, 1000, labels.New(labels.Label{Name: "ext1", Value: "val1"}), 42, metadata.SHA256Func)
+	}, 100, 0, 1000, labels.New(labels.Label{Name: "ext1", Value: "val1"}), 42, metadata.SHA256Func, nil)
 	testutil.Ok(t, err)
 
 	testutil.Ok(t, Upload(ctx, log.NewNopLogger(), instrumentedBkt, path.Join(tmpDir, b1.String()), metadata.SHA256Func))
@@ -550,7 +550,7 @@ func TestUploadCleanup(t *testing.T) {
 		labels.New(labels.Label{Name: "a", Value: "3"}),
 		labels.New(labels.Label{Name: "a", Value: "4"}),
 		labels.New(labels.Label{Name: "b", Value: "1"}),
-	}, 100, 0, 1000, labels.New(labels.Label{Name: "ext1", Value: "val1"}), 124, metadata.NoneFunc)
+	}, 100, 0, 1000, labels.New(labels.Label{Name: "ext1", Value: "val1"}), 124, metadata.NoneFunc, nil)
 	testutil.Ok(t, err)
 
 	{
@@ -635,7 +635,7 @@ func TestRemoveMarkForDeletion(t *testing.T) {
 				labels.New(labels.Label{Name: "cluster-eu1", Value: "service-3"}),
 				labels.New(labels.Label{Name: "cluster-us1", Value: "service-1"}),
 				labels.New(labels.Label{Name: "cluster-us1", Value: "service-2"}),
-			}, 100, 0, 1000, labels.New(labels.Label{Name: "region-1", Value: "eu-west"}), 124, metadata.NoneFunc)
+			}, 100, 0, 1000, labels.New(labels.Label{Name: "region-1", Value: "eu-west"}), 124, metadata.NoneFunc, nil)
 			testutil.Ok(t, err)
 			testcases.preDelete(t, id, bkt)
 			counter := promauto.With(nil).NewCounter(prometheus.CounterOpts{})
@@ -682,7 +682,7 @@ func TestRemoveMarkForNoCompact(t *testing.T) {
 				labels.New(labels.Label{Name: "cluster-eu1", Value: "service-3"}),
 				labels.New(labels.Label{Name: "cluster-us1", Value: "service-1"}),
 				labels.New(labels.Label{Name: "cluster-us1", Value: "service-2"}),
-			}, 100, 0, 1000, labels.New(labels.Label{Name: "region-1", Value: "eu-west"}), 124, metadata.NoneFunc)
+			}, 100, 0, 1000, labels.New(labels.Label{Name: "region-1", Value: "eu-west"}), 124, metadata.NoneFunc, nil)
 			testutil.Ok(t, err)
 			testCases.preDelete(t, id, bkt)
 			counter := promauto.With(nil).NewCounter(prometheus.CounterOpts{})
@@ -729,7 +729,7 @@ func TestRemoveMmarkForNoDownsample(t *testing.T) {
 				labels.New(labels.Label{Name: "cluster-eu1", Value: "service-3"}),
 				labels.New(labels.Label{Name: "cluster-us1", Value: "service-1"}),
 				labels.New(labels.Label{Name: "cluster-us1", Value: "service-2"}),
-			}, 100, 0, 1000, labels.New(labels.Label{Name: "region-1", Value: "eu-west"}), 124, metadata.NoneFunc)
+			}, 100, 0, 1000, labels.New(labels.Label{Name: "region-1", Value: "eu-west"}), 124, metadata.NoneFunc, nil)
 			testutil.Ok(t, err)
 			testCases.preDelete(t, id, bkt)
 			counter := promauto.With(nil).NewCounter(prometheus.CounterOpts{})

--- a/pkg/block/index_test.go
+++ b/pkg/block/index_test.go
@@ -34,7 +34,7 @@ func TestRewrite(t *testing.T) {
 		labels.New(labels.Label{Name: "a", Value: "4"}),
 		labels.New(labels.Label{Name: "a", Value: "1"}),
 		labels.New(labels.Label{Name: "b", Value: "1"}),
-	}, 150, 0, 1000, labels.EmptyLabels(), 124, metadata.NoneFunc)
+	}, 150, 0, 1000, labels.EmptyLabels(), 124, metadata.NoneFunc, nil)
 	testutil.Ok(t, err)
 
 	ir, err := index.NewFileReader(filepath.Join(tmpDir, b.String(), IndexFilename), index.DecodePostingsRaw)

--- a/pkg/block/indexheader/header_test.go
+++ b/pkg/block/indexheader/header_test.go
@@ -67,7 +67,7 @@ func TestReaders(t *testing.T) {
 		labels.FromStrings("cluster", "a-eu-west-1"),
 		labels.FromStrings("cluster", "b-eu-west-1"),
 		labels.FromStrings("cluster", "c-eu-west-1"),
-	}, 100, 0, 1000, labels.FromStrings("ext1", "1"), 124, metadata.NoneFunc)
+	}, 100, 0, 1000, labels.FromStrings("ext1", "1"), 124, metadata.NoneFunc, nil)
 	testutil.Ok(t, err)
 
 	testutil.Ok(t, block.Upload(ctx, log.NewNopLogger(), bkt, filepath.Join(tmpDir, id1.String()), metadata.NoneFunc))
@@ -464,7 +464,7 @@ func benchmarkBinaryReaderLookupSymbol(b *testing.B, numSeries int) {
 	}
 
 	// Create a block.
-	id1, err := e2eutil.CreateBlock(ctx, tmpDir, seriesLabels, 100, 0, 1000, labels.FromStrings("ext1", "1"), 124, metadata.NoneFunc)
+	id1, err := e2eutil.CreateBlock(ctx, tmpDir, seriesLabels, 100, 0, 1000, labels.FromStrings("ext1", "1"), 124, metadata.NoneFunc, nil)
 	testutil.Ok(b, err)
 	testutil.Ok(b, block.Upload(ctx, logger, bkt, filepath.Join(tmpDir, id1.String()), metadata.NoneFunc))
 
@@ -598,7 +598,7 @@ func TestReaderPostingsOffsets(t *testing.T) {
 	bkt, err := filesystem.NewBucket(filepath.Join(tmpDir, "bkt"))
 	testutil.Ok(t, err)
 	defer func() { testutil.Ok(t, bkt.Close()) }()
-	id, err := e2eutil.CreateBlock(ctx, tmpDir, lbls, 100, 0, 1000, labels.FromStrings("ext1", "1"), 124, metadata.NoneFunc)
+	id, err := e2eutil.CreateBlock(ctx, tmpDir, lbls, 100, 0, 1000, labels.FromStrings("ext1", "1"), 124, metadata.NoneFunc, nil)
 	testutil.Ok(t, err)
 
 	testutil.Ok(t, block.Upload(ctx, log.NewNopLogger(), bkt, filepath.Join(tmpDir, id.String()), metadata.NoneFunc))

--- a/pkg/block/indexheader/lazy_binary_reader_test.go
+++ b/pkg/block/indexheader/lazy_binary_reader_test.go
@@ -63,7 +63,7 @@ func TestNewLazyBinaryReader_ShouldBuildIndexHeaderFromBucket(t *testing.T) {
 			blockID, err := e2eutil.CreateBlock(ctx, tmpDir, []labels.Labels{
 				labels.FromStrings("a", "1"),
 				labels.FromStrings("a", "2"),
-			}, 100, 0, 1000, labels.FromStrings("ext1", "1"), 124, metadata.NoneFunc)
+			}, 100, 0, 1000, labels.FromStrings("ext1", "1"), 124, metadata.NoneFunc, nil)
 			testutil.Ok(t, err)
 			testutil.Ok(t, block.Upload(ctx, log.NewNopLogger(), bkt, filepath.Join(tmpDir, blockID.String()), metadata.NoneFunc))
 
@@ -114,7 +114,7 @@ func TestNewLazyBinaryReader_ShouldRebuildCorruptedIndexHeader(t *testing.T) {
 	blockID, err := e2eutil.CreateBlock(ctx, tmpDir, []labels.Labels{
 		labels.FromStrings("a", "1"),
 		labels.FromStrings("a", "2"),
-	}, 100, 0, 1000, labels.FromStrings("ext1", "1"), 124, metadata.NoneFunc)
+	}, 100, 0, 1000, labels.FromStrings("ext1", "1"), 124, metadata.NoneFunc, nil)
 	testutil.Ok(t, err)
 	testutil.Ok(t, block.Upload(ctx, log.NewNopLogger(), bkt, filepath.Join(tmpDir, blockID.String()), metadata.NoneFunc))
 
@@ -157,7 +157,7 @@ func TestLazyBinaryReader_ShouldReopenOnUsageAfterClose(t *testing.T) {
 	blockID, err := e2eutil.CreateBlock(ctx, tmpDir, []labels.Labels{
 		labels.FromStrings("a", "1"),
 		labels.FromStrings("a", "2"),
-	}, 100, 0, 1000, labels.FromStrings("ext1", "1"), 124, metadata.NoneFunc)
+	}, 100, 0, 1000, labels.FromStrings("ext1", "1"), 124, metadata.NoneFunc, nil)
 	testutil.Ok(t, err)
 	testutil.Ok(t, block.Upload(ctx, log.NewNopLogger(), bkt, filepath.Join(tmpDir, blockID.String()), metadata.NoneFunc))
 
@@ -212,7 +212,7 @@ func TestLazyBinaryReader_unload_ShouldReturnErrorIfNotIdle(t *testing.T) {
 	blockID, err := e2eutil.CreateBlock(ctx, tmpDir, []labels.Labels{
 		labels.FromStrings("a", "1"),
 		labels.FromStrings("a", "2"),
-	}, 100, 0, 1000, labels.FromStrings("ext1", "1"), 124, metadata.NoneFunc)
+	}, 100, 0, 1000, labels.FromStrings("ext1", "1"), 124, metadata.NoneFunc, nil)
 	testutil.Ok(t, err)
 	testutil.Ok(t, block.Upload(ctx, log.NewNopLogger(), bkt, filepath.Join(tmpDir, blockID.String()), metadata.NoneFunc))
 
@@ -266,7 +266,7 @@ func TestLazyBinaryReader_LoadUnloadRaceCondition(t *testing.T) {
 	blockID, err := e2eutil.CreateBlock(ctx, tmpDir, []labels.Labels{
 		labels.FromStrings("a", "1"),
 		labels.FromStrings("a", "2"),
-	}, 100, 0, 1000, labels.FromStrings("ext1", "1"), 124, metadata.NoneFunc)
+	}, 100, 0, 1000, labels.FromStrings("ext1", "1"), 124, metadata.NoneFunc, nil)
 	testutil.Ok(t, err)
 	testutil.Ok(t, block.Upload(ctx, log.NewNopLogger(), bkt, filepath.Join(tmpDir, blockID.String()), metadata.NoneFunc))
 

--- a/pkg/block/indexheader/reader_pool_test.go
+++ b/pkg/block/indexheader/reader_pool_test.go
@@ -50,7 +50,7 @@ func TestReaderPool_NewBinaryReader(t *testing.T) {
 	blockID, err := e2eutil.CreateBlock(ctx, tmpDir, []labels.Labels{
 		labels.FromStrings("a", "1"),
 		labels.FromStrings("a", "2"),
-	}, 100, 0, 1000, labels.FromStrings("ext1", "1"), 124, metadata.NoneFunc)
+	}, 100, 0, 1000, labels.FromStrings("ext1", "1"), 124, metadata.NoneFunc, nil)
 	testutil.Ok(t, err)
 	testutil.Ok(t, block.Upload(ctx, log.NewNopLogger(), bkt, filepath.Join(tmpDir, blockID.String()), metadata.NoneFunc))
 
@@ -89,7 +89,7 @@ func TestReaderPool_ShouldCloseIdleLazyReaders(t *testing.T) {
 	blockID, err := e2eutil.CreateBlock(ctx, tmpDir, []labels.Labels{
 		labels.FromStrings("a", "1"),
 		labels.FromStrings("a", "2"),
-	}, 100, 0, 1000, labels.FromStrings("ext1", "1"), 124, metadata.NoneFunc)
+	}, 100, 0, 1000, labels.FromStrings("ext1", "1"), 124, metadata.NoneFunc, nil)
 	testutil.Ok(t, err)
 	testutil.Ok(t, block.Upload(ctx, log.NewNopLogger(), bkt, filepath.Join(tmpDir, blockID.String()), metadata.NoneFunc))
 	meta, err := metadata.ReadFromDir(filepath.Join(tmpDir, blockID.String()))

--- a/pkg/compact/compact_e2e_test.go
+++ b/pkg/compact/compact_e2e_test.go
@@ -433,7 +433,7 @@ func createBlock(t testing.TB, ctx context.Context, prepareDir string, b blockge
 	if b.numSamples == 0 {
 		id, err = e2eutil.CreateEmptyBlock(prepareDir, b.mint, b.maxt, b.extLset, b.res)
 	} else {
-		id, err = e2eutil.CreateBlock(ctx, prepareDir, b.series, b.numSamples, b.mint, b.maxt, b.extLset, b.res, metadata.NoneFunc)
+		id, err = e2eutil.CreateBlock(ctx, prepareDir, b.series, b.numSamples, b.mint, b.maxt, b.extLset, b.res, metadata.NoneFunc, nil)
 	}
 	testutil.Ok(t, err)
 

--- a/pkg/compact/downsample/aggr_test.go
+++ b/pkg/compact/downsample/aggr_test.go
@@ -14,11 +14,11 @@ import (
 func TestAggrChunk(t *testing.T) {
 	var input [5][]sample
 
-	input[AggrCount] = []sample{{100, 30}, {200, 50}, {300, 60}, {400, 67}}
-	input[AggrSum] = []sample{{100, 130}, {200, 1000}, {300, 2000}, {400, 5555}}
-	input[AggrMin] = []sample{{100, 0}, {200, -10}, {300, 1000}, {400, -9.5}}
+	input[AggrCount] = []sample{{t: 100, v: 30}, {t: 200, v: 50}, {t: 300, v: 60}, {t: 400, v: 67}}
+	input[AggrSum] = []sample{{t: 100, v: 130}, {t: 200, v: 1000}, {t: 300, v: 2000}, {t: 400, v: 5555}}
+	input[AggrMin] = []sample{{t: 100, v: 0}, {t: 200, v: -10}, {t: 300, v: 1000}, {t: 400, v: -9.5}}
 	// Maximum is absent.
-	input[AggrCounter] = []sample{{100, 5}, {200, 10}, {300, 10.1}, {400, 15}, {400, 3}}
+	input[AggrCounter] = []sample{{t: 100, v: 5}, {t: 200, v: 10}, {t: 300, v: 10.1}, {t: 400, v: 15}, {t: 400, v: 3}}
 
 	var chks [5]chunkenc.Chunk
 
@@ -41,7 +41,7 @@ func TestAggrChunk(t *testing.T) {
 	for _, at := range []AggrType{AggrCount, AggrSum, AggrMin, AggrMax, AggrCounter} {
 		if c, err := ac.Get(at); err != ErrAggrNotExist {
 			testutil.Ok(t, err)
-			testutil.Ok(t, expandChunkIterator(c.Iterator(nil), &res[at]))
+			testutil.Ok(t, expandXorChunkIterator(c.Iterator(nil), &res[at]))
 		}
 	}
 	testutil.Equals(t, input, res)
@@ -53,7 +53,7 @@ func TestAggrChunk(t *testing.T) {
 	for _, at := range []AggrType{AggrCount, AggrSum, AggrMin, AggrMax, AggrCounter} {
 		if c, err := nc.Get(at); err != ErrAggrNotExist {
 			testutil.Ok(t, err)
-			testutil.Ok(t, expandChunkIterator(c.Iterator(nil), &res[at]))
+			testutil.Ok(t, expandXorChunkIterator(c.Iterator(nil), &res[at]))
 		}
 	}
 	testutil.Equals(t, input, res)

--- a/pkg/compact/downsample/downsample.go
+++ b/pkg/compact/downsample/downsample.go
@@ -114,11 +114,13 @@ func Downsample(
 		aggrChunks []*AggrChunk
 		all        []sample
 		chks       []chunks.Meta
+		resChunks  []chunks.Meta
 		builder    labels.ScratchBuilder
 		reuseIt    chunkenc.Iterator
 	)
 	for postings.Next() {
 		chks = chks[:0]
+		resChunks = resChunks[:0]
 		all = all[:0]
 		aggrChunks = aggrChunks[:0]
 
@@ -148,57 +150,106 @@ func Downsample(
 
 		// Raw and already downsampled data need different processing.
 		if origMeta.Thanos.Downsample.Resolution == 0 {
+			var prevEnc chunkenc.Encoding = chks[0].Chunk.Encoding()
+
 			for _, c := range chks {
+				if prevEnc != c.Chunk.Encoding() {
+					resChunks = append(resChunks, DownsampleRaw(all, resolution)...)
+					all = all[:0]
+					prevEnc = c.Chunk.Encoding()
+				}
 				// TODO(bwplotka): We can optimize this further by using in WriteSeries iterators of each chunk instead of
 				// samples. Also ensure 120 sample limit, otherwise we have gigantic chunks.
 				// https://github.com/thanos-io/thanos/issues/2542.
-				if err := expandChunkIterator(c.Chunk.Iterator(reuseIt), &all); err != nil {
+				if err := expandChunkIterator(c.Chunk.Iterator(reuseIt), c.Chunk.Encoding(), &all); err != nil {
 					return id, errors.Wrapf(err, "expand chunk %d, series %d", c.Ref, postings.At())
 				}
 			}
-			if err := streamedBlockWriter.WriteSeries(lset, DownsampleRaw(all, resolution)); err != nil {
+			resChunks = append(resChunks, DownsampleRaw(all, resolution)...)
+			if err := streamedBlockWriter.WriteSeries(lset, resChunks); err != nil {
 				return id, errors.Wrapf(err, "downsample raw data, series: %d", postings.At())
 			}
 		} else {
-			// Downsample a block that contains aggregated chunks already.
-			for _, c := range chks {
-				ac, ok := c.Chunk.(*AggrChunk)
-				if !ok {
-					if c.Chunk.NumSamples() == 0 {
-						// Downsampled block can erroneously contain empty XOR chunks, skip those
-						// https://github.com/thanos-io/thanos/issues/5272
-						level.Warn(logger).Log("msg", fmt.Sprintf("expected downsampled chunk (*downsample.AggrChunk) got an empty %T instead for series: %d", c.Chunk, postings.At()))
-						continue
-					} else {
-						if err := expandChunkIterator(c.Chunk.Iterator(reuseIt), &all); err != nil {
-							return id, errors.Wrapf(err, "expand chunk %d, series %d", c.Ref, postings.At())
-						}
-						aggrDataChunks := DownsampleRaw(all, ResLevel1)
-						for _, cn := range aggrDataChunks {
-							ac, ok = cn.Chunk.(*AggrChunk)
-							if !ok {
-								return id, errors.New("Not able to convert non-empty XOR chunks to 5m downsampled aggregated chunks.")
-							}
-						}
-					}
+			var (
+				previousIsHistogram bool
+				mint, maxt          int64
+			)
 
+			fixedChks := make([]chunks.Meta, 0, len(chks))
+
+			// First loop through chunks and fix chunks if possible.
+			// See https://github.com/thanos-io/thanos/commit/a159680ca437576bf78f7b08a14715a61f5d3ca9 for context.
+			for _, c := range chks {
+				_, ok := c.Chunk.(*AggrChunk)
+				if ok {
+					fixedChks = append(fixedChks, c)
+					continue
+				}
+				if c.Chunk.NumSamples() == 0 {
+					// Downsampled block can erroneously contain empty XOR chunks, skip those
+					// https://github.com/thanos-io/thanos/issues/5272
+					level.Warn(logger).Log("msg", fmt.Sprintf("expected downsampled chunk (*downsample.AggrChunk) got an empty %T instead for series: %d", c.Chunk, postings.At()))
+					continue
+				} else {
+					if err := expandChunkIterator(c.Chunk.Iterator(reuseIt), c.Chunk.Encoding(), &all); err != nil {
+						return id, errors.Wrapf(err, "expand chunk %d, series %d", c.Ref, postings.At())
+					}
+					aggrDataChunks := DownsampleRaw(all, ResLevel1)
+					for _, cn := range aggrDataChunks {
+						_, ok = cn.Chunk.(*AggrChunk)
+						if !ok {
+							return id, errors.New("Not able to convert non-empty chunks to 5m downsampled aggregated chunks.")
+						}
+						fixedChks = append(fixedChks, cn)
+					}
+					all = all[:0]
+				}
+			}
+
+			// Downsample a block that contains aggregated chunks already.
+			for i, c := range fixedChks {
+				ac := c.Chunk.(*AggrChunk)
+				if i > 0 && previousIsHistogram != isHistogram(ac) {
+					err := downsampleAggr(
+						aggrChunks,
+						&all,
+						mint,
+						maxt,
+						origMeta.Thanos.Downsample.Resolution,
+						resolution,
+						&resChunks,
+					)
+					if err != nil {
+						return id, errors.Wrapf(err, "downsample aggregate block, series: %d", postings.At())
+					}
+					previousIsHistogram = isHistogram(ac)
+					aggrChunks = aggrChunks[:0]
+					mint = c.MinTime
 				}
 				aggrChunks = append(aggrChunks, ac)
 
+				if i == 0 {
+					mint = c.MinTime
+					previousIsHistogram = isHistogram(ac)
+				}
+				maxt = c.MaxTime
 			}
-			downsampledChunks, err := downsampleAggr(
+
+			err = downsampleAggr(
 				aggrChunks,
 				&all,
-				chks[0].MinTime,
-				chks[len(chks)-1].MaxTime,
+				mint,
+				maxt,
 				origMeta.Thanos.Downsample.Resolution,
 				resolution,
+				&resChunks,
 			)
 			if err != nil {
 				return id, errors.Wrapf(err, "downsample aggregate block, series: %d", postings.At())
 			}
-			if err := streamedBlockWriter.WriteSeries(lset, downsampledChunks); err != nil {
-				return id, errors.Wrapf(err, "write series: %d", postings.At())
+
+			if err := streamedBlockWriter.WriteSeries(lset, resChunks); err != nil {
+				return id, errors.Wrapf(err, "write aggr series: %d", postings.At())
 			}
 		}
 	}
@@ -245,8 +296,197 @@ func targetChunkCount(mint, maxt, inRes, outRes int64, count int) (x int) {
 	return x
 }
 
-// aggregator collects cumulative stats for a stream of values.
-type aggregator struct {
+type histogramAggregator struct {
+	total    int                       // Total histograms processed.
+	count    int                       // Histograms in current window.
+	sum      *histogram.FloatHistogram // Value sum of current window (for gauge histograms).
+	counter  *histogram.FloatHistogram // Total counter state since beginning (for counter histograms).
+	previous *histogram.FloatHistogram // Previously added value.
+	schema   int32                     // Smallest schema in the batch that's being aggregated.
+}
+
+func newHistogramAggregator(schema int32) *histogramAggregator {
+	return &histogramAggregator{
+		schema: schema,
+	}
+}
+
+func (h *histogramAggregator) reset() {
+	h.count = 0
+	h.sum = nil
+}
+
+func mustHistogramOp(_ *histogram.FloatHistogram, err error) {
+	// NOTE(GiedriusS): this can only happen with custom
+	// boundaries. We do not support them yet.
+	if err != nil {
+		panic(fmt.Sprintf("unexpected error: %v", err))
+	}
+}
+
+func (h *histogramAggregator) add(s sample) {
+	fh := s.fh
+	if fh.Schema < h.schema {
+		panic("schema must be greater or equal to aggregator schema")
+	}
+
+	// A schema increase is treated as a reset, so we need to preserve
+	// the original histogram in case the schema is adjusted.
+	oFh := fh
+	// If schema of the sample is greater than the
+	// aggregator schema, we need to reduce the resolution.
+	if fh.Schema > h.schema {
+		fh = fh.CopyToSchema(h.schema)
+	}
+
+	if h.total > 0 {
+		if fh.CounterResetHint != histogram.GaugeType && oFh.DetectReset(h.previous) {
+			// Counter reset, correct the value.
+			mustHistogramOp(h.counter.Add(fh))
+		} else {
+			// Add delta with previous value to the counter.
+			deltaFh, err := fh.Copy().Sub(h.previous)
+			if err != nil {
+				// TODO(GiedriusS): support native histograms with custom buckets.
+				// This can only happen with custom buckets.
+				panic(fmt.Sprintf("unexpected error: %v", err))
+			}
+
+			mustHistogramOp(h.counter.Add(deltaFh))
+		}
+	} else {
+		// First sample sets the counter.
+		h.counter = fh.Copy()
+	}
+
+	if h.sum == nil {
+		h.sum = fh.Copy()
+	} else {
+		mustHistogramOp(h.sum.Add(fh))
+	}
+
+	// This needs to be h gauge histogram, otherwise reset detection will be triggered
+	// when appending the aggregated chunk and histogram.count < appender.count.
+	h.sum.CounterResetHint = histogram.GaugeType
+
+	h.previous = fh
+
+	h.count++
+	h.total++
+}
+
+func (h *histogramAggregator) processedSamples() int {
+	return h.total
+}
+
+func (f *floatAggregator) processedSamples() int {
+	return f.total
+}
+
+func newHistogramAggrChunkBuilder(isGaugeSamples bool) *aggrChunkBuilder {
+	b := &aggrChunkBuilder{
+		mint:           math.MaxInt64,
+		maxt:           math.MinInt64,
+		isGaugeSamples: isGaugeSamples,
+	}
+
+	b.chunks[AggrCount] = chunkenc.NewXORChunk()
+	b.chunks[AggrSum] = chunkenc.NewFloatHistogramChunk()
+	b.chunks[AggrCounter] = chunkenc.NewFloatHistogramChunk()
+
+	for i, c := range b.chunks {
+		if c != nil {
+			b.apps[i], _ = c.Appender()
+		}
+	}
+	return b
+}
+
+func minSchema(samples []sample) int32 {
+	schema := int32(math.MaxInt32)
+	for _, s := range samples {
+		if s.fh != nil && !value.IsStaleNaN(s.fh.Sum) && s.fh.Schema < schema {
+			schema = s.fh.Schema
+		}
+	}
+	return schema
+}
+
+func downsampleFloatBatch(batch []sample, resolution int64) chunks.Meta {
+	ab := newAggrChunkBuilder()
+	// Encode first raw value; see ApplyCounterResetsSeriesIterator.
+	ab.apps[AggrCounter].Append(batch[0].t, batch[0].v)
+	lastT := downsampleBatch(batch, resolution, &floatAggregator{}, ab.add)
+	// Encode last raw value; see ApplyCounterResetsSeriesIterator.
+	ab.apps[AggrCounter].Append(lastT, batch[len(batch)-1].v)
+	return ab.encode()
+}
+
+func downsampleHistogramBatch(batch []sample, resolution int64) chunks.Meta {
+	// We need to know the smallest schema in advanced otherwise we might end
+	// up with a non appendable histogram if histogram.schema < chunk.schema.
+	schema := minSchema(batch)
+	ab := newHistogramAggrChunkBuilder(isGaugeSamples(batch))
+	downsampleBatch(batch, resolution, newHistogramAggregator(schema), ab.addHistogram)
+	return ab.encode()
+}
+
+type sampleAggregator interface {
+	reset()
+	add(s sample)
+	processedSamples() int
+}
+
+func (b *aggrChunkBuilder) addHistogram(t int64, a sampleAggregator) {
+	if t < b.mint {
+		b.mint = t
+	}
+	if t > b.maxt {
+		b.maxt = t
+	}
+
+	aggr := mustGetHistogramAggregator(a)
+
+	// NOTE(GiedriusS): For gauge histograms we need to set these to gauge too
+	// so that append wouldn't fail when sum_window_n > sum_window_n+1.
+	if b.isGaugeSamples {
+		aggr.counter.CounterResetHint = histogram.GaugeType
+		aggr.sum.CounterResetHint = histogram.GaugeType
+	}
+	b.appendFloatHistogram(AggrCounter, t, aggr.counter)
+	b.appendFloatHistogram(AggrSum, t, aggr.sum)
+	b.apps[AggrCount].Append(t, float64(aggr.count))
+
+	b.added++
+}
+
+// Mostly copied from https://github.com/prometheus/prometheus/blob/fd8992cdbd6bf7274f2a815e4af64a0b8734841b/tsdb/head_append.go#L1235-L1326
+// but we shouldn't have the not appendable case.
+func (b *aggrChunkBuilder) appendFloatHistogram(t AggrType, ts int64, fh *histogram.FloatHistogram) {
+	app := b.apps[t].(*chunkenc.FloatHistogramAppender)
+
+	ch, _, cApp, err := b.apps[t].AppendFloatHistogram(app, ts, fh, false)
+	if err != nil {
+		panic("unexpected error: " + err.Error())
+	}
+	// NOTE(GiedriusS): from docs:
+	// The returned Chunk c is nil if sample could be appended to the current Chunk, otherwise c is the new Chunk.
+
+	if ch != nil {
+		b.chunks[t] = ch
+	}
+	b.apps[t] = cApp
+}
+
+func isGaugeSamples(samples []sample) bool {
+	if len(samples) == 0 {
+		return false
+	}
+	return samples[0].fh.CounterResetHint == histogram.GaugeType
+}
+
+// floatAggregator collects cumulative stats for a stream of values.
+type floatAggregator struct {
 	total   int     // Total samples processed.
 	count   int     // Samples in current window.
 	sum     float64 // Value sum of current window.
@@ -258,38 +498,38 @@ type aggregator struct {
 }
 
 // reset the stats to start a new aggregation window.
-func (a *aggregator) reset() {
+func (a *floatAggregator) reset() {
 	a.count = 0
 	a.sum = 0
 	a.min = math.MaxFloat64
 	a.max = -math.MaxFloat64
 }
 
-func (a *aggregator) add(v float64) {
+func (a *floatAggregator) add(s sample) {
 	if a.total > 0 {
-		if v < a.last {
+		if s.v < a.last {
 			// Counter reset, correct the value.
-			a.counter += v
+			a.counter += s.v
 			a.resets++
 		} else {
 			// Add delta with last value to the counter.
-			a.counter += v - a.last
+			a.counter += s.v - a.last
 		}
 	} else {
 		// First sample sets the counter.
-		a.counter = v
+		a.counter = s.v
 	}
-	a.last = v
+	a.last = s.v
 
-	a.sum += v
+	a.sum += s.v
 	a.count++
 	a.total++
 
-	if v < a.min {
-		a.min = v
+	if s.v < a.min {
+		a.min = s.v
 	}
-	if v > a.max {
-		a.max = v
+	if s.v > a.max {
+		a.max = s.v
 	}
 }
 
@@ -300,6 +540,8 @@ type aggrChunkBuilder struct {
 
 	chunks [5]chunkenc.Chunk
 	apps   [5]chunkenc.Appender
+
+	isGaugeSamples bool
 }
 
 func newAggrChunkBuilder() *aggrChunkBuilder {
@@ -321,13 +563,31 @@ func newAggrChunkBuilder() *aggrChunkBuilder {
 	return b
 }
 
-func (b *aggrChunkBuilder) add(t int64, aggr *aggregator) {
+func mustGetFloatAggregator(aggr sampleAggregator) *floatAggregator {
+	a, ok := aggr.(*floatAggregator)
+	if !ok {
+		panic("aggregator is not of type *floatAggregator")
+	}
+	return a
+}
+
+func mustGetHistogramAggregator(aggr sampleAggregator) *histogramAggregator {
+	a, ok := aggr.(*histogramAggregator)
+	if !ok {
+		panic("aggregator is not of type *histogramAggregator")
+	}
+	return a
+}
+
+func (b *aggrChunkBuilder) add(t int64, a sampleAggregator) {
 	if t < b.mint {
 		b.mint = t
 	}
 	if t > b.maxt {
 		b.maxt = t
 	}
+
+	aggr := mustGetFloatAggregator(a)
 	b.apps[AggrSum].Append(t, aggr.sum)
 	b.apps[AggrMin].Append(t, aggr.min)
 	b.apps[AggrMax].Append(t, aggr.max)
@@ -355,12 +615,30 @@ func DownsampleRaw(data []sample, resolution int64) []chunks.Meta {
 	// We assume a raw resolution of 1 minute. In practice it will often be lower
 	// but this is sufficient for our heuristic to produce well-sized chunks.
 	numChunks := targetChunkCount(mint, maxt, 1*60*1000, resolution, len(data))
-	return downsampleRawLoop(data, resolution, numChunks)
+	chks := make([]chunks.Meta, 0, numChunks)
+
+	// First sample determines the type of the samples, since we process
+	// one chunk and all samples of one chunk have the same type.
+	if data[0].fh != nil {
+		downsampleRawLoop(data, resolution, numChunks, &chks, downsampleHistogramBatch)
+	} else {
+		downsampleRawLoop(data, resolution, numChunks, &chks, downsampleFloatBatch)
+	}
+
+	return chks
 }
 
-func downsampleRawLoop(data []sample, resolution int64, numChunks int) []chunks.Meta {
+func downsampleRawLoop(
+	data []sample,
+	resolution int64,
+	numChunks int,
+	chks *[]chunks.Meta,
+	downsampleBatchFn func(batch []sample, resolution int64) chunks.Meta,
+) {
+	if len(data) == 0 {
+		return
+	}
 	batchSize := (len(data) / numChunks) + 1
-	chks := make([]chunks.Meta, 0, numChunks)
 
 	for len(data) > 0 {
 		j := batchSize
@@ -379,6 +657,9 @@ func downsampleRawLoop(data []sample, resolution int64, numChunks int) []chunks.
 			if math.IsNaN(s.v) {
 				continue
 			}
+			if s.fh != nil && math.IsNaN(s.fh.Sum) {
+				continue
+			}
 			batch = append(batch, s)
 		}
 		data = data[j:]
@@ -386,38 +667,148 @@ func downsampleRawLoop(data []sample, resolution int64, numChunks int) []chunks.
 			continue
 		}
 
-		ab := newAggrChunkBuilder()
+		*chks = append(*chks, downsampleBatchFn(batch, resolution))
+	}
+}
 
-		// Encode first raw value; see ApplyCounterResetsSeriesIterator.
-		ab.apps[AggrCounter].Append(batch[0].t, batch[0].v)
+func downsampleHistogramAggrBatch(chks []*AggrChunk, buf *[]sample, resolution int64) (chk chunks.Meta, err error) {
+	mint, maxt := int64(math.MaxInt64), int64(math.MinInt64)
+	var reuseIt chunkenc.Iterator
 
-		lastT := downsampleBatch(batch, resolution, ab.add)
+	// Native histograms support counter, sum, count types.
 
-		// Encode last raw value; see ApplyCounterResetsSeriesIterator.
-		ab.apps[AggrCounter].Append(lastT, batch[len(batch)-1].v)
-
-		chks = append(chks, ab.encode())
+	// Expand all samples for the counter aggregate type.
+	*buf = (*buf)[:0]
+	for _, achk := range chks {
+		c, err := achk.Get(AggrCounter)
+		if err == ErrAggrNotExist {
+			continue
+		} else if err != nil {
+			return chk, err
+		}
+		if err := expandFloatHistogramChunkIterator(c.Iterator(reuseIt), buf); err != nil {
+			return chk, err
+		}
 	}
 
-	return chks
+	ab := newHistogramAggrChunkBuilder(isGaugeSamples(*buf))
+
+	schema := minSchema(*buf)
+	downsampleBatch(*buf, resolution, newHistogramAggregator(schema), func(t int64, a sampleAggregator) {
+		if t < mint {
+			mint = t
+		}
+		if t > maxt {
+			maxt = t
+		}
+		ab.appendFloatHistogram(AggrCounter, t, mustGetHistogramAggregator(a).counter)
+	})
+
+	// Expand all samples for the sum aggregate.
+	*buf = (*buf)[:0]
+	for _, achk := range chks {
+		c, err := achk.Get(AggrSum)
+		if err == ErrAggrNotExist {
+			continue
+		} else if err != nil {
+			return chk, err
+		}
+		if err := expandFloatHistogramChunkIterator(c.Iterator(reuseIt), buf); err != nil {
+			return chk, err
+		}
+	}
+	if len(*buf) == 0 {
+		return chk, nil
+	}
+
+	schema = minSchema(*buf)
+	downsampleBatch(*buf, resolution, newHistogramAggregator(schema), func(t int64, a sampleAggregator) {
+		if t < mint {
+			mint = t
+		}
+		if t > maxt {
+			maxt = t
+		}
+		ab.appendFloatHistogram(AggrSum, t, mustGetHistogramAggregator(a).sum)
+	})
+
+	*buf = (*buf)[:0]
+	batchMint, batchMaxt, err := genericAggregate(AggrCount, chks, buf, ab, resolution, func(a sampleAggregator) float64 {
+		aggr := mustGetFloatAggregator(a)
+		return aggr.sum
+	})
+	if err != nil {
+		return chk, err
+	}
+	if batchMint < mint {
+		mint = batchMint
+	}
+	if batchMaxt > maxt {
+		maxt = batchMaxt
+	}
+
+	ab.mint = mint
+	ab.maxt = maxt
+	return ab.encode(), nil
+}
+
+// genericAggregate does a generic aggregation for count, sum, min, and max aggregates.
+// Counters need special treatment.
+func genericAggregate(
+	at AggrType,
+	chks []*AggrChunk,
+	buf *[]sample,
+	ab *aggrChunkBuilder,
+	resolution int64,
+	f func(a sampleAggregator) float64,
+) (int64, int64, error) {
+	var mint, maxt int64 = math.MaxInt64, math.MinInt64
+	var reuseIt chunkenc.Iterator
+	*buf = (*buf)[:0]
+
+	// Expand all samples for the aggregate type.
+	for _, chk := range chks {
+		c, err := chk.Get(at)
+		if err == ErrAggrNotExist {
+			continue
+		} else if err != nil {
+			return 0, 0, err
+		}
+		if err := expandXorChunkIterator(c.Iterator(reuseIt), buf); err != nil {
+			return 0, 0, err
+		}
+	}
+	if len(*buf) == 0 {
+		return 0, 0, nil
+	}
+	ab.chunks[at] = chunkenc.NewXORChunk()
+	ab.apps[at], _ = ab.chunks[at].Appender()
+
+	downsampleBatch(*buf, resolution, &floatAggregator{}, func(t int64, a sampleAggregator) {
+		if t < mint {
+			mint = t
+		}
+		if t > maxt {
+			maxt = t
+		}
+		ab.apps[at].Append(t, f(a))
+	})
+
+	return mint, maxt, nil
 }
 
 // downsampleBatch aggregates the data over the given resolution and calls add each time
 // the end of a resolution was reached.
-func downsampleBatch(data []sample, resolution int64, add func(int64, *aggregator)) int64 {
+func downsampleBatch(data []sample, resolution int64, aggr sampleAggregator, add func(int64, sampleAggregator)) int64 {
 	var (
-		aggr  aggregator
 		nextT = int64(-1)
 		lastT = data[len(data)-1].t
 	)
 	// Fill up one aggregate chunk with up to m samples.
 	for _, s := range data {
-		if value.IsStaleNaN(s.v) {
-			continue
-		}
 		if s.t > nextT {
 			if nextT != -1 {
-				add(nextT, &aggr)
+				add(nextT, aggr)
 			}
 			aggr.reset()
 			nextT = currentWindow(s.t, resolution)
@@ -429,25 +820,78 @@ func downsampleBatch(data []sample, resolution int64, add func(int64, *aggregato
 				nextT = lastT
 			}
 		}
-		aggr.add(s.v)
+		aggr.add(s)
 	}
-	// Add the last sample.
-	add(nextT, &aggr)
+	// Add the last sample if any samples were processed.
+	if aggr.processedSamples() > 0 {
+		// Add the last sample.
+		add(nextT, aggr)
+	}
 
 	return nextT
 }
 
-// downsampleAggr downsamples a sequence of aggregation chunks to the given resolution.
-func downsampleAggr(chks []*AggrChunk, buf *[]sample, mint, maxt, inRes, outRes int64) ([]chunks.Meta, error) {
-	var numSamples int
-	for _, c := range chks {
-		numSamples += c.NumSamples()
+func isHistogram(c *AggrChunk) bool {
+	// If it is an aggregated chunk histogram chunk, the counter will be of the type histogram.
+	cntr, err := c.Get(AggrCounter)
+	if err != nil {
+		return false
 	}
-	numChunks := targetChunkCount(mint, maxt, inRes, outRes, numSamples)
-	return downsampleAggrLoop(chks, buf, outRes, numChunks)
+	return cntr.Encoding() == chunkenc.EncHistogram || cntr.Encoding() == chunkenc.EncFloatHistogram
 }
 
-func downsampleAggrLoop(chks []*AggrChunk, buf *[]sample, resolution int64, numChunks int) ([]chunks.Meta, error) {
+// downsampleAggr downsamples a sequence of aggregation chunks to the given resolution.
+func downsampleAggr(
+	chks []*AggrChunk,
+	buf *[]sample,
+	mint, maxt, inRes, outRes int64,
+	res *[]chunks.Meta,
+) error {
+	var fChks, hChks []*AggrChunk
+	var numSamples int
+
+	for _, c := range chks {
+		if isHistogram(c) {
+			hChks = append(hChks, c)
+			numSamples += c.NumSamples()
+		} else {
+			fChks = append(fChks, c)
+			numSamples += c.NumSamples()
+		}
+	}
+
+	var (
+		rescChks []chunks.Meta
+		err      error
+	)
+
+	numChunks := targetChunkCount(mint, maxt, inRes, outRes, numSamples)
+
+	if len(fChks) > 0 {
+		rescChks, err = downsampleAggrLoop(fChks, buf, outRes, numChunks, downsampleFloatAggrBatch)
+		if err != nil {
+			return err
+		}
+	} else {
+		rescChks, err = downsampleAggrLoop(hChks, buf, outRes, numChunks, downsampleHistogramAggrBatch)
+		if err != nil {
+			return err
+		}
+	}
+
+	*res = append(*res, rescChks...)
+	return nil
+}
+
+type downsampleAggrFunc = func(chks []*AggrChunk, buf *[]sample, resolution int64) (chk chunks.Meta, err error)
+
+func downsampleAggrLoop(
+	chks []*AggrChunk,
+	buf *[]sample,
+	resolution int64,
+	numChunks int,
+	downsampleAggr downsampleAggrFunc,
+) ([]chunks.Meta, error) {
 	// We downsample aggregates only along chunk boundaries. This is required
 	// for counters to be downsampled correctly since a chunk's first and last
 	// counter values are the true values of the original series. We need
@@ -463,7 +907,12 @@ func downsampleAggrLoop(chks []*AggrChunk, buf *[]sample, resolution int64, numC
 		part := chks[:j]
 		chks = chks[j:]
 
-		chk, err := downsampleAggrBatch(part, buf, resolution)
+		chk, err := downsampleAggr(part, buf, resolution)
+		if chk.MinTime == math.MaxInt64 || chk.MaxTime == math.MinInt64 {
+			msg := fmt.Sprintf("invalid range for downsampled aggregate chunk: mint=%d maxt=%d", chk.MinTime, chk.MaxTime)
+			return nil, errors.New(msg)
+		}
+
 		if err != nil {
 			return nil, err
 		}
@@ -473,82 +922,120 @@ func downsampleAggrLoop(chks []*AggrChunk, buf *[]sample, resolution int64, numC
 	return res, nil
 }
 
-// expandChunkIterator reads all samples from the iterator and appends them to buf.
+func expandChunkIterator(it chunkenc.Iterator, encoding chunkenc.Encoding, samples *[]sample) error {
+	switch encoding {
+	case chunkenc.EncXOR:
+		return expandXorChunkIterator(it, samples)
+	case chunkenc.EncFloatHistogram:
+		return expandFloatHistogramChunkIterator(it, samples)
+	case chunkenc.EncHistogram:
+		return expandHistogramChunkIterator(it, samples)
+	default:
+		return errors.Errorf("unexpected chunk encoding %d %s", encoding, encoding)
+	}
+}
+
+// expandXorChunkIterator reads all samples from the iterator and appends them to buf.
 // Stale markers and out of order samples are skipped.
-func expandChunkIterator(it chunkenc.Iterator, buf *[]sample) error {
+func expandXorChunkIterator(it chunkenc.Iterator, buf *[]sample) error {
 	// For safety reasons, we check for each sample that it does not go back in time.
 	// If it does, we skip it.
 	lastT := int64(0)
-
 	for it.Next() != chunkenc.ValNone {
 		t, v := it.At()
 		if value.IsStaleNaN(v) {
 			continue
 		}
 		if t >= lastT {
-			*buf = append(*buf, sample{t, v})
+			*buf = append(*buf, sample{t: t, v: v})
 			lastT = t
 		}
 	}
 	return it.Err()
 }
 
-func downsampleAggrBatch(chks []*AggrChunk, buf *[]sample, resolution int64) (chk chunks.Meta, err error) {
+// expandHistogramChunkIterator reads all histograms from the iterator and appends them to buf.
+func expandHistogramChunkIterator(it chunkenc.Iterator, buf *[]sample) error {
+	// For safety reasons, we check for each sample that it does not go back in time.
+	// If it does, we skip it.
+	var (
+		lastT int64
+		t     int64
+		h     *histogram.Histogram
+	)
+
+	for it.Next() != chunkenc.ValNone {
+		t, h = it.AtHistogram(h)
+		if value.IsStaleNaN(h.Sum) {
+			continue
+		}
+		if t >= lastT {
+			*buf = append(*buf, sample{t: t, fh: h.ToFloat(nil)})
+			lastT = t
+		}
+	}
+	return it.Err()
+}
+
+// expandHistogramChunkIterator reads all histograms from the iterator and appends them to buf.
+func expandFloatHistogramChunkIterator(it chunkenc.Iterator, buf *[]sample) error {
+	// For safety reasons, we check for each sample that it does not go back in time.
+	// If it does, we skip it.
+	var (
+		fh    *histogram.FloatHistogram
+		t     int64
+		lastT int64
+	)
+
+	for it.Next() != chunkenc.ValNone {
+		t, fh = it.AtFloatHistogram(nil)
+		if value.IsStaleNaN(fh.Sum) {
+			continue
+		}
+		if t >= lastT {
+			*buf = append(*buf, sample{t: t, fh: fh})
+			lastT = t
+		}
+	}
+	return it.Err()
+}
+
+func downsampleFloatAggrBatch(chks []*AggrChunk, buf *[]sample, resolution int64) (chk chunks.Meta, err error) {
 	ab := &aggrChunkBuilder{}
 	mint, maxt := int64(math.MaxInt64), int64(math.MinInt64)
 	var reuseIt chunkenc.Iterator
 
 	// do does a generic aggregation for count, sum, min, and max aggregates.
 	// Counters need special treatment.
-	do := func(at AggrType, f func(a *aggregator) float64) error {
-		*buf = (*buf)[:0]
-		// Expand all samples for the aggregate type.
-		for _, chk := range chks {
-			c, err := chk.Get(at)
-			if err == ErrAggrNotExist {
-				continue
-			} else if err != nil {
-				return err
-			}
-			if err := expandChunkIterator(c.Iterator(reuseIt), buf); err != nil {
-				return err
-			}
+	do := func(at AggrType, f func(a sampleAggregator) float64) error {
+		aggrMint, aggrMaxt, err := genericAggregate(at, chks, buf, ab, resolution, f)
+		if aggrMint < mint {
+			mint = aggrMint
 		}
-		if len(*buf) == 0 {
-			return nil
+		if aggrMaxt > maxt {
+			maxt = aggrMaxt
 		}
-		ab.chunks[at] = chunkenc.NewXORChunk()
-		ab.apps[at], _ = ab.chunks[at].Appender()
-
-		downsampleBatch(*buf, resolution, func(t int64, a *aggregator) {
-			if t < mint {
-				mint = t
-			} else if t > maxt {
-				maxt = t
-			}
-			ab.apps[at].Append(t, f(a))
-		})
-		return nil
+		return err
 	}
-	if err := do(AggrCount, func(a *aggregator) float64 {
+	if err := do(AggrCount, func(a sampleAggregator) float64 {
 		// To get correct count of elements from already downsampled count chunk
 		// we have to sum those values.
-		return a.sum
+		return mustGetFloatAggregator(a).sum
 	}); err != nil {
 		return chk, err
 	}
-	if err = do(AggrSum, func(a *aggregator) float64 {
-		return a.sum
+	if err = do(AggrSum, func(a sampleAggregator) float64 {
+		return mustGetFloatAggregator(a).sum
 	}); err != nil {
 		return chk, err
 	}
-	if err := do(AggrMin, func(a *aggregator) float64 {
-		return a.min
+	if err := do(AggrMin, func(a sampleAggregator) float64 {
+		return mustGetFloatAggregator(a).min
 	}); err != nil {
 		return chk, err
 	}
-	if err := do(AggrMax, func(a *aggregator) float64 {
-		return a.max
+	if err := do(AggrMax, func(a sampleAggregator) float64 {
+		return mustGetFloatAggregator(a).max
 	}); err != nil {
 		return chk, err
 	}
@@ -567,7 +1054,7 @@ func downsampleAggrBatch(chks []*AggrChunk, buf *[]sample, resolution int64) (ch
 	*buf = (*buf)[:0]
 	it := NewApplyCounterResetsIterator(acs...)
 
-	if err := expandChunkIterator(it, buf); err != nil {
+	if err := expandXorChunkIterator(it, buf); err != nil {
 		return chk, err
 	}
 	if len(*buf) == 0 {
@@ -581,13 +1068,14 @@ func downsampleAggrBatch(chks []*AggrChunk, buf *[]sample, resolution int64) (ch
 	// Retain first raw value; see ApplyCounterResetsSeriesIterator.
 	ab.apps[AggrCounter].Append((*buf)[0].t, (*buf)[0].v)
 
-	lastT := downsampleBatch(*buf, resolution, func(t int64, a *aggregator) {
+	lastT := downsampleBatch(*buf, resolution, &floatAggregator{}, func(t int64, a sampleAggregator) {
 		if t < mint {
 			mint = t
-		} else if t > maxt {
+		}
+		if t > maxt {
 			maxt = t
 		}
-		ab.apps[AggrCounter].Append(t, a.counter)
+		ab.apps[AggrCounter].Append(t, mustGetFloatAggregator(a).counter)
 	})
 
 	// Retain last raw value; see ApplyCounterResetsSeriesIterator.
@@ -599,8 +1087,9 @@ func downsampleAggrBatch(chks []*AggrChunk, buf *[]sample, resolution int64) (ch
 }
 
 type sample struct {
-	t int64
-	v float64
+	t  int64
+	v  float64
+	fh *histogram.FloatHistogram
 }
 
 // ApplyCounterResetsSeriesIterator generates monotonically increasing values by iterating
@@ -730,30 +1219,44 @@ type AverageChunkIterator struct {
 	t     int64
 	v     float64
 	err   error
+	fh    *histogram.FloatHistogram
 }
 
 func NewAverageChunkIterator(cnt, sum chunkenc.Iterator) *AverageChunkIterator {
 	return &AverageChunkIterator{cntIt: cnt, sumIt: sum}
 }
 
-// TODO(rabenhorst): Native histogram support needs to be added, float type is hardcoded.
 func (it *AverageChunkIterator) Next() chunkenc.ValueType {
-	cok, sok := it.cntIt.Next(), it.sumIt.Next()
-	if cok != sok {
+	ct, st := it.cntIt.Next(), it.sumIt.Next()
+
+	if (ct != chunkenc.ValNone && st == chunkenc.ValNone) ||
+		(ct == chunkenc.ValNone && st != chunkenc.ValNone) {
 		it.err = errors.New("sum and count iterator not aligned")
 		return chunkenc.ValNone
 	}
-	if cok == chunkenc.ValNone {
+
+	if ct == chunkenc.ValNone {
 		return chunkenc.ValNone
 	}
 
-	cntT, cntV := it.cntIt.At()
-	sumT, sumV := it.sumIt.At()
+	cntT := it.cntIt.AtT()
+	sumT := it.sumIt.AtT()
 	if cntT != sumT {
 		it.err = errors.New("sum and count timestamps not aligned")
 		return chunkenc.ValNone
 	}
-	it.t, it.v = cntT, sumV/cntV
+
+	it.t = cntT
+	_, cntV := it.cntIt.At()
+
+	if st == chunkenc.ValFloatHistogram {
+		_, sumV := it.sumIt.AtFloatHistogram(nil)
+		it.fh = sumV.Div(cntV)
+		return chunkenc.ValFloatHistogram
+	}
+
+	_, sumV := it.sumIt.At()
+	it.v = sumV / cntV
 	return chunkenc.ValFloat
 }
 
@@ -763,16 +1266,23 @@ func (it *AverageChunkIterator) Seek(t int64) chunkenc.ValueType {
 }
 
 func (it *AverageChunkIterator) At() (int64, float64) {
+	if it.fh != nil {
+		panic("not float histogram iterator")
+	}
 	return it.t, it.v
 }
 
-// TODO(rabenhorst): Needs to be implemented for native histogram support.
+// This should never be called since the result of an histogram calculation
+// is always a float histogram.
 func (it *AverageChunkIterator) AtHistogram(*histogram.Histogram) (int64, *histogram.Histogram) {
-	panic("not implemented")
+	panic("it is always a float histogram")
 }
 
 func (it *AverageChunkIterator) AtFloatHistogram(*histogram.FloatHistogram) (int64, *histogram.FloatHistogram) {
-	panic("not implemented")
+	if it.fh == nil {
+		panic("not float histogram iterator")
+	}
+	return it.t, it.fh
 }
 
 func (it *AverageChunkIterator) AtT() int64 {

--- a/pkg/compact/downsample/downsample_test.go
+++ b/pkg/compact/downsample/downsample_test.go
@@ -2864,3 +2864,12 @@ func assertValidChunkTime(t *testing.T, chks []chunks.Meta) {
 		testutil.Assert(t, chk.MaxTime >= chk.MinTime, "chunk MaxTime is not greater equal to  MinTime")
 	}
 }
+
+func TestDownsampleNHCutNewChunk(t *testing.T) {
+	require.False(t, cutNewChunk(chunkenc.EncFloatHistogram, chunkenc.EncHistogram))
+	require.False(t, cutNewChunk(chunkenc.EncHistogram, chunkenc.EncFloatHistogram))
+	require.False(t, cutNewChunk(chunkenc.EncHistogram, chunkenc.EncHistogram))
+	require.False(t, cutNewChunk(chunkenc.EncFloatHistogram, chunkenc.EncFloatHistogram))
+	require.True(t, cutNewChunk(chunkenc.EncXOR, chunkenc.EncFloatHistogram))
+	require.True(t, cutNewChunk(chunkenc.EncXOR, chunkenc.EncHistogram))
+}

--- a/pkg/compact/downsample/testutils.go
+++ b/pkg/compact/downsample/testutils.go
@@ -1,0 +1,81 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package downsample
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/efficientgo/core/testutil"
+	"github.com/oklog/ulid"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/tsdb/chunkenc"
+	"github.com/prometheus/prometheus/tsdb/chunks"
+	"github.com/prometheus/prometheus/tsdb/index"
+	"github.com/thanos-io/thanos/pkg/block"
+	"github.com/thanos-io/thanos/pkg/block/metadata"
+)
+
+func GetMetaLabelsAndChunks(t *testing.T, dir string, id ulid.ULID) (*metadata.Meta, []labels.Labels, [][]chunks.Meta) {
+	meta, err := metadata.ReadFromDir(filepath.Join(dir, id.String()))
+	testutil.Ok(t, err)
+
+	indexr, err := index.NewFileReader(filepath.Join(dir, id.String(), block.IndexFilename), index.DecodePostingsRaw)
+	testutil.Ok(t, err)
+	defer func() { testutil.Ok(t, indexr.Close()) }()
+
+	allPostingsK, allPostingsV := index.AllPostingsKey()
+	pall, err := indexr.Postings(context.Background(), allPostingsK, allPostingsV)
+	testutil.Ok(t, err)
+
+	var series []storage.SeriesRef
+	for pall.Next() {
+		series = append(series, pall.At())
+	}
+	testutil.Ok(t, pall.Err())
+
+	var (
+		lbls []labels.Labels
+		chks [][]chunks.Meta
+	)
+	for _, s := range series {
+		var builder labels.ScratchBuilder
+		var seriesChks []chunks.Meta
+		testutil.Ok(t, indexr.Series(s, &builder, &seriesChks))
+		lbls = append(lbls, builder.Labels())
+		chks = append(chks, seriesChks)
+	}
+
+	return meta, lbls, chks
+}
+
+func GetAggregateFromChunk(t *testing.T, chunkr *chunks.Reader, c chunks.Meta, aggrType AggrType) []sample {
+	chk, _, err := chunkr.ChunkOrIterable(c)
+	testutil.Ok(t, err)
+
+	ac, ok := chk.(*AggrChunk)
+	testutil.Assert(t, ok)
+
+	var samples []sample
+
+	subChunk, err := ac.Get(aggrType)
+	testutil.Ok(t, err)
+	it := subChunk.Iterator(nil)
+	for valueType := it.Next(); valueType != chunkenc.ValNone; valueType = it.Next() {
+		switch valueType {
+		case chunkenc.ValFloat:
+			t, v := it.At()
+			samples = append(samples, sample{t: t, v: v})
+		case chunkenc.ValFloatHistogram:
+			t, fh := it.AtFloatHistogram(nil)
+			samples = append(samples, sample{t: t, fh: fh})
+		default:
+			t.Fatalf("unexpected value type %v", valueType)
+		}
+	}
+
+	return samples
+}

--- a/pkg/promclient/promclient_e2e_test.go
+++ b/pkg/promclient/promclient_e2e_test.go
@@ -113,7 +113,7 @@ func TestSnapshot_e2e(t *testing.T) {
 			timestamp.FromTime(now.Add(-4*time.Hour)),
 			labels.EmptyLabels(),
 			0,
-			metadata.NoneFunc,
+			metadata.NoneFunc, nil,
 		)
 		testutil.Ok(t, err)
 
@@ -184,7 +184,7 @@ func TestQueryRange_e2e(t *testing.T) {
 			timestamp.FromTime(now),
 			labels.EmptyLabels(),
 			0,
-			metadata.NoneFunc,
+			metadata.NoneFunc, nil,
 		)
 		testutil.Ok(t, err)
 

--- a/pkg/store/bucket_e2e_test.go
+++ b/pkg/store/bucket_e2e_test.go
@@ -108,9 +108,9 @@ func prepareTestBlocks(t testing.TB, now time.Time, count int, dir string, bkt o
 
 		// Create two blocks per time slot. Only add 10 samples each so only one chunk
 		// gets created each. This way we can easily verify we got 10 chunks per series below.
-		id1, err := e2eutil.CreateBlock(ctx, dir, series[:4], 10, mint, maxt, extLset, 0, metadata.NoneFunc)
+		id1, err := e2eutil.CreateBlock(ctx, dir, series[:4], 10, mint, maxt, extLset, 0, metadata.NoneFunc, nil)
 		testutil.Ok(t, err)
-		id2, err := e2eutil.CreateBlock(ctx, dir, series[4:], 10, mint, maxt, extLset, 0, metadata.NoneFunc)
+		id2, err := e2eutil.CreateBlock(ctx, dir, series[4:], 10, mint, maxt, extLset, 0, metadata.NoneFunc, nil)
 		testutil.Ok(t, err)
 
 		dir1, dir2 := filepath.Join(dir, id1.String()), filepath.Join(dir, id2.String())

--- a/pkg/store/bucket_test.go
+++ b/pkg/store/bucket_test.go
@@ -685,7 +685,7 @@ func TestBucketStore_TSDBInfo(t *testing.T) {
 		{mint: 0, maxt: 1000, extLabels: labels.FromStrings("a", "d")},
 		{mint: 2000, maxt: 3000, extLabels: labels.FromStrings("a", "d")},
 	} {
-		id1, err := e2eutil.CreateBlock(ctx, dir, series, 10, tt.mint, tt.maxt, tt.extLabels, 0, metadata.NoneFunc)
+		id1, err := e2eutil.CreateBlock(ctx, dir, series, 10, tt.mint, tt.maxt, tt.extLabels, 0, metadata.NoneFunc, nil)
 		testutil.Ok(t, err)
 		testutil.Ok(t, block.Upload(ctx, logger, bkt, filepath.Join(dir, id1.String()), metadata.NoneFunc))
 	}
@@ -788,19 +788,19 @@ func TestBucketStore_Sharding(t *testing.T) {
 	bkt := objstore.NewInMemBucket()
 	series := []labels.Labels{labels.FromStrings("a", "1", "b", "1")}
 
-	id1, err := e2eutil.CreateBlock(ctx, dir, series, 10, 0, 1000, labels.FromStrings("cluster", "a", "region", "r1"), 0, metadata.NoneFunc)
+	id1, err := e2eutil.CreateBlock(ctx, dir, series, 10, 0, 1000, labels.FromStrings("cluster", "a", "region", "r1"), 0, metadata.NoneFunc, nil)
 	testutil.Ok(t, err)
 	testutil.Ok(t, block.Upload(ctx, logger, bkt, filepath.Join(dir, id1.String()), metadata.NoneFunc))
 
-	id2, err := e2eutil.CreateBlock(ctx, dir, series, 10, 1000, 2000, labels.FromStrings("cluster", "a", "region", "r1"), 0, metadata.NoneFunc)
+	id2, err := e2eutil.CreateBlock(ctx, dir, series, 10, 1000, 2000, labels.FromStrings("cluster", "a", "region", "r1"), 0, metadata.NoneFunc, nil)
 	testutil.Ok(t, err)
 	testutil.Ok(t, block.Upload(ctx, logger, bkt, filepath.Join(dir, id2.String()), metadata.NoneFunc))
 
-	id3, err := e2eutil.CreateBlock(ctx, dir, series, 10, 0, 1000, labels.FromStrings("cluster", "b", "region", "r1"), 0, metadata.NoneFunc)
+	id3, err := e2eutil.CreateBlock(ctx, dir, series, 10, 0, 1000, labels.FromStrings("cluster", "b", "region", "r1"), 0, metadata.NoneFunc, nil)
 	testutil.Ok(t, err)
 	testutil.Ok(t, block.Upload(ctx, logger, bkt, filepath.Join(dir, id3.String()), metadata.NoneFunc))
 
-	id4, err := e2eutil.CreateBlock(ctx, dir, series, 10, 0, 1000, labels.FromStrings("cluster", "a", "region", "r2"), 0, metadata.NoneFunc)
+	id4, err := e2eutil.CreateBlock(ctx, dir, series, 10, 0, 1000, labels.FromStrings("cluster", "a", "region", "r2"), 0, metadata.NoneFunc, nil)
 	testutil.Ok(t, err)
 	testutil.Ok(t, block.Upload(ctx, logger, bkt, filepath.Join(dir, id4.String()), metadata.NoneFunc))
 

--- a/pkg/testutil/e2eutil/prometheus.go
+++ b/pkg/testutil/e2eutil/prometheus.go
@@ -430,8 +430,9 @@ func CreateBlock(
 	extLset labels.Labels,
 	resolution int64,
 	hashFunc metadata.HashFunc,
+	sampleTypes []chunkenc.ValueType,
 ) (id ulid.ULID, err error) {
-	return createBlock(ctx, dir, series, numSamples, mint, maxt, extLset, resolution, false, hashFunc, chunkenc.ValFloat)
+	return createBlock(ctx, dir, series, numSamples, mint, maxt, extLset, resolution, false, hashFunc, sampleTypes)
 }
 
 // CreateBlockWithTombstone is same as CreateBlock but leaves tombstones which mimics the Prometheus local block.
@@ -444,8 +445,9 @@ func CreateBlockWithTombstone(
 	extLset labels.Labels,
 	resolution int64,
 	hashFunc metadata.HashFunc,
+	sampleTypes []chunkenc.ValueType,
 ) (id ulid.ULID, err error) {
-	return createBlock(ctx, dir, series, numSamples, mint, maxt, extLset, resolution, true, hashFunc, chunkenc.ValFloat)
+	return createBlock(ctx, dir, series, numSamples, mint, maxt, extLset, resolution, true, hashFunc, sampleTypes)
 }
 
 // CreateBlockWithBlockDelay writes a block with the given series and numSamples samples each.
@@ -461,8 +463,9 @@ func CreateBlockWithBlockDelay(
 	extLset labels.Labels,
 	resolution int64,
 	hashFunc metadata.HashFunc,
+	sampleTypes []chunkenc.ValueType,
 ) (ulid.ULID, error) {
-	return createBlockWithDelay(ctx, dir, series, numSamples, mint, maxt, blockDelay, extLset, resolution, hashFunc, chunkenc.ValFloat)
+	return createBlockWithDelay(ctx, dir, series, numSamples, mint, maxt, blockDelay, extLset, resolution, hashFunc, sampleTypes)
 }
 
 // CreateHistogramBlockWithDelay writes a block with the given native histogram series and numSamples samples each.
@@ -478,7 +481,7 @@ func CreateHistogramBlockWithDelay(
 	resolution int64,
 	hashFunc metadata.HashFunc,
 ) (id ulid.ULID, err error) {
-	return createBlockWithDelay(ctx, dir, series, numSamples, mint, maxt, blockDelay, extLset, resolution, hashFunc, chunkenc.ValHistogram)
+	return createBlockWithDelay(ctx, dir, series, numSamples, mint, maxt, blockDelay, extLset, resolution, hashFunc, []chunkenc.ValueType{chunkenc.ValHistogram})
 }
 
 // CreateFloatHistogramBlockWithDelay writes a block with the given float native histogram series and numSamples samples each.
@@ -494,11 +497,11 @@ func CreateFloatHistogramBlockWithDelay(
 	resolution int64,
 	hashFunc metadata.HashFunc,
 ) (id ulid.ULID, err error) {
-	return createBlockWithDelay(ctx, dir, series, numSamples, mint, maxt, blockDelay, extLset, resolution, hashFunc, chunkenc.ValFloatHistogram)
+	return createBlockWithDelay(ctx, dir, series, numSamples, mint, maxt, blockDelay, extLset, resolution, hashFunc, []chunkenc.ValueType{chunkenc.ValFloatHistogram})
 }
 
-func createBlockWithDelay(ctx context.Context, dir string, series []labels.Labels, numSamples int, mint int64, maxt int64, blockDelay time.Duration, extLset labels.Labels, resolution int64, hashFunc metadata.HashFunc, samplesType chunkenc.ValueType) (ulid.ULID, error) {
-	blockID, err := createBlock(ctx, dir, series, numSamples, mint, maxt, extLset, resolution, false, hashFunc, samplesType)
+func createBlockWithDelay(ctx context.Context, dir string, series []labels.Labels, numSamples int, mint int64, maxt int64, blockDelay time.Duration, extLset labels.Labels, resolution int64, hashFunc metadata.HashFunc, sampleTypes []chunkenc.ValueType) (ulid.ULID, error) {
+	blockID, err := createBlock(ctx, dir, series, numSamples, mint, maxt, extLset, resolution, false, hashFunc, sampleTypes)
 	if err != nil {
 		return ulid.ULID{}, errors.Wrap(err, "block creation")
 	}
@@ -534,7 +537,7 @@ func createBlock(
 	resolution int64,
 	tombstones bool,
 	hashFunc metadata.HashFunc,
-	sampleType chunkenc.ValueType,
+	sampleTypes []chunkenc.ValueType,
 ) (id ulid.ULID, err error) {
 	headOpts := tsdb.DefaultHeadOptions()
 	headOpts.ChunkDirRoot = filepath.Join(dir, "chunks")
@@ -557,7 +560,11 @@ func createBlock(
 	r := rand.New(rand.NewSource(int64(numSamples)))
 	var randMutex sync.Mutex
 
-	for len(series) > 0 {
+	if sampleTypes == nil {
+		sampleTypes = []chunkenc.ValueType{chunkenc.ValFloat}
+	}
+
+	for si := atomic.NewInt64(-1); len(series) > 0; {
 		l := batchSize
 		if len(series) < 1000 {
 			l = len(series)
@@ -573,6 +580,9 @@ func createBlock(
 
 				for _, lset := range batch {
 					var err error
+
+					var sampleType = sampleTypes[si.Add(1)%int64(len(sampleTypes))]
+
 					if sampleType == chunkenc.ValFloat {
 						randMutex.Lock()
 						_, err = app.Append(0, lset, t, r.Float64())

--- a/test/e2e/compact_test.go
+++ b/test/e2e/compact_test.go
@@ -1044,5 +1044,5 @@ func TestCompactorDownsampleNativeHistograms(t *testing.T) {
 		Type:   client.S3,
 		Config: e2ethanos.NewS3Config(bucket, m.InternalEndpoint("http"), m.InternalDir()),
 	})
-	testutil.NotOk(t, bds.Start())
+	testutil.Ok(t, bds.Start())
 }

--- a/test/e2e/compact_test.go
+++ b/test/e2e/compact_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/timestamp"
+	"github.com/prometheus/prometheus/tsdb/chunkenc"
 
 	"github.com/thanos-io/objstore"
 	"github.com/thanos-io/objstore/client"
@@ -65,11 +66,11 @@ type blockDesc struct {
 	hashFunc           metadata.HashFunc
 }
 
-func (b *blockDesc) Create(ctx context.Context, dir string, delay time.Duration, hf metadata.HashFunc, numSamples int) (ulid.ULID, error) {
+func (b *blockDesc) Create(ctx context.Context, dir string, delay time.Duration, hf metadata.HashFunc, numSamples int, sampleTypes []chunkenc.ValueType) (ulid.ULID, error) {
 	if delay == 0*time.Second {
-		return e2eutil.CreateBlock(ctx, dir, b.series, numSamples, b.mint, b.maxt, b.extLset, 0, hf)
+		return e2eutil.CreateBlock(ctx, dir, b.series, numSamples, b.mint, b.maxt, b.extLset, 0, hf, sampleTypes)
 	}
-	return e2eutil.CreateBlockWithBlockDelay(ctx, dir, b.series, numSamples, b.mint, b.maxt, delay, b.extLset, 0, hf)
+	return e2eutil.CreateBlockWithBlockDelay(ctx, dir, b.series, numSamples, b.mint, b.maxt, delay, b.extLset, 0, hf, sampleTypes)
 }
 
 func TestCompactWithStoreGateway(t *testing.T) {
@@ -359,7 +360,7 @@ func testCompactWithStoreGateway(t *testing.T, penaltyDedup bool) {
 
 	rawBlockIDs := map[ulid.ULID]struct{}{}
 	for _, b := range blocks {
-		id, err := b.Create(ctx, dir, justAfterConsistencyDelay, b.hashFunc, 120)
+		id, err := b.Create(ctx, dir, justAfterConsistencyDelay, b.hashFunc, 120, nil)
 		testutil.Ok(t, err)
 		testutil.Ok(t, runutil.Retry(time.Second, ctx.Done(), func() error {
 			return objstore.UploadDir(ctx, logger, bkt, path.Join(dir, id.String()), id.String())
@@ -385,7 +386,7 @@ func testCompactWithStoreGateway(t *testing.T, penaltyDedup bool) {
 		maxt:    timestamp.FromTime(now.Add(10 * 24 * time.Hour)),
 	}
 	// New block that will be downsampled.
-	downsampledRawID, err := downsampledBase.Create(ctx, dir, justAfterConsistencyDelay, metadata.NoneFunc, 1200)
+	downsampledRawID, err := downsampledBase.Create(ctx, dir, justAfterConsistencyDelay, metadata.NoneFunc, 1200, nil)
 	testutil.Ok(t, err)
 	testutil.Ok(t, objstore.UploadDir(ctx, logger, bkt, path.Join(dir, downsampledRawID.String()), downsampledRawID.String()))
 
@@ -399,33 +400,33 @@ func testCompactWithStoreGateway(t *testing.T, penaltyDedup bool) {
 		}
 
 		// New Partial block.
-		id, err := malformedBase.Create(ctx, dir, 0*time.Second, metadata.NoneFunc, 120)
+		id, err := malformedBase.Create(ctx, dir, 0*time.Second, metadata.NoneFunc, 120, nil)
 		testutil.Ok(t, err)
 		testutil.Ok(t, os.Remove(path.Join(dir, id.String(), metadata.MetaFilename)))
 		testutil.Ok(t, objstore.UploadDir(ctx, logger, bkt, path.Join(dir, id.String()), id.String()))
 
 		// New Partial block + deletion mark.
-		id, err = malformedBase.Create(ctx, dir, 0*time.Second, metadata.NoneFunc, 120)
+		id, err = malformedBase.Create(ctx, dir, 0*time.Second, metadata.NoneFunc, 120, nil)
 		testutil.Ok(t, err)
 		testutil.Ok(t, os.Remove(path.Join(dir, id.String(), metadata.MetaFilename)))
 		testutil.Ok(t, block.MarkForDeletion(ctx, logger, bkt, id, "", promauto.With(nil).NewCounter(prometheus.CounterOpts{})))
 		testutil.Ok(t, objstore.UploadDir(ctx, logger, bkt, path.Join(dir, id.String()), id.String()))
 
 		// Partial block after consistency delay.
-		id, err = malformedBase.Create(ctx, dir, justAfterConsistencyDelay, metadata.NoneFunc, 120)
+		id, err = malformedBase.Create(ctx, dir, justAfterConsistencyDelay, metadata.NoneFunc, 120, nil)
 		testutil.Ok(t, err)
 		testutil.Ok(t, os.Remove(path.Join(dir, id.String(), metadata.MetaFilename)))
 		testutil.Ok(t, objstore.UploadDir(ctx, logger, bkt, path.Join(dir, id.String()), id.String()))
 
 		// Partial block after consistency delay + deletion mark.
-		id, err = malformedBase.Create(ctx, dir, justAfterConsistencyDelay, metadata.NoneFunc, 120)
+		id, err = malformedBase.Create(ctx, dir, justAfterConsistencyDelay, metadata.NoneFunc, 120, nil)
 		testutil.Ok(t, err)
 		testutil.Ok(t, os.Remove(path.Join(dir, id.String(), metadata.MetaFilename)))
 		testutil.Ok(t, block.MarkForDeletion(ctx, logger, bkt, id, "", promauto.With(nil).NewCounter(prometheus.CounterOpts{})))
 		testutil.Ok(t, objstore.UploadDir(ctx, logger, bkt, path.Join(dir, id.String()), id.String()))
 
 		// Partial block after consistency delay + old deletion mark ready to be deleted.
-		id, err = malformedBase.Create(ctx, dir, justAfterConsistencyDelay, metadata.NoneFunc, 120)
+		id, err = malformedBase.Create(ctx, dir, justAfterConsistencyDelay, metadata.NoneFunc, 120, nil)
 		testutil.Ok(t, err)
 		testutil.Ok(t, os.Remove(path.Join(dir, id.String(), metadata.MetaFilename)))
 		deletionMark, err := json.Marshal(metadata.DeletionMark{
@@ -439,13 +440,13 @@ func testCompactWithStoreGateway(t *testing.T, penaltyDedup bool) {
 		testutil.Ok(t, objstore.UploadDir(ctx, logger, bkt, path.Join(dir, id.String()), id.String()))
 
 		// Partial block after delete threshold.
-		id, err = malformedBase.Create(ctx, dir, 50*time.Hour, metadata.NoneFunc, 120)
+		id, err = malformedBase.Create(ctx, dir, 50*time.Hour, metadata.NoneFunc, 120, nil)
 		testutil.Ok(t, err)
 		testutil.Ok(t, os.Remove(path.Join(dir, id.String(), metadata.MetaFilename)))
 		testutil.Ok(t, objstore.UploadDir(ctx, logger, bkt, path.Join(dir, id.String()), id.String()))
 
 		// Partial block after delete threshold + deletion mark.
-		id, err = malformedBase.Create(ctx, dir, 50*time.Hour, metadata.NoneFunc, 120)
+		id, err = malformedBase.Create(ctx, dir, 50*time.Hour, metadata.NoneFunc, 120, nil)
 		testutil.Ok(t, err)
 		testutil.Ok(t, os.Remove(path.Join(dir, id.String(), metadata.MetaFilename)))
 		testutil.Ok(t, block.MarkForDeletion(ctx, logger, bkt, id, "", promauto.With(nil).NewCounter(prometheus.CounterOpts{})))
@@ -911,7 +912,7 @@ func TestCompactorDownsampleIgnoresMarked(t *testing.T) {
 	// New block that will be downsampled.
 	justAfterConsistencyDelay := 30 * time.Minute
 
-	downsampledRawID, err := downsampledBase.Create(context.Background(), dir, justAfterConsistencyDelay, metadata.NoneFunc, 1200)
+	downsampledRawID, err := downsampledBase.Create(context.Background(), dir, justAfterConsistencyDelay, metadata.NoneFunc, 1200, nil)
 	testutil.Ok(t, err)
 	testutil.Ok(t, objstore.UploadDir(context.Background(), logger, bkt, path.Join(dir, downsampledRawID.String()), downsampledRawID.String()))
 	testutil.Ok(t, block.MarkForNoDownsample(context.Background(), logger, bkt, downsampledRawID, metadata.ManualNoDownsampleReason, "why not", promauto.With(nil).NewCounter(prometheus.CounterOpts{})))
@@ -958,7 +959,7 @@ func TestCompactorIssue6775(t *testing.T) {
 	}
 
 	for i := 0; i < 2; i++ {
-		rawBlockID, err := baseBlockDesc.Create(context.Background(), dir, 0, metadata.NoneFunc, 1200+i)
+		rawBlockID, err := baseBlockDesc.Create(context.Background(), dir, 0, metadata.NoneFunc, 1200+i, nil)
 		testutil.Ok(t, err)
 		testutil.Ok(t, objstore.UploadDir(context.Background(), logger, bkt, path.Join(dir, rawBlockID.String()), rawBlockID.String()))
 	}
@@ -1000,4 +1001,48 @@ func TestCompactorIssue6775(t *testing.T) {
 	}, nil, "--compact.enable-vertical-compaction")
 	testutil.Ok(t, e2e.StartAndWaitReady(c))
 	testutil.Ok(t, c.WaitSumMetricsWithOptions(e2emon.Greater(0), []string{"thanos_compact_iterations_total"}, e2emon.WaitMissingMetrics()))
+}
+
+func TestCompactorDownsampleNativeHistograms(t *testing.T) {
+	logger := log.NewNopLogger()
+	e, err := e2e.NewDockerEnvironment("c-dspl-hstg")
+	testutil.Ok(t, err)
+	t.Cleanup(e2ethanos.CleanScenario(t, e))
+
+	dir := filepath.Join(e.SharedDir(), "tmp")
+	testutil.Ok(t, os.MkdirAll(dir, os.ModePerm))
+
+	const bucket = "compact-test"
+	m := e2edb.NewMinio(e, "minio", bucket, e2edb.WithMinioTLS())
+	testutil.Ok(t, e2e.StartAndWaitReady(m))
+
+	bkt, err := s3.NewBucketWithConfig(logger,
+		e2ethanos.NewS3Config(bucket, m.Endpoint("http"), m.Dir()), "test-feed", nil)
+	testutil.Ok(t, err)
+
+	maxt := time.Now()
+	mint := maxt.Add(-7 * 24 * time.Hour)
+
+	justAfterConsistencyDelay := 30 * time.Minute
+
+	baseBlockDesc := blockDesc{
+		series: []labels.Labels{
+			labels.FromStrings("z", "1", "b", "2"),
+			labels.FromStrings("z", "1", "b", "5"),
+			labels.FromStrings("z", "1", "b", "6"),
+		},
+		extLset: labels.FromStrings("case", "downsampled-block-with-nativehistograms"),
+		mint:    timestamp.FromTime(mint),
+		maxt:    timestamp.FromTime(maxt),
+	}
+
+	rawBlockID, err := baseBlockDesc.Create(context.Background(), dir, justAfterConsistencyDelay, metadata.NoneFunc, 1200, []chunkenc.ValueType{chunkenc.ValHistogram, chunkenc.ValFloatHistogram, chunkenc.ValFloat})
+	testutil.Ok(t, err)
+	testutil.Ok(t, objstore.UploadDir(context.Background(), logger, bkt, path.Join(dir, rawBlockID.String()), rawBlockID.String()))
+	// Downsample them first.
+	bds := e2ethanos.NewToolsBucketDownsample(e, "downsample", client.BucketConfig{
+		Type:   client.S3,
+		Config: e2ethanos.NewS3Config(bucket, m.InternalEndpoint("http"), m.InternalDir()),
+	})
+	testutil.NotOk(t, bds.Start())
 }

--- a/test/e2e/distributed_query_test.go
+++ b/test/e2e/distributed_query_test.go
@@ -127,7 +127,7 @@ func TestDistributedEngineWithOverlappingIntervalsEnabled(t *testing.T) {
 		30*time.Minute,
 		labels.FromStrings("prometheus", "p1", "replica", "0"),
 		0,
-		metadata.NoneFunc,
+		metadata.NoneFunc, nil,
 	)
 	testutil.Ok(t, err)
 	testutil.Ok(t, objstore.UploadDir(ctx, l, bkt1, path.Join(dir1, blockID1.String()), blockID1.String()))
@@ -141,7 +141,7 @@ func TestDistributedEngineWithOverlappingIntervalsEnabled(t *testing.T) {
 		30*time.Minute,
 		labels.FromStrings("prometheus", "p1", "replica", "0"),
 		0,
-		metadata.NoneFunc,
+		metadata.NoneFunc, nil,
 	)
 	testutil.Ok(t, err)
 	testutil.Ok(t, objstore.UploadDir(ctx, l, bkt1, path.Join(dir1, blockID2.String()), blockID2.String()))
@@ -220,7 +220,7 @@ func TestDistributedEngineWithoutOverlappingIntervals(t *testing.T) {
 		30*time.Minute,
 		labels.FromStrings("prometheus", "p1", "replica", "0"),
 		0,
-		metadata.NoneFunc,
+		metadata.NoneFunc, nil,
 	)
 	testutil.Ok(t, err)
 	testutil.Ok(t, objstore.UploadDir(ctx, l, bkt1, path.Join(dir1, blockID1.String()), blockID1.String()))
@@ -234,7 +234,7 @@ func TestDistributedEngineWithoutOverlappingIntervals(t *testing.T) {
 		30*time.Minute,
 		labels.FromStrings("prometheus", "p1", "replica", "0"),
 		0,
-		metadata.NoneFunc,
+		metadata.NoneFunc, nil,
 	)
 	testutil.Ok(t, err)
 	testutil.Ok(t, objstore.UploadDir(ctx, l, bkt1, path.Join(dir1, blockID2.String()), blockID2.String()))

--- a/test/e2e/query_test.go
+++ b/test/e2e/query_test.go
@@ -652,7 +652,7 @@ func TestQueryStoreMetrics(t *testing.T) {
 				30*time.Minute,
 				externalLabels,
 				0,
-				metadata.NoneFunc,
+				metadata.NoneFunc, nil,
 			)
 			testutil.Ok(t, err)
 			testutil.Ok(t, objstore.UploadDir(ctx, l, bkt, path.Join(dir, blockID.String()), blockID.String()))
@@ -1012,7 +1012,7 @@ func createSimpleReplicatedBlocksInS3(
 			30*time.Minute,
 			s.extLabels,
 			0,
-			metadata.NoneFunc,
+			metadata.NoneFunc, nil,
 		)
 		testutil.Ok(t, err)
 		blockPath := path.Join(dir, blockID.String())
@@ -2062,7 +2062,7 @@ func TestQueryTenancyEnforcement(t *testing.T) {
 		30*time.Minute,
 		tenantLabel01,
 		0,
-		metadata.NoneFunc,
+		metadata.NoneFunc, nil,
 	)
 	testutil.Ok(t, err)
 
@@ -2075,7 +2075,7 @@ func TestQueryTenancyEnforcement(t *testing.T) {
 		30*time.Minute,
 		tenantLabel02,
 		0,
-		metadata.NoneFunc,
+		metadata.NoneFunc, nil,
 	)
 	testutil.Ok(t, err)
 
@@ -2088,7 +2088,7 @@ func TestQueryTenancyEnforcement(t *testing.T) {
 		30*time.Minute,
 		tenantLabel03,
 		0,
-		metadata.NoneFunc,
+		metadata.NoneFunc, nil,
 	)
 	testutil.Ok(t, err)
 

--- a/test/e2e/store_gateway_test.go
+++ b/test/e2e/store_gateway_test.go
@@ -113,13 +113,13 @@ metafile_content_ttl: 0s`, memcached.InternalEndpoint("memcached"))
 	t.Cleanup(cancel)
 
 	now := time.Now()
-	id1, err := e2eutil.CreateBlockWithBlockDelay(ctx, dir, floatSeries, 10, timestamp.FromTime(now), timestamp.FromTime(now.Add(2*time.Hour)), 30*time.Minute, extLset, 0, metadata.NoneFunc)
+	id1, err := e2eutil.CreateBlockWithBlockDelay(ctx, dir, floatSeries, 10, timestamp.FromTime(now), timestamp.FromTime(now.Add(2*time.Hour)), 30*time.Minute, extLset, 0, metadata.NoneFunc, nil)
 	testutil.Ok(t, err)
-	id2, err := e2eutil.CreateBlockWithBlockDelay(ctx, dir, floatSeries, 10, timestamp.FromTime(now), timestamp.FromTime(now.Add(2*time.Hour)), 30*time.Minute, extLset2, 0, metadata.NoneFunc)
+	id2, err := e2eutil.CreateBlockWithBlockDelay(ctx, dir, floatSeries, 10, timestamp.FromTime(now), timestamp.FromTime(now.Add(2*time.Hour)), 30*time.Minute, extLset2, 0, metadata.NoneFunc, nil)
 	testutil.Ok(t, err)
-	id3, err := e2eutil.CreateBlockWithBlockDelay(ctx, dir, floatSeries, 10, timestamp.FromTime(now), timestamp.FromTime(now.Add(2*time.Hour)), 30*time.Minute, extLset3, 0, metadata.NoneFunc)
+	id3, err := e2eutil.CreateBlockWithBlockDelay(ctx, dir, floatSeries, 10, timestamp.FromTime(now), timestamp.FromTime(now.Add(2*time.Hour)), 30*time.Minute, extLset3, 0, metadata.NoneFunc, nil)
 	testutil.Ok(t, err)
-	id4, err := e2eutil.CreateBlock(ctx, dir, floatSeries, 10, timestamp.FromTime(now), timestamp.FromTime(now.Add(2*time.Hour)), extLset, 0, metadata.NoneFunc)
+	id4, err := e2eutil.CreateBlock(ctx, dir, floatSeries, 10, timestamp.FromTime(now), timestamp.FromTime(now.Add(2*time.Hour)), extLset, 0, metadata.NoneFunc, nil)
 	testutil.Ok(t, err)
 	id5, err := e2eutil.CreateHistogramBlockWithDelay(ctx, dir, nativeHistogramSeries, 10, timestamp.FromTime(now), timestamp.FromTime(now.Add(2*time.Hour)), 30*time.Minute, extLset5, 0, metadata.NoneFunc)
 	testutil.Ok(t, err)
@@ -279,7 +279,7 @@ metafile_content_ttl: 0s`, memcached.InternalEndpoint("memcached"))
 		testutil.Ok(t, s1.WaitSumMetrics(e2emon.Equals(8+3), "thanos_bucket_store_series_blocks_queried"))
 	})
 	t.Run("upload block id5, similar to id1", func(t *testing.T) {
-		id5, err := e2eutil.CreateBlockWithBlockDelay(ctx, dir, floatSeries, 10, timestamp.FromTime(now), timestamp.FromTime(now.Add(2*time.Hour)), 30*time.Minute, extLset4, 0, metadata.NoneFunc)
+		id5, err := e2eutil.CreateBlockWithBlockDelay(ctx, dir, floatSeries, 10, timestamp.FromTime(now), timestamp.FromTime(now.Add(2*time.Hour)), 30*time.Minute, extLset4, 0, metadata.NoneFunc, nil)
 		testutil.Ok(t, err)
 		testutil.Ok(t, objstore.UploadDir(ctx, l, bkt, path.Join(dir, id5.String()), id5.String()))
 
@@ -443,13 +443,13 @@ func TestStoreGatewayNoCacheFile(t *testing.T) {
 	t.Cleanup(cancel)
 
 	now := time.Now()
-	id1, err := e2eutil.CreateBlockWithBlockDelay(ctx, dir, series, 10, timestamp.FromTime(now), timestamp.FromTime(now.Add(2*time.Hour)), 30*time.Minute, extLset, 0, metadata.NoneFunc)
+	id1, err := e2eutil.CreateBlockWithBlockDelay(ctx, dir, series, 10, timestamp.FromTime(now), timestamp.FromTime(now.Add(2*time.Hour)), 30*time.Minute, extLset, 0, metadata.NoneFunc, nil)
 	testutil.Ok(t, err)
-	id2, err := e2eutil.CreateBlockWithBlockDelay(ctx, dir, series, 10, timestamp.FromTime(now), timestamp.FromTime(now.Add(2*time.Hour)), 30*time.Minute, extLset2, 0, metadata.NoneFunc)
+	id2, err := e2eutil.CreateBlockWithBlockDelay(ctx, dir, series, 10, timestamp.FromTime(now), timestamp.FromTime(now.Add(2*time.Hour)), 30*time.Minute, extLset2, 0, metadata.NoneFunc, nil)
 	testutil.Ok(t, err)
-	id3, err := e2eutil.CreateBlockWithBlockDelay(ctx, dir, series, 10, timestamp.FromTime(now), timestamp.FromTime(now.Add(2*time.Hour)), 30*time.Minute, extLset3, 0, metadata.NoneFunc)
+	id3, err := e2eutil.CreateBlockWithBlockDelay(ctx, dir, series, 10, timestamp.FromTime(now), timestamp.FromTime(now.Add(2*time.Hour)), 30*time.Minute, extLset3, 0, metadata.NoneFunc, nil)
 	testutil.Ok(t, err)
-	id4, err := e2eutil.CreateBlock(ctx, dir, series, 10, timestamp.FromTime(now), timestamp.FromTime(now.Add(2*time.Hour)), extLset, 0, metadata.NoneFunc)
+	id4, err := e2eutil.CreateBlock(ctx, dir, series, 10, timestamp.FromTime(now), timestamp.FromTime(now.Add(2*time.Hour)), extLset, 0, metadata.NoneFunc, nil)
 	testutil.Ok(t, err)
 	l := log.NewLogfmtLogger(os.Stdout)
 	bkt, err := s3.NewBucketWithConfig(l,
@@ -542,7 +542,7 @@ func TestStoreGatewayNoCacheFile(t *testing.T) {
 		testutil.Ok(t, s1.WaitSumMetrics(e2emon.Equals(4+1), "thanos_bucket_store_series_blocks_queried"))
 	})
 	t.Run("upload block id5, similar to id1", func(t *testing.T) {
-		id5, err := e2eutil.CreateBlockWithBlockDelay(ctx, dir, series, 10, timestamp.FromTime(now), timestamp.FromTime(now.Add(2*time.Hour)), 30*time.Minute, extLset4, 0, metadata.NoneFunc)
+		id5, err := e2eutil.CreateBlockWithBlockDelay(ctx, dir, series, 10, timestamp.FromTime(now), timestamp.FromTime(now.Add(2*time.Hour)), 30*time.Minute, extLset4, 0, metadata.NoneFunc, nil)
 		testutil.Ok(t, err)
 		testutil.Ok(t, objstore.UploadDir(ctx, l, bkt, path.Join(dir, id5.String()), id5.String()))
 
@@ -667,7 +667,7 @@ blocks_iter_ttl: 0s`, memcached.InternalEndpoint("memcached"))
 	t.Cleanup(cancel)
 
 	now := time.Now()
-	id, err := e2eutil.CreateBlockWithBlockDelay(ctx, dir, series, 10, timestamp.FromTime(now), timestamp.FromTime(now.Add(2*time.Hour)), 30*time.Minute, extLset, 0, metadata.NoneFunc)
+	id, err := e2eutil.CreateBlockWithBlockDelay(ctx, dir, series, 10, timestamp.FromTime(now), timestamp.FromTime(now.Add(2*time.Hour)), 30*time.Minute, extLset, 0, metadata.NoneFunc, nil)
 	testutil.Ok(t, err)
 
 	l := log.NewLogfmtLogger(os.Stdout)
@@ -803,7 +803,7 @@ metafile_content_ttl: 0s`
 	t.Cleanup(cancel)
 
 	now := time.Now()
-	id, err := e2eutil.CreateBlockWithBlockDelay(ctx, dir, series, 10, timestamp.FromTime(now), timestamp.FromTime(now.Add(2*time.Hour)), 30*time.Minute, extLset, 0, metadata.NoneFunc)
+	id, err := e2eutil.CreateBlockWithBlockDelay(ctx, dir, series, 10, timestamp.FromTime(now), timestamp.FromTime(now.Add(2*time.Hour)), 30*time.Minute, extLset, 0, metadata.NoneFunc, nil)
 	testutil.Ok(t, err)
 
 	l := log.NewLogfmtLogger(os.Stdout)
@@ -924,13 +924,13 @@ config:
 	t.Cleanup(cancel)
 
 	now := time.Now()
-	id1, err := e2eutil.CreateBlockWithBlockDelay(ctx, dir, series, 10, timestamp.FromTime(now), timestamp.FromTime(now.Add(2*time.Hour)), 30*time.Minute, extLset, 0, metadata.NoneFunc)
+	id1, err := e2eutil.CreateBlockWithBlockDelay(ctx, dir, series, 10, timestamp.FromTime(now), timestamp.FromTime(now.Add(2*time.Hour)), 30*time.Minute, extLset, 0, metadata.NoneFunc, nil)
 	testutil.Ok(t, err)
-	id2, err := e2eutil.CreateBlockWithBlockDelay(ctx, dir, series, 10, timestamp.FromTime(now), timestamp.FromTime(now.Add(2*time.Hour)), 30*time.Minute, extLset2, 0, metadata.NoneFunc)
+	id2, err := e2eutil.CreateBlockWithBlockDelay(ctx, dir, series, 10, timestamp.FromTime(now), timestamp.FromTime(now.Add(2*time.Hour)), 30*time.Minute, extLset2, 0, metadata.NoneFunc, nil)
 	testutil.Ok(t, err)
-	id3, err := e2eutil.CreateBlockWithBlockDelay(ctx, dir, series, 10, timestamp.FromTime(now), timestamp.FromTime(now.Add(2*time.Hour)), 30*time.Minute, extLset3, 0, metadata.NoneFunc)
+	id3, err := e2eutil.CreateBlockWithBlockDelay(ctx, dir, series, 10, timestamp.FromTime(now), timestamp.FromTime(now.Add(2*time.Hour)), 30*time.Minute, extLset3, 0, metadata.NoneFunc, nil)
 	testutil.Ok(t, err)
-	id4, err := e2eutil.CreateBlockWithBlockDelay(ctx, dir, series, 10, timestamp.FromTime(now), timestamp.FromTime(now.Add(2*time.Hour)), 30*time.Minute, extLset4, 0, metadata.NoneFunc)
+	id4, err := e2eutil.CreateBlockWithBlockDelay(ctx, dir, series, 10, timestamp.FromTime(now), timestamp.FromTime(now.Add(2*time.Hour)), 30*time.Minute, extLset4, 0, metadata.NoneFunc, nil)
 	testutil.Ok(t, err)
 	l := log.NewLogfmtLogger(os.Stdout)
 	bkt, err := s3.NewBucketWithConfig(l,
@@ -1063,7 +1063,7 @@ config:
 	t.Cleanup(cancel)
 
 	now := time.Now()
-	id, err := e2eutil.CreateBlockWithBlockDelay(ctx, dir, series, 10, timestamp.FromTime(now), timestamp.FromTime(now.Add(2*time.Hour)), 30*time.Minute, extLset, 0, metadata.NoneFunc)
+	id, err := e2eutil.CreateBlockWithBlockDelay(ctx, dir, series, 10, timestamp.FromTime(now), timestamp.FromTime(now.Add(2*time.Hour)), 30*time.Minute, extLset, 0, metadata.NoneFunc, nil)
 	testutil.Ok(t, err)
 
 	l := log.NewLogfmtLogger(os.Stdout)
@@ -1175,7 +1175,7 @@ func TestStoreGatewayLazyExpandedPostingsEnabled(t *testing.T) {
 	t.Cleanup(cancel)
 
 	now := time.Now()
-	id, err := e2eutil.CreateBlockWithBlockDelay(ctx, dir, ss, 10, timestamp.FromTime(now), timestamp.FromTime(now.Add(2*time.Hour)), 30*time.Minute, extLset, 0, metadata.NoneFunc)
+	id, err := e2eutil.CreateBlockWithBlockDelay(ctx, dir, ss, 10, timestamp.FromTime(now), timestamp.FromTime(now.Add(2*time.Hour)), 30*time.Minute, extLset, 0, metadata.NoneFunc, nil)
 	testutil.Ok(t, err)
 
 	l := log.NewLogfmtLogger(os.Stdout)

--- a/test/e2e/tools_bucket_web_test.go
+++ b/test/e2e/tools_bucket_web_test.go
@@ -190,7 +190,7 @@ func TestToolsBucketWebWithTimeAndRelabelFilter(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		t.Cleanup(cancel)
 
-		id, err := b.Create(ctx, dir, 0, b.hashFunc, 120)
+		id, err := b.Create(ctx, dir, 0, b.hashFunc, 120, nil)
 		testutil.Ok(t, err)
 		testutil.Ok(t, runutil.Retry(time.Second, ctx.Done(), func() error {
 			return objstore.UploadDir(ctx, logger, bkt, path.Join(dir, id.String()), id.String())


### PR DESCRIPTION
Update https://github.com/thanos-io/thanos/pull/6350:

- Add some tests from me
- Update to the newest API changes
- Refactored downsampling loop to be clearer like I've commented
- Updated Sebastian's tests to have proper "sum"
- Unify "sum" in the histogram aggrchunks to be like in the float aggrchunks
- Added a blurb to compactor's documentation
- Added sample e2e test

Closes #5907.
Closes #6350.