### PR TITLE
bug: fix possible race condition when re-allocating batch

### DIFF
--- a/pkg/store/batchable.go
+++ b/pkg/store/batchable.go
@@ -37,7 +37,7 @@ func (b *batchableServer) Flush() error {
 		if err := b.Store_SeriesServer.Send(storepb.NewBatchResponse(b.series)); err != nil {
 			return err
 		}
-		b.series = b.series[:0]
+		b.series = make([]*storepb.Series, 0, b.batchSize)
 	}
 
 	return nil
@@ -50,7 +50,7 @@ func (b *batchableServer) Send(response *storepb.SeriesResponse) error {
 			if err := b.Store_SeriesServer.Send(storepb.NewBatchResponse(b.series)); err != nil {
 				return err
 			}
-			b.series = b.series[:0]
+			b.series = make([]*storepb.Series, 0, b.batchSize)
 		}
 		return b.Store_SeriesServer.Send(response)
 	}
@@ -61,7 +61,7 @@ func (b *batchableServer) Send(response *storepb.SeriesResponse) error {
 		if err := b.Store_SeriesServer.Send(storepb.NewBatchResponse(b.series)); err != nil {
 			return err
 		}
-		b.series = b.series[:0]
+		b.series = make([]*storepb.Series, 0, b.batchSize)
 	}
 
 	return nil


### PR DESCRIPTION
Modifying the batch while it is being sent may cause a race condition

From grpc-go [1]:
```
It is not safe to modify the message after calling SendMsg. Tracing
libraries and stats handlers may use the message lazily.
``` 



[1] - https://github.com/grpc/grpc-go/blob/629ef39c3da583f56463213975f191661ac40dd2/stream.go#L135-L136