### PR TITLE
rule: add tsdb.enable-native-histograms flag

### DIFF
--- a/docs/components/rule.md
+++ b/docs/components/rule.md
@@ -503,6 +503,9 @@ Flags:
                                  options for now: promql-experimental-functions
                                  (enables promql experimental functions for
                                  ruler)
+      --[no-]tsdb.enable-native-histograms
+                                 [EXPERIMENTAL] Enables the ingestion of native
+                                 histograms.
       --remote-write.config-file=<file-path>
                                  Path to YAML config for the remote-write
                                  configurations, that specify servers

--- a/test/e2e/e2ethanos/services.go
+++ b/test/e2e/e2ethanos/services.go
@@ -777,6 +777,7 @@ type RulerBuilder struct {
 	evalInterval         string
 	forGracePeriod       string
 	restoreIgnoredLabels []string
+	nativeHistograms     bool
 }
 
 // NewRulerBuilder is a Ruler future that allows extra configuration before initialization.
@@ -824,6 +825,11 @@ func (r *RulerBuilder) WithForGracePeriod(forGracePeriod string) *RulerBuilder {
 
 func (r *RulerBuilder) WithRestoreIgnoredLabels(labels ...string) *RulerBuilder {
 	r.restoreIgnoredLabels = labels
+	return r
+}
+
+func (r *RulerBuilder) WithNativeHistograms() *RulerBuilder {
+	r.nativeHistograms = true
 	return r
 }
 
@@ -892,6 +898,10 @@ func (r *RulerBuilder) initRule(internalRuleDir string, queryCfg []clientconfig.
 			return &e2eobs.Observable{Runnable: e2e.NewFailedRunnable(r.Name(), errors.Wrapf(err, "generate remote write config: %v", remoteWriteCfg))}
 		}
 		ruleArgs["--remote-write.config"] = string(rwCfgBytes)
+	}
+
+	if r.nativeHistograms {
+		ruleArgs["--tsdb.enable-native-histograms"] = ""
 	}
 
 	args := e2e.BuildArgs(ruleArgs)


### PR DESCRIPTION
* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Native histogram has been added in https://github.com/thanos-io/thanos/issues/5907, but ruler needs to use remote write for native histogram aggregation.
This change add flag to enable ruler's tsdb with native histogram.

## Verification

New e2e test has been added.
