### PR TITLE
component: add parquet gateway

### DIFF
--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -89,6 +89,7 @@ var (
 	Store           = storeAPI{component: component{name: "store"}}
 	UnknownStoreAPI = storeAPI{component: component{name: "unknown-store-api"}}
 	Query           = storeAPI{component: component{name: "query"}}
+	ParquetGateway  = storeAPI{component: component{name: "parquet-gateway"}}
 
 	All = []Component{
 		Bucket,
@@ -108,5 +109,6 @@ var (
 		Store,
 		UnknownStoreAPI,
 		Query,
+		ParquetGateway,
 	}
 )


### PR DESCRIPTION
Add parquet gateway as a component type. This will make it stand-out in
the stores page. It's a bit special because it implements StoreAPI &
QueryAPI.

Signed-off-by: Giedrius Statkevičius <giedrius.statkevicius@vinted.com>
