### PR TITLE
docs: update changed repositories links in docs/ to correct location

### DIFF
--- a/docs/components/query.md
+++ b/docs/components/query.md
@@ -114,13 +114,13 @@ Note that deduplication of HA groups is not supported by the `chain` algorithm.
 
 ## Thanos PromQL Engine (experimental)
 
-By default, Thanos querier comes with standard Prometheus PromQL engine. However, when `--query.promql-engine=thanos` is specified, Thanos will use [experimental Thanos PromQL engine](http://github.com/thanos-community/promql-engine) which is a drop-in, efficient implementation of PromQL engine with query planner and optimizers.
+By default, Thanos querier comes with standard Prometheus PromQL engine. However, when `--query.promql-engine=thanos` is specified, Thanos will use [experimental Thanos PromQL engine](http://github.com/thanos-io/promql-engine) which is a drop-in, efficient implementation of PromQL engine with query planner and optimizers.
 
 To learn more, see [the introduction talk](https://youtu.be/pjkWzDVxWk4?t=3609) from [the PromConEU 2022](https://promcon.io/2022-munich/talks/opening-pandoras-box-redesigning/).
 
 This feature is still **experimental** given active development. All queries should be supported due to bulit-in fallback to old PromQL if something is not yet implemented.
 
-For new engine bugs/issues, please use https://github.com/thanos-community/promql-engine GitHub issues.
+For new engine bugs/issues, please use https://github.com/thanos-io/promql-engine GitHub issues.
 
 ### Distributed execution mode
 

--- a/docs/proposals-done/202301-distributed-query-execution.md
+++ b/docs/proposals-done/202301-distributed-query-execution.md
@@ -11,7 +11,7 @@ menu: proposals-accepted
 * https://github.com/thanos-io/thanos/pull/5250
 * https://github.com/thanos-io/thanos/pull/4917
 * https://github.com/thanos-io/thanos/pull/5350
-* https://github.com/thanos-community/promql-engine/issues/25
+* https://github.com/thanos-io/promql-engine/issues/25
 
 ## 2 Why
 
@@ -75,7 +75,7 @@ Keeping PromQL execution in Query components allows for deduplication between Pr
 
 <img src="../img/distributed-execution-proposal-1.png" alt="Distributed query execution" width="400"/>
 
-The initial version of the solution can be found here: https://github.com/thanos-community/promql-engine/pull/139
+The initial version of the solution can be found here: https://github.com/thanos-io/promql-engine/pull/139
 
 ### Query rewrite algorithm
 

--- a/docs/proposals-done/202304-query-path-tenancy.md
+++ b/docs/proposals-done/202304-query-path-tenancy.md
@@ -92,7 +92,7 @@ Enforcing tenancy label in queries:
 
 #### Apply verification and enforcement logic in the Query Frontend instead of Querier.
 
-The Query Frontend is an optional component on any Thanos deployment, while the Querier is always present. Plus, there might be deployments with multiple Querier layers where one or more might need to apply tenant verification and enforcement. On top of this, doing it in the Querier supports future work on using the [new Thanos PromQL engine](https://github.com/thanos-community/promql-engine), which can potentially make the Query Frontend unnecessary.
+The Query Frontend is an optional component on any Thanos deployment, while the Querier is always present. Plus, there might be deployments with multiple Querier layers where one or more might need to apply tenant verification and enforcement. On top of this, doing it in the Querier supports future work on using the [new Thanos PromQL engine](https://github.com/thanos-io/promql-engine), which can potentially make the Query Frontend unnecessary.
 
 #### Add the tenant identification as an optional field in the Store API protobuffer spec instead of an HTTP header.
 

--- a/docs/proposals-rejected/201807-config.md
+++ b/docs/proposals-rejected/201807-config.md
@@ -143,4 +143,4 @@ An alternative to this is to use the existing [hashmod](https://prometheus.io/do
 
 Once a Prometheus instance has been drained and no longer has targets to scrape we will wish to scale down and remove the instance. However, we will need to ensure that the data that is currently in the WAL block but not uploaded to object storage is flushed before we can remove the instance. Failing to do so will mean that any data in the WAL is lost when the Prometheus node is terminated. During this flush period until it is confirmed that the WAL has been uploaded we should still have the Prometheus instance serve requests for the data in the WAL.
 
-See [prometheus/tsdb - Issue 346](https://github.com/prometheus/tsdb/issues/346) for more information.
+See [prometheus/tsdb - Issue 346](https://github.com/prometheus-junkyard/tsdb/issues/346) for more information.


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes
Fixes the CI issues with `make docs`
Updates the the links in `docs/` of repositories which have been moved to different location
<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
`make docs`
