### PR TITLE
Fix: DataRace in TestEndpointSetUpdate_StrictEndpointMetadata test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#8211](https://github.com/thanos-io/thanos/pull/8211) Query: fix panic on nested partial response in distributed instant query
 - [#8216](https://github.com/thanos-io/thanos/pull/8216) Query/Receive: fix iter race between `next()` and `stop()` introduced in https://github.com/thanos-io/thanos/pull/7821.
 - [#8212](https://github.com/thanos-io/thanos/pull/8212) Receive: Ensure forward/replication metrics are incremented in err cases
+- [#8288](https://github.com/thanos-io/thanos/pull/8288) Fix: DataRace in TestEndpointSetUpdate_StrictEndpointMetadata test
 
 ## [v0.38.0](https://github.com/thanos-io/thanos/tree/release-0.38) - 03.04.2025
 

--- a/pkg/query/endpointset_test.go
+++ b/pkg/query/endpointset_test.go
@@ -466,9 +466,12 @@ func TestEndpointSetUpdate_EndpointComingOnline(t *testing.T) {
 func TestEndpointSetUpdate_StrictEndpointMetadata(t *testing.T) {
 	t.Parallel()
 
-	info := sidecarInfo
-	info.Store.MinTime = 111
-	info.Store.MaxTime = 222
+	infoCopy := *sidecarInfo
+	infoCopy.Store = &infopb.StoreInfo{
+		MinTime: 111,
+		MaxTime: 222,
+	}
+	info := &infoCopy
 	endpoints, err := startTestEndpoints([]testEndpointMeta{
 		{
 			err:          fmt.Errorf("endpoint unavailable"),


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->
This PR resolves #8286.

To solve the issue of DataRacing in `TestEndpointSetUpdate_StrictEndpointMetadata` we create a deep copy of the shared `sidecarInfo` variable instead of using the same pointer across parallel test goroutines

## Verification

<!-- How you tested it? How do you know it works? -->
