### PR TITLE
refactor: chown on COPY in Dockerfile to reduce image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,13 +3,13 @@ ARG BASE_DOCKER_SHA="14d68ca3d69fceaa6224250c83d81d935c053fb13594c811038c4611945
 FROM quay.io/prometheus/busybox@sha256:${BASE_DOCKER_SHA}
 LABEL maintainer="The Thanos Authors"
 
-COPY /thanos_tmp_for_docker /bin/thanos
-
 RUN adduser \
     -D `#Dont assign a password` \
     -H `#Dont create home directory` \
     -u 1001 `#User id`\
-    thanos && \
-    chown thanos /bin/thanos
+    thanos
+
+COPY --chown=thanos /thanos_tmp_for_docker /bin/thanos
+
 USER 1001
 ENTRYPOINT [ "/bin/thanos" ]


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

Modified the Dockerfile to perform the chown when copying the Thanos binary into the image. This reduces the image size by a significant amount, from 244 MB to 141 MB.

We just migrated away from the to-be💵images provided by Bitnami/Broadcom, and I was a bit surprised by the difference in image size between the official Thanos image and the bitnami/thanos image.

## Verification

<!-- How you tested it? How do you know it works? -->

I ran `make docker` and verified that the image built starts as normal.