### PR TITLE
receive: remove Get() method from hashring

### DIFF
--- a/pkg/receive/hashring.go
+++ b/pkg/receive/hashring.go
@@ -51,8 +51,6 @@ func (i *insufficientNodesError) Error() string {
 // for a specified tenant.
 // It returns the node and any error encountered.
 type Hashring interface {
-	// Get returns the first node that should handle the given tenant and time series.
-	Get(tenant string, timeSeries *prompb.TimeSeries) (Endpoint, error)
 	// GetN returns the nth node that should handle the given tenant and time series.
 	GetN(tenant string, timeSeries *prompb.TimeSeries, n uint64) (Endpoint, error)
 	// Nodes returns a sorted slice of nodes that are in this hashring. Addresses could be duplicated
@@ -62,11 +60,6 @@ type Hashring interface {
 
 // SingleNodeHashring always returns the same node.
 type SingleNodeHashring string
-
-// Get implements the Hashring interface.
-func (s SingleNodeHashring) Get(tenant string, ts *prompb.TimeSeries) (Endpoint, error) {
-	return s.GetN(tenant, ts, 0)
-}
 
 func (s SingleNodeHashring) Nodes() []Endpoint {
 	return []Endpoint{{Address: string(s), CapNProtoAddress: string(s)}}

--- a/pkg/receive/hashring_test.go
+++ b/pkg/receive/hashring_test.go
@@ -201,7 +201,7 @@ func TestHashringGet(t *testing.T) {
 		hs, err := NewMultiHashring(AlgorithmHashmod, 3, tc.cfg)
 		require.NoError(t, err)
 
-		h, err := hs.Get(tc.tenant, ts)
+		h, err := hs.GetN(tc.tenant, ts, 0)
 		if tc.nodes != nil {
 			if err != nil {
 				t.Errorf("case %q: got unexpected error: %v", tc.name, err)


### PR DESCRIPTION
Get() is equivalent to GetN(1) so remove it. It's not used.
