### PR TITLE
ci: bump Node.js from 14 to 20 in react workflow

### DIFF
--- a/.github/workflows/react.yml
+++ b/.github/workflows/react.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [ '14' ]
+        node: [ '20' ]
     name: React UI test on Node ${{ matrix.node }}
     steps:
       - name: Checkout code


### PR DESCRIPTION
* [x] Change is not relevant to the end user.

## Changes

Node 14 EOL since April 2023. Bump to Node 20 LTS.

## Verification

react-scripts 5.x supports Node 20.