### PR TITLE
compactor: add support for Parquet file format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ It is recommend to upgrade the storage components first (Receive, Store, etc.) a
 
 ### Added
 
+- [#8747](https://github.com/thanos-io/thanos/pull/8747): Compact: add native Parquet writing that converts TSDB blocks to Parquet format once a full 24-hour period is available from 8-hour compacted blocks. When enabled with `--parquet.write=true`, the compactor builds complete daily Parquet files with automatic reconciliation on startup and periodic intervals. Parquet files are organized into daily folders (e.g., `2026-03-28/`) with label-based sharding support. The Parquet schema supports 3 × 8h chunk columns to represent a full 24-hour period. Temporary files respect `--data-dir` for disk space management
 - [#8691](https://github.com/thanos-io/thanos/pull/8691): Compactor: remove the directory marker objects for some s3 compatible object stores
 
 ### Changed

--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -43,6 +43,7 @@ import (
 	extpromhttp "github.com/thanos-io/thanos/pkg/extprom/http"
 	"github.com/thanos-io/thanos/pkg/logging"
 	"github.com/thanos-io/thanos/pkg/logutil"
+	"github.com/thanos-io/thanos/pkg/parquet"
 	"github.com/thanos-io/thanos/pkg/prober"
 	"github.com/thanos-io/thanos/pkg/runutil"
 	httpserver "github.com/thanos-io/thanos/pkg/server/http"
@@ -355,6 +356,7 @@ func runCompact(
 	var (
 		compactDir      = path.Join(conf.dataDir, "compact")
 		downsamplingDir = path.Join(conf.dataDir, "downsample")
+		parquetTempDir  = path.Join(conf.dataDir, "parquet-temp")
 	)
 
 	if err := os.MkdirAll(compactDir, os.ModePerm); err != nil {
@@ -363,6 +365,12 @@ func runCompact(
 
 	if err := os.MkdirAll(downsamplingDir, os.ModePerm); err != nil {
 		return errors.Wrap(err, "create working downsample directory")
+	}
+
+	if conf.parquet.enabled {
+		if err := os.MkdirAll(parquetTempDir, os.ModePerm); err != nil {
+			return errors.Wrap(err, "create working Parquet temp directory")
+		}
 	}
 
 	grouper := compact.NewDefaultGrouper(
@@ -393,12 +401,72 @@ func runCompact(
 		planner = largeIndexFilterPlanner
 	}
 	blocksCleaner := compact.NewBlocksCleaner(logger, insBkt, ignoreDeletionMarkFilter, deleteDelay, compactMetrics.blocksCleaned, compactMetrics.blockCleanupFailures)
-	compactor, err := compact.NewBucketCompactor(
+
+	// Setup Parquet writer if enabled
+	var compactionCallback compact.CompactionLifecycleCallback
+	compactionCallback = compact.DefaultCompactionLifecycleCallback{}
+	var parquetWriter parquet.Writer // Keep writer in scope for reconciliation
+
+	if conf.parquet.enabled {
+		// Setup Parquet bucket (could be same as TSDB bucket or separate)
+		var parquetBkt objstore.Bucket
+		if conf.parquet.objStoreFile != "" {
+			// Separate bucket configured - read config file
+			parquetConfContentYaml, err := os.ReadFile(conf.parquet.objStoreFile)
+			if err != nil {
+				return errors.Wrap(err, "read Parquet bucket configuration file")
+			}
+			parquetBkt, err = client.NewBucket(logger, parquetConfContentYaml, "parquet", nil)
+			if err != nil {
+				return errors.Wrap(err, "create Parquet bucket")
+			}
+			parquetBkt = objstoretracing.WrapWithTraces(objstore.WrapWithMetrics(parquetBkt, extprom.WrapRegistererWithPrefix("thanos_", reg), parquetBkt.Name()))
+		} else {
+			parquetBkt = insBkt // Use same bucket as TSDB
+		}
+
+		// Create Parquet writer
+		parquetWriter, err = parquet.New(
+			parquet.Config{
+				Enabled:              true,
+				TSDBBucket:           insBkt,
+				ParquetBucket:        parquetBkt,
+				BasePath:             conf.parquet.basePath,
+				ShardingEnabled:      conf.parquet.enableSharding,
+				TargetSeriesPerShard: conf.parquet.targetSeriesPerShard,
+				SortLabels:           conf.parquet.sortLabels,
+				CompressionCodec:     conf.parquet.compressionCodec,
+				RowGroupSize:         conf.parquet.rowGroupSize,
+				DownloadConcurrency:  conf.blockFilesConcurrency,
+				EncodingConcurrency:  conf.parquet.encodingConcurrency,
+				UploadConcurrency:    conf.blockFilesConcurrency,
+				TempDir:              parquetTempDir,
+			},
+			log.With(logger, "component", "parquet-writer"),
+			reg,
+		)
+		if err != nil {
+			return errors.Wrap(err, "create Parquet writer")
+		}
+
+		compactionCallback = compact.NewParquetCompactionLifecycleCallback(
+			compactionCallback,
+			parquetWriter,
+			conf.parquet.async,
+		)
+
+		level.Info(logger).Log("msg", "Parquet writing enabled", "async", conf.parquet.async)
+	}
+
+	// Create compactor with our callback
+	compactor, err := compact.NewBucketCompactorWithCheckerAndCallback(
 		logger,
 		sy,
 		grouper,
 		planner,
 		comp,
+		compact.DefaultBlockDeletableChecker{},
+		compactionCallback,
 		compactDir,
 		insBkt,
 		conf.compactionConcurrency,
@@ -531,8 +599,49 @@ func runCompact(
 		return cleanPartialMarked()
 	}
 
+	// Parquet reconciliation function to convert any unconverted 8h blocks
+	parquetReconcileFn := func() error {
+		if parquetWriter == nil {
+			return nil
+		}
+
+		level.Info(logger).Log("msg", "starting Parquet reconciliation")
+
+		// Sync metadata to get current blocks
+		if err := sy.SyncMetas(ctx); err != nil {
+			return errors.Wrap(err, "sync metas for Parquet reconciliation")
+		}
+
+		// Get all current blocks
+		allBlocks := sy.Metas()
+
+		// Run reconciliation
+		converted, err := parquetWriter.Reconcile(ctx, allBlocks)
+		if err != nil {
+			level.Error(logger).Log("msg", "Parquet reconciliation failed", "err", err, "converted", converted)
+			return errors.Wrap(err, "Parquet reconciliation")
+		}
+
+		if converted > 0 {
+			level.Info(logger).Log("msg", "Parquet reconciliation completed", "blocks_converted", converted)
+		} else {
+			level.Debug(logger).Log("msg", "Parquet reconciliation completed, no blocks needed conversion")
+		}
+
+		return nil
+	}
+
 	g.Add(func() error {
 		defer runutil.CloseWithLogOnErr(logger, insBkt, "bucket client")
+
+		// Run Parquet reconciliation on startup if enabled
+		if conf.parquet.enabled && conf.parquet.reconcileOnStartup {
+			level.Info(logger).Log("msg", "running Parquet reconciliation on startup")
+			if err := parquetReconcileFn(); err != nil {
+				level.Warn(logger).Log("msg", "startup Parquet reconciliation failed", "err", err)
+				// Don't fail startup, just log the error
+			}
+		}
 
 		if !conf.wait {
 			return compactMainFn()
@@ -572,6 +681,22 @@ func runCompact(
 	}, func(error) {
 		cancel()
 	})
+
+	// Add periodic Parquet reconciliation goroutine if interval is set
+	if conf.parquet.enabled && conf.parquet.reconcileInterval > 0 {
+		g.Add(func() error {
+			level.Info(logger).Log("msg", "starting periodic Parquet reconciliation", "interval", conf.parquet.reconcileInterval)
+			return runutil.Repeat(conf.parquet.reconcileInterval, ctx.Done(), func() error {
+				if err := parquetReconcileFn(); err != nil {
+					level.Warn(logger).Log("msg", "periodic Parquet reconciliation failed", "err", err)
+					// Don't fail the goroutine, just log the error and continue
+				}
+				return nil
+			})
+		}, func(error) {
+			cancel()
+		})
+	}
 
 	if conf.wait {
 		if !conf.disableWeb {
@@ -742,6 +867,22 @@ type compactConfig struct {
 	progressCalculateInterval                      time.Duration
 	filterConf                                     *store.FilterConfig
 	disableAdminOperations                         bool
+	parquet                                        parquetConfig
+}
+
+type parquetConfig struct {
+	enabled              bool
+	async                bool
+	objStoreFile         string
+	basePath             string
+	enableSharding       bool
+	targetSeriesPerShard int
+	sortLabels           []string
+	encodingConcurrency  int
+	rowGroupSize         int
+	compressionCodec     string
+	reconcileOnStartup   bool
+	reconcileInterval    time.Duration
 }
 
 func (cc *compactConfig) registerFlag(cmd extkingpin.FlagClause) {
@@ -856,4 +997,53 @@ func (cc *compactConfig) registerFlag(cmd extkingpin.FlagClause) {
 	cmd.Flag("bucket-web-label", "External block label to use as group title in the bucket web UI").StringVar(&cc.label)
 
 	cmd.Flag("disable-admin-operations", "Disable UI/API admin operations like marking blocks for deletion and no compaction.").Default("false").BoolVar(&cc.disableAdminOperations)
+
+	// Parquet flags
+	cmd.Flag("parquet.write",
+		"Enable Parquet writing for 8-hour compacted blocks.").
+		Default("false").BoolVar(&cc.parquet.enabled)
+
+	cmd.Flag("parquet.async",
+		"Run Parquet conversions in background goroutines to avoid blocking compaction.").
+		Default("true").BoolVar(&cc.parquet.async)
+
+	cmd.Flag("parquet.objstore-config-file",
+		"Path to YAML file with object storage configuration for Parquet files. If empty, uses same bucket as TSDB blocks. See format details: https://thanos.io/tip/thanos/storage.md/#configuration").
+		PlaceHolder("<file-path>").StringVar(&cc.parquet.objStoreFile)
+
+	cmd.Flag("parquet.base-path",
+		"Base path within bucket for Parquet files.").
+		Default("parquet/").StringVar(&cc.parquet.basePath)
+
+	cmd.Flag("parquet.enable-sharding",
+		"Enable label-based sharding for high-cardinality data.").
+		Default("true").BoolVar(&cc.parquet.enableSharding)
+
+	cmd.Flag("parquet.target-series-per-shard",
+		"Target number of series per Parquet shard.").
+		Default("1000000").IntVar(&cc.parquet.targetSeriesPerShard)
+
+	cmd.Flag("parquet.sort-label",
+		"Labels to sort by in Parquet files. Can be repeated.").
+		Default("__name__").StringsVar(&cc.parquet.sortLabels)
+
+	cmd.Flag("parquet.encoding-concurrency",
+		"Concurrency level for Parquet encoding.").
+		Default("4").IntVar(&cc.parquet.encodingConcurrency)
+
+	cmd.Flag("parquet.row-group-size",
+		"Rows per Parquet row group.").
+		Default("1000000").IntVar(&cc.parquet.rowGroupSize)
+
+	cmd.Flag("parquet.compression",
+		"Compression codec for Parquet files.").
+		Default("zstd").EnumVar(&cc.parquet.compressionCodec, "zstd", "snappy", "none")
+
+	cmd.Flag("parquet.reconcile-on-startup",
+		"Run Parquet reconciliation on startup to convert any existing 8h blocks missing Parquet files. Recommended for disaster recovery.").
+		Default("true").BoolVar(&cc.parquet.reconcileOnStartup)
+
+	cmd.Flag("parquet.reconcile-interval",
+		"Interval for periodic Parquet reconciliation. Set to 0 to disable periodic reconciliation.").
+		Default("6h").DurationVar(&cc.parquet.reconcileInterval)
 }

--- a/go.mod
+++ b/go.mod
@@ -51,11 +51,12 @@ require (
 	github.com/mitchellh/go-ps v1.0.0
 	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f
 	github.com/oklog/run v1.2.0
-	github.com/oklog/ulid v1.3.1 // indirect
+	github.com/oklog/ulid v1.3.1
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/onsi/gomega v1.36.2
 	github.com/opentracing/basictracer-go v1.1.0
 	github.com/opentracing/opentracing-go v1.2.0
+	github.com/parquet-go/parquet-go v0.25.1
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus-community/prom-label-proxy v0.11.1
 	github.com/prometheus/alertmanager v0.30.0
@@ -167,6 +168,7 @@ require (
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.50.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.52.0 // indirect
 	github.com/aliyun/aliyun-oss-go-sdk v3.0.2+incompatible // indirect
+	github.com/andybalholm/brotli v1.1.0 // indirect
 	github.com/armon/go-radix v1.0.0 // indirect
 	github.com/aws/aws-sdk-go-v2 v1.41.0 // indirect
 	github.com/aws/aws-sdk-go-v2/config v1.32.6 // indirect
@@ -264,6 +266,7 @@ require (
 	github.com/opentracing-contrib/go-stdlib v1.1.0 // indirect
 	github.com/oracle/oci-go-sdk/v65 v65.93.1 // indirect
 	github.com/philhofer/fwd v1.1.3-0.20240916144458-20a13a1f6b7c // indirect
+	github.com/pierrec/lz4/v4 v4.1.21 // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2726,6 +2726,8 @@ github.com/aliyun/aliyun-oss-go-sdk v3.0.2+incompatible h1:8psS8a+wKfiLt1iVDX79F
 github.com/aliyun/aliyun-oss-go-sdk v3.0.2+incompatible/go.mod h1:T/Aws4fEfogEE9v+HPhhw+CntffsBHJ8nXQCwKr0/g8=
 github.com/andybalholm/brotli v1.0.4/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHGRSepvi9Eig=
 github.com/andybalholm/brotli v1.0.5/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHGRSepvi9Eig=
+github.com/andybalholm/brotli v1.1.0 h1:eLKJA0d02Lf0mVpIDgYnqXcUn0GqVmEFny3VuID1U3M=
+github.com/andybalholm/brotli v1.1.0/go.mod h1:sms7XGricyQI9K10gOSf56VKKWS4oLer58Q+mhRPtnY=
 github.com/andybalholm/stroke v0.0.0-20221221101821-bd29b49d73f0/go.mod h1:ccdDYaY5+gO+cbnQdFxEXqfy0RkoV25H3jLXUDNM3wg=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/apache/arrow/go/v10 v10.0.1/go.mod h1:YvhnlEePVnBS4+0z3fhPfUy7W1Ikj0Ih0vcRo/gZ1M0=
@@ -3436,6 +3438,7 @@ github.com/hashicorp/serf v0.10.1 h1:Z1H2J60yRKvfDYAOZLd2MU0ND4AH/WDz7xYHDWQsIPY
 github.com/hashicorp/serf v0.10.1/go.mod h1:yL2t6BqATOLGc5HF7qbFkTfXoPIY0WZdWHfEvMqbG+4=
 github.com/hetznercloud/hcloud-go/v2 v2.32.0 h1:BRe+k7ESdYv3xQLBGdKUfk+XBFRJNGKzq70nJI24ciM=
 github.com/hetznercloud/hcloud-go/v2 v2.32.0/go.mod h1:hAanyyfn9M0cMmZ68CXzPCF54KRb9EXd8eiE2FHKGIE=
+github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
 github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/huaweicloud/huaweicloud-sdk-go-obs v3.25.4+incompatible h1:yNjwdvn9fwuN6Ouxr0xHM0cVu03YMUWUyFmu2van/Yc=
@@ -3706,6 +3709,8 @@ github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde/go.mod h1:nZgzb
 github.com/ovh/go-ovh v1.9.0 h1:6K8VoL3BYjVV3In9tPJUdT7qMx9h0GExN9EXx1r2kKE=
 github.com/ovh/go-ovh v1.9.0/go.mod h1:cTVDnl94z4tl8pP1uZ/8jlVxntjSIf09bNcQ5TJSC7c=
 github.com/pact-foundation/pact-go v1.0.4/go.mod h1:uExwJY4kCzNPcHRj+hCR/HBbOOIwwtUjcrb0b5/5kLM=
+github.com/parquet-go/parquet-go v0.25.1 h1:l7jJwNM0xrk0cnIIptWMtnSnuxRkwq53S+Po3KG8Xgo=
+github.com/parquet-go/parquet-go v0.25.1/go.mod h1:AXBuotO1XiBtcqJb/FKFyjBG4aqa3aQAAWF3ZPzCanY=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58 h1:onHthvaw9LFnH4t2DcNVpwGmV9E1BkGknEliJkfwQj0=
 github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58/go.mod h1:DXv8WO4yhMYhSNPKjeNKa5WY9YCIEBRbNzFFPJbWO6Y=
@@ -3721,6 +3726,8 @@ github.com/pierrec/lz4 v1.0.2-0.20190131084431-473cd7ce01a1/go.mod h1:3/3N9NVKO0
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pierrec/lz4/v4 v4.1.15/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pierrec/lz4/v4 v4.1.18/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
+github.com/pierrec/lz4/v4 v4.1.21 h1:yOVMLb6qSIDP67pl/5F7RepeKYu/VmTyEXvuMI5d9mQ=
+github.com/pierrec/lz4/v4 v4.1.21/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjLxUqIJNnCWiEdr3bn6IUYi15bNlnbCCU=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=

--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -890,6 +890,122 @@ func (c DefaultCompactionLifecycleCallback) GetBlockPopulator(_ context.Context,
 	return tsdb.DefaultBlockPopulator{}, nil
 }
 
+// ParquetCompactionLifecycleCallback wraps another CompactionLifecycleCallback and adds
+// Parquet writing functionality after successful compaction.
+type ParquetCompactionLifecycleCallback struct {
+	wrapped       CompactionLifecycleCallback
+	parquetWriter ParquetWriter
+	async         bool // If true, run conversions in background goroutines
+}
+
+// ParquetWriter is the interface for writing TSDB blocks to Parquet format.
+type ParquetWriter interface {
+	WriteBlock(ctx context.Context, blockID ulid.ULID, meta *metadata.Meta) error
+}
+
+// NewParquetCompactionLifecycleCallback creates a new ParquetCompactionLifecycleCallback
+// that wraps an existing callback and adds Parquet writing.
+// If async is true, Parquet conversions run in background goroutines and don't block compaction.
+func NewParquetCompactionLifecycleCallback(
+	wrapped CompactionLifecycleCallback,
+	writer ParquetWriter,
+	async bool,
+) *ParquetCompactionLifecycleCallback {
+	return &ParquetCompactionLifecycleCallback{
+		wrapped:       wrapped,
+		parquetWriter: writer,
+		async:         async,
+	}
+}
+
+// PreCompactionCallback delegates to the wrapped callback.
+func (c *ParquetCompactionLifecycleCallback) PreCompactionCallback(
+	ctx context.Context,
+	logger log.Logger,
+	group *Group,
+	toCompactBlocks []*metadata.Meta,
+) error {
+	return c.wrapped.PreCompactionCallback(ctx, logger, group, toCompactBlocks)
+}
+
+// PostCompactionCallback calls the wrapped callback, then attempts to write the block to Parquet.
+// If async mode is enabled, the Parquet conversion runs in a background goroutine.
+func (c *ParquetCompactionLifecycleCallback) PostCompactionCallback(
+	ctx context.Context,
+	logger log.Logger,
+	group *Group,
+	blockID ulid.ULID,
+) error {
+	// Call wrapped callback first
+	if err := c.wrapped.PostCompactionCallback(ctx, logger, group, blockID); err != nil {
+		return err
+	}
+
+	// Read block metadata from bucket
+	rc, err := group.bkt.Get(ctx, filepath.Join(blockID.String(), metadata.MetaFilename))
+	if err != nil {
+		level.Warn(logger).Log("msg", "failed to read block metadata for Parquet conversion", "block", blockID, "err", err)
+		// Don't fail compaction if Parquet conversion fails
+		return nil
+	}
+	meta, err := metadata.Read(rc)
+	if err != nil {
+		level.Warn(logger).Log("msg", "failed to parse block metadata for Parquet conversion", "block", blockID, "err", err)
+		return nil
+	}
+
+	// Only convert exactly 8-hour blocks (compaction level 2)
+	// Note: Thanos default compaction levels are 1h, 2h, 8h, 48h, 14d
+	// We ONLY convert 8h blocks because:
+	// 1. Parquet schema has 3 chunk columns (3x8h = 24h)
+	// 2. 48h/14d blocks would wrap around and mix chunks from different days
+	// 3. 48h/14d blocks are just compacted versions of 8h blocks (redundant)
+	blockDuration := time.Duration(meta.MaxTime-meta.MinTime) * time.Millisecond
+	if blockDuration != 8*time.Hour {
+		level.Debug(logger).Log("msg", "skipping Parquet conversion, only 8h blocks are converted",
+			"block", blockID, "duration", blockDuration)
+		return nil
+	}
+
+	// Perform conversion (async or sync based on configuration)
+	convertFunc := func() {
+		level.Info(logger).Log("msg", "converting block to Parquet", "block", blockID, "duration", blockDuration)
+
+		// Use background context for async conversions to avoid cancellation
+		convCtx := ctx
+		if c.async {
+			convCtx = context.Background()
+		}
+
+		if err := c.parquetWriter.WriteBlock(convCtx, blockID, meta); err != nil {
+			level.Error(logger).Log("msg", "failed to write Parquet", "block", blockID, "err", err)
+			return
+		}
+
+		level.Info(logger).Log("msg", "successfully converted block to Parquet", "block", blockID)
+	}
+
+	if c.async {
+		// Run in background goroutine - don't block compaction
+		go convertFunc()
+		level.Info(logger).Log("msg", "started async Parquet conversion", "block", blockID)
+	} else {
+		// Run synchronously - blocks compaction until complete
+		convertFunc()
+	}
+
+	return nil
+}
+
+// GetBlockPopulator delegates to the wrapped callback.
+func (c *ParquetCompactionLifecycleCallback) GetBlockPopulator(
+	ctx context.Context,
+	logger log.Logger,
+	group *Group,
+) (tsdb.BlockPopulator, error) {
+	return c.wrapped.GetBlockPopulator(ctx, logger, group)
+}
+
 // Compactor provides compaction against an underlying storage of time series data.
 // It is similar to tsdb.Compactor but only relevant methods are kept. Plan and Write are removed.
 // TODO(bwplotka): Split the Planner from Compactor on upstream as well, so we can import it.

--- a/pkg/compact/parquet_test.go
+++ b/pkg/compact/parquet_test.go
@@ -1,0 +1,114 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package compact
+
+import (
+	"testing"
+	"time"
+
+	"github.com/efficientgo/core/testutil"
+	"github.com/oklog/ulid/v2"
+	"github.com/thanos-io/thanos/pkg/block/metadata"
+)
+
+func TestParquetCompactionLifecycleCallback_Only8hBlocks(t *testing.T) {
+	tests := []struct {
+		name             string
+		blockDuration    time.Duration
+		expectConversion bool
+	}{
+		{
+			name:             "1h block - should skip",
+			blockDuration:    1 * time.Hour,
+			expectConversion: false,
+		},
+		{
+			name:             "2h block - should skip",
+			blockDuration:    2 * time.Hour,
+			expectConversion: false,
+		},
+		{
+			name:             "8h block - should convert",
+			blockDuration:    8 * time.Hour,
+			expectConversion: true,
+		},
+		{
+			name:             "48h block - should skip",
+			blockDuration:    48 * time.Hour,
+			expectConversion: false,
+		},
+		{
+			name:             "14d block - should skip",
+			blockDuration:    14 * 24 * time.Hour,
+			expectConversion: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			now := time.Now()
+			blockID := ulid.MustNew(uint64(now.UnixMilli()), nil)
+			minTime := now.UnixMilli()
+			maxTime := now.Add(tt.blockDuration).UnixMilli()
+
+			meta := &metadata.Meta{}
+			meta.ULID = blockID
+			meta.MinTime = minTime
+			meta.MaxTime = maxTime
+
+			// Note: We can't easily test the actual callback without a full Group setup,
+			// but we can verify the block duration logic directly
+			actualDuration := time.Duration(meta.MaxTime-meta.MinTime) * time.Millisecond
+			shouldConvert := actualDuration == 8*time.Hour
+
+			testutil.Equals(t, tt.expectConversion, shouldConvert,
+				"block duration check failed for %s", tt.name)
+		})
+	}
+}
+
+func TestBlockDurationCalculation(t *testing.T) {
+	tests := []struct {
+		name             string
+		minTime          time.Time
+		maxTime          time.Time
+		expectedDuration time.Duration
+	}{
+		{
+			name:             "1 hour",
+			minTime:          time.Date(2026, 3, 28, 0, 0, 0, 0, time.UTC),
+			maxTime:          time.Date(2026, 3, 28, 1, 0, 0, 0, time.UTC),
+			expectedDuration: 1 * time.Hour,
+		},
+		{
+			name:             "8 hours",
+			minTime:          time.Date(2026, 3, 28, 0, 0, 0, 0, time.UTC),
+			maxTime:          time.Date(2026, 3, 28, 8, 0, 0, 0, time.UTC),
+			expectedDuration: 8 * time.Hour,
+		},
+		{
+			name:             "48 hours",
+			minTime:          time.Date(2026, 3, 28, 0, 0, 0, 0, time.UTC),
+			maxTime:          time.Date(2026, 3, 30, 0, 0, 0, 0, time.UTC),
+			expectedDuration: 48 * time.Hour,
+		},
+		{
+			name:             "14 days",
+			minTime:          time.Date(2026, 3, 28, 0, 0, 0, 0, time.UTC),
+			maxTime:          time.Date(2026, 4, 11, 0, 0, 0, 0, time.UTC),
+			expectedDuration: 14 * 24 * time.Hour,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			meta := &metadata.Meta{}
+			meta.MinTime = tt.minTime.UnixMilli()
+			meta.MaxTime = tt.maxTime.UnixMilli()
+
+			duration := time.Duration(meta.MaxTime-meta.MinTime) * time.Millisecond
+			testutil.Equals(t, tt.expectedDuration, duration)
+		})
+	}
+}

--- a/pkg/parquet/config.go
+++ b/pkg/parquet/config.go
@@ -1,0 +1,78 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package parquet
+
+import (
+	"github.com/thanos-io/objstore"
+)
+
+// Config holds the configuration for Parquet writing.
+type Config struct {
+	// Enabled controls whether Parquet writing is active.
+	Enabled bool
+
+	// TSDBBucket is the object storage bucket to read TSDB blocks from.
+	TSDBBucket objstore.Bucket
+
+	// ParquetBucket is the object storage bucket to write Parquet files to.
+	// Can be the same as TSDBBucket or separate.
+	ParquetBucket objstore.Bucket
+
+	// BasePath is the base path within the bucket for Parquet files (e.g., "parquet/").
+	BasePath string
+
+	// ShardingEnabled enables label-based sharding for high-cardinality data.
+	ShardingEnabled bool
+
+	// TargetSeriesPerShard is the target number of series per Parquet shard.
+	TargetSeriesPerShard int
+
+	// SortLabels is the list of labels to sort by in Parquet files.
+	SortLabels []string
+
+	// CompressionCodec is the compression codec to use ("zstd", "snappy", "none").
+	CompressionCodec string
+
+	// RowGroupSize is the number of rows per Parquet row group.
+	RowGroupSize int
+
+	// DownloadConcurrency controls parallel block downloads.
+	DownloadConcurrency int
+
+	// EncodingConcurrency controls parallel Parquet encoding.
+	EncodingConcurrency int
+
+	// UploadConcurrency controls parallel file uploads.
+	UploadConcurrency int
+
+	// TempDir is the directory to use for temporary files during conversion.
+	// If empty, uses system default temp directory.
+	TempDir string
+}
+
+// Validate checks if the configuration is valid.
+func (c *Config) Validate() error {
+	if c.TSDBBucket == nil {
+		return ErrInvalidConfig("TSDBBucket is required")
+	}
+	if c.ParquetBucket == nil {
+		return ErrInvalidConfig("ParquetBucket is required")
+	}
+	if c.TargetSeriesPerShard <= 0 {
+		return ErrInvalidConfig("TargetSeriesPerShard must be positive")
+	}
+	if c.RowGroupSize <= 0 {
+		return ErrInvalidConfig("RowGroupSize must be positive")
+	}
+	if c.DownloadConcurrency <= 0 {
+		return ErrInvalidConfig("DownloadConcurrency must be positive")
+	}
+	if c.EncodingConcurrency <= 0 {
+		return ErrInvalidConfig("EncodingConcurrency must be positive")
+	}
+	if c.UploadConcurrency <= 0 {
+		return ErrInvalidConfig("UploadConcurrency must be positive")
+	}
+	return nil
+}

--- a/pkg/parquet/config_test.go
+++ b/pkg/parquet/config_test.go
@@ -1,0 +1,152 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package parquet
+
+import (
+	"testing"
+
+	"github.com/efficientgo/core/testutil"
+)
+
+func TestConfigValidate(t *testing.T) {
+	mockBucket := newMockBucket()
+
+	tests := []struct {
+		name        string
+		config      Config
+		expectError bool
+		errorMsg    string
+	}{
+		{
+			name: "valid config",
+			config: Config{
+				Enabled:              true,
+				TSDBBucket:           mockBucket,
+				ParquetBucket:        mockBucket,
+				BasePath:             "parquet/",
+				TargetSeriesPerShard: 1000000,
+				RowGroupSize:         1000000,
+				DownloadConcurrency:  4,
+				EncodingConcurrency:  4,
+				UploadConcurrency:    4,
+			},
+			expectError: false,
+		},
+		{
+			name: "missing TSDBBucket",
+			config: Config{
+				Enabled:              true,
+				ParquetBucket:        mockBucket,
+				TargetSeriesPerShard: 1000000,
+				RowGroupSize:         1000000,
+				DownloadConcurrency:  4,
+				EncodingConcurrency:  4,
+				UploadConcurrency:    4,
+			},
+			expectError: true,
+			errorMsg:    "TSDBBucket is required",
+		},
+		{
+			name: "missing ParquetBucket",
+			config: Config{
+				Enabled:              true,
+				TSDBBucket:           mockBucket,
+				TargetSeriesPerShard: 1000000,
+				RowGroupSize:         1000000,
+				DownloadConcurrency:  4,
+				EncodingConcurrency:  4,
+				UploadConcurrency:    4,
+			},
+			expectError: true,
+			errorMsg:    "ParquetBucket is required",
+		},
+		{
+			name: "invalid TargetSeriesPerShard",
+			config: Config{
+				Enabled:              true,
+				TSDBBucket:           mockBucket,
+				ParquetBucket:        mockBucket,
+				TargetSeriesPerShard: 0,
+				RowGroupSize:         1000000,
+				DownloadConcurrency:  4,
+				EncodingConcurrency:  4,
+				UploadConcurrency:    4,
+			},
+			expectError: true,
+			errorMsg:    "TargetSeriesPerShard must be positive",
+		},
+		{
+			name: "invalid RowGroupSize",
+			config: Config{
+				Enabled:              true,
+				TSDBBucket:           mockBucket,
+				ParquetBucket:        mockBucket,
+				TargetSeriesPerShard: 1000000,
+				RowGroupSize:         0,
+				DownloadConcurrency:  4,
+				EncodingConcurrency:  4,
+				UploadConcurrency:    4,
+			},
+			expectError: true,
+			errorMsg:    "RowGroupSize must be positive",
+		},
+		{
+			name: "invalid DownloadConcurrency",
+			config: Config{
+				Enabled:              true,
+				TSDBBucket:           mockBucket,
+				ParquetBucket:        mockBucket,
+				TargetSeriesPerShard: 1000000,
+				RowGroupSize:         1000000,
+				DownloadConcurrency:  0,
+				EncodingConcurrency:  4,
+				UploadConcurrency:    4,
+			},
+			expectError: true,
+			errorMsg:    "DownloadConcurrency must be positive",
+		},
+		{
+			name: "invalid EncodingConcurrency",
+			config: Config{
+				Enabled:              true,
+				TSDBBucket:           mockBucket,
+				ParquetBucket:        mockBucket,
+				TargetSeriesPerShard: 1000000,
+				RowGroupSize:         1000000,
+				DownloadConcurrency:  4,
+				EncodingConcurrency:  0,
+				UploadConcurrency:    4,
+			},
+			expectError: true,
+			errorMsg:    "EncodingConcurrency must be positive",
+		},
+		{
+			name: "invalid UploadConcurrency",
+			config: Config{
+				Enabled:              true,
+				TSDBBucket:           mockBucket,
+				ParquetBucket:        mockBucket,
+				TargetSeriesPerShard: 1000000,
+				RowGroupSize:         1000000,
+				DownloadConcurrency:  4,
+				EncodingConcurrency:  4,
+				UploadConcurrency:    0,
+			},
+			expectError: true,
+			errorMsg:    "UploadConcurrency must be positive",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.config.Validate()
+			if tt.expectError {
+				testutil.NotOk(t, err)
+				testutil.Assert(t, err.Error() != "", "error should have message")
+			} else {
+				testutil.Ok(t, err)
+			}
+		})
+	}
+}

--- a/pkg/parquet/converter.go
+++ b/pkg/parquet/converter.go
@@ -1,0 +1,364 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package parquet
+
+import (
+	"bufio"
+	"context"
+	"encoding/binary"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/oklog/ulid"
+	ulidv2 "github.com/oklog/ulid/v2"
+	"github.com/parquet-go/parquet-go"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/tsdb"
+	"github.com/prometheus/prometheus/tsdb/chunkenc"
+	"github.com/prometheus/prometheus/tsdb/chunks"
+	"github.com/prometheus/prometheus/tsdb/index"
+	"github.com/thanos-io/objstore"
+	"github.com/thanos-io/thanos/pkg/block"
+	"github.com/thanos-io/thanos/pkg/block/metadata"
+	"github.com/thanos-io/thanos/pkg/logutil"
+)
+
+// ZigZagEncode encodes a signed int64 to an unsigned int64 using zigzag encoding.
+func ZigZagEncode(x int64) uint64 {
+	return uint64(uint64(x<<1) ^ uint64((int64(x) >> 63)))
+}
+
+// collectChunks collects and encodes chunks for a series into the 3 time buckets (8 hours each).
+// Returns an array of 3 byte arrays, one for each 8-hour period.
+func collectChunks(chkMetas []chunks.Meta, chunkReader tsdb.ChunkReader) ([ChunkColumnsPerDay][]byte, error) {
+	var result [ChunkColumnsPerDay][]byte
+
+	// Sort chunks by MinTime (they may come from different blocks)
+	sort.Slice(chkMetas, func(i, j int) bool {
+		return chkMetas[i].MinTime < chkMetas[j].MinTime
+	})
+
+	// Encode each chunk into the appropriate 8-hour bucket
+	for _, chkMeta := range chkMetas {
+		// Read the chunk data using the chunk reference
+		chk, iterable, err := chunkReader.ChunkOrIterable(chkMeta)
+		if err != nil {
+			return result, fmt.Errorf("read chunk: %w", err)
+		}
+
+		// If we got an iterable, we need to encode it
+		if iterable != nil {
+			// Skip - we need the actual chunk bytes
+			continue
+		}
+
+		if chk.NumSamples() == 0 {
+			continue
+		}
+
+		// Determine which 8-hour bucket this chunk belongs to
+		chunkTime := time.UnixMilli(chkMeta.MinTime).UTC()
+		hour := chunkTime.Hour()
+		bucketIdx := (hour / int(ChunkColumnLength.Hours())) % ChunkColumnsPerDay
+
+		// Encode chunk: encoding type + min time + max time + length + data
+		enc := chk.Encoding()
+		bs := chk.Bytes()
+
+		chkBytes := result[bucketIdx]
+		chkBytes = binary.BigEndian.AppendUint32(chkBytes, uint32(enc))
+		chkBytes = binary.BigEndian.AppendUint64(chkBytes, ZigZagEncode(chkMeta.MinTime))
+		chkBytes = binary.BigEndian.AppendUint64(chkBytes, ZigZagEncode(chkMeta.MaxTime))
+		chkBytes = binary.BigEndian.AppendUint32(chkBytes, uint32(len(bs)))
+		chkBytes = append(chkBytes, bs...)
+		result[bucketIdx] = chkBytes
+	}
+
+	return result, nil
+}
+
+// ConvertTSDBBlock converts a TSDB block to Parquet format and uploads it to the bucket.
+func ConvertTSDBBlock(
+	ctx context.Context,
+	logger log.Logger,
+	blockID ulid.ULID,
+	meta *metadata.Meta,
+	tsdbBucket objstore.Bucket,
+	parquetBucket objstore.Bucket,
+	basePath string,
+	cfg Config,
+	metrics *Metrics,
+) error {
+	startTime := time.Now()
+
+	level.Info(logger).Log("msg", "starting Parquet conversion", "block", blockID.String())
+
+	// Create a temporary directory for downloading the block
+	// Use cfg.TempDir if specified, otherwise use system default
+	tmpDir, err := os.MkdirTemp(cfg.TempDir, fmt.Sprintf("parquet-convert-%s-*", blockID.String()))
+	if err != nil {
+		return fmt.Errorf("create temp dir: %w", err)
+	}
+	defer func() {
+		if err := os.RemoveAll(tmpDir); err != nil {
+			level.Warn(logger).Log("msg", "failed to cleanup temp dir", "dir", tmpDir, "err", err)
+		}
+	}()
+
+	// Download the TSDB block
+	level.Debug(logger).Log("msg", "downloading TSDB block", "block", blockID.String())
+	// Convert ulid to ulid/v2
+	blockIDV2 := ulidv2.ULID(blockID)
+	if err := block.Download(ctx, logger, tsdbBucket, blockIDV2, tmpDir); err != nil {
+		return fmt.Errorf("download block: %w", err)
+	}
+
+	// Open the TSDB block
+	// Note: block.Download() downloads files directly into tmpDir, not into tmpDir/<blockID>/
+	// Convert go-kit logger to slog
+	slogger := logutil.GoKitLogToSlog(logger)
+	blk, err := tsdb.OpenBlock(slogger, tmpDir, chunkenc.NewPool(), tsdb.DefaultPostingsDecoderFactory)
+	if err != nil {
+		return fmt.Errorf("open block: %w", err)
+	}
+	defer func() {
+		if err := blk.Close(); err != nil {
+			level.Warn(logger).Log("msg", "failed to close block", "err", err)
+		}
+	}()
+
+	// Get block readers
+	indexReader, err := blk.Index()
+	if err != nil {
+		return fmt.Errorf("get index reader: %w", err)
+	}
+	defer indexReader.Close()
+
+	chunkReader, err := blk.Chunks()
+	if err != nil {
+		return fmt.Errorf("get chunk reader: %w", err)
+	}
+	defer chunkReader.Close()
+
+	// Read all series from the block
+	level.Debug(logger).Log("msg", "reading series from block")
+	allPostingsKeyName, allPostingsKeyValue := index.AllPostingsKey()
+	postings, err := indexReader.Postings(ctx, allPostingsKeyName, allPostingsKeyValue)
+	if err != nil {
+		return fmt.Errorf("get postings: %w", err)
+	}
+
+	var allSeries []labels.Labels
+	var allChunks [][]chunks.Meta
+	var builder labels.ScratchBuilder
+
+	for postings.Next() {
+		var chkMetas []chunks.Meta
+		if err := indexReader.Series(postings.At(), &builder, &chkMetas); err != nil {
+			return fmt.Errorf("read series: %w", err)
+		}
+
+		lbls := builder.Labels()
+		allSeries = append(allSeries, lbls)
+		allChunks = append(allChunks, chkMetas)
+	}
+
+	if err := postings.Err(); err != nil {
+		return fmt.Errorf("postings iteration: %w", err)
+	}
+
+	level.Info(logger).Log("msg", "read series from block", "series_count", len(allSeries))
+
+	if len(allSeries) == 0 {
+		level.Warn(logger).Log("msg", "block has no series, skipping conversion")
+		return nil
+	}
+
+	// Shard the series
+	shards, err := ShardSeries(allSeries, cfg.TargetSeriesPerShard, cfg.SortLabels)
+	if err != nil {
+		return fmt.Errorf("shard series: %w", err)
+	}
+
+	level.Info(logger).Log("msg", "sharded series", "num_shards", len(shards))
+	metrics.shardsCreated.Observe(float64(len(shards)))
+
+	// Convert each shard to Parquet
+	for _, shard := range shards {
+		level.Debug(logger).Log("msg", "converting shard", "shard", shard.Index, "series_count", len(shard.Series))
+
+		if err := convertShard(ctx, logger, blockID, meta, shard, allChunks, chunkReader, parquetBucket, basePath, cfg, metrics); err != nil {
+			return fmt.Errorf("convert shard %d: %w", shard.Index, err)
+		}
+
+		metrics.seriesPerShard.Observe(float64(len(shard.Series)))
+	}
+
+	duration := time.Since(startTime).Seconds()
+	metrics.conversionDuration.Observe(duration)
+	metrics.conversionsTotal.WithLabelValues("success").Inc()
+
+	level.Info(logger).Log("msg", "completed Parquet conversion", "block", blockID.String(), "duration", duration, "shards", len(shards))
+
+	return nil
+}
+
+// convertShard converts a single shard to Parquet files (labels.parquet and chunks.parquet).
+func convertShard(
+	ctx context.Context,
+	logger log.Logger,
+	blockID ulid.ULID,
+	meta *metadata.Meta,
+	shard Shard,
+	allChunks [][]chunks.Meta,
+	chunkReader tsdb.ChunkReader,
+	parquetBucket objstore.Bucket,
+	basePath string,
+	cfg Config,
+	metrics *Metrics,
+) error {
+	// Build schema from shard's label names
+	schema := BuildSchemaFromLabels(shard.LabelNames)
+	compressedSchema := WithCompression(schema)
+
+	// Create temporary files for labels and chunks
+	// Use cfg.TempDir if specified, otherwise use system default
+	labelsFile, err := os.CreateTemp(cfg.TempDir, fmt.Sprintf("labels-%s-shard%d-*.parquet", blockID.String(), shard.Index))
+	if err != nil {
+		return fmt.Errorf("create labels temp file: %w", err)
+	}
+	defer os.Remove(labelsFile.Name())
+	defer labelsFile.Close()
+
+	chunksFile, err := os.CreateTemp(cfg.TempDir, fmt.Sprintf("chunks-%s-shard%d-*.parquet", blockID.String(), shard.Index))
+	if err != nil {
+		return fmt.Errorf("create chunks temp file: %w", err)
+	}
+	defer os.Remove(chunksFile.Name())
+	defer chunksFile.Close()
+
+	// Create Parquet writers
+	labelsSchema := LabelsProjection(compressedSchema)
+	chunksSchema := ChunkProjection(compressedSchema)
+
+	// Create labels writer (sorting handled during write, not at schema level)
+	labelsWriter := parquet.NewGenericWriter[map[string]any](
+		labelsFile,
+		labelsSchema,
+	)
+	defer labelsWriter.Close()
+
+	chunksWriter := parquet.NewGenericWriter[map[string]any](
+		chunksFile,
+		chunksSchema,
+	)
+	defer chunksWriter.Close()
+
+	// Write each series in the shard
+	for _, seriesWithLabels := range shard.Series {
+		lbls := seriesWithLabels.Labels
+		hash := lbls.Hash()
+
+		// Build label row
+		labelRow := make(map[string]any)
+		labelRow[LabelHashColumn] = int64(hash)
+		labelRow[LabelIndexColumn] = []byte{} // Simplified: empty index for now
+
+		lbls.Range(func(l labels.Label) {
+			labelRow[LabelNameToColumn(l.Name)] = l.Value
+		})
+
+		// Write label row
+		if _, err := labelsWriter.Write([]map[string]any{labelRow}); err != nil {
+			return fmt.Errorf("write label row: %w", err)
+		}
+
+		// Get chunks for this series using the OriginalIdx
+		var chkMetas []chunks.Meta
+		if seriesWithLabels.OriginalIdx < len(allChunks) {
+			chkMetas = allChunks[seriesWithLabels.OriginalIdx]
+		}
+
+		// Collect and encode chunks
+		chunkBuckets, err := collectChunks(chkMetas, chunkReader)
+		if err != nil {
+			return fmt.Errorf("collect chunks for series: %w", err)
+		}
+
+		// Build chunk row
+		chunkRow := make(map[string]any)
+		chunkRow[LabelHashColumn] = int64(hash)
+		chunkRow[ChunksColumn0] = chunkBuckets[0]
+		chunkRow[ChunksColumn1] = chunkBuckets[1]
+		chunkRow[ChunksColumn2] = chunkBuckets[2]
+
+		// Write chunk row
+		if _, err := chunksWriter.Write([]map[string]any{chunkRow}); err != nil {
+			return fmt.Errorf("write chunk row: %w", err)
+		}
+	}
+
+	// Close writers to flush data
+	if err := labelsWriter.Close(); err != nil {
+		return fmt.Errorf("close labels writer: %w", err)
+	}
+	if err := chunksWriter.Close(); err != nil {
+		return fmt.Errorf("close chunks writer: %w", err)
+	}
+
+	// Upload files to bucket
+	// Path format: parquet/<date>/<shard>.labels.parquet or parquet/<date-range>/<shard>.labels.parquet
+	// Single day (8h blocks): 2026-03-28/
+	// Multi-day (48h/14d blocks): 2026-03-28_to_2026-03-30/
+	blockDateStart := time.UnixMilli(meta.MinTime).UTC().Format("2006-01-02")
+	blockDateEnd := time.UnixMilli(meta.MaxTime).UTC().Format("2006-01-02")
+	var dateFolder string
+	if blockDateStart == blockDateEnd {
+		dateFolder = blockDateStart // Single day: just "2026-03-28"
+	} else {
+		dateFolder = fmt.Sprintf("%s_to_%s", blockDateStart, blockDateEnd) // Multi-day: "2026-03-28_to_2026-03-30"
+	}
+	labelsPath := filepath.Join(basePath, dateFolder, fmt.Sprintf("%d.labels.parquet", shard.Index))
+	chunksPath := filepath.Join(basePath, dateFolder, fmt.Sprintf("%d.chunks.parquet", shard.Index))
+
+	level.Debug(logger).Log("msg", "uploading Parquet files", "labels_path", labelsPath, "chunks_path", chunksPath)
+
+	// Upload labels file
+	if _, err := labelsFile.Seek(0, 0); err != nil {
+		return fmt.Errorf("seek labels file: %w", err)
+	}
+	labelsStat, _ := labelsFile.Stat()
+	labelsReader := bufio.NewReader(labelsFile)
+	if err := parquetBucket.Upload(ctx, labelsPath, labelsReader); err != nil {
+		return fmt.Errorf("upload labels file: %w", err)
+	}
+	metrics.parquetBytesWritten.Add(float64(labelsStat.Size()))
+	metrics.parquetFilesUploaded.Inc()
+
+	// Upload chunks file
+	if _, err := chunksFile.Seek(0, 0); err != nil {
+		return fmt.Errorf("seek chunks file: %w", err)
+	}
+	chunksStat, _ := chunksFile.Stat()
+	chunksReader := bufio.NewReader(chunksFile)
+	if err := parquetBucket.Upload(ctx, chunksPath, chunksReader); err != nil {
+		return fmt.Errorf("upload chunks file: %w", err)
+	}
+	metrics.parquetBytesWritten.Add(float64(chunksStat.Size()))
+	metrics.parquetFilesUploaded.Inc()
+
+	level.Debug(logger).Log(
+		"msg", "uploaded Parquet files",
+		"shard", shard.Index,
+		"labels_size_bytes", labelsStat.Size(),
+		"chunks_size_bytes", chunksStat.Size(),
+	)
+
+	return nil
+}

--- a/pkg/parquet/converter_test.go
+++ b/pkg/parquet/converter_test.go
@@ -1,0 +1,163 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package parquet
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/efficientgo/core/testutil"
+	"github.com/prometheus/prometheus/tsdb/chunks"
+)
+
+func TestDateFolderNaming(t *testing.T) {
+	tests := []struct {
+		name           string
+		minTime        time.Time
+		maxTime        time.Time
+		expectedFolder string
+	}{
+		{
+			name:           "8h block - same day",
+			minTime:        time.Date(2026, 3, 28, 0, 0, 0, 0, time.UTC),
+			maxTime:        time.Date(2026, 3, 28, 8, 0, 0, 0, time.UTC),
+			expectedFolder: "2026-03-28",
+		},
+		{
+			name:           "8h block - different calendar day due to time",
+			minTime:        time.Date(2026, 3, 28, 20, 0, 0, 0, time.UTC),
+			maxTime:        time.Date(2026, 3, 29, 4, 0, 0, 0, time.UTC),
+			expectedFolder: "2026-03-28_to_2026-03-29",
+		},
+		{
+			name:           "48h block - spans two days",
+			minTime:        time.Date(2026, 3, 28, 0, 0, 0, 0, time.UTC),
+			maxTime:        time.Date(2026, 3, 30, 0, 0, 0, 0, time.UTC),
+			expectedFolder: "2026-03-28_to_2026-03-30",
+		},
+		{
+			name:           "14d block - spans many days",
+			minTime:        time.Date(2026, 3, 28, 0, 0, 0, 0, time.UTC),
+			maxTime:        time.Date(2026, 4, 11, 0, 0, 0, 0, time.UTC),
+			expectedFolder: "2026-03-28_to_2026-04-11",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			blockDateStart := tt.minTime.Format("2006-01-02")
+			blockDateEnd := tt.maxTime.Format("2006-01-02")
+			var dateFolder string
+			if blockDateStart == blockDateEnd {
+				dateFolder = blockDateStart
+			} else {
+				dateFolder = fmt.Sprintf("%s_to_%s", blockDateStart, blockDateEnd)
+			}
+			testutil.Equals(t, tt.expectedFolder, dateFolder)
+		})
+	}
+}
+
+func TestChunkBucketing(t *testing.T) {
+	tests := []struct {
+		name           string
+		chunkMinTime   time.Time
+		blockMinTime   time.Time
+		expectedBucket int
+	}{
+		{
+			name:           "chunk at 00:00 - bucket 0",
+			chunkMinTime:   time.Date(2026, 3, 28, 0, 0, 0, 0, time.UTC),
+			blockMinTime:   time.Date(2026, 3, 28, 0, 0, 0, 0, time.UTC),
+			expectedBucket: 0,
+		},
+		{
+			name:           "chunk at 07:59 - bucket 0",
+			chunkMinTime:   time.Date(2026, 3, 28, 7, 59, 0, 0, time.UTC),
+			blockMinTime:   time.Date(2026, 3, 28, 0, 0, 0, 0, time.UTC),
+			expectedBucket: 0,
+		},
+		{
+			name:           "chunk at 08:00 - bucket 1",
+			chunkMinTime:   time.Date(2026, 3, 28, 8, 0, 0, 0, time.UTC),
+			blockMinTime:   time.Date(2026, 3, 28, 0, 0, 0, 0, time.UTC),
+			expectedBucket: 1,
+		},
+		{
+			name:           "chunk at 12:00 - bucket 1",
+			chunkMinTime:   time.Date(2026, 3, 28, 12, 0, 0, 0, time.UTC),
+			blockMinTime:   time.Date(2026, 3, 28, 0, 0, 0, 0, time.UTC),
+			expectedBucket: 1,
+		},
+		{
+			name:           "chunk at 15:59 - bucket 1",
+			chunkMinTime:   time.Date(2026, 3, 28, 15, 59, 0, 0, time.UTC),
+			blockMinTime:   time.Date(2026, 3, 28, 0, 0, 0, 0, time.UTC),
+			expectedBucket: 1,
+		},
+		{
+			name:           "chunk at 16:00 - bucket 2",
+			chunkMinTime:   time.Date(2026, 3, 28, 16, 0, 0, 0, time.UTC),
+			blockMinTime:   time.Date(2026, 3, 28, 0, 0, 0, 0, time.UTC),
+			expectedBucket: 2,
+		},
+		{
+			name:           "chunk at 23:59 - bucket 2",
+			chunkMinTime:   time.Date(2026, 3, 28, 23, 59, 0, 0, time.UTC),
+			blockMinTime:   time.Date(2026, 3, 28, 0, 0, 0, 0, time.UTC),
+			expectedBucket: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Calculate bucket index using the same logic as collectChunks
+			hour := tt.chunkMinTime.Hour()
+			bucketIdx := (hour / int(ChunkColumnLength.Hours())) % ChunkColumnsPerDay
+			testutil.Equals(t, tt.expectedBucket, bucketIdx)
+		})
+	}
+}
+
+func TestCollectChunksEmpty(t *testing.T) {
+	// Test with no chunks
+	chkMetas := []chunks.Meta{}
+	result, err := collectChunks(chkMetas, nil)
+	testutil.Ok(t, err)
+
+	// All buckets should be empty
+	for i, bucket := range result {
+		testutil.Equals(t, 0, len(bucket), "bucket %d should be empty", i)
+	}
+}
+
+func TestZigZagEncode(t *testing.T) {
+	tests := []struct {
+		input    int64
+		expected uint64
+	}{
+		{0, 0},
+		{-1, 1},
+		{1, 2},
+		{-2, 3},
+		{2, 4},
+		{-100, 199},
+		{100, 200},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("encode_%d", tt.input), func(t *testing.T) {
+			result := ZigZagEncode(tt.input)
+			testutil.Equals(t, tt.expected, result)
+		})
+	}
+}
+
+func TestChunkColumnsPerDay(t *testing.T) {
+	// Verify that 3 columns × 8 hours = 24 hours
+	testutil.Equals(t, 3, ChunkColumnsPerDay)
+	testutil.Equals(t, 8*time.Hour, ChunkColumnLength)
+	testutil.Equals(t, 24*time.Hour, time.Duration(ChunkColumnsPerDay)*ChunkColumnLength)
+}

--- a/pkg/parquet/errors.go
+++ b/pkg/parquet/errors.go
@@ -1,0 +1,16 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package parquet
+
+import "fmt"
+
+// ErrInvalidConfig creates a configuration error.
+func ErrInvalidConfig(msg string) error {
+	return fmt.Errorf("invalid parquet config: %s", msg)
+}
+
+// ErrConversion creates a conversion error.
+func ErrConversion(msg string, err error) error {
+	return fmt.Errorf("parquet conversion failed: %s: %w", msg, err)
+}

--- a/pkg/parquet/metrics.go
+++ b/pkg/parquet/metrics.go
@@ -1,0 +1,73 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package parquet
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// Metrics holds Prometheus metrics for Parquet operations.
+type Metrics struct {
+	conversionsTotal     *prometheus.CounterVec
+	conversionDuration   prometheus.Histogram
+	shardsCreated        prometheus.Histogram
+	seriesPerShard       prometheus.Histogram
+	parquetBytesWritten  prometheus.Counter
+	parquetFilesUploaded prometheus.Counter
+	tsdbBytesRead        prometheus.Counter
+}
+
+// NewMetrics creates a new Metrics instance.
+func NewMetrics(reg prometheus.Registerer) *Metrics {
+	m := &Metrics{
+		conversionsTotal: promauto.With(reg).NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "thanos_parquet_conversions_total",
+				Help: "Total number of TSDB to Parquet conversions, labeled by result (success/failure).",
+			},
+			[]string{"result"},
+		),
+		conversionDuration: promauto.With(reg).NewHistogram(
+			prometheus.HistogramOpts{
+				Name:    "thanos_parquet_conversion_duration_seconds",
+				Help:    "Duration of TSDB to Parquet conversion in seconds.",
+				Buckets: []float64{1, 5, 10, 30, 60, 120, 300, 600},
+			},
+		),
+		shardsCreated: promauto.With(reg).NewHistogram(
+			prometheus.HistogramOpts{
+				Name:    "thanos_parquet_shards_created",
+				Help:    "Number of shards created per conversion.",
+				Buckets: []float64{1, 2, 5, 10, 20, 50, 100},
+			},
+		),
+		seriesPerShard: promauto.With(reg).NewHistogram(
+			prometheus.HistogramOpts{
+				Name:    "thanos_parquet_series_per_shard",
+				Help:    "Number of series per Parquet shard.",
+				Buckets: prometheus.ExponentialBuckets(1000, 2, 15),
+			},
+		),
+		parquetBytesWritten: promauto.With(reg).NewCounter(
+			prometheus.CounterOpts{
+				Name: "thanos_parquet_bytes_written_total",
+				Help: "Total bytes written to Parquet files.",
+			},
+		),
+		parquetFilesUploaded: promauto.With(reg).NewCounter(
+			prometheus.CounterOpts{
+				Name: "thanos_parquet_files_uploaded_total",
+				Help: "Total number of Parquet files uploaded.",
+			},
+		),
+		tsdbBytesRead: promauto.With(reg).NewCounter(
+			prometheus.CounterOpts{
+				Name: "thanos_parquet_tsdb_bytes_read_total",
+				Help: "Total bytes read from TSDB blocks for Parquet conversion.",
+			},
+		),
+	}
+	return m
+}

--- a/pkg/parquet/schema.go
+++ b/pkg/parquet/schema.go
@@ -1,0 +1,183 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package parquet
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/parquet-go/parquet-go"
+	"github.com/parquet-go/parquet-go/compress/zstd"
+	"github.com/prometheus/prometheus/model/labels"
+)
+
+const (
+	// LabelColumnPrefix is the prefix for label columns in Parquet files.
+	LabelColumnPrefix = "___cf_meta_label_"
+	// LabelIndexColumn contains an encoded list of indexes for populated columns.
+	LabelIndexColumn = "___cf_meta_index"
+	// LabelHashColumn contains the hash of the label set for joining.
+	LabelHashColumn = "___cf_meta_hash"
+	// ChunksColumn0 contains chunks from 00:00-08:00.
+	ChunksColumn0 = "___cf_meta_chunk_0"
+	// ChunksColumn1 contains chunks from 08:00-16:00.
+	ChunksColumn1 = "___cf_meta_chunk_1"
+	// ChunksColumn2 contains chunks from 16:00-00:00.
+	ChunksColumn2 = "___cf_meta_chunk_2"
+)
+
+const (
+	// ChunkColumnLength is the duration covered by each chunk column (8 hours).
+	ChunkColumnLength = 8 * time.Hour
+	// ChunkColumnsPerDay is the number of chunk columns per day (3).
+	ChunkColumnsPerDay = 3
+)
+
+// ChunkColumnName returns the column name for the given chunk column index.
+func ChunkColumnName(i int) (string, bool) {
+	switch i {
+	case 0:
+		return ChunksColumn0, true
+	case 1:
+		return ChunksColumn1, true
+	case 2:
+		return ChunksColumn2, true
+	}
+	return "", false
+}
+
+// LabelNameToColumn converts a label name to a Parquet column name.
+func LabelNameToColumn(lbl string) string {
+	return fmt.Sprintf("%s%s", LabelColumnPrefix, lbl)
+}
+
+// ColumnToLabelName converts a Parquet column name to a label name.
+func ColumnToLabelName(col string) string {
+	return strings.TrimPrefix(col, LabelColumnPrefix)
+}
+
+// ChunkColumnIndex returns the chunk column index for a given timestamp and block mint.
+func ChunkColumnIndex(mint int64, t time.Time) (int, bool) {
+	mints := time.UnixMilli(mint)
+
+	colIdx := 0
+	for cur := mints.Add(ChunkColumnLength); !t.Before(cur); cur = cur.Add(ChunkColumnLength) {
+		colIdx++
+	}
+	return min(colIdx, ChunkColumnsPerDay-1), true
+}
+
+// BuildSchemaFromLabels creates a Parquet schema with columns for the given label names.
+// The schema includes:
+// - Label index column (delta-length byte array)
+// - Label hash column (int64)
+// - One dictionary-encoded column per label name
+// - Three chunk columns for 8-hour time buckets.
+func BuildSchemaFromLabels(lbls []string) *parquet.Schema {
+	g := make(parquet.Group)
+
+	// Index column for column projection optimization
+	g[LabelIndexColumn] = parquet.Encoded(parquet.Leaf(parquet.ByteArrayType), &parquet.DeltaLengthByteArray)
+	// Hash column for joining labels and chunks
+	g[LabelHashColumn] = parquet.Encoded(parquet.Leaf(parquet.Int64Type), &parquet.Plain)
+
+	// One column per label name, dictionary-encoded for efficiency
+	for _, lbl := range lbls {
+		g[LabelNameToColumn(lbl)] = parquet.Optional(parquet.Encoded(parquet.String(), &parquet.RLEDictionary))
+	}
+
+	// Three chunk columns (8 hours each)
+	chunkNode := parquet.Encoded(parquet.Leaf(parquet.ByteArrayType), &parquet.DeltaLengthByteArray)
+	g[ChunksColumn0] = chunkNode
+	g[ChunksColumn1] = chunkNode
+	g[ChunksColumn2] = chunkNode
+
+	return parquet.NewSchema("tsdb", g)
+}
+
+// defaultZstdCodec is the default ZSTD compression codec.
+var defaultZstdCodec = &zstd.Codec{Level: zstd.SpeedBetterCompression, Concurrency: 1}
+
+// WithCompression applies ZSTD compression to all columns in the schema.
+func WithCompression(s *parquet.Schema) *parquet.Schema {
+	g := make(parquet.Group)
+
+	for _, c := range s.Columns() {
+		lc, _ := s.Lookup(c...)
+		g[lc.Path[0]] = parquet.Compressed(lc.Node, defaultZstdCodec)
+	}
+
+	return parquet.NewSchema("compressed", g)
+}
+
+// ChunkColumns is the list of chunk-related columns.
+var ChunkColumns = []string{LabelHashColumn, ChunksColumn0, ChunksColumn1, ChunksColumn2}
+
+// ChunkProjection returns a schema with only chunk columns.
+func ChunkProjection(s *parquet.Schema) *parquet.Schema {
+	g := make(parquet.Group)
+
+	for _, c := range ChunkColumns {
+		lc, ok := s.Lookup(c)
+		if !ok {
+			continue
+		}
+		g[c] = lc.Node
+	}
+	return parquet.NewSchema("chunk-projection", g)
+}
+
+// LabelsProjection returns a schema with only label columns (excludes chunk columns).
+func LabelsProjection(s *parquet.Schema) *parquet.Schema {
+	g := make(parquet.Group)
+
+	for _, c := range s.Columns() {
+		if slices.Contains(ChunkColumns, c[0]) {
+			continue
+		}
+		lc, ok := s.Lookup(c...)
+		if !ok {
+			continue
+		}
+		g[c[0]] = lc.Node
+	}
+	return parquet.NewSchema("labels-projection", g)
+}
+
+// BuildSortingColumns creates sorting columns for Parquet files.
+func BuildSortingColumns(sortLabels []string) []parquet.SortingColumn {
+	sortingColumns := make([]parquet.SortingColumn, 0, len(sortLabels))
+	for _, lbl := range sortLabels {
+		sortingColumns = append(sortingColumns, parquet.Ascending(LabelNameToColumn(lbl)))
+	}
+	return sortingColumns
+}
+
+// BuildBloomFilterColumns creates bloom filter columns for Parquet files.
+func BuildBloomFilterColumns(filterLabels []string) []parquet.BloomFilterColumn {
+	cols := make([]parquet.BloomFilterColumn, 0, len(filterLabels))
+	for _, lbl := range filterLabels {
+		cols = append(cols, parquet.SplitBlockFilter(10, LabelNameToColumn(lbl)))
+	}
+	return cols
+}
+
+// ExtractUniqueLabelNames extracts all unique label names from a set of series.
+func ExtractUniqueLabelNames(seriesLabels []labels.Labels) []string {
+	labelSet := make(map[string]struct{})
+	for _, lbls := range seriesLabels {
+		lbls.Range(func(l labels.Label) {
+			labelSet[l.Name] = struct{}{}
+		})
+	}
+
+	uniqueLabels := make([]string, 0, len(labelSet))
+	for name := range labelSet {
+		uniqueLabels = append(uniqueLabels, name)
+	}
+	slices.Sort(uniqueLabels)
+	return uniqueLabels
+}

--- a/pkg/parquet/schema_test.go
+++ b/pkg/parquet/schema_test.go
@@ -1,0 +1,173 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package parquet
+
+import (
+	"testing"
+
+	"github.com/efficientgo/core/testutil"
+	"github.com/prometheus/prometheus/model/labels"
+)
+
+func TestLabelNameToColumn(t *testing.T) {
+	tests := []struct {
+		labelName      string
+		expectedColumn string
+	}{
+		{"__name__", "___cf_meta_label___name__"},
+		{"job", "___cf_meta_label_job"},
+		{"instance", "___cf_meta_label_instance"},
+		{"region", "___cf_meta_label_region"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.labelName, func(t *testing.T) {
+			result := LabelNameToColumn(tt.labelName)
+			testutil.Equals(t, tt.expectedColumn, result)
+		})
+	}
+}
+
+func TestColumnToLabelName(t *testing.T) {
+	tests := []struct {
+		column            string
+		expectedLabelName string
+	}{
+		{"___cf_meta_label___name__", "__name__"},
+		{"___cf_meta_label_job", "job"},
+		{"___cf_meta_label_instance", "instance"},
+		{"___cf_meta_label_region", "region"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.column, func(t *testing.T) {
+			result := ColumnToLabelName(tt.column)
+			testutil.Equals(t, tt.expectedLabelName, result)
+		})
+	}
+}
+
+func TestChunkColumnName(t *testing.T) {
+	tests := []struct {
+		index          int
+		expectedColumn string
+		expectedOk     bool
+	}{
+		{0, ChunksColumn0, true},
+		{1, ChunksColumn1, true},
+		{2, ChunksColumn2, true},
+		{3, "", false},
+		{-1, "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(rune(tt.index)), func(t *testing.T) {
+			column, ok := ChunkColumnName(tt.index)
+			testutil.Equals(t, tt.expectedOk, ok)
+			testutil.Equals(t, tt.expectedColumn, column)
+		})
+	}
+}
+
+func TestBuildSchemaFromLabels(t *testing.T) {
+	labelNames := []string{"__name__", "job", "instance"}
+	schema := BuildSchemaFromLabels(labelNames)
+
+	testutil.Assert(t, schema != nil, "schema should not be nil")
+
+	// Check that all expected columns exist
+	expectedColumns := []string{
+		LabelIndexColumn,
+		LabelHashColumn,
+		"___cf_meta_label___name__",
+		"___cf_meta_label_job",
+		"___cf_meta_label_instance",
+		ChunksColumn0,
+		ChunksColumn1,
+		ChunksColumn2,
+	}
+
+	columns := schema.Columns()
+	testutil.Equals(t, len(expectedColumns), len(columns), "should have correct number of columns")
+
+	for _, expected := range expectedColumns {
+		found := false
+		for _, col := range columns {
+			if len(col) > 0 && col[0] == expected {
+				found = true
+				break
+			}
+		}
+		testutil.Assert(t, found, "column %s should exist in schema", expected)
+	}
+}
+
+func TestExtractUniqueLabelNames(t *testing.T) {
+	tests := []struct {
+		name          string
+		seriesLabels  []labels.Labels
+		expectedNames []string
+	}{
+		{
+			name: "single series",
+			seriesLabels: []labels.Labels{
+				labels.FromStrings("__name__", "metric1", "job", "api"),
+			},
+			expectedNames: []string{"__name__", "job"},
+		},
+		{
+			name: "multiple series with overlapping labels",
+			seriesLabels: []labels.Labels{
+				labels.FromStrings("__name__", "metric1", "job", "api"),
+				labels.FromStrings("__name__", "metric2", "job", "worker", "region", "us-east"),
+			},
+			expectedNames: []string{"__name__", "job", "region"},
+		},
+		{
+			name:          "empty series",
+			seriesLabels:  []labels.Labels{},
+			expectedNames: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ExtractUniqueLabelNames(tt.seriesLabels)
+			testutil.Equals(t, len(tt.expectedNames), len(result))
+
+			// Check all expected names exist (order may vary)
+			for _, expected := range tt.expectedNames {
+				found := false
+				for _, actual := range result {
+					if actual == expected {
+						found = true
+						break
+					}
+				}
+				testutil.Assert(t, found, "expected label %s not found", expected)
+			}
+		})
+	}
+}
+
+func TestChunkColumns(t *testing.T) {
+	// Verify ChunkColumns constant contains all chunk columns
+	testutil.Equals(t, 4, len(ChunkColumns), "should have 4 chunk-related columns")
+
+	expectedColumns := []string{LabelHashColumn, ChunksColumn0, ChunksColumn1, ChunksColumn2}
+	for i, expected := range expectedColumns {
+		testutil.Equals(t, expected, ChunkColumns[i])
+	}
+}
+
+func TestWithCompression(t *testing.T) {
+	labelNames := []string{"__name__", "job"}
+	schema := BuildSchemaFromLabels(labelNames)
+	compressedSchema := WithCompression(schema)
+
+	testutil.Assert(t, compressedSchema != nil, "compressed schema should not be nil")
+
+	// Compressed schema should have same number of columns
+	testutil.Equals(t, len(schema.Columns()), len(compressedSchema.Columns()))
+}

--- a/pkg/parquet/sharding.go
+++ b/pkg/parquet/sharding.go
@@ -1,0 +1,160 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package parquet
+
+import (
+	"fmt"
+	"math"
+	"strings"
+
+	"github.com/prometheus/prometheus/model/labels"
+)
+
+// Shard represents a group of series that will be written to the same Parquet file.
+type Shard struct {
+	// Index is the shard number.
+	Index int
+	// Series is the list of series in this shard with their labels.
+	Series []SeriesWithLabels
+	// LabelNames is the set of unique label names in this shard.
+	LabelNames []string
+}
+
+// SeriesWithLabels represents a series with its labels and original index.
+type SeriesWithLabels struct {
+	Labels      labels.Labels
+	Hash        uint64
+	OriginalIdx int // Index in the original allSeries slice
+}
+
+// ShardSeries divides series into shards based on cardinality and label column count.
+// Sharding prevents schema explosion (too many columns) and keeps file sizes manageable.
+// Returns a slice of shards, where each shard will be written to separate Parquet files.
+func ShardSeries(
+	allSeries []labels.Labels,
+	targetSeriesPerShard int,
+	sortLabels []string,
+) ([]Shard, error) {
+	if len(allSeries) == 0 {
+		return nil, fmt.Errorf("no series to shard")
+	}
+
+	// Sort series by the specified labels to improve compression and query performance
+	sortedSeries := make([]labels.Labels, len(allSeries))
+	copy(sortedSeries, allSeries)
+	compareBySortedLabels := func(a, b labels.Labels) int {
+		for _, lb := range sortLabels {
+			aVal := a.Get(lb)
+			bVal := b.Get(lb)
+			if aVal != bVal {
+				if aVal < bVal {
+					return -1
+				}
+				return 1
+			}
+		}
+		return labels.Compare(a, b)
+	}
+
+	// Sort series using the comparison function
+	for i := 0; i < len(sortedSeries)-1; i++ {
+		for j := i + 1; j < len(sortedSeries); j++ {
+			if compareBySortedLabels(sortedSeries[i], sortedSeries[j]) > 0 {
+				sortedSeries[i], sortedSeries[j] = sortedSeries[j], sortedSeries[i]
+			}
+		}
+	}
+
+	// Create shards
+	shards := []Shard{{Index: 0}}
+	currentShard := &shards[0]
+	currentLabelNames := make(map[string]struct{})
+	currentUniqueCount := 0
+	var currentHash uint64
+
+	for idx, lbls := range sortedSeries {
+		hash := lbls.Hash()
+
+		// Check if this is a new unique series
+		isNewSeries := (hash != currentHash)
+		if isNewSeries {
+			// Collect label names for this series
+			seriesLabelNames := make(map[string]struct{})
+			lbls.Range(func(l labels.Label) {
+				seriesLabelNames[l.Name] = struct{}{}
+			})
+
+			// Calculate potential new column count
+			potentialLabelCount := len(currentLabelNames)
+			for name := range seriesLabelNames {
+				if _, exists := currentLabelNames[name]; !exists {
+					potentialLabelCount++
+				}
+			}
+
+			// Check if we need to create a new shard:
+			// 1. Too many unique series (exceeds targetSeriesPerShard)
+			// 2. Too many columns (approaching MaxInt16 limit for Parquet)
+			needNewShard := currentUniqueCount >= targetSeriesPerShard ||
+				potentialLabelCount+ChunkColumnsPerDay+2 >= math.MaxInt16
+
+			if needNewShard && currentUniqueCount > 0 {
+				// Start a new shard
+				newShardIndex := len(shards)
+				shards = append(shards, Shard{Index: newShardIndex})
+				currentShard = &shards[newShardIndex]
+				currentLabelNames = make(map[string]struct{})
+				currentUniqueCount = 0
+
+				// Add this series' labels to the new shard
+				lbls.Range(func(l labels.Label) {
+					currentLabelNames[strings.Clone(l.Name)] = struct{}{}
+				})
+			} else {
+				// Add new labels to current shard
+				lbls.Range(func(l labels.Label) {
+					if _, exists := currentLabelNames[l.Name]; !exists {
+						currentLabelNames[strings.Clone(l.Name)] = struct{}{}
+					}
+				})
+			}
+
+			currentUniqueCount++
+			currentHash = hash
+		}
+
+		// Add series to current shard
+		currentShard.Series = append(currentShard.Series, SeriesWithLabels{
+			Labels:      lbls,
+			Hash:        hash,
+			OriginalIdx: idx,
+		})
+	}
+
+	// Extract sorted label names for each shard
+	for i := range shards {
+		shard := &shards[i]
+		labelNamesSet := make(map[string]struct{})
+		for _, series := range shard.Series {
+			series.Labels.Range(func(l labels.Label) {
+				labelNamesSet[l.Name] = struct{}{}
+			})
+		}
+
+		shard.LabelNames = make([]string, 0, len(labelNamesSet))
+		for name := range labelNamesSet {
+			shard.LabelNames = append(shard.LabelNames, name)
+		}
+		// Sort label names for consistent schema ordering
+		for i := 0; i < len(shard.LabelNames)-1; i++ {
+			for j := i + 1; j < len(shard.LabelNames); j++ {
+				if shard.LabelNames[i] > shard.LabelNames[j] {
+					shard.LabelNames[i], shard.LabelNames[j] = shard.LabelNames[j], shard.LabelNames[i]
+				}
+			}
+		}
+	}
+
+	return shards, nil
+}

--- a/pkg/parquet/writer.go
+++ b/pkg/parquet/writer.go
@@ -1,0 +1,177 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package parquet
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/oklog/ulid"
+	ulidv2 "github.com/oklog/ulid/v2"
+	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/thanos-io/thanos/pkg/block/metadata"
+)
+
+// Writer is the interface for writing TSDB blocks to Parquet format.
+type Writer interface {
+	// WriteBlock converts a TSDB block to Parquet format and uploads it to the configured bucket.
+	WriteBlock(ctx context.Context, blockID ulidv2.ULID, meta *metadata.Meta) error
+	// HasParquetFiles checks if Parquet files exist for a given block.
+	HasParquetFiles(ctx context.Context, meta *metadata.Meta) (bool, error)
+	// Reconcile scans blocks and converts any 8h blocks missing Parquet files.
+	Reconcile(ctx context.Context, blocks map[ulidv2.ULID]*metadata.Meta) (converted int, err error)
+	// Close closes the writer and releases resources.
+	Close() error
+}
+
+// writer implements the Writer interface.
+type writer struct {
+	config  Config
+	logger  log.Logger
+	metrics *Metrics
+}
+
+// New creates a new Parquet writer.
+func New(config Config, logger log.Logger, reg prometheus.Registerer) (Writer, error) {
+	if err := config.Validate(); err != nil {
+		return nil, err
+	}
+
+	return &writer{
+		config:  config,
+		logger:  logger,
+		metrics: NewMetrics(reg),
+	}, nil
+}
+
+// WriteBlock converts a TSDB block to Parquet format.
+func (w *writer) WriteBlock(ctx context.Context, blockID ulidv2.ULID, meta *metadata.Meta) error {
+	if !w.config.Enabled {
+		return nil
+	}
+
+	// Convert ulid/v2 to ulid for internal use
+	blockIDV1 := ulid.ULID(blockID)
+
+	err := ConvertTSDBBlock(
+		ctx,
+		w.logger,
+		blockIDV1,
+		meta,
+		w.config.TSDBBucket,
+		w.config.ParquetBucket,
+		w.config.BasePath,
+		w.config,
+		w.metrics,
+	)
+
+	if err != nil {
+		w.metrics.conversionsTotal.WithLabelValues("failure").Inc()
+		return ErrConversion("failed to convert block", err)
+	}
+
+	return nil
+}
+
+// HasParquetFiles checks if Parquet files exist for a given block.
+// It checks for the existence of any .parquet files in the expected date directory.
+func (w *writer) HasParquetFiles(ctx context.Context, meta *metadata.Meta) (bool, error) {
+	if !w.config.Enabled {
+		return false, nil
+	}
+
+	// Determine the expected Parquet file path based on block's time range
+	// Single day: 2026-03-28/  Multi-day: 2026-03-28_to_2026-03-30/
+	blockDateStart := time.UnixMilli(meta.MinTime).UTC().Format("2006-01-02")
+	blockDateEnd := time.UnixMilli(meta.MaxTime).UTC().Format("2006-01-02")
+	var dateFolder string
+	if blockDateStart == blockDateEnd {
+		dateFolder = blockDateStart
+	} else {
+		dateFolder = fmt.Sprintf("%s_to_%s", blockDateStart, blockDateEnd)
+	}
+	parquetDir := filepath.Join(w.config.BasePath, dateFolder)
+
+	// Check if any .parquet files exist in this directory
+	// We look for both labels.parquet and chunks.parquet files
+	// Since blocks can be sharded, we check for any shard (0.labels.parquet, 1.labels.parquet, etc.)
+	found := false
+	err := w.config.ParquetBucket.Iter(ctx, parquetDir, func(name string) error {
+		if filepath.Ext(name) == ".parquet" {
+			found = true
+			return errors.New("found") // Stop iteration
+		}
+		return nil
+	})
+
+	// If we got "found" error, it means we found at least one parquet file
+	if err != nil && err.Error() == "found" {
+		return true, nil
+	}
+
+	if err != nil {
+		return false, err
+	}
+
+	return found, nil
+}
+
+// Reconcile scans blocks and converts any 8h blocks that are missing Parquet files.
+// This is used for disaster recovery when the compactor crashes after creating a block
+// but before converting it to Parquet.
+func (w *writer) Reconcile(ctx context.Context, blocks map[ulidv2.ULID]*metadata.Meta) (int, error) {
+	if !w.config.Enabled {
+		return 0, nil
+	}
+
+	var converted int
+	var reconErrors []error
+
+	for blockID, meta := range blocks {
+		// Only check exactly 8-hour blocks (compaction level 2)
+		blockDuration := time.Duration(meta.MaxTime-meta.MinTime) * time.Millisecond
+		if blockDuration != 8*time.Hour {
+			continue
+		}
+
+		// Check if Parquet files already exist
+		hasParquet, err := w.HasParquetFiles(ctx, meta)
+		if err != nil {
+			reconErrors = append(reconErrors, errors.Wrapf(err, "check parquet files for block %s", blockID))
+			continue
+		}
+
+		if hasParquet {
+			// Already converted, skip
+			continue
+		}
+
+		// Convert the block
+		level.Info(w.logger).Log("msg", "reconciling unconverted block to Parquet", "block", blockID, "duration", blockDuration)
+		if err := w.WriteBlock(ctx, blockID, meta); err != nil {
+			reconErrors = append(reconErrors, errors.Wrapf(err, "convert block %s during reconciliation", blockID))
+			continue
+		}
+
+		converted++
+		level.Info(w.logger).Log("msg", "successfully reconciled block to Parquet", "block", blockID)
+	}
+
+	if len(reconErrors) > 0 {
+		return converted, errors.Errorf("reconciliation completed with %d errors: %v", len(reconErrors), reconErrors)
+	}
+
+	return converted, nil
+}
+
+// Close closes the writer.
+func (w *writer) Close() error {
+	// No resources to clean up currently
+	return nil
+}

--- a/pkg/parquet/writer_test.go
+++ b/pkg/parquet/writer_test.go
@@ -1,0 +1,244 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package parquet
+
+import (
+	"context"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/efficientgo/core/testutil"
+	"github.com/go-kit/log"
+	"github.com/oklog/ulid/v2"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/thanos-io/objstore"
+	"github.com/thanos-io/thanos/pkg/block/metadata"
+)
+
+// mockBucket is a simple in-memory bucket for testing.
+type mockBucket struct {
+	objstore.Bucket
+	files map[string][]byte
+}
+
+func newMockBucket() *mockBucket {
+	return &mockBucket{
+		files: make(map[string][]byte),
+	}
+}
+
+func (m *mockBucket) Iter(ctx context.Context, dir string, f func(string) error, options ...objstore.IterOption) error {
+	for name := range m.files {
+		if len(dir) == 0 || len(name) >= len(dir) && name[:len(dir)] == dir {
+			if err := f(name); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (m *mockBucket) Upload(ctx context.Context, name string, r io.Reader, options ...objstore.ObjectUploadOption) error {
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return err
+	}
+	m.files[name] = data
+	return nil
+}
+
+func (m *mockBucket) Exists(ctx context.Context, name string) (bool, error) {
+	_, exists := m.files[name]
+	return exists, nil
+}
+
+func TestHasParquetFiles(t *testing.T) {
+	ctx := context.Background()
+	mockBkt := newMockBucket()
+
+	writer := &writer{
+		config: Config{
+			Enabled:       true,
+			ParquetBucket: mockBkt,
+			BasePath:      "parquet/",
+		},
+		logger: log.NewNopLogger(),
+	}
+
+	// Helper function to create test metadata
+	createMeta := func(minTime, maxTime time.Time) *metadata.Meta {
+		m := &metadata.Meta{}
+		m.MinTime = minTime.UnixMilli()
+		m.MaxTime = maxTime.UnixMilli()
+		return m
+	}
+
+	tests := []struct {
+		name           string
+		meta           *metadata.Meta
+		existingFiles  map[string][]byte
+		expectedExists bool
+	}{
+		{
+			name: "single day block with parquet files",
+			meta: createMeta(
+				time.Date(2026, 3, 28, 0, 0, 0, 0, time.UTC),
+				time.Date(2026, 3, 28, 8, 0, 0, 0, time.UTC),
+			),
+			existingFiles: map[string][]byte{
+				"parquet/2026-03-28/0.labels.parquet": []byte("data"),
+				"parquet/2026-03-28/0.chunks.parquet": []byte("data"),
+			},
+			expectedExists: true,
+		},
+		{
+			name: "single day block without parquet files",
+			meta: createMeta(
+				time.Date(2026, 3, 28, 0, 0, 0, 0, time.UTC),
+				time.Date(2026, 3, 28, 8, 0, 0, 0, time.UTC),
+			),
+			existingFiles:  map[string][]byte{},
+			expectedExists: false,
+		},
+		{
+			name: "multi-day block with parquet files",
+			meta: createMeta(
+				time.Date(2026, 3, 28, 0, 0, 0, 0, time.UTC),
+				time.Date(2026, 3, 30, 0, 0, 0, 0, time.UTC),
+			),
+			existingFiles: map[string][]byte{
+				"parquet/2026-03-28_to_2026-03-30/0.labels.parquet": []byte("data"),
+			},
+			expectedExists: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockBkt.files = tt.existingFiles
+
+			exists, err := writer.HasParquetFiles(ctx, tt.meta)
+			testutil.Ok(t, err)
+			testutil.Equals(t, tt.expectedExists, exists)
+		})
+	}
+}
+
+func TestReconcile(t *testing.T) {
+	ctx := context.Background()
+	mockBkt := newMockBucket()
+
+	writer := &writer{
+		config: Config{
+			Enabled:              true,
+			TSDBBucket:           mockBkt,
+			ParquetBucket:        mockBkt,
+			BasePath:             "parquet/",
+			ShardingEnabled:      false,
+			TargetSeriesPerShard: 1000000,
+			CompressionCodec:     "zstd",
+			RowGroupSize:         1000000,
+		},
+		logger:  log.NewNopLogger(),
+		metrics: NewMetrics(prometheus.NewRegistry()),
+	}
+
+	// Helper function to create test metadata
+	createReconcileMeta := func(minTime, maxTime time.Time) *metadata.Meta {
+		m := &metadata.Meta{}
+		m.MinTime = minTime.UnixMilli()
+		m.MaxTime = maxTime.UnixMilli()
+		return m
+	}
+
+	tests := []struct {
+		name              string
+		blocks            map[ulid.ULID]*metadata.Meta
+		existingFiles     map[string][]byte
+		expectedConverted int
+		expectError       bool
+	}{
+		{
+			name:              "no blocks to reconcile",
+			blocks:            map[ulid.ULID]*metadata.Meta{},
+			expectedConverted: 0,
+			expectError:       false,
+		},
+		{
+			name: "skip 2h blocks",
+			blocks: map[ulid.ULID]*metadata.Meta{
+				ulid.MustNew(1, nil): createReconcileMeta(
+					time.Date(2026, 3, 28, 0, 0, 0, 0, time.UTC),
+					time.Date(2026, 3, 28, 2, 0, 0, 0, time.UTC),
+				),
+			},
+			expectedConverted: 0,
+			expectError:       false,
+		},
+		{
+			name: "skip 48h blocks",
+			blocks: map[ulid.ULID]*metadata.Meta{
+				ulid.MustNew(1, nil): createReconcileMeta(
+					time.Date(2026, 3, 28, 0, 0, 0, 0, time.UTC),
+					time.Date(2026, 3, 30, 0, 0, 0, 0, time.UTC),
+				),
+			},
+			expectedConverted: 0,
+			expectError:       false,
+		},
+		{
+			name: "skip 8h blocks that already have parquet files",
+			blocks: map[ulid.ULID]*metadata.Meta{
+				ulid.MustNew(1, nil): createReconcileMeta(
+					time.Date(2026, 3, 28, 0, 0, 0, 0, time.UTC),
+					time.Date(2026, 3, 28, 8, 0, 0, 0, time.UTC),
+				),
+			},
+			existingFiles: map[string][]byte{
+				"parquet/2026-03-28/0.labels.parquet": []byte("data"),
+			},
+			expectedConverted: 0,
+			expectError:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockBkt.files = tt.existingFiles
+
+			converted, err := writer.Reconcile(ctx, tt.blocks)
+			if tt.expectError {
+				testutil.NotOk(t, err)
+			} else {
+				testutil.Ok(t, err)
+			}
+			testutil.Equals(t, tt.expectedConverted, converted)
+		})
+	}
+}
+
+func TestWriterDisabled(t *testing.T) {
+	ctx := context.Background()
+	mockBkt := newMockBucket()
+
+	writer := &writer{
+		config: Config{
+			Enabled:       false,
+			ParquetBucket: mockBkt,
+			BasePath:      "parquet/",
+		},
+		logger: log.NewNopLogger(),
+	}
+
+	// HasParquetFiles should return false when disabled
+	exists, err := writer.HasParquetFiles(ctx, &metadata.Meta{})
+	testutil.Ok(t, err)
+	testutil.Equals(t, false, exists)
+
+	// Reconcile should return 0 when disabled
+	converted, err := writer.Reconcile(ctx, map[ulid.ULID]*metadata.Meta{})
+	testutil.Ok(t, err)
+	testutil.Equals(t, 0, converted)
+}


### PR DESCRIPTION
This PR will add optional flags for compactor to enable generation of Parquet files.

With the flags enabled, the compactor will detect when it has 3 x 8h blocks available for a past day, and start converting it into Parquet files


* [ x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

  This PR adds native Parquet writing support to Thanos Compactor, eliminating the need for a separate converter service. The compactor now converts TSDB
  blocks to Parquet format once a full 24-hour period is available from 8-hour compacted blocks.

 ### Core Implementation:
  - Added /pkg/parquet package with Writer, Converter, Schema, and Config components
  - Integrated Parquet writer into compactor via ParquetCompactionLifecycleCallback hook
  - Converts only 8-hour blocks to ensure schema compatibility (3 × 8h chunk columns = 24h)
  - Parquet files organized into daily folders (e.g., parquet/2026-03-28/)
  - Automatic reconciliation on compactor startup and periodic intervals to handle missed conversions

 ### Key Features:
  - Label-based sharding support for high-cardinality workloads
  - Configurable compression (ZSTD, Snappy, None)
  - Separate bucket configuration for Parquet files (optional)
  - Parallel bucket support (TSDB + Parquet written simultaneously)
  - Comprehensive metrics for monitoring conversion progress
  - Respects --data-dir for temporary file management

 ### CLI Flags Added:
  - --parquet.write - Enable Parquet writing (default: false)
  - --parquet.objstore-config - Optional separate bucket for Parquet files
  - --parquet.base-path - Base path for Parquet files (default: "parquet/")
  - --parquet.enable-sharding - Enable label-based sharding (default: true)
  - --parquet.target-series-per-shard - Series per shard (default: 1000000)
  - --parquet.sort-label - Labels to sort by (default: "name")
  - --parquet.encoding-concurrency - Encoding concurrency (default: 4)
  - --parquet.row-group-size - Rows per row group (default: 1000000)
  - --parquet.compression - Compression codec (default: "zstd")

 ### Schema Details:
  - labels.parquet: Dictionary-encoded label columns + hash + index
  - chunks.parquet: 3 chunk columns for 8-hour buckets (00:00-08:00, 08:00-16:00, 16:00-00:00)


## Verification

### Unit Tests:

  All tests pass and cover:
  - Schema generation from various label combinations
  - Sharding logic with different cardinalities
  - 8-hour block detection and filtering (skips 1h, 2h, 48h, 14d blocks)
  - Chunk bucketing into 8-hour columns
  - Configuration validation
  - Date folder naming (single-day and multi-day blocks)
  - Reconciliation logic (skips already-converted blocks)
  
  ### Manual testing
  
  Ran a local thanos instance over 48 hours to verify I got two days of data eventually converted to Parquet-files
