### PR TITLE
Init thanos_status metrics on startup

### DIFF
--- a/pkg/prober/intrumentation.go
+++ b/pkg/prober/intrumentation.go
@@ -44,6 +44,10 @@ func NewInstrumentation(component component.Component, logger log.Logger, reg pr
 			[]string{"check"},
 		),
 	}
+	// Init both ready and healthy metrics here so they are 0 until Ready() or Healthy() is called.
+	// Without this both are missing until the first time these methods are called.
+	p.statusMetric.WithLabelValues(ready).Set(0)
+	p.statusMetric.WithLabelValues(healthy).Set(0)
 	return &p
 }
 


### PR DESCRIPTION
thanos_status metrics are not being reported until the metric is set to 1 when the server starts. This is fine for services that start quickly, but for Thanos Receive we replay the WAL on startup during which server isn't ready but we don't have the thanos_status metric until it's ready. Fix it by setting the metric to 0 when it's created, so it's exported instantly.

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
