### PR TITLE
ci: pin codespell actions to SHA and fix Go version in codeql/mixin

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -44,7 +44,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
       with:
-        go-version: 1.22.x
+        go-version: 1.26.x
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -132,9 +132,9 @@ jobs:
     name: Check misspelled words
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - name: Run codespell
-        uses: codespell-project/actions-codespell@v2
+        uses: codespell-project/actions-codespell@406322ec52dd7b488e48c1c4b82e2a8b3a1bf630 # v2
         with:
           check_filenames: false
           check_hidden: true

--- a/.github/workflows/mixin.yaml
+++ b/.github/workflows/mixin.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
         with:
-          go-version: 1.22.x
+          go-version: 1.26.x
 
       - name: Generate
         run: make examples
@@ -37,7 +37,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
         with:
-          go-version: 1.22.x
+          go-version: 1.26.x
 
       - name: Format
         run: |


### PR DESCRIPTION
* [x] Change is not relevant to the end user.

## Changes

SHA-pin actions in codespell job for consistency with the rest of go.yaml. Update Go 1.22.x → 1.26.x in codeql-analysis.yml and mixin.yaml.

## Verification

SHAs verified against upstream tags.