### PR TITLE
CI: Only run docs checks on PRs with documentation changes

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -4,8 +4,14 @@ on:
   push:
     branches:
       - main
+    paths:
+      - "**/*.md"
     tags:
   pull_request:
+    branches:
+      - main
+    paths:
+      - "**/*.md"
 
 permissions:  
   contents: read


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes
Currently, docs checks run on all PRs, causing CI failures even for non doc changes when there are dead links or other doc issues. This change modifies the CI workflow to only trigger docs checks when PRs contain doc changes 

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
