### PR TITLE
WIP: query: prune TSDBInfos in `query.remoteEndpoints.Engines()`

### DIFF
--- a/pkg/api/query/grpc.go
+++ b/pkg/api/query/grpc.go
@@ -99,9 +99,16 @@ func (g *GRPCAPI) Query(request *querypb.QueryRequest, server querypb.Query_Quer
 		query.NoopSeriesStatsReporter,
 	)
 
+	var ts time.Time
+	if request.TimeSeconds == 0 {
+		ts = g.now()
+	} else {
+		ts = time.Unix(request.TimeSeconds, 0)
+	}
 	remoteEndpoints := g.remoteEndpointsCreate(
 		replicaLabels,
 		request.EnablePartialResponse,
+		ts, ts,
 	)
 
 	var qry promql.Query
@@ -197,9 +204,13 @@ func (g *GRPCAPI) QueryRange(request *querypb.QueryRangeRequest, srv querypb.Que
 		query.NoopSeriesStatsReporter,
 	)
 
+	start := time.Unix(request.StartTimeSeconds, 0)
+	end := time.Unix(request.EndTimeSeconds, 0)
 	remoteEndpoints := g.remoteEndpointsCreate(
 		replicaLabels,
 		request.EnablePartialResponse,
+		start,
+		end,
 	)
 
 	var qry promql.Query

--- a/pkg/api/query/v1.go
+++ b/pkg/api/query/v1.go
@@ -548,6 +548,8 @@ func (qapi *QueryAPI) queryExplain(r *http.Request) (any, []error, *api.ApiError
 		remoteEndpoints := qapi.remoteEndpointsCreate(
 			replicaLabels,
 			enablePartialResponse,
+			ts,
+			ts,
 		)
 		queryOpts := &engine.QueryOpts{
 			LookbackDeltaParam: lookbackDelta,
@@ -656,6 +658,8 @@ func (qapi *QueryAPI) query(r *http.Request) (any, []error, *api.ApiError, func(
 		remoteEndpoints := qapi.remoteEndpointsCreate(
 			replicaLabels,
 			enablePartialResponse,
+			ts,
+			ts,
 		)
 		queryOpts := &engine.QueryOpts{
 			LookbackDeltaParam: lookbackDelta,
@@ -836,6 +840,8 @@ func (qapi *QueryAPI) queryRangeExplain(r *http.Request) (any, []error, *api.Api
 		remoteEndpoints := qapi.remoteEndpointsCreate(
 			replicaLabels,
 			enablePartialResponse,
+			start,
+			end,
 		)
 		queryOpts := &engine.QueryOpts{
 			LookbackDeltaParam: lookbackDelta,
@@ -969,6 +975,8 @@ func (qapi *QueryAPI) queryRange(r *http.Request) (any, []error, *api.ApiError, 
 		remoteEndpoints := qapi.remoteEndpointsCreate(
 			replicaLabels,
 			enablePartialResponse,
+			start,
+			end,
 		)
 		queryOpts := &engine.QueryOpts{
 			LookbackDeltaParam: lookbackDelta,


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

> See #8597 for more details.

> [!important]
> In this implementation we ignore vector operations and offsets in queries. We need to compensate for them before pruning. 

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->

---

Issue: #8597

CC: @MichaHoffmann 
