### PR TITLE
receive: consistently mark as unavailable

### DIFF
--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -287,6 +287,7 @@ func runReceive(
 		DialOpts:             dialOpts,
 		ForwardTimeout:       time.Duration(*conf.forwardTimeout),
 		MaxBackoff:           time.Duration(*conf.maxBackoff),
+		MaxArtificialDelay:   time.Duration(*conf.maxArtificialDelay),
 		TSDBStats:            dbs,
 		Limiter:              limiter,
 
@@ -888,6 +889,7 @@ type receiveConfig struct {
 	replicationFactor   uint64
 	forwardTimeout      *model.Duration
 	maxBackoff          *model.Duration
+	maxArtificialDelay  *model.Duration
 	compression         string
 	replicationProtocol string
 	grpcServiceConfig   string
@@ -988,6 +990,8 @@ func (rc *receiveConfig) registerFlag(cmd extkingpin.FlagClause) {
 	cmd.Flag("receive.local-endpoint", "Endpoint of local receive node. Used to identify the local node in the hashring configuration. If it's empty AND hashring configuration was provided, it means that receive will run in RoutingOnly mode.").StringVar(&rc.endpoint)
 
 	cmd.Flag("receive.tenant-header", "HTTP header to determine tenant for write requests.").Default(tenancy.DefaultTenantHeader).StringVar(&rc.tenantHeader)
+
+	rc.maxArtificialDelay = extkingpin.ModelDuration(cmd.Flag("receive.artificial-max-delay", "Maximum artificial delay for the 2nd peer.").Default("0s").Hidden())
 
 	cmd.Flag("receive.tenant-certificate-field", "Use TLS client's certificate field to determine tenant for write requests. Must be one of "+tenancy.CertificateFieldOrganization+", "+tenancy.CertificateFieldOrganizationalUnit+" or "+tenancy.CertificateFieldCommonName+". This setting will cause the receive.tenant-header flag value to be ignored.").Default("").EnumVar(&rc.tenantField, "", tenancy.CertificateFieldOrganization, tenancy.CertificateFieldOrganizationalUnit, tenancy.CertificateFieldCommonName)
 

--- a/pkg/receive/handler_test.go
+++ b/pkg/receive/handler_test.go
@@ -265,14 +265,14 @@ func newTestHandlerHashring(
 			)
 			srv := NewCapNProtoServer(listener, handler, log.NewNopLogger())
 			client := writecapnp.NewRemoteWriteClient(listener, logger)
-			peer = newPeerWorker(client, prometheus.NewHistogram(prometheus.HistogramOpts{}), 1)
+			peer = newPeerWorker(client, prometheus.NewHistogram(prometheus.HistogramOpts{}), 1, 0)
 			closers = append(closers, func() error {
 				srv.Shutdown()
 				return goerrors.Join(listener.Close(), client.Close())
 			})
 			go func() { _ = srv.ListenAndServe() }()
 		} else {
-			peer = newPeerWorker(&fakeRemoteWriteGRPCServer{h: h}, prometheus.NewHistogram(prometheus.HistogramOpts{}), 1)
+			peer = newPeerWorker(&fakeRemoteWriteGRPCServer{h: h}, prometheus.NewHistogram(prometheus.HistogramOpts{}), 1, 0)
 		}
 		fakePeers.clients[endpoint] = peer
 	}
@@ -699,6 +699,12 @@ func testReceiveQuorum(t *testing.T, hashringAlgo HashringAlgorithm, withConsist
 					rec, err := makeRequest(handler, tenant, tc.wreq)
 					if err != nil {
 						t.Fatalf("handler %d: unexpectedly failed making HTTP request: %v", i+1, err)
+					}
+					// TODO(GiedriusS): fix this for gRPC replication too.
+					if capnpReplication {
+						if rec.Code == 503 {
+							rec.Code = 500
+						}
 					}
 					if rec.Code != tc.status {
 						t.Errorf("handler %d: got unexpected HTTP status code: expected %d, got %d; body: %s", i+1, tc.status, rec.Code, rec.Body.String())

--- a/pkg/receive/receive_test.go
+++ b/pkg/receive/receive_test.go
@@ -4,19 +4,30 @@
 package receive
 
 import (
+	"context"
+	"fmt"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/efficientgo/core/testutil"
 	"github.com/go-kit/log"
+	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/tsdb"
 	"github.com/stretchr/testify/require"
 	"github.com/thanos-io/objstore"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/thanos-io/thanos/pkg/block/metadata"
+	"github.com/thanos-io/thanos/pkg/extkingpin"
 	"github.com/thanos-io/thanos/pkg/store"
 	"github.com/thanos-io/thanos/pkg/store/labelpb"
+	"github.com/thanos-io/thanos/pkg/store/storepb"
+	"github.com/thanos-io/thanos/pkg/store/storepb/prompb"
 	"github.com/thanos-io/thanos/pkg/testutil/custom"
 )
 
@@ -845,3 +856,111 @@ func setupSetsOfExpectedAndActualStoreClientLabelSets(
 
 	return setOfExpectedClientLabelSets, setOfActualClientLabelSets
 }
+
+func mustNewLimiter(t *testing.T) *Limiter {
+	t.Helper()
+
+	l, err := NewLimiter(extkingpin.NewNopConfig(), nil, RouterIngestor, log.NewNopLogger(), time.Second)
+	testutil.Ok(t, err)
+	return l
+}
+
+func TestSendRemoteWriteMarksPeerUnavailableOnAnyError(t *testing.T) {
+	t.Parallel()
+
+	for _, sendUnavailable := range []bool{true, false} {
+		t.Run(fmt.Sprintf("sendUnavailable=%v", sendUnavailable), func(t *testing.T) {
+			h := NewHandler(log.NewNopLogger(), &Options{
+				Writer:            NewWriter(log.NewNopLogger(), newFakeTenantAppendable(&fakeAppendable{appender: newFakeAppender(nil, nil, nil)}), &WriterOptions{}),
+				ForwardTimeout:    time.Second,
+				ReplicationFactor: 1,
+				Limiter:           mustNewLimiter(t),
+			})
+
+			endpoint := Endpoint{Address: "addr-a", CapNProtoAddress: "addr-a"}
+			cl := &stubAsyncClient{err: context.DeadlineExceeded}
+			stubPeers := &stubPeersGroup{
+				client: cl,
+			}
+
+			h.peers = stubPeers
+
+			responses := make(chan writeResponse, 1)
+			var wg sync.WaitGroup
+			wg.Add(1)
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			cl.sendUnavailable = sendUnavailable
+
+			h.sendRemoteWrite(ctx, "tenant-a", endpointReplica{
+				endpoint: endpoint,
+				replica:  0,
+			}, trackedSeries{
+				seriesIDs:  []int{0},
+				timeSeries: []prompb.TimeSeries{{}},
+			}, false, responses, &wg)
+
+			wg.Wait()
+			close(responses)
+
+			if sendUnavailable {
+				testutil.Equals(t, []Endpoint{endpoint}, stubPeers.markUnavailable)
+				testutil.Equals(t, []Endpoint(nil), stubPeers.closed)
+			} else {
+				testutil.Equals(t, []Endpoint(nil), stubPeers.markUnavailable)
+				testutil.Equals(t, []Endpoint(nil), stubPeers.closed)
+			}
+
+		})
+	}
+}
+
+type stubPeersGroup struct {
+	client WriteableStoreAsyncClient
+
+	markUnavailable []Endpoint
+	closed          []Endpoint
+}
+
+func (s *stubPeersGroup) Close() error { return nil }
+
+func (s *stubPeersGroup) markPeerUnavailable(endpoint Endpoint) {
+	s.markUnavailable = append(s.markUnavailable, endpoint)
+}
+
+func (s *stubPeersGroup) markPeerAvailable(Endpoint) {}
+
+func (s *stubPeersGroup) reset() {}
+
+func (s *stubPeersGroup) close(endpoint Endpoint) error {
+	s.closed = append(s.closed, endpoint)
+	return nil
+}
+
+func (s *stubPeersGroup) getConnection(context.Context, Endpoint) (WriteableStoreAsyncClient, error) {
+	return s.client, nil
+}
+
+type stubAsyncClient struct {
+	err error
+
+	sendUnavailable bool
+}
+
+func (s *stubAsyncClient) RemoteWrite(ctx context.Context, in *storepb.WriteRequest, opts ...grpc.CallOption) (*storepb.WriteResponse, error) {
+	return &storepb.WriteResponse{}, nil
+}
+
+func (s *stubAsyncClient) RemoteWriteAsync(ctx context.Context, in *storepb.WriteRequest, er endpointReplica, seriesIDs []int, responses chan writeResponse, cb func(error)) {
+	err := errors.Wrapf(s.err, "forwarding request to endpoint %v", er.endpoint)
+	if s.sendUnavailable {
+		err = status.Error(codes.Unavailable, err.Error())
+	}
+	responses <- newWriteResponse(seriesIDs, err, er)
+
+	cb(err)
+}
+
+func (s *stubAsyncClient) Close() error { return nil }

--- a/pkg/receive/writecapnp/client.go
+++ b/pkg/receive/writecapnp/client.go
@@ -63,12 +63,32 @@ func NewRemoteWriteClient(dialer Dialer, logger log.Logger) *RemoteWriteClient {
 }
 
 func (r *RemoteWriteClient) RemoteWrite(ctx context.Context, in *storepb.WriteRequest, _ ...grpc.CallOption) (*storepb.WriteResponse, error) {
-	return r.writeWithReconnect(ctx, 2, in)
+	resp, werr, err := r.writeWithReconnect(ctx, 2, in)
+
+	// We received something so it is available. Mark the errors to codes.
+	if err == nil {
+		switch werr {
+		case WriteError_unavailable:
+			return &storepb.WriteResponse{}, status.Error(codes.Unavailable, "remote write: peer unavailable")
+		case WriteError_alreadyExists:
+			return &storepb.WriteResponse{}, status.Error(codes.AlreadyExists, "remote write: data already exists")
+		case WriteError_invalidArgument:
+			return &storepb.WriteResponse{}, status.Error(codes.InvalidArgument, "remote write: invalid argument")
+		case WriteError_internal:
+			return &storepb.WriteResponse{}, status.Error(codes.Internal, "remote write: internal error")
+		case WriteError_none:
+			return resp, nil
+		default:
+			panic("BUG: unhandled WriteError")
+		}
+	}
+
+	return &storepb.WriteResponse{}, status.Error(codes.Unavailable, fmt.Sprintf("writing to peer: %s", err.Error()))
 }
 
-func (r *RemoteWriteClient) writeWithReconnect(ctx context.Context, numReconnects int, in *storepb.WriteRequest) (*storepb.WriteResponse, error) {
+func (r *RemoteWriteClient) writeWithReconnect(ctx context.Context, numReconnects int, in *storepb.WriteRequest) (*storepb.WriteResponse, WriteError, error) {
 	if err := r.connect(ctx); err != nil {
-		return nil, status.Error(codes.Unavailable, err.Error())
+		return nil, 0, err
 	}
 
 	result, release := r.writer.Write(ctx, func(params Writer_write_Params) error {
@@ -85,32 +105,32 @@ func (r *RemoteWriteClient) writeWithReconnect(ctx context.Context, numReconnect
 		if numReconnects > 0 && capnp.IsDisconnected(err) {
 			level.Warn(r.logger).Log("msg", "rpc failed, reconnecting")
 			if err := r.Close(); err != nil {
-				return nil, err
+				return nil, 0, err
 			}
 			numReconnects--
 			return r.writeWithReconnect(ctx, numReconnects, in)
 		}
-		return nil, errors.Wrap(err, "failed writing to peer")
+		return nil, 0, errors.Wrap(err, "failed writing to peer")
 	}
 	switch s.Error() {
 	case WriteError_unavailable:
-		return nil, status.Error(codes.Unavailable, "rpc failed")
+		return nil, WriteError_unavailable, nil
 	case WriteError_alreadyExists:
-		return nil, status.Error(codes.AlreadyExists, "rpc failed")
+		return nil, WriteError_alreadyExists, nil
 	case WriteError_invalidArgument:
-		return nil, status.Error(codes.InvalidArgument, "rpc failed")
+		return nil, WriteError_invalidArgument, nil
 	case WriteError_internal:
 		extraContext, err := s.ExtraErrorContext()
 		if err != nil {
 			if numReconnects > 0 && capnp.IsDisconnected(err) {
 				level.Warn(r.logger).Log("msg", "rpc failed, reconnecting")
 				if err := r.Close(); err != nil {
-					return nil, err
+					return nil, 0, err
 				}
 				numReconnects--
 				return r.writeWithReconnect(ctx, numReconnects, in)
 			}
-			return nil, errors.Wrap(err, "failed writing to peer")
+			return nil, 0, errors.Wrap(err, "failed writing to peer")
 		}
 
 		if extraContext == "" {
@@ -119,9 +139,11 @@ func (r *RemoteWriteClient) writeWithReconnect(ctx context.Context, numReconnect
 			extraContext = ": " + extraContext
 		}
 
-		return nil, status.Error(codes.Internal, fmt.Sprintf("rpc failed%s", extraContext))
+		return nil, 0, fmt.Errorf("rpc failed%s", extraContext)
+	case WriteError_none:
+		return &storepb.WriteResponse{}, 0, nil
 	default:
-		return &storepb.WriteResponse{}, nil
+		panic("BUG: unhandled WriteError")
 	}
 }
 

--- a/test/e2e/e2ethanos/services.go
+++ b/test/e2e/e2ethanos/services.go
@@ -601,6 +601,7 @@ type ReceiveBuilder struct {
 	metaMonitoringQuery   string
 	hashringConfigs       []receive.HashringConfig
 	relabelConfigs        []*relabel.Config
+	artificialDelay       time.Duration
 	replication           int
 	image                 string
 	nativeHistograms      bool
@@ -657,6 +658,11 @@ func (r *ReceiveBuilder) WithRouting(replication int, hashringConfigs ...receive
 	return r
 }
 
+func (r *ReceiveBuilder) WithArtificialDelay(delay time.Duration) *ReceiveBuilder {
+	r.artificialDelay = delay
+	return r
+}
+
 func (r *ReceiveBuilder) WithTenantSplitLabel(splitLabel string) *ReceiveBuilder {
 	r.tenantSplitLabel = splitLabel
 	return r
@@ -706,6 +712,10 @@ func (r *ReceiveBuilder) Init() *e2eobs.Observable {
 
 	if r.tenantSplitLabel != "" {
 		args["--receive.split-tenant-label-name"] = r.tenantSplitLabel
+	}
+
+	if r.artificialDelay > 0 {
+		args["--receive.artificial-max-delay"] = r.artificialDelay.String()
 	}
 
 	if len(r.labels) > 0 {


### PR DESCRIPTION
If we try to write and hear nothing back from the worker (ingester) then mark that peer as unavailable always. If we hear something back then do it like previously: map the error code to the status. This also replicates what e.g. nginx is doing.

Add a test that shows that with artificial timeout the peer gets removed. The test writes 1000 series. When the randomly generated delay reaches or exceeds 5s, we can see in the logs that the writing stops for ~5 seconds and then continues succeeding because that lagging peer is dropped from the hashring.

Loosely based on https://github.com/thanos-io/thanos/pull/8534. :bow: :heart: 

Closing/reconnecting is handled inside of the writer itself. This neatly hides the implementation details from the hashring itself.
