### PR TITLE
*: bump thanos-community/grpc-go to fix CVE-2026-33186

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ It is recommend to upgrade the storage components first (Receive, Store, etc.) a
 
 ### Fixed
 
+- [#8726](https://github.com/thanos-io/thanos/pull/8726): *: Bump `thanos-community/grpc-go` fork to fix CVE-2026-33186 (CVSS 9.1), an authorization bypass via malformed `:path` headers that could bypass path-based "deny" rules in `grpc/authz` interceptors.
 - [#8714](https://github.com/thanos-io/thanos/pull/8714): Tracing: Fix `tls_config` fields (`ca_file`, `cert_file`, `key_file`) being silently ignored when using the OTLP gRPC exporter. Previously, deployments using a private CA or mTLS client certificates had to work around this via `OTEL_EXPORTER_OTLP_CERTIFICATE` and related environment variables.
 - [#8128](https://github.com/thanos-io/thanos/issues/8128): Query-Frontend: Fix panic in `AnalyzesMerge` caused by indexing the wrong slice variable, leading to an out-of-range access when merging more than two query analyses.
 - [#8720](https://github.com/thanos-io/thanos/issues/8720): Receive: Fix 503 errors during restarts in some cases.

--- a/go.mod
+++ b/go.mod
@@ -334,7 +334,7 @@ replace (
 
 	github.com/vimeo/galaxycache => github.com/thanos-community/galaxycache v0.0.0-20211122094458-3a32041a1f1e
 
-	google.golang.org/grpc => github.com/thanos-community/grpc-go v0.0.0-20251106112228-b9020406f781
+	google.golang.org/grpc => github.com/thanos-community/grpc-go v0.0.0-20260331083222-a7315f1dfb76
 
 	// Overriding to use latest commit.
 	gopkg.in/alecthomas/kingpin.v2 => github.com/alecthomas/kingpin v1.3.8-0.20210301060133-17f40c25f497

--- a/go.sum
+++ b/go.sum
@@ -3919,8 +3919,8 @@ github.com/tencentyun/cos-go-sdk-v5 v0.7.66 h1:O4O6EsozBoDjxWbltr3iULgkI7WPj/BFN
 github.com/tencentyun/cos-go-sdk-v5 v0.7.66/go.mod h1:8+hG+mQMuRP/OIS9d83syAvXvrMj9HhkND6Q1fLghw0=
 github.com/thanos-community/galaxycache v0.0.0-20211122094458-3a32041a1f1e h1:f1Zsv7OAU9iQhZwigp50Yl38W10g/vd5NC8Rdk1Jzng=
 github.com/thanos-community/galaxycache v0.0.0-20211122094458-3a32041a1f1e/go.mod h1:jXcofnrSln/cLI6/dhlBxPQZEEQHVPCcFaH75M+nSzM=
-github.com/thanos-community/grpc-go v0.0.0-20251106112228-b9020406f781 h1:e9c72LR6jBSpBjjBRjqeoNp1qQLZQqMyeHzNqvou5NE=
-github.com/thanos-community/grpc-go v0.0.0-20251106112228-b9020406f781/go.mod h1:YnIHHmJ2ND31zdEiJmIw5W6dtr05o2clL82wnWwFnn0=
+github.com/thanos-community/grpc-go v0.0.0-20260331083222-a7315f1dfb76 h1:RheGORM3blydQlRgttQK1rEk9fFXqsupByS4yo+hsUE=
+github.com/thanos-community/grpc-go v0.0.0-20260331083222-a7315f1dfb76/go.mod h1:YnIHHmJ2ND31zdEiJmIw5W6dtr05o2clL82wnWwFnn0=
 github.com/thanos-io/objstore v0.0.0-20250804093838-71d60dfee488 h1:khBsQLLRoF1KzXgTlwFZa6mC32bwYUUAu/AeP49V7UM=
 github.com/thanos-io/objstore v0.0.0-20250804093838-71d60dfee488/go.mod h1:uDHLkMKOGDAnlN75EAz8VrRzob1+VbgYSuUleatWuF0=
 github.com/thanos-io/promql-engine v0.0.0-20260119085929-dd5223783674 h1:C5yBEuIZCaeLh90lcUGfnGepmwDfGGYLu6+w7RxR7og=


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [X] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Bump the `thanos-community/grpc-go` fork to pick up the cherry-picked fix for
CVE-2026-33186 (CVSS 9.1) from [thanos-community/grpc-go#1](https://github.com/thanos-community/grpc-go/pull/1).
This enforces strict path checking for incoming requests on the server,
rejecting any request with a non-canonical `:path` header (missing the leading
slash) with an `Unimplemented` error. Without this fix, malformed paths could
bypass path-based restricted "deny" rules in interceptors like `grpc/authz`.

## Verification

Dependency-only change (`go.mod` / `go.sum`). The fix itself is tested upstream
in [grpc/grpc-go#8985](https://github.com/grpc/grpc-go/pull/8985).

