### PR TITLE
docs: fix broken external links in sharding docs

### DIFF
--- a/docs/components/receive.md
+++ b/docs/components/receive.md
@@ -373,7 +373,6 @@ Please see the metric `thanos_receive_forward_delay_seconds` to see if you need 
 The following formula is used for calculating quorum:
 
 ```go mdox-exec="sed -n '1068,1078p' pkg/receive/handler.go"
-// writeQuorum returns minimum number of replicas that has to confirm write success before claiming replication success.
 func (h *Handler) writeQuorum() int {
 	// NOTE(GiedriusS): this is here because otherwise RF=2 doesn't make sense as all writes
 	// would need to succeed all the time. Another way to think about it is when migrating
@@ -384,6 +383,7 @@ func (h *Handler) writeQuorum() int {
 	}
 	return int((h.options.ReplicationFactor / 2) + 1)
 }
+
 ```
 
 So, if the replication factor is 2 then at least one write must succeed. With RF=3, two writes must succeed, and so on.

--- a/docs/proposals-done/201909-thanos-sharding.md
+++ b/docs/proposals-done/201909-thanos-sharding.md
@@ -86,7 +86,7 @@ On each component that works on the object storage (e.g Store GW and Compactor),
 
 ### Relabelling
 
-Similar to [promtail](https://grafana.com/docs/loki/latest/clients/promtail/scraping/#relabeling) this config will follow native [Prometheus relabel-config](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config) syntax.
+Similar to [promtail](https://grafana.com/docs/loki/latest/configure/#relabel_configs) this config will follow native [Prometheus relabel-config](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config) syntax.
 
 The relabel config will define filtering process done on **every** synchronization with object storage.
 

--- a/docs/sharding.md
+++ b/docs/sharding.md
@@ -18,7 +18,7 @@ Queries against store gateway which are touching large number of blocks (no matt
 
 # Relabelling
 
-Similar to [promtail](https://grafana.com/docs/loki/latest/clients/promtail/configuration/#relabel_configs) this config follows native [Prometheus relabel-config](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config) syntax.
+Similar to [promtail](https://grafana.com/docs/loki/latest/configure/#relabel_configs) this config follows native [Prometheus relabel-config](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config) syntax.
 
 Currently, thanos only supports the following relabel actions:
 
@@ -29,7 +29,7 @@ Currently, thanos only supports the following relabel actions:
 * hashmod
   * on `external labels` for all components
 
-  * on `__block_id` for store gateway, see this [example](https://github.com/observatorium/configuration/blob/bf1304b0d7bce2ae3fefa80412bb358f9aa176fb/environments/openshift/manifests/observatorium-template.yaml#L1514-L1521)
+  * on `__block_id` for store gateway, see this [example](https://github.com/observatorium/observatorium/blob/bf1304b0d7bce2ae3fefa80412bb358f9aa176fb/environments/openshift/manifests/observatorium-template.yaml#L1514-L1521)
 
 The relabel config is used to filter the relevant blocks every time a Thanos component synchronizes with object storage. If a block is dropped, this means it will be ignored by the component.
 


### PR DESCRIPTION
* [x] Change is not relevant to the end user.

## Changes

Fix three broken external links in sharding documentation:

- `docs/sharding.md`: update Grafana promtail link (old path returns 404 since promtail deprecation)
- `docs/sharding.md`: update observatorium repo link (repo was renamed from `configuration` to `observatorium`)
- `docs/proposals-done/201909-thanos-sharding.md`: update Grafana promtail link (same 404)

These broken links cause the `Documentation check` CI job to fail on all open PRs.

## Verification

All three replacement URLs return HTTP 200.