### PR TITLE
query, query-frontend: Add support to use promQL experimental functions

### DIFF
--- a/cmd/thanos/query_frontend.go
+++ b/cmd/thanos/query_frontend.go
@@ -97,6 +97,8 @@ func registerQueryFrontend(app *extkingpin.App) {
 	cmd.Flag("query-frontend.enable-x-functions", "Enable experimental x- functions in query-frontend. --no-query-frontend.enable-x-functions for disabling.").
 		Default("false").BoolVar(&cfg.EnableXFunctions)
 
+	cmd.Flag("enable-feature", "Comma separated feature names to enable. Valid options for now: promql-experimental-functions (enables promql experimental functions in query-frontend)").Default("").StringsVar(&cfg.EnableFeatures)
+
 	cmd.Flag("query-range.max-query-length", "Limit the query time range (end - start time) in the query-frontend, 0 disables it.").
 		Default("0").DurationVar((*time.Duration)(&cfg.QueryRangeConfig.Limits.MaxQueryLength))
 
@@ -298,6 +300,15 @@ func runQueryFrontend(
 	if cfg.EnableXFunctions {
 		for fname, v := range parse.XFunctions {
 			parser.Functions[fname] = v
+		}
+	}
+
+	if len(cfg.EnableFeatures) > 0 {
+		for _, feature := range cfg.EnableFeatures {
+			if feature == promqlExperimentalFunctions {
+				parser.EnableExperimentalFunctions = true
+				level.Info(logger).Log("msg", "Experimental PromQL functions enabled.", "option", promqlExperimentalFunctions)
+			}
 		}
 	}
 

--- a/pkg/queryfrontend/config.go
+++ b/pkg/queryfrontend/config.go
@@ -213,6 +213,7 @@ type Config struct {
 	DefaultTenant          string
 	TenantCertField        string
 	EnableXFunctions       bool
+	EnableFeatures         []string
 }
 
 // QueryRangeConfig holds the config for query range tripperware.

--- a/pkg/queryfrontend/queryinstant_codec.go
+++ b/pkg/queryfrontend/queryinstant_codec.go
@@ -380,19 +380,19 @@ func sortPlanForQuery(q string) (sortPlan, error) {
 	if err != nil {
 		return 0, err
 	}
-	// Check if the root expression is topk or bottomk
+	// Check if the root expression is topk, bottomk, limitk or limit_ratio
 	if aggr, ok := expr.(*parser.AggregateExpr); ok {
-		if aggr.Op == parser.TOPK || aggr.Op == parser.BOTTOMK {
+		if aggr.Op == parser.TOPK || aggr.Op == parser.BOTTOMK || aggr.Op == parser.LIMITK || aggr.Op == parser.LIMIT_RATIO {
 			return mergeOnly, nil
 		}
 	}
 	checkForSort := func(expr parser.Expr) (sortAsc, sortDesc bool) {
 		if n, ok := expr.(*parser.Call); ok {
 			if n.Func != nil {
-				if n.Func.Name == "sort" {
+				if n.Func.Name == "sort" || n.Func.Name == "sort_by_label" {
 					sortAsc = true
 				}
-				if n.Func.Name == "sort_desc" {
+				if n.Func.Name == "sort_desc" || n.Func.Name == "sort_by_label_desc" {
 					sortDesc = true
 				}
 			}

--- a/test/e2e/e2ethanos/services.go
+++ b/test/e2e/e2ethanos/services.go
@@ -1067,7 +1067,7 @@ func NewQueryFrontend(e e2e.Environment, name, downstreamURL string, config quer
 	}
 
 	if len(config.EnableFeatures) > 0 {
-		flags["--enable-feature"] = fmt.Sprintf("%s", config.EnableFeatures)
+		flags["--enable-feature"] = strings.Join(config.EnableFeatures, ",")
 	}
 
 	return e2eobs.AsObservable(e.Runnable(fmt.Sprintf("query-frontend-%s", name)).

--- a/test/e2e/e2ethanos/services.go
+++ b/test/e2e/e2ethanos/services.go
@@ -1066,6 +1066,10 @@ func NewQueryFrontend(e e2e.Environment, name, downstreamURL string, config quer
 		flags["--query-frontend.default-tenant"] = config.DefaultTenant
 	}
 
+	if len(config.EnableFeatures) > 0 {
+		flags["--enable-feature"] = fmt.Sprintf("%s", config.EnableFeatures)
+	}
+
 	return e2eobs.AsObservable(e.Runnable(fmt.Sprintf("query-frontend-%s", name)).
 		WithPorts(map[string]int{"http": 8080}).
 		Init(e2e.StartOptions{

--- a/test/e2e/query_frontend_test.go
+++ b/test/e2e/query_frontend_test.go
@@ -849,7 +849,8 @@ func TestInstantQueryShardingWithRandomData(t *testing.T) {
 		QueryRangeConfig: queryfrontend.QueryRangeConfig{
 			AlignRangeWithStep: false,
 		},
-		NumShards: 2,
+		NumShards:      2,
+		EnableFeatures: []string{"promql-experimental-functions"},
 	}
 	qfe := e2ethanos.NewQueryFrontend(e, "query-frontend", "http://"+q1.InternalEndpoint("http"), config, inMemoryCacheConfig)
 	testutil.Ok(t, e2e.StartAndWaitReady(qfe))
@@ -903,6 +904,11 @@ func TestInstantQueryShardingWithRandomData(t *testing.T) {
 		{
 			name:           "multiple aggregations with grouping",
 			qryFunc:        func() string { return `max by (handler) (sum(http_requests_total) by (pod, handler))` },
+			expectedSeries: 2,
+		},
+		{
+			name:           "aggregations with parameter",
+			qryFunc:        func() string { return `topk(2, limitk by (pod) (4, http_requests_total))` },
 			expectedSeries: 2,
 		},
 	} {

--- a/test/e2e/query_frontend_test.go
+++ b/test/e2e/query_frontend_test.go
@@ -835,7 +835,8 @@ func TestInstantQueryShardingWithRandomData(t *testing.T) {
 
 	testutil.Ok(t, remoteWrite(ctx, samplespb, i.Endpoint("remote-write")))
 
-	q1 := e2ethanos.NewQuerierBuilder(e, "q1", i.InternalEndpoint("grpc")).Init()
+	enableFeature := []string{"promql-experimental-functions"}
+	q1 := e2ethanos.NewQuerierBuilder(e, "q1", i.InternalEndpoint("grpc")).WithEnabledFeatures(enableFeature).Init()
 	testutil.Ok(t, e2e.StartAndWaitReady(q1))
 
 	inMemoryCacheConfig := queryfrontend.CacheProviderConfig{
@@ -850,7 +851,7 @@ func TestInstantQueryShardingWithRandomData(t *testing.T) {
 			AlignRangeWithStep: false,
 		},
 		NumShards:      2,
-		EnableFeatures: []string{"promql-experimental-functions"},
+		EnableFeatures: enableFeature,
 	}
 	qfe := e2ethanos.NewQueryFrontend(e, "query-frontend", "http://"+q1.InternalEndpoint("http"), config, inMemoryCacheConfig)
 	testutil.Ok(t, e2e.StartAndWaitReady(qfe))

--- a/test/e2e/query_test.go
+++ b/test/e2e/query_test.go
@@ -358,7 +358,7 @@ func TestQueryWithExtendedFunctions(t *testing.T) {
 func TestQueryWithExperimentalFunctions(t *testing.T) {
 	t.Parallel()
 
-	e, err := e2e.New(e2e.WithName("e2e-qry-experimental-func"))
+	e, err := e2e.New(e2e.WithName("e2e-qry-exp-func"))
 	testutil.Ok(t, err)
 	t.Cleanup(e2ethanos.CleanScenario(t, e))
 
@@ -383,17 +383,19 @@ func TestQueryWithExperimentalFunctions(t *testing.T) {
 	testutil.Ok(t, remoteWriteSeriesWithLabels(ctx, prom, samples))
 
 	queryAndAssertSeries(t, ctx, q.Endpoint("http"), func() string {
-		return `limitk(2, http_requests_total) by (pod)`
+		return `limitk(1, http_requests_total) by (pod)`
 	}, time.Now, promclient.QueryOptions{
 		Deduplicate: false,
 	}, []model.Metric{
 		{
+			"__name__":   "http_requests_total",
 			"pod":        "nginx-1",
 			"instance":   "1",
 			"prometheus": "prom",
 			"replica":    "0",
 		},
 		{
+			"__name__":   "http_requests_total",
 			"pod":        "nginx-2",
 			"instance":   "1",
 			"prometheus": "prom",

--- a/test/e2e/query_test.go
+++ b/test/e2e/query_test.go
@@ -355,6 +355,53 @@ func TestQueryWithExtendedFunctions(t *testing.T) {
 	})
 }
 
+func TestQueryWithExperimentalFunctions(t *testing.T) {
+	t.Parallel()
+
+	e, err := e2e.New(e2e.WithName("e2e-qry-experimental-func"))
+	testutil.Ok(t, err)
+	t.Cleanup(e2ethanos.CleanScenario(t, e))
+
+	// create prom + sidecar
+	prom, sidecar := e2ethanos.NewPrometheusWithSidecar(e, "prom", e2ethanos.DefaultPromConfig("prom", 0, "", "", e2ethanos.LocalPrometheusTarget), "", e2ethanos.DefaultPrometheusImage(), "")
+	testutil.Ok(t, e2e.StartAndWaitReady(prom, sidecar))
+
+	// create querier with enabling experimental features
+	q := e2ethanos.NewQuerierBuilder(e, "1", sidecar.InternalEndpoint("grpc")).WithEngine("thanos").WithEnabledFeatures([]string{"promql-experimental-functions"}).Init()
+	testutil.Ok(t, e2e.StartAndWaitReady(q))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+	t.Cleanup(cancel)
+
+	// send series to prom
+	samples := []seriesWithLabels{
+		{intLabels: labels.FromStrings("__name__", "http_requests_total", "pod", "nginx-1", "instance", "1")},
+		{intLabels: labels.FromStrings("__name__", "http_requests_total", "pod", "nginx-1", "instance", "2")},
+		{intLabels: labels.FromStrings("__name__", "http_requests_total", "pod", "nginx-2", "instance", "1")},
+		{intLabels: labels.FromStrings("__name__", "http_requests_total", "pod", "nginx-2", "instance", "2")},
+	}
+	testutil.Ok(t, remoteWriteSeriesWithLabels(ctx, prom, samples))
+
+	queryAndAssertSeries(t, ctx, q.Endpoint("http"), func() string {
+		return `limitk(2, http_requests_total) by (pod)`
+	}, time.Now, promclient.QueryOptions{
+		Deduplicate: false,
+	}, []model.Metric{
+		{
+			"pod":        "nginx-1",
+			"instance":   "1",
+			"prometheus": "prom",
+			"replica":    "0",
+		},
+		{
+			"pod":        "nginx-2",
+			"instance":   "1",
+			"prometheus": "prom",
+			"replica":    "0",
+		},
+	})
+}
+
 func TestQueryExternalPrefixWithoutReverseProxy(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

This PR adds a new `promql-experimental-functions` option in `enable-feature` flag for querier and query-frontend, which will enable promql experimental functions like (limit, limit_ratio, sort_by_label, sort_by_label_desc, info, etc) to be used and also adds additional tests and changes in query frontend.
<!-- Enumerate changes you made -->

## Verification
<!-- How you tested it? How do you know it works? -->
