### PR TITLE
query: handle query.Analyze returning nil gracefully

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 ### Removed
 
 ### Fixed
+- [#8199](https://github.com/thanos-io/thanos/pull/8199) Query: handle panics or nil pointer dereference in querier gracefully when query analyze returns nil
 
 - [#8211](https://github.com/thanos-io/thanos/pull/8211) Query: fix panic on nested partial response in distributed instant query
 - [#8216](https://github.com/thanos-io/thanos/pull/8216) Query/Receive: fix iter race between `next()` and `stop()` introduced in https://github.com/thanos-io/thanos/pull/7821.

--- a/pkg/api/query/grpc.go
+++ b/pkg/api/query/grpc.go
@@ -273,6 +273,9 @@ func extractQueryStats(qry promql.Query) *querypb.QueryStats {
 	}
 	if explQry, ok := qry.(engine.ExplainableQuery); ok {
 		analyze := explQry.Analyze()
+		if analyze == nil {
+			return stats
+		}
 		stats.SamplesTotal = analyze.TotalSamples()
 		stats.PeakSamples = analyze.PeakSamples()
 	}

--- a/pkg/api/query/v1.go
+++ b/pkg/api/query/v1.go
@@ -407,7 +407,6 @@ func (qapi *QueryAPI) getQueryExplain(query promql.Query) (*engine.ExplainOutput
 		return eq.Explain(), nil
 	}
 	return nil, &api.ApiError{Typ: api.ErrorBadData, Err: errors.Errorf("Query not explainable")}
-
 }
 
 func (qapi *QueryAPI) parseQueryAnalyzeParam(r *http.Request) bool {
@@ -543,7 +542,6 @@ func (qapi *QueryAPI) queryExplain(r *http.Request) (interface{}, []error, *api.
 		var qErr error
 		qry, qErr = qapi.queryCreate.makeInstantQuery(ctx, engineParam, queryable, remoteEndpoints, planOrQuery{query: queryStr}, queryOpts, ts)
 		return qErr
-
 	}); err != nil {
 		return nil, nil, &api.ApiError{Typ: api.ErrorBadData, Err: err}, func() {}
 	}
@@ -652,7 +650,6 @@ func (qapi *QueryAPI) query(r *http.Request) (interface{}, []error, *api.ApiErro
 		var qErr error
 		qry, qErr = qapi.queryCreate.makeInstantQuery(ctx, engineParam, queryable, remoteEndpoints, planOrQuery{query: queryStr}, queryOpts, ts)
 		return qErr
-
 	}); err != nil {
 		return nil, nil, &api.ApiError{Typ: api.ErrorBadData, Err: err}, func() {}
 	}
@@ -831,7 +828,6 @@ func (qapi *QueryAPI) queryRangeExplain(r *http.Request) (interface{}, []error, 
 		var qErr error
 		qry, qErr = qapi.queryCreate.makeRangeQuery(ctx, engineParam, queryable, remoteEndpoints, planOrQuery{query: queryStr}, queryOpts, start, end, step)
 		return qErr
-
 	}); err != nil {
 		return nil, nil, &api.ApiError{Typ: api.ErrorBadData, Err: err}, func() {}
 	}
@@ -965,7 +961,6 @@ func (qapi *QueryAPI) queryRange(r *http.Request) (interface{}, []error, *api.Ap
 		var qErr error
 		qry, qErr = qapi.queryCreate.makeRangeQuery(ctx, engineParam, queryable, remoteEndpoints, planOrQuery{query: queryStr}, queryOpts, start, end, step)
 		return qErr
-
 	}); err != nil {
 		return nil, nil, &api.ApiError{Typ: api.ErrorBadData, Err: err}, func() {}
 	}
@@ -1168,7 +1163,6 @@ func (qapi *QueryAPI) series(r *http.Request) (interface{}, []error, *api.ApiErr
 		nil,
 		query.NoopSeriesStatsReporter,
 	).Querier(timestamp.FromTime(start), timestamp.FromTime(end))
-
 	if err != nil {
 		return nil, nil, &api.ApiError{Typ: api.ErrorExec, Err: err}, func() {}
 	}
@@ -1623,4 +1617,3 @@ func NewMetricMetadataHandler(client metadata.UnaryClient, enablePartialResponse
 		return t, warnings.AsErrors(), nil, func() {}
 	}
 }
-

--- a/pkg/api/query/v1.go
+++ b/pkg/api/query/v1.go
@@ -416,7 +416,11 @@ func (qapi *QueryAPI) parseQueryAnalyzeParam(r *http.Request) bool {
 
 func analyzeQueryOutput(query promql.Query, engineType PromqlEngineType) (queryTelemetry, error) {
 	if eq, ok := query.(engine.ExplainableQuery); ok {
-		return processAnalysis(eq.Analyze()), nil
+		if analyze := eq.Analyze(); analyze != nil {
+			return processAnalysis(analyze), nil
+		} else {
+			return queryTelemetry{}, errors.Errorf("Query: %v not analyzable", query)
+		}
 	}
 
 	var warning error
@@ -1619,3 +1623,4 @@ func NewMetricMetadataHandler(client metadata.UnaryClient, enablePartialResponse
 		return t, warnings.AsErrors(), nil, func() {}
 	}
 }
+


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Should fix #8198 

<!-- Enumerate changes you made -->

In engine query.Analyze returns nil if query.exec  doesn't implements `telemetry.ObservableVectorOperator`. This PR handles it gracefully as later o/p of it excesses the respective fields 

## Verification

Not exactly how tagged issue might be stating but if try to analyze the query when its of type [noop] (with query.mode=distributed), the similar type of behaviour occurs (which also gets handled)

