### PR TITLE
[docs] Updating documentation around --compact flags

### DIFF
--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -998,7 +998,7 @@ func (rc *receiveConfig) registerFlag(cmd extkingpin.FlagClause) {
 
 	rc.tsdbOutOfOrderTimeWindow = extkingpin.ModelDuration(cmd.Flag("tsdb.out-of-order.time-window",
 		"[EXPERIMENTAL] Configures the allowed time window for ingestion of out-of-order samples. Disabled (0s) by default"+
-			"Please note if you enable this option and you use compactor, make sure you have the --enable-vertical-compaction flag enabled, otherwise you might risk compactor halt.",
+			"Please note if you enable this option and you use compactor, make sure you have the --compact.enable-vertical-compaction flag enabled, otherwise you might risk compactor halt.",
 	).Default("0s"))
 
 	cmd.Flag("tsdb.out-of-order.cap-max",

--- a/docs/components/receive.md
+++ b/docs/components/receive.md
@@ -594,13 +594,14 @@ Flags:
                                  receive local NTP time + configured duration
                                  due to clock skew in remote write clients.
       --tsdb.out-of-order.time-window=0s
-                                 [EXPERIMENTAL] Configures the allowed time
-                                 window for ingestion of out-of-order samples.
-                                 Disabled (0s) by defaultPlease note if you
-                                 enable this option and you use compactor, make
-                                 sure you have the --enable-vertical-compaction
-                                 flag enabled, otherwise you might risk
-                                 compactor halt.
+                                 [EXPERIMENTAL] Configures the allowed
+                                 time window for ingestion of out-of-order
+                                 samples. Disabled (0s) by defaultPlease
+                                 note if you enable this option and you
+                                 use compactor, make sure you have the
+                                 --compact.enable-vertical-compaction flag
+                                 enabled, otherwise you might risk compactor
+                                 halt.
       --tsdb.out-of-order.cap-max=0
                                  [EXPERIMENTAL] Configures the maximum capacity
                                  for out-of-order chunks (in samples). If set to


### PR DESCRIPTION
Editing the documentation to reflect the correct flag. 

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

* Minor correction to the documentation `--enable-vertical-compaction` -> `--compact.enable-vertical-compaction`

## Verification

* https://github.com/thanos-io/thanos/blob/main/cmd/thanos/compact.go#L268