### PR TITLE
query: add missing xincrease/xrate aggregation

### DIFF
--- a/pkg/query/querier.go
+++ b/pkg/query/querier.go
@@ -234,7 +234,7 @@ func aggrsFromFunc(f string) []storepb.Aggr {
 	if strings.HasPrefix(f, "sum_") {
 		return []storepb.Aggr{storepb.Aggr_SUM}
 	}
-	if f == "increase" || f == "rate" || f == "irate" || f == "resets" {
+	if f == "increase" || f == "rate" || f == "irate" || f == "resets" || f == "xincrease" || f == "xrate" {
 		return []storepb.Aggr{storepb.Aggr_COUNTER}
 	}
 	// In the default case, we retrieve count and sum to compute an average.


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

see #8111 

The function aggrsFromFunc was missing COUNTER aggregation for xincrease and xrate. Added these functions to the conditional check to ensure proper aggregation.

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
