### PR TITLE
Query: dynamic endpointgroups are allowed

### DIFF
--- a/cmd/thanos/endpointset.go
+++ b/cmd/thanos/endpointset.go
@@ -320,9 +320,6 @@ func setupEndpointSet(
 		specs := make([]*query.GRPCEndpointSpec, 0)
 		for _, ecfg := range endpointConfig.Endpoints {
 			strict, group, addr := ecfg.Strict, ecfg.Group, ecfg.Address
-			if dns.IsDynamicNode(addr) {
-				continue
-			}
 			if group {
 				specs = append(specs, query.NewGRPCEndpointSpec(fmt.Sprintf("thanos:///%s", addr), strict, append(dialOpts, extgrpc.EndpointGroupGRPCOpts()...)...))
 			} else {


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Fix a bug where dynamic endpoint groups are silently ignored.

## Verification

<!-- How you tested it? How do you know it works? -->
