### PR TITLE
docs: Prevent image overflow on quick tutorial page

### DIFF
--- a/docs/quick-tutorial.md
+++ b/docs/quick-tutorial.md
@@ -40,7 +40,7 @@ Deployment with Thanos Sidecar for Kubernetes:
 Source file to copy and edit: https://docs.google.com/drawings/d/1AiMc1qAjASMbtqL6PNs0r9-ynGoZ9LIAtf0b9PjILxw/edit?usp=sharing
 -->
 
-![Sidecar](https://docs.google.com/drawings/d/e/2PACX-1vSJd32gPh8-MC5Ko0-P-v1KQ0Xnxa0qmsVXowtkwVGlczGfVW-Vd415Y6F129zvh3y0vHLBZcJeZEoz/pub?w=960&h=720)
+<img src="https://docs.google.com/drawings/d/e/2PACX-1vSJd32gPh8-MC5Ko0-P-v1KQ0Xnxa0qmsVXowtkwVGlczGfVW-Vd415Y6F129zvh3y0vHLBZcJeZEoz/pub?w=960&h=720" alt="Sidecar" width="100%">
 
 Deployment via Receive in order to scale out or integrate with other remote write-compatible sources:
 
@@ -48,7 +48,7 @@ Deployment via Receive in order to scale out or integrate with other remote writ
 Source file to copy and edit: https://docs.google.com/drawings/d/1iimTbcicKXqz0FYtSfz04JmmVFLVO9BjAjEzBm5538w/edit?usp=sharing
 -->
 
-![Receive](https://docs.google.com/drawings/d/e/2PACX-1vRdYP__uDuygGR5ym1dxBzU6LEx5v7Rs1cAUKPsl5BZrRGVl5YIj5lsD_FOljeIVOGWatdAI9pazbCP/pub?w=960&h=720)
+<img src="https://docs.google.com/drawings/d/e/2PACX-1vRdYP__uDuygGR5ym1dxBzU6LEx5v7Rs1cAUKPsl5BZrRGVl5YIj5lsD_FOljeIVOGWatdAI9pazbCP/pub?w=960&h=720" alt="Receive" width="100%">
 
 ### Sidecar
 


### PR DESCRIPTION
* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

This PR fixes a layout issue on the "Quick Tutorial" page (https://thanos.io/tip/thanos/quick-tutorial.md/) where the architecture diagrams for Sidecar and Receive were overflowing the main content container.

- The images are now constrained within their parent container.
- This ensures the diagrams scale down correctly with the viewport, preventing horizontal scrolling and maintaining the page layout.

## Verification

**Before:**
*(The image overflows the content area, requiring horizontal scroll.)*
<img width="400" alt="quick-tutorial-before" src="https://github.com/user-attachments/assets/bacc3f06-f153-42d7-995e-cf484ebe0e0f" />


**After:**
*(The image now scales down correctly within the content area.)*
<img width="400" alt="quick-tutorial-after" src="https://github.com/user-attachments/assets/9b3ec7e1-98f1-4a95-9c5e-84217c264b0c" />
