### PR TITLE
*: add CLI arguments to configure TLS  ciphers for gRPC servers + remote-write receiver's server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ It is recommend to upgrade the storage components first (Receive, Store, etc.) a
 ### Added
 
 - [#8691](https://github.com/thanos-io/thanos/pull/8691): Compactor: remove the directory marker objects for some s3 compatible object stores
+- [#8730](https://github.com/thanos-io/thanos/pull/8730): *: add `--grpc-server-tls-ciphers` to configure cipher suites for gRPC servers.
+- [#8730](https://github.com/thanos-io/thanos/pull/8730): Receive: add `--remote-write.server-tls-ciphers` to configure cipher suites for the HTTP server.
 
 ### Changed
 

--- a/cmd/thanos/config.go
+++ b/cmd/thanos/config.go
@@ -35,6 +35,7 @@ type grpcConfig struct {
 	tlsSrvKey        string
 	tlsSrvClientCA   string
 	tlsMinVersion    string
+	tlsCiphers       []string
 	gracePeriod      time.Duration
 	maxConnectionAge time.Duration
 }
@@ -55,6 +56,9 @@ func (gc *grpcConfig) registerFlag(cmd extkingpin.FlagClause) *grpcConfig {
 	cmd.Flag("grpc-server-tls-min-version",
 		"TLS supported minimum version for gRPC server. If no version is specified, it'll default to 1.3. Allowed values: [\"1.0\", \"1.1\", \"1.2\", \"1.3\"]").
 		Default("1.3").StringVar(&gc.tlsMinVersion)
+	cmd.Flag("grpc-server-tls-ciphers",
+		"TLS cipher suites for gRPC server (repeatable). If not specified, the default Go cipher suites are used. See https://pkg.go.dev/crypto/tls#pkg-constants for valid values.").
+		StringsVar(&gc.tlsCiphers)
 	cmd.Flag("grpc-server-max-connection-age", "The grpc server max connection age. This controls how often to re-establish connections and redo TLS handshakes.").
 		Default("60m").DurationVar(&gc.maxConnectionAge)
 	cmd.Flag("grpc-grace-period",

--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -595,7 +595,7 @@ func runQuery(
 	}
 	// Start query (proxy) gRPC StoreAPI.
 	{
-		tlsCfg, err := tls.NewServerConfig(log.With(logger, "protocol", "gRPC"), grpcServerConfig.tlsSrvCert, grpcServerConfig.tlsSrvKey, grpcServerConfig.tlsSrvClientCA, grpcServerConfig.tlsMinVersion)
+		tlsCfg, err := tls.NewServerConfig(log.With(logger, "protocol", "gRPC"), grpcServerConfig.tlsSrvCert, grpcServerConfig.tlsSrvKey, grpcServerConfig.tlsSrvClientCA, grpcServerConfig.tlsMinVersion, grpcServerConfig.tlsCiphers)
 		if err != nil {
 			return errors.Wrap(err, "setup gRPC server")
 		}

--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -153,7 +153,7 @@ func runReceive(
 		}
 	}
 
-	rwTLSConfig, err := tls.NewServerConfig(log.With(logger, "protocol", "HTTP"), conf.rwServerCert, conf.rwServerKey, conf.rwServerClientCA, conf.rwServerTlsMinVersion)
+	rwTLSConfig, err := tls.NewServerConfig(log.With(logger, "protocol", "HTTP"), conf.rwServerCert, conf.rwServerKey, conf.rwServerClientCA, conf.rwServerTlsMinVersion, nil)
 	if err != nil {
 		return err
 	}
@@ -346,7 +346,7 @@ func runReceive(
 
 	level.Debug(logger).Log("msg", "setting up gRPC server")
 	{
-		tlsCfg, err := tls.NewServerConfig(log.With(logger, "protocol", "gRPC"), conf.grpcConfig.tlsSrvCert, conf.grpcConfig.tlsSrvKey, conf.grpcConfig.tlsSrvClientCA, conf.grpcConfig.tlsMinVersion)
+		tlsCfg, err := tls.NewServerConfig(log.With(logger, "protocol", "gRPC"), conf.grpcConfig.tlsSrvCert, conf.grpcConfig.tlsSrvKey, conf.grpcConfig.tlsSrvClientCA, conf.grpcConfig.tlsMinVersion, conf.grpcConfig.tlsCiphers)
 		if err != nil {
 			return errors.Wrap(err, "setup gRPC server")
 		}

--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -153,7 +153,7 @@ func runReceive(
 		}
 	}
 
-	rwTLSConfig, err := tls.NewServerConfig(log.With(logger, "protocol", "HTTP"), conf.rwServerCert, conf.rwServerKey, conf.rwServerClientCA, conf.rwServerTlsMinVersion, nil)
+	rwTLSConfig, err := tls.NewServerConfig(log.With(logger, "protocol", "HTTP"), conf.rwServerCert, conf.rwServerKey, conf.rwServerClientCA, conf.rwServerTlsMinVersion, conf.rwServerTlsCiphers)
 	if err != nil {
 		return err
 	}
@@ -851,6 +851,7 @@ type receiveConfig struct {
 	rwClientServerName    string
 	rwClientSkipVerify    bool
 	rwServerTlsMinVersion string
+	rwServerTlsCiphers    []string
 
 	dataDir   string
 	labelStrs []string
@@ -935,7 +936,9 @@ func (rc *receiveConfig) registerFlag(cmd extkingpin.FlagClause) {
 
 	cmd.Flag("remote-write.server-tls-client-ca", "TLS CA to verify clients against. If no client CA is specified, there is no client verification on server side. (tls.NoClientCert)").Default("").StringVar(&rc.rwServerClientCA)
 
-	cmd.Flag("remote-write.server-tls-min-version", "TLS version for the gRPC server, leave blank to default to TLS 1.3, allow values: [\"1.0\", \"1.1\", \"1.2\", \"1.3\"]").Default("1.3").StringVar(&rc.rwServerTlsMinVersion)
+	cmd.Flag("remote-write.server-tls-min-version", "TLS version for the HTTP server, leave blank to default to TLS 1.3, allow values: [\"1.0\", \"1.1\", \"1.2\", \"1.3\"]").Default("1.3").StringVar(&rc.rwServerTlsMinVersion)
+
+	cmd.Flag("remote-write.server-tls-ciphers", "TLS cipher suites for the HTTP server (repeatable). If not specified, the default Go cipher suites are used. See https://pkg.go.dev/crypto/tls#pkg-constants for valid values.").StringsVar(&rc.rwServerTlsCiphers)
 
 	cmd.Flag("remote-write.client-tls-cert", "TLS Certificates to use to identify this client to the server.").Default("").StringVar(&rc.rwClientCert)
 

--- a/cmd/thanos/rule.go
+++ b/cmd/thanos/rule.go
@@ -735,7 +735,7 @@ func runRule(
 	)
 
 	// Start gRPC server.
-	tlsCfg, err := tls.NewServerConfig(log.With(logger, "protocol", "gRPC"), conf.grpc.tlsSrvCert, conf.grpc.tlsSrvKey, conf.grpc.tlsSrvClientCA, conf.grpc.tlsMinVersion)
+	tlsCfg, err := tls.NewServerConfig(log.With(logger, "protocol", "gRPC"), conf.grpc.tlsSrvCert, conf.grpc.tlsSrvKey, conf.grpc.tlsSrvClientCA, conf.grpc.tlsMinVersion, conf.grpc.tlsCiphers)
 	if err != nil {
 		return errors.Wrap(err, "setup gRPC server")
 	}

--- a/cmd/thanos/sidecar.go
+++ b/cmd/thanos/sidecar.go
@@ -317,7 +317,7 @@ func runSidecar(
 		}
 
 		tlsCfg, err := tls.NewServerConfig(log.With(logger, "protocol", "gRPC"),
-			conf.grpc.tlsSrvCert, conf.grpc.tlsSrvKey, conf.grpc.tlsSrvClientCA, conf.grpc.tlsMinVersion)
+			conf.grpc.tlsSrvCert, conf.grpc.tlsSrvKey, conf.grpc.tlsSrvClientCA, conf.grpc.tlsMinVersion, conf.grpc.tlsCiphers)
 		if err != nil {
 			return errors.Wrap(err, "setup gRPC server")
 		}

--- a/cmd/thanos/store.go
+++ b/cmd/thanos/store.go
@@ -555,7 +555,7 @@ func runStore(
 
 	// Start query (proxy) gRPC StoreAPI.
 	{
-		tlsCfg, err := tls.NewServerConfig(log.With(logger, "protocol", "gRPC"), conf.grpcConfig.tlsSrvCert, conf.grpcConfig.tlsSrvKey, conf.grpcConfig.tlsSrvClientCA, conf.grpcConfig.tlsMinVersion)
+		tlsCfg, err := tls.NewServerConfig(log.With(logger, "protocol", "gRPC"), conf.grpcConfig.tlsSrvCert, conf.grpcConfig.tlsSrvKey, conf.grpcConfig.tlsSrvClientCA, conf.grpcConfig.tlsMinVersion, conf.grpcConfig.tlsCiphers)
 		if err != nil {
 			return errors.Wrap(err, "setup gRPC server")
 		}

--- a/docs/components/query.md
+++ b/docs/components/query.md
@@ -346,6 +346,12 @@ Flags:
                                  If no version is specified, it'll default to
                                  1.3. Allowed values: ["1.0", "1.1", "1.2",
                                  "1.3"]
+      --grpc-server-tls-ciphers=GRPC-SERVER-TLS-CIPHERS ...
+                                 TLS cipher suites for gRPC server
+                                 (repeatable). If not specified,
+                                 the default Go cipher suites are used.
+                                 See https://pkg.go.dev/crypto/tls#pkg-constants
+                                 for valid values.
       --grpc-server-max-connection-age=60m
                                  The grpc server max connection age. This
                                  controls how often to re-establish connections

--- a/docs/components/receive.md
+++ b/docs/components/receive.md
@@ -373,7 +373,6 @@ Please see the metric `thanos_receive_forward_delay_seconds` to see if you need 
 The following formula is used for calculating quorum:
 
 ```go mdox-exec="sed -n '1068,1078p' pkg/receive/handler.go"
-// writeQuorum returns minimum number of replicas that has to confirm write success before claiming replication success.
 func (h *Handler) writeQuorum() int {
 	// NOTE(GiedriusS): this is here because otherwise RF=2 doesn't make sense as all writes
 	// would need to succeed all the time. Another way to think about it is when migrating
@@ -384,6 +383,7 @@ func (h *Handler) writeQuorum() int {
 	}
 	return int((h.options.ReplicationFactor / 2) + 1)
 }
+
 ```
 
 So, if the replication factor is 2 then at least one write must succeed. With RF=3, two writes must succeed, and so on.
@@ -442,6 +442,12 @@ Flags:
                                  If no version is specified, it'll default to
                                  1.3. Allowed values: ["1.0", "1.1", "1.2",
                                  "1.3"]
+      --grpc-server-tls-ciphers=GRPC-SERVER-TLS-CIPHERS ...
+                                 TLS cipher suites for gRPC server
+                                 (repeatable). If not specified,
+                                 the default Go cipher suites are used.
+                                 See https://pkg.go.dev/crypto/tls#pkg-constants
+                                 for valid values.
       --grpc-server-max-connection-age=60m
                                  The grpc server max connection age. This
                                  controls how often to re-establish connections
@@ -472,9 +478,15 @@ Flags:
                                  client CA is specified, there is no client
                                  verification on server side. (tls.NoClientCert)
       --remote-write.server-tls-min-version="1.3"
-                                 TLS version for the gRPC server, leave blank
+                                 TLS version for the HTTP server, leave blank
                                  to default to TLS 1.3, allow values: ["1.0",
                                  "1.1", "1.2", "1.3"]
+      --remote-write.server-tls-ciphers=REMOTE-WRITE.SERVER-TLS-CIPHERS ...
+                                 TLS cipher suites for the HTTP server
+                                 (repeatable). If not specified,
+                                 the default Go cipher suites are used.
+                                 See https://pkg.go.dev/crypto/tls#pkg-constants
+                                 for valid values.
       --remote-write.client-tls-cert=""
                                  TLS Certificates to use to identify this client
                                  to the server.

--- a/docs/components/rule.md
+++ b/docs/components/rule.md
@@ -316,6 +316,12 @@ Flags:
                                  If no version is specified, it'll default to
                                  1.3. Allowed values: ["1.0", "1.1", "1.2",
                                  "1.3"]
+      --grpc-server-tls-ciphers=GRPC-SERVER-TLS-CIPHERS ...
+                                 TLS cipher suites for gRPC server
+                                 (repeatable). If not specified,
+                                 the default Go cipher suites are used.
+                                 See https://pkg.go.dev/crypto/tls#pkg-constants
+                                 for valid values.
       --grpc-server-max-connection-age=60m
                                  The grpc server max connection age. This
                                  controls how often to re-establish connections

--- a/docs/components/sidecar.md
+++ b/docs/components/sidecar.md
@@ -142,6 +142,12 @@ Flags:
                                  If no version is specified, it'll default to
                                  1.3. Allowed values: ["1.0", "1.1", "1.2",
                                  "1.3"]
+      --grpc-server-tls-ciphers=GRPC-SERVER-TLS-CIPHERS ...
+                                 TLS cipher suites for gRPC server
+                                 (repeatable). If not specified,
+                                 the default Go cipher suites are used.
+                                 See https://pkg.go.dev/crypto/tls#pkg-constants
+                                 for valid values.
       --grpc-server-max-connection-age=60m
                                  The grpc server max connection age. This
                                  controls how often to re-establish connections

--- a/docs/components/store.md
+++ b/docs/components/store.md
@@ -95,6 +95,12 @@ Flags:
                                  If no version is specified, it'll default to
                                  1.3. Allowed values: ["1.0", "1.1", "1.2",
                                  "1.3"]
+      --grpc-server-tls-ciphers=GRPC-SERVER-TLS-CIPHERS ...
+                                 TLS cipher suites for gRPC server
+                                 (repeatable). If not specified,
+                                 the default Go cipher suites are used.
+                                 See https://pkg.go.dev/crypto/tls#pkg-constants
+                                 for valid values.
       --grpc-server-max-connection-age=60m
                                  The grpc server max connection age. This
                                  controls how often to re-establish connections

--- a/pkg/tls/options.go
+++ b/pkg/tls/options.go
@@ -20,7 +20,7 @@ import (
 )
 
 // NewServerConfig provides new server TLS configuration.
-func NewServerConfig(logger log.Logger, certPath, keyPath, clientCA, tlsMinVersion string) (*tls.Config, error) {
+func NewServerConfig(logger log.Logger, certPath, keyPath, clientCA, tlsMinVersion string, ciphers []string) (*tls.Config, error) {
 	if keyPath == "" && certPath == "" {
 		if clientCA != "" {
 			return nil, errors.New("when a client CA is used a server key and certificate must also be provided")
@@ -44,6 +44,13 @@ func NewServerConfig(logger log.Logger, certPath, keyPath, clientCA, tlsMinVersi
 	tlsCfg := &tls.Config{
 		MinVersion: minTlsVersion,
 	}
+
+	cipherSuiteIDs, err := getCipherSuiteIDs(ciphers)
+	if err != nil {
+		return nil, err
+	}
+	tlsCfg.CipherSuites = cipherSuiteIDs
+
 	// Certificate is loaded during server startup to check for any errors.
 	certificate, err := tls.LoadX509KeyPair(certPath, keyPath)
 	if err != nil {
@@ -213,8 +220,34 @@ func (validOption validOption) joinString() string {
 	return strings.Join(keys, ", ")
 }
 
-func getTlsVersion(tlsMinVersion string) (uint16, error) {
+func getCipherSuiteIDs(ciphers []string) ([]uint16, error) {
+	if len(ciphers) == 0 {
+		return nil, nil
+	}
 
+	supported := tls.CipherSuites()
+	cipherMap := make(map[string]uint16, len(supported))
+	for _, cs := range supported {
+		cipherMap[cs.Name] = cs.ID
+	}
+
+	ids := make([]uint16, 0, len(ciphers))
+	for _, name := range ciphers {
+		id, ok := cipherMap[name]
+		if !ok {
+			validNames := make([]string, 0, len(cipherMap))
+			for n := range cipherMap {
+				validNames = append(validNames, n)
+			}
+			sort.Strings(validNames)
+			return nil, errors.New(fmt.Sprintf("invalid cipher suite: %s, valid values are %s", name, strings.Join(validNames, ", ")))
+		}
+		ids = append(ids, id)
+	}
+	return ids, nil
+}
+
+func getTlsVersion(tlsMinVersion string) (uint16, error) {
 	validOption := validOption{
 		tlsOption: map[string]uint16{
 			"1.0": tls.VersionTLS10,

--- a/pkg/tls/options_test.go
+++ b/pkg/tls/options_test.go
@@ -11,6 +11,79 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestGetCipherSuiteIDs(t *testing.T) {
+	supported := tls.CipherSuites()
+	require.NotEmpty(t, supported, "tls.CipherSuites() must return at least one suite")
+
+	first := supported[0]
+	second := supported[1]
+
+	tests := []struct {
+		name        string
+		input       []string
+		wantIDs     []uint16
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:    "empty input returns nil",
+			input:   []string{},
+			wantIDs: nil,
+		},
+		{
+			name:    "nil input returns nil",
+			input:   nil,
+			wantIDs: nil,
+		},
+		{
+			name:    "single valid cipher",
+			input:   []string{first.Name},
+			wantIDs: []uint16{first.ID},
+		},
+		{
+			name:    "multiple valid ciphers preserves order",
+			input:   []string{second.Name, first.Name},
+			wantIDs: []uint16{second.ID, first.ID},
+		},
+		{
+			name:    "duplicate cipher returns duplicate IDs",
+			input:   []string{first.Name, first.Name},
+			wantIDs: []uint16{first.ID, first.ID},
+		},
+		{
+			name:        "unknown cipher returns error",
+			input:       []string{"INVALID_CIPHER"},
+			wantErr:     true,
+			errContains: "INVALID_CIPHER",
+		},
+		{
+			name:        "error message contains valid cipher names",
+			input:       []string{"BAD_CIPHER"},
+			wantErr:     true,
+			errContains: first.Name,
+		},
+		{
+			name:        "valid cipher followed by invalid returns error",
+			input:       []string{first.Name, "UNKNOWN"},
+			wantErr:     true,
+			errContains: "UNKNOWN",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ids, err := getCipherSuiteIDs(tc.input)
+			if tc.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.errContains)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantIDs, ids)
+		})
+	}
+}
+
 func TestTlsOptions(t *testing.T) {
 	var tests = []struct {
 		input  string

--- a/test/e2e/tls_test.go
+++ b/test/e2e/tls_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"crypto/rand"
 	"crypto/rsa"
+	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
@@ -94,6 +95,109 @@ func TestGRPCServerCertAutoRotate(t *testing.T) {
 	resp, err = clt.UnaryEcho(context.Background(), &pb.EchoRequest{Message: expMessage})
 	testutil.Ok(t, err)
 	testutil.Equals(t, expMessage, resp.Message)
+}
+
+func TestGRPCServerTLSCiphersAndVersions(t *testing.T) {
+	defer leaktest.CheckTimeout(t, 10*time.Second)() // To see whether any goroutines leaked.
+
+	logger := log.NewLogfmtLogger(os.Stderr)
+	expMessage := "hello world"
+
+	tmpDirClt := t.TempDir()
+	caClt := filepath.Join(tmpDirClt, "ca")
+	certClt := filepath.Join(tmpDirClt, "cert")
+	keyClt := filepath.Join(tmpDirClt, "key")
+
+	tmpDirSrv := t.TempDir()
+	caSrv := filepath.Join(tmpDirSrv, "ca")
+	certSrv := filepath.Join(tmpDirSrv, "cert")
+	keySrv := filepath.Join(tmpDirSrv, "key")
+	tlsMinVersion := "1.2"
+
+	genCerts(t, certSrv, keySrv, caClt)
+	genCerts(t, certClt, keyClt, caSrv)
+
+	configSrv, err := thTLS.NewServerConfig(logger, certSrv, keySrv, caSrv, tlsMinVersion, []string{"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256", "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"})
+	testutil.Ok(t, err)
+
+	srv := grpc.NewServer(grpc.KeepaliveParams(keepalive.ServerParameters{MaxConnectionAge: 1 * time.Millisecond}), grpc.Creds(credentials.NewTLS(configSrv)))
+
+	pb.RegisterEchoServer(srv, &ecServer{})
+	p, err := e2eutil.FreePort()
+	testutil.Ok(t, err)
+	addr := fmt.Sprint("localhost:", p)
+	lis, err := net.Listen("tcp", addr)
+	testutil.Ok(t, err)
+
+	go func() {
+		testutil.Ok(t, srv.Serve(lis))
+	}()
+	defer func() { srv.Stop() }()
+	time.Sleep(50 * time.Millisecond) // Wait for the server to start.
+
+	t.Run("compatible configurations", func(t *testing.T) {
+		// Setup the connection and the client.
+		configClt, err := thTLS.NewClientConfig(logger, certClt, keyClt, caClt, serverName, false)
+		testutil.Ok(t, err)
+
+		// Configure TLS version 1.2 only with a cipher suite supported by the server.
+		configClt.MinVersion = tls.VersionTLS12
+		configClt.MaxVersion = tls.VersionTLS12
+		configClt.CipherSuites = []uint16{tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384}
+
+		conn, err := grpc.NewClient(addr, grpc.WithConnectParams(grpc.ConnectParams{MinConnectTimeout: 1 * time.Minute}), grpc.WithTransportCredentials(credentials.NewTLS(configClt)))
+		testutil.Ok(t, err)
+		defer func() {
+			testutil.Ok(t, conn.Close())
+		}()
+		clt := pb.NewEchoClient(conn)
+
+		// Check a good state.
+		resp, err := clt.UnaryEcho(context.Background(), &pb.EchoRequest{Message: expMessage})
+		testutil.Ok(t, err)
+		testutil.Equals(t, expMessage, resp.Message)
+	})
+
+	t.Run("cipher suite mismatch", func(t *testing.T) {
+		configClt, err := thTLS.NewClientConfig(logger, certClt, keyClt, caClt, serverName, false)
+		testutil.Ok(t, err)
+
+		// Configure TLS version 1.2 only with a cipher suite NOT supported by the server.
+		configClt.MinVersion = tls.VersionTLS12
+		configClt.MaxVersion = tls.VersionTLS12
+		configClt.CipherSuites = []uint16{tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256}
+
+		conn, err := grpc.NewClient(addr, grpc.WithConnectParams(grpc.ConnectParams{MinConnectTimeout: 1 * time.Minute}), grpc.WithTransportCredentials(credentials.NewTLS(configClt)))
+		testutil.Ok(t, err)
+		defer func() {
+			testutil.Ok(t, conn.Close())
+		}()
+		clt := pb.NewEchoClient(conn)
+
+		// Check a bad state.
+		_, err = clt.UnaryEcho(context.Background(), &pb.EchoRequest{Message: expMessage})
+		testutil.NotOk(t, err)
+	})
+
+	t.Run("TLS version mismatch", func(t *testing.T) {
+		configClt, err := thTLS.NewClientConfig(logger, certClt, keyClt, caClt, serverName, false)
+		testutil.Ok(t, err)
+
+		// Configure TLS version 1.1 only.
+		configClt.MinVersion = tls.VersionTLS11
+		configClt.MaxVersion = tls.VersionTLS11
+
+		conn, err := grpc.NewClient(addr, grpc.WithConnectParams(grpc.ConnectParams{MinConnectTimeout: 1 * time.Minute}), grpc.WithTransportCredentials(credentials.NewTLS(configClt)))
+		testutil.Ok(t, err)
+		defer func() {
+			testutil.Ok(t, conn.Close())
+		}()
+		clt := pb.NewEchoClient(conn)
+
+		// Check a bad state.
+		_, err = clt.UnaryEcho(context.Background(), &pb.EchoRequest{Message: expMessage})
+		testutil.NotOk(t, err)
+	})
 }
 
 var caRoot = &x509.Certificate{

--- a/test/e2e/tls_test.go
+++ b/test/e2e/tls_test.go
@@ -54,7 +54,7 @@ func TestGRPCServerCertAutoRotate(t *testing.T) {
 	genCerts(t, certSrv, keySrv, caClt)
 	genCerts(t, certClt, keyClt, caSrv)
 
-	configSrv, err := thTLS.NewServerConfig(logger, certSrv, keySrv, caSrv, tlsMinVersion)
+	configSrv, err := thTLS.NewServerConfig(logger, certSrv, keySrv, caSrv, tlsMinVersion, nil)
 	testutil.Ok(t, err)
 
 	srv := grpc.NewServer(grpc.KeepaliveParams(keepalive.ServerParameters{MaxConnectionAge: 1 * time.Millisecond}), grpc.Creds(credentials.NewTLS(configSrv)))
@@ -190,6 +190,6 @@ func TestInvalidCertAndKey(t *testing.T) {
 	keySrv := filepath.Join(tmpDirSrv, "key")
 	tlsMinVersion := "1.3"
 	// Certificate and key are not present in the above path
-	_, err := thTLS.NewServerConfig(logger, certSrv, keySrv, caSrv, tlsMinVersion)
+	_, err := thTLS.NewServerConfig(logger, certSrv, keySrv, caSrv, tlsMinVersion, nil)
 	testutil.NotOk(t, err)
 }


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [X] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Related to #8685

* Extend NewServerConfig() to configure TLS ciphers
* Add `--grpc-server-tls-ciphers` CLI argument to configure gRPC servers.
* Add `--remote-write.server-tls-ciphers` CLI arguments to configure the remote-write receiver server.

## Verification

Unit + end-to-end tests added.