### PR TITLE
receive: Don't increment forward/replication metrics on AlreadyExists

### DIFF
--- a/pkg/receive/handler.go
+++ b/pkg/receive/handler.go
@@ -1027,9 +1027,12 @@ func (h *Handler) sendRemoteWrite(
 			}
 			h.peers.markPeerAvailable(endpoint)
 		} else {
-			h.forwardRequests.WithLabelValues(labelError).Inc()
-			if !alreadyReplicated {
-				h.replications.WithLabelValues(labelError).Inc()
+			// Only increment error metrics if the error is not AlreadyExists.
+			if st, ok := status.FromError(err); !ok || st.Code() != codes.AlreadyExists {
+				h.forwardRequests.WithLabelValues(labelError).Inc()
+				if !alreadyReplicated {
+					h.replications.WithLabelValues(labelError).Inc()
+				}
 			}
 
 			// Check if peer connection is unavailable, update the peer state to avoid spamming that peer.


### PR DESCRIPTION
This commit ensures, forward and replication metric with error labels won't be incremented if the error is AlreadyExists as that is acceptable and is only a 409.

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
