### PR TITLE
receive: add ketama_static hashring algorithm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 
 ### Added
 
+- [#8639](https://github.com/thanos-io/thanos/pull/8639): Receive: add `ketama_static` hashring algorithm with static replica alignment based on ordinals.
 - [#](https://github.com/thanos-io/thanos/pull/8623): Query: support sending a batch of Series per SeriesResponse with `--query.series-response-batch-size` flag.
 - [#](https://github.com/thanos-io/thanos/pull/8582): Sidecar: support --storage.tsdb.delay-compact-file.path Prometheus flag.
 

--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -979,10 +979,10 @@ func (rc *receiveConfig) registerFlag(cmd extkingpin.FlagClause) {
 
 	cmd.Flag("receive.hashrings", "Alternative to 'receive.hashrings-file' flag (lower priority). Content of file that contains the hashring configuration.").PlaceHolder("<content>").StringVar(&rc.hashringsFileContent)
 
-	hashringAlgorithmsHelptext := strings.Join([]string{string(receive.AlgorithmHashmod), string(receive.AlgorithmKetama)}, ", ")
+	hashringAlgorithmsHelptext := strings.Join([]string{string(receive.AlgorithmHashmod), string(receive.AlgorithmKetama), string(receive.AlgorithmKetamaStatic)}, ", ")
 	cmd.Flag("receive.hashrings-algorithm", "The algorithm used when distributing series in the hashrings. Must be one of "+hashringAlgorithmsHelptext+". Will be overwritten by the tenant-specific algorithm in the hashring config.").
 		Default(string(receive.AlgorithmHashmod)).
-		EnumVar(&rc.hashringsAlgorithm, string(receive.AlgorithmHashmod), string(receive.AlgorithmKetama))
+		EnumVar(&rc.hashringsAlgorithm, string(receive.AlgorithmHashmod), string(receive.AlgorithmKetama), string(receive.AlgorithmKetamaStatic))
 
 	rc.refreshInterval = extkingpin.ModelDuration(cmd.Flag("receive.hashrings-file-refresh-interval", "Refresh interval to re-read the hashring configuration file. (used as a fallback)").
 		Default("5m"))

--- a/pkg/receive/config.go
+++ b/pkg/receive/config.go
@@ -67,9 +67,10 @@ type Endpoint struct {
 	Address          string `json:"address"`
 	CapNProtoAddress string `json:"capnproto_address"`
 	AZ               string `json:"az"`
+	Ordinal          int    `json:"ordinal,omitempty"`
 }
 
-func (e *Endpoint) String() string {
+func (e Endpoint) String() string {
 	return fmt.Sprintf("addr: %s, capnp_addr: %s, az: %s", e.Address, e.CapNProtoAddress, e.AZ)
 }
 
@@ -113,6 +114,7 @@ func (e *Endpoint) unmarshal(data []byte) error {
 	e.Address = configEndpoint.Address
 	e.AZ = configEndpoint.AZ
 	e.CapNProtoAddress = configEndpoint.CapNProtoAddress
+	e.Ordinal = configEndpoint.Ordinal
 	return nil
 }
 


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->
  Add `ketama_static` hashring algorithm with static replica alignment based on explicit ordinals.

  Unlike regular AZ-aware ketama where replicas are determined dynamically by walking the hash ring, `ketama_static` uses explicit ordinal values to form replica groups: endpoints with the same ordinal across different AZs always replicate together.
  This provides predictable replica placement where, for example, `pod-0` in `zone-a` always replicates to `pod-0` in `zone-b` and `zone-c`. With this enabled, we can achieve better fault tolerance. For example, with 3 AZs, if a-0 and b-1 and c-2 are down we can still return a complete query result and achieve 100% metrics ingestion availability.

With another PR on the query path, we should be able to resolve https://github.com/thanos-io/thanos/issues/6368 and the need in this Slack thread https://cloud-native.slack.com/archives/CK5RSSC10/p1747832229649549

  Example config:
```
  [
      {
          "algorithm": "ketama_static",
          "endpoints": [
              { "address": "10.0.1.1:10901", "az": "zone-a", "ordinal": 0 },
              { "address": "10.0.2.1:10901", "az": "zone-b", "ordinal": 0 },
              { "address": "10.0.3.1:10901", "az": "zone-c", "ordinal": 0 }
          ]
      }
]
```
<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
