### PR TITLE
*: Restore certain omitempty tags after modernize

### DIFF
--- a/internal/cortex/querier/queryrange/util.go
+++ b/internal/cortex/querier/queryrange/util.go
@@ -41,7 +41,7 @@ func DoRequests(ctx context.Context, downstream Handler, reqs []Request, limits 
 
 	respChan, errChan := make(chan RequestResponse), make(chan error)
 	parallelism := min(validation.SmallestPositiveIntPerTenant(tenantIDs, limits.MaxQueryParallelism), len(reqs))
-	for i := 0; i < parallelism; i++ {
+	for range parallelism {
 		go func() {
 			for req := range intermediate {
 				resp, err := downstream.Do(ctx, req)

--- a/pkg/api/query/v1.go
+++ b/pkg/api/query/v1.go
@@ -251,7 +251,7 @@ type queryData struct {
 	Result     parser.Value     `json:"result"`
 	Stats      stats.QueryStats `json:"stats,omitempty"`
 	// Additional Thanos Response field.
-	QueryAnalysis queryTelemetry `json:"analysis"`
+	QueryAnalysis queryTelemetry `json:"analysis,omitempty"`
 	Warnings      []error        `json:"warnings,omitempty"`
 }
 

--- a/pkg/block/metadata/meta.go
+++ b/pkg/block/metadata/meta.go
@@ -100,14 +100,14 @@ type Thanos struct {
 	Rewrites []Rewrite `json:"rewrites,omitempty"`
 
 	// IndexStats contains stats info related to block index.
-	IndexStats IndexStats `json:"index_stats"`
+	IndexStats IndexStats `json:"index_stats,omitempty"`
 
 	// Extensions are used for plugin any arbitrary additional information for block. Optional.
 	Extensions any `json:"extensions,omitempty"`
 
 	// UploadTime is used to track when the meta.json file was uploaded to the object storage
 	// without an extra Attributes call. Used for consistency filter.
-	UploadTime time.Time `json:"upload_time"`
+	UploadTime time.Time `json:"upload_time,omitempty"`
 }
 
 type IndexStats struct {

--- a/pkg/receive/config.go
+++ b/pkg/receive/config.go
@@ -124,9 +124,9 @@ type HashringConfig struct {
 	TenantMatcherType tenantMatcher     `json:"tenant_matcher_type,omitempty"`
 	Endpoints         []Endpoint        `json:"endpoints"`
 	Algorithm         HashringAlgorithm `json:"algorithm,omitempty"`
-	ExternalLabels    labels.Labels     `json:"external_labels"`
+	ExternalLabels    labels.Labels     `json:"external_labels,omitempty"`
 	// If non-zero then enable shuffle sharding.
-	ShuffleShardingConfig ShuffleShardingConfig `json:"shuffle_sharding_config"`
+	ShuffleShardingConfig ShuffleShardingConfig `json:"shuffle_sharding_config,omitempty"`
 }
 
 type ShuffleShardingOverrideConfig struct {


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

We do not want these changes from modernize I think.

To run modernize in the future without omitempty changes `go run golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest -category=-omitzero -fix -test ./...`

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
