### PR TITLE
compact: ignore blocks with deletion mark in partial deletes

### DIFF
--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -442,7 +442,7 @@ func runCompact(
 			return errors.Wrap(err, "syncing metas")
 		}
 
-		compact.BestEffortCleanAbortedPartialUploads(ctx, logger, sy.Partial(), insBkt, compactMetrics.partialUploadDeleteAttempts, compactMetrics.blocksCleaned, compactMetrics.blockCleanupFailures)
+		compact.BestEffortCleanAbortedPartialUploads(ctx, logger, sy.Partial(), insBkt, compactMetrics.partialUploadDeleteAttempts, compactMetrics.blocksCleaned, compactMetrics.blockCleanupFailures, ignoreDeletionMarkFilter.DeletionMarkBlocks())
 		if err := blocksCleaner.DeleteMarkedBlocks(ctx); err != nil {
 			return errors.Wrap(err, "cleaning marked blocks")
 		}

--- a/cmd/thanos/tools_bucket.go
+++ b/cmd/thanos/tools_bucket.go
@@ -917,7 +917,7 @@ func registerBucketCleanup(app extkingpin.AppClause, objStoreConfig *extflag.Pat
 
 		level.Info(logger).Log("msg", "synced blocks done")
 
-		compact.BestEffortCleanAbortedPartialUploads(ctx, logger, sy.Partial(), insBkt, stubCounter, stubCounter, stubCounter)
+		compact.BestEffortCleanAbortedPartialUploads(ctx, logger, sy.Partial(), insBkt, stubCounter, stubCounter, stubCounter, ignoreDeletionMarkFilter.DeletionMarkBlocks())
 		if err := blocksCleaner.DeleteMarkedBlocks(ctx); err != nil {
 			return errors.Wrap(err, "error cleaning blocks")
 		}

--- a/pkg/compact/clean.go
+++ b/pkg/compact/clean.go
@@ -17,6 +17,7 @@ import (
 	"github.com/thanos-io/objstore"
 
 	"github.com/thanos-io/thanos/pkg/block"
+	"github.com/thanos-io/thanos/pkg/block/metadata"
 )
 
 const (
@@ -61,10 +62,19 @@ func BestEffortCleanAbortedPartialUploads(
 	deleteAttempts prometheus.Counter,
 	blockCleanups prometheus.Counter,
 	blockCleanupFailures prometheus.Counter,
+	deletionMarkBlocks map[ulid.ULID]*metadata.DeletionMark,
 ) {
 	level.Info(logger).Log("msg", "started cleaning of aborted partial uploads")
 
 	for id := range partial {
+		// NOTE(GiedriusS): we start to delete blocks from meta.json so at that point they are marked as partial.
+		// If you have multiple compactor shards then they might try to delete the same block here.
+		// We do not want to delete blocks that are marked for deletion, as they are already scheduled for deletion in the blocks cleaner.
+		if _, ok := deletionMarkBlocks[id]; ok {
+			level.Debug(logger).Log("msg", "ignoring block marked for deletion", "block", id)
+			continue
+		}
+
 		lastModifiedTime, err := getOldestModifiedTime(ctx, id, bkt)
 		if err != nil {
 			level.Warn(logger).Log("msg", "failed to get last modified time for block; falling back to block creation time", "block", id, "err", err)


### PR DESCRIPTION
Blocks deletion always starts with meta.json so if there are multiple shards of the compactor then one shard can also start to try to delete the same block because it detects them as partial. Hence, ignore deletion marks in the partial block cleaning function because blocks with deletion mark as handled in the other flow.
