### PR TITLE
Add Retry-After header with backoff and jitter to active-series-limiting and quorum-unavailable responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 
 ### Added
 
+- [#8356](https://github.com/thanos-io/thanos/pull/8356): receive: Add retry-after backoff with jitter via header field to active-series-limiting (429) and quorum-unavailable (503) responses
 - [#8882](https://github.com/thanos-io/thanos/pull/8882) Receive: implement multi-tenant writes; greatly improves throughput when using the split tenant label functionality.
 - [#8876](https://github.com/thanos-io/thanos/pull/8876): Query-Frontend: Reuse compatible lower-step query range cache entries by subsampling cached responses.
 

--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -1152,9 +1152,9 @@ func (rc *receiveConfig) registerFlag(cmd extkingpin.FlagClause) {
 	cmd.Flag("receive.lazy-retrieval-max-buffered-responses", "The lazy retrieval strategy can buffer up to this number of responses. This is to limit the memory usage. This flag takes effect only when the lazy retrieval strategy is enabled.").
 		Default("20").IntVar(&rc.lazyRetrievalMaxBufferedResponses)
 
-	rc.retryAfterBackoff = extkingpin.ModelDuration(cmd.Flag("receive.active-series-limiting.retry-after-backoff", "Backoff duration for the Retry-After header returned on 429 (active-series-limiting exceeded) and 503 (quorum unavailable) responses.").Default("5s"))
+	rc.retryAfterBackoff = extkingpin.ModelDuration(cmd.Flag("receive.retry-after-backoff", "Backoff duration for the Retry-After header returned on 429 (active-series-limiting exceeded) and 503 (quorum unavailable) responses.").Default("5s"))
 
-	cmd.Flag("receive.active-series-limiting.retry-after-jitter", "Fraction of the backoff duration to use as random jitter for the Retry-After header (e.g. 0.5 = ±50%).").Default("0.5").Float64Var(&rc.retryAfterJitter)
+	cmd.Flag("receive.retry-after-jitter", "Fraction of the backoff duration to use as random jitter for the Retry-After header (e.g. 0.5 = ±50%).").Default("0.5").Float64Var(&rc.retryAfterJitter)
 }
 
 // determineMode returns the ReceiverMode that this receiver is configured to run in.

--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -299,6 +299,8 @@ func runReceive(
 		ReplicationProtocol:     receive.ReplicationProtocol(conf.replicationProtocol),
 		OtlpEnableTargetInfo:    conf.otlpEnableTargetInfo,
 		OtlpResourceAttributes:  conf.otlpResourceAttributes,
+		RetryAfterBackoff:       time.Duration(*conf.retryAfterBackoff),
+		RetryAfterJitter:        conf.retryAfterJitter,
 	})
 
 	grpcProbe := prober.NewGRPC()
@@ -912,6 +914,8 @@ type receiveConfig struct {
 	compression         string
 	replicationProtocol string
 	grpcServiceConfig   string
+	retryAfterBackoff   *model.Duration
+	retryAfterJitter    float64
 
 	tsdbMinBlockDuration         *model.Duration
 	tsdbMaxBlockDuration         *model.Duration
@@ -1147,6 +1151,10 @@ func (rc *receiveConfig) registerFlag(cmd extkingpin.FlagClause) {
 
 	cmd.Flag("receive.lazy-retrieval-max-buffered-responses", "The lazy retrieval strategy can buffer up to this number of responses. This is to limit the memory usage. This flag takes effect only when the lazy retrieval strategy is enabled.").
 		Default("20").IntVar(&rc.lazyRetrievalMaxBufferedResponses)
+
+	rc.retryAfterBackoff = extkingpin.ModelDuration(cmd.Flag("receive.active-series-limiting.retry-after-backoff", "Backoff duration for the Retry-After header returned on 429 (active-series-limiting exceeded) and 503 (quorum unavailable) responses.").Default("5s"))
+
+	cmd.Flag("receive.active-series-limiting.retry-after-jitter", "Fraction of the backoff duration to use as random jitter for the Retry-After header (e.g. 0.5 = ±50%).").Default("0.5").Float64Var(&rc.retryAfterJitter)
 }
 
 // determineMode returns the ReceiverMode that this receiver is configured to run in.

--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -1149,9 +1149,9 @@ func (rc *receiveConfig) registerFlag(cmd extkingpin.FlagClause) {
 	cmd.Flag("receive.lazy-retrieval-max-buffered-responses", "The lazy retrieval strategy can buffer up to this number of responses. This is to limit the memory usage. This flag takes effect only when the lazy retrieval strategy is enabled.").
 		Default("20").IntVar(&rc.lazyRetrievalMaxBufferedResponses)
 
-	rc.retryAfterBackoff = extkingpin.ModelDuration(cmd.Flag("receive.active-series-limiting.retry-after-backoff", "Backoff duration for the Retry-After header returned on 429 (active-series-limiting exceeded) and 503 (quorum unavailable) responses.").Default("5s"))
+	rc.retryAfterBackoff = extkingpin.ModelDuration(cmd.Flag("receive.retry-after-backoff", "Backoff duration for the Retry-After header returned on 429 (active-series-limiting exceeded) and 503 (quorum unavailable) responses.").Default("5s"))
 
-	cmd.Flag("receive.active-series-limiting.retry-after-jitter", "Fraction of the backoff duration to use as random jitter for the Retry-After header (e.g. 0.5 = ±50%).").Default("0.5").Float64Var(&rc.retryAfterJitter)
+	cmd.Flag("receive.retry-after-jitter", "Fraction of the backoff duration to use as random jitter for the Retry-After header (e.g. 0.5 = ±50%).").Default("0.5").Float64Var(&rc.retryAfterJitter)
 }
 
 // determineMode returns the ReceiverMode that this receiver is configured to run in.

--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -298,6 +298,8 @@ func runReceive(
 		ReplicationProtocol:     receive.ReplicationProtocol(conf.replicationProtocol),
 		OtlpEnableTargetInfo:    conf.otlpEnableTargetInfo,
 		OtlpResourceAttributes:  conf.otlpResourceAttributes,
+		RetryAfterBackoff:       time.Duration(*conf.retryAfterBackoff),
+		RetryAfterJitter:        conf.retryAfterJitter,
 	})
 
 	grpcProbe := prober.NewGRPC()
@@ -914,6 +916,8 @@ type receiveConfig struct {
 	compression         string
 	replicationProtocol string
 	grpcServiceConfig   string
+	retryAfterBackoff   *model.Duration
+	retryAfterJitter    float64
 
 	tsdbMinBlockDuration         *model.Duration
 	tsdbMaxBlockDuration         *model.Duration
@@ -1144,6 +1148,10 @@ func (rc *receiveConfig) registerFlag(cmd extkingpin.FlagClause) {
 
 	cmd.Flag("receive.lazy-retrieval-max-buffered-responses", "The lazy retrieval strategy can buffer up to this number of responses. This is to limit the memory usage. This flag takes effect only when the lazy retrieval strategy is enabled.").
 		Default("20").IntVar(&rc.lazyRetrievalMaxBufferedResponses)
+
+	rc.retryAfterBackoff = extkingpin.ModelDuration(cmd.Flag("receive.active-series-limiting.retry-after-backoff", "Backoff duration for the Retry-After header returned on 429 (active-series-limiting exceeded) and 503 (quorum unavailable) responses.").Default("5s"))
+
+	cmd.Flag("receive.active-series-limiting.retry-after-jitter", "Fraction of the backoff duration to use as random jitter for the Retry-After header (e.g. 0.5 = ±50%).").Default("0.5").Float64Var(&rc.retryAfterJitter)
 }
 
 // determineMode returns the ReceiverMode that this receiver is configured to run in.

--- a/docs/components/receive.md
+++ b/docs/components/receive.md
@@ -372,7 +372,7 @@ Please see the metric `thanos_receive_forward_delay_seconds` to see if you need 
 
 The following formula is used for calculating quorum:
 
-```go mdox-exec="sed -n '1333,1343p' pkg/receive/handler.go"
+```go mdox-exec="sed -n '1348,1358p' pkg/receive/handler.go"
 // writeQuorum returns minimum number of replicas that has to confirm write success before claiming replication success.
 func (h *Handler) writeQuorum() int {
 	// NOTE(GiedriusS): this is here because otherwise RF=2 doesn't make sense as all writes
@@ -701,5 +701,14 @@ Flags:
                                  this number of responses. This is to limit the
                                  memory usage. This flag takes effect only when
                                  the lazy retrieval strategy is enabled.
+      --receive.active-series-limiting.retry-after-backoff=5s
+                                 Backoff duration for the Retry-After header
+                                 returned on 429 (active-series-limiting
+                                 exceeded) and 503 (quorum unavailable)
+                                 responses.
+      --receive.active-series-limiting.retry-after-jitter=0.5
+                                 Fraction of the backoff duration to use as
+                                 random jitter for the Retry-After header (e.g.
+                                 0.5 = ±50%).
 
 ```

--- a/docs/components/receive.md
+++ b/docs/components/receive.md
@@ -701,12 +701,12 @@ Flags:
                                  this number of responses. This is to limit the
                                  memory usage. This flag takes effect only when
                                  the lazy retrieval strategy is enabled.
-      --receive.active-series-limiting.retry-after-backoff=5s
+      --receive.retry-after-backoff=5s
                                  Backoff duration for the Retry-After header
                                  returned on 429 (active-series-limiting
                                  exceeded) and 503 (quorum unavailable)
                                  responses.
-      --receive.active-series-limiting.retry-after-jitter=0.5
+      --receive.retry-after-jitter=0.5
                                  Fraction of the backoff duration to use as
                                  random jitter for the Retry-After header (e.g.
                                  0.5 = ±50%).

--- a/pkg/receive/handler.go
+++ b/pkg/receive/handler.go
@@ -759,7 +759,7 @@ func (h *Handler) handleV1HTTP(ctx context.Context, w http.ResponseWriter, r *ht
 			responseStatusCode = http.StatusInternalServerError
 		}
 		if responseStatusCode == http.StatusServiceUnavailable {
-			w.Header().Add("Retry-After", time.Now().Add(h.retryAfterDuration()).Format(http.TimeFormat))
+			w.Header().Add("Retry-After", time.Now().UTC().Add(h.retryAfterDuration()).Format(http.TimeFormat))
 		}
 		http.Error(w, err.Error(), responseStatusCode)
 	}
@@ -806,7 +806,7 @@ func (h *Handler) receiveHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// Fail request fully if tenant has exceeded set limit.
 	if !under {
-		w.Header().Add("Retry-After", time.Now().Add(h.retryAfterDuration()).Format(http.TimeFormat))
+		w.Header().Add("Retry-After", time.Now().UTC().Add(h.retryAfterDuration()).Format(http.TimeFormat))
 		http.Error(w, "tenant is above active series limit", http.StatusTooManyRequests)
 		return
 	}

--- a/pkg/receive/handler.go
+++ b/pkg/receive/handler.go
@@ -46,6 +46,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/thanos-io/thanos/internal/cortex/util"
 	"github.com/thanos-io/thanos/pkg/api"
 	statusapi "github.com/thanos-io/thanos/pkg/api/status"
 	"github.com/thanos-io/thanos/pkg/logging"
@@ -128,6 +129,8 @@ type Options struct {
 	ReplicationProtocol     ReplicationProtocol
 	OtlpEnableTargetInfo    bool
 	OtlpResourceAttributes  []string
+	RetryAfterBackoff       time.Duration
+	RetryAfterJitter        float64
 }
 
 // Handler serves a Prometheus remote write receiving HTTP endpoint.
@@ -532,6 +535,15 @@ func newWriteResponse(seriesIDs []int, err error, er endpointReplica) writeRespo
 	}
 }
 
+// retryAfterDuration returns the backoff duration for the Retry-After header,
+// applying jitter when configured. A jitter of 0 returns the plain backoff.
+func (h *Handler) retryAfterDuration() time.Duration {
+	if h.options.RetryAfterJitter <= 0 {
+		return h.options.RetryAfterBackoff
+	}
+	return util.DurationWithJitter(h.options.RetryAfterBackoff, h.options.RetryAfterJitter)
+}
+
 func determineRWVersion(r *http.Request) (int, error) {
 	if r.Header.Get("X-Prometheus-Remote-Write-Version") != "2.0.0" {
 		return 1, nil
@@ -746,6 +758,9 @@ func (h *Handler) handleV1HTTP(ctx context.Context, w http.ResponseWriter, r *ht
 			level.Error(tLogger).Log("err", err, "msg", "internal server error")
 			responseStatusCode = http.StatusInternalServerError
 		}
+		if responseStatusCode == http.StatusServiceUnavailable {
+			w.Header().Add("Retry-After", time.Now().Add(h.retryAfterDuration()).Format(http.TimeFormat))
+		}
 		http.Error(w, err.Error(), responseStatusCode)
 	}
 
@@ -791,6 +806,7 @@ func (h *Handler) receiveHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// Fail request fully if tenant has exceeded set limit.
 	if !under {
+		w.Header().Add("Retry-After", time.Now().Add(h.retryAfterDuration()).Format(http.TimeFormat))
 		http.Error(w, "tenant is above active series limit", http.StatusTooManyRequests)
 		return
 	}
@@ -847,7 +863,6 @@ func (h *Handler) receiveHTTP(w http.ResponseWriter, r *http.Request) {
 	default:
 		panic("unsupported remote_write version")
 	}
-
 }
 
 type requestStats struct {

--- a/pkg/receive/handler_test.go
+++ b/pkg/receive/handler_test.go
@@ -45,6 +45,8 @@ import (
 	"github.com/prometheus/prometheus/tsdb"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/grpc/test/bufconn"
 
 	"github.com/thanos-io/thanos/pkg/block/metadata"
@@ -2408,4 +2410,124 @@ func TestPeerGroupResetRace(t *testing.T) {
 	}()
 
 	wg.Wait()
+}
+
+// fakeAlwaysOverLimitSeriesLimiter is a headSeriesLimiter that always reports the tenant as over limit.
+type fakeAlwaysOverLimitSeriesLimiter struct{}
+
+func (f *fakeAlwaysOverLimitSeriesLimiter) QueryMetaMonitoring(_ context.Context) error { return nil }
+func (f *fakeAlwaysOverLimitSeriesLimiter) isUnderLimit(_ string) (bool, error)         { return false, nil }
+
+// fakeUnavailableRemoteWriteClient is a WriteableStoreAsyncClient that always returns codes.Unavailable.
+type fakeUnavailableRemoteWriteClient struct{}
+
+func (f *fakeUnavailableRemoteWriteClient) RemoteWrite(_ context.Context, _ *storepb.WriteRequest, _ ...grpc.CallOption) (*storepb.WriteResponse, error) {
+	return nil, status.Error(codes.Unavailable, "peer unavailable")
+}
+
+func (f *fakeUnavailableRemoteWriteClient) RemoteWriteAsync(_ context.Context, _ *storepb.WriteRequest, er endpointReplica, seriesIDs []int, responses chan writeResponse, cb func(error)) {
+	err := status.Error(codes.Unavailable, "peer unavailable")
+	responses <- writeResponse{er: er, err: err, seriesIDs: seriesIDs}
+	cb(err)
+}
+
+func (f *fakeUnavailableRemoteWriteClient) Close() error { return nil }
+
+// TestRetryAfterHeaderOnActiveSeriesLimitExceeded verifies that the Retry-After header is set
+// when a tenant exceeds the active-series limit (429 Too Many Requests).
+func TestRetryAfterHeaderOnActiveSeriesLimitExceeded(t *testing.T) {
+	t.Parallel()
+
+	const backoff = 10 * time.Second
+
+	appendable := &fakeAppendable{appender: newFakeAppender(nil, nil, nil)}
+	limiter, err := NewLimiter(extkingpin.NewNopConfig(), nil, RouterIngestor, log.NewNopLogger(), 1*time.Second)
+	require.NoError(t, err)
+
+	h := NewHandler(log.NewNopLogger(), &Options{
+		TenantHeader:      tenancy.DefaultTenantHeader,
+		ReplicaHeader:     DefaultReplicaHeader,
+		ReplicationFactor: 1,
+		ForwardTimeout:    5 * time.Second,
+		Writer:            NewWriter(log.NewNopLogger(), newFakeTenantAppendable(appendable), &WriterOptions{}),
+		Limiter:           limiter,
+		RetryAfterBackoff: backoff,
+		RetryAfterJitter:  0,
+	})
+
+	// Replace the head series limiter with one that always reports over-limit.
+	h.Limiter.headSeriesLimiterMtx.Lock()
+	h.Limiter.headSeriesLimiter = &fakeAlwaysOverLimitSeriesLimiter{}
+	h.Limiter.headSeriesLimiterMtx.Unlock()
+
+	hashring, err := newSimpleHashring([]Endpoint{{Address: "http://localhost:12345"}})
+	require.NoError(t, err)
+	h.Hashring(hashring)
+	h.options.Endpoint = "http://localhost:12345"
+
+	wreq := &prompb.WriteRequest{Timeseries: makeSeriesWithValues(1)}
+	rec, reqErr := makeRequest(h, "test-tenant", wreq)
+	require.NoError(t, reqErr)
+
+	require.Equal(t, http.StatusTooManyRequests, rec.Code)
+	retryAfter := rec.Header().Get("Retry-After")
+	require.NotEmpty(t, retryAfter, "Retry-After header must be set on 429")
+	retryTime, parseErr := http.ParseTime(retryAfter)
+	require.NoError(t, parseErr, "Retry-After header must be a valid HTTP date")
+	require.True(t, retryTime.After(time.Now()), "Retry-After must be in the future")
+}
+
+// TestRetryAfterHeaderOnQuorumUnavailable verifies that the Retry-After header is set
+// when a write fails due to quorum being unavailable (503 Service Unavailable).
+func TestRetryAfterHeaderOnQuorumUnavailable(t *testing.T) {
+	t.Parallel()
+
+	const backoff = 10 * time.Second
+
+	appendables := []*fakeAppendable{
+		{appender: newFakeAppender(nil, nil, nil)},
+		{appender: newFakeAppender(nil, nil, nil)},
+		{appender: newFakeAppender(nil, nil, nil)},
+	}
+
+	handlers, _, closeFunc, err := newTestHandlerHashring("retry_after_quorum_unavailable", appendables, 3, AlgorithmHashmod, false)
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, closeFunc())
+		time.AfterFunc(50*time.Millisecond, func() {
+			for _, hh := range handlers {
+				hh.Close()
+			}
+		})
+	}()
+
+	// Replace every peer connection with a client that always returns codes.Unavailable,
+	// so that quorum (2 out of 3) can never be reached when replicating.
+	unavailableClient := newPeerWorker(&fakeUnavailableRemoteWriteClient{}, prometheus.NewHistogram(prometheus.HistogramOpts{}), 1, 0)
+	for _, hh := range handlers {
+		hh.options.RetryAfterBackoff = backoff
+		hh.options.RetryAfterJitter = 0
+		pg := hh.peers.(*fakePeersGroup)
+		for endpoint := range pg.clients {
+			pg.clients[endpoint] = unavailableClient
+		}
+	}
+
+	wreq := &prompb.WriteRequest{Timeseries: makeSeriesWithValues(1)}
+
+	for i, hh := range handlers {
+		rec, reqErr := makeRequest(hh, "test-tenant", wreq)
+		require.NoError(t, reqErr)
+
+		if rec.Code != http.StatusServiceUnavailable {
+			// Not all nodes will necessarily return 503 (depends on hashing), skip those that don't.
+			continue
+		}
+
+		retryAfter := rec.Header().Get("Retry-After")
+		require.NotEmptyf(t, retryAfter, "handler %d: Retry-After header must be set on 503", i)
+		retryTime, parseErr := http.ParseTime(retryAfter)
+		require.NoErrorf(t, parseErr, "handler %d: Retry-After header must be a valid HTTP date", i)
+		require.Truef(t, retryTime.After(time.Now()), "handler %d: Retry-After must be in the future", i)
+	}
 }

--- a/pkg/receive/handler_test.go
+++ b/pkg/receive/handler_test.go
@@ -45,6 +45,8 @@ import (
 	"github.com/prometheus/prometheus/tsdb"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/grpc/test/bufconn"
 
 	"github.com/thanos-io/thanos/pkg/block/metadata"
@@ -2410,4 +2412,125 @@ func TestPeerGroupResetRace(t *testing.T) {
 	}()
 
 	wg.Wait()
+}
+
+// fakeAlwaysOverLimitSeriesLimiter is a headSeriesLimiter that always reports the tenant as over limit.
+type fakeAlwaysOverLimitSeriesLimiter struct{}
+
+func (f *fakeAlwaysOverLimitSeriesLimiter) QueryMetaMonitoring(_ context.Context) error { return nil }
+func (f *fakeAlwaysOverLimitSeriesLimiter) isUnderLimit(_ string) (bool, error)         { return false, nil }
+
+// fakeUnavailableRemoteWriteClient is a WriteableStoreAsyncClient that always returns codes.Unavailable.
+type fakeUnavailableRemoteWriteClient struct{}
+
+func (f *fakeUnavailableRemoteWriteClient) RemoteWrite(_ context.Context, _ *storepb.WriteRequest, _ ...grpc.CallOption) (*storepb.WriteResponse, error) {
+	return nil, status.Error(codes.Unavailable, "peer unavailable")
+}
+
+func (f *fakeUnavailableRemoteWriteClient) RemoteWriteAsync(_ context.Context, _ *storepb.WriteRequest, er endpointReplica, seriesIDs []int, responses chan writeResponse, cb func(error)) {
+	err := status.Error(codes.Unavailable, "peer unavailable")
+	responses <- writeResponse{er: er, err: err, seriesIDs: seriesIDs}
+	cb(err)
+}
+
+func (f *fakeUnavailableRemoteWriteClient) Close() error { return nil }
+
+// TestRetryAfterHeaderOnActiveSeriesLimitExceeded verifies that the Retry-After header is set
+// when a tenant exceeds the active-series limit (429 Too Many Requests).
+// synctest.Test controls fake time so t.Parallel() is not used.
+func TestRetryAfterHeaderOnActiveSeriesLimitExceeded(t *testing.T) {
+	const backoff = 10 * time.Second
+
+	appendable := &fakeAppendable{appender: newFakeAppender(nil, nil, nil)}
+	limiter, err := NewLimiter(extkingpin.NewNopConfig(), nil, RouterIngestor, log.NewNopLogger(), 1*time.Second)
+	require.NoError(t, err)
+
+	h := NewHandler(log.NewNopLogger(), &Options{
+		TenantHeader:      tenancy.DefaultTenantHeader,
+		ReplicaHeader:     DefaultReplicaHeader,
+		ReplicationFactor: 1,
+		ForwardTimeout:    5 * time.Second,
+		Writer:            NewWriter(log.NewNopLogger(), newFakeTenantAppendable(appendable), &WriterOptions{}),
+		Limiter:           limiter,
+		RetryAfterBackoff: backoff,
+		RetryAfterJitter:  0,
+	})
+
+	// Replace the head series limiter with one that always reports over-limit.
+	h.Limiter.headSeriesLimiterMtx.Lock()
+	h.Limiter.headSeriesLimiter = &fakeAlwaysOverLimitSeriesLimiter{}
+	h.Limiter.headSeriesLimiterMtx.Unlock()
+
+	hashring, err := newSimpleHashring([]Endpoint{{Address: "http://localhost:12345"}})
+	require.NoError(t, err)
+	h.Hashring(hashring)
+	h.options.Endpoint = "http://localhost:12345"
+
+	wreq := &prompb.WriteRequest{Timeseries: makeSeriesWithValues(1)}
+
+	synctest.Test(t, func(t *testing.T) {
+		rec, reqErr := makeRequest(h, "test-tenant", wreq)
+		require.NoError(t, reqErr)
+
+		require.Equal(t, http.StatusTooManyRequests, rec.Code)
+		require.Equal(t, time.Now().UTC().Add(backoff).Format(http.TimeFormat), rec.Header().Get("Retry-After"))
+	})
+}
+
+// TestRetryAfterHeaderOnQuorumUnavailable verifies that the Retry-After header is set
+// when a write fails due to quorum being unavailable (503 Service Unavailable).
+// synctest.Test controls fake time so t.Parallel() is not used.
+func TestRetryAfterHeaderOnQuorumUnavailable(t *testing.T) {
+	const backoff = 10 * time.Second
+
+	appendables := []*fakeAppendable{
+		{appender: newFakeAppender(nil, nil, nil)},
+		{appender: newFakeAppender(nil, nil, nil)},
+		{appender: newFakeAppender(nil, nil, nil)},
+	}
+
+	handlers, _, closeFunc, err := newTestHandlerHashring("retry_after_quorum_unavailable", appendables, 3, AlgorithmHashmod, false)
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, closeFunc())
+		for _, hh := range handlers {
+			hh.Close()
+		}
+	}()
+
+	for _, hh := range handlers {
+		hh.options.RetryAfterBackoff = backoff
+		hh.options.RetryAfterJitter = 0
+	}
+
+	wreq := &prompb.WriteRequest{Timeseries: makeSeriesWithValues(1)}
+
+	synctest.Test(t, func(t *testing.T) {
+		// The peer workers must be created and closed inside the bubble: their
+		// goroutines only exit on Close(), and they pass work over channels that
+		// cannot cross the bubble boundary.
+		unavailableClient := newPeerWorker(&fakeUnavailableRemoteWriteClient{}, prometheus.NewHistogram(prometheus.HistogramOpts{}), 1, 0)
+		t.Cleanup(unavailableClient.wp.Close)
+
+		// Replace every peer connection with a client that always returns codes.Unavailable,
+		// so that quorum (2 out of 3) can never be reached when replicating.
+		for _, hh := range handlers {
+			pg := hh.peers.(*fakePeersGroup)
+			for endpoint := range pg.clients {
+				pg.clients[endpoint] = unavailableClient
+			}
+		}
+
+		for i, hh := range handlers {
+			rec, reqErr := makeRequest(hh, "test-tenant", wreq)
+			require.NoError(t, reqErr)
+
+			if rec.Code != http.StatusServiceUnavailable {
+				// Not all nodes will necessarily return 503 (depends on hashing), skip those that don't.
+				continue
+			}
+
+			require.Equalf(t, time.Now().UTC().Add(backoff).Format(http.TimeFormat), rec.Header().Get("Retry-After"), "handler %d", i)
+		}
+	})
 }


### PR DESCRIPTION
* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

By default, active-series-limiting returns only a `429` when a tenant exceeds the limit, and a quorum failure returns only a `503`. Prometheus [parses the `Retry-After` header natively](https://github.com/prometheus/prometheus/blob/9ec59baffb547e24f1468a53eb82901e58feabd8/storage/remote/client.go#L322-L323). Without it, the sender falls back to its own remote-write backoff, which starts at `MinBackoff` (30ms) and doubles up to [`MaxBackoff` (5s by default)](https://github.com/prometheus/prometheus/blob/9ec59baffb547e24f1468a53eb82901e58feabd8/config/config.go#L239-L240) with no jitter. So the first retries come in fast, and with no jitter many senders that hit the limit at the same moment keep retrying in lockstep, which is what piles load onto an already constrained receiver.

This change sets the `Retry-After` header on:
- `429`: tenant has exceeded the active-series limit (honoured by senders that set `retry_on_http_429`)
- `503`: write quorum cannot be reached (replication unavailable)

Two flags control the behaviour, both with defaults so most users never touch them:
- `--receive.retry-after-backoff` (default `5s`): base backoff duration returned in the `Retry-After` header
- `--receive.retry-after-jitter` (default `0.5`): fraction of the backoff added as random jitter (±50% by default)

Setting jitter to `0` disables randomisation and returns the plain backoff value.

## Verification

Added two unit tests in `pkg/receive/handler_test.go`:

- `TestRetryAfterHeaderOnActiveSeriesLimitExceeded`: wires a `fakeAlwaysOverLimitSeriesLimiter` (always returns `isUnderLimit=false`) into the handler with a `10s` backoff and asserts the response carries HTTP `429` and a `Retry-After` header that is a valid HTTP date in the future.
- `TestRetryAfterHeaderOnQuorumUnavailable`: replaces all peer connections with a `fakeUnavailableRemoteWriteClient` (always returns `codes.Unavailable`) in a 3-node hashring with replication factor 3 so quorum can never be reached, and asserts handlers returning `503` carry a `Retry-After` header that is a valid HTTP date in the future.

Without the change, neither response carries a `Retry-After` header, so senders retry on their own jitter-less backoff and tend to retry in lockstep against a recovering endpoint.