### PR TITLE
feat(dns): add dual-stack DNS resolution with dnsdualstack+ scheme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ It is recommend to upgrade the storage components first (Receive, Store, etc.) a
 
 ### Added
 
+- [#8651](https://github.com/thanos-io/thanos/pull/8651) Query/Ruler: Add dual-stack DNS resolution with `dnsdualstack+` scheme for resolving both IPv4 and IPv6 addresses with automatic failover via gRPC health checking.
 - [#](https://github.com/thanos-io/thanos/pull/8623): Query: Enable batching of Series per SeriesResponse.
 - [#](https://github.com/thanos-io/thanos/pull/8582): Sidecar: support --storage.tsdb.delay-compact-file.path Prometheus flag.
 - [#](https://github.com/thanos-io/thanos/pull/8595): *: add --shipper.upload-compacted flag for controlling upload concurrency in components that use shippper

--- a/docs/service-discovery.md
+++ b/docs/service-discovery.md
@@ -96,6 +96,12 @@ This configuration will instruct Thanos to discover all endpoints within the `th
 --endpoint=dnssrvnoa+_thanosstores._tcp.mycompany.org
 ```
 
+* `dnsdualstack+` - the domain name after this prefix will be looked up as both A and AAAA queries simultaneously, returning all resolved addresses. This provides dual-stack resilience by resolving both IPv4 and IPv6 addresses, with automatic failover handled by gRPC's built-in health checking. *A port is required for this query type*. For example:
+
+```
+--store=dnsdualstack+stores.thanos.mycompany.org:9090
+```
+
 The default interval between DNS lookups is 30s. This interval can be changed using the `store.sd-dns-interval` flag for `StoreAPI` configuration in `Thanos Querier`, or `query.sd-dns-interval` for `QueryAPI` configuration in `Thanos Ruler`.
 
 ## Other

--- a/docs/service-discovery.md
+++ b/docs/service-discovery.md
@@ -96,10 +96,10 @@ This configuration will instruct Thanos to discover all endpoints within the `th
 --endpoint=dnssrvnoa+_thanosstores._tcp.mycompany.org
 ```
 
-* `dnsdualstack+` - the domain name after this prefix will be looked up as both A and AAAA queries simultaneously, returning all resolved addresses. This provides dual-stack resilience by resolving both IPv4 and IPv6 addresses, with automatic failover handled by gRPC's built-in health checking. *A port is required for this query type*. For example:
+* `dnsdualstack+` - the domain name after this prefix will be looked up as both A and AAAA queries simultaneously, returning all resolved addresses. This provides dual-stack resilience by resolving both IPv4 and IPv6 addresses, with automatic failover handled by gRPC's built-in health checking. *A port is required for this query type*. This is most useful with `--endpoint-group`, which allows gRPC to manage all resolved addresses as a single logical group with automatic failover. For example:
 
 ```
---store=dnsdualstack+stores.thanos.mycompany.org:9090
+--endpoint-group=dnsdualstack+stores.thanos.mycompany.org:9090
 ```
 
 The default interval between DNS lookups is 30s. This interval can be changed using the `store.sd-dns-interval` flag for `StoreAPI` configuration in `Thanos Querier`, or `query.sd-dns-interval` for `QueryAPI` configuration in `Thanos Ruler`.

--- a/docs/service-discovery.md
+++ b/docs/service-discovery.md
@@ -96,7 +96,7 @@ This configuration will instruct Thanos to discover all endpoints within the `th
 --endpoint=dnssrvnoa+_thanosstores._tcp.mycompany.org
 ```
 
-* `dnsdualstack+` - the domain name after this prefix will be looked up as both A and AAAA queries simultaneously, returning all resolved addresses. This provides dual-stack resilience by resolving both IPv4 and IPv6 addresses, with automatic failover handled by gRPC's built-in health checking. *A port is required for this query type*. This is most useful with `--endpoint-group`, which allows gRPC to manage all resolved addresses as a single logical group with automatic failover. For example:
+* `dnsdualstack+` - the domain name after this prefix will be looked up as both A and AAAA queries, returning all resolved addresses. This provides dual-stack resilience by resolving both IPv4 and IPv6 addresses, with automatic failover handled by gRPC's built-in health checking. *A port is required for this query type*. This is most useful with `--endpoint-group`, which allows gRPC to manage all resolved addresses as a single logical group with automatic failover. For example:
 
 ```
 --endpoint-group=dnsdualstack+stores.thanos.mycompany.org:9090

--- a/pkg/discovery/dns/godns/resolver.go
+++ b/pkg/discovery/dns/godns/resolver.go
@@ -10,43 +10,19 @@ import (
 	"github.com/pkg/errors"
 )
 
-var errNoSuchHost = &net.DNSError{
-	Err:        "no such host",
-	IsNotFound: true,
-}
-
 // Resolver is a wrapper for net.Resolver.
 type Resolver struct {
 	*net.Resolver
 }
 
-func (r *Resolver) LookupIPAddrDualStack(ctx context.Context, host string) ([]net.IPAddr, error) {
-	seen := make(map[string]struct{})
-	var result []net.IPAddr
-
-	for _, network := range []string{"ip6", "ip4"} {
-		select {
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		default:
-		}
-
-		ips, err := r.LookupIP(ctx, network, host)
-		if err != nil {
-			continue
-		}
-
-		for _, ip := range ips {
-			ipStr := ip.String()
-			if _, ok := seen[ipStr]; !ok {
-				seen[ipStr] = struct{}{}
-				result = append(result, net.IPAddr{IP: ip})
-			}
-		}
+func (r *Resolver) LookupIPAddrByNetwork(ctx context.Context, network, host string) ([]net.IPAddr, error) {
+	ips, err := r.LookupIP(ctx, network, host)
+	if err != nil {
+		return nil, err
 	}
-
-	if len(result) == 0 {
-		return nil, errNoSuchHost
+	result := make([]net.IPAddr, len(ips))
+	for i, ip := range ips {
+		result[i] = net.IPAddr{IP: ip}
 	}
 	return result, nil
 }

--- a/pkg/discovery/dns/godns/resolver.go
+++ b/pkg/discovery/dns/godns/resolver.go
@@ -4,6 +4,7 @@
 package godns
 
 import (
+	"context"
 	"net"
 
 	"github.com/pkg/errors"
@@ -12,6 +13,44 @@ import (
 // Resolver is a wrapper for net.Resolver.
 type Resolver struct {
 	*net.Resolver
+}
+
+func (r *Resolver) LookupIPAddrDualStack(ctx context.Context, host string) ([]net.IPAddr, error) {
+	seen := make(map[string]struct{})
+	var result []net.IPAddr
+
+	for _, network := range []string{"ip6", "ip4"} {
+		select {
+		case <-ctx.Done():
+			if len(result) > 0 {
+				return result, nil
+			}
+			return nil, ctx.Err()
+		default:
+		}
+
+		ips, err := r.LookupIP(ctx, network, host)
+		if err != nil {
+			continue
+		}
+
+		for _, ip := range ips {
+			ipStr := ip.String()
+			if _, ok := seen[ipStr]; !ok {
+				seen[ipStr] = struct{}{}
+				result = append(result, net.IPAddr{IP: ip})
+			}
+		}
+	}
+
+	if len(result) == 0 {
+		return nil, &net.DNSError{
+			Err:        "no such host",
+			Name:       host,
+			IsNotFound: true,
+		}
+	}
+	return result, nil
 }
 
 // IsNotFound checkout if DNS record is not found.

--- a/pkg/discovery/dns/godns/resolver.go
+++ b/pkg/discovery/dns/godns/resolver.go
@@ -10,6 +10,11 @@ import (
 	"github.com/pkg/errors"
 )
 
+var errNoSuchHost = &net.DNSError{
+	Err:        "no such host",
+	IsNotFound: true,
+}
+
 // Resolver is a wrapper for net.Resolver.
 type Resolver struct {
 	*net.Resolver
@@ -22,9 +27,6 @@ func (r *Resolver) LookupIPAddrDualStack(ctx context.Context, host string) ([]ne
 	for _, network := range []string{"ip6", "ip4"} {
 		select {
 		case <-ctx.Done():
-			if len(result) > 0 {
-				return result, nil
-			}
 			return nil, ctx.Err()
 		default:
 		}
@@ -44,11 +46,7 @@ func (r *Resolver) LookupIPAddrDualStack(ctx context.Context, host string) ([]ne
 	}
 
 	if len(result) == 0 {
-		return nil, &net.DNSError{
-			Err:        "no such host",
-			Name:       host,
-			IsNotFound: true,
-		}
+		return nil, errNoSuchHost
 	}
 	return result, nil
 }

--- a/pkg/discovery/dns/godns/resolver.go
+++ b/pkg/discovery/dns/godns/resolver.go
@@ -6,6 +6,7 @@ package godns
 import (
 	"context"
 	"net"
+	"net/netip"
 
 	"github.com/pkg/errors"
 )
@@ -20,9 +21,15 @@ func (r *Resolver) LookupIPAddrByNetwork(ctx context.Context, network, host stri
 	if err != nil {
 		return nil, err
 	}
+	// LookupIP returns bare IPs, so preserve the zone from scoped IP literals.
+	var zone string
+	if addr, err := netip.ParseAddr(host); err == nil {
+		zone = addr.Zone()
+	}
+
 	result := make([]net.IPAddr, len(ips))
 	for i, ip := range ips {
-		result[i] = net.IPAddr{IP: ip}
+		result[i] = net.IPAddr{IP: ip, Zone: zone}
 	}
 	return result, nil
 }

--- a/pkg/discovery/dns/godns/resolver_test.go
+++ b/pkg/discovery/dns/godns/resolver_test.go
@@ -1,0 +1,21 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package godns
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/efficientgo/core/testutil"
+)
+
+func TestResolverLookupIPAddrByNetworkPreservesLiteralIPv6Zone(t *testing.T) {
+	resolver := Resolver{Resolver: net.DefaultResolver}
+
+	addrs, err := resolver.LookupIPAddrByNetwork(context.Background(), "ip6", "fe80::1%eth0")
+	testutil.Ok(t, err)
+	testutil.Equals(t, 1, len(addrs))
+	testutil.Equals(t, "eth0", addrs[0].Zone)
+}

--- a/pkg/discovery/dns/miekgdns/resolver.go
+++ b/pkg/discovery/dns/miekgdns/resolver.go
@@ -69,19 +69,19 @@ func (r *Resolver) LookupIPAddr(_ context.Context, host string) ([]net.IPAddr, e
 }
 
 func (r *Resolver) LookupIPAddrByNetwork(ctx context.Context, network, host string) ([]net.IPAddr, error) {
-	var qtype uint16
+	var qtype dns.Type
 	switch network {
 	case "ip6":
-		qtype = dns.TypeAAAA
+		qtype = dns.Type(dns.TypeAAAA)
 	case "ip4":
-		qtype = dns.TypeA
+		qtype = dns.Type(dns.TypeA)
 	default:
 		return nil, errors.Errorf("unsupported network %q", network)
 	}
 	return r.lookupIPAddrByNetwork(ctx, host, qtype, 1, 8)
 }
 
-func (r *Resolver) lookupIPAddrByNetwork(ctx context.Context, host string, qtype uint16, currIteration, maxIterations int) ([]net.IPAddr, error) {
+func (r *Resolver) lookupIPAddrByNetwork(ctx context.Context, host string, qtype dns.Type, currIteration, maxIterations int) ([]net.IPAddr, error) {
 	if currIteration > maxIterations {
 		return nil, errors.Errorf("maximum number of recursive iterations reached (%d)", maxIterations)
 	}
@@ -92,7 +92,7 @@ func (r *Resolver) lookupIPAddrByNetwork(ctx context.Context, host string, qtype
 	default:
 	}
 
-	response, err := r.lookupWithSearchPath(host, dns.Type(qtype))
+	response, err := r.lookupWithSearchPath(host, qtype)
 	if err != nil {
 		return nil, err
 	}
@@ -107,7 +107,7 @@ func (r *Resolver) lookupIPAddrByNetwork(ctx context.Context, host string, qtype
 		case *dns.CNAME:
 			addrs, err := r.lookupIPAddrByNetwork(ctx, addr.Target, qtype, currIteration+1, maxIterations)
 			if err != nil {
-				continue
+				return nil, errors.Wrapf(err, "recursively resolve %s", addr.Target)
 			}
 			result = append(result, addrs...)
 		}

--- a/pkg/discovery/dns/provider.go
+++ b/pkg/discovery/dns/provider.go
@@ -108,8 +108,14 @@ func GetQTypeName(addr string) (qtype, name string) {
 	return qtypeAndName[0], qtypeAndName[1]
 }
 
+// IsDualStackNode returns true if the address uses dual-stack DNS resolution (dnsdualstack+).
+func IsDualStackNode(addr string) bool {
+	return strings.HasPrefix(addr, string(ADualStack)+"+")
+}
+
 // Resolve stores a list of provided addresses or their DNS records if requested.
 // Addresses prefixed with `dns+` or `dnssrv+` will be resolved through respective DNS lookup (A/AAAA or SRV).
+// Addresses prefixed with `dnsdualstack+` will resolve both A and AAAA records.
 // For non-SRV records, it will return an error if a port is not supplied.
 func (p *Provider) Resolve(ctx context.Context, addrs []string, flushOld bool) error {
 	resolvedAddrs := map[string][]string{}

--- a/pkg/discovery/dns/provider.go
+++ b/pkg/discovery/dns/provider.go
@@ -108,11 +108,6 @@ func GetQTypeName(addr string) (qtype, name string) {
 	return qtypeAndName[0], qtypeAndName[1]
 }
 
-// IsDualStackNode returns true if the address uses dual-stack DNS resolution (dnsdualstack+).
-func IsDualStackNode(addr string) bool {
-	return strings.HasPrefix(addr, string(ADualStack)+"+")
-}
-
 // Resolve stores a list of provided addresses or their DNS records if requested.
 // Addresses prefixed with `dns+` or `dnssrv+` will be resolved through respective DNS lookup (A/AAAA or SRV).
 // Addresses prefixed with `dnsdualstack+` will resolve both A and AAAA records.

--- a/pkg/discovery/dns/resolver.go
+++ b/pkg/discovery/dns/resolver.go
@@ -32,7 +32,8 @@ const (
 type Resolver interface {
 	// Resolve performs a DNS lookup and returns a list of records.
 	// name is the domain name to be resolved.
-	// qtype is the query type. Accepted values are `dns` for A/AAAA lookup and `dnssrv` for SRV lookup.
+	// qtype is the query type. Accepted values are `dns` for A/AAAA lookup, `dnssrv` for SRV lookup,
+	// `dnssrvnoa` for SRV lookup without A/AAAA, and `dnsdualstack` for combined A and AAAA lookup.
 	// If scheme is passed through name, it is preserved on IP results.
 	Resolve(ctx context.Context, name string, qtype QType) ([]string, error)
 }

--- a/pkg/discovery/dns/resolver.go
+++ b/pkg/discovery/dns/resolver.go
@@ -157,7 +157,7 @@ func (s *dnsSD) Resolve(ctx context.Context, name string, qtype QType) ([]string
 			res = append(res, appendScheme(scheme, net.JoinHostPort(ip.String(), port)))
 		}
 		if len(ips) == 0 {
-			level.Error(s.logger).Log("msg", "failed to lookup IP addresses (dual-stack)", "host", host)
+			level.Error(s.logger).Log("msg", "found no IP addresses (dual-stack)", "host", host)
 		}
 	default:
 		return nil, errors.Errorf("invalid lookup scheme %q", qtype)

--- a/pkg/discovery/dns/resolver.go
+++ b/pkg/discovery/dns/resolver.go
@@ -13,6 +13,8 @@ import (
 	"github.com/go-kit/log/level"
 
 	"github.com/pkg/errors"
+
+	"github.com/thanos-io/thanos/pkg/errutil"
 )
 
 type QType string
@@ -136,28 +138,25 @@ func (s *dnsSD) Resolve(ctx context.Context, name string, qtype QType) ([]string
 			return nil, errors.Errorf("missing port in address given for dnsdualstack lookup: %v", name)
 		}
 		var ips []net.IPAddr
-		var lastErr error
+		lookupErrs := errutil.MultiError{}
 
 		for _, network := range []string{"ip6", "ip4"} {
 			addrs, err := s.resolver.LookupIPAddrByNetwork(ctx, network, host)
 			if err != nil {
 				if !s.resolver.IsNotFound(err) {
-					lastErr = err
+					lookupErrs.Add(err)
 				}
 				continue
 			}
 			ips = append(ips, addrs...)
 		}
 
-		if len(ips) == 0 && lastErr != nil {
-			return nil, errors.Wrapf(lastErr, "lookup IP addresses (dual-stack) %q", host)
+		if err := lookupErrs.Err(); len(ips) == 0 && err != nil {
+			return nil, errors.Wrapf(err, "lookup IP addresses (dual-stack) %q", host)
 		}
 
 		for _, ip := range ips {
 			res = append(res, appendScheme(scheme, net.JoinHostPort(ip.String(), port)))
-		}
-		if len(ips) == 0 {
-			level.Error(s.logger).Log("msg", "found no IP addresses (dual-stack)", "host", host)
 		}
 	default:
 		return nil, errors.Errorf("invalid lookup scheme %q", qtype)

--- a/pkg/discovery/dns/resolver_test.go
+++ b/pkg/discovery/dns/resolver_test.go
@@ -17,15 +17,28 @@ import (
 )
 
 type mockHostnameResolver struct {
-	resultIPs  map[string][]net.IPAddr
-	resultSRVs map[string][]*net.SRV
-	err        error
+	resultIPs          map[string][]net.IPAddr
+	resultDualStackIPs map[string][]net.IPAddr
+	resultSRVs         map[string][]*net.SRV
+	err                error
+	dualStackErr       error
 }
 
 func (m mockHostnameResolver) LookupIPAddr(ctx context.Context, host string) ([]net.IPAddr, error) {
 	if m.err != nil {
 		return nil, m.err
 	}
+	return m.resultIPs[host], nil
+}
+
+func (m mockHostnameResolver) LookupIPAddrDualStack(ctx context.Context, host string) ([]net.IPAddr, error) {
+	if m.dualStackErr != nil {
+		return nil, m.dualStackErr
+	}
+	if m.resultDualStackIPs != nil {
+		return m.resultDualStackIPs[host], nil
+	}
+	// Fall back to regular IPs if dual-stack not configured.
 	return m.resultIPs[host], nil
 }
 
@@ -202,4 +215,182 @@ func testDnsSd(t *testing.T, tt DNSSDTest) {
 	}
 	sort.Strings(result)
 	testutil.Equals(t, tt.expectedResult, result)
+}
+
+func TestDnsSD_ResolveDualStack(t *testing.T) {
+	ipv6 := net.ParseIP("2001:db8::1")
+	ipv4 := net.ParseIP("192.168.1.1")
+
+	tests := []struct {
+		name           string
+		addr           string
+		resolver       *mockHostnameResolver
+		expectedResult []string
+		expectedErr    error
+	}{
+		{
+			name: "dual-stack returns both IPv6 and IPv4",
+			addr: "test.mycompany.com:8080",
+			resolver: &mockHostnameResolver{
+				resultDualStackIPs: map[string][]net.IPAddr{
+					"test.mycompany.com": {
+						{IP: ipv6},
+						{IP: ipv4},
+					},
+				},
+			},
+			expectedResult: []string{"[2001:db8::1]:8080", "192.168.1.1:8080"},
+		},
+		{
+			name: "dual-stack IPv6 only",
+			addr: "test.mycompany.com:8080",
+			resolver: &mockHostnameResolver{
+				resultDualStackIPs: map[string][]net.IPAddr{
+					"test.mycompany.com": {{IP: ipv6}},
+				},
+			},
+			expectedResult: []string{"[2001:db8::1]:8080"},
+		},
+		{
+			name: "dual-stack IPv4 only",
+			addr: "test.mycompany.com:8080",
+			resolver: &mockHostnameResolver{
+				resultDualStackIPs: map[string][]net.IPAddr{
+					"test.mycompany.com": {{IP: ipv4}},
+				},
+			},
+			expectedResult: []string{"192.168.1.1:8080"},
+		},
+		{
+			name: "dual-stack preserves scheme",
+			addr: "http://test.mycompany.com:8080",
+			resolver: &mockHostnameResolver{
+				resultDualStackIPs: map[string][]net.IPAddr{
+					"test.mycompany.com": {
+						{IP: ipv6},
+						{IP: ipv4},
+					},
+				},
+			},
+			expectedResult: []string{"http://[2001:db8::1]:8080", "http://192.168.1.1:8080"},
+		},
+		{
+			name:           "dual-stack requires port",
+			addr:           "test.mycompany.com",
+			resolver:       &mockHostnameResolver{},
+			expectedResult: nil,
+			expectedErr:    errors.New("missing port in address given for dnsdualstack lookup: test.mycompany.com"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.TODO()
+			dnsSD := dnsSD{tt.resolver, log.NewNopLogger()}
+
+			result, err := dnsSD.Resolve(ctx, tt.addr, ADualStack)
+			if tt.expectedErr != nil {
+				testutil.NotOk(t, err)
+				testutil.Assert(t, tt.expectedErr.Error() == err.Error(), "expected error '%v', but got '%v'", tt.expectedErr.Error(), err.Error())
+			} else {
+				testutil.Ok(t, err)
+			}
+			sort.Strings(result)
+			sort.Strings(tt.expectedResult)
+			testutil.Equals(t, tt.expectedResult, result)
+		})
+	}
+}
+
+func TestDnsSD_ResolveDualStack_Errors(t *testing.T) {
+	ipv4 := net.ParseIP("192.168.1.1")
+
+	tests := []struct {
+		name           string
+		dualStackErr   error
+		dualStackAddrs []net.IPAddr
+		expectErr      bool
+		expectAddrs    int
+	}{
+		{
+			name:         "network unreachable error propagates",
+			dualStackErr: errors.New("network unreachable"),
+			expectErr:    true,
+			expectAddrs:  0,
+		},
+		{
+			name:         "timeout error propagates",
+			dualStackErr: errors.New("i/o timeout"),
+			expectErr:    true,
+			expectAddrs:  0,
+		},
+		{
+			name:         "DNS server failure propagates",
+			dualStackErr: errors.New("server misbehaving"),
+			expectErr:    true,
+			expectAddrs:  0,
+		},
+		{
+			name:           "successful resolution with addresses",
+			dualStackErr:   nil,
+			dualStackAddrs: []net.IPAddr{{IP: ipv4}},
+			expectErr:      false,
+			expectAddrs:    1,
+		},
+		{
+			name:           "empty result without error",
+			dualStackErr:   nil,
+			dualStackAddrs: []net.IPAddr{},
+			expectErr:      false,
+			expectAddrs:    0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.TODO()
+			resolver := &mockHostnameResolver{
+				dualStackErr: tt.dualStackErr,
+			}
+			if tt.dualStackAddrs != nil {
+				resolver.resultDualStackIPs = map[string][]net.IPAddr{
+					"test.mycompany.com": tt.dualStackAddrs,
+				}
+			}
+			dnsSD := dnsSD{resolver, log.NewNopLogger()}
+
+			result, err := dnsSD.Resolve(ctx, "test.mycompany.com:8080", ADualStack)
+
+			if tt.expectErr {
+				testutil.NotOk(t, err)
+			} else {
+				testutil.Ok(t, err)
+				testutil.Equals(t, tt.expectAddrs, len(result))
+			}
+		})
+	}
+}
+
+func TestDnsSD_ResolveDualStack_DNSError(t *testing.T) {
+	// Test with a proper *net.DNSError.
+	notFoundErr := &net.DNSError{
+		Err:        "no such host",
+		Name:       "test.mycompany.com",
+		IsNotFound: true,
+	}
+
+	ctx := context.TODO()
+	resolver := &mockHostnameResolver{
+		dualStackErr: notFoundErr,
+	}
+	dnsSD := dnsSD{resolver, log.NewNopLogger()}
+
+	result, err := dnsSD.Resolve(ctx, "test.mycompany.com:8080", ADualStack)
+
+	// DNS not found errors should still propagate.
+	testutil.NotOk(t, err)
+	testutil.Equals(t, 0, len(result))
+
+	// Verify it's wrapped with context.
+	testutil.Assert(t, err != nil, "expected error")
 }

--- a/pkg/discovery/dns/resolver_test.go
+++ b/pkg/discovery/dns/resolver_test.go
@@ -21,10 +21,13 @@ type mockHostnameResolver struct {
 	resultSRVs map[string][]*net.SRV
 	err        error
 
-	// Per-network results for LookupIPAddrByNetwork. Key format: "network:host".
 	resultByNetwork map[string][]net.IPAddr
 	errByNetwork    map[string]error
 	isNotFound      func(error) bool
+}
+
+func lookupKey(network, host string) string {
+	return network + ":" + host
 }
 
 func (m mockHostnameResolver) LookupIPAddr(ctx context.Context, host string) ([]net.IPAddr, error) {
@@ -35,7 +38,7 @@ func (m mockHostnameResolver) LookupIPAddr(ctx context.Context, host string) ([]
 }
 
 func (m mockHostnameResolver) LookupIPAddrByNetwork(_ context.Context, network, host string) ([]net.IPAddr, error) {
-	key := network + ":" + host
+	key := lookupKey(network, host)
 	if m.errByNetwork != nil {
 		if err, ok := m.errByNetwork[key]; ok {
 			return nil, err
@@ -242,8 +245,8 @@ func TestDnsSD_ResolveDualStack(t *testing.T) {
 			addr: host + ":8080",
 			resolver: &mockHostnameResolver{
 				resultByNetwork: map[string][]net.IPAddr{
-					"ip6:" + host: {{IP: ipv6}},
-					"ip4:" + host: {{IP: ipv4}},
+					lookupKey("ip6", host): {{IP: ipv6}},
+					lookupKey("ip4", host): {{IP: ipv4}},
 				},
 			},
 			expectedResult: []string{"[2001:db8::1]:8080", "192.168.1.1:8080"},
@@ -253,7 +256,7 @@ func TestDnsSD_ResolveDualStack(t *testing.T) {
 			addr: host + ":8080",
 			resolver: &mockHostnameResolver{
 				resultByNetwork: map[string][]net.IPAddr{
-					"ip6:" + host: {{IP: ipv6}},
+					lookupKey("ip6", host): {{IP: ipv6}},
 				},
 			},
 			expectedResult: []string{"[2001:db8::1]:8080"},
@@ -263,7 +266,7 @@ func TestDnsSD_ResolveDualStack(t *testing.T) {
 			addr: host + ":8080",
 			resolver: &mockHostnameResolver{
 				resultByNetwork: map[string][]net.IPAddr{
-					"ip4:" + host: {{IP: ipv4}},
+					lookupKey("ip4", host): {{IP: ipv4}},
 				},
 			},
 			expectedResult: []string{"192.168.1.1:8080"},
@@ -280,10 +283,10 @@ func TestDnsSD_ResolveDualStack(t *testing.T) {
 			addr: host + ":8080",
 			resolver: &mockHostnameResolver{
 				resultByNetwork: map[string][]net.IPAddr{
-					"ip4:" + host: {{IP: ipv4}},
+					lookupKey("ip4", host): {{IP: ipv4}},
 				},
 				errByNetwork: map[string]error{
-					"ip6:" + host: errors.New("network unreachable"),
+					lookupKey("ip6", host): errors.New("network unreachable"),
 				},
 			},
 			expectedResult: []string{"192.168.1.1:8080"},
@@ -293,10 +296,10 @@ func TestDnsSD_ResolveDualStack(t *testing.T) {
 			addr: host + ":8080",
 			resolver: &mockHostnameResolver{
 				resultByNetwork: map[string][]net.IPAddr{
-					"ip6:" + host: {{IP: ipv6}},
+					lookupKey("ip6", host): {{IP: ipv6}},
 				},
 				errByNetwork: map[string]error{
-					"ip4:" + host: errors.New("network unreachable"),
+					lookupKey("ip4", host): errors.New("network unreachable"),
 				},
 			},
 			expectedResult: []string{"[2001:db8::1]:8080"},
@@ -329,8 +332,8 @@ func TestDnsSD_ResolveDualStack_Errors(t *testing.T) {
 	t.Run("both families fail propagates error", func(t *testing.T) {
 		resolver := &mockHostnameResolver{
 			errByNetwork: map[string]error{
-				"ip6:" + host: errors.New("network unreachable"),
-				"ip4:" + host: errors.New("network unreachable"),
+				lookupKey("ip6", host): errors.New("network unreachable"),
+				lookupKey("ip4", host): errors.New("network unreachable"),
 			},
 		}
 		dnsSD := dnsSD{resolver, log.NewNopLogger()}
@@ -343,8 +346,8 @@ func TestDnsSD_ResolveDualStack_Errors(t *testing.T) {
 		notFound := &net.DNSError{Err: "no such host", Name: host, IsNotFound: true}
 		resolver := &mockHostnameResolver{
 			errByNetwork: map[string]error{
-				"ip6:" + host: notFound,
-				"ip4:" + host: notFound,
+				lookupKey("ip6", host): notFound,
+				lookupKey("ip4", host): notFound,
 			},
 			isNotFound: func(err error) bool {
 				dnsErr, ok := err.(*net.DNSError)
@@ -362,8 +365,8 @@ func TestDnsSD_ResolveDualStack_Errors(t *testing.T) {
 		notFound := &net.DNSError{Err: "no such host", Name: host, IsNotFound: true}
 		resolver := &mockHostnameResolver{
 			errByNetwork: map[string]error{
-				"ip6:" + host: notFound,
-				"ip4:" + host: errors.New("server misbehaving"),
+				lookupKey("ip6", host): notFound,
+				lookupKey("ip4", host): errors.New("server misbehaving"),
 			},
 			isNotFound: func(err error) bool {
 				dnsErr, ok := err.(*net.DNSError)


### PR DESCRIPTION
Add dnsdualstack+ DNS scheme that resolves both A and AAAA records, enabling IPv4/IPv6 failover for store connections. Failover is handled automatically by gRPC's built-in health checking and round_robin balancer.

Usage:
  --store=dnsdualstack+store.example.com:10901
* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes
- Add `ADualStack` resolver type that queries both A and AAAA DNS records
- Add `LookupIPAddrDualStack` to godns and miekgdns resolvers
- Add `dnsdualstack+` scheme prefix for service discovery
- Document new scheme in service-discovery.md

## Verification
- `go test ./pkg/discovery/dns/... -v` - all tests pass
- `go build ./cmd/thanos/...` - builds clean
