### PR TITLE
extgrpc: call gogo methods from the codec

### DIFF
--- a/pkg/extgrpc/client_test.go
+++ b/pkg/extgrpc/client_test.go
@@ -1,0 +1,101 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package extgrpc
+
+import (
+	"testing"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/stretchr/testify/require"
+	"github.com/thanos-io/thanos/pkg/info/infopb"
+	"github.com/thanos-io/thanos/pkg/store/labelpb"
+	"google.golang.org/grpc/encoding"
+)
+
+func BenchmarkVanillaProtoMarshal(b *testing.B) {
+	ls := []labels.Labels{}
+
+	for i := range 1000 {
+		ls = append(ls, labels.FromStrings("label_"+string(rune(i)), "value_"+string(rune(i))))
+	}
+	i := &infopb.InfoResponse{
+		LabelSets: labelpb.ZLabelSetsFromPromLabels(
+			ls...,
+		),
+		ComponentType: "asdsadsadsa",
+		Store: &infopb.StoreInfo{
+			MinTime:          123,
+			MaxTime:          456,
+			SupportsSharding: true,
+			TsdbInfos: []infopb.TSDBInfo{
+				{
+					Labels:  labelpb.ZLabelSet{Labels: labelpb.ZLabelsFromPromLabels(labels.FromStrings("replica", "1"))},
+					MinTime: 100,
+					MaxTime: 200,
+				},
+			},
+		},
+		Rules:          &infopb.RulesInfo{},
+		MetricMetadata: &infopb.MetricMetadataInfo{},
+		Exemplars: &infopb.ExemplarsInfo{
+			MinTime: 100,
+			MaxTime: 200,
+		},
+	}
+
+	c := &nonPoolingCodec{}
+
+	ogCodec := encoding.GetCodecV2("proto").(*nonPoolingCodec).CodecV2
+
+	b.Run("vanilla proto marshal", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			_, err := ogCodec.Marshal(i)
+			require.NoError(b, err)
+		}
+	})
+
+	b.Run("non pooling codec marshal", func(b *testing.B) {
+		for b.Loop() {
+			_, err := c.Marshal(i)
+			require.NoError(b, err)
+		}
+	})
+}
+
+func TestNonPoolingCodecMarshal(t *testing.T) {
+	i := &infopb.InfoResponse{
+		LabelSets: labelpb.ZLabelSetsFromPromLabels(
+			labels.FromStrings("foo", "bar"),
+			labels.FromStrings("baz", "qux"),
+			labels.FromStrings("aaa", "bbb"),
+		),
+		ComponentType: "asdsadsadsa",
+		Store: &infopb.StoreInfo{
+			MinTime:          123,
+			MaxTime:          456,
+			SupportsSharding: true,
+			TsdbInfos: []infopb.TSDBInfo{
+				{
+					Labels:  labelpb.ZLabelSet{Labels: labelpb.ZLabelsFromPromLabels(labels.FromStrings("replica", "1"))},
+					MinTime: 100,
+					MaxTime: 200,
+				},
+			},
+		},
+		Rules:          &infopb.RulesInfo{},
+		MetricMetadata: &infopb.MetricMetadataInfo{},
+		Exemplars: &infopb.ExemplarsInfo{
+			MinTime: 100,
+			MaxTime: 200,
+		},
+	}
+
+	c := &nonPoolingCodec{}
+
+	_, err := c.Marshal(i)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
Oops, I missed this part somehow - the original Go protobuf Size() code calls Marshal() to find out the Size() of the buffer.

Benchmarks:

```
goos: linux
goarch: amd64
pkg: github.com/thanos-io/thanos/pkg/extgrpc
cpu: Intel(R) Core(TM) i9-10885H CPU @ 2.40GHz
                                                 │    benchy    │
                                                 │    sec/op    │
VanillaProtoMarshal/vanilla_proto_marshal-16       78.79µ ± ∞ ¹
VanillaProtoMarshal/non_pooling_codec_marshal-16   41.94µ ± ∞ ¹
geomean                                            57.49µ
¹ need >= 6 samples for confidence interval at level 0.95

                                                 │    benchy     │
                                                 │     B/op      │
VanillaProtoMarshal/vanilla_proto_marshal-16       80.32Ki ± ∞ ¹
VanillaProtoMarshal/non_pooling_codec_marshal-16   32.21Ki ± ∞ ¹
geomean                                            50.86Ki
¹ need >= 6 samples for confidence interval at level 0.95

                                                 │   benchy    │
                                                 │  allocs/op  │
VanillaProtoMarshal/vanilla_proto_marshal-16       8.000 ± ∞ ¹
VanillaProtoMarshal/non_pooling_codec_marshal-16   6.000 ± ∞ ¹
geomean                                            6.928
¹ need >= 6 samples for confidence interval at level 0.95
```
