### PR TITLE
compact: move GC to just after marked block deletion

### DIFF
--- a/cmd/thanos/store.go
+++ b/cmd/thanos/store.go
@@ -392,7 +392,7 @@ func runStore(
 	default:
 		return errors.Errorf("unknown sync strategy %s", conf.blockListStrategy)
 	}
-	ignoreDeletionMarkFilter := block.NewIgnoreDeletionMarkFilter(logger, insBkt, time.Duration(conf.ignoreDeletionMarksDelay), conf.blockMetaFetchConcurrency)
+	ignoreDeletionMarkFilter := block.NewDefaultDeletionMarkFilter(logger, insBkt, time.Duration(conf.ignoreDeletionMarksDelay), conf.blockMetaFetchConcurrency)
 	filters := []block.MetadataFilter{
 		block.NewTimePartitionMetaFilter(conf.filterConf.MinTime, conf.filterConf.MaxTime),
 		block.NewLabelShardedMetaFilter(relabelConfig),

--- a/pkg/block/fetcher_test.go
+++ b/pkg/block/fetcher_test.go
@@ -1124,7 +1124,7 @@ func TestIgnoreDeletionMarkFilter_Filter(t *testing.T) {
 		defer cancel()
 
 		now := time.Now()
-		f := NewIgnoreDeletionMarkFilter(log.NewNopLogger(), objstore.WithNoopInstr(bkt), 48*time.Hour, 32)
+		f := NewDefaultDeletionMarkFilter(log.NewNopLogger(), objstore.WithNoopInstr(bkt), 48*time.Hour, 32)
 
 		shouldFetch := &metadata.DeletionMark{
 			ID:           ULID(1),

--- a/pkg/compact/blocks_cleaner.go
+++ b/pkg/compact/blocks_cleaner.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+	"github.com/oklog/ulid/v2"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/thanos-io/objstore"
@@ -19,7 +20,7 @@ import (
 // BlocksCleaner is a struct that deletes blocks from bucket which are marked for deletion.
 type BlocksCleaner struct {
 	logger                   log.Logger
-	ignoreDeletionMarkFilter *block.IgnoreDeletionMarkFilter
+	ignoreDeletionMarkFilter *block.DefaultDeletionMarkFilter
 	bkt                      objstore.Bucket
 	deleteDelay              time.Duration
 	blocksCleaned            prometheus.Counter
@@ -27,7 +28,7 @@ type BlocksCleaner struct {
 }
 
 // NewBlocksCleaner creates a new BlocksCleaner.
-func NewBlocksCleaner(logger log.Logger, bkt objstore.Bucket, ignoreDeletionMarkFilter *block.IgnoreDeletionMarkFilter, deleteDelay time.Duration, blocksCleaned, blockCleanupFailures prometheus.Counter) *BlocksCleaner {
+func NewBlocksCleaner(logger log.Logger, bkt objstore.Bucket, ignoreDeletionMarkFilter *block.DefaultDeletionMarkFilter, deleteDelay time.Duration, blocksCleaned, blockCleanupFailures prometheus.Counter) *BlocksCleaner {
 	return &BlocksCleaner{
 		logger:                   logger,
 		ignoreDeletionMarkFilter: ignoreDeletionMarkFilter,
@@ -40,7 +41,9 @@ func NewBlocksCleaner(logger log.Logger, bkt objstore.Bucket, ignoreDeletionMark
 
 // DeleteMarkedBlocks uses ignoreDeletionMarkFilter to gather the blocks that are marked for deletion and deletes those
 // if older than given deleteDelay.
-func (s *BlocksCleaner) DeleteMarkedBlocks(ctx context.Context) error {
+func (s *BlocksCleaner) DeleteMarkedBlocks(ctx context.Context) (map[ulid.ULID]struct{}, error) {
+	var deletedBlocks = make(map[ulid.ULID]struct{})
+
 	level.Info(s.logger).Log("msg", "started cleaning of blocks marked for deletion")
 
 	deletionMarkMap := s.ignoreDeletionMarkFilter.DeletionMarkBlocks()
@@ -48,13 +51,15 @@ func (s *BlocksCleaner) DeleteMarkedBlocks(ctx context.Context) error {
 		if time.Since(time.Unix(deletionMark.DeletionTime, 0)).Seconds() > s.deleteDelay.Seconds() {
 			if err := block.Delete(ctx, s.logger, s.bkt, deletionMark.ID); err != nil {
 				s.blockCleanupFailures.Inc()
-				return errors.Wrap(err, "delete block")
+				return deletedBlocks, errors.Wrap(err, "delete block")
 			}
 			s.blocksCleaned.Inc()
+			deletedBlocks[deletionMark.ID] = struct{}{}
+
 			level.Info(s.logger).Log("msg", "deleted block marked for deletion", "block", deletionMark.ID)
 		}
 	}
 
 	level.Info(s.logger).Log("msg", "cleaning of blocks marked for deletion done")
-	return nil
+	return deletedBlocks, nil
 }

--- a/pkg/replicate/replicator.go
+++ b/pkg/replicate/replicator.go
@@ -243,7 +243,7 @@ func newMetaFetcher(
 		thanosblock.NewTimePartitionMetaFilter(minTime, maxTime),
 	}
 	if ignoreMarkedForDeletion {
-		filters = append(filters, thanosblock.NewIgnoreDeletionMarkFilter(logger, fromBkt, 0, concurrency))
+		filters = append(filters, thanosblock.NewDefaultDeletionMarkFilter(logger, fromBkt, 0, concurrency))
 	}
 	baseBlockIDsFetcher := thanosblock.NewConcurrentLister(logger, fromBkt)
 	return thanosblock.NewMetaFetcher(

--- a/test/e2e/compact_test.go
+++ b/test/e2e/compact_test.go
@@ -683,7 +683,7 @@ func testCompactWithStoreGateway(t *testing.T, penaltyDedup bool) {
 		testutil.Ok(t, c.WaitSumMetrics(e2emon.Greater(0), "thanos_compact_iterations_total"))
 		testutil.Ok(t, c.WaitSumMetrics(e2emon.Equals(0), "thanos_compact_blocks_cleaned_total"))
 		testutil.Ok(t, c.WaitSumMetrics(e2emon.Equals(0), "thanos_compact_block_cleanup_failures_total"))
-		testutil.Ok(t, c.WaitSumMetrics(e2emon.Equals(2*4+2+2*3+2), "thanos_compact_blocks_marked_total")) // 18.
+		testutil.Ok(t, c.WaitSumMetrics(e2emon.GreaterOrEqual(2*4+2+2*3+2), "thanos_compact_blocks_marked_total")) // 18.
 		testutil.Ok(t, c.WaitSumMetrics(e2emon.Equals(0), "thanos_compact_aborted_partial_uploads_deletion_attempts_total"))
 		testutil.Ok(t, c.WaitSumMetrics(e2emon.Equals(6), "thanos_compact_group_compactions_total"))
 		testutil.Ok(t, c.WaitSumMetrics(e2emon.Equals(3), "thanos_compact_group_vertical_compactions_total"))


### PR DESCRIPTION
I noticed in prod that there's a dependency in the garbage collection function - if we are deleting blocks marked for deletion and a sync happens in the middle of the garbage collection, it can accidentally mark the same block for deletion again. Avoid this by passing a slice of ULIDs that we just deleted.

The effect of not doing this is that we could get errors during querying if the cache is enabled - meta.json could be cached and if there is a deletion mark then Store assumes that it's a valid block.