### PR TITLE
query/receive: trim labelsets from String()

### DIFF
--- a/pkg/query/endpointset.go
+++ b/pkg/query/endpointset.go
@@ -764,8 +764,8 @@ func (er *endpointRef) SupportsWithoutReplicaLabels() bool {
 func (er *endpointRef) String() string {
 	mint, maxt := er.TimeRange()
 	return fmt.Sprintf(
-		"Addr: %s LabelSets: %v MinTime: %d MaxTime: %d",
-		er.addr, labelpb.PromLabelSetsToString(er.LabelSets()), mint, maxt,
+		"Addr: %s MinTime: %d MaxTime: %d",
+		er.addr, mint, maxt,
 	)
 }
 

--- a/pkg/receive/multitsdb.go
+++ b/pkg/receive/multitsdb.go
@@ -248,8 +248,8 @@ func (l *localClient) TSDBInfos() []infopb.TSDBInfo {
 func (l *localClient) String() string {
 	mint, maxt := l.store.TimeRange()
 	return fmt.Sprintf(
-		"LabelSets: %v MinTime: %d MaxTime: %d",
-		labelpb.PromLabelSetsToString(l.LabelSets()), mint, maxt,
+		"MinTime: %d MaxTime: %d",
+		mint, maxt,
 	)
 }
 

--- a/pkg/receive/multitsdb_test.go
+++ b/pkg/receive/multitsdb_test.go
@@ -213,7 +213,7 @@ func testMulitTSDBSeries(t *testing.T, m *MultiTSDB) {
 		for _, s := range ss {
 			s := s
 
-			switch isFoo := strings.Contains(s.String(), "foo"); isFoo {
+			switch isFoo := strings.Contains(labelpb.PromLabelSetsToString(s.LabelSets()), "foo"); isFoo {
 			case true:
 				g.Go(func() error {
 					return getResponses(s, respFoo)


### PR DESCRIPTION
We have lots of tenants & labels so adding them to String() makes the error messages REALLY long and unreadable so I am just suggesting to remove them entirely from String().
