### PR TITLE
doc: remove reference to `--store=<store>` flag

### DIFF
--- a/docs/service-discovery.md
+++ b/docs/service-discovery.md
@@ -20,7 +20,7 @@ The simplest way to tell a component about a peer is to use a static flag.
 
 ### Thanos Querier
 
-The repeatable flag `--store=<store>` can be used to specify a `StoreAPI` that `Thanos Querier` should use.
+The repeatable flag `--endpoint=<endpoint>` can be used to specify a `StoreAPI` that `Thanos Querier` should use.
 
 ### Thanos Ruler
 
@@ -73,19 +73,19 @@ To use DNS SD, just add one of the following prefixes to the domain name in your
 * `dns+` - the domain name after this prefix will be looked up as an A/AAAA query. *A port is required for this query type*. An example using this lookup with a static flag:
 
 ```
---store=dns+stores.thanos.mycompany.org:9090
+--endpoint=dns+stores.thanos.mycompany.org:9090
 ```
 
 * `dnssrv+` - the domain name after this prefix will be looked up as a SRV query, and then each SRV record will be looked up as an A/AAAA query. You do not need to specify a port as the one from the query results will be used. For example:
 
 ```
---store=dnssrv+_thanosstores._tcp.mycompany.org
+--endpoint=dnssrv+_thanosstores._tcp.mycompany.org
 ```
 
 DNS SRV record discovery also work well within Kubernetes. Consider the following example:
 
 ```
---store=dnssrv+_grpc._tcp.thanos-store.monitoring.svc
+--endpoint=dnssrv+_grpc._tcp.thanos-store.monitoring.svc
 ```
 
 This configuration will instruct Thanos to discover all endpoints within the `thanos-store` service in the `monitoring` namespace and use the declared port named `grpc`.
@@ -93,7 +93,7 @@ This configuration will instruct Thanos to discover all endpoints within the `th
 * `dnssrvnoa+` - the domain name after this prefix will be looked up as a SRV query, with no A/AAAA lookup made after that. Similar to the `dnssrv+` case, you do not need to specify a port. For example:
 
 ```
---store=dnssrvnoa+_thanosstores._tcp.mycompany.org
+--endpoint=dnssrvnoa+_thanosstores._tcp.mycompany.org
 ```
 
 The default interval between DNS lookups is 30s. This interval can be changed using the `store.sd-dns-interval` flag for `StoreAPI` configuration in `Thanos Querier`, or `query.sd-dns-interval` for `QueryAPI` configuration in `Thanos Ruler`.


### PR DESCRIPTION
The flag doesn't exist anymore. Replaced by `--endpoint`.

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [X] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
