### PR TITLE
docs: update service-discovery docs query flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#7012](https://github.com/thanos-io/thanos/pull/7012) Query: Automatically adjust `max_source_resolution` based on promql query to avoid querying data from higher resolution resulting empty results.
 - [#8118](https://github.com/thanos-io/thanos/pull/8118) Query: Bumped promql-engine
 - [#8135](https://github.com/thanos-io/thanos/pull/8135) Query: respect partial response in distributed engine
+- [#8136](https://github.com/thanos-io/thanos/pull/8136) Query,Ruler: Documentation change legacy flags
 
 ### Removed
 

--- a/docs/service-discovery.md
+++ b/docs/service-discovery.md
@@ -20,7 +20,7 @@ The simplest way to tell a component about a peer is to use a static flag.
 
 ### Thanos Querier
 
-The repeatable flag `--store=<store>` can be used to specify a `StoreAPI` that `Thanos Querier` should use.
+The repeatable flag `--endpoint.sd-config=<content>` can be used to specify a `StoreAPI` that `Thanos Querier` should use.
 
 ### Thanos Ruler
 
@@ -54,9 +54,9 @@ As a fallback, the file contents are periodically re-read at an interval that ca
 
 ### Thanos Querier
 
-The repeatable flag `--store.sd-files=<path>` can be used to specify the path to files that contain addresses of `StoreAPI` servers. The `<path>` can be a glob pattern so you can specify several files using a single flag.
+The repeatable flag `--endpoint.sd-config-file` can be used to specify the path to files that contain addresses of `StoreAPI` servers. The `<path>` can be a glob pattern so you can specify several files using a single flag.
 
-The flag `--store.sd-interval=<5m>` can be used to change the fallback re-read interval from the default 5 minutes.
+The flag `--endpoint.sd-config-reload-interval=<5m>` can be used to change the fallback re-read interval from the default 5 minutes.
 
 ### Thanos Ruler
 
@@ -73,19 +73,19 @@ To use DNS SD, just add one of the following prefixes to the domain name in your
 * `dns+` - the domain name after this prefix will be looked up as an A/AAAA query. *A port is required for this query type*. An example using this lookup with a static flag:
 
 ```
---store=dns+stores.thanos.mycompany.org:9090
+--endpoint.sd-config=dns+stores.thanos.mycompany.org:9090
 ```
 
 * `dnssrv+` - the domain name after this prefix will be looked up as a SRV query, and then each SRV record will be looked up as an A/AAAA query. You do not need to specify a port as the one from the query results will be used. For example:
 
 ```
---store=dnssrv+_thanosstores._tcp.mycompany.org
+--endpoint.sd-config=dnssrv+_thanosstores._tcp.mycompany.org
 ```
 
 DNS SRV record discovery also work well within Kubernetes. Consider the following example:
 
 ```
---store=dnssrv+_grpc._tcp.thanos-store.monitoring.svc
+--endpoint.sd-config=dnssrv+_grpc._tcp.thanos-store.monitoring.svc
 ```
 
 This configuration will instruct Thanos to discover all endpoints within the `thanos-store` service in the `monitoring` namespace and use the declared port named `grpc`.
@@ -93,7 +93,7 @@ This configuration will instruct Thanos to discover all endpoints within the `th
 * `dnssrvnoa+` - the domain name after this prefix will be looked up as a SRV query, with no A/AAAA lookup made after that. Similar to the `dnssrv+` case, you do not need to specify a port. For example:
 
 ```
---store=dnssrvnoa+_thanosstores._tcp.mycompany.org
+--endpoint.sd-config=dnssrvnoa+_thanosstores._tcp.mycompany.org
 ```
 
 The default interval between DNS lookups is 30s. This interval can be changed using the `store.sd-dns-interval` flag for `StoreAPI` configuration in `Thanos Querier`, or `query.sd-dns-interval` for `QueryAPI` configuration in `Thanos Ruler`.


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

Updated thanos query examples in service-discovery docs to reflect deprecated --store and --store.sd-files flags

## Verification

<!-- How you tested it? How do you know it works? -->
