### PR TITLE
compact: ensure we don't mark blocks for deletion again

### DIFF
--- a/cmd/thanos/tools_bucket.go
+++ b/cmd/thanos/tools_bucket.go
@@ -918,7 +918,7 @@ func registerBucketCleanup(app extkingpin.AppClause, objStoreConfig *extflag.Pat
 		level.Info(logger).Log("msg", "synced blocks done")
 
 		compact.BestEffortCleanAbortedPartialUploads(ctx, logger, sy.Partial(), insBkt, stubCounter, stubCounter, stubCounter, ignoreDeletionMarkFilter.DeletionMarkBlocks())
-		if err := blocksCleaner.DeleteMarkedBlocks(ctx); err != nil {
+		if _, err := blocksCleaner.DeleteMarkedBlocks(ctx); err != nil {
 			return errors.Wrap(err, "error cleaning blocks")
 		}
 

--- a/pkg/compact/compact_e2e_test.go
+++ b/pkg/compact/compact_e2e_test.go
@@ -113,7 +113,7 @@ func TestSyncer_GarbageCollect_e2e(t *testing.T) {
 
 		// Do one initial synchronization with the bucket.
 		testutil.Ok(t, sy.SyncMetas(ctx))
-		testutil.Ok(t, sy.GarbageCollect(ctx))
+		testutil.Ok(t, sy.GarbageCollect(ctx, nil))
 
 		var rem []ulid.ULID
 		err = bkt.Iter(ctx, "", func(n string) error {
@@ -140,7 +140,7 @@ func TestSyncer_GarbageCollect_e2e(t *testing.T) {
 
 		// After another sync the changes should also be reflected in the local groups.
 		testutil.Ok(t, sy.SyncMetas(ctx))
-		testutil.Ok(t, sy.GarbageCollect(ctx))
+		testutil.Ok(t, sy.GarbageCollect(ctx, nil))
 
 		// Only the level 3 block, the last source block in both resolutions should be left.
 		grouper := NewDefaultGrouper(nil, bkt, false, false, nil, blocksMarkedForDeletion, garbageCollectedBlocks, blockMarkedForNoCompact, metadata.NoneFunc, 10, 10)
@@ -492,7 +492,7 @@ func TestGarbageCollectDoesntCreateEmptyBlocksWithDeletionMarksOnly(t *testing.T
 
 		// Do one initial synchronization with the bucket.
 		testutil.Ok(t, sy.SyncMetas(ctx))
-		testutil.Ok(t, sy.GarbageCollect(ctx))
+		testutil.Ok(t, sy.GarbageCollect(ctx, nil))
 		testutil.Equals(t, 2.0, promtest.ToFloat64(garbageCollectedBlocks))
 
 		rem, err := listBlocksMarkedForDeletion(ctx, bkt)
@@ -511,7 +511,7 @@ func TestGarbageCollectDoesntCreateEmptyBlocksWithDeletionMarksOnly(t *testing.T
 
 		// After another garbage-collect, we should not find new blocks that are deleted with new deletion mark files.
 		testutil.Ok(t, sy.SyncMetas(ctx))
-		testutil.Ok(t, sy.GarbageCollect(ctx))
+		testutil.Ok(t, sy.GarbageCollect(ctx, nil))
 
 		rem, err = listBlocksMarkedForDeletion(ctx, bkt)
 		testutil.Ok(t, err)

--- a/pkg/compact/compact_test.go
+++ b/pkg/compact/compact_test.go
@@ -631,8 +631,6 @@ func TestNoMarkFilterAtomic(t *testing.T) {
 }
 
 func TestGarbageCollect_FilterRace(t *testing.T) {
-	t.Skip("expected to fail")
-
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 	t.Cleanup(cancel)
 
@@ -642,16 +640,20 @@ func TestGarbageCollect_FilterRace(t *testing.T) {
 	metaParent.Version = 1
 	metaParent.ULID = ulid.MustNew(uint64(0), nil)
 
+	children := []ulid.ULID{
+		ulid.MustNew(uint64(1), nil), ulid.MustNew(uint64(2), nil), ulid.MustNew(uint64(3), nil),
+	}
+	metaParent.Compaction.Sources = children
+
 	var buf bytes.Buffer
 	testutil.Ok(t, json.NewEncoder(&buf).Encode(&metaParent))
 	testutil.Ok(t, bkt.Upload(ctx, path.Join(metaParent.ULID.String(), metadata.MetaFilename), &buf))
 
 	createBlocks := func() {
-		for i := 1; i <= 3; i++ {
+		for _, ch := range children {
 			var metaChild metadata.Meta
 			metaChild.Version = 1
-			metaChild.ULID = ulid.MustNew(uint64(i), nil)
-			metaChild.Compaction.Sources = []ulid.ULID{metaParent.ULID}
+			metaChild.ULID = ch
 
 			var buf bytes.Buffer
 			testutil.Ok(t, json.NewEncoder(&buf).Encode(&metaChild))
@@ -698,37 +700,27 @@ func TestGarbageCollect_FilterRace(t *testing.T) {
 		testutil.Equals(t, float64(0.0), promtestutil.ToFloat64(garbageCollection))
 
 		createBlocks()
-		testutil.Ok(t, block.MarkForDeletion(context.Background(), log.NewNopLogger(), objstore.WithNoopInstr(bkt), ulid.MustNew(1, nil), "foo", promauto.With(prometheus.NewRegistry()).NewCounter(
-			prometheus.CounterOpts{Name: "test_block_marked_for_deletion"},
-		)))
-		testutil.Ok(t, block.MarkForDeletion(context.Background(), log.NewNopLogger(), objstore.WithNoopInstr(bkt), ulid.MustNew(2, nil), "foo", promauto.With(prometheus.NewRegistry()).NewCounter(
-			prometheus.CounterOpts{Name: "test_block_marked_for_deletion"},
-		)))
-		testutil.Ok(t, block.MarkForDeletion(context.Background(), log.NewNopLogger(), objstore.WithNoopInstr(bkt), ulid.MustNew(3, nil), "foo", promauto.With(prometheus.NewRegistry()).NewCounter(
-			prometheus.CounterOpts{Name: "test_block_marked_for_deletion"},
-		)))
+		for _, ch := range children {
+			testutil.Ok(t, block.MarkForDeletion(context.Background(), log.NewNopLogger(), objstore.WithNoopInstr(bkt), ch, "foo", promauto.With(prometheus.NewRegistry()).NewCounter(
+				prometheus.CounterOpts{Name: "test_block_marked_for_deletion"},
+			)))
+		}
 		testutil.Ok(t, syncer.SyncMetas(context.Background()))
 
 		startWg := &sync.WaitGroup{}
 		startWg.Add(1)
 
 		wg := &sync.WaitGroup{}
-		wg.Add(3)
+		wg.Add(2)
 
 		go func() {
 			defer wg.Done()
 			startWg.Wait()
 			r := rand.Uint32N(20)
 			time.Sleep(time.Duration(r) * time.Millisecond)
-			testutil.Ok(t, syncer.GarbageCollect(context.Background()))
-		}()
-
-		go func() {
-			defer wg.Done()
-			startWg.Wait()
-			r := rand.Uint32N(20)
-			time.Sleep(time.Duration(r) * time.Millisecond)
-			testutil.Ok(t, blocksCleaner.DeleteMarkedBlocks(context.Background()))
+			deleted, err := blocksCleaner.DeleteMarkedBlocks(context.Background())
+			testutil.Ok(t, err)
+			testutil.Ok(t, syncer.GarbageCollect(context.Background(), deleted))
 		}()
 
 		go func() {


### PR DESCRIPTION
Fix #8442 by not marking blocks for deletion again if they were just deleted.
