### PR TITLE
receive: disable isolation

### DIFF
--- a/pkg/receive/multitsdb.go
+++ b/pkg/receive/multitsdb.go
@@ -771,6 +771,10 @@ func (t *MultiTSDB) startTSDB(logger log.Logger, tenantID string, tenant *tenant
 	// into other ones. This presents a race between compaction and the shipper (if it is configured to upload compacted blocks).
 	// Hence, avoid this situation by disabling overlapping compaction. Vertical compaction must be enabled on the compactor.
 	opts.EnableOverlappingCompaction = false
+
+	// We don't do scrapes ourselves so this only gives us a performance penalty.
+	opts.IsolationDisabled = true
+
 	s, err := tsdb.Open(
 		dataDir,
 		logutil.GoKitLogToSlog(logger),


### PR DESCRIPTION
Isolation is not needed here as we don't do scrapes. This issue of
inconsistent data is probably best solved by a global query offset.

Signed-off-by: Giedrius Statkevičius <giedrius.statkevicius@vinted.com>
