### PR TITLE
Query-Frontend: Fix not logging requests when external-prefix is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 ### Fixed
 
 - [#8378](https://github.com/thanos-io/thanos/pull/8378): Store: fix the reuse of dirty posting slices
+- [#8558](https://github.com/thanos-io/thanos/pull/8558): Query-Frontend: Fix not logging requests when external-prefix is set in query
 
 ### Added
 

--- a/internal/cortex/frontend/transport/handler.go
+++ b/internal/cortex/frontend/transport/handler.go
@@ -166,7 +166,7 @@ func (f *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // query-related endpoints.
 // Example: /api/v1/query, /api/v1/query_range, /api/v1/series, /api/v1/label, /api/v1/labels
 func isQueryEndpoint(path string) bool {
-	return strings.HasPrefix(path, "/api/v1")
+	return strings.Contains(path, "/api/v1")
 }
 
 // reportSlowQuery reports slow queries.

--- a/internal/cortex/frontend/transport/handler_test.go
+++ b/internal/cortex/frontend/transport/handler_test.go
@@ -75,6 +75,18 @@ func TestHandler_SlowQueryLog(t *testing.T) {
 			},
 		},
 		{
+			name: "Query with prefixed API string",
+			url:  "/external-prefix/api/v1/query?query=absent(up)&start=1714262400&end=1714266000",
+			logParts: []string{
+				"slow query detected",
+				"time_taken=",
+				"path=/external-prefix/api/v1/query",
+				"param_query=absent(up)",
+				"param_start=1714262400",
+				"param_end=1714266000",
+			},
+		},
+		{
 			name: "Non-query endpoint",
 			url:  "/favicon.ico",
 			// No slow query log for non-query endpoints


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Updated Query-Frontend so that slowlogs still work if query has `--web.external-prefix=` set 

Previously we only logged if query didn't have any prefix

## Verification

<!-- How you tested it? How do you know it works? -->

Added a test with the new path
