### PR TITLE
Force sync writes to meta.json in case of host crash

### DIFF
--- a/pkg/block/metadata/meta.go
+++ b/pkg/block/metadata/meta.go
@@ -209,6 +209,11 @@ func (m Meta) WriteToDir(logger log.Logger, dir string) error {
 		runutil.CloseWithLogOnErr(logger, f, "close meta")
 		return err
 	}
+
+	// Force the kernel to persist the file on disk to avoid data loss if the host crashes.
+	if err := f.Sync(); err != nil {
+		return err
+	}
 	if err := f.Close(); err != nil {
 		return err
 	}

--- a/pkg/shipper/shipper.go
+++ b/pkg/shipper/shipper.go
@@ -467,6 +467,11 @@ func WriteMetaFile(logger log.Logger, path string, meta *Meta) error {
 		runutil.CloseWithLogOnErr(logger, f, "write meta file close")
 		return err
 	}
+
+	// Force the kernel to persist the file on disk to avoid data loss if the host crashes.
+	if err := f.Sync(); err != nil {
+		return err
+	}
 	if err := f.Close(); err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes
Force sync the content written to `meta.json.tmp` before closing the file and renaming it to prevent data loss in case of host crash.

Addresses https://github.com/thanos-io/thanos/issues/8281

<!-- Enumerate changes you made -->

## Verification

Difficult to verify but this is a similar resolution to a prior Prometheus issue https://github.com/prometheus/prometheus/issues/4058
<!-- How you tested it? How do you know it works? -->
