### PR TITLE
fix: query announced endpoints match relabel-config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 
 ### Changed
 
+- [#8370](https://github.com/thanos-io/thanos/pull/8370) Query: announced labelset now reflects relabel-config
+
 ### Removed
 
 ### Fixed

--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -553,6 +553,7 @@ func runQuery(
 			tenantCertField,
 			enforceTenancy,
 			tenantLabel,
+			tsdbSelector,
 		)
 
 		api.Register(router.WithPrefix("/api/v1"), tracer, logger, ins, logMiddleware)

--- a/pkg/api/query/v1.go
+++ b/pkg/api/query/v1.go
@@ -1299,21 +1299,19 @@ func (qapi *QueryAPI) stores(_ *http.Request) (interface{}, []error, *api.ApiErr
 		if status.ComponentType == nil {
 			continue
 		}
-		
+
 		// Apply TSDBSelector filtering to LabelSets if selector is configured
 		filteredStatus := status
 		if qapi.tsdbSelector != nil && len(status.LabelSets) > 0 {
 			matches, filteredLabelSets := qapi.tsdbSelector.MatchLabelSets(status.LabelSets...)
 			if !matches {
-				// Skip this endpoint if it doesn't match the TSDBSelector
 				continue
 			}
 			if filteredLabelSets != nil {
-				// Use the filtered label sets if available
 				filteredStatus.LabelSets = filteredLabelSets
 			}
 		}
-		
+
 		statuses[status.ComponentType.String()] = append(statuses[status.ComponentType.String()], filteredStatus)
 	}
 	return statuses, nil, nil, func() {}

--- a/pkg/api/query/v1.go
+++ b/pkg/api/query/v1.go
@@ -111,6 +111,7 @@ type QueryAPI struct {
 
 	replicaLabels  []string
 	endpointStatus func() []query.EndpointStatus
+	tsdbSelector   *store.TSDBSelector
 
 	defaultRangeQueryStep                  time.Duration
 	defaultInstantQueryMaxSourceResolution time.Duration
@@ -160,6 +161,7 @@ func NewQueryAPI(
 	tenantCertField string,
 	enforceTenancy bool,
 	tenantLabel string,
+	tsdbSelector *store.TSDBSelector,
 ) *QueryAPI {
 	if statsAggregatorFactory == nil {
 		statsAggregatorFactory = &store.NoopSeriesStatsAggregatorFactory{}
@@ -195,6 +197,7 @@ func NewQueryAPI(
 		tenantCertField:                        tenantCertField,
 		enforceTenancy:                         enforceTenancy,
 		tenantLabel:                            tenantLabel,
+		tsdbSelector:                           tsdbSelector,
 
 		queryRangeHist: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
 			Name:    "thanos_query_range_requested_timespan_duration_seconds",
@@ -1296,7 +1299,22 @@ func (qapi *QueryAPI) stores(_ *http.Request) (interface{}, []error, *api.ApiErr
 		if status.ComponentType == nil {
 			continue
 		}
-		statuses[status.ComponentType.String()] = append(statuses[status.ComponentType.String()], status)
+		
+		// Apply TSDBSelector filtering to LabelSets if selector is configured
+		filteredStatus := status
+		if qapi.tsdbSelector != nil && len(status.LabelSets) > 0 {
+			matches, filteredLabelSets := qapi.tsdbSelector.MatchLabelSets(status.LabelSets...)
+			if !matches {
+				// Skip this endpoint if it doesn't match the TSDBSelector
+				continue
+			}
+			if filteredLabelSets != nil {
+				// Use the filtered label sets if available
+				filteredStatus.LabelSets = filteredLabelSets
+			}
+		}
+		
+		statuses[status.ComponentType.String()] = append(statuses[status.ComponentType.String()], filteredStatus)
 	}
 	return statuses, nil, nil, func() {}
 }

--- a/pkg/store/acceptance_test.go
+++ b/pkg/store/acceptance_test.go
@@ -1243,102 +1243,51 @@ func TestProxyStoreWithReplicas_Acceptance(t *testing.T) {
 func TestTSDBSelectorFilteringBehavior(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
-
-	// Create two TSDB stores with different tenant labels
-	db1, err := e2eutil.NewTSDB()
-	testutil.Ok(t, err)
-	t.Cleanup(func() { testutil.Ok(t, db1.Close()) })
-
-	db2, err := e2eutil.NewTSDB()
-	testutil.Ok(t, err)
-	t.Cleanup(func() { testutil.Ok(t, db2.Close()) })
-
-	// Add test data to both stores
-	app1 := db1.Appender(ctx)
-	_, err = app1.Append(0, labels.FromStrings("__name__", "test_metric", "job", "test"), 0, 1.0)
-	testutil.Ok(t, err)
-	testutil.Ok(t, app1.Commit())
-
-	app2 := db2.Appender(ctx)
-	_, err = app2.Append(0, labels.FromStrings("__name__", "test_metric", "job", "test"), 0, 2.0)
-	testutil.Ok(t, err)
-	testutil.Ok(t, app2.Commit())
-
-	// Create stores with different tenant labels
-	extLset1 := labels.FromStrings("tenant_id", "team-a", "region", "us-east")
-	extLset2 := labels.FromStrings("tenant_id", "team-b", "region", "us-west")
-
-	store1 := NewTSDBStore(nil, db1, component.Rule, extLset1)
-	store2 := NewTSDBStore(nil, db2, component.Rule, extLset2)
-
-	clients := []Client{
-		storetestutil.TestClient{
-			StoreClient:    storepb.ServerAsClient(store1),
-			ExtLset:        []labels.Labels{extLset1},
-			StoreTSDBInfos: store1.TSDBInfos(),
-		},
-		storetestutil.TestClient{
-			StoreClient:    storepb.ServerAsClient(store2),
-			ExtLset:        []labels.Labels{extLset2},
-			StoreTSDBInfos: store2.TSDBInfos(),
-		},
-	}
-
-	// Create relabel config to keep only tenant_id="team-a"
-	relabelCfgs := []*relabel.Config{{
-		SourceLabels: []model.LabelName{"tenant_id"},
-		Regex:        relabel.MustNewRegexp("team-a"),
-		Action:       relabel.Keep,
-	}}
-
-	proxyStore := NewProxyStore(
-		nil, nil,
-		func() []Client { return clients },
-		component.Query,
-		labels.EmptyLabels(),
-		0*time.Second,
-		RetrievalStrategy(EagerRetrieval),
-		WithTSDBSelector(NewTSDBSelector(relabelCfgs)),
-	)
-
-	// Test 1: TSDBInfos should only return info from team-a store
-	tsdbInfos := proxyStore.TSDBInfos()
-	testutil.Equals(t, 1, len(tsdbInfos), "Should only have one TSDB (team-a)")
-
-	// Verify it's the team-a store
-	found := false
-	for _, info := range tsdbInfos {
-		lbls := info.Labels.Labels
-		for _, label := range lbls {
-			if label.Name == "tenant_id" && label.Value == "team-a" {
-				found = true
-				break
-			}
+	startStore := func(tt *testing.T, extLset labels.Labels, appendFn func(app storage.Appender)) storepb.StoreServer {
+		startNestedStore := func(tt *testing.T, appendFn func(app storage.Appender), extLset labels.Labels) storepb.StoreServer {
+			db, err := e2eutil.NewTSDB()
+			testutil.Ok(tt, err)
+			tt.Cleanup(func() { testutil.Ok(tt, db.Close()) })
+			appendFn(db.Appender(context.Background()))
+			// Create the store with the provided external label sets
+			return NewTSDBStore(nil, db, component.Rule, extLset)
 		}
+
+		extLset1 := labels.NewBuilder(extLset).Set("tenant_id", "team-a").Set("region", "us-east").Labels()
+		extLset2 := labels.NewBuilder(extLset).Set("tenant_id", "team-b").Set("region", "us-west").Labels()
+
+		store1 := startNestedStore(tt, appendFn, extLset1)
+		store2 := startNestedStore(tt, appendFn, extLset2)
+
+		clients := []Client{
+			storetestutil.TestClient{
+				StoreClient: storepb.ServerAsClient(store1),
+				ExtLset:     []labels.Labels{extLset1},
+			},
+			storetestutil.TestClient{
+				StoreClient: storepb.ServerAsClient(store2),
+				ExtLset:     []labels.Labels{extLset2},
+			},
+		}
+
+		// Create relabel config to keep only tenant_id="team-a"
+		relabelCfgs := []*relabel.Config{{
+			SourceLabels: []model.LabelName{"tenant_id"},
+			Regex:        relabel.MustNewRegexp("team-a"),
+			Action:       relabel.Keep,
+		}}
+
+		return NewProxyStore(
+			nil, nil,
+			func() []Client { return clients },
+			component.Query,
+			labels.EmptyLabels(),
+			0*time.Second,
+			RetrievalStrategy(EagerRetrieval),
+			WithTSDBSelector(NewTSDBSelector(relabelCfgs)),
+		)
 	}
-	testutil.Assert(t, found, "Should find team-a in TSDBInfos")
 
-	// Test 2: LabelValues should only return values from team-a
-	labelValuesResp, err := proxyStore.LabelValues(ctx, &storepb.LabelValuesRequest{
-		Label: "tenant_id",
-		Start: 0,
-		End:   1000,
-	})
-	testutil.Ok(t, err)
-	testutil.Equals(t, []string{"team-a"}, labelValuesResp.Values, "Should only return team-a tenant")
+	testStoreAPIsAcceptance(t, startStore)
 
-	// Test 3: Verify filtering works by comparing with unfiltered proxy store
-	proxyStoreNoFilter := NewProxyStore(
-		nil, nil,
-		func() []Client { return clients },
-		component.Query,
-		labels.EmptyLabels(),
-		0*time.Second,
-		RetrievalStrategy(EagerRetrieval),
-		// No TSDBSelector filter
-	)
-	unfiltered := proxyStoreNoFilter.TSDBInfos()
-	testutil.Equals(t, 2, len(unfiltered), "Unfiltered should have both TSDBs")
-	testutil.Equals(t, 1, len(tsdbInfos), "Filtered should have only one TSDB")
 }

--- a/pkg/store/proxy.go
+++ b/pkg/store/proxy.go
@@ -202,21 +202,19 @@ func (s *ProxyStore) LabelSet() []labelpb.ZLabelSet {
 
 	mergedLabelSets := make(map[uint64]labelpb.ZLabelSet, len(stores))
 	for _, st := range stores {
-		// Apply TSDBSelector filtering to each individual label set
 		matches, filteredLabelSets := s.tsdbSelector.MatchLabelSets(st.LabelSets()...)
-		
+
 		if !matches {
 			continue
 		}
-		
-		// Use the filtered label sets if available, otherwise use original
+
 		var labelSetsToProcess []labels.Labels
 		if filteredLabelSets != nil {
 			labelSetsToProcess = filteredLabelSets
 		} else {
 			labelSetsToProcess = st.LabelSets()
 		}
-		
+
 		for _, lset := range labelSetsToProcess {
 			mergedLabelSet := labelpb.ExtendSortedLabels(lset, s.selectorLabels)
 			mergedLabelSets[mergedLabelSet.Hash()] = labelpb.ZLabelSet{Labels: labelpb.ZLabelsFromPromLabels(mergedLabelSet)}
@@ -264,7 +262,6 @@ func (s *ProxyStore) TimeRange() (int64, int64) {
 		}
 	}
 
-	// If no stores match the selector, return the full range as fallback
 	if !hasMatchingStores {
 		return math.MinInt64, math.MaxInt64
 	}


### PR DESCRIPTION
The `--selector.relabel-config flag` was only filtering stores during query execution, but not when announcing available label sets via the Info API or /stores endpoint. This caused a mismatch where:

* Queries correctly returned filtered results
* UI and inter-querier communication showed unfiltered label sets

This happens because ProxyStore's `LabelSet()` method ignored filtered results from `TSDBSelector.MatchLabelSets()` and always included all label sets from matching stores.

In this PR, label set announcements now match the actual queryable data, fixing confusion in multi-tier querier deployments where root queriers would see all tenant labels despite leaf queriers being configured to filter specific tenants.

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

* Apply TSDBSelector filtering consistently in `ProxyStore.LabelSet()` and `TimeRange()`
* Filter `/stores` REST endpoint using same TSDBSelector logic
* Pass TSDBSelector to QueryAPI for UI consistency

## Verification

I have this working in our DEV env. We have a leaf querier that's setup with a hashmod relabel config across our ingester fleet.

> For simplicity, I show this with a `keep` relabel config as well (both work)

```yaml
        - --endpoint=dnssrvnoa+_grpc._tcp.thanos-ingester.thanos.svc.cluster.local
        - |
          - action: keep
            source_labels: [tenant_id]
            regex: sdp
```
We also have a root querier plugged into all leaf querier shards.
```yaml
        - --endpoint=thanos-ingester-querier-0.thanos.svc.cluster.local:10901
        - --endpoint=thanos-ingester-querier-1.thanos.svc.cluster.local:10901
        - --endpoint=thanos-ingester-querier-2.thanos.svc.cluster.local:10901
```

Without the patch, in both the leaf and root queriers, the `/stores` endpoint shows all external labels on every endpoint.

<img width="1676" height="1213" alt="image" src="https://github.com/user-attachments/assets/f7978929-fa9c-4fb5-b47d-79b0f1e543da" />

<img width="1676" height="1213" alt="image" src="https://github.com/user-attachments/assets/f1d03bac-b592-48a6-be1f-511930e49d3f" />

With the patch, the result is more expected:

<img width="1676" height="628" alt="image" src="https://github.com/user-attachments/assets/92290a17-b371-450e-8e2d-b12fe4beaa77" />

<img width="1676" height="517" alt="image" src="https://github.com/user-attachments/assets/e064875d-2230-4f48-8a5b-4c8ba97be2b7" />

