### PR TITLE
receive: Unhide tsdb.enable-native-histograms flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 
 ## Unreleased
 - [#8190](https://github.com/thanos-io/thanos/pull/8190) Fix markdown formatting in CHANGELOG.
+- [#8202](https://github.com/thanos-io/thanos/pull/8202) Receive: Unhide `--tsdb.enable-native-histograms` flag
 
 ### Added
 

--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -1045,7 +1045,7 @@ func (rc *receiveConfig) registerFlag(cmd extkingpin.FlagClause) {
 
 	cmd.Flag("tsdb.enable-native-histograms",
 		"[EXPERIMENTAL] Enables the ingestion of native histograms.").
-		Default("false").Hidden().BoolVar(&rc.tsdbEnableNativeHistograms)
+		Default("false").BoolVar(&rc.tsdbEnableNativeHistograms)
 
 	cmd.Flag("writer.intern",
 		"[EXPERIMENTAL] Enables string interning in receive writer, for more optimized memory usage.").

--- a/docs/components/receive.md
+++ b/docs/components/receive.md
@@ -568,6 +568,9 @@ Flags:
       --tsdb.block.expanded-postings-cache-size=0
                                  [EXPERIMENTAL] If non-zero, enables expanded
                                  postings cache for compacted blocks.
+      --tsdb.enable-native-histograms
+                                 [EXPERIMENTAL] Enables the ingestion of native
+                                 histograms.
       --tsdb.head.expanded-postings-cache-size=0
                                  [EXPERIMENTAL] If non-zero, enables expanded
                                  postings cache for the head block.


### PR DESCRIPTION
* [X] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

* receive: Unhide tsdb.enable-native-histograms flag

## Verification

* Flag appears in `thanos receive --help`
