### PR TITLE
receive: recycle capnp peers on timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 
 ## Unreleased
 
+### Fixed
+
+- Receive: recycle Cap'n Proto remote write peers on timeouts to heal stale connections.
+
 ## [v0.40.0](https://github.com/thanos-io/thanos/tree/release-0.40) - 2025 10 20 (in progress)
 
 ### Fixed

--- a/pkg/receive/writecapnp/client_test.go
+++ b/pkg/receive/writecapnp/client_test.go
@@ -1,0 +1,100 @@
+package writecapnp
+
+import (
+	"context"
+	"errors"
+	"net"
+	"sync"
+	"testing"
+
+	"capnproto.org/go/capnp/v3"
+	"capnproto.org/go/capnp/v3/rpc"
+	"github.com/go-kit/log"
+
+	"github.com/efficientgo/core/testutil"
+
+	"github.com/thanos-io/thanos/pkg/store/storepb"
+)
+
+type writerFunc func(context.Context, Writer_write) error
+
+func (w writerFunc) Write(ctx context.Context, call Writer_write) error {
+	return w(ctx, call)
+}
+
+func newPipeConn(t *testing.T, server Writer_Server) (net.Conn, func()) {
+	t.Helper()
+
+	serverConn, clientConn := net.Pipe()
+	done := make(chan struct{})
+
+	go func() {
+		writerClient := Writer_ServerToClient(server)
+		rpcConn := rpc.NewConn(rpc.NewPackedStreamTransport(serverConn), &rpc.Options{
+			BootstrapClient: capnp.Client(writerClient).AddRef(),
+		})
+		<-rpcConn.Done()
+		writerClient.Release()
+		close(done)
+	}()
+
+	cleanup := func() {
+		_ = clientConn.Close()
+		<-done
+	}
+
+	return clientConn, cleanup
+}
+
+type sequenceDialer struct {
+	mu     sync.Mutex
+	conns  []net.Conn
+	clean  []func()
+	dialed int
+}
+
+func (d *sequenceDialer) Dial() (net.Conn, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if len(d.conns) == 0 {
+		return nil, errors.New("no more connections")
+	}
+	conn := d.conns[0]
+	d.conns = d.conns[1:]
+	d.dialed++
+	return conn, nil
+}
+
+func (d *sequenceDialer) cleanup() {
+	for _, c := range d.clean {
+		c()
+	}
+}
+
+func TestRemoteWriteClientReconnectsOnDeadline(t *testing.T) {
+	t.Parallel()
+
+	firstConn, firstCleanup := newPipeConn(t, writerFunc(func(ctx context.Context, call Writer_write) error {
+		call.Go()
+		return context.DeadlineExceeded
+	}))
+	secondConn, secondCleanup := newPipeConn(t, writerFunc(func(ctx context.Context, call Writer_write) error {
+		call.Go()
+		_, err := call.AllocResults()
+		return err
+	}))
+
+	dialer := &sequenceDialer{
+		conns: []net.Conn{firstConn, secondConn},
+		clean: []func(){firstCleanup, secondCleanup},
+	}
+	defer dialer.cleanup()
+
+	client := NewRemoteWriteClient(dialer, log.NewNopLogger())
+	defer func() { _ = client.Close() }()
+
+	_, err := client.RemoteWrite(context.Background(), &storepb.WriteRequest{})
+	testutil.Ok(t, err)
+
+	testutil.Equals(t, 2, dialer.dialed)
+}


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

Detect Cap’n Proto fan-out timeouts, mark the receiver peer down, and force a reconnect so distributor pods self-heal instead of spinning on dead sockets.

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->
- Mark Cap’n Proto peer connections unavailable on any forward error and close them to trigger a fresh dial.
- Teach the Cap’n Proto remote write client to reconnect after context deadline / send errors, covering wrapped exceptions.
- Add focused regression tests for handler peer recycling and Cap’n Proto client reconnects.

## Verification

<!-- How you tested it? How do you know it works? -->
- `go test ./pkg/receive -run TestSendRemoteWriteMarksPeerUnavailableOnAnyError`
- `go test ./pkg/receive/writecapnp -run TestRemoteWriteClientReconnectsOnDeadline`