### PR TITLE
block: output cleanup err

### DIFF
--- a/pkg/block/block.go
+++ b/pkg/block/block.go
@@ -169,7 +169,7 @@ func cleanUp(logger log.Logger, bkt objstore.Bucket, id ulid.ULID, err error) er
 	// Cleanup the dir with an uncancelable context.
 	cleanErr := Delete(context.Background(), logger, bkt, id)
 	if cleanErr != nil {
-		return errors.Wrapf(err, "failed to clean block after upload issue. Partial block in system. Err: %s", err.Error())
+		return errors.Wrapf(err, "failed to clean block after upload issue. Partial block in system. Err: %s", cleanErr.Error())
 	}
 	return err
 }


### PR DESCRIPTION
Now, if cleanup fails then we don't know why it failed. Surface the error.
