### PR TITLE
Fix: Enforce tenant isolation in /api/v1/rules endpoint

### DIFF
--- a/pkg/api/query/v1.go
+++ b/pkg/api/query/v1.go
@@ -62,6 +62,7 @@ import (
 	"github.com/thanos-io/thanos/pkg/status"
 	"github.com/thanos-io/thanos/pkg/status/statuspb"
 	"github.com/thanos-io/thanos/pkg/store"
+	"github.com/thanos-io/thanos/pkg/store/labelpb"
 	"github.com/thanos-io/thanos/pkg/store/storepb"
 	"github.com/thanos-io/thanos/pkg/targets"
 	"github.com/thanos-io/thanos/pkg/targets/targetspb"
@@ -244,7 +245,7 @@ func (qapi *QueryAPI) Register(r *route.Router, tracer opentracing.Tracer, logge
 	r.Get("/stores", instr("stores", qapi.stores))
 
 	r.Get("/alerts", instr("alerts", NewAlertsHandler(qapi.ruleGroups, qapi.enableRulePartialResponse)))
-	r.Get("/rules", instr("rules", NewRulesHandler(qapi.ruleGroups, qapi.enableRulePartialResponse)))
+	r.Get("/rules", instr("rules", NewRulesHandler(qapi.ruleGroups, qapi.enableRulePartialResponse, qapi.tenantHeader, qapi.defaultTenant, qapi.tenantCertField, qapi.enforceTenancy)))
 
 	r.Get("/targets", instr("targets", NewTargetsHandler(qapi.targets, qapi.enableTargetPartialResponse)))
 
@@ -1412,7 +1413,7 @@ func NewAlertsHandler(client rules.UnaryClient, enablePartialResponse bool) func
 
 // NewRulesHandler created handler compatible with HTTP /api/v1/rules https://prometheus.io/docs/prometheus/latest/querying/api/#rules
 // which uses gRPC Unary Rules API.
-func NewRulesHandler(client rules.UnaryClient, enablePartialResponse bool) func(*http.Request) (any, []error, *api.ApiError, func()) {
+func NewRulesHandler(client rules.UnaryClient, enablePartialResponse bool, tenantHeader, defaultTenant, tenantCertField string, enforceTenancy bool) func(*http.Request) (any, []error, *api.ApiError, func()) {
 	ps := storepb.PartialResponseStrategy_ABORT
 	if enablePartialResponse {
 		ps = storepb.PartialResponseStrategy_WARN
@@ -1426,7 +1427,16 @@ func NewRulesHandler(client rules.UnaryClient, enablePartialResponse bool) func(
 			groups   *rulespb.RuleGroups
 			warnings annotations.Annotations
 			err      error
+			tenant   string
 		)
+
+		// Extract tenant from request if tenancy enforcement is enabled
+		if enforceTenancy {
+			tenant, err = tenancy.GetTenantFromHTTP(r, tenantHeader, defaultTenant, tenantCertField)
+			if err != nil {
+				return nil, nil, &api.ApiError{Typ: api.ErrorBadData, Err: err}, func() {}
+			}
+		}
 
 		typeParam := r.URL.Query().Get("type")
 		typ, ok := rulespb.RulesRequest_Type_value[strings.ToUpper(typeParam)]
@@ -1456,6 +1466,19 @@ func NewRulesHandler(client rules.UnaryClient, enablePartialResponse bool) func(
 		if err != nil {
 			return nil, nil, &api.ApiError{Typ: api.ErrorInternal, Err: errors.Errorf("error retrieving rules: %v", err)}, func() {}
 		}
+
+		// Filter rules by tenant if tenancy is enforced
+		if enforceTenancy && tenant != "" && groups != nil {
+			filteredGroups := &rulespb.RuleGroups{}
+			for _, group := range groups.Groups {
+				// Check if this rule group has a tenant label matching the request
+				if groupBelongsToTenant(group, tenant) {
+					filteredGroups.Groups = append(filteredGroups.Groups, group)
+				}
+			}
+			groups = filteredGroups
+		}
+
 		return groups, warnings.AsErrors(), nil, func() {}
 	}
 }
@@ -1730,4 +1753,67 @@ func convertToTSDBStat(stats []statuspb.Statistic, limit int) []v1.TSDBStat {
 	}
 
 	return statuspb.ConvertToPrometheusTSDBStat(stats)
+}
+
+// groupBelongsToTenant checks if a rule group belongs to the specified tenant.
+// It checks for the presence of a tenant_id label in any of the rules within the group.
+func groupBelongsToTenant(group *rulespb.RuleGroup, tenant string) bool {
+	if group == nil || group.Rules == nil {
+		return false
+	}
+
+	// Check if any rule in the group has a tenant_id label matching the tenant
+	for _, rule := range group.Rules {
+		if rule == nil {
+			continue
+		}
+
+		// Check both Alert and RecordingRule types
+		var labels *labelpb.ZLabelSet
+		if alert := rule.GetAlert(); alert != nil {
+			labels = &alert.Labels
+		} else if recording := rule.GetRecording(); recording != nil {
+			labels = &recording.Labels
+		}
+
+		if labels != nil {
+			for _, label := range labels.Labels {
+				if label.Name == tenancy.DefaultTenantLabel && label.Value == tenant {
+					return true
+				}
+			}
+		}
+	}
+
+	// If no tenant label is found in any rule, include it in default tenant results
+	if tenant == tenancy.DefaultTenant {
+		hasTenantLabel := false
+		for _, rule := range group.Rules {
+			if rule == nil {
+				continue
+			}
+
+			var labels *labelpb.ZLabelSet
+			if alert := rule.GetAlert(); alert != nil {
+				labels = &alert.Labels
+			} else if recording := rule.GetRecording(); recording != nil {
+				labels = &recording.Labels
+			}
+
+			if labels != nil {
+				for _, label := range labels.Labels {
+					if label.Name == tenancy.DefaultTenantLabel {
+						hasTenantLabel = true
+						break
+					}
+				}
+				if hasTenantLabel {
+					break
+				}
+			}
+		}
+		return !hasTenantLabel
+	}
+
+	return false
 }

--- a/pkg/api/query/v1_test.go
+++ b/pkg/api/query/v1_test.go
@@ -1782,7 +1782,7 @@ func TestRulesHandler(t *testing.T) {
 				},
 			},
 		},
-	}, false)
+	}, false, "", "", "", false)
 
 	type test struct {
 		params   map[string]string

--- a/pkg/api/rule/v1.go
+++ b/pkg/api/rule/v1.go
@@ -60,5 +60,5 @@ func (rapi *RuleAPI) Register(r *route.Router, tracer opentracing.Tracer, logger
 	r.Get("/alerts", instr("alerts", func(r *http.Request) (any, []error, *api.ApiError, func()) {
 		return struct{ Alerts []*rulespb.AlertInstance }{Alerts: rapi.alerts.Active()}, nil, nil, func() {}
 	}))
-	r.Get("/rules", instr("rules", qapi.NewRulesHandler(rapi.ruleGroups, false)))
+	r.Get("/rules", instr("rules", qapi.NewRulesHandler(rapi.ruleGroups, false, "", "", "", false)))
 }


### PR DESCRIPTION
This commit addresses issue #8140 by implementing tenant-based filtering for the Rules API endpoint, ensuring that tenants can only access their own alert and recording rules.

Changes:
- Updated NewRulesHandler signature to accept tenancy parameters (tenantHeader, defaultTenant, tenantCertField, enforceTenancy)
- Added tenant extraction from HTTP request headers using tenancy.GetTenantFromHTTP()
- Implemented filtering logic to return only rule groups that belong to the requesting tenant
- Added groupBelongsToTenant() helper function to check tenant ownership based on tenant_id label
- Updated RegisterRoutes to pass QueryAPI tenancy configuration to NewRulesHandler

The implementation follows the same pattern used in other QueryAPI methods (e.g., tsdbStatus) for consistent multi-tenancy enforcement across all API endpoints.

Fixes #8140

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
