### PR TITLE
fix: prevent goroutine leak in basic_service by running runningFn in separate goroutine

### DIFF
--- a/internal/cortex/util/services/basic_service.go
+++ b/internal/cortex/util/services/basic_service.go
@@ -190,7 +190,16 @@ func (b *BasicService) main() {
 
 	stoppingFrom = Running
 	if b.runningFn != nil {
-		err = b.runningFn(b.serviceContext)
+		errCh := make(chan error, 1)
+		go func() {
+			errCh <- b.runningFn(b.serviceContext)
+		}()
+		select {
+		case err = <-errCh:
+			// runningFn finished
+		case <-b.serviceContext.Done():
+			err = nil // context canceled, normal stop
+		}
 	}
 
 stop:


### PR DESCRIPTION
## Summary
- Run `runningFn` in a separate goroutine to prevent blocking `serviceCancel()`
- Previously, if `runningFn` blocked indefinitely, the goroutine leaked because `serviceCancel()` was never called

## Root Cause
In `basic_service.go`, `runningFn` runs in the same goroutine as the service lifecycle management. If `runningFn` blocks (e.g., waiting on I/O), `serviceCancel()` is never called, causing a goroutine leak.

## Testing
- Existing test suite passes

Fixes #8178

Made with [Cursor](https://cursor.com)