### PR TITLE
DOC: ignore few links verification and update prometheus blog link

### DIFF
--- a/.mdox.validate.yaml
+++ b/.mdox.validate.yaml
@@ -53,3 +53,12 @@ validators:
   # TLS certificate issues
   - regex: 'itnext\.io'
     type: 'ignore'
+  - regex: 'medium\.com'
+    type: 'ignore'
+  - regex: 'engineering\.hellofresh\.com'
+    type: 'ignore'
+  - regex: 'blog\.devops\.dev'
+    type: 'ignore'
+  - regex: 'codeburst\.io'
+    type: 'ignore'
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,6 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 
 ### Added
 
-
 ### Changed
 
 - [#8555](https://github.com/thanos-io/thanos/pull/8555): Promu: re-add Darwin and FreeBSD as release platforms

--- a/docs/blog/welcome.md
+++ b/docs/blog/welcome.md
@@ -8,4 +8,4 @@ Welcome 👋🏼
 
 This space was created for the Thanos community to share learnings, insights, best practices and cool things to the world. If you are interested in contributing relevant content to Thanos blog, feel free to add Pull Request (PR) to [Thanos repo's blog directory](http://github.com/thanos-io/thanos). See ya there!
 
-PS: For Prometheus specific content, consider contributing to [Prometheus blog space](https://prometheus.io/blog/) by creating PR to [Prometheus docs repo](https://github.com/prometheus/docs/tree/main/blog-posts).
+PS: For Prometheus specific content, consider contributing to [Prometheus blog space](https://prometheus.io/blog/) by creating PR to [Prometheus docs repo](https://github.com/prometheus/docs/tree/main/blog/posts).


### PR DESCRIPTION
Since a couple of times, few website decided to block GitHub. We had the same issue in Perses.

This PR is updating the file `mdox.validate.yaml` to reflect these websites blocking GitHub.

I have also updated the link to the Prometheus blog post folder that changed when Julius updated the website.