### PR TITLE
Query: limit LazyRetrieval memory buffer size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#8211](https://github.com/thanos-io/thanos/pull/8211) Query: fix panic on nested partial response in distributed instant query
 - [#8216](https://github.com/thanos-io/thanos/pull/8216) Query/Receive: fix iter race between `next()` and `stop()` introduced in https://github.com/thanos-io/thanos/pull/7821.
 - [#8212](https://github.com/thanos-io/thanos/pull/8212) Receive: Ensure forward/replication metrics are incremented in err cases
+- [#8296](https://github.com/thanos-io/thanos/pull/8296) Query: limit LazyRetrieval memory buffer size
 
 ## [v0.38.0](https://github.com/thanos-io/thanos/tree/release-0.38) - 03.04.2025
 

--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -354,10 +354,14 @@ func runReceive(
 			return errors.Wrap(err, "setup gRPC server")
 		}
 
+		if conf.lazyRetrievalMaxBufferedResponses <= 0 {
+			return errors.New("--receive.lazy-retrieval-max-buffered-responses must be > 0")
+		}
 		options := []store.ProxyStoreOption{
 			store.WithProxyStoreDebugLogging(debugLogging),
 			store.WithMatcherCache(cache),
 			store.WithoutDedup(),
+			store.WithLazyRetrievalMaxBufferedResponsesForProxy(conf.lazyRetrievalMaxBufferedResponses),
 		}
 
 		proxy := store.NewProxyStore(
@@ -895,6 +899,8 @@ type receiveConfig struct {
 
 	matcherCacheSize int
 
+	lazyRetrievalMaxBufferedResponses int
+
 	featureList *[]string
 
 	headExpandedPostingsCacheSize            uint64
@@ -1068,6 +1074,9 @@ func (rc *receiveConfig) registerFlag(cmd extkingpin.FlagClause) {
 	cmd.Flag("receive.otlp-promote-resource-attributes", "(Repeatable) Resource attributes to include in OTLP metrics ingested by Receive.").Default("").StringsVar(&rc.otlpResourceAttributes)
 
 	rc.featureList = cmd.Flag("enable-feature", "Comma separated experimental feature names to enable. The current list of features is "+metricNamesFilter+".").Default("").Strings()
+
+	cmd.Flag("receive.lazy-retrieval-max-buffered-responses", "The lazy retrieval strategy can buffer up to this number of responses. This is to limit the memory usage. This flag takes effect only when the lazy retrieval strategy is enabled.").
+		Default("20").IntVar(&rc.lazyRetrievalMaxBufferedResponses)
 }
 
 // determineMode returns the ReceiverMode that this receiver is configured to run in.

--- a/docs/components/receive.md
+++ b/docs/components/receive.md
@@ -665,5 +665,10 @@ Flags:
       --enable-feature= ...      Comma separated experimental feature names
                                  to enable. The current list of features is
                                  metric-names-filter.
+      --receive.lazy-retrieval-max-buffered-responses=20
+                                 The lazy retrieval strategy can buffer up to
+                                 this number of responses. This is to limit the
+                                 memory usage. This flag takes effect only when
+                                 the lazy retrieval strategy is enabled.
 
 ```

--- a/pkg/store/bucket_test.go
+++ b/pkg/store/bucket_test.go
@@ -1790,12 +1790,13 @@ func TestBucketSeries_OneBlock_InMemIndexCacheSegfault(t *testing.T) {
 			b1.meta.ULID: b1,
 			b2.meta.ULID: b2,
 		},
-		queryGate:            gate.NewNoop(),
-		chunksLimiterFactory: NewChunksLimiterFactory(0),
-		seriesLimiterFactory: NewSeriesLimiterFactory(0),
-		bytesLimiterFactory:  NewBytesLimiterFactory(0),
-		seriesBatchSize:      SeriesBatchSize,
-		requestLoggerFunc:    NoopRequestLoggerFunc,
+		queryGate:                         gate.NewNoop(),
+		chunksLimiterFactory:              NewChunksLimiterFactory(0),
+		seriesLimiterFactory:              NewSeriesLimiterFactory(0),
+		bytesLimiterFactory:               NewBytesLimiterFactory(0),
+		seriesBatchSize:                   SeriesBatchSize,
+		requestLoggerFunc:                 NoopRequestLoggerFunc,
+		lazyRetrievalMaxBufferedResponses: 1,
 	}
 
 	t.Run("invoke series for one block. Fill the cache on the way.", func(t *testing.T) {

--- a/pkg/store/proxy_merge.go
+++ b/pkg/store/proxy_merge.go
@@ -191,6 +191,11 @@ func NewProxyResponseLoserTree(seriesSets ...respSet) *losertree.Tree[*storepb.S
 		} else if a.GetSeries() != nil && b.GetSeries() == nil {
 			return false
 		}
+
+		if a.GetWarning() != "" && b.GetWarning() != "" {
+			return len(a.GetWarning()) < len(b.GetWarning())
+		}
+
 		return false
 	}
 
@@ -222,7 +227,7 @@ type ringBuffer struct {
 	bufferedResponses []*storepb.SeriesResponse
 	ringHead          int
 	ringTail          int
-	closed 		  	  bool
+	closed            bool
 }
 
 // NB: A call site of any method of ringBuffer must hold the mtx lock
@@ -287,7 +292,7 @@ type lazyRespSet struct {
 	frameTimeout   time.Duration
 
 	// Internal bookkeeping.
-	dataOrFinishEvent    *sync.Cond
+	dataOrFinishEvent *sync.Cond
 
 	// bufferedResponsMtx protects all the following fields.
 	bufferedResponsesMtx *sync.Mutex

--- a/pkg/store/proxy_merge.go
+++ b/pkg/store/proxy_merge.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"math"
 	"sort"
 	"sync"
 	"time"
@@ -212,10 +213,69 @@ func (l *lazyRespSet) StoreLabels() map[string]struct{} {
 	return l.storeLabels
 }
 
+type ringBuffer struct {
+	// This event firing means the buffer has a slot for more data.
+	bufferSlotEvent *sync.Cond
+	fixedBufferSize int
+	// This a ring buffer of size fixedBufferSize.
+	// A ring buffer of size N can hold N - 1 elements at most in order to distinguish being empty from being full.
+	bufferedResponses []*storepb.SeriesResponse
+	ringHead          int
+	ringTail          int
+	closed 		  	  bool
+}
+
+// NB: A call site of any method of ringBuffer must hold the mtx lock
+func newRingBuffer(fixedBufferSize int, mtx *sync.Mutex) *ringBuffer {
+	return &ringBuffer{
+		bufferedResponses: make([]*storepb.SeriesResponse, fixedBufferSize+1),
+		fixedBufferSize:   fixedBufferSize + 1,
+		bufferSlotEvent:   sync.NewCond(mtx),
+		ringHead:          0,
+		ringTail:          0,
+		closed:            false,
+	}
+}
+
+// Can block until there is a slot for more data or the ring buffer is closed.
+func (rb *ringBuffer) append(resp *storepb.SeriesResponse) bool {
+	for rb.isFull() && !rb.closed {
+		rb.bufferSlotEvent.Wait()
+	}
+	if !rb.closed {
+		rb.bufferedResponses[rb.ringTail] = resp
+		rb.ringTail = (rb.ringTail + 1) % rb.fixedBufferSize
+		return true
+	}
+	return false
+}
+
+func (rb *ringBuffer) close() {
+	rb.closed = true
+	rb.bufferSlotEvent.Signal()
+}
+
+func (rb *ringBuffer) pop() *storepb.SeriesResponse {
+	defer rb.bufferSlotEvent.Signal()
+
+	resp := rb.bufferedResponses[rb.ringHead]
+	rb.ringHead = (rb.ringHead + 1) % rb.fixedBufferSize
+	return resp
+}
+
+func (rb *ringBuffer) isEmpty() bool {
+	return rb.ringHead == rb.ringTail
+}
+
+func (rb *ringBuffer) isFull() bool {
+	return (rb.ringTail+1)%rb.fixedBufferSize == rb.ringHead
+}
+
 // lazyRespSet is a lazy storepb.SeriesSet that buffers
 // everything as fast as possible while at the same it permits
 // reading response-by-response. It blocks if there is no data
 // in Next().
+// NB: It is not thread-safe, so its metholds must be called from the same goroutine.
 type lazyRespSet struct {
 	// Generic parameters.
 	span           opentracing.Span
@@ -228,12 +288,13 @@ type lazyRespSet struct {
 
 	// Internal bookkeeping.
 	dataOrFinishEvent    *sync.Cond
-	bufferedResponses    []*storepb.SeriesResponse
-	bufferedResponsesMtx *sync.Mutex
-	lastResp             *storepb.SeriesResponse
 
-	noMoreData  bool
-	initialized bool
+	// bufferedResponsMtx protects all the following fields.
+	bufferedResponsesMtx *sync.Mutex
+	rb                   *ringBuffer
+	initialized          bool
+	noMoreData           bool
+	lastResp             *storepb.SeriesResponse
 
 	shardMatcher *storepb.ShardMatcher
 }
@@ -244,18 +305,18 @@ func (l *lazyRespSet) Empty() bool {
 
 	// NOTE(GiedriusS): need to wait here for at least one
 	// response so that we could build the heap properly.
-	if l.noMoreData && len(l.bufferedResponses) == 0 {
+	if l.noMoreData && l.rb.isEmpty() {
 		return true
 	}
 
-	for len(l.bufferedResponses) == 0 {
+	for l.rb.isEmpty() {
 		l.dataOrFinishEvent.Wait()
-		if l.noMoreData && len(l.bufferedResponses) == 0 {
+		if l.noMoreData && l.rb.isEmpty() {
 			break
 		}
 	}
 
-	return len(l.bufferedResponses) == 0 && l.noMoreData
+	return l.rb.isEmpty() && l.noMoreData
 }
 
 // Next either blocks until more data is available or reads
@@ -267,24 +328,21 @@ func (l *lazyRespSet) Next() bool {
 
 	l.initialized = true
 
-	if l.noMoreData && len(l.bufferedResponses) == 0 {
+	if l.noMoreData && l.rb.isEmpty() {
 		l.lastResp = nil
 
 		return false
 	}
 
-	for len(l.bufferedResponses) == 0 {
+	for l.rb.isEmpty() {
 		l.dataOrFinishEvent.Wait()
-		if l.noMoreData && len(l.bufferedResponses) == 0 {
+		if l.noMoreData && l.rb.isEmpty() {
 			break
 		}
 	}
 
-	if len(l.bufferedResponses) > 0 {
-		l.lastResp = l.bufferedResponses[0]
-		if l.initialized {
-			l.bufferedResponses = l.bufferedResponses[1:]
-		}
+	if !l.rb.isEmpty() {
+		l.lastResp = l.rb.pop()
 		return true
 	}
 
@@ -293,11 +351,25 @@ func (l *lazyRespSet) Next() bool {
 }
 
 func (l *lazyRespSet) At() *storepb.SeriesResponse {
+	// NB: don't need hold l.responsesMtx lock here, because a call site must not call At() and Next() concurrently.
 	if !l.initialized {
 		panic("please call Next before At")
 	}
 
 	return l.lastResp
+}
+
+func (l *lazyRespSet) Close() {
+	l.bufferedResponsesMtx.Lock()
+	defer l.bufferedResponsesMtx.Unlock()
+
+	l.closeSeries()
+	l.rb.close()
+	l.noMoreData = true
+	l.dataOrFinishEvent.Signal()
+
+	l.shardMatcher.Close()
+	_ = l.cl.CloseSend()
 }
 
 func newLazyRespSet(
@@ -310,10 +382,9 @@ func newLazyRespSet(
 	shardMatcher *storepb.ShardMatcher,
 	applySharding bool,
 	emptyStreamResponses prometheus.Counter,
+	fixedBufferSize int,
 ) respSet {
-	bufferedResponses := []*storepb.SeriesResponse{}
 	bufferedResponsesMtx := &sync.Mutex{}
-	dataAvailable := sync.NewCond(bufferedResponsesMtx)
 
 	respSet := &lazyRespSet{
 		frameTimeout:         frameTimeout,
@@ -322,9 +393,11 @@ func newLazyRespSet(
 		cl:                   cl,
 		closeSeries:          closeSeries,
 		span:                 span,
-		dataOrFinishEvent:    dataAvailable,
+		dataOrFinishEvent:    sync.NewCond(bufferedResponsesMtx),
 		bufferedResponsesMtx: bufferedResponsesMtx,
-		bufferedResponses:    bufferedResponses,
+		rb:                   newRingBuffer(fixedBufferSize, bufferedResponsesMtx),
+		initialized:          false,
+		noMoreData:           false,
 		shardMatcher:         shardMatcher,
 	}
 	respSet.storeLabels = make(map[string]struct{})
@@ -378,15 +451,19 @@ func newLazyRespSet(
 				} else {
 					rerr = errors.Wrapf(err, "receive series from %s", st)
 				}
-
 				l.span.SetTag("err", rerr.Error())
 
 				l.bufferedResponsesMtx.Lock()
-				l.bufferedResponses = append(l.bufferedResponses, storepb.NewWarnSeriesResponse(rerr))
+				l.rb.append(storepb.NewWarnSeriesResponse(rerr))
 				l.noMoreData = true
 				l.dataOrFinishEvent.Signal()
 				l.bufferedResponsesMtx.Unlock()
 				return false
+			}
+			if t != nil {
+				// frameTimeout only applies to cl.Recv() gRPC call because the goroutine may be blocked on waiting for an empty buffer slot.
+				// Set the timeout to the largest possible value to avoid triggering it.
+				t.Reset(time.Duration(math.MaxInt64))
 			}
 
 			numResponses++
@@ -401,8 +478,9 @@ func newLazyRespSet(
 			}
 
 			l.bufferedResponsesMtx.Lock()
-			l.bufferedResponses = append(l.bufferedResponses, resp)
-			l.dataOrFinishEvent.Signal()
+			if l.rb.append(resp) {
+				l.dataOrFinishEvent.Signal()
+			}
 			l.bufferedResponsesMtx.Unlock()
 			return true
 		}
@@ -446,6 +524,7 @@ func newAsyncRespSet(
 	shardInfo *storepb.ShardInfo,
 	logger log.Logger,
 	emptyStreamResponses prometheus.Counter,
+	lazyRetrievalMaxBufferedResponses int,
 ) (respSet, error) {
 
 	var (
@@ -458,9 +537,10 @@ func newAsyncRespSet(
 		"target": storeAddr,
 	})
 	span, seriesCtx = tracing.StartSpan(seriesCtx, "proxy.series", tracing.Tags{
-		"store.id":       storeID,
-		"store.is_local": isLocalStore,
-		"store.addr":     storeAddr,
+		"store.id":           storeID,
+		"store.is_local":     isLocalStore,
+		"store.addr":         storeAddr,
+		"retrieval_strategy": retrievalStrategy,
 	})
 
 	seriesCtx, cancel = context.WithCancel(seriesCtx)
@@ -496,6 +576,11 @@ func newAsyncRespSet(
 
 	switch retrievalStrategy {
 	case LazyRetrieval:
+		if lazyRetrievalMaxBufferedResponses < 1 {
+			// Some unit and e2e tests hit this path.
+			lazyRetrievalMaxBufferedResponses = 1
+		}
+
 		return newLazyRespSet(
 			span,
 			frameTimeout,
@@ -506,6 +591,7 @@ func newAsyncRespSet(
 			shardMatcher,
 			applySharding,
 			emptyStreamResponses,
+			lazyRetrievalMaxBufferedResponses,
 		), nil
 	case EagerRetrieval:
 		return newEagerRespSet(
@@ -523,18 +609,6 @@ func newAsyncRespSet(
 	default:
 		panic(fmt.Sprintf("unsupported retrieval strategy %s", retrievalStrategy))
 	}
-}
-
-func (l *lazyRespSet) Close() {
-	l.bufferedResponsesMtx.Lock()
-	defer l.bufferedResponsesMtx.Unlock()
-
-	l.closeSeries()
-	l.noMoreData = true
-	l.dataOrFinishEvent.Signal()
-
-	l.shardMatcher.Close()
-	_ = l.cl.CloseSend()
 }
 
 // eagerRespSet is a SeriesSet that blocks until all data is retrieved from

--- a/pkg/store/proxy_merge.go
+++ b/pkg/store/proxy_merge.go
@@ -230,7 +230,7 @@ type ringBuffer struct {
 	closed            bool
 }
 
-// NB: A call site of any method of ringBuffer must hold the mtx lock
+// NB: A call site of any method of ringBuffer must hold the mtx lock.
 func newRingBuffer(fixedBufferSize int, mtx *sync.Mutex) *ringBuffer {
 	return &ringBuffer{
 		bufferedResponses: make([]*storepb.SeriesResponse, fixedBufferSize+1),

--- a/pkg/store/proxy_test.go
+++ b/pkg/store/proxy_test.go
@@ -1239,7 +1239,7 @@ func TestProxyStore_SeriesSlowStores(t *testing.T) {
 					chunks: [][]sample{{{1, 1}, {2, 2}, {3, 3}}},
 				},
 			},
-			expectedErr: errors.New("rpc error: code = Aborted desc = receive series from test: context deadline exceeded"),
+			expectedErr: errors.New("rpc error: code = Aborted desc = receive series from : context deadline exceeded"),
 		},
 		{
 			title: "partial response enabled; all stores respond 3s",
@@ -1278,12 +1278,16 @@ func TestProxyStore_SeriesSlowStores(t *testing.T) {
 			},
 			expectedSeries: []rawSeries{
 				{
-					lset:   labels.FromStrings("a", "b"),
-					chunks: [][]sample{{{1, 1}, {2, 2}, {3, 3}}},
+					lset: labels.FromStrings("a", "b"),
+					chunks: [][]sample{
+						[]sample{{1, 1}, {2, 2}, {3, 3}},
+					},
 				},
 				{
-					lset:   labels.FromStrings("b", "c"),
-					chunks: [][]sample{{{1, 1}, {2, 2}, {3, 3}}},
+					lset: labels.FromStrings("b", "c"),
+					chunks: [][]sample{
+						[]sample{{1, 1}, {2, 2}, {3, 3}},
+					},
 				},
 			},
 			expectedWarningsLen: 2,

--- a/pkg/store/proxy_test.go
+++ b/pkg/store/proxy_test.go
@@ -1280,13 +1280,13 @@ func TestProxyStore_SeriesSlowStores(t *testing.T) {
 				{
 					lset: labels.FromStrings("a", "b"),
 					chunks: [][]sample{
-						[]sample{{1, 1}, {2, 2}, {3, 3}},
+						{{1, 1}, {2, 2}, {3, 3}},
 					},
 				},
 				{
 					lset: labels.FromStrings("b", "c"),
 					chunks: [][]sample{
-						[]sample{{1, 1}, {2, 2}, {3, 3}},
+						{{1, 1}, {2, 2}, {3, 3}},
 					},
 				},
 			},

--- a/pkg/store/proxy_test.go
+++ b/pkg/store/proxy_test.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
-	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -808,11 +807,6 @@ func TestProxyStore_Series(t *testing.T) {
 func TestProxyStore_SeriesSlowStores(t *testing.T) {
 	t.Parallel()
 
-	enable := os.Getenv("THANOS_ENABLE_STORE_READ_TIMEOUT_TESTS")
-	if enable == "" {
-		t.Skip("enable THANOS_ENABLE_STORE_READ_TIMEOUT_TESTS to run store-read-timeout tests")
-	}
-
 	for _, tc := range []struct {
 		title          string
 		storeAPIs      []Client
@@ -913,7 +907,7 @@ func TestProxyStore_SeriesSlowStores(t *testing.T) {
 				PartialResponseDisabled: true,
 				PartialResponseStrategy: storepb.PartialResponseStrategy_ABORT,
 			},
-			expectedErr: errors.New("rpc error: code = Aborted desc = failed to receive any data in 4s from test: context canceled"),
+			expectedErr: errors.New("rpc error: code = Aborted desc = warning"),
 		},
 		{
 			title: "partial response disabled; 1st store is fast, 2nd store is slow;",
@@ -935,7 +929,7 @@ func TestProxyStore_SeriesSlowStores(t *testing.T) {
 							storepb.NewWarnSeriesResponse(errors.New("warning")),
 							storeSeriesResponse(t, labels.FromStrings("a", "b"), []sample{{1, 1}, {2, 2}, {3, 3}}),
 						},
-						RespDuration: 10 * time.Second,
+						RespDuration: 2 * time.Second,
 					},
 					ExtLset: []labels.Labels{labels.FromStrings("ext", "1")},
 					MinTime: 1,
@@ -1207,21 +1201,13 @@ func TestProxyStore_SeriesSlowStores(t *testing.T) {
 				},
 			},
 			req: &storepb.SeriesRequest{
-				MinTime:  1,
-				MaxTime:  300,
-				Matchers: []storepb.LabelMatcher{{Name: "ext", Value: "1", Type: storepb.LabelMatcher_EQ}},
+				MinTime:                 1,
+				MaxTime:                 300,
+				Matchers:                []storepb.LabelMatcher{{Name: "ext", Value: "1", Type: storepb.LabelMatcher_EQ}},
+				PartialResponseDisabled: true,
+				PartialResponseStrategy: storepb.PartialResponseStrategy_ABORT,
 			},
-			expectedSeries: []rawSeries{
-				{
-					lset:   labels.FromStrings("a", "b"),
-					chunks: [][]sample{{{1, 1}, {2, 2}, {3, 3}}},
-				},
-				{
-					lset:   labels.FromStrings("b", "c"),
-					chunks: [][]sample{{{1, 1}, {2, 2}, {3, 3}}},
-				},
-			},
-			expectedWarningsLen: 3,
+			expectedErr: errors.New("rpc error: code = Aborted desc = warning"),
 		},
 		{
 			title: "partial response disabled; all stores respond 3s",
@@ -1303,6 +1289,10 @@ func TestProxyStore_SeriesSlowStores(t *testing.T) {
 			expectedWarningsLen: 2,
 		},
 	} {
+
+		options := []ProxyStoreOption{
+			WithLazyRetrievalMaxBufferedResponsesForProxy(1),
+		}
 		if ok := t.Run(tc.title, func(t *testing.T) {
 			for _, strategy := range []RetrievalStrategy{EagerRetrieval, LazyRetrieval} {
 				if ok := t.Run(string(strategy), func(t *testing.T) {
@@ -1312,6 +1302,7 @@ func TestProxyStore_SeriesSlowStores(t *testing.T) {
 						component.Query,
 						tc.selectorLabels,
 						4*time.Second, strategy,
+						options...,
 					)
 
 					ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes
<!-- Enumerate changes you made -->
The lazy retrieval strategy, implemented by newLazyRespSet(), has unnecessarily unbounded memory usage.
It proactively (via a dedicated goroutine) and continuously fetches data from the underlying store and appends it to a dynamically growing memory buffer until all time series are fetched. If the call site doesn’t consume time series fast enough, the lazy retrieval strategy retains nearly all fetched series in memory.

This unbounded buffer leads to excessive memory usage in Querier for expensive queries. However, the deduplication function—newLazyRespSet()‘s call site—doesn’t need access to all series at once. Since time series from each store are sorted, the deduplication logic only needs the next series from each store to perform streaming deduplication.

This PR introduces a configurable fixed-size ring buffer to newLazyRespSet(). When the ring buffer is full, the fetching goroutine blocks on a condition variable until a time series is consumed by the call site.


## Verification

### Unit tests
All the unit tests using lazy retrieval strategy automatically uses this new feature with max buffered responses = 1. 

### Battle-tested at Databricks
Databricks has a speciall Querier deployment which only serves series() streaming gRPC calls. This new feature reduces Querier memory usage by 200x.
![image](https://github.com/user-attachments/assets/3f5efa65-a11b-4ebf-9088-1954b185d5fa)

Databricks has a large number of Pantheon Receive deployments and it uses the lazy retrieval strategy by default. This new feature has been running in those deployments for months.

<!-- How you tested it? How do you know it works? -->
