### PR TITLE
Add post-release-merge.sh to automate merging release branch into main

### DIFF
--- a/scripts/post-release-merge.sh
+++ b/scripts/post-release-merge.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Usage: ./scripts/post-release-merge.sh release-0.38
+
+set -e
+
+RELEASE_BRANCH="$1"
+
+if [ -z "$RELEASE_BRANCH" ]; then
+  echo "Usage: $0 <release-branch>"
+  exit 1
+fi
+
+echo "Fetching all branches..."
+git fetch --all
+
+echo "Checking out main branch..."
+git checkout main
+
+echo "Merging $RELEASE_BRANCH into main..."
+git merge --no-ff "$RELEASE_BRANCH" -m "Merge $RELEASE_BRANCH into main after release"
+
+echo "Pushing changes to origin..."
+git push origin main
+
+echo "✅ Done: $RELEASE_BRANCH merged into main."


### PR DESCRIPTION
## Summary

This PR adds a shell script `scripts/post-release-merge.sh` to automate merging a release branch (e.g. `release-0.38`) back into the `main` branch after a release is cut. 

This step ensures that the release tag remains reachable from `main`, which is important for tools like `git describe` that rely on linear tag ancestry.

## Motivation

As discussed in issue #8311, the tag for v0.38.0 was not merged back into `main`, leading to issues for downstream tools that rely on release tags being present in the mainline. This script can be run manually (or integrated into a future CI workflow) to fix that gap.

## Usage

```bash
./scripts/post-release-merge.sh release-0.38


<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
