### PR TITLE
test(interactve): update interactive tests to update non-supported querier store flags 

### DIFF
--- a/examples/interactive/interactive_test.go
+++ b/examples/interactive/interactive_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	execlib "os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/efficientgo/e2e"
@@ -329,19 +330,25 @@ func TestReadOnlyThanosSetup(t *testing.T) {
 	//                                                                         │   Sidecar  │◄─────┘
 	//                                                                         └────────────┘
 	//
+
+	storeAPIEndpoints := []string{
+		store1.InternalEndpoint("grpc"),
+		store2.InternalEndpoint("grpc"),
+		sidecarHA0.InternalEndpoint("grpc"),
+		sidecarHA1.InternalEndpoint("grpc"),
+		sidecar2.InternalEndpoint("grpc"),
+		receive1.InternalEndpoint("grpc"),
+	}
+
 	query1 := e2edb.NewThanosQuerier(
 		e,
 		"query1",
-		[]string{
-			store1.InternalEndpoint("grpc"),
-			store2.InternalEndpoint("grpc"),
-			sidecarHA0.InternalEndpoint("grpc"),
-			sidecarHA1.InternalEndpoint("grpc"),
-			sidecar2.InternalEndpoint("grpc"),
-			receive1.InternalEndpoint("grpc"),
-		},
+		[]string{},
 		e2edb.WithImage("thanos:latest"),
-		e2edb.WithFlagOverride(map[string]string{"--tracing.config": string(jaegerConfig)}),
+		e2edb.WithFlagOverride(map[string]string{
+			"--tracing.config": string(jaegerConfig),
+			"--endpoint":       strings.Join(storeAPIEndpoints, ","),
+		}),
 	)
 	testutil.Ok(t, e2e.StartAndWaitReady(query1))
 


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.



## Changes

<!-- Enumerate changes you made -->

From v0.32 in querier, `--store` flags needs to be changed to `--endpoint` flags, thus same needs to be replaced in interactive test

regarding: https://github.com/efficientgo/e2e/issues/74

(we can pass it from here only instead of making change in the e2e repository)

## Verification

<!-- How you tested it? How do you know it works? -->
Running the test, previously it was giving error for using `--store` flags, which is resolved now