### PR TITLE
Makefile: add test-local-short

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -319,13 +319,19 @@ test: export THANOS_TEST_ALERTMANAGER_PATH= $(ALERTMANAGER)
 test: check-git install-tool-deps
 	@echo ">> install thanos GOOPTS=${GOOPTS}"
 	@echo ">> running unit tests (without /test/e2e). Do export THANOS_TEST_OBJSTORE_SKIP=GCS,S3,AZURE,SWIFT,COS,ALIYUNOSS,BOS,OCI,OBS if you want to skip e2e tests against all real store buckets. Current value: ${THANOS_TEST_OBJSTORE_SKIP}"
-	@go test -tags slicelabels -race -timeout 15m $(shell go list ./... | grep -v /vendor/ | grep -v /test/e2e);
+	@go test $(SHORT) -tags slicelabels -race -timeout 15m $(shell go list ./... | grep -v /vendor/ | grep -v /test/e2e);
 
 .PHONY: test-local
 test-local: ## Runs test excluding tests for ALL  object storage integrations.
 test-local: export THANOS_TEST_OBJSTORE_SKIP=GCS,S3,AZURE,SWIFT,COS,ALIYUNOSS,BOS,OCI,OBS
 test-local:
 	$(MAKE) test
+
+.PHONY: test-local-short
+test-local-short: ## Runs test excluding tests for ALL  object storage integrations. Only quick tests (<5s).
+test-local-short: export THANOS_TEST_OBJSTORE_SKIP=GCS,S3,AZURE,SWIFT,COS,ALIYUNOSS,BOS,OCI,OBS
+test-local-short:
+	$(MAKE) test SHORT="-short"
 
 .PHONY: test-e2e
 test-e2e: ## Runs all Thanos e2e docker-based e2e tests from test/e2e. Required access to docker daemon.

--- a/docs/contributing/coding-style-guide.md
+++ b/docs/contributing/coding-style-guide.md
@@ -880,6 +880,8 @@ for _, tcase := range []struct{
 
 Avoid unit testing based on real-time. Always try to mock time that is used within struct by using, for example, a `timeNow func() time.Time` field. For production code, you can initialize the field with `time.Now`. For test code, you can set a custom time that will be used by the struct.
 
+You can also try using the new `synctest` package to simulate time.
+
 <table>
 <tbody>
 <tr><th>Avoid 🔥</th></tr>

--- a/docs/contributing/committing.md
+++ b/docs/contributing/committing.md
@@ -1,0 +1,21 @@
+# Tips for committing
+
+## Prefer & run short tests
+
+Ideally, each test should be parallel i.e. not use any any shared state and run as fast as possible.
+
+Consider using `synctest` to make the tests not timing dependent. If it is still
+not possible then please add this clause to your tests to skip them if `-short`
+is passed:
+
+```go
+if testing.Short() { t.Skip() }
+```
+
+We have a suite of tests that can run very quickly. It's recommended to run them on every commit. Do that with:
+
+```
+make test-local-short
+```
+
+We have an intention to provide pre-commit hooks that would automate this workflow in the future.

--- a/pkg/block/indexheader/lazy_binary_reader_test.go
+++ b/pkg/block/indexheader/lazy_binary_reader_test.go
@@ -252,6 +252,11 @@ func TestLazyBinaryReader_unload_ShouldReturnErrorIfNotIdle(t *testing.T) {
 }
 
 func TestLazyBinaryReader_LoadUnloadRaceCondition(t *testing.T) {
+	if testing.
+		Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	// Run the test for a fixed amount of time.
 	const runDuration = 5 * time.Second
 

--- a/pkg/compact/compact_e2e_test.go
+++ b/pkg/compact/compact_e2e_test.go
@@ -176,11 +176,21 @@ func MetricCount(c prometheus.Collector) int {
 }
 
 func TestGroupCompactE2E(t *testing.T) {
+	if testing.
+		Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	testGroupCompactE2e(t, nil)
 }
 
 // Penalty based merger should get the same result as the blocks don't have overlap.
 func TestGroupCompactPenaltyDedupE2E(t *testing.T) {
+	if testing.
+		Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	testGroupCompactE2e(t, dedup.NewChunkSeriesMerger())
 }
 

--- a/pkg/compact/compact_test.go
+++ b/pkg/compact/compact_test.go
@@ -553,6 +553,11 @@ func TestDownsampleProgressCalculate(t *testing.T) {
 }
 
 func TestNoMarkFilterAtomic(t *testing.T) {
+	if testing.
+		Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	ctx := context.TODO()
@@ -631,6 +636,11 @@ func TestNoMarkFilterAtomic(t *testing.T) {
 }
 
 func TestGarbageCollect_FilterRace(t *testing.T) {
+	if testing.
+		Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	timeoutCtx, timeoutCancel := context.WithTimeout(context.Background(), 20*time.Second)
 	t.Cleanup(timeoutCancel)
 

--- a/pkg/compactv2/compactor_test.go
+++ b/pkg/compactv2/compactor_test.go
@@ -35,6 +35,11 @@ import (
 )
 
 func TestCompactor_WriteSeries_e2e(t *testing.T) {
+	if testing.
+		Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 

--- a/pkg/metadata/prometheus_test.go
+++ b/pkg/metadata/prometheus_test.go
@@ -27,6 +27,11 @@ func TestMain(m *testing.M) {
 }
 
 func TestPrometheus_Metadata_e2e(t *testing.T) {
+	if testing.
+		Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	p, err := e2eutil.NewPrometheus()
 	testutil.Ok(t, err)
 	defer func() { testutil.Ok(t, p.Stop()) }()

--- a/pkg/query/endpointset_test.go
+++ b/pkg/query/endpointset_test.go
@@ -613,6 +613,11 @@ func TestEndpointSetUpdate_AtomicEndpointAdditions(t *testing.T) {
 }
 
 func TestEndpointSetUpdate_AvailabilityScenarios(t *testing.T) {
+	if testing.
+		Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	endpoints, err := startTestEndpoints([]testEndpointMeta{
@@ -1107,6 +1112,11 @@ func TestEndpointSet_Update_NoneAvailable(t *testing.T) {
 
 // TestEndpoint_Update_QuerierStrict tests what happens when the strict mode is enabled/disabled.
 func TestEndpoint_Update_QuerierStrict(t *testing.T) {
+	if testing.
+		Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	endpoints, err := startTestEndpoints([]testEndpointMeta{

--- a/pkg/query/query_bench_test.go
+++ b/pkg/query/query_bench_test.go
@@ -147,6 +147,11 @@ func BenchmarkGRPCServer(b *testing.B) {
 // this many times and within different interval e.g
 // TODO(bwplotka): Add benchmarks with PromQL involvement.
 func TestQuerySelect(t *testing.T) {
+	if testing.
+		Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	tb := testutil.NewTB(t)

--- a/pkg/query/query_test.go
+++ b/pkg/query/query_test.go
@@ -57,6 +57,11 @@ func (sc *safeClients) append(c store.Client) {
 }
 
 func TestQuerier_Proxy(t *testing.T) {
+	if testing.
+		Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	files, err := filepath.Glob("testdata/promql/**/*.test")
 	testutil.Ok(t, err)
 	testutil.Equals(t, 10, len(files), "%v", files)

--- a/pkg/receive/capnproto_server_test.go
+++ b/pkg/receive/capnproto_server_test.go
@@ -17,6 +17,11 @@ import (
 )
 
 func TestCapNProtoServer_SingleConcurrentClient(t *testing.T) {
+	if testing.
+		Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	var (

--- a/pkg/receive/handler_test.go
+++ b/pkg/receive/handler_test.go
@@ -771,6 +771,11 @@ func TestReceiveQuorumKetama(t *testing.T) {
 }
 
 func TestReceiveWithConsistencyDelayHashmod(t *testing.T) {
+	if testing.
+		Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	for _, capnpReplication := range []bool{false, true} {
@@ -781,6 +786,11 @@ func TestReceiveWithConsistencyDelayHashmod(t *testing.T) {
 }
 
 func TestReceiveWithConsistencyDelayKetama(t *testing.T) {
+	if testing.
+		Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	for _, capnpReplication := range []bool{false, true} {
@@ -997,6 +1007,11 @@ func BenchmarkHandlerReceiveHTTP(b *testing.B) {
 }
 
 func TestHandlerReceiveHTTP(t *testing.T) {
+	if testing.
+		Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	benchmarkHandlerMultiTSDBReceiveRemoteWrite(testutil.NewTB(t))

--- a/pkg/receive/hashring_test.go
+++ b/pkg/receive/hashring_test.go
@@ -377,6 +377,11 @@ func TestKetamaHashringIncreaseInMiddle(t *testing.T) {
 }
 
 func TestKetamaHashringReplicationConsistency(t *testing.T) {
+	if testing.
+		Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	series := makeSeries()
@@ -399,6 +404,11 @@ func TestKetamaHashringReplicationConsistency(t *testing.T) {
 }
 
 func TestKetamaHashringReplicationConsistencyWithAZs(t *testing.T) {
+	if testing.
+		Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	for _, tt := range []struct {

--- a/pkg/receive/multitsdb_test.go
+++ b/pkg/receive/multitsdb_test.go
@@ -530,6 +530,11 @@ func TestMultiTSDBRecreatePrunedTenant(t *testing.T) {
 }
 
 func TestMultiTSDBAddNewTenant(t *testing.T) {
+	if testing.
+		Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	const iterations = 10
 	// This test detects race conditions, so we run it multiple times to increase the chance of catching the issue.
@@ -961,6 +966,11 @@ func TestMultiTSDBDoesNotDeleteNotUploadedBlocks(t *testing.T) {
 }
 
 func TestMultiTSDBDoesNotReturnPrunedTenants(t *testing.T) {
+	if testing.
+		Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	dir := t.TempDir()

--- a/pkg/receive/receive_test.go
+++ b/pkg/receive/receive_test.go
@@ -25,6 +25,11 @@ func TestMain(m *testing.M) {
 }
 
 func TestAddingExternalLabelsForTenants(t *testing.T) {
+	if testing.
+		Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	for _, tc := range []struct {
@@ -350,6 +355,11 @@ func TestLabelSetsOfTenantsWhenAddingTenants(t *testing.T) {
 }
 
 func TestLabelSetsOfTenantsWhenChangingLabels(t *testing.T) {
+	if testing.
+		Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	initialConfig := []HashringConfig{
@@ -582,6 +592,11 @@ func TestLabelSetsOfTenantsWhenChangingLabels(t *testing.T) {
 }
 
 func TestAddingLabelsWhenTenantAppearsInMultipleHashrings(t *testing.T) {
+	if testing.
+		Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	initialConfig := []HashringConfig{

--- a/pkg/receive/writer_test.go
+++ b/pkg/receive/writer_test.go
@@ -30,6 +30,11 @@ import (
 )
 
 func TestWriter(t *testing.T) {
+	if testing.
+		Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	now := model.Now()

--- a/pkg/reloader/reloader_test.go
+++ b/pkg/reloader/reloader_test.go
@@ -33,6 +33,11 @@ func TestMain(m *testing.M) {
 }
 
 func TestReloader_ConfigApply(t *testing.T) {
+	if testing.
+		Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
@@ -199,6 +204,11 @@ config:
 }
 
 func TestReloader_ConfigRollback(t *testing.T) {
+	if testing.
+		Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)

--- a/pkg/store/acceptance_test.go
+++ b/pkg/store/acceptance_test.go
@@ -926,6 +926,11 @@ func testStoreAPIsSeriesSplitSamplesIntoChunksWithMaxSizeOf120(t *testing.T, sta
 }
 
 func TestBucketStore_Acceptance(t *testing.T) {
+	if testing.
+		Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	ctx := context.Background()
@@ -1022,6 +1027,11 @@ func TestBucketStore_Acceptance(t *testing.T) {
 }
 
 func TestPrometheusStore_Acceptance(t *testing.T) {
+	if testing.
+		Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	startStore := func(tt *testing.T, extLset labels.Labels, appendFn func(app storage.Appender)) storepb.StoreServer {
@@ -1055,6 +1065,11 @@ func TestPrometheusStore_Acceptance(t *testing.T) {
 }
 
 func TestTSDBStore_Acceptance(t *testing.T) {
+	if testing.
+		Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	startStore := func(tt *testing.T, extLset labels.Labels, appendFn func(app storage.Appender)) storepb.StoreServer {
@@ -1207,6 +1222,11 @@ func TestProxyStoreWithTSDBSelector_Acceptance(t *testing.T) {
 }
 
 func TestProxyStoreWithReplicas_Acceptance(t *testing.T) {
+	if testing.
+		Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	startStore := func(tt *testing.T, extLset labels.Labels, appendFn func(app storage.Appender)) storepb.StoreServer {
@@ -1241,6 +1261,11 @@ func TestProxyStoreWithReplicas_Acceptance(t *testing.T) {
 // based on relabel configuration, ensuring that only matching stores are included
 // in TSDBInfos, LabelValues, and other metadata operations.
 func TestTSDBSelectorFilteringBehavior(t *testing.T) {
+	if testing.
+		Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	startStore := func(tt *testing.T, extLset labels.Labels, appendFn func(app storage.Appender)) storepb.StoreServer {

--- a/pkg/store/bucket_e2e_test.go
+++ b/pkg/store/bucket_e2e_test.go
@@ -483,6 +483,11 @@ func testBucketStore_e2e(t *testing.T, ctx context.Context, s *storeSuite) {
 }
 
 func TestBucketStore_e2e(t *testing.T) {
+	if testing.
+		Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	objtesting.ForeachStore(t, func(t *testing.T, bkt objstore.Bucket) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -536,6 +541,11 @@ func (g naivePartitioner) Partition(length int, rng func(int) (uint64, uint64)) 
 // This tests if our, sometimes concurrent, fetches for different parts works.
 // Regression test against: https://github.com/thanos-io/thanos/issues/829.
 func TestBucketStore_ManyParts_e2e(t *testing.T) {
+	if testing.
+		Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	objtesting.ForeachStore(t, func(t *testing.T, bkt objstore.Bucket) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -556,6 +566,11 @@ func TestBucketStore_ManyParts_e2e(t *testing.T) {
 }
 
 func TestBucketStore_TimePartitioning_e2e(t *testing.T) {
+	if testing.
+		Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	ctx := t.Context()
@@ -610,6 +625,11 @@ func TestBucketStore_TimePartitioning_e2e(t *testing.T) {
 }
 
 func TestBucketStore_Series_ChunksLimiter_e2e(t *testing.T) {
+	if testing.
+		Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	// The query will fetch 2 series from 6 blocks, so we do expect to hit a total of 12 chunks.
@@ -681,6 +701,11 @@ func TestBucketStore_Series_ChunksLimiter_e2e(t *testing.T) {
 }
 
 func TestBucketStore_Series_CustomBytesLimiters_e2e(t *testing.T) {
+	if testing.
+		Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	ctx := t.Context()
@@ -722,6 +747,11 @@ func TestBucketStore_Series_CustomBytesLimiters_e2e(t *testing.T) {
 }
 
 func TestBucketStore_LabelNames_e2e(t *testing.T) {
+	if testing.
+		Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	objtesting.ForeachStore(t, func(t *testing.T, bkt objstore.Bucket) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -826,6 +856,11 @@ func TestBucketStore_LabelNames_e2e(t *testing.T) {
 }
 
 func TestBucketStore_LabelNames_SeriesLimiter_e2e(t *testing.T) {
+	if testing.
+		Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	cases := map[string]struct {
@@ -878,6 +913,11 @@ func TestBucketStore_LabelNames_SeriesLimiter_e2e(t *testing.T) {
 }
 
 func TestBucketStore_LabelValues_e2e(t *testing.T) {
+	if testing.
+		Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	objtesting.ForeachStore(t, func(t *testing.T, bkt objstore.Bucket) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -985,6 +1025,11 @@ func TestBucketStore_LabelValues_e2e(t *testing.T) {
 }
 
 func TestBucketStore_LabelValues_SeriesLimiter_e2e(t *testing.T) {
+	if testing.
+		Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	cases := map[string]struct {

--- a/pkg/store/bucket_test.go
+++ b/pkg/store/bucket_test.go
@@ -662,6 +662,11 @@ func TestBucketStoreConfig_validate(t *testing.T) {
 }
 
 func TestBucketStore_TSDBInfo(t *testing.T) {
+	if testing.
+		Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	ctx := t.Context()
@@ -1389,6 +1394,11 @@ func TestLazyExpandedPostingsEmptyPostings(t *testing.T) {
 }
 
 func TestBucketSeries(t *testing.T) {
+	if testing.
+		Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	tb := testutil.NewTB(t)
@@ -1398,6 +1408,11 @@ func TestBucketSeries(t *testing.T) {
 }
 
 func TestBucketSeriesLazyExpandedPostings(t *testing.T) {
+	if testing.
+		Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	tb := testutil.NewTB(t)
@@ -1407,6 +1422,11 @@ func TestBucketSeriesLazyExpandedPostings(t *testing.T) {
 }
 
 func TestBucketHistogramSeries(t *testing.T) {
+	if testing.
+		Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	tb := testutil.NewTB(t)
@@ -1416,6 +1436,11 @@ func TestBucketHistogramSeries(t *testing.T) {
 }
 
 func TestBucketFloatHistogramSeries(t *testing.T) {
+	if testing.
+		Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	tb := testutil.NewTB(t)
@@ -1425,6 +1450,11 @@ func TestBucketFloatHistogramSeries(t *testing.T) {
 }
 
 func TestBucketSkipChunksSeries(t *testing.T) {
+	if testing.
+		Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	tb := testutil.NewTB(t)
@@ -3547,6 +3577,11 @@ func TestToPostingGroup(t *testing.T) {
 
 // TestExpandedPostings is a test whether there is a race between multiple ExpandPostings() calls.
 func TestExpandedPostingsRace(t *testing.T) {
+	if testing.
+		Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	const blockCount = 10
@@ -4038,6 +4073,11 @@ func (m *compositeBytesLimiterMock) ReserveWithType(num uint64, dataType StoreDa
 }
 
 func TestBucketStoreMetadataLimit(t *testing.T) {
+	if testing.
+		Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	tb := testutil.NewTB(t)

--- a/pkg/store/postings_codec_test.go
+++ b/pkg/store/postings_codec_test.go
@@ -26,6 +26,11 @@ import (
 )
 
 func TestStreamedSnappyMaximumDecodedLen(t *testing.T) {
+	if testing.
+		Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	t.Run("compressed", func(t *testing.T) {
@@ -72,6 +77,11 @@ func TestStreamedSnappyMaximumDecodedLen(t *testing.T) {
 }
 
 func TestDiffVarintCodec(t *testing.T) {
+	if testing.
+		Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	chunksDir := t.TempDir()

--- a/pkg/store/proxy_test.go
+++ b/pkg/store/proxy_test.go
@@ -2090,6 +2090,11 @@ func storeSeriesResponse(t testing.TB, lset labels.Labels, smplChunks ...[]sampl
 }
 
 func TestProxySeries(t *testing.T) {
+	if testing.
+		Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	tb := testutil.NewTB(t)

--- a/pkg/store/storepb/custom_test.go
+++ b/pkg/store/storepb/custom_test.go
@@ -393,6 +393,11 @@ func BenchmarkMergedSeriesSet(b *testing.B) {
 }
 
 func TestMergedSeriesSet_Labels(t *testing.T) {
+	if testing.
+		Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Run("overlapping chunks", func(t *testing.T) {
 		benchmarkMergedSeriesSet(testutil.NewTB(t), true)
 	})

--- a/pkg/targets/prometheus_test.go
+++ b/pkg/targets/prometheus_test.go
@@ -25,6 +25,11 @@ import (
 )
 
 func TestPrometheus_Targets_e2e(t *testing.T) {
+	if testing.
+		Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	p, err := e2eutil.NewPrometheus()
 	testutil.Ok(t, err)
 	defer func() { testutil.Ok(t, p.Stop()) }()


### PR DESCRIPTION
Add test-local-short that will run only short and local tests. The
intention is to have a suite of tests we could quickly run on each
developer's machine before creating a commit in git.
