### PR TITLE
Tools: fix panic on rewriting downsampled blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 ### Fixed
 
 - [#8211](https://github.com/thanos-io/thanos/pull/8211) Query: fix panic on nested partial response in distributed instant query
+- [#8219](https://github.com/thanos-io/thanos/pull/8219) Tools: fix panic on rewriting downsampled blocks
 
 ## [v0.38.0](https://github.com/thanos-io/thanos/tree/release-0.38) - 03.04.2025
 

--- a/cmd/thanos/tools_bucket.go
+++ b/cmd/thanos/tools_bucket.go
@@ -1234,6 +1234,10 @@ func registerBucketRewrite(app extkingpin.AppClause, objStoreConfig *extflag.Pat
 				if err != nil {
 					return errors.Wrapf(err, "read meta of %v", id)
 				}
+
+				if meta.Thanos.Downsample.Resolution != 0 {
+					chunkPool = downsample.NewPool()
+				}
 				b, err := tsdb.OpenBlock(logutil.GoKitLogToSlog(logger), filepath.Join(tbc.tmpDir, id.String()), chunkPool, nil)
 				if err != nil {
 					return errors.Wrapf(err, "open block %v", id)


### PR DESCRIPTION
* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

This PR is heavily based on previous work:
* https://github.com/thanos-io/thanos/pull/5725 - @igorwwwwwwwwwwwwwwwwwwww 
* https://github.com/thanos-io/thanos/compare/main...yeya24:thanos:rewrite-relabel-downsample-blocks - @yeya24 

Big thanks to those two for doing most of the work here.

Previously, attempting to rewrite a downsampled chunk would result in a segfault. This happens because it attempted to read the chunk using the prometheus `chunkenc.pool.Get` function. Now the rewrite function will detect when a chunk is downsampled, and load the chunk into a `downsample.pool` instead of a `chunkenc.pool`. Additionally, logic has been updated to ensure that the rewritten block will still be in the original aggr encoding.

## Verification

I rewrote multiple chunks to remove certain series while leaving others. I confirmed that the resulting data was still readable by Thanos, and no longer contained the deleted metric series.
