### PR TITLE
fix(receive): resolve 503 errors during ingestor restarts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ It is recommend to upgrade the storage components first (Receive, Store, etc.) a
 
 - [#8714](https://github.com/thanos-io/thanos/pull/8714): Tracing: Fix `tls_config` fields (`ca_file`, `cert_file`, `key_file`) being silently ignored when using the OTLP gRPC exporter. Previously, deployments using a private CA or mTLS client certificates had to work around this via `OTEL_EXPORTER_OTLP_CERTIFICATE` and related environment variables.
 - [#8128](https://github.com/thanos-io/thanos/issues/8128): Query-Frontend: Fix panic in `AnalyzesMerge` caused by indexing the wrong slice variable, leading to an out-of-range access when merging more than two query analyses.
+- [#8720](https://github.com/thanos-io/thanos/issues/8720): Receive: Fix 503 errors during restarts in some cases.
 
 ### Added
 

--- a/pkg/pool/worker_pool.go
+++ b/pkg/pool/worker_pool.go
@@ -16,8 +16,9 @@ type WorkerPool interface {
 	// Init initializes the worker pool.
 	Init()
 
-	// Go waits until the next worker becomes available and executes the given work.
-	Go(work Work)
+	// Go waits until the next worker becomes available or the context is canceled.
+	// Returns ctx.Err() if the context is canceled before a worker slot is available.
+	Go(ctx context.Context, work Work) error
 
 	// Close cancels all workers and waits for them to finish.
 	Close()
@@ -60,9 +61,14 @@ func (p *workerPool) Init() {
 	})
 }
 
-func (p *workerPool) Go(work Work) {
+func (p *workerPool) Go(ctx context.Context, work Work) error {
 	p.Init()
-	p.workCh <- work
+	select {
+	case p.workCh <- work:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
 func (p *workerPool) Close() {

--- a/pkg/pool/worker_pool_test.go
+++ b/pkg/pool/worker_pool_test.go
@@ -4,6 +4,7 @@
 package pool
 
 import (
+	"context"
 	"sync"
 	"testing"
 
@@ -22,14 +23,40 @@ func TestGo(t *testing.T) {
 	var wg sync.WaitGroup
 	for i := 0; i < int(workerPoolSize*3); i++ {
 		wg.Add(1)
-		p.Go(func() {
+		err := p.Go(context.Background(), func() {
 			mu.Lock()
 			defer mu.Unlock()
 			expectedWorksDone++
 			wg.Done()
 		})
+		require.NoError(t, err)
 	}
 	wg.Wait()
 	require.Equal(t, uint32(workerPoolSize*3), expectedWorksDone)
 	require.Equal(t, int(workerPoolSize), p.Size())
+}
+
+func TestGo_ContextCanceled(t *testing.T) {
+	p := NewWorkerPool(1)
+	p.Init()
+	defer p.Close()
+
+	// Fill the pool's buffer and worker with blocking work.
+	blocked := make(chan struct{})
+	defer close(blocked)
+
+	// Fill the worker (1 worker running this).
+	err := p.Go(context.Background(), func() { <-blocked })
+	require.NoError(t, err)
+
+	// Fill the buffer (capacity 1).
+	err = p.Go(context.Background(), func() {})
+	require.NoError(t, err)
+
+	// Now the pool is saturated. A canceled context should return immediately.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err = p.Go(ctx, func() { t.Fatal("work should not execute") })
+	require.ErrorIs(t, err, context.Canceled)
 }

--- a/pkg/receive/handler.go
+++ b/pkg/receive/handler.go
@@ -808,9 +808,8 @@ func (h *Handler) fanoutForward(ctx context.Context, params remoteWriteParams) (
 	responses := make(chan writeResponse, maxBufferedResponses)
 	wg := sync.WaitGroup{}
 
-	h.sendWrites(ctx, &wg, params, localWrites, remoteWrites, responses)
-
 	go func() {
+		h.sendWrites(ctx, &wg, params, localWrites, remoteWrites, responses)
 		wg.Wait()
 		close(responses)
 	}()
@@ -1475,7 +1474,7 @@ type peersContainer interface {
 
 func (p *peerWorker) RemoteWriteAsync(ctx context.Context, req *storepb.WriteRequest, er endpointReplica, seriesIDs []int, responseWriter chan writeResponse, cb func(error)) {
 	now := time.Now()
-	p.wp.Go(func() {
+	if err := p.wp.Go(ctx, func() {
 		if p.maxArtificialDelay > 0 {
 			var randDuration = time.Duration(rand.Int63n(int64(p.maxArtificialDelay)))
 			if randDuration < 1*time.Second {
@@ -1506,7 +1505,14 @@ func (p *peerWorker) RemoteWriteAsync(ctx context.Context, req *storepb.WriteReq
 			"endpoint": er.endpoint,
 			"replica":  er.replica,
 		})
-	})
+	}); err != nil {
+		responseWriter <- newWriteResponse(
+			seriesIDs,
+			errors.Wrapf(err, "scheduling forward request for endpoint %v", er.endpoint),
+			er,
+		)
+		cb(err)
+	}
 }
 
 type peerGroup struct {

--- a/pkg/receive/handler.go
+++ b/pkg/receive/handler.go
@@ -1506,12 +1506,20 @@ func (p *peerWorker) RemoteWriteAsync(ctx context.Context, req *storepb.WriteReq
 			"replica":  er.replica,
 		})
 	}); err != nil {
-		responseWriter <- newWriteResponse(
-			seriesIDs,
-			errors.Wrapf(err, "scheduling forward request for endpoint %v", er.endpoint),
-			er,
-		)
-		cb(err)
+		tracing.DoInSpan(ctx, "receive_forward", func(ctx context.Context) {
+			sp := trace.SpanFromContext(ctx)
+			sp.SetAttributes(attribute.Bool("error", true))
+			sp.SetAttributes(attribute.String("error.msg", err.Error()))
+			responseWriter <- newWriteResponse(
+				seriesIDs,
+				errors.Wrapf(err, "scheduling forward request for endpoint %v", er.endpoint),
+				er,
+			)
+			cb(err)
+		}, opentracing.Tags{
+			"endpoint": er.endpoint,
+			"replica":  er.replica,
+		})
 	}
 }
 

--- a/pkg/receive/writecapnp/client.go
+++ b/pkg/receive/writecapnp/client.go
@@ -80,8 +80,11 @@ func (r *RemoteWriteClient) RemoteWrite(ctx context.Context, in *storepb.WriteRe
 		}
 	}
 
-	if ctx.Err() != nil {
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 		return &storepb.WriteResponse{}, status.Error(codes.DeadlineExceeded, fmt.Sprintf("writing to peer: %s", err.Error()))
+	}
+	if errors.Is(ctx.Err(), context.Canceled) {
+		return &storepb.WriteResponse{}, status.Error(codes.Canceled, fmt.Sprintf("writing to peer: %s", err.Error()))
 	}
 	return &storepb.WriteResponse{}, status.Error(codes.Unavailable, fmt.Sprintf("writing to peer: %s", err.Error()))
 }

--- a/pkg/receive/writecapnp/client.go
+++ b/pkg/receive/writecapnp/client.go
@@ -22,7 +22,7 @@ import (
 )
 
 type Dialer interface {
-	Dial() (net.Conn, error)
+	DialContext(ctx context.Context) (net.Conn, error)
 }
 
 type TCPDialer struct {
@@ -33,12 +33,9 @@ func NewTCPDialer(address string) *TCPDialer {
 	return &TCPDialer{address: address}
 }
 
-func (t TCPDialer) Dial() (net.Conn, error) {
-	addr, err := net.ResolveTCPAddr("tcp", t.address)
-	if err != nil {
-		return nil, err
-	}
-	conn, err := net.DialTCP("tcp", nil, addr)
+func (t TCPDialer) DialContext(ctx context.Context) (net.Conn, error) {
+	var d net.Dialer
+	conn, err := d.DialContext(ctx, "tcp", t.address)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to dial peer %s", t.address)
 	}
@@ -83,6 +80,9 @@ func (r *RemoteWriteClient) RemoteWrite(ctx context.Context, in *storepb.WriteRe
 		}
 	}
 
+	if ctx.Err() != nil {
+		return &storepb.WriteResponse{}, status.Error(codes.DeadlineExceeded, fmt.Sprintf("writing to peer: %s", err.Error()))
+	}
 	return &storepb.WriteResponse{}, status.Error(codes.Unavailable, fmt.Sprintf("writing to peer: %s", err.Error()))
 }
 
@@ -154,7 +154,7 @@ func (r *RemoteWriteClient) connect(ctx context.Context) error {
 		return nil
 	}
 
-	conn, err := r.dialer.Dial()
+	conn, err := r.dialer.DialContext(ctx)
 	if err != nil {
 		return errors.Wrap(err, "failed to dial peer")
 	}

--- a/pkg/receive/writecapnp/client_test.go
+++ b/pkg/receive/writecapnp/client_test.go
@@ -1,0 +1,72 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package writecapnp
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/thanos-io/thanos/pkg/store/storepb"
+)
+
+type errorDialer struct{}
+
+func (d *errorDialer) DialContext(ctx context.Context) (net.Conn, error) {
+	return nil, fmt.Errorf("dial failed")
+}
+
+func TestRemoteWriteErrorCodes(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name     string
+		ctx      func() (context.Context, context.CancelFunc)
+		wantCode codes.Code
+	}{
+		{
+			name: "deadline exceeded",
+			ctx: func() (context.Context, context.CancelFunc) {
+				return context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+			},
+			wantCode: codes.DeadlineExceeded,
+		},
+		{
+			name: "canceled",
+			ctx: func() (context.Context, context.CancelFunc) {
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+				return ctx, cancel
+			},
+			wantCode: codes.Canceled,
+		},
+		{
+			name: "unavailable",
+			ctx: func() (context.Context, context.CancelFunc) {
+				return context.Background(), func() {}
+			},
+			wantCode: codes.Unavailable,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			client := NewRemoteWriteClient(&errorDialer{}, log.NewNopLogger())
+			ctx, cancel := tc.ctx()
+			defer cancel()
+
+			_, err := client.RemoteWrite(ctx, &storepb.WriteRequest{})
+			require.Error(t, err)
+
+			st, ok := status.FromError(err)
+			require.True(t, ok)
+			require.Equal(t, tc.wantCode, st.Code())
+		})
+	}
+}


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

- Make Dialer interface context-aware (DialContext) so TCP connections respect forwarding timeouts
- Move `sendWrites` into a goroutine to unblock the response collection loop
- Return `codes.DeadlineExceeded` instead of `codes.Unavailable` for context-originated failures in Cap'n Proto client
- Replace `WorkerPool.Go(Work)` with `Go(ctx, Work) error` to support context cancellation on saturated pools

Closes #8710

## Verification

I've tested it in our test environment with separate routers/ingestors, RF=2 and Cap'n Proto - and it looks good. However it certainly needs a thoughtful review.