### PR TITLE
receive: add worker address to `thanos_receive_forward_delay_seconds`

### DIFF
--- a/docs/components/receive.md
+++ b/docs/components/receive.md
@@ -372,8 +372,7 @@ Please see the metric `thanos_receive_forward_delay_seconds` to see if you need 
 
 The following formula is used for calculating quorum:
 
-```go mdox-exec="sed -n '1065,1076p' pkg/receive/handler.go"
-
+```go mdox-exec="sed -n '1068,1078p' pkg/receive/handler.go"
 // writeQuorum returns minimum number of replicas that has to confirm write success before claiming replication success.
 func (h *Handler) writeQuorum() int {
 	// NOTE(GiedriusS): this is here because otherwise RF=2 doesn't make sense as all writes

--- a/pkg/receive/handler.go
+++ b/pkg/receive/handler.go
@@ -180,12 +180,14 @@ func NewHandler(logger log.Logger, o *Options) *Handler {
 				Max:    o.MaxBackoff,
 				Jitter: true,
 			},
-			promauto.With(registerer).NewHistogram(
+			promauto.With(registerer).NewHistogramVec(
 				prometheus.HistogramOpts{
-					Name:    "thanos_receive_forward_delay_seconds",
-					Help:    "The delay between the time the request was received and the time it was forwarded to a worker. ",
-					Buckets: prometheus.ExponentialBuckets(0.001, 2, 16),
-				},
+					Name:                           "thanos_receive_forward_delay_seconds",
+					Help:                           "The delay between the time the request was received and the time it was forwarded to a worker. ",
+					Buckets:                        prometheus.ExponentialBuckets(0.001, 2, 16),
+					NativeHistogramBucketFactor:    1.1,
+					NativeHistogramMaxBucketNumber: 100,
+				}, []string{"worker"},
 			),
 			workers,
 			o.MaxArtificialDelay,
@@ -1396,7 +1398,7 @@ func newReplicationErrors(threshold, numErrors int) []*replicationErrors {
 	return errs
 }
 
-func newPeerWorker(client peerClient, forwardDelay prometheus.Histogram, asyncWorkerCount uint, maxArtificialDelay time.Duration) *peerWorker {
+func newPeerWorker(client peerClient, forwardDelay prometheus.Observer, asyncWorkerCount uint, maxArtificialDelay time.Duration) *peerWorker {
 	return &peerWorker{
 		client:             client,
 		wp:                 pool.NewWorkerPool(asyncWorkerCount),
@@ -1434,14 +1436,14 @@ type peerWorker struct {
 	client peerClient
 	wp     pool.WorkerPool
 
-	forwardDelay       prometheus.Histogram
+	forwardDelay       prometheus.Observer
 	maxArtificialDelay time.Duration
 }
 
 func newPeerGroup(
 	logger log.Logger,
 	backoff backoff.Backoff,
-	forwardDelay prometheus.Histogram,
+	forwardDelay *prometheus.HistogramVec,
 	asyncForwardWorkersCount uint,
 	maxArtificialDelay time.Duration,
 	replicationProtocol ReplicationProtocol,
@@ -1513,7 +1515,7 @@ type peerGroup struct {
 	connections              map[Endpoint]*peerWorker
 	peerStates               map[Endpoint]*retryState
 	expBackoff               backoff.Backoff
-	forwardDelay             prometheus.Histogram
+	forwardDelay             *prometheus.HistogramVec
 	asyncForwardWorkersCount uint
 	replicationProtocol      ReplicationProtocol
 	maxArtificialDelay       time.Duration
@@ -1544,6 +1546,7 @@ func (p *peerGroup) close(endpoint Endpoint) error {
 		return nil
 	}
 
+	p.forwardDelay.Delete(prometheus.Labels{"worker": endpoint.Address})
 	p.connections[endpoint].wp.Close()
 	delete(p.connections, endpoint)
 	if err := c.client.Close(); err != nil {
@@ -1598,7 +1601,7 @@ func (p *peerGroup) getConnection(ctx context.Context, endpoint Endpoint) (Write
 		delay = p.maxArtificialDelay
 	}
 
-	p.connections[endpoint] = newPeerWorker(client, p.forwardDelay, p.asyncForwardWorkersCount, delay)
+	p.connections[endpoint] = newPeerWorker(client, p.forwardDelay.WithLabelValues(endpoint.Address), p.asyncForwardWorkersCount, delay)
 	return p.connections[endpoint], nil
 }
 


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

## Changes

* Add `worker` label to `thanos_receive_forward_delay_seconds` metric to find if any specific ingestor is falling behind.