### PR TITLE
Index Cache: Refactor FetchMultiPostings to return indexed slices 

### DIFF
--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -467,8 +467,14 @@ func (s *BucketStore) validate() error {
 type noopCache struct{}
 
 func (noopCache) StorePostings(ulid.ULID, labels.Label, []byte, string) {}
-func (noopCache) FetchMultiPostings(_ context.Context, _ ulid.ULID, keys []labels.Label, tenant string) (map[labels.Label][]byte, []labels.Label) {
-	return map[labels.Label][]byte{}, keys
+func (noopCache) FetchMultiPostings(_ context.Context, _ ulid.ULID, keys []labels.Label, tenant string) ([][]byte, []uint64) {
+	hits := make([][]byte, len(keys))
+	misses := make([]uint64, len(keys))
+	for i := range keys {
+		misses[i] = uint64(i)
+	}
+
+	return hits, misses
 }
 
 func (noopCache) StoreExpandedPostings(_ ulid.ULID, _ []*labels.Matcher, _ []byte, tenant string) {}
@@ -3173,7 +3179,7 @@ func (r *bucketIndexReader) fetchPostings(ctx context.Context, keys []labels.Lab
 			}
 		}
 		// Get postings for the given key from cache first.
-		if b, ok := fromCache[key]; ok {
+		if b := fromCache[ix]; b != nil {
 			r.stats.add(PostingsTouched, 1, len(b))
 
 			l, closer, err := r.decodeCachedPostings(b)

--- a/pkg/store/bucket_e2e_test.go
+++ b/pkg/store/bucket_e2e_test.go
@@ -63,7 +63,7 @@ func (c *swappableCache) StorePostings(blockID ulid.ULID, l labels.Label, v []by
 	c.ptr.StorePostings(blockID, l, v, tenant)
 }
 
-func (c *swappableCache) FetchMultiPostings(ctx context.Context, blockID ulid.ULID, keys []labels.Label, tenant string) (map[labels.Label][]byte, []labels.Label) {
+func (c *swappableCache) FetchMultiPostings(ctx context.Context, blockID ulid.ULID, keys []labels.Label, tenant string) ([][]byte, []uint64) {
 	return c.ptr.FetchMultiPostings(ctx, blockID, keys, tenant)
 }
 

--- a/pkg/store/cache/cache.go
+++ b/pkg/store/cache/cache.go
@@ -46,7 +46,7 @@ type IndexCache interface {
 
 	// FetchMultiPostings fetches multiple postings - each identified by a label -
 	// and returns a map containing cache hits, along with a list of missing keys.
-	FetchMultiPostings(ctx context.Context, blockID ulid.ULID, keys []labels.Label, tenant string) (hits map[labels.Label][]byte, misses []labels.Label)
+	FetchMultiPostings(ctx context.Context, blockID ulid.ULID, keys []labels.Label, tenant string) (hits [][]byte, misses []uint64)
 
 	// StoreExpandedPostings stores expanded postings for a set of label matchers.
 	StoreExpandedPostings(blockID ulid.ULID, matchers []*labels.Matcher, v []byte, tenant string)

--- a/pkg/store/cache/filter_cache.go
+++ b/pkg/store/cache/filter_cache.go
@@ -39,11 +39,15 @@ func (c *FilteredIndexCache) StorePostings(blockID ulid.ULID, l labels.Label, v 
 
 // FetchMultiPostings fetches multiple postings - each identified by a label -
 // and returns a map containing cache hits, along with a list of missing keys.
-func (c *FilteredIndexCache) FetchMultiPostings(ctx context.Context, blockID ulid.ULID, keys []labels.Label, tenant string) (hits map[labels.Label][]byte, misses []labels.Label) {
+func (c *FilteredIndexCache) FetchMultiPostings(ctx context.Context, blockID ulid.ULID, keys []labels.Label, tenant string) (hits [][]byte, misses []uint64) {
 	if c.postingsEnabled {
 		return c.cache.FetchMultiPostings(ctx, blockID, keys, tenant)
 	}
-	return nil, keys
+	key := make([]uint64, len(keys))
+	for i := range keys {
+		key[i] = uint64(i)
+	}
+	return nil, key
 }
 
 // StoreExpandedPostings stores expanded postings for a set of label matchers.

--- a/pkg/store/cache/filter_cache_test.go
+++ b/pkg/store/cache/filter_cache_test.go
@@ -54,7 +54,7 @@ func TestFilterCache(t *testing.T) {
 
 				hits, missed := c.FetchMultiPostings(ctx, blockID, postingKeys, tenancy.DefaultTenant)
 				testutil.Equals(t, 0, len(missed))
-				testutil.Equals(t, testPostingData, hits[postingKeys[0]])
+				testutil.Equals(t, testPostingData, hits[0])
 
 				ep, hit := c.FetchExpandedPostings(ctx, blockID, expandedPostingsMatchers, tenancy.DefaultTenant)
 				testutil.Equals(t, true, hit)
@@ -75,7 +75,7 @@ func TestFilterCache(t *testing.T) {
 
 				hits, missed := c.FetchMultiPostings(ctx, blockID, postingKeys, tenancy.DefaultTenant)
 				testutil.Equals(t, 0, len(missed))
-				testutil.Equals(t, testPostingData, hits[postingKeys[0]])
+				testutil.Equals(t, testPostingData, hits[0])
 
 				ep, hit := c.FetchExpandedPostings(ctx, blockID, expandedPostingsMatchers, tenancy.DefaultTenant)
 				testutil.Assert(t, true, hit)
@@ -96,7 +96,7 @@ func TestFilterCache(t *testing.T) {
 
 				hits, missed := c.FetchMultiPostings(ctx, blockID, postingKeys, tenancy.DefaultTenant)
 				testutil.Equals(t, 0, len(missed))
-				testutil.Equals(t, testPostingData, hits[postingKeys[0]])
+				testutil.Equals(t, testPostingData, hits[0])
 
 				_, hit := c.FetchExpandedPostings(ctx, blockID, expandedPostingsMatchers, tenancy.DefaultTenant)
 				testutil.Equals(t, false, hit)

--- a/pkg/store/cache/inmemory.go
+++ b/pkg/store/cache/inmemory.go
@@ -298,11 +298,12 @@ func (c *InMemoryIndexCache) StorePostings(blockID ulid.ULID, l labels.Label, v 
 
 // FetchMultiPostings fetches multiple postings - each identified by a label -
 // and returns a map containing cache hits, along with a list of missing keys.
-func (c *InMemoryIndexCache) FetchMultiPostings(ctx context.Context, blockID ulid.ULID, keys []labels.Label, tenant string) (hits map[labels.Label][]byte, misses []labels.Label) {
+func (c *InMemoryIndexCache) FetchMultiPostings(ctx context.Context, blockID ulid.ULID, keys []labels.Label, tenant string) (hits [][]byte, misses []uint64) {
 	timer := prometheus.NewTimer(c.commonMetrics.FetchLatency.WithLabelValues(CacheTypePostings, tenant))
 	defer timer.ObserveDuration()
 
-	hits = map[labels.Label][]byte{}
+	hits = make([][]byte, len(keys))
+	misses = make([]uint64, 0, len(keys))
 
 	blockIDKey := blockID.String()
 	requests := 0
@@ -318,15 +319,20 @@ func (c *InMemoryIndexCache) FetchMultiPostings(ctx context.Context, blockID uli
 		requests++
 		if b, ok := c.get(CacheKey{blockIDKey, CacheKeyPostings(key), ""}); ok {
 			hit++
-			hits[key] = b
+			hits[i] = b
 			continue
 		}
 
-		misses = append(misses, key)
+		misses = append(misses, uint64(i))
 	}
 	c.commonMetrics.RequestTotal.WithLabelValues(CacheTypePostings, tenant).Add(float64(requests))
 	c.commonMetrics.HitsTotal.WithLabelValues(CacheTypePostings, tenant).Add(float64(hit))
-
+	if hit == 0 {
+		return hits, misses
+	}
+	if len(misses) == 0 {
+		return hits, nil
+	}
 	return hits, misses
 }
 

--- a/pkg/store/cache/inmemory_test.go
+++ b/pkg/store/cache/inmemory_test.go
@@ -137,8 +137,8 @@ func TestInMemoryIndexCache_UpdateItem(t *testing.T) {
 			set: func(id storage.SeriesRef, b []byte) { cache.StorePostings(uid(id), lbl, b, tenancy.DefaultTenant) },
 			get: func(id storage.SeriesRef) ([]byte, bool) {
 				hits, _ := cache.FetchMultiPostings(ctx, uid(id), []labels.Label{lbl}, tenancy.DefaultTenant)
-				b, ok := hits[lbl]
-
+				b := hits[0]
+				ok := (b != nil)
 				return b, ok
 			},
 		},
@@ -250,14 +250,14 @@ func TestInMemoryIndexCache_Eviction_WithMetrics(t *testing.T) {
 	id := ulid.MustNew(0, nil)
 	lbls := labels.Label{Name: "test", Value: "123"}
 	ctx := context.Background()
-	emptyPostingsHits := map[labels.Label][]byte{}
-	emptyPostingsMisses := []labels.Label(nil)
+	emptyPostingsHits := [][]byte{nil}
+	emptyPostingsMisses := []uint64(nil)
 	emptySeriesHits := map[storage.SeriesRef][]byte{}
 	emptySeriesMisses := []storage.SeriesRef(nil)
 
 	pHits, pMisses := cache.FetchMultiPostings(ctx, id, []labels.Label{lbls}, tenancy.DefaultTenant)
 	testutil.Equals(t, emptyPostingsHits, pHits, "no such key")
-	testutil.Equals(t, []labels.Label{lbls}, pMisses)
+	testutil.Equals(t, []uint64{0}, pMisses)
 
 	// Add sliceHeaderSize + 2 bytes.
 	cache.StorePostings(id, lbls, []byte{42, 33}, tenancy.DefaultTenant)
@@ -274,16 +274,16 @@ func TestInMemoryIndexCache_Eviction_WithMetrics(t *testing.T) {
 	testutil.Equals(t, float64(0), promtest.ToFloat64(cache.evicted.WithLabelValues(CacheTypeSeries)))
 
 	pHits, pMisses = cache.FetchMultiPostings(ctx, id, []labels.Label{lbls}, tenancy.DefaultTenant)
-	testutil.Equals(t, map[labels.Label][]byte{lbls: {42, 33}}, pHits, "key exists")
+	testutil.Equals(t, [][]byte{{42, 33}}, pHits, "key exists")
 	testutil.Equals(t, emptyPostingsMisses, pMisses)
 
 	pHits, pMisses = cache.FetchMultiPostings(ctx, ulid.MustNew(1, nil), []labels.Label{lbls}, tenancy.DefaultTenant)
 	testutil.Equals(t, emptyPostingsHits, pHits, "no such key")
-	testutil.Equals(t, []labels.Label{lbls}, pMisses)
+	testutil.Equals(t, []uint64{0}, pMisses)
 
 	pHits, pMisses = cache.FetchMultiPostings(ctx, id, []labels.Label{{Name: "test", Value: "124"}}, tenancy.DefaultTenant)
 	testutil.Equals(t, emptyPostingsHits, pHits, "no such key")
-	testutil.Equals(t, []labels.Label{{Name: "test", Value: "124"}}, pMisses)
+	testutil.Equals(t, []uint64{0}, pMisses)
 
 	// Add sliceHeaderSize + 3 more bytes.
 	cache.StoreSeries(id, 1234, []byte{222, 223, 224}, tenancy.DefaultTenant)
@@ -327,14 +327,14 @@ func TestInMemoryIndexCache_Eviction_WithMetrics(t *testing.T) {
 	// Evicted.
 	pHits, pMisses = cache.FetchMultiPostings(ctx, id, []labels.Label{lbls}, tenancy.DefaultTenant)
 	testutil.Equals(t, emptyPostingsHits, pHits, "no such key")
-	testutil.Equals(t, []labels.Label{lbls}, pMisses)
+	testutil.Equals(t, []uint64{0}, pMisses)
 
 	sHits, sMisses = cache.FetchMultiSeries(ctx, id, []storage.SeriesRef{1234}, tenancy.DefaultTenant)
 	testutil.Equals(t, emptySeriesHits, sHits, "no such key")
 	testutil.Equals(t, []storage.SeriesRef{1234}, sMisses)
 
 	pHits, pMisses = cache.FetchMultiPostings(ctx, id, []labels.Label{lbls2}, tenancy.DefaultTenant)
-	testutil.Equals(t, map[labels.Label][]byte{lbls2: v}, pHits)
+	testutil.Equals(t, [][]byte{v}, pHits)
 	testutil.Equals(t, emptyPostingsMisses, pMisses)
 
 	// Add same item again.
@@ -353,7 +353,7 @@ func TestInMemoryIndexCache_Eviction_WithMetrics(t *testing.T) {
 	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.evicted.WithLabelValues(CacheTypeSeries)))
 
 	pHits, pMisses = cache.FetchMultiPostings(ctx, id, []labels.Label{lbls2}, tenancy.DefaultTenant)
-	testutil.Equals(t, map[labels.Label][]byte{lbls2: v}, pHits)
+	testutil.Equals(t, [][]byte{v}, pHits)
 	testutil.Equals(t, emptyPostingsMisses, pMisses)
 
 	// Add too big item.
@@ -405,7 +405,7 @@ func TestInMemoryIndexCache_Eviction_WithMetrics(t *testing.T) {
 	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.evicted.WithLabelValues(CacheTypeSeries)))
 
 	pHits, pMisses = cache.FetchMultiPostings(ctx, id, []labels.Label{lbls3}, tenancy.DefaultTenant)
-	testutil.Equals(t, map[labels.Label][]byte{lbls3: {}}, pHits, "key exists")
+	testutil.Equals(t, [][]byte{{}}, pHits, "key exists")
 	testutil.Equals(t, emptyPostingsMisses, pMisses)
 
 	// nil works and still allocates empty slice.
@@ -425,7 +425,7 @@ func TestInMemoryIndexCache_Eviction_WithMetrics(t *testing.T) {
 	testutil.Equals(t, float64(1), promtest.ToFloat64(cache.evicted.WithLabelValues(CacheTypeSeries)))
 
 	pHits, pMisses = cache.FetchMultiPostings(ctx, id, []labels.Label{lbls4}, tenancy.DefaultTenant)
-	testutil.Equals(t, map[labels.Label][]byte{lbls4: {}}, pHits, "key exists")
+	testutil.Equals(t, [][]byte{{}}, pHits, "key exists")
 	testutil.Equals(t, emptyPostingsMisses, pMisses)
 
 	// Other metrics.

--- a/pkg/store/cache/memcached.go
+++ b/pkg/store/cache/memcached.go
@@ -92,9 +92,11 @@ func (c *RemoteIndexCache) StorePostings(blockID ulid.ULID, l labels.Label, v []
 // FetchMultiPostings fetches multiple postings - each identified by a label -
 // and returns a map containing cache hits, along with a list of missing keys.
 // In case of error, it logs and return an empty cache hits map.
-func (c *RemoteIndexCache) FetchMultiPostings(ctx context.Context, blockID ulid.ULID, lbls []labels.Label, tenant string) (hits map[labels.Label][]byte, misses []labels.Label) {
+func (c *RemoteIndexCache) FetchMultiPostings(ctx context.Context, blockID ulid.ULID, lbls []labels.Label, tenant string) (hits [][]byte, misses []uint64) {
 	timer := prometheus.NewTimer(c.fetchLatency.WithLabelValues(CacheTypePostings, tenant))
 	defer timer.ObserveDuration()
+	hits = make([][]byte, len(lbls))
+	misses = make([]uint64, 0, len(lbls))
 
 	keys := make([]string, 0, len(lbls))
 
@@ -109,24 +111,26 @@ func (c *RemoteIndexCache) FetchMultiPostings(ctx context.Context, blockID ulid.
 
 	results := c.memcached.GetMulti(ctx, keys)
 	if len(results) == 0 {
-		return nil, lbls
+
+		for i := range lbls {
+			misses = append(misses, uint64(i))
+		}
+		return hits, misses
 	}
 
 	// Construct the resulting hits map and list of missing keys. We iterate on the input
 	// list of labels to be able to easily create the list of ones in a single iteration.
-	hits = make(map[labels.Label][]byte, len(results))
-	for i, lbl := range lbls {
+
+	for i := range lbls {
 		// Check if the key has been found in memcached. If not, we add it to the list
 		// of missing keys.
-		value, ok := results[keys[i]]
-		if !ok {
-			misses = append(misses, lbl)
-			continue
+		if value, ok := results[keys[i]]; ok {
+			hits[i] = value
+		} else {
+			misses = append(misses, uint64(i))
 		}
-
-		hits[lbl] = value
 	}
-	c.hitsTotal.WithLabelValues(CacheTypePostings, tenant).Add(float64(len(hits)))
+	c.hitsTotal.WithLabelValues(CacheTypePostings, tenant).Add(float64(len(lbls) - len(misses)))
 	return hits, misses
 }
 

--- a/pkg/store/cache/tracing_index_cache.go
+++ b/pkg/store/cache/tracing_index_cache.go
@@ -30,7 +30,7 @@ func (c *TracingIndexCache) StorePostings(blockID ulid.ULID, l labels.Label, v [
 
 // FetchMultiPostings fetches multiple postings - each identified by a label -
 // and returns a map containing cache hits, along with a list of missing keys.
-func (c *TracingIndexCache) FetchMultiPostings(ctx context.Context, blockID ulid.ULID, keys []labels.Label, tenant string) (hits map[labels.Label][]byte, misses []labels.Label) {
+func (c *TracingIndexCache) FetchMultiPostings(ctx context.Context, blockID ulid.ULID, keys []labels.Label, tenant string) (hits [][]byte, misses []uint64) {
 	span, newCtx := tracing.StartSpan(ctx, "fetch_multi_postings", tracing.Tags{
 		"name":      c.name,
 		"block.id":  blockID.String(),


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->
This PR refactors the FetchMultiPostings method within the IndexCache interface and all its implementations (RemoteIndexCache, InMemoryIndexCache, noopCache, swappableCache).

## Verification
Updated existing unit tests  to validate the new return types and logic for hits, misses, and metrics.
<!-- How you tested it? How do you know it works? -->
