### PR TITLE
receive/multitsdb: fix pruning job to avoid inconsistent state

### DIFF
--- a/pkg/api/query/v1_test.go
+++ b/pkg/api/query/v1_test.go
@@ -30,6 +30,8 @@ import (
 	"testing"
 	"time"
 
+	"go.uber.org/atomic"
+
 	"github.com/efficientgo/core/testutil"
 	"github.com/go-kit/log"
 	"github.com/prometheus/client_golang/prometheus"
@@ -669,7 +671,7 @@ func TestQueryAnalyzeEndpoints(t *testing.T) {
 func newProxyStoreWithTSDBStore(db store.TSDBReader) *store.ProxyStore {
 	c := &storetestutil.TestClient{
 		Name:        "1",
-		StoreClient: storepb.ServerAsClient(store.NewTSDBStore(nil, db, component.Query, labels.EmptyLabels())),
+		StoreClient: storepb.ServerAsClient(store.NewTSDBStore(nil, db, component.Query, labels.EmptyLabels()), atomic.Bool{}),
 		MinTime:     math.MinInt64, MaxTime: math.MaxInt64,
 	}
 

--- a/pkg/query/querier_test.go
+++ b/pkg/query/querier_test.go
@@ -16,6 +16,8 @@ import (
 	"testing"
 	"time"
 
+	"go.uber.org/atomic"
+
 	"github.com/efficientgo/core/testutil"
 	"github.com/go-kit/log"
 	"github.com/pkg/errors"
@@ -848,7 +850,7 @@ func newProxyStore(storeAPIs ...storepb.StoreServer) *store.ProxyStore {
 		}
 		cls[i] = &storetestutil.TestClient{
 			Name:        fmt.Sprintf("%v", i),
-			StoreClient: storepb.ServerAsClient(s),
+			StoreClient: storepb.ServerAsClient(s, atomic.Bool{}),
 			MinTime:     math.MinInt64, MaxTime: math.MaxInt64,
 			WithoutReplicaLabelsEnabled: withoutReplicaLabelsEnabled,
 		}

--- a/pkg/query/query_test.go
+++ b/pkg/query/query_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/prometheus/prometheus/storage"
+	"go.uber.org/atomic"
 
 	"github.com/thanos-io/thanos/pkg/component"
 	"github.com/thanos-io/thanos/pkg/dedup"
@@ -86,7 +87,7 @@ func TestQuerier_Proxy(t *testing.T) {
 				// TODO(bwplotka): Parse external labels.
 				sc.append(&storetestutil.TestClient{
 					Name:        fmt.Sprintf("store number %v", i),
-					StoreClient: storepb.ServerAsClient(selectedStore(store.NewTSDBStore(logger, st.storage.DB, component.Debug, labels.EmptyLabels()), m, st.mint, st.maxt)),
+					StoreClient: storepb.ServerAsClient(selectedStore(store.NewTSDBStore(logger, st.storage.DB, component.Debug, labels.EmptyLabels()), m, st.mint, st.maxt), atomic.Bool{}),
 					MinTime:     st.mint,
 					MaxTime:     st.maxt,
 				})

--- a/pkg/receive/multitsdb.go
+++ b/pkg/receive/multitsdb.go
@@ -6,6 +6,7 @@ package receive
 import (
 	"context"
 	"fmt"
+	"maps"
 	"os"
 	"path"
 	"path/filepath"
@@ -201,10 +202,10 @@ type localClient struct {
 	client storepb.StoreClient
 }
 
-func newLocalClient(store *store.TSDBStore) *localClient {
+func newLocalClient(store *store.TSDBStore, readOnly atomic.Bool) *localClient {
 	return &localClient{
 		store:  store,
-		client: storepb.ServerAsClient(store),
+		client: storepb.ServerAsClient(store, readOnly),
 	}
 }
 
@@ -268,12 +269,18 @@ func (l *localClient) SupportsWithoutReplicaLabels() bool {
 	return true
 }
 
+func (t *tenant) setReadOnly(ro bool) {
+	t.readOnly.Store(ro)
+}
+
 type tenant struct {
 	readyS        *ReadyStorage
 	storeTSDB     *store.TSDBStore
 	exemplarsTSDB *exemplars.TSDB
 	ship          *shipper.Shipper
 	reg           *UnRegisterer
+
+	readOnly atomic.Bool
 
 	mtx  *sync.RWMutex
 	tsdb *tsdb.DB
@@ -338,7 +345,7 @@ func (t *tenant) client() store.Client {
 		return nil
 	}
 
-	return newLocalClient(tsdbStore)
+	return newLocalClient(tsdbStore, t.readOnly)
 }
 
 func (t *tenant) exemplars() *exemplars.TSDB {
@@ -472,14 +479,21 @@ func (t *MultiTSDB) Prune(ctx context.Context) error {
 
 		prunedTenants []string
 		pmtx          sync.Mutex
+
+		tenants = make(map[string]*tenant)
 	)
+
 	t.mtx.RLock()
-	for tenantID, tenantInstance := range t.tenants {
+	maps.Copy(tenants, t.tenants)
+	t.mtx.RUnlock()
+
+	begin := time.Now()
+	for tenantID, tenantInstance := range tenants {
 		wg.Add(1)
 		go func(tenantID string, tenantInstance *tenant) {
 			defer wg.Done()
-			tlog := log.With(t.logger, "tenant", tenantID)
-			pruned, err := t.pruneTSDB(ctx, tlog, tenantInstance)
+
+			pruned, err := t.pruneTSDB(ctx, log.With(t.logger, "tenant", tenantID), tenantInstance, tenantID)
 			if err != nil {
 				merr.Add(err)
 				return
@@ -493,50 +507,35 @@ func (t *MultiTSDB) Prune(ctx context.Context) error {
 		}(tenantID, tenantInstance)
 	}
 	wg.Wait()
-	t.mtx.RUnlock()
 
-	t.mtx.Lock()
-	defer t.mtx.Unlock()
-	for _, tenantID := range prunedTenants {
-		// Check that the tenant hasn't been reinitialized in-between locks.
-		if t.tenants[tenantID].readyStorage().get() != nil {
-			continue
-		}
-
-		level.Info(t.logger).Log("msg", "Pruned tenant", "tenant", tenantID)
-		t.removeTenantUnlocked(tenantID)
-	}
+	level.Info(t.logger).Log("msg", "Pruning job completed", "pruned_tenants_count", len(prunedTenants), "pruned_tenants", prunedTenants, "took_seconds", time.Since(begin).Seconds())
 
 	return merr.Err()
 }
 
 // pruneTSDB removes a TSDB if its past the retention period.
 // It compacts the TSDB head, sends all remaining blocks to S3 and removes the TSDB from disk.
-func (t *MultiTSDB) pruneTSDB(ctx context.Context, logger log.Logger, tenantInstance *tenant) (pruned bool, rerr error) {
+func (t *MultiTSDB) pruneTSDB(ctx context.Context, logger log.Logger, tenantInstance *tenant, tenantID string) (pruned bool, rerr error) {
 	tenantTSDB := tenantInstance.readyStorage()
 	if tenantTSDB == nil {
 		return false, nil
 	}
-	tenantTSDB.mtx.RLock()
-	if tenantTSDB.a == nil || tenantTSDB.a.db == nil {
-		tenantTSDB.mtx.RUnlock()
+
+	tdb := tenantTSDB.Get()
+	if tdb == nil {
 		return false, nil
 	}
 
-	tdb := tenantTSDB.a.db
 	head := tdb.Head()
 	if head.MaxTime() < 0 {
-		tenantTSDB.mtx.RUnlock()
 		return false, nil
 	}
 
 	sinceLastAppendMillis := time.Since(time.UnixMilli(head.MaxTime())).Milliseconds()
 	compactThreshold := int64(1.5 * float64(t.tsdbOpts.MaxBlockDuration))
 	if sinceLastAppendMillis <= compactThreshold {
-		tenantTSDB.mtx.RUnlock()
 		return false, nil
 	}
-	tenantTSDB.mtx.RUnlock()
 
 	// Acquire a write lock and check that no writes have occurred in-between locks.
 	tenantTSDB.mtx.Lock()
@@ -585,6 +584,15 @@ func (t *MultiTSDB) pruneTSDB(ctx context.Context, logger log.Logger, tenantInst
 		}
 	}
 
+	tenantInstance.setReadOnly(true)
+	defer func() {
+		if pruned {
+			return
+		}
+
+		tenantInstance.setReadOnly(false)
+	}()
+
 	if err := tdb.Close(); err != nil {
 		return false, err
 	}
@@ -597,6 +605,10 @@ func (t *MultiTSDB) pruneTSDB(ctx context.Context, logger log.Logger, tenantInst
 	tenantInstance.readyS.set(nil)
 	tenantInstance.setComponents(nil, nil, nil, nil, nil)
 	tenantInstance.mtx.Unlock()
+
+	t.mtx.Lock()
+	t.removeTenantUnlocked(tenantID)
+	t.mtx.Unlock()
 
 	return true, nil
 }

--- a/pkg/store/acceptance_test.go
+++ b/pkg/store/acceptance_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/efficientgo/core/testutil"
 	"github.com/go-kit/log"
 	"github.com/pkg/errors"
+	"go.uber.org/atomic"
 
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
@@ -1163,7 +1164,7 @@ func TestProxyStoreWithTSDBSelector_Acceptance(t *testing.T) {
 		p1 := startNestedStore(tt, appendFn, extLset1, extLset2, extLset3)
 
 		clients := []Client{
-			storetestutil.TestClient{StoreClient: storepb.ServerAsClient(p1), ExtLset: []labels.Labels{extLset1, extLset2, extLset3}},
+			storetestutil.TestClient{StoreClient: storepb.ServerAsClient(p1, atomic.Bool{}), ExtLset: []labels.Labels{extLset1, extLset2, extLset3}},
 		}
 
 		relabelCfgs := []*relabel.Config{{
@@ -1226,8 +1227,8 @@ func TestProxyStoreWithReplicas_Acceptance(t *testing.T) {
 		p2 := startNestedStore(tt, extLset2, appendFn)
 
 		clients := []Client{
-			storetestutil.TestClient{StoreClient: storepb.ServerAsClient(p1), ExtLset: []labels.Labels{extLset1}},
-			storetestutil.TestClient{StoreClient: storepb.ServerAsClient(p2), ExtLset: []labels.Labels{extLset2}},
+			storetestutil.TestClient{StoreClient: storepb.ServerAsClient(p1, atomic.Bool{}), ExtLset: []labels.Labels{extLset1}},
+			storetestutil.TestClient{StoreClient: storepb.ServerAsClient(p2, atomic.Bool{}), ExtLset: []labels.Labels{extLset2}},
 		}
 
 		return NewProxyStore(nil, nil, func() []Client { return clients }, component.Query, labels.EmptyLabels(), 0*time.Second, RetrievalStrategy(EagerRetrieval))
@@ -1261,11 +1262,11 @@ func TestTSDBSelectorFilteringBehavior(t *testing.T) {
 
 		clients := []Client{
 			storetestutil.TestClient{
-				StoreClient: storepb.ServerAsClient(store1),
+				StoreClient: storepb.ServerAsClient(store1, atomic.Bool{}),
 				ExtLset:     []labels.Labels{extLset},
 			},
 			storetestutil.TestClient{
-				StoreClient: storepb.ServerAsClient(store2),
+				StoreClient: storepb.ServerAsClient(store2, atomic.Bool{}),
 				ExtLset:     []labels.Labels{droppedLset},
 			},
 		}

--- a/pkg/store/limiter_test.go
+++ b/pkg/store/limiter_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	prom_testutil "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/prometheus/prometheus/model/labels"
+	"go.uber.org/atomic"
 
 	"github.com/thanos-io/thanos/pkg/store/storepb"
 )
@@ -101,7 +102,7 @@ func TestRateLimitedServer(t *testing.T) {
 			defer cancel()
 
 			store := NewLimitedStoreServer(newStoreServerStub(test.series), prometheus.NewRegistry(), test.limits)
-			client := storepb.ServerAsClient(store)
+			client := storepb.ServerAsClient(store, atomic.Bool{})
 			seriesClient, err := client.Series(ctx, &storepb.SeriesRequest{})
 			testutil.Ok(t, err)
 			for {

--- a/pkg/store/proxy_test.go
+++ b/pkg/store/proxy_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/prometheus/prometheus/model/timestamp"
 	"github.com/prometheus/prometheus/tsdb"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
+	"go.uber.org/atomic"
 	"google.golang.org/grpc"
 
 	"github.com/thanos-io/thanos/pkg/block"
@@ -679,7 +680,7 @@ func TestProxyStore_Series(t *testing.T) {
 								},
 							},
 						}
-					}, component.Store, labels.FromStrings("role", "proxy"), 1*time.Minute, EagerRetrieval)),
+					}, component.Store, labels.FromStrings("role", "proxy"), 1*time.Minute, EagerRetrieval), atomic.Bool{}),
 				},
 				&storetestutil.TestClient{
 					MinTime: 1,
@@ -2345,7 +2346,7 @@ func TestProxyStore_NotLeakingOnPrematureFinish(t *testing.T) {
 								storeSeriesResponse(t, labels.FromStrings("b", "b"), []sample{{0, 0}, {2, 1}, {3, 2}}),
 								storeSeriesResponse(t, labels.FromStrings("b", "c"), []sample{{0, 0}, {2, 1}, {3, 2}}),
 							},
-						}),
+						}, atomic.Bool{}),
 						MinTime: math.MinInt64,
 						MaxTime: math.MaxInt64,
 					},

--- a/pkg/store/recover_test.go
+++ b/pkg/store/recover_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/efficientgo/core/testutil"
 	"github.com/go-kit/log"
+	"go.uber.org/atomic"
 
 	"github.com/thanos-io/thanos/pkg/store/storepb"
 )
@@ -20,7 +21,7 @@ func TestRecoverableServer(t *testing.T) {
 	store := NewRecoverableStoreServer(logger, &panicStoreServer{})
 
 	ctx := t.Context()
-	client := storepb.ServerAsClient(store)
+	client := storepb.ServerAsClient(store, atomic.Bool{})
 	seriesClient, err := client.Series(ctx, &storepb.SeriesRequest{})
 	testutil.Ok(t, err)
 

--- a/pkg/store/storepb/inprocess_test.go
+++ b/pkg/store/storepb/inprocess_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/thanos-io/thanos/pkg/testutil/custom"
+	"go.uber.org/atomic"
 
 	"github.com/efficientgo/core/testutil"
 	"github.com/pkg/errors"
@@ -81,7 +82,7 @@ func TestServerAsClient(t *testing.T) {
 					Matchers:                []LabelMatcher{{Value: "wfsdfs", Name: "__name__", Type: LabelMatcher_EQ}},
 					PartialResponseStrategy: PartialResponseStrategy_ABORT,
 				}
-				client, err := ServerAsClient(s).Series(ctx, r)
+				client, err := ServerAsClient(s, atomic.Bool{}).Series(ctx, r)
 				testutil.Ok(t, err)
 				var resps []*SeriesResponse
 				for {
@@ -106,7 +107,7 @@ func TestServerAsClient(t *testing.T) {
 					Matchers:                []LabelMatcher{{Value: "wfsdfs", Name: "__name__", Type: LabelMatcher_EQ}},
 					PartialResponseStrategy: PartialResponseStrategy_ABORT,
 				}
-				client, err := ServerAsClient(s).Series(ctx, r)
+				client, err := ServerAsClient(s, atomic.Bool{}).Series(ctx, r)
 				testutil.Ok(t, err)
 				var resps []*SeriesResponse
 				for {
@@ -134,7 +135,7 @@ func TestServerAsClient(t *testing.T) {
 					Matchers:                []LabelMatcher{{Value: "wfsdfs", Name: "__name__", Type: LabelMatcher_EQ}},
 					PartialResponseStrategy: PartialResponseStrategy_ABORT,
 				}
-				client, err := ServerAsClient(s).Series(ctx, r)
+				client, err := ServerAsClient(s, atomic.Bool{}).Series(ctx, r)
 				testutil.Ok(t, err)
 				var resps []*SeriesResponse
 				for {
@@ -162,7 +163,7 @@ func TestServerAsClient(t *testing.T) {
 					Matchers:                []LabelMatcher{{Value: "wfsdfs", Name: "__name__", Type: LabelMatcher_EQ}},
 					PartialResponseStrategy: PartialResponseStrategy_ABORT,
 				}
-				client, err := ServerAsClient(s).Series(ctx, r)
+				client, err := ServerAsClient(s, atomic.Bool{}).Series(ctx, r)
 				testutil.Ok(t, err)
 				var wg sync.WaitGroup
 				wg.Go(func() {
@@ -188,7 +189,7 @@ func TestServerAsClient(t *testing.T) {
 					End:                     234,
 					PartialResponseStrategy: PartialResponseStrategy_ABORT,
 				}
-				resp, err := ServerAsClient(s).LabelNames(ctx, r)
+				resp, err := ServerAsClient(s, atomic.Bool{}).LabelNames(ctx, r)
 				testutil.Ok(t, err)
 				testutil.Equals(t, s.labelNames, resp)
 				testutil.Equals(t, r, s.labelNamesLastReq)
@@ -203,7 +204,7 @@ func TestServerAsClient(t *testing.T) {
 					End:                     234,
 					PartialResponseStrategy: PartialResponseStrategy_ABORT,
 				}
-				_, err := ServerAsClient(s).LabelNames(ctx, r)
+				_, err := ServerAsClient(s, atomic.Bool{}).LabelNames(ctx, r)
 				testutil.NotOk(t, err)
 				testutil.Equals(t, s.err, err)
 			}
@@ -224,7 +225,7 @@ func TestServerAsClient(t *testing.T) {
 					End:                     234,
 					PartialResponseStrategy: PartialResponseStrategy_ABORT,
 				}
-				resp, err := ServerAsClient(s).LabelValues(ctx, r)
+				resp, err := ServerAsClient(s, atomic.Bool{}).LabelValues(ctx, r)
 				testutil.Ok(t, err)
 				testutil.Equals(t, s.labelValues, resp)
 				testutil.Equals(t, r, s.labelValuesLastReq)
@@ -240,7 +241,7 @@ func TestServerAsClient(t *testing.T) {
 					End:                     234,
 					PartialResponseStrategy: PartialResponseStrategy_ABORT,
 				}
-				_, err := ServerAsClient(s).LabelValues(ctx, r)
+				_, err := ServerAsClient(s, atomic.Bool{}).LabelValues(ctx, r)
 				testutil.NotOk(t, err)
 				testutil.Equals(t, s.err, err)
 			}

--- a/test/e2e/query_test.go
+++ b/test/e2e/query_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/go-kit/log"
 	"github.com/gogo/protobuf/proto"
 	"github.com/golang/snappy"
+	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
 	config_util "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
@@ -1494,7 +1495,9 @@ func queryWaitAndAssert(t *testing.T, ctx context.Context, addr string, q func()
 		if reflect.DeepEqual(expected, result) {
 			return nil
 		}
-		return errors.New("series are different")
+
+		return fmt.Errorf("series are different: %s",
+			cmp.Diff(expected, result))
 	}))
 
 	testutil.Equals(t, expected, result)

--- a/test/e2e/receive_test.go
+++ b/test/e2e/receive_test.go
@@ -895,8 +895,7 @@ test_metric{a="2", b="2"} 1`)
 		// We run three avalanches, one tenant which exceeds the limit, one tenant which remains under it, and one for the unlimited tenant.
 
 		// Avalanche in this configuration, would send 5 requests each with 10 new timeseries.
-		// One request always fails due to TSDB not being ready for new tenant.
-		// So without limiting we end up with 40 timeseries and 40 samples.
+		// So without limiting we end up with 50 timeseries and 50 samples.
 		avalanche1 := e2ethanos.NewAvalanche(e, "avalanche-1",
 			e2ethanos.AvalancheOptions{
 				MetricCount:    "10",
@@ -914,8 +913,7 @@ test_metric{a="2", b="2"} 1`)
 			})
 
 		// Avalanche in this configuration, would send 5 requests each with 5 of the same timeseries.
-		// One request always fails due to TSDB not being ready for new tenant.
-		// So we end up with 5 timeseries, 20 samples.
+		// So we end up with 5 timeseries, 25 samples.
 		avalanche2 := e2ethanos.NewAvalanche(e, "avalanche-2",
 			e2ethanos.AvalancheOptions{
 				MetricCount:    "5",
@@ -933,8 +931,7 @@ test_metric{a="2", b="2"} 1`)
 			})
 
 		// Avalanche in this configuration, would send 5 requests each with 10 new timeseries.
-		// One request always fails due to TSDB not being ready for new tenant.
-		// So without limiting we end up with 40 timeseries and 40 samples.
+		// So without limiting we end up with 50 timeseries and 50 samples.
 		avalanche3 := e2ethanos.NewAvalanche(e, "avalanche-3",
 			e2ethanos.AvalancheOptions{
 				MetricCount:    "10",
@@ -953,9 +950,9 @@ test_metric{a="2", b="2"} 1`)
 
 		testutil.Ok(t, e2e.StartAndWaitReady(avalanche1, avalanche2, avalanche3))
 
-		// Here, 3/5 requests are failed due to limiting, as one request fails due to TSDB readiness and we ingest one initial request.
-		// 3 limited requests belong to the exceed-tenant.
-		testutil.Ok(t, i1Runnable.WaitSumMetricsWithOptions(e2emon.Equals(3), []string{"thanos_receive_head_series_limited_requests_total"}, e2emon.WithWaitBackoff(&backoff.Config{Min: 1 * time.Second, Max: 10 * time.Minute, MaxRetries: 200}), e2emon.WaitMissingMetrics()))
+		// Here, 4/5 requests are failed due to limiting as we ingest one initial request.
+		// 4 limited requests belong to the exceed-tenant.
+		testutil.Ok(t, i1Runnable.WaitSumMetricsWithOptions(e2emon.Equals(4), []string{"thanos_receive_head_series_limited_requests_total"}, e2emon.WithWaitBackoff(&backoff.Config{Min: 1 * time.Second, Max: 10 * time.Minute, MaxRetries: 200}), e2emon.WaitMissingMetrics()))
 
 		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
 		t.Cleanup(cancel)
@@ -1028,7 +1025,7 @@ test_metric{a="2", b="2"} 1`)
 					"job":      "receive-i1",
 					"tenant":   "exceed-tenant",
 				},
-				Value: model.SampleValue(3),
+				Value: model.SampleValue(4),
 			},
 		})
 	})


### PR DESCRIPTION
The current implementation prunes tenants first and then updates `t.tenants`. TSDB clients are gathered from the `t.tenants` map. If a Series() call comes in the middle then the Querier could get an error like the following:

```
open chunk reader: can't read from a closed head
```

This commit tries to fix that by adding a "readOnly" mode where just before closing we now turn it on. It ensures that all RecvMsg() calls just return io.EOF.

Also, did various tuning to tests so that they would pass more reliably.
Now the first request doesn't fail. Adjust for that.
