### PR TITLE
api: add infos field to query API response for Prometheus compatibility

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -122,6 +122,7 @@ type response struct {
 	ErrorType ErrorType `json:"errorType,omitempty"`
 	Error     string    `json:"error,omitempty"`
 	Warnings  []string  `json:"warnings,omitempty"`
+	Infos     []string  `json:"infos,omitempty"`
 }
 
 type TenantStats struct {
@@ -277,7 +278,11 @@ func Respond(w http.ResponseWriter, data any, warnings []error, logger log.Logge
 		Data:   data,
 	}
 	for _, warn := range warnings {
-		resp.Warnings = append(resp.Warnings, warn.Error())
+		if extannotations.IsPromQLInfo(warn.Error()) {
+			resp.Infos = append(resp.Infos, warn.Error())
+		} else {
+			resp.Warnings = append(resp.Warnings, warn.Error())
+		}
 	}
 
 	json := jsoniter.ConfigCompatibleWithStandardLibrary

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -17,6 +17,7 @@
 package api
 
 import (
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -30,6 +31,7 @@ import (
 	promLabels "github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/prometheus/prometheus/util/annotations"
 	promApiV1 "github.com/prometheus/prometheus/web/api/v1"
 
 	"github.com/efficientgo/core/testutil"
@@ -143,6 +145,38 @@ func TestRespondError(t *testing.T) {
 	}
 	if !reflect.DeepEqual(&res, exp) {
 		t.Fatalf("Expected response \n%v\n but got \n%v\n", res, exp)
+	}
+}
+
+func TestRespondInfosAndWarnings(t *testing.T) {
+	infoErr := fmt.Errorf("%w: metric might not be a counter", annotations.PromQLInfo)
+	warnErr := fmt.Errorf("%w: some warning", annotations.PromQLWarning)
+
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		Respond(w, "test", []error{infoErr, warnErr}, log.NewNopLogger())
+	}))
+	defer s.Close()
+
+	resp, err := http.Get(s.URL)
+	if err != nil {
+		t.Fatalf("Error on test request: %s", err)
+	}
+	body, err := io.ReadAll(resp.Body)
+	defer func() { testutil.Ok(t, resp.Body.Close()) }()
+	if err != nil {
+		t.Fatalf("Error reading response body: %s", err)
+	}
+
+	var res response
+	if err = json.Unmarshal([]byte(body), &res); err != nil {
+		t.Fatalf("Error unmarshaling JSON body: %s", err)
+	}
+
+	if len(res.Infos) != 1 || res.Infos[0] != infoErr.Error() {
+		t.Fatalf("Expected infos %v but got %v", []string{infoErr.Error()}, res.Infos)
+	}
+	if len(res.Warnings) != 1 || res.Warnings[0] != warnErr.Error() {
+		t.Fatalf("Expected warnings %v but got %v", []string{warnErr.Error()}, res.Warnings)
 	}
 }
 

--- a/pkg/extannotations/annotations.go
+++ b/pkg/extannotations/annotations.go
@@ -13,3 +13,10 @@ func IsPromQLAnnotation(s string) bool {
 	// We cannot use "errors.Is(w, annotations.PromQLInfo)" here because of gRPC so we use a string as argument
 	return strings.HasPrefix(s, annotations.PromQLInfo.Error()) || strings.HasPrefix(s, annotations.PromQLWarning.Error())
 }
+
+// IsPromQLInfo returns true if the annotation string originates from a PromQL info annotation.
+// We rely on a string prefix check rather than errors.Is because errors serialized over gRPC
+// lose their type information.
+func IsPromQLInfo(s string) bool {
+	return strings.HasPrefix(s, annotations.PromQLInfo.Error())
+}


### PR DESCRIPTION
## What does this PR do?

Prometheus added a separate `infos` field to the query API response in [prometheus/prometheus#14327](https://github.com/prometheus/prometheus/pull/14327) to distinguish informational PromQL annotations (like histogram monotonicity corrections) from actionable warnings. Without this field, Thanos returns all PromQL infos mixed into `warnings`, which breaks clients that depend on Prometheus API compatibility.

This PR adds the `infos` field to Thanos's query API response and separates PromQL info annotations from warnings at the response layer.

Closes #7597

## Changes

- `pkg/api/api.go`: added `Infos []string` field to the `response` struct; updated `Respond()` to route PromQL info annotations to `infos` instead of `warnings`
- `pkg/extannotations/annotations.go`: added `IsPromQLInfo()` helper (string-prefix based, matching the existing `IsPromQLAnnotation` approach, since gRPC serialization strips error type info)
- `pkg/api/api_test.go`: added `TestRespondInfosAndWarnings` to verify the routing logic

## Example response

```json
{
  "status": "success",
  "data": { ... },
  "warnings": ["PromQL warning: mixed floats and histograms for ..."],
  "infos": ["PromQL info: input to histogram_quantile needed to be fixed for monotonicity ..."]
}
```

## Checklist

- [x] I added unit tests for the new behavior
- [x] DCO sign-off included in commit
- [x] No existing tests broken by this change (pre-existing `TestQueryEndpoints` failure also reproduces on `main` without this PR)

Signed-off-by: Abhay Chaurasiya <abhaychaurasiya19@gmail.com>