### PR TITLE
feat: add configurable gRPC keepalive and window size

### DIFF
--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -641,6 +641,9 @@ func runQuery(
 			grpcserver.WithListen(grpcServerConfig.bindAddress),
 			grpcserver.WithGracePeriod(grpcServerConfig.gracePeriod),
 			grpcserver.WithMaxConnAge(grpcServerConfig.maxConnectionAge),
+			grpcserver.WithKeepaliveParams(grpcServerConfig.keepaliveTime, grpcServerConfig.keepaliveTimeout, grpcServerConfig.keepalivePermitWithoutStream),
+			grpcserver.WithKeepaliveEnforcementPolicy(grpcServerConfig.keepaliveMinTime, grpcServerConfig.keepalivePermitWithoutStream),
+			grpcserver.WithInitialWindowSize(int32(grpcServerConfig.initialWindowSize), int32(grpcServerConfig.initialConnWindowSize)),
 			grpcserver.WithTLSConfig(tlsCfg),
 		)
 

--- a/cmd/thanos/rule.go
+++ b/cmd/thanos/rule.go
@@ -744,7 +744,10 @@ func runRule(
 		grpcserver.WithServer(thanosrules.RegisterRulesServer(ruleMgr)),
 		grpcserver.WithListen(conf.grpc.bindAddress),
 		grpcserver.WithGracePeriod(conf.grpc.gracePeriod),
-		grpcserver.WithGracePeriod(conf.grpc.maxConnectionAge),
+		grpcserver.WithMaxConnAge(conf.grpc.maxConnectionAge),
+		grpcserver.WithKeepaliveParams(conf.grpc.keepaliveTime, conf.grpc.keepaliveTimeout, conf.grpc.keepalivePermitWithoutStream),
+		grpcserver.WithKeepaliveEnforcementPolicy(conf.grpc.keepaliveMinTime, conf.grpc.keepalivePermitWithoutStream),
+		grpcserver.WithInitialWindowSize(int32(conf.grpc.initialWindowSize), int32(conf.grpc.initialConnWindowSize)),
 		grpcserver.WithTLSConfig(tlsCfg),
 	}
 	infoOptions := []info.ServerOptionFunc{info.WithRulesInfoFunc()}

--- a/cmd/thanos/sidecar.go
+++ b/cmd/thanos/sidecar.go
@@ -358,6 +358,9 @@ func runSidecar(
 			grpcserver.WithListen(conf.grpc.bindAddress),
 			grpcserver.WithGracePeriod(conf.grpc.gracePeriod),
 			grpcserver.WithMaxConnAge(conf.grpc.maxConnectionAge),
+			grpcserver.WithKeepaliveParams(conf.grpc.keepaliveTime, conf.grpc.keepaliveTimeout, conf.grpc.keepalivePermitWithoutStream),
+			grpcserver.WithKeepaliveEnforcementPolicy(conf.grpc.keepaliveMinTime, conf.grpc.keepalivePermitWithoutStream),
+			grpcserver.WithInitialWindowSize(int32(conf.grpc.initialWindowSize), int32(conf.grpc.initialConnWindowSize)),
 			grpcserver.WithTLSConfig(tlsCfg),
 		)
 

--- a/cmd/thanos/store.go
+++ b/cmd/thanos/store.go
@@ -557,6 +557,9 @@ func runStore(
 			grpcserver.WithListen(conf.grpcConfig.bindAddress),
 			grpcserver.WithGracePeriod(conf.grpcConfig.gracePeriod),
 			grpcserver.WithMaxConnAge(conf.grpcConfig.maxConnectionAge),
+			grpcserver.WithKeepaliveParams(conf.grpcConfig.keepaliveTime, conf.grpcConfig.keepaliveTimeout, conf.grpcConfig.keepalivePermitWithoutStream),
+			grpcserver.WithKeepaliveEnforcementPolicy(conf.grpcConfig.keepaliveMinTime, conf.grpcConfig.keepalivePermitWithoutStream),
+			grpcserver.WithInitialWindowSize(int32(conf.grpcConfig.initialWindowSize), int32(conf.grpcConfig.initialConnWindowSize)),
 			grpcserver.WithTLSConfig(tlsCfg),
 		)
 

--- a/pkg/extgrpc/client_options_test.go
+++ b/pkg/extgrpc/client_options_test.go
@@ -1,0 +1,42 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package extgrpc
+
+import (
+	"testing"
+	"time"
+
+	"github.com/efficientgo/core/testutil"
+)
+
+func TestDefaultClientOptions(t *testing.T) {
+	opts := defaultClientOptions()
+
+	testutil.Equals(t, 10*time.Second, opts.keepaliveTime)
+	testutil.Equals(t, 5*time.Second, opts.keepaliveTimeout)
+	testutil.Equals(t, true, opts.keepalivePermitWithoutStream)
+	testutil.Equals(t, int32(4<<20), opts.initialWindowSize)
+	testutil.Equals(t, int32(4<<20), opts.initialConnWindowSize)
+}
+
+func TestWithKeepaliveParams(t *testing.T) {
+	opts := defaultClientOptions()
+
+	opt := WithKeepaliveParams(20*time.Second, 10*time.Second, false)
+	opt(opts)
+
+	testutil.Equals(t, 20*time.Second, opts.keepaliveTime)
+	testutil.Equals(t, 10*time.Second, opts.keepaliveTimeout)
+	testutil.Equals(t, false, opts.keepalivePermitWithoutStream)
+}
+
+func TestWithInitialWindowSize(t *testing.T) {
+	opts := defaultClientOptions()
+
+	opt := WithInitialWindowSize(1024, 2048)
+	opt(opts)
+
+	testutil.Equals(t, int32(1024), opts.initialWindowSize)
+	testutil.Equals(t, int32(2048), opts.initialConnWindowSize)
+}

--- a/pkg/server/grpc/option.go
+++ b/pkg/server/grpc/option.go
@@ -20,6 +20,14 @@ type options struct {
 
 	tlsConfig *tls.Config
 
+	keepaliveTime                time.Duration
+	keepaliveTimeout             time.Duration
+	keepalivePermitWithoutStream bool
+	keepaliveMinTime             time.Duration
+
+	initialWindowSize     int32
+	initialConnWindowSize int32
+
 	grpcOpts []grpc.ServerOption
 }
 
@@ -86,5 +94,29 @@ func WithTLSConfig(cfg *tls.Config) Option {
 func WithMaxConnAge(t time.Duration) Option {
 	return optionFunc(func(o *options) {
 		o.maxConnAge = t
+	})
+}
+
+// WithKeepaliveParams sets the keepalive parameters for gRPC server.
+func WithKeepaliveParams(time, timeout time.Duration, permitWithoutStream bool) Option {
+	return optionFunc(func(o *options) {
+		o.keepaliveTime = time
+		o.keepaliveTimeout = timeout
+		o.keepalivePermitWithoutStream = permitWithoutStream
+	})
+}
+
+// WithKeepaliveEnforcementPolicy sets the keepalive enforcement policy for gRPC server.
+func WithKeepaliveEnforcementPolicy(minTime time.Duration, permitWithoutStream bool) Option {
+	return optionFunc(func(o *options) {
+		o.keepaliveMinTime = minTime
+	})
+}
+
+// WithInitialWindowSize sets the initial window size for gRPC server.
+func WithInitialWindowSize(streamWindow, connWindow int32) Option {
+	return optionFunc(func(o *options) {
+		o.initialWindowSize = streamWindow
+		o.initialConnWindowSize = connWindow
 	})
 }

--- a/pkg/server/grpc/option_test.go
+++ b/pkg/server/grpc/option_test.go
@@ -1,0 +1,41 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package grpc
+
+import (
+	"testing"
+	"time"
+
+	"github.com/efficientgo/core/testutil"
+)
+
+func TestWithKeepaliveParams(t *testing.T) {
+	opts := &options{}
+
+	opt := WithKeepaliveParams(15*time.Second, 10*time.Second, true)
+	opt.apply(opts)
+
+	testutil.Equals(t, 15*time.Second, opts.keepaliveTime)
+	testutil.Equals(t, 10*time.Second, opts.keepaliveTimeout)
+	testutil.Equals(t, true, opts.keepalivePermitWithoutStream)
+}
+
+func TestWithKeepaliveEnforcementPolicy(t *testing.T) {
+	opts := &options{}
+
+	opt := WithKeepaliveEnforcementPolicy(5*time.Second, true)
+	opt.apply(opts)
+
+	testutil.Equals(t, 5*time.Second, opts.keepaliveMinTime)
+}
+
+func TestWithInitialWindowSize(t *testing.T) {
+	opts := &options{}
+
+	opt := WithInitialWindowSize(1024, 2048)
+	opt.apply(opts)
+
+	testutil.Equals(t, int32(1024), opts.initialWindowSize)
+	testutil.Equals(t, int32(2048), opts.initialConnWindowSize)
+}


### PR DESCRIPTION
Add CLI flags to configure gRPC keepalive parameters and initial window sizes for both server and client connections. This enables fine-tuning of connection health checks and flow control.

- Add server flags: keepalive-time, keepalive-timeout, keepalive-permit-without-stream, keepalive-min-time, initial-window-size, initial-conn-window-size
- Add client flags: keepalive-time, keepalive-timeout, keepalive-permit-without-stream, initial-window-size, initial-conn-window-size
- Apply settings to query, receive, rule, sidecar, and store
- Add functional options pattern for gRPC client configuration
- Add unit tests for new option functions

Change-Id: e0bf6c7f2cae00cfa5fb540eba0e73e2
Change-Id-Short: lzoktnskxnpl

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
