### PR TITLE
receive: Return most common err instead on writeErr cause

### DIFF
--- a/pkg/receive/handler.go
+++ b/pkg/receive/handler.go
@@ -1305,8 +1305,8 @@ func (es *writeErrors) ErrOrNil() error {
 }
 
 // Cause returns the primary cause for a write failure.
-// If multiple errors have occurred, Cause will prefer
-// recoverable over non-recoverable errors.
+// If multiple errors have occurred, Cause will return the most
+// frequently occurring error type.
 func (es *writeErrors) Cause() error {
 	if len(es.errs) == 0 {
 		return nil
@@ -1336,10 +1336,10 @@ func (es *writeErrors) Cause() error {
 		}
 	}
 
-	for _, exp := range expErrs {
-		if exp.count > 0 {
-			return exp.err
-		}
+	// Sort by count descending and return the most frequent error.
+	sort.Sort(sort.Reverse(expErrs))
+	if expErrs[0].count > 0 {
+		return expErrs[0].err
 	}
 
 	return unknownErr

--- a/pkg/receive/handler_test.go
+++ b/pkg/receive/handler_test.go
@@ -2001,3 +2001,56 @@ func TestHandlerFlippingHashrings(t *testing.T) {
 	cancel()
 	wg.Wait()
 }
+
+// TestReplicationErrorsConflictScenario tests what happens in RF=3, Quorum=2
+// when 1 replica is unavailable and 2 replicas return conflict errors.
+func TestReplicationErrorsConflictScenario(t *testing.T) {
+	t.Parallel()
+
+	// Simulate RF=3, Quorum=2 scenario:
+	// - 1 replica returns unavailable
+	// - 2 replicas return conflict
+	errs := &replicationErrors{
+		threshold: 2,
+	}
+
+	// Add 1 unavailable error
+	errs.Add(errUnavailable)
+	// Add 2 conflict errors
+	errs.Add(storage.ErrOutOfOrderSample)
+	errs.Add(storage.ErrDuplicateSampleForTimestamp)
+
+	// Call Cause() to see what error is returned
+	cause := errs.Cause()
+
+	// With threshold=2:
+	// - conflict count = 2 (>= threshold)
+	// - unavailable count = 1 (< threshold)
+	// Since conflict count meets the threshold, errConflict is returned
+	// This then gets mapped to HTTP 409 Conflict in the handler
+
+	require.Equal(t, errConflict, cause, "Expected errConflict since 2 conflicts meet the quorum threshold of 2")
+}
+
+func TestWriteErrorsConflictScenario(t *testing.T) {
+	t.Parallel()
+
+	errs := &writeErrors{}
+
+	// Add 1 unavailable error
+	errs.Add(errUnavailable)
+	// Add 2 conflict errors
+	errs.Add(storage.ErrOutOfOrderSample)
+	errs.Add(storage.ErrDuplicateSampleForTimestamp)
+
+	// Call Cause() to see what error is returned
+	cause := errs.Cause()
+
+	// writeErrors.Cause() now returns the most frequent error:
+	// - conflict count = 2
+	// - unavailable count = 1
+	// Since conflict is most frequent, errConflict is returned
+	// This maps to HTTP 409 Conflict
+
+	require.Equal(t, errConflict, cause, "Expected errConflict since it's the most frequent error (2 vs 1)")
+}


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

Trying to fix https://github.com/thanos-io/thanos/issues/8727

The added writeError test fails on current main as it returns errUnavailable on 409 + 409 + 503.
Which is sort of wrong, as an rw req with 409 on both will never achieve quorum anyway, even after remaining rep comes back up.

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
