### PR TITLE
shipper: allow shipper sync to skip corrupted blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#8238](https://github.com/thanos-io/thanos/pull/8238) Receive: add shuffle sharding support
 - [#8266](https://github.com/thanos-io/thanos/pull/8266) Website: maintain expanded state based on current page
 - [#8245](https://github.com/thanos-io/thanos/pull/8245) Querier/Query-Frontend/Ruler: Add `--enable-feature=promql-experimental-functions` flag option to enable using promQL experimental functions in respective Thanos components
-- [#8259](https://github.com/thanos-io/thanos/pull/8259) Shipper: Add `--shipper.skip-corrupted-blocks` flat to allow `Sync()` to continue upload when finding a corrupted block
+- [#8259](https://github.com/thanos-io/thanos/pull/8259) Shipper: Add `--shipper.skip-corrupted-blocks` flag to allow `Sync()` to continue upload when finding a corrupted block
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#8238](https://github.com/thanos-io/thanos/pull/8238) Receive: add shuffle sharding support
 - [#8266](https://github.com/thanos-io/thanos/pull/8266) Website: maintain expanded state based on current page
 - [#8245](https://github.com/thanos-io/thanos/pull/8245) Querier/Query-Frontend/Ruler: Add `--enable-feature=promql-experimental-functions` flag option to enable using promQL experimental functions in respective Thanos components
+- [#8259](https://github.com/thanos-io/thanos/pull/8259) Shipper: Add `--shipper.skip-corrupted-blocks` flat to allow `Sync()` to continue upload when finding a corrupted block
 
 ### Changed
 

--- a/cmd/thanos/config.go
+++ b/cmd/thanos/config.go
@@ -203,6 +203,7 @@ type shipperConfig struct {
 	uploadCompacted       bool
 	ignoreBlockSize       bool
 	allowOutOfOrderUpload bool
+	skipCorruptedBlocks   bool
 	hashFunc              string
 	metaFileName          string
 }
@@ -219,6 +220,11 @@ func (sc *shipperConfig) registerFlag(cmd extkingpin.FlagClause) *shipperConfig 
 			"This can trigger compaction without those blocks and as a result will create an overlap situation. Set it to true if you have vertical compaction enabled and wish to upload blocks as soon as possible without caring"+
 			"about order.").
 		Default("false").Hidden().BoolVar(&sc.allowOutOfOrderUpload)
+	cmd.Flag("shipper.skip-corrupted-blocks",
+		"If true, shipper will skip corrupted blocks in the given iteration and retry later. This means that some newer blocks might be uploaded sooner than older blocks."+
+			"This can trigger compaction without those blocks and as a result will create an overlap situation. Set it to true if you have vertical compaction enabled and wish to upload blocks as soon as possible without caring"+
+			"about order.").
+		Default("false").Hidden().BoolVar(&sc.skipCorruptedBlocks)
 	cmd.Flag("hash-func", "Specify which hash function to use when calculating the hashes of produced files. If no function has been specified, it does not happen. This permits avoiding downloading some files twice albeit at some performance cost. Possible values are: \"\", \"SHA256\".").
 		Default("").EnumVar(&sc.hashFunc, "SHA256", "")
 	cmd.Flag("shipper.meta-file-name", "the file to store shipper metadata in").Default(shipper.DefaultMetaFilename).StringVar(&sc.metaFileName)

--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -243,6 +243,7 @@ func runReceive(
 		conf.tenantLabelName,
 		bkt,
 		conf.allowOutOfOrderUpload,
+		conf.skipCorruptedBlocks,
 		hashFunc,
 		multiTSDBOptions...,
 	)
@@ -895,6 +896,7 @@ type receiveConfig struct {
 
 	ignoreBlockSize       bool
 	allowOutOfOrderUpload bool
+	skipCorruptedBlocks   bool
 
 	reqLogConfig      *extflag.PathOrContent
 	relabelConfigPath *extflag.PathOrContent
@@ -1061,6 +1063,12 @@ func (rc *receiveConfig) registerFlag(cmd extkingpin.FlagClause) {
 			"This can trigger compaction without those blocks and as a result will create an overlap situation. Set it to true if you have vertical compaction enabled and wish to upload blocks as soon as possible without caring"+
 			"about order.").
 		Default("false").Hidden().BoolVar(&rc.allowOutOfOrderUpload)
+
+	cmd.Flag("shipper.skip-corrupted-blocks",
+		"If true, shipper will skip corrupted blocks in the given iteration and retry later. This means that some newer blocks might be uploaded sooner than older blocks."+
+			"This can trigger compaction without those blocks and as a result will create an overlap situation. Set it to true if you have vertical compaction enabled and wish to upload blocks as soon as possible without caring"+
+			"about order.").
+		Default("false").Hidden().BoolVar(&rc.skipCorruptedBlocks)
 
 	cmd.Flag("matcher-cache-size", "Max number of cached matchers items. Using 0 disables caching.").Default("0").IntVar(&rc.matcherCacheSize)
 

--- a/cmd/thanos/rule.go
+++ b/cmd/thanos/rule.go
@@ -850,7 +850,7 @@ func runRule(
 			}
 		}()
 
-		s := shipper.New(logger, reg, conf.dataDir, bkt, func() labels.Labels { return conf.lset }, metadata.RulerSource, nil, conf.shipper.allowOutOfOrderUpload, metadata.HashFunc(conf.shipper.hashFunc), conf.shipper.metaFileName)
+		s := shipper.New(logger, reg, conf.dataDir, bkt, func() labels.Labels { return conf.lset }, metadata.RulerSource, nil, conf.shipper.allowOutOfOrderUpload, conf.shipper.skipCorruptedBlocks, metadata.HashFunc(conf.shipper.hashFunc), conf.shipper.metaFileName)
 
 		ctx, cancel := context.WithCancel(context.Background())
 

--- a/cmd/thanos/rule.go
+++ b/cmd/thanos/rule.go
@@ -850,7 +850,7 @@ func runRule(
 			}
 		}()
 
-		s := shipper.New(logger, reg, conf.dataDir, bkt, func() labels.Labels { return conf.lset }, metadata.RulerSource, nil, conf.shipper.allowOutOfOrderUpload, conf.shipper.skipCorruptedBlocks, metadata.HashFunc(conf.shipper.hashFunc), conf.shipper.metaFileName)
+		s := shipper.New(logger, reg, conf.dataDir, bkt, metadata.RulerSource, metadata.HashFunc(conf.shipper.hashFunc), conf.shipper.metaFileName, func() labels.Labels { return conf.lset }, nil, func() bool { return conf.shipper.allowOutOfOrderUpload }, func() bool { return conf.shipper.skipCorruptedBlocks })
 
 		ctx, cancel := context.WithCancel(context.Background())
 

--- a/cmd/thanos/rule.go
+++ b/cmd/thanos/rule.go
@@ -850,7 +850,18 @@ func runRule(
 			}
 		}()
 
-		s := shipper.New(logger, reg, conf.dataDir, bkt, metadata.RulerSource, metadata.HashFunc(conf.shipper.hashFunc), conf.shipper.metaFileName, func() labels.Labels { return conf.lset }, nil, func() bool { return conf.shipper.allowOutOfOrderUpload }, func() bool { return conf.shipper.skipCorruptedBlocks })
+		s := shipper.New(
+			bkt,
+			conf.dataDir,
+			shipper.WithLogger(logger),
+			shipper.WithRegisterer(reg),
+			shipper.WithSource(metadata.RulerSource),
+			shipper.WithHashFunc(metadata.HashFunc(conf.shipper.hashFunc)),
+			shipper.WithMetaFileName(conf.shipper.metaFileName),
+			shipper.WithLabels(func() labels.Labels { return conf.lset }),
+			shipper.WithAllowOutOfOrderUploads(conf.shipper.allowOutOfOrderUpload),
+			shipper.WithSkipCorruptedBlocks(conf.shipper.skipCorruptedBlocks),
+		)
 
 		ctx, cancel := context.WithCancel(context.Background())
 

--- a/cmd/thanos/sidecar.go
+++ b/cmd/thanos/sidecar.go
@@ -414,11 +414,19 @@ func runSidecar(
 				return errors.Wrapf(err, "aborting as no external labels found after waiting %s", promReadyTimeout)
 			}
 
-			uploadCompactedFunc := func() bool { return conf.shipper.uploadCompacted }
-			allowOutOfOrderUploadFunc := func() bool { return conf.shipper.allowOutOfOrderUpload }
-			skipCorruptedBlocksFunc := func() bool { return conf.shipper.skipCorruptedBlocks }
-			s := shipper.New(logger, reg, conf.tsdb.path, bkt, metadata.SidecarSource, metadata.HashFunc(conf.shipper.hashFunc), conf.shipper.metaFileName,
-				m.Labels, uploadCompactedFunc, allowOutOfOrderUploadFunc, skipCorruptedBlocksFunc)
+			s := shipper.New(
+				bkt,
+				conf.tsdb.path,
+				shipper.WithLogger(logger),
+				shipper.WithRegisterer(reg),
+				shipper.WithSource(metadata.SidecarSource),
+				shipper.WithHashFunc(metadata.HashFunc(conf.shipper.hashFunc)),
+				shipper.WithMetaFileName(conf.shipper.metaFileName),
+				shipper.WithLabels(m.Labels),
+				shipper.WithUploadCompacted(conf.shipper.uploadCompacted),
+				shipper.WithAllowOutOfOrderUploads(conf.shipper.allowOutOfOrderUpload),
+				shipper.WithSkipCorruptedBlocks(conf.shipper.skipCorruptedBlocks),
+			)
 
 			return runutil.Repeat(30*time.Second, ctx.Done(), func() error {
 				if uploaded, err := s.Sync(ctx); err != nil {

--- a/cmd/thanos/sidecar.go
+++ b/cmd/thanos/sidecar.go
@@ -416,7 +416,7 @@ func runSidecar(
 
 			uploadCompactedFunc := func() bool { return conf.shipper.uploadCompacted }
 			s := shipper.New(logger, reg, conf.tsdb.path, bkt, m.Labels, metadata.SidecarSource,
-				uploadCompactedFunc, conf.shipper.allowOutOfOrderUpload, metadata.HashFunc(conf.shipper.hashFunc), conf.shipper.metaFileName)
+				uploadCompactedFunc, conf.shipper.allowOutOfOrderUpload, conf.shipper.skipCorruptedBlocks, metadata.HashFunc(conf.shipper.hashFunc), conf.shipper.metaFileName)
 
 			return runutil.Repeat(30*time.Second, ctx.Done(), func() error {
 				if uploaded, err := s.Sync(ctx); err != nil {

--- a/cmd/thanos/sidecar.go
+++ b/cmd/thanos/sidecar.go
@@ -415,8 +415,10 @@ func runSidecar(
 			}
 
 			uploadCompactedFunc := func() bool { return conf.shipper.uploadCompacted }
-			s := shipper.New(logger, reg, conf.tsdb.path, bkt, m.Labels, metadata.SidecarSource,
-				uploadCompactedFunc, conf.shipper.allowOutOfOrderUpload, conf.shipper.skipCorruptedBlocks, metadata.HashFunc(conf.shipper.hashFunc), conf.shipper.metaFileName)
+			allowOutOfOrderUploadFunc := func() bool { return conf.shipper.allowOutOfOrderUpload }
+			skipCorruptedBlocksFunc := func() bool { return conf.shipper.skipCorruptedBlocks }
+			s := shipper.New(logger, reg, conf.tsdb.path, bkt, metadata.SidecarSource, metadata.HashFunc(conf.shipper.hashFunc), conf.shipper.metaFileName,
+				m.Labels, uploadCompactedFunc, allowOutOfOrderUploadFunc, skipCorruptedBlocksFunc)
 
 			return runutil.Repeat(30*time.Second, ctx.Done(), func() error {
 				if uploaded, err := s.Sync(ctx); err != nil {

--- a/cmd/thanos/tools_bucket.go
+++ b/cmd/thanos/tools_bucket.go
@@ -1500,8 +1500,8 @@ func registerBucketUploadBlocks(app extkingpin.AppClause, objStoreConfig *extfla
 
 		bkt = objstoretracing.WrapWithTraces(objstore.WrapWithMetrics(bkt, extprom.WrapRegistererWithPrefix("thanos_", reg), bkt.Name()))
 
-		s := shipper.New(logger, reg, tbc.path, bkt, func() labels.Labels { return lset }, metadata.BucketUploadSource,
-			nil, false, false, metadata.HashFunc(""), shipper.DefaultMetaFilename)
+		s := shipper.New(logger, reg, tbc.path, bkt, metadata.BucketUploadSource, shipper.DefaultMetaFilename, shipper.DefaultMetaFilename, func() labels.Labels { return lset },
+			nil, nil, nil)
 
 		ctx, cancel := context.WithCancel(context.Background())
 		g.Add(func() error {

--- a/cmd/thanos/tools_bucket.go
+++ b/cmd/thanos/tools_bucket.go
@@ -1501,7 +1501,7 @@ func registerBucketUploadBlocks(app extkingpin.AppClause, objStoreConfig *extfla
 		bkt = objstoretracing.WrapWithTraces(objstore.WrapWithMetrics(bkt, extprom.WrapRegistererWithPrefix("thanos_", reg), bkt.Name()))
 
 		s := shipper.New(logger, reg, tbc.path, bkt, func() labels.Labels { return lset }, metadata.BucketUploadSource,
-			nil, false, metadata.HashFunc(""), shipper.DefaultMetaFilename)
+			nil, false, false, metadata.HashFunc(""), shipper.DefaultMetaFilename)
 
 		ctx, cancel := context.WithCancel(context.Background())
 		g.Add(func() error {

--- a/cmd/thanos/tools_bucket.go
+++ b/cmd/thanos/tools_bucket.go
@@ -1500,8 +1500,15 @@ func registerBucketUploadBlocks(app extkingpin.AppClause, objStoreConfig *extfla
 
 		bkt = objstoretracing.WrapWithTraces(objstore.WrapWithMetrics(bkt, extprom.WrapRegistererWithPrefix("thanos_", reg), bkt.Name()))
 
-		s := shipper.New(logger, reg, tbc.path, bkt, metadata.BucketUploadSource, shipper.DefaultMetaFilename, shipper.DefaultMetaFilename, func() labels.Labels { return lset },
-			nil, nil, nil)
+		s := shipper.New(
+			bkt,
+			tbc.path,
+			shipper.WithLogger(logger),
+			shipper.WithRegisterer(reg),
+			shipper.WithSource(metadata.BucketUploadSource),
+			shipper.WithMetaFileName(shipper.DefaultMetaFilename),
+			shipper.WithLabels(func() labels.Labels { return lset }),
+		)
 
 		ctx, cancel := context.WithCancel(context.Background())
 		g.Add(func() error {

--- a/pkg/receive/handler_test.go
+++ b/pkg/receive/handler_test.go
@@ -1108,6 +1108,7 @@ func benchmarkHandlerMultiTSDBReceiveRemoteWrite(b testutil.TB) {
 		"tenant_id",
 		nil,
 		false,
+		false,
 		metadata.NoneFunc,
 	)
 	defer func() { testutil.Ok(b, m.Close()) }()

--- a/pkg/receive/multitsdb.go
+++ b/pkg/receive/multitsdb.go
@@ -760,13 +760,13 @@ func (t *MultiTSDB) startTSDB(logger log.Logger, tenantID string, tenant *tenant
 			reg,
 			dataDir,
 			t.bucket,
-			func() labels.Labels { return lset },
 			metadata.ReceiveSource,
-			nil,
-			t.allowOutOfOrderUpload,
-			t.skipCorruptedBlocks,
 			t.hashFunc,
 			shipper.DefaultMetaFilename,
+			func() labels.Labels { return lset },
+			nil,
+			func() bool { return t.allowOutOfOrderUpload },
+			func() bool { return t.skipCorruptedBlocks },
 		)
 	}
 	var options []store.TSDBStoreOption

--- a/pkg/receive/multitsdb.go
+++ b/pkg/receive/multitsdb.go
@@ -756,17 +756,16 @@ func (t *MultiTSDB) startTSDB(logger log.Logger, tenantID string, tenant *tenant
 	var ship *shipper.Shipper
 	if t.bucket != nil {
 		ship = shipper.New(
-			logger,
-			reg,
-			dataDir,
 			t.bucket,
-			metadata.ReceiveSource,
-			t.hashFunc,
-			shipper.DefaultMetaFilename,
-			func() labels.Labels { return lset },
-			nil,
-			func() bool { return t.allowOutOfOrderUpload },
-			func() bool { return t.skipCorruptedBlocks },
+			dataDir,
+			shipper.WithLogger(logger),
+			shipper.WithRegisterer(reg),
+			shipper.WithSource(metadata.ReceiveSource),
+			shipper.WithHashFunc(t.hashFunc),
+			shipper.WithMetaFileName(shipper.DefaultMetaFilename),
+			shipper.WithLabels(func() labels.Labels { return lset }),
+			shipper.WithAllowOutOfOrderUploads(t.allowOutOfOrderUpload),
+			shipper.WithSkipCorruptedBlocks(t.skipCorruptedBlocks),
 		)
 	}
 	var options []store.TSDBStoreOption

--- a/pkg/receive/multitsdb.go
+++ b/pkg/receive/multitsdb.go
@@ -61,6 +61,7 @@ type MultiTSDB struct {
 	mtx                   *sync.RWMutex
 	tenants               map[string]*tenant
 	allowOutOfOrderUpload bool
+	skipCorruptedBlocks   bool
 	hashFunc              metadata.HashFunc
 	hashringConfigs       []HashringConfig
 
@@ -114,6 +115,7 @@ func NewMultiTSDB(
 	tenantLabelName string,
 	bucket objstore.Bucket,
 	allowOutOfOrderUpload bool,
+	skipCorruptedBlocks bool,
 	hashFunc metadata.HashFunc,
 	options ...MultiTSDBOption,
 ) *MultiTSDB {
@@ -134,6 +136,7 @@ func NewMultiTSDB(
 		tenantLabelName:       tenantLabelName,
 		bucket:                bucket,
 		allowOutOfOrderUpload: allowOutOfOrderUpload,
+		skipCorruptedBlocks:   skipCorruptedBlocks,
 		hashFunc:              hashFunc,
 		matcherCache:          storecache.NoopMatchersCache,
 	}
@@ -761,6 +764,7 @@ func (t *MultiTSDB) startTSDB(logger log.Logger, tenantID string, tenant *tenant
 			metadata.ReceiveSource,
 			nil,
 			t.allowOutOfOrderUpload,
+			t.skipCorruptedBlocks,
 			t.hashFunc,
 			shipper.DefaultMetaFilename,
 		)

--- a/pkg/receive/multitsdb_test.go
+++ b/pkg/receive/multitsdb_test.go
@@ -952,7 +952,13 @@ func TestMultiTSDBDoesNotDeleteNotUploadedBlocks(t *testing.T) {
 			Uploaded: []ulid.ULID{mockBlockIDs[0]},
 		}))
 
-		tenant.ship = shipper.New(log.NewNopLogger(), nil, td, nil, metadata.BucketUploadSource, metadata.NoneFunc, "", nil, nil, nil, nil)
+		tenant.ship = shipper.New(
+			nil,
+			td,
+			shipper.WithLogger(log.NewNopLogger()),
+			shipper.WithSource(metadata.BucketUploadSource),
+			shipper.WithHashFunc(metadata.NoneFunc),
+		)
 		require.Equal(t, map[ulid.ULID]struct{}{
 			mockBlockIDs[0]: {},
 		}, tenant.blocksToDelete(nil))

--- a/pkg/receive/multitsdb_test.go
+++ b/pkg/receive/multitsdb_test.go
@@ -53,7 +53,7 @@ func TestMultiTSDB(t *testing.T) {
 			NoLockfile:            true,
 			MaxExemplars:          100,
 			EnableExemplarStorage: true,
-		}, labels.FromStrings("replica", "01"), "tenant_id", nil, false, metadata.NoneFunc)
+		}, labels.FromStrings("replica", "01"), "tenant_id", nil, false, false, metadata.NoneFunc)
 		defer func() { testutil.Ok(t, m.Close()) }()
 
 		testutil.Ok(t, m.Flush())
@@ -136,6 +136,7 @@ func TestMultiTSDB(t *testing.T) {
 			"tenant_id",
 			nil,
 			false,
+			false,
 			metadata.NoneFunc,
 		)
 		defer func() { testutil.Ok(t, m.Close()) }()
@@ -173,7 +174,7 @@ func TestMultiTSDB(t *testing.T) {
 			MaxBlockDuration:  (2 * time.Hour).Milliseconds(),
 			RetentionDuration: (6 * time.Hour).Milliseconds(),
 			NoLockfile:        true,
-		}, labels.FromStrings("replica", "01"), "tenant_id", nil, false, metadata.NoneFunc)
+		}, labels.FromStrings("replica", "01"), "tenant_id", nil, false, false, metadata.NoneFunc)
 		defer func() { testutil.Ok(t, m.Close()) }()
 
 		testutil.Ok(t, m.Flush())
@@ -441,6 +442,7 @@ func TestMultiTSDBPrune(t *testing.T) {
 				"tenant_id",
 				test.bucket,
 				false,
+				false,
 				metadata.NoneFunc,
 			)
 			defer func() { testutil.Ok(t, m.Close()) }()
@@ -516,6 +518,7 @@ func TestMultiTSDBRecreatePrunedTenant(t *testing.T) {
 		"tenant_id",
 		objstore.NewInMemBucket(),
 		false,
+		false,
 		metadata.NoneFunc,
 	)
 	defer func() { testutil.Ok(t, m.Close()) }()
@@ -544,6 +547,7 @@ func TestMultiTSDBAddNewTenant(t *testing.T) {
 				labels.FromStrings("replica", "test"),
 				"tenant_id",
 				objstore.NewInMemBucket(),
+				false,
 				false,
 				metadata.NoneFunc,
 			)
@@ -619,6 +623,7 @@ func TestAlignedHeadFlush(t *testing.T) {
 				labels.FromStrings("replica", "test"),
 				"tenant_id",
 				test.bucket,
+				false,
 				false,
 				metadata.NoneFunc,
 			)
@@ -696,6 +701,7 @@ func TestMultiTSDBStats(t *testing.T) {
 				"tenant_id",
 				nil,
 				false,
+				false,
 				metadata.NoneFunc,
 			)
 			defer func() { testutil.Ok(t, m.Close()) }()
@@ -726,6 +732,7 @@ func TestMultiTSDBWithNilStore(t *testing.T) {
 		labels.FromStrings("replica", "test"),
 		"tenant_id",
 		nil,
+		false,
 		false,
 		metadata.NoneFunc,
 	)
@@ -769,6 +776,7 @@ func TestProxyLabelValues(t *testing.T) {
 		labels.FromStrings("replica", "01"),
 		"tenant_id",
 		nil,
+		false,
 		false,
 		metadata.NoneFunc,
 	)
@@ -863,6 +871,7 @@ func BenchmarkMultiTSDB(b *testing.B) {
 		"tenant_id",
 		nil,
 		false,
+		false,
 		metadata.NoneFunc,
 	)
 	defer func() { testutil.Ok(b, m.Close()) }()
@@ -943,7 +952,7 @@ func TestMultiTSDBDoesNotDeleteNotUploadedBlocks(t *testing.T) {
 			Uploaded: []ulid.ULID{mockBlockIDs[0]},
 		}))
 
-		tenant.ship = shipper.New(log.NewNopLogger(), nil, td, nil, nil, metadata.BucketUploadSource, nil, false, metadata.NoneFunc, "")
+		tenant.ship = shipper.New(log.NewNopLogger(), nil, td, nil, nil, metadata.BucketUploadSource, nil, false, false, metadata.NoneFunc, "")
 		require.Equal(t, map[ulid.ULID]struct{}{
 			mockBlockIDs[0]: {},
 		}, tenant.blocksToDelete(nil))

--- a/pkg/receive/multitsdb_test.go
+++ b/pkg/receive/multitsdb_test.go
@@ -952,7 +952,7 @@ func TestMultiTSDBDoesNotDeleteNotUploadedBlocks(t *testing.T) {
 			Uploaded: []ulid.ULID{mockBlockIDs[0]},
 		}))
 
-		tenant.ship = shipper.New(log.NewNopLogger(), nil, td, nil, nil, metadata.BucketUploadSource, nil, false, false, metadata.NoneFunc, "")
+		tenant.ship = shipper.New(log.NewNopLogger(), nil, td, nil, metadata.BucketUploadSource, metadata.NoneFunc, "", nil, nil, nil, nil)
 		require.Equal(t, map[ulid.ULID]struct{}{
 			mockBlockIDs[0]: {},
 		}, tenant.blocksToDelete(nil))

--- a/pkg/receive/receive_test.go
+++ b/pkg/receive/receive_test.go
@@ -818,6 +818,7 @@ func initializeMultiTSDB(dir string) *MultiTSDB {
 		"tenant_id",
 		bucket,
 		false,
+		false,
 		metadata.NoneFunc,
 	)
 

--- a/pkg/receive/writer_test.go
+++ b/pkg/receive/writer_test.go
@@ -439,6 +439,7 @@ func setupMultitsdb(t *testing.T, maxExemplars int64) (log.Logger, *MultiTSDB, A
 		"tenant_id",
 		nil,
 		false,
+		false,
 		metadata.NoneFunc,
 	)
 	t.Cleanup(func() { testutil.Ok(t, m.Close()) })
@@ -503,6 +504,7 @@ func benchmarkWriter(b *testing.B, labelsNum int, seriesNum int, generateHistogr
 		labels.FromStrings("replica", "01"),
 		"tenant_id",
 		nil,
+		false,
 		false,
 		metadata.NoneFunc,
 	)

--- a/pkg/shipper/shipper_e2e_test.go
+++ b/pkg/shipper/shipper_e2e_test.go
@@ -44,7 +44,7 @@ func TestShipper_SyncBlocks_e2e(t *testing.T) {
 		dir := t.TempDir()
 
 		extLset := labels.FromStrings("prometheus", "prom-1")
-		shipper := New(log.NewLogfmtLogger(os.Stderr), nil, dir, metricsBucket, func() labels.Labels { return extLset }, metadata.TestSource, nil, false, metadata.NoneFunc, DefaultMetaFilename)
+		shipper := New(log.NewLogfmtLogger(os.Stderr), nil, dir, metricsBucket, func() labels.Labels { return extLset }, metadata.TestSource, nil, false, false, metadata.NoneFunc, DefaultMetaFilename)
 
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -204,7 +204,7 @@ func TestShipper_SyncBlocksWithMigrating_e2e(t *testing.T) {
 		testutil.Ok(t, p.Restart(context.Background(), logger))
 
 		uploadCompactedFunc := func() bool { return true }
-		shipper := New(log.NewLogfmtLogger(os.Stderr), nil, dir, bkt, func() labels.Labels { return extLset }, metadata.TestSource, uploadCompactedFunc, false, metadata.NoneFunc, DefaultMetaFilename)
+		shipper := New(log.NewLogfmtLogger(os.Stderr), nil, dir, bkt, func() labels.Labels { return extLset }, metadata.TestSource, uploadCompactedFunc, false, false, metadata.NoneFunc, DefaultMetaFilename)
 
 		// Create 10 new blocks. 9 of them (non compacted) should be actually uploaded.
 		var (
@@ -347,7 +347,7 @@ func TestShipper_SyncOverlapBlocks_e2e(t *testing.T) {
 
 	uploadCompactedFunc := func() bool { return true }
 	// Here, the allowOutOfOrderUploads flag is set to true, which allows blocks with overlaps to be uploaded.
-	shipper := New(log.NewLogfmtLogger(os.Stderr), nil, dir, bkt, func() labels.Labels { return extLset }, metadata.TestSource, uploadCompactedFunc, true, metadata.NoneFunc, DefaultMetaFilename)
+	shipper := New(log.NewLogfmtLogger(os.Stderr), nil, dir, bkt, func() labels.Labels { return extLset }, metadata.TestSource, uploadCompactedFunc, true, false, metadata.NoneFunc, DefaultMetaFilename)
 
 	// Creating 2 overlapping blocks - both uploaded when OOO uploads allowed.
 	var (

--- a/pkg/shipper/shipper_e2e_test.go
+++ b/pkg/shipper/shipper_e2e_test.go
@@ -44,7 +44,14 @@ func TestShipper_SyncBlocks_e2e(t *testing.T) {
 		dir := t.TempDir()
 
 		extLset := labels.FromStrings("prometheus", "prom-1")
-		shipper := New(log.NewLogfmtLogger(os.Stderr), nil, dir, metricsBucket, metadata.TestSource, metadata.NoneFunc, DefaultMetaFilename, func() labels.Labels { return extLset }, nil, nil, nil)
+		shipper := New(
+			metricsBucket,
+			dir,
+			WithLogger(log.NewLogfmtLogger(os.Stderr)),
+			WithSource(metadata.TestSource),
+			WithHashFunc(metadata.NoneFunc),
+			WithLabels(func() labels.Labels { return extLset }),
+		)
 
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -203,8 +210,15 @@ func TestShipper_SyncBlocksWithMigrating_e2e(t *testing.T) {
 		p.DisableCompaction()
 		testutil.Ok(t, p.Restart(context.Background(), logger))
 
-		uploadCompactedFunc := func() bool { return true }
-		shipper := New(log.NewLogfmtLogger(os.Stderr), nil, dir, bkt, metadata.TestSource, metadata.NoneFunc, DefaultMetaFilename, func() labels.Labels { return extLset }, uploadCompactedFunc, nil, nil)
+		shipper := New(
+			bkt,
+			dir,
+			WithLogger(log.NewLogfmtLogger(os.Stderr)),
+			WithSource(metadata.TestSource),
+			WithHashFunc(metadata.NoneFunc),
+			WithLabels(func() labels.Labels { return extLset }),
+			WithUploadCompacted(true),
+		)
 
 		// Create 10 new blocks. 9 of them (non compacted) should be actually uploaded.
 		var (
@@ -345,10 +359,17 @@ func TestShipper_SyncOverlapBlocks_e2e(t *testing.T) {
 	p.DisableCompaction()
 	testutil.Ok(t, p.Restart(context.Background(), logger))
 
-	uploadCompactedFunc := func() bool { return true }
 	// Here, the allowOutOfOrderUploads flag is set to true, which allows blocks with overlaps to be uploaded.
-	shipper := New(log.NewLogfmtLogger(os.Stderr), nil, dir, bkt, metadata.TestSource, metadata.NoneFunc, DefaultMetaFilename, func() labels.Labels { return extLset }, uploadCompactedFunc, nil, nil)
-
+	shipper := New(
+		bkt,
+		dir,
+		WithLogger(log.NewLogfmtLogger(os.Stderr)),
+		WithSource(metadata.TestSource),
+		WithHashFunc(metadata.NoneFunc),
+		WithLabels(func() labels.Labels { return extLset }),
+		WithUploadCompacted(true),
+		WithAllowOutOfOrderUploads(true),
+	)
 	// Creating 2 overlapping blocks - both uploaded when OOO uploads allowed.
 	var (
 		expBlocks = map[ulid.ULID]struct{}{}

--- a/pkg/shipper/shipper_e2e_test.go
+++ b/pkg/shipper/shipper_e2e_test.go
@@ -44,7 +44,7 @@ func TestShipper_SyncBlocks_e2e(t *testing.T) {
 		dir := t.TempDir()
 
 		extLset := labels.FromStrings("prometheus", "prom-1")
-		shipper := New(log.NewLogfmtLogger(os.Stderr), nil, dir, metricsBucket, func() labels.Labels { return extLset }, metadata.TestSource, nil, false, false, metadata.NoneFunc, DefaultMetaFilename)
+		shipper := New(log.NewLogfmtLogger(os.Stderr), nil, dir, metricsBucket, metadata.TestSource, metadata.NoneFunc, DefaultMetaFilename, func() labels.Labels { return extLset }, nil, nil, nil)
 
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -204,7 +204,7 @@ func TestShipper_SyncBlocksWithMigrating_e2e(t *testing.T) {
 		testutil.Ok(t, p.Restart(context.Background(), logger))
 
 		uploadCompactedFunc := func() bool { return true }
-		shipper := New(log.NewLogfmtLogger(os.Stderr), nil, dir, bkt, func() labels.Labels { return extLset }, metadata.TestSource, uploadCompactedFunc, false, false, metadata.NoneFunc, DefaultMetaFilename)
+		shipper := New(log.NewLogfmtLogger(os.Stderr), nil, dir, bkt, metadata.TestSource, metadata.NoneFunc, DefaultMetaFilename, func() labels.Labels { return extLset }, uploadCompactedFunc, nil, nil)
 
 		// Create 10 new blocks. 9 of them (non compacted) should be actually uploaded.
 		var (
@@ -347,7 +347,7 @@ func TestShipper_SyncOverlapBlocks_e2e(t *testing.T) {
 
 	uploadCompactedFunc := func() bool { return true }
 	// Here, the allowOutOfOrderUploads flag is set to true, which allows blocks with overlaps to be uploaded.
-	shipper := New(log.NewLogfmtLogger(os.Stderr), nil, dir, bkt, func() labels.Labels { return extLset }, metadata.TestSource, uploadCompactedFunc, true, false, metadata.NoneFunc, DefaultMetaFilename)
+	shipper := New(log.NewLogfmtLogger(os.Stderr), nil, dir, bkt, metadata.TestSource, metadata.NoneFunc, DefaultMetaFilename, func() labels.Labels { return extLset }, uploadCompactedFunc, nil, nil)
 
 	// Creating 2 overlapping blocks - both uploaded when OOO uploads allowed.
 	var (

--- a/pkg/shipper/shipper_test.go
+++ b/pkg/shipper/shipper_test.go
@@ -103,7 +103,7 @@ func TestIterBlockMetasWhenMissingMeta(t *testing.T) {
 
 	shipper := New(nil, nil, dir, nil, nil, metadata.TestSource, nil, false, true, metadata.NoneFunc, DefaultMetaFilename)
 	metas, failedBlocks, err := shipper.blockMetasFromOldest()
-	testutil.Ok(t, err)
+	testutil.NotOk(t, err)
 	testutil.Equals(t, 1, len(failedBlocks))
 	testutil.Equals(t, id2.String(), failedBlocks[0])
 	testutil.Equals(t, 2, len(metas))

--- a/pkg/shipper/shipper_test.go
+++ b/pkg/shipper/shipper_test.go
@@ -229,8 +229,13 @@ func TestShipperSkipCorruptedBlocks(t *testing.T) {
 	testutil.Ok(t, promtest.GatherAndCompare(metrics, strings.NewReader(`
 				# HELP thanos_shipper_upload_failures_total Total number of block upload failures
 				# TYPE thanos_shipper_upload_failures_total counter
-				thanos_shipper_upload_failures_total{} 1
+				thanos_shipper_upload_failures_total{} 0
 				`), `thanos_shipper_upload_failures_total`))
+	testutil.Ok(t, promtest.GatherAndCompare(metrics, strings.NewReader(`
+				# HELP thanos_shipper_corrupted_blocks_total Total number of corrupted blocks
+				# TYPE thanos_shipper_corrupted_blocks_total counter
+				thanos_shipper_corrupted_blocks_total{} 1
+				`), `thanos_shipper_corrupted_blocks_total`))
 }
 
 func TestShipperNotSkipCorruptedBlocks(t *testing.T) {

--- a/pkg/shipper/shipper_test.go
+++ b/pkg/shipper/shipper_test.go
@@ -64,7 +64,7 @@ func TestIterBlockMetas(t *testing.T) {
 		},
 	}.WriteToDir(log.NewNopLogger(), path.Join(dir, id3.String())))
 
-	shipper := New(nil, nil, dir, nil, nil, metadata.TestSource, nil, false, false, metadata.NoneFunc, DefaultMetaFilename)
+	shipper := New(nil, nil, dir, nil, metadata.TestSource, metadata.NoneFunc, DefaultMetaFilename, nil, nil, nil, nil)
 	metas, failedBlocks, err := shipper.blockMetasFromOldest()
 	testutil.Ok(t, err)
 	testutil.Equals(t, 0, len(failedBlocks))
@@ -101,7 +101,7 @@ func TestIterBlockMetasWhenMissingMeta(t *testing.T) {
 		},
 	}.WriteToDir(log.NewNopLogger(), path.Join(dir, id3.String())))
 
-	shipper := New(nil, nil, dir, nil, nil, metadata.TestSource, nil, false, true, metadata.NoneFunc, DefaultMetaFilename)
+	shipper := New(nil, nil, dir, nil, metadata.TestSource, metadata.NoneFunc, DefaultMetaFilename, nil, nil, nil, func() bool { return true })
 	metas, failedBlocks, err := shipper.blockMetasFromOldest()
 	testutil.NotOk(t, err)
 	testutil.Equals(t, 1, len(failedBlocks))
@@ -135,7 +135,7 @@ func BenchmarkIterBlockMetas(b *testing.B) {
 	})
 	b.ResetTimer()
 
-	shipper := New(nil, nil, dir, nil, nil, metadata.TestSource, nil, false, false, metadata.NoneFunc, DefaultMetaFilename)
+	shipper := New(nil, nil, dir, nil, metadata.TestSource, metadata.NoneFunc, DefaultMetaFilename, nil, nil, nil, nil)
 
 	_, _, err := shipper.blockMetasFromOldest()
 	testutil.Ok(b, err)
@@ -148,7 +148,7 @@ func TestShipperAddsSegmentFiles(t *testing.T) {
 
 	metrics := prometheus.NewRegistry()
 	lbls := labels.FromStrings("test", "test")
-	s := New(nil, metrics, dir, inmemory, func() labels.Labels { return lbls }, metadata.TestSource, nil, false, false, metadata.NoneFunc, DefaultMetaFilename)
+	s := New(nil, metrics, dir, inmemory, metadata.TestSource, metadata.NoneFunc, DefaultMetaFilename, func() labels.Labels { return lbls }, nil, nil, nil)
 
 	id := ulid.MustNew(1, nil)
 	blockDir := path.Join(dir, id.String())
@@ -194,7 +194,7 @@ func TestShipperSkipCorruptedBlocks(t *testing.T) {
 
 	metrics := prometheus.NewRegistry()
 	lbls := labels.FromStrings("test", "test")
-	s := New(nil, metrics, dir, inmemory, func() labels.Labels { return lbls }, metadata.TestSource, nil, false, true, metadata.NoneFunc, DefaultMetaFilename)
+	s := New(nil, metrics, dir, inmemory, metadata.TestSource, metadata.NoneFunc, DefaultMetaFilename, func() labels.Labels { return lbls }, nil, nil, func() bool { return true })
 
 	id1 := ulid.MustNew(1, nil)
 	blockDir1 := path.Join(dir, id1.String())
@@ -245,7 +245,7 @@ func TestShipperNotSkipCorruptedBlocks(t *testing.T) {
 
 	metrics := prometheus.NewRegistry()
 	lbls := labels.FromStrings("test", "test")
-	s := New(nil, metrics, dir, inmemory, func() labels.Labels { return lbls }, metadata.TestSource, nil, false, false, metadata.NoneFunc, DefaultMetaFilename)
+	s := New(nil, metrics, dir, inmemory, metadata.TestSource, metadata.NoneFunc, DefaultMetaFilename, func() labels.Labels { return lbls }, nil, nil, nil)
 
 	id := ulid.MustNew(2, nil)
 	blockDir := path.Join(dir, id.String())
@@ -303,7 +303,7 @@ func TestShipperExistingThanosLabels(t *testing.T) {
 	inmemory := objstore.NewInMemBucket()
 
 	lbls := labels.FromStrings("test", "test")
-	s := New(nil, nil, dir, inmemory, func() labels.Labels { return lbls }, metadata.TestSource, nil, false, false, metadata.NoneFunc, DefaultMetaFilename)
+	s := New(nil, nil, dir, inmemory, metadata.TestSource, metadata.NoneFunc, DefaultMetaFilename, func() labels.Labels { return lbls }, nil, nil, nil)
 
 	id := ulid.MustNew(1, nil)
 	id2 := ulid.MustNew(2, nil)


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes
Fixes issue: https://github.com/thanos-io/thanos/issues/8253

Added a new configuration to allow shipper to ignore corrupted blocks. For the metrics i did some changes as well. `dirSyncFailures` was not being used. Now if we return error from Sync before completion, sync will increment metric `s.metrics.dirSyncFailures`. Also updated return to return the uploaded number of blocks when fails instead of 0

## Verification
Added unit tests to check for blocks with missing meta and check if metrics were published