### PR TITLE
Support to adjust the maximum open files on containerize env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,12 +4,15 @@ FROM quay.io/prometheus/busybox@sha256:${BASE_DOCKER_SHA}
 LABEL maintainer="The Thanos Authors"
 
 COPY /thanos_tmp_for_docker /bin/thanos
+COPY entrypoint.sh /entrypoint.sh
 
 RUN adduser \
     -D `#Dont assign a password` \
     -H `#Dont create home directory` \
     -u 1001 `#User id`\
     thanos && \
-    chown thanos /bin/thanos
+    chown thanos /bin/thanos && \
+    chown thanos /entrypoint.sh && \
+    chmod +x /entrypoint.sh
 USER 1001
-ENTRYPOINT [ "/bin/thanos" ]
+ENTRYPOINT [ "/entrypoint.sh" ]

--- a/Dockerfile.multi-arch
+++ b/Dockerfile.multi-arch
@@ -8,12 +8,15 @@ ARG ARCH="amd64"
 ARG OS="linux"
 
 COPY .build/${OS}-${ARCH}/thanos /bin/thanos
+COPY entrypoint.sh /entrypoint.sh
 
 RUN adduser \
     -D `#Dont assign a password` \
     -H `#Dont create home directory` \
     -u 1001 `#User id`\
     thanos && \
-    chown thanos /bin/thanos
+    chown thanos /bin/thanos && \
+    chown thanos /entrypoint.sh && \
+    chmod +x /entrypoint.sh
 USER 1001
-ENTRYPOINT [ "/bin/thanos" ]
+ENTRYPOINT [ "/entrypoint.sh" ]

--- a/Dockerfile.multi-stage
+++ b/Dockerfile.multi-stage
@@ -20,12 +20,15 @@ FROM quay.io/prometheus/busybox@sha256:${BASE_DOCKER_SHA}
 LABEL maintainer="The Thanos Authors"
 
 COPY --from=builder /go/bin/thanos /bin/thanos
+COPY entrypoint.sh /entrypoint.sh
 
 RUN adduser \
     -D `#Dont assign a password` \
     -H `#Dont create home directory` \
     -u 1001 `#User id`\
     thanos && \
-    chown thanos /bin/thanos
+    chown thanos /bin/thanos && \
+    chown thanos /entrypoint.sh && \
+    chmod +x /entrypoint.sh
 USER 1001
-ENTRYPOINT [ "/bin/thanos" ]
+ENTRYPOINT [ "/entrypoint.sh" ]

--- a/docs/operating/binary-index-header.md
+++ b/docs/operating/binary-index-header.md
@@ -61,7 +61,9 @@ Since the index-header is built downloading specific segments of the original bl
 
 ## Impact on number of open file descriptors
 
-The Store Gateway stores each block's index-header on the local disk and loads it via mmap. This means that the Gateway keeps a file descriptor for each loaded block. If your Thanos setup has many blocks in the bucket, the Gateway may hit the `file-max` ulimit (maximum number of open file descriptions by a process); in such case, we recommend increasing the limit on your system.
+The Store Gateway stores each block's index-header on the local disk and loads it via mmap. This means that the Gateway keeps a file descriptor for each loaded block. If your Thanos setup has many blocks in the bucket, the Gateway may hit the `file-max` ulimit (maximum number of open file descriptions by a process); in such case, we recommend increasing the limit on your system or running more Store Gateway instances with blocks sharding enabled.
+
+The rule of thumb is that a production system shouldn't have the `file-max` ulimit below `65536`, but higher values are recommended (eg. `1048576`).
 
 ## Impact on CPU, memory and disk
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+# Resources limits: maximum number of open file descriptors
+if [ -n "${THANOS_ULIMIT_NOFILES:-}" ]; then
+    current_limit=$(ulimit -n)
+    if [ "$current_limit" != "unlimited" ]; then
+        # shellcheck disable=SC2086
+        if [ $THANOS_ULIMIT_NOFILES -gt $current_limit ]; then
+            echo "Setting file description limit to $THANOS_ULIMIT_NOFILES"
+            ulimit -n $THANOS_ULIMIT_NOFILES
+        fi
+    fi
+fi
+
+exec /bin/thanos "$@"


### PR DESCRIPTION
Enable users to modify the maximum number of open file descriptors by setting the THANOS_ULIMIT_NOFILES environment variable, as in Kubernetes environment, adjusting this value can be challenging.