### PR TITLE
query: make grpc service config for endpoint groups configurable

### DIFF
--- a/pkg/extgrpc/client.go
+++ b/pkg/extgrpc/client.go
@@ -24,8 +24,9 @@ import (
 
 // EndpointGroupGRPCOpts creates gRPC dial options for connecting to endpoint groups.
 // For details on retry capabilities, see https://github.com/grpc/proposal/blob/master/A6-client-retries.md#retry-policy-capabilities
-func EndpointGroupGRPCOpts() []grpc.DialOption {
-	serviceConfig := `
+func EndpointGroupGRPCOpts(serviceConfig string) []grpc.DialOption {
+	if serviceConfig == "" {
+		serviceConfig = `
 {
   "loadBalancingPolicy":"round_robin",
   "retryPolicy": {
@@ -37,6 +38,7 @@ func EndpointGroupGRPCOpts() []grpc.DialOption {
     ]
   }
 }`
+	}
 
 	return []grpc.DialOption{
 		grpc.WithDefaultServiceConfig(serviceConfig),


### PR DESCRIPTION
We add a "service_config" field to endpoint config file that we can use to override the default service_config for endpoint groups. This enables us to configure retry policy or loadbalncing on an endpoint level.

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
