### PR TITLE
receive: only start CapNProto server when explicitly configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#8378](https://github.com/thanos-io/thanos/pull/8378): Store: fix the reuse of dirty posting slices
 - [#8558](https://github.com/thanos-io/thanos/pull/8558): Query-Frontend: Fix not logging requests when external-prefix is set in query
 - [#8254](https://github.com/thanos-io/thanos/issues/8254) Receive: Endless loop of retried replication with capnproto and distributors
+- [#8093](https://github.com/thanos-io/thanos/issues/8093) Receive: Fixed CapNProto server starting unconditionally. The server now only starts when `--receive.replication-protocol=capnproto` is explicitly set, preventing port conflicts and unnecessary resource usage when using the default Protobuf protocol.
+
 
 ### Added
 

--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -519,7 +519,9 @@ func runReceive(
 		}
 	}
 
-	{
+	// Only start CapNProto server when replication protocol is set to capnproto.
+	if receive.ReplicationProtocol(conf.replicationProtocol) == receive.CapNProtoReplication {
+		level.Info(logger).Log("msg", "starting Cap'n Proto server", "address", conf.replicationAddr)
 		capNProtoWriter := receive.NewCapNProtoWriter(logger, dbs, &receive.CapNProtoWriterOptions{
 			TooFarInFutureTimeWindow: int64(time.Duration(*conf.tsdbTooFarInFutureTimeWindow)),
 		})
@@ -537,6 +539,8 @@ func runReceive(
 				level.Warn(logger).Log("msg", "Cap'n Proto server did not shut down gracefully", "err", err.Error())
 			}
 		})
+	} else {
+		level.Info(logger).Log("msg", "Cap'n Proto server disabled", "reason", "replication protocol is not set to capnproto", "current_protocol", conf.replicationProtocol)
 	}
 
 	level.Info(logger).Log("msg", "starting receiver")


### PR DESCRIPTION
The CapNProto server was starting unconditionally even when using the default Protobuf protocol. This caused port conflicts when running multiple receiver instances locally and wasted resources.

Fixes #8093

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

- Wrap CapNProto server startup in conditional check for `--receive.replication-protocol=capnproto`
- Server now only starts when explicitly configured to use CapNProto
- Add info log when CapNProto server is disabled (default behavior)
- Add info log when CapNProto server is starting (when enabled)

## Verification

- `make build` passes
- `go vet ./cmd/thanos/...` passes
- `make format` passes

