### PR TITLE
Thanos deduplication fix to correct inflated values when rate/increas…

### DIFF
--- a/pkg/dedup/iter_test.go
+++ b/pkg/dedup/iter_test.go
@@ -272,7 +272,7 @@ func TestOverlapSplitSet(t *testing.T) {
 		},
 	}
 
-	got := toChunkedSeriesSlice(t, NewOverlapSplit(newChunkedSeriesSet(input)))
+	got := toChunkedSeriesSlice(t, NewOverlapSplit(newChunkedSeriesSet(input), ""))
 	testutil.Equals(t, exp, got)
 }
 

--- a/pkg/query/querier.go
+++ b/pkg/query/querier.go
@@ -382,7 +382,7 @@ func (q *querier) selectFn(ctx context.Context, hints *storage.SelectHints, ms .
 	// This however require big refactor, caring about correct AggrChunk to iterator conversion and counter reset apply.
 	// For now we apply simple logic that splits potential overlapping chunks into separate replica series, so we can split the work.
 	set := NewPromSeriesSet(
-		dedup.NewOverlapSplit(newStoreSeriesSet(resp.seriesSet)),
+		dedup.NewOverlapSplit(newStoreSeriesSet(resp.seriesSet), hints.Func),
 		q.mint,
 		q.maxt,
 		aggrs,


### PR DESCRIPTION
Thanos deduplication fix to correct inflated values when rate/increase/irate functions used over counter metrics across prometheus HA replicas when deduplication is enabled

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Changes are made in overlapSplitSet Next function to filter out the prometheus replica/instance counter metric value whenever lower timestamps has higher values. The issue is explained in detail in https://github.com/thanos-io/thanos/issues/7623

Most of the chunks from different replicas are merged and few leftover separate chunks are returned from loser tree and the separate non merged chunks when fed to dedup.NewSeriesSet in querier.go doesn't have any effect. Hence the changes are made in dedup.NewOverlapSplit to filter out samples which has higher values at lower timestamps

Note: Current dedup bug was resulting in many false alerts breaching the treshold and hence it is very important to fix the dedup bug ASAP

## Verification

Tests are being performed. Before this change rate function was returning result of 1200 for below samples. When the fix is applied rate function only result in 0.46 which is accurate

Dedup issue

304528 1731358720.447
304530 1731358725.97
304532 1731358750.447
304536 1731358780.447
304540 1731358810.447
304543 1731358816.021 -- This sample has been filtered after fix
304542 1731358816.028

replica 0
304531 1731358726.028
304535 1731358756.028
304539 1731358786.028
304542 1731358816.028

replica 1
304530 1731358725.97
304534 1731358755.97
304538 1731358785.97
304543 1731358816.021

replica 2
304528 1731358720.447
304532 1731358750.447
304536 1731358780.447
304540 1731358810.447

Please review the changes
