### PR TITLE
compact: delete directory markers in block.Delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ It is recommend to upgrade the storage components first (Receive, Store, etc.) a
 
 ### Added
 
+- [#8691](https://github.com/thanos-io/thanos/pull/8691): Compactor: remove the directory marker objects for some s3 compatible object stores
+
 ### Changed
 
 - [#8670](https://github.com/thanos-io/thanos/pull/8670): Receive: *breaking :warning:* removed `--shipper.ignore-unequal-block-size`. TSDB now delays compaction until blocks have been uploaded by the shipper, allowing compaction while uploading without risking data loss.

--- a/pkg/block/block.go
+++ b/pkg/block/block.go
@@ -242,15 +242,16 @@ func Delete(ctx context.Context, logger log.Logger, bkt objstore.Bucket, id ulid
 
 	// Some object storages represent directories as explicit empty objects.
 	// We try to delete the directory marker objects themselves after all their contents are removed.
-	chunksDirName := path.Join(id.String(), ChunksDirname) + objstore.DirDelim
-	if err := bkt.Delete(ctx, chunksDirName); err != nil && !bkt.IsObjNotFoundErr(err) {
-		level.Debug(logger).Log("msg", "failed to delete directory marker object", "dir", chunksDirName, "err", err)
-	}
+directoryMarkerPaths := []string{
+    path.Join(id.String(), ChunksDirname) + objstore.DirDelim,
+    id.String() + objstore.DirDelim,
+}
 
-	dirName := id.String() + objstore.DirDelim
-	if err := bkt.Delete(ctx, dirName); err != nil && !bkt.IsObjNotFoundErr(err) {
-		level.Debug(logger).Log("msg", "failed to delete directory marker object", "dir", dirName, "err", err)
-	}
+for _, p := range directoryMarkerPaths {
+    if err := bkt.Delete(ctx, p); err != nil && !bkt.IsObjNotFoundErr(err) {
+        level.Debug(logger).Log("msg", "failed to delete directory marker object", "dir", p, "err", err)
+    }
+}
 
 	return nil
 }

--- a/pkg/block/block.go
+++ b/pkg/block/block.go
@@ -242,16 +242,16 @@ func Delete(ctx context.Context, logger log.Logger, bkt objstore.Bucket, id ulid
 
 	// Some object storages represent directories as explicit empty objects.
 	// We try to delete the directory marker objects themselves after all their contents are removed.
-directoryMarkerPaths := []string{
-    path.Join(id.String(), ChunksDirname) + objstore.DirDelim,
-    id.String() + objstore.DirDelim,
-}
+	directoryMarkerPaths := []string{
+		path.Join(id.String(), ChunksDirname) + objstore.DirDelim,
+		id.String() + objstore.DirDelim,
+	}
 
-for _, p := range directoryMarkerPaths {
-    if err := bkt.Delete(ctx, p); err != nil && !bkt.IsObjNotFoundErr(err) {
-        level.Debug(logger).Log("msg", "failed to delete directory marker object", "dir", p, "err", err)
-    }
-}
+	for _, p := range directoryMarkerPaths {
+		if err := bkt.Delete(ctx, p); err != nil && !bkt.IsObjNotFoundErr(err) {
+			level.Debug(logger).Log("msg", "failed to delete directory marker object", "dir", p, "err", err)
+		}
+	}
 
 	return nil
 }

--- a/pkg/block/block.go
+++ b/pkg/block/block.go
@@ -240,6 +240,18 @@ func Delete(ctx context.Context, logger log.Logger, bkt objstore.Bucket, id ulid
 		level.Debug(logger).Log("msg", "deleted file", "file", deletionMarkFile, "bucket", bkt.Name())
 	}
 
+	// Some object storages represent directories as explicit empty objects.
+	// We try to delete the directory marker objects themselves after all their contents are removed.
+	chunksDirName := path.Join(id.String(), ChunksDirname) + objstore.DirDelim
+	if err := bkt.Delete(ctx, chunksDirName); err != nil && !bkt.IsObjNotFoundErr(err) {
+		level.Debug(logger).Log("msg", "failed to delete directory marker object", "dir", chunksDirName, "err", err)
+	}
+
+	dirName := id.String() + objstore.DirDelim
+	if err := bkt.Delete(ctx, dirName); err != nil && !bkt.IsObjNotFoundErr(err) {
+		level.Debug(logger).Log("msg", "failed to delete directory marker object", "dir", dirName, "err", err)
+	}
+
 	return nil
 }
 

--- a/pkg/block/block_test.go
+++ b/pkg/block/block_test.go
@@ -257,6 +257,22 @@ func TestDelete(t *testing.T) {
 		testutil.Ok(t, Delete(ctx, log.NewNopLogger(), bkt, b2))
 		testutil.Equals(t, 0, len(bkt.Objects()))
 	}
+	{
+		b3 := ulid.MustNew(3, nil)
+
+		// Upload explicit directory markers.
+		dirName := b3.String() + objstore.DirDelim
+		testutil.Ok(t, bkt.Upload(ctx, dirName, bytes.NewReader([]byte{})))
+
+		chunksDirName := path.Join(b3.String(), ChunksDirname) + objstore.DirDelim
+		testutil.Ok(t, bkt.Upload(ctx, chunksDirName, bytes.NewReader([]byte{})))
+
+		testutil.Equals(t, 2, len(bkt.Objects()))
+
+		// Check if delete also deletes the directory markers.
+		testutil.Ok(t, Delete(ctx, log.NewNopLogger(), bkt, b3))
+		testutil.Equals(t, 0, len(bkt.Objects()))
+	}
 }
 
 func TestMarkForDeletion(t *testing.T) {


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Some S3-compatible object storages (like seaweedfs, Hitachi Content Platform) represent directories as explicit 0-byte objects. Thanos currently leaves these behind during block deletion because the storage iterator typically skips the root prefix itself. These persistent empty directories are then misidentified as "aborted partial uploads" in subsequent scans.

This PR updates `block.Delete` to explicitly attempt to remove the directory marker object (`ULID/`) and the `chunks` subdirectory as the final step of the deletion process.

- Prevents "ghost" partial blocks on certain storage providers.
- Includes a unit test to verify the deletion of directory markers.
- Safely ignores "Not Found" errors for backends that don't use directory objects.

Fixes https://github.com/thanos-io/thanos/issues/7840

## Verification

<!-- How you tested it? How do you know it works? -->
