### PR TITLE
feat(compact): Add Pushgateway metrics support for one-shot runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 
 ### Added
 
+- [#8488](https://github.com/thanos-io/thanos/pull/8488) Compact: Add ability to push metrics to a Pushgateway for one-shot runs, including metrics for failed runs.
 - [#8366](https://github.com/thanos-io/thanos/pull/8366) Store: optionally ignore Parquet migrated blocks
 - [#8359](https://github.com/thanos-io/thanos/pull/8359) Tools: add `--shipper.upload-compacted` flag for uploading compacted blocks to bucket upload-blocks
 


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

This change introduces the ability for the `thanos compact` command to
push its metrics to a Prometheus Pushgateway when running in one-shot
mode (without the `--wait` flag).

This is particularly useful for monitoring the compactor when it is run
as a periodic batch job, such as a cron job.

The following changes have been made:
- Refactored progress metric calculation to run in one-shot mode.
- Added `--push-gateway.url` and `--push-gateway.job` flags to configure
the Pushgateway endpoint and job name.
- Implemented the logic to push all registered metrics upon successful
completion of a one-shot compaction run.

## Verification

I've tested the metrics availability in the --wait mode and with a Pushgateway.