### PR TITLE
docs: update stale Go version requirement and prometheus-operator links

### DIFF
--- a/docs/contributing/how-to-change-go-version.md
+++ b/docs/contributing/how-to-change-go-version.md
@@ -4,7 +4,7 @@ Thanos build system is pinned to certain Golang version. This is to ensure that 
 
 To update Thanos build system to newer Golang:
 
-1. Edit [.promu.yaml](../../.promu.yml) and edit `go: version: <go version>` in YAML to desired version. This will ensure that all artifacts are built with desired Golang version. How to verify? Download tarball, unpack and invoke `thanos --version`
+1. Edit [.promu.yml](../../.promu.yml) and edit `go: version: <go version>` in YAML to desired version. This will ensure that all artifacts are built with desired Golang version. How to verify? Download tarball, unpack and invoke `thanos --version`
 2. Edit [.circleci/config.yaml](../../.circleci/config.yml) and update ` - image: cimg/go:<go version>-node` to desired Golang version. This will ensure that all docker images and go tests are using desired Golang version. How to verify? Invoke `docker pull quay.io/thanos/thanos:<version> --version`
-3. Edit [.github/workflows/docs.yaml](../../.github/workflows/docs.yaml) [.github/workflows/go.yaml](../../.github/workflows/go.yaml) and update Go version.
+3. Edit [.github/workflows/docs.yaml](../../.github/workflows/docs.yaml) [.github/workflows/go.yaml](../../.github/workflows/go.yaml) [.github/workflows/mixin.yaml](../../.github/workflows/mixin.yaml) [.github/workflows/codeql-analysis.yml](../../.github/workflows/codeql-analysis.yml) and update Go version.
 4. Edit [Dockerfile.e2e-tests](../../Dockerfile.e2e-tests) and update Go version.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -40,7 +40,7 @@ Thanos can **not** be downloaded nor installed via the `go get` or `go install` 
 
 Thanos uses the directive *replace*. The reason is to provide a way to unblock ourselves promptly while also being flexible in the packages that we (re)use. Support for `go install` is not likely at this point.
 
-If you want to build Thanos from source you would need a working installation of the Go 1.18+ [toolchain](https://github.com/golang/tools) (`GOPATH`, `PATH=${GOPATH}/bin:${PATH}`). Next one should make a clone of our repository:
+If you want to build Thanos from source you would need a working installation of the Go 1.26+ [toolchain](https://github.com/golang/tools) (`GOPATH`, `PATH=${GOPATH}/bin:${PATH}`). Next one should make a clone of our repository:
 
 ```
 git clone git@github.com:thanos-io/thanos.git
@@ -71,7 +71,7 @@ Thanos is **not** tied to Kubernetes. However, Kubernetes, Thanos and Prometheus
 
 Our friendly community maintains a few different ways of installing Thanos on Kubernetes. See those below:
 
-* [prometheus-operator](https://github.com/coreos/prometheus-operator): Prometheus operator has support for deploying Prometheus with Thanos
+* [prometheus-operator](https://github.com/prometheus-operator/prometheus-operator): Prometheus operator has support for deploying Prometheus with Thanos
 * [kube-thanos](https://github.com/thanos-io/kube-thanos): Jsonnet based Kubernetes templates.
 * [Community Helm charts](https://artifacthub.io/packages/search?ts_query_web=thanos)
 

--- a/docs/proposals-done/201909-thanos-sharding.md
+++ b/docs/proposals-done/201909-thanos-sharding.md
@@ -86,7 +86,7 @@ On each component that works on the object storage (e.g Store GW and Compactor),
 
 ### Relabelling
 
-Similar to [promtail](https://grafana.com/docs/loki/latest/clients/promtail/scraping/#relabeling) this config will follow native [Prometheus relabel-config](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config) syntax.
+Similar to [promtail](https://grafana.com/docs/loki/v3.5.x/send-data/promtail/scraping/#relabeling) this config will follow native [Prometheus relabel-config](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config) syntax.
 
 The relabel config will define filtering process done on **every** synchronization with object storage.
 

--- a/docs/quick-tutorial.md
+++ b/docs/quick-tutorial.md
@@ -77,7 +77,7 @@ Rolling this out has little to no impact on the running Prometheus instance. Thi
 
 If you are not interested in backing up any data, the `--objstore.config-file` flag can simply be omitted.
 
-* *[Example Kubernetes manifests using Prometheus operator](https://github.com/coreos/prometheus-operator/tree/master/example/thanos)*
+* *[Example Kubernetes manifests using Prometheus operator](https://github.com/prometheus-operator/prometheus-operator/tree/main/example/thanos)*
 * *[Example Deploying Sidecar using official Prometheus Helm Chart](../tutorials/kubernetes-helm/README.md)*
 * *[Details & Config for other object stores](storage.md)*
 * *[Example Thanos Setup integrated with Cilium(Service Map)](../tutorials/thanos-with-cilium/README.md)*
@@ -97,7 +97,7 @@ thanos sidecar \
     --grpc-address              0.0.0.0:19090              # GRPC endpoint for StoreAPI
 ```
 
-* *[Example Kubernetes manifests using Prometheus operator](https://github.com/coreos/prometheus-operator/tree/master/example/thanos)*
+* *[Example Kubernetes manifests using Prometheus operator](https://github.com/prometheus-operator/prometheus-operator/tree/main/example/thanos)*
 
 ### Uploading Old Metrics
 
@@ -190,7 +190,7 @@ thanos query \
 
 Read more details [here](service-discovery.md).
 
-* *[Example Kubernetes manifests using Prometheus operator](https://github.com/coreos/prometheus-operator/tree/master/example/thanos)*
+* *[Example Kubernetes manifests using Prometheus operator](https://github.com/prometheus-operator/prometheus-operator/tree/main/example/thanos)*
 
 ## Store Gateway
 

--- a/docs/sharding.md
+++ b/docs/sharding.md
@@ -18,7 +18,7 @@ Queries against store gateway which are touching large number of blocks (no matt
 
 # Relabelling
 
-Similar to [promtail](https://grafana.com/docs/loki/latest/clients/promtail/configuration/#relabel_configs) this config follows native [Prometheus relabel-config](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config) syntax.
+Similar to [promtail](https://grafana.com/docs/loki/v3.5.x/send-data/promtail/configuration/#relabel_configs) this config follows native [Prometheus relabel-config](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config) syntax.
 
 Currently, thanos only supports the following relabel actions:
 

--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -172,7 +172,7 @@ config:
 
 Client for [Lightstep](https://www.servicenow.com/products/observability.html).
 
-In order to configure Thanos to interact with Lightstep you need to provide at least an [access token](https://docs.lightstep.com/docs/create-and-use-access-tokens) in the configuration file. The `collector` key is optional and used when you have on-premise satellites.
+In order to configure Thanos to interact with Lightstep you need to provide at least an [access token](https://docs.lightstep.com/docs/create-and-manage-access-tokens) in the configuration file. The `collector` key is optional and used when you have on-premise satellites.
 
 ```yaml mdox-exec="go run scripts/cfggen/main.go --name=lightstep.Config"
 type: LIGHTSTEP


### PR DESCRIPTION
* [x] Change is not relevant to the end user.

## Changes

Update Go requirement from 1.18+ to 1.26+ to match go.mod. Update `coreos/prometheus-operator` links to `prometheus-operator/prometheus-operator`. Add missing workflows to Go version change guide, fix `.promu.yaml` → `.promu.yml`.

## Verification

Checked go.mod and GitHub org redirect.