### PR TITLE
Bug: Compactor lists blocks with marks as partial

### DIFF
--- a/pkg/block/fetcher.go
+++ b/pkg/block/fetcher.go
@@ -227,7 +227,7 @@ func (f *RecursiveLister) GetActiveAndPartialBlockIDs(ctx context.Context, activ
 		}
 
 		lastModified, _ := attrs.LastModified()
-		delete(partialBlocks, id)
+		partialBlocks[id] = false
 
 		select {
 		case <-ctx.Done():


### PR DESCRIPTION
A recent change (https://github.com/thanos-io/thanos/pull/8389) in fetcher.go makes the compactor list as partial any block with marks, like `no-compact` or `no-delete`, when using a recursive discovery strategy.

In the previous implementation, the compactor used to run the following checks:

```golang
for id, _ := range blocks {
    for _, file := range blocks[id] {
        if _, ok := partialBlocks[id]; !ok {
            partialBlocks[id] = true
        }
        if IsBlockMetaFile {
            partialBlocks[id] = false
        }
    }
}
```

In the current one:

```golang
for id, _ := range blocks {
    for _, file := range blocks[id] {
        if _, ok := partialBlocks[id]; !ok {
            partialBlocks[id] = true
        }
        if IsBlockMetaFile {
           delete(partialBlocks, id)
        }
    }
}
```

If the bucket [iterator](https://github.com/thanos-io/thanos/blob/main/pkg/block/fetcher.go#L213) returns any file after `meta.json`, like `no-compact-mark.json`, `partialBlocks[id]` will be empty and set to `true`, even though a `meta.json` has been already found for the block.

## Changes

<!-- Enumerate changes you made -->

I'm changing the line back to ` partialBlocks[id] = false`

## Verification

<!-- How you tested it? How do you know it works? -->

Added a small test to replicate the error.
