### PR TITLE
thanos/receive: add feature flag to put ext labels into TSDB

### DIFF
--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -60,6 +60,7 @@ import (
 const (
 	compressionNone   = "none"
 	metricNamesFilter = "metric-names-filter"
+	extLabelsInTSDB   = "ext-labels-in-tsdb"
 )
 
 func registerReceive(app *extkingpin.App) {
@@ -151,6 +152,11 @@ func runReceive(
 		if feature == metricNamesFilter {
 			multiTSDBOptions = append(multiTSDBOptions, receive.WithMetricNameFilterEnabled())
 			level.Info(logger).Log("msg", "metric name filter feature enabled")
+		}
+
+		if feature == extLabelsInTSDB {
+			multiTSDBOptions = append(multiTSDBOptions, receive.WithExternalLabelsInTSDB())
+			level.Info(logger).Log("msg", "external labels in TSDB feature enabled. This will make Receive dump the head block if external labels are changed.")
 		}
 	}
 
@@ -1100,7 +1106,7 @@ func (rc *receiveConfig) registerFlag(cmd extkingpin.FlagClause) {
 	cmd.Flag("receive.otlp-enable-target-info", "Enables target information in OTLP metrics ingested by Receive. If enabled, it converts the resource to the target info metric").Default("true").BoolVar(&rc.otlpEnableTargetInfo)
 	cmd.Flag("receive.otlp-promote-resource-attributes", "(Repeatable) Resource attributes to include in OTLP metrics ingested by Receive.").Default("").StringsVar(&rc.otlpResourceAttributes)
 
-	rc.featureList = cmd.Flag("enable-feature", "Comma separated experimental feature names to enable. The current list of features is "+metricNamesFilter+".").Default("").Strings()
+	rc.featureList = cmd.Flag("enable-feature", "Comma separated experimental feature names to enable. The current list of features is "+metricNamesFilter+","+extLabelsInTSDB+".").Default("").Strings()
 
 	cmd.Flag("receive.lazy-retrieval-max-buffered-responses", "The lazy retrieval strategy can buffer up to this number of responses. This is to limit the memory usage. This flag takes effect only when the lazy retrieval strategy is enabled.").
 		Default("20").IntVar(&rc.lazyRetrievalMaxBufferedResponses)

--- a/docs/components/receive.md
+++ b/docs/components/receive.md
@@ -388,6 +388,18 @@ func (h *Handler) writeQuorum() int {
 
 So, if the replication factor is 2 then at least one write must succeed. With RF=3, two writes must succeed, and so on.
 
+## Feature Flags
+
+### metric-names-filter
+
+If enabled then every 15 seconds Receiver will query all available metric names in each tenant and build a bloom filter from them.
+
+This allows filtering out certain tenants from queriers and thus it will not require spawning a Go routine for them.
+
+### ext-labels-in-tsdb
+
+If enabled then it will put the current external labels as "normal" labels inside of the TSDB. This also adds a special marker to the meta files in blocks so that it would be known whether external labels are part of the series inside of the TSDB.
+
 ## Flags
 
 ```$ mdox-exec="thanos receive --help"
@@ -664,7 +676,7 @@ Flags:
                                  OTLP metrics ingested by Receive.
       --enable-feature= ...      Comma separated experimental feature names
                                  to enable. The current list of features is
-                                 metric-names-filter.
+                                 metric-names-filter,ext-labels-in-tsdb.
       --receive.lazy-retrieval-max-buffered-responses=20
                                  The lazy retrieval strategy can buffer up to
                                  this number of responses. This is to limit the

--- a/pkg/block/metadata/meta.go
+++ b/pkg/block/metadata/meta.go
@@ -59,6 +59,11 @@ const (
 	// that the block has been migrated to parquet format and can be safely ignored
 	// by store gateways.
 	ParquetMigratedExtensionKey = "parquet_migrated"
+
+	// ExtLabelsInTSDBKey is the key used in block extensions to indicate that
+	// external labels have been put in the TSDB and the Series() API can
+	// stream.
+	ExtLabelsInTSDBKey = "ext_labels_in_tsdb"
 )
 
 // Meta describes the a block's meta. It wraps the known TSDB meta structure and

--- a/pkg/store/proxy_test.go
+++ b/pkg/store/proxy_test.go
@@ -53,6 +53,10 @@ type mockedStartTimeDB struct {
 	startTime int64
 }
 
+func (db *mockedStartTimeDB) Blocks() []*tsdb.Block {
+	return []*tsdb.Block{}
+}
+
 func (db *mockedStartTimeDB) StartTime() (int64, error) { return db.startTime, nil }
 
 func TestProxyStore_TSDBInfos(t *testing.T) {

--- a/test/e2e/e2ethanos/services.go
+++ b/test/e2e/e2ethanos/services.go
@@ -578,6 +578,8 @@ type ReceiveBuilder struct {
 	nativeHistograms      bool
 	labels                []string
 	tenantSplitLabel      string
+
+	extLabelsInTSDB bool
 }
 
 func NewReceiveBuilder(e e2e.Environment, name string) *ReceiveBuilder {
@@ -654,6 +656,11 @@ func (r *ReceiveBuilder) WithNativeHistograms() *ReceiveBuilder {
 	return r
 }
 
+func (r *ReceiveBuilder) WithExtLabelsInTSDB() *ReceiveBuilder {
+	r.extLabelsInTSDB = true
+	return r
+}
+
 // Init creates a Thanos Receive instance.
 // If ingestion is enabled it will be configured for ingesting samples.
 // If routing is configured (i.e. hashring configuration is provided) it routes samples to other receivers.
@@ -674,6 +681,10 @@ func (r *ReceiveBuilder) Init() *e2eobs.Observable {
 		"--log.level":                          infoLogLevel,
 		"--tsdb.max-exemplars":                 fmt.Sprintf("%v", r.maxExemplars),
 		"--tsdb.too-far-in-future.time-window": "5m",
+	}
+
+	if r.extLabelsInTSDB {
+		args["--enable-feature"] = "ext-labels-in-tsdb"
 	}
 
 	if r.tenantSplitLabel != "" {

--- a/test/e2e/receive_test.go
+++ b/test/e2e/receive_test.go
@@ -1211,7 +1211,7 @@ func TestReceiveCpnp(t *testing.T) {
 	testutil.Ok(t, err)
 	t.Cleanup(e2ethanos.CleanScenario(t, e))
 
-	i := e2ethanos.NewReceiveBuilder(e, "ingestor").WithIngestionEnabled().WithExemplarsInMemStorage(100).Init()
+	i := e2ethanos.NewReceiveBuilder(e, "ingestor").WithIngestionEnabled().WithExemplarsInMemStorage(100).WithExtLabelsInTSDB().Init()
 	testutil.Ok(t, e2e.StartAndWaitReady(i))
 
 	h := receive.HashringConfig{
@@ -1282,5 +1282,4 @@ func TestReceiveCpnp(t *testing.T) {
 			return nil
 		},
 	)
-
 }


### PR DESCRIPTION
Enable streaming by putting external labels into the TSDB. If the external labels ever change then the head is pruned during startup.
