### PR TITLE
query: remove unused replica labels map in querier

### DIFF
--- a/pkg/query/querier.go
+++ b/pkg/query/querier.go
@@ -173,10 +173,6 @@ func newQuerier(
 	if logger == nil {
 		logger = log.NewNopLogger()
 	}
-	rl := make(map[string]struct{})
-	for _, replicaLabel := range replicaLabels {
-		rl[replicaLabel] = struct{}{}
-	}
 
 	partialResponseStrategy := storepb.PartialResponseStrategy_ABORT
 	if partialResponse {


### PR DESCRIPTION
* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

Remove unused local variable `rl` in newQuerier function that was creating a map from replicaLabels but never being used.