### PR TITLE
 extgrpc: fix use-after-free in Marshal with unsafe ZLabel pointers

### DIFF
--- a/pkg/extgrpc/client.go
+++ b/pkg/extgrpc/client.go
@@ -64,18 +64,18 @@ func (c *nonPoolingCodec) Marshal(v any) (mem.BufferSlice, error) {
 		return c.CodecV2.Marshal(v)
 	}
 	size := gmsg.Size()
-	pool := mem.DefaultBufferPool()
-	buf := pool.Get(size)
+	// Use nopPool instead of DefaultBufferPool to avoid use-after-free with unsafe label strings.
+	// See TODO comment in Unmarshal: we use unsafe code around labels so we cannot use pooling.
+	buf := nopPool.Get(size)
 
 	n, err := gmsg.MarshalToSizedBuffer((*buf)[:size])
 	if err != nil {
-		pool.Put(buf)
 		return mem.BufferSlice{}, err
 	}
 
 	bufExact := (*buf)[:n]
 
-	return mem.BufferSlice{mem.NewBuffer(&bufExact, pool)}, nil
+	return mem.BufferSlice{mem.NewBuffer(&bufExact, &nopPool)}, nil
 }
 
 // EndpointGroupGRPCOpts creates gRPC dial options for connecting to endpoint groups.


### PR DESCRIPTION
  This PR disables buffer pooling in the Marshal path.

  Problem:
  PR #8553 fixed memory over-allocation by switching Unmarshal to use
  nopPool instead of DefaultBufferPool. However, it left Marshal still
  using the default pool. This creates a use-after-free race condition:

  1. Thread A: Unmarshal creates ZLabels with unsafe pointers into buffer1
  2. Thread A: buffer1 stays alive (nopPool doesn't recycle it)
  3. Thread B: Marshal allocates from DefaultBufferPool, gets a buffer
  4. Thread B: Buffer is returned to pool after send completes
  5. Thread A: Tries to Marshal its response, calls gmsg.Size()
  6. Thread C: Unmarshal (different request) could reuse that buffer
  7. Thread A: ZLabel.Size() reads string lengths from potentially overwritten memory, returns garbage (e.g., 6.7 exabytes)
  8. Thread A: pool.Get(garbage_size) panics

hence, we see:
```
panic: runtime error: makeslice: len out of range

goroutine 56 [running]:
google.golang.org/grpc/mem.(*simpleBufferPool).Get(0xc00048d858, 0x5e94517a36ddaf0d)
	/go/src/github.com/improbable-eng/thanos/vendor/google.golang.org/grpc/mem/buffer_pool.go:175 +0xc5
google.golang.org/grpc/mem.(*tieredBufferPool).Get(0xc0009cd9e0?, 0x5e94517a36ddaf0d)
	/go/src/github.com/improbable-eng/thanos/vendor/google.golang.org/grpc/mem/buffer_pool.go:91 +0x26
github.com/thanos-io/thanos/pkg/extgrpc.(*nonPoolingCodec).Marshal(0xc00058f420?, {0x3310980?, 0xc0009cd9e0})
	/go/src/github.com/improbable-eng/thanos/pkg/extgrpc/client.go:68 +0x82
google.golang.org/grpc.encode({0x7fd4b7457f70?, 0xc00058f420?}, {0x3310980?, 0xc0009cd9e0?})
	/go/src/github.com/improbable-eng/thanos/vendor/google.golang.org/grpc/rpc_util.go:734 +0x4a
google.golang.org/grpc.(*Server).sendResponse(0xc0005c9448, {0x42cb6b8, 0xc0009cecf0}, 0xc000588820, {0x3310980, 0xc0009cd9e0}, {0x0, 0x0}, 0xc000a764b8, {0x0, ...})
	/go/src/github.com/improbable-eng/thanos/vendor/google.golang.org/grpc/server.go:1174 +0x9f
google.golang.org/grpc.(*Server).processUnaryRPC(0xc0005c9448, {0x42cb6b8, 0xc0009cec60}, 0xc000588820, 0xc000692810, 0x5fb5540, 0x0)
	/go/src/github.com/improbable-eng/thanos/vendor/google.golang.org/grpc/server.go:1475 +0x12c5
google.golang.org/grpc.(*Server).handleStream(0xc0005c9448, {0x42cd078, 0xc000588680}, 0xc000588820)
	/go/src/github.com/improbable-eng/thanos/vendor/google.golang.org/grpc/server.go:1832 +0xdc6
google.golang.org/grpc.(*Server).serveStreams.func2.1()
	/go/src/github.com/improbable-eng/thanos/vendor/google.golang.org/grpc/server.go:1063 +0x7f
created by google.golang.org/grpc.(*Server).serveStreams.func2 in goroutine 55
	/go/src/github.com/improbable-eng/thanos/vendor/google.golang.org/grpc/server.go:1074 +0x11d
```

