### PR TITLE
store/tsdb: use TSDB native sharding

### DIFF
--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -1653,6 +1653,7 @@ func (s *BucketStore) Series(req *storepb.SeriesRequest, seriesSrv storepb.Store
 				resHints.AddQueriedBlock(blk.meta.ULID)
 			}
 
+			// TODO(GiedriusS): just select NOT all postings.
 			shardMatcher := req.ShardInfo.Matcher(&s.buffers)
 
 			blockClient := newBlockSeriesClient(


### PR DESCRIPTION
Well, somehow I missed this - use TSDB native sharding instead of our hashing based one.

This avoids GC costs because we won't have to materialize labels before sharding.