### PR TITLE
config: simplify grpc options

### DIFF
--- a/cmd/thanos/config.go
+++ b/cmd/thanos/config.go
@@ -70,6 +70,7 @@ type grpcClientConfig struct {
 	cert, key, caCert string
 	serverName        string
 	compression       string
+	serviceConfig     string
 }
 
 func (gc *grpcClientConfig) registerFlag(cmd extkingpin.FlagClause) *grpcClientConfig {
@@ -81,19 +82,34 @@ func (gc *grpcClientConfig) registerFlag(cmd extkingpin.FlagClause) *grpcClientC
 	cmd.Flag("grpc-client-server-name", "Server name to verify the hostname on the returned gRPC certificates. See https://tools.ietf.org/html/rfc4366#section-3.1").Default("").StringVar(&gc.serverName)
 	compressionOptions := strings.Join([]string{snappy.Name, compressionNone}, ", ")
 	cmd.Flag("grpc-compression", "Compression algorithm to use for gRPC requests to other clients. Must be one of: "+compressionOptions).Default(compressionNone).EnumVar(&gc.compression, snappy.Name, compressionNone)
+	cmd.Flag("grpc-service-config", "gRPC service configuration in JSON format. See https://github.com/grpc/grpc/blob/master/doc/service_config.md").Default("").StringVar(&gc.serviceConfig)
+
+	return gc
+}
+
+func (gc *grpcClientConfig) registerReceiverFlag(cmd extkingpin.FlagClause) *grpcClientConfig {
+	cmd.Flag("remote-write.client-tls-secure", "Use TLS when talking to the other receivers.").Default("false").BoolVar(&gc.secure)
+	cmd.Flag("remote-write.client-tls-skip-verify", "Disable TLS certificate verification when talking to the other receivers i.e self signed, signed by fake CA.").Default("false").BoolVar(&gc.skipVerify)
+	cmd.Flag("remote-write.client-tls-cert", "TLS Certificates to use to identify this client to the server.").Default("").StringVar(&gc.cert)
+	cmd.Flag("remote-write.client-tls-key", "TLS Key for the client's certificate.").Default("").StringVar(&gc.key)
+	cmd.Flag("remote-write.client-tls-ca", "TLS CA Certificates to use to verify servers.").Default("").StringVar(&gc.caCert)
+	cmd.Flag("remote-write.client-server-name", "Server name to verify the hostname on the returned TLS certificates. See https://tools.ietf.org/html/rfc4366#section-3.1").Default("").StringVar(&gc.serverName)
+	compressionOptions := strings.Join([]string{snappy.Name, compressionNone}, ", ")
+	cmd.Flag("receive.grpc-compression", "Compression algorithm to use for gRPC requests to other receivers. Must be one of: "+compressionOptions).Default(snappy.Name).EnumVar(&gc.compression, snappy.Name, compressionNone)
+	cmd.Flag("receive.grpc-service-config", "gRPC service configuration file or content in JSON format. See https://github.com/grpc/grpc/blob/master/doc/service_config.md").PlaceHolder("<content>").Default("").StringVar(&gc.serviceConfig)
 
 	return gc
 }
 
 func (gc *grpcClientConfig) dialOptions(logger log.Logger, reg prometheus.Registerer, tracer opentracing.Tracer) ([]grpc.DialOption, error) {
-	dialOpts, err := extgrpc.StoreClientGRPCOpts(logger, reg, tracer, gc.secure, gc.skipVerify, gc.cert, gc.key, gc.caCert, gc.serverName)
-	if err != nil {
-		return nil, errors.Wrapf(err, "building gRPC client")
+	opts := []extgrpc.StoreClientGRPCOption{
+		extgrpc.WithCompression(gc.compression),
+		extgrpc.WithServiceConfig(gc.serviceConfig),
 	}
-	if gc.compression != compressionNone {
-		dialOpts = append(dialOpts, grpc.WithDefaultCallOptions(grpc.UseCompressor(gc.compression)))
+	if gc.secure {
+		opts = append(opts, extgrpc.WithTLS(gc.cert, gc.key, gc.caCert, gc.serverName, gc.skipVerify))
 	}
-	return dialOpts, nil
+	return extgrpc.StoreClientGRPCOpts(logger, reg, tracer, opts...)
 }
 
 type httpConfig struct {

--- a/cmd/thanos/endpointset.go
+++ b/cmd/thanos/endpointset.go
@@ -26,7 +26,6 @@ import (
 	"github.com/thanos-io/thanos/pkg/discovery/cache"
 	"github.com/thanos-io/thanos/pkg/discovery/dns"
 	"github.com/thanos-io/thanos/pkg/errors"
-	"github.com/thanos-io/thanos/pkg/extgrpc"
 	"github.com/thanos-io/thanos/pkg/extkingpin"
 	"github.com/thanos-io/thanos/pkg/extprom"
 	"github.com/thanos-io/thanos/pkg/logutil"
@@ -115,9 +114,6 @@ func validateEndpointConfig(cfg EndpointConfig) error {
 	for _, ecfg := range cfg.Endpoints {
 		if dns.IsDynamicNode(ecfg.Address) && ecfg.Strict {
 			return errors.Newf("%s is a dynamically specified endpoint i.e. it uses SD and that is not permitted under strict mode.", ecfg.Address)
-		}
-		if !ecfg.Group && len(ecfg.ServiceConfig) != 0 {
-			return errors.Newf("%s service_config is only valid for endpoint groups.", ecfg.Address)
 		}
 	}
 	return nil
@@ -354,15 +350,19 @@ func setupEndpointSet(
 		// groups and non dynamic endpoints
 		for _, ecfg := range endpointConfig.Endpoints {
 			strict, group, addr := ecfg.Strict, ecfg.Group, ecfg.Address
+			opts := dialOpts
+			if ecfg.ServiceConfig != "" {
+				opts = append(append(make([]grpc.DialOption, 0, len(dialOpts)+1), dialOpts...), grpc.WithDefaultServiceConfig(ecfg.ServiceConfig))
+			}
 			if group {
-				specs = append(specs, query.NewGRPCEndpointSpec(fmt.Sprintf("thanos:///%s", addr), strict, append(dialOpts, extgrpc.EndpointGroupGRPCOpts(ecfg.ServiceConfig)...)...))
+				specs = append(specs, query.NewGRPCEndpointSpec(fmt.Sprintf("thanos:///%s", addr), strict, opts...))
 			} else if !dns.IsDynamicNode(addr) {
-				specs = append(specs, query.NewGRPCEndpointSpec(addr, strict, dialOpts...))
+				specs = append(specs, query.NewGRPCEndpointSpec(fmt.Sprintf("passthrough:///%s", addr), strict, opts...))
 			}
 		}
 		// dynamic endpoints
 		for _, addr := range dnsEndpointProvider.Addresses() {
-			specs = append(specs, query.NewGRPCEndpointSpec(addr, false, dialOpts...))
+			specs = append(specs, query.NewGRPCEndpointSpec(fmt.Sprintf("passthrough:///%s", addr), false, dialOpts...))
 		}
 		return removeDuplicateEndpointSpecs(specs)
 	}, unhealthyTimeout, endpointTimeout, queryTimeout, queryConnMetricLabels...)

--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -30,15 +30,12 @@ import (
 	"github.com/thanos-io/objstore"
 	"github.com/thanos-io/objstore/client"
 	objstoretracing "github.com/thanos-io/objstore/tracing/opentracing"
-	"google.golang.org/grpc"
 	"gopkg.in/yaml.v2"
 
 	"github.com/thanos-io/thanos/pkg/block/metadata"
 	"github.com/thanos-io/thanos/pkg/component"
 	"github.com/thanos-io/thanos/pkg/compressutil"
 	"github.com/thanos-io/thanos/pkg/exemplars"
-	"github.com/thanos-io/thanos/pkg/extgrpc"
-	"github.com/thanos-io/thanos/pkg/extgrpc/snappy"
 	"github.com/thanos-io/thanos/pkg/extkingpin"
 	"github.com/thanos-io/thanos/pkg/extprom"
 	"github.com/thanos-io/thanos/pkg/info"
@@ -158,26 +155,9 @@ func runReceive(
 		return err
 	}
 
-	dialOpts, err := extgrpc.StoreClientGRPCOpts(
-		logger,
-		reg,
-		tracer,
-		conf.rwClientSecure,
-		conf.rwClientSkipVerify,
-		conf.rwClientCert,
-		conf.rwClientKey,
-		conf.rwClientServerCA,
-		conf.rwClientServerName,
-	)
+	dialOpts, err := conf.rwClientConfig.dialOptions(logger, reg, tracer)
 	if err != nil {
 		return err
-	}
-	if conf.compression != compressionNone {
-		dialOpts = append(dialOpts, grpc.WithDefaultCallOptions(grpc.UseCompressor(conf.compression)))
-	}
-
-	if conf.grpcServiceConfig != "" {
-		dialOpts = append(dialOpts, grpc.WithDefaultServiceConfig(conf.grpcServiceConfig))
 	}
 
 	var bkt objstore.Bucket
@@ -844,12 +824,7 @@ type receiveConfig struct {
 	rwServerCert          string
 	rwServerKey           string
 	rwServerClientCA      string
-	rwClientCert          string
-	rwClientKey           string
-	rwClientSecure        bool
-	rwClientServerCA      string
-	rwClientServerName    string
-	rwClientSkipVerify    bool
+	rwClientConfig        grpcClientConfig
 	rwServerTlsMinVersion string
 
 	dataDir   string
@@ -873,9 +848,7 @@ type receiveConfig struct {
 	forwardTimeout      *model.Duration
 	maxBackoff          *model.Duration
 	maxArtificialDelay  *model.Duration
-	compression         string
 	replicationProtocol string
-	grpcServiceConfig   string
 
 	tsdbMinBlockDuration         *model.Duration
 	tsdbMaxBlockDuration         *model.Duration
@@ -937,17 +910,7 @@ func (rc *receiveConfig) registerFlag(cmd extkingpin.FlagClause) {
 
 	cmd.Flag("remote-write.server-tls-min-version", "TLS version for the gRPC server, leave blank to default to TLS 1.3, allow values: [\"1.0\", \"1.1\", \"1.2\", \"1.3\"]").Default("1.3").StringVar(&rc.rwServerTlsMinVersion)
 
-	cmd.Flag("remote-write.client-tls-cert", "TLS Certificates to use to identify this client to the server.").Default("").StringVar(&rc.rwClientCert)
-
-	cmd.Flag("remote-write.client-tls-key", "TLS Key for the client's certificate.").Default("").StringVar(&rc.rwClientKey)
-
-	cmd.Flag("remote-write.client-tls-secure", "Use TLS when talking to the other receivers.").Default("false").BoolVar(&rc.rwClientSecure)
-
-	cmd.Flag("remote-write.client-tls-skip-verify", "Disable TLS certificate verification when talking to the other receivers i.e self signed, signed by fake CA.").Default("false").BoolVar(&rc.rwClientSkipVerify)
-
-	cmd.Flag("remote-write.client-tls-ca", "TLS CA Certificates to use to verify servers.").Default("").StringVar(&rc.rwClientServerCA)
-
-	cmd.Flag("remote-write.client-server-name", "Server name to verify the hostname on the returned TLS certificates. See https://tools.ietf.org/html/rfc4366#section-3.1").Default("").StringVar(&rc.rwClientServerName)
+	rc.rwClientConfig.registerReceiverFlag(cmd)
 
 	cmd.Flag("tsdb.path", "Data directory of TSDB.").
 		Default("./data").StringVar(&rc.dataDir)
@@ -987,8 +950,6 @@ func (rc *receiveConfig) registerFlag(cmd extkingpin.FlagClause) {
 	cmd.Flag("receive.replica-header", "HTTP header specifying the replica number of a write request.").Default(receive.DefaultReplicaHeader).StringVar(&rc.replicaHeader)
 
 	cmd.Flag("receive.forward.async-workers", "Number of concurrent workers processing forwarding of remote-write requests.").Default("5").UintVar(&rc.asyncForwardWorkerCount)
-	compressionOptions := strings.Join([]string{snappy.Name, compressionNone}, ", ")
-	cmd.Flag("receive.grpc-compression", "Compression algorithm to use for gRPC requests to other receivers. Must be one of: "+compressionOptions).Default(snappy.Name).EnumVar(&rc.compression, snappy.Name, compressionNone)
 
 	cmd.Flag("receive.replication-factor", "How many times to replicate incoming write requests.").Default("1").Uint64Var(&rc.replicationFactor)
 
@@ -998,8 +959,6 @@ func (rc *receiveConfig) registerFlag(cmd extkingpin.FlagClause) {
 		EnumVar(&rc.replicationProtocol, replicationProtocols...)
 
 	cmd.Flag("receive.capnproto-address", "Address for the Cap'n Proto server.").Default(fmt.Sprintf("0.0.0.0:%s", receive.DefaultCapNProtoPort)).StringVar(&rc.replicationAddr)
-
-	cmd.Flag("receive.grpc-service-config", "gRPC service configuration file or content in JSON format. See https://github.com/grpc/grpc/blob/master/doc/service_config.md").PlaceHolder("<content>").Default("").StringVar(&rc.grpcServiceConfig)
 
 	rc.forwardTimeout = extkingpin.ModelDuration(cmd.Flag("receive-forward-timeout", "Timeout for each forward request.").Default("5s").Hidden())
 

--- a/cmd/thanos/rule.go
+++ b/cmd/thanos/rule.go
@@ -417,17 +417,7 @@ func runRule(
 	}
 
 	if len(grpcEndpoints) > 0 {
-		dialOpts, err := extgrpc.StoreClientGRPCOpts(
-			logger,
-			reg,
-			tracer,
-			false,
-			false,
-			"",
-			"",
-			"",
-			"",
-		)
+		dialOpts, err := extgrpc.StoreClientGRPCOpts(logger, reg, tracer)
 		if err != nil {
 			return err
 		}

--- a/docs/components/query.md
+++ b/docs/components/query.md
@@ -368,6 +368,8 @@ Flags:
                                  https://tools.ietf.org/html/rfc4366#section-3.1
       --grpc-compression=none    Compression algorithm to use for gRPC requests
                                  to other clients. Must be one of: snappy, none
+      --grpc-service-config=""   gRPC service configuration in JSON format. See
+                                 https://github.com/grpc/grpc/blob/master/doc/service_config.md
       --web.route-prefix=""      Prefix for API and UI endpoints. This allows
                                  thanos UI to be served on a sub-path.
                                  Defaults to the value of --web.external-prefix.

--- a/docs/components/receive.md
+++ b/docs/components/receive.md
@@ -373,7 +373,6 @@ Please see the metric `thanos_receive_forward_delay_seconds` to see if you need 
 The following formula is used for calculating quorum:
 
 ```go mdox-exec="sed -n '1068,1078p' pkg/receive/handler.go"
-// writeQuorum returns minimum number of replicas that has to confirm write success before claiming replication success.
 func (h *Handler) writeQuorum() int {
 	// NOTE(GiedriusS): this is here because otherwise RF=2 doesn't make sense as all writes
 	// would need to succeed all the time. Another way to think about it is when migrating
@@ -384,6 +383,7 @@ func (h *Handler) writeQuorum() int {
 	}
 	return int((h.options.ReplicationFactor / 2) + 1)
 }
+
 ```
 
 So, if the replication factor is 2 then at least one write must succeed. With RF=3, two writes must succeed, and so on.
@@ -475,23 +475,31 @@ Flags:
                                  TLS version for the gRPC server, leave blank
                                  to default to TLS 1.3, allow values: ["1.0",
                                  "1.1", "1.2", "1.3"]
-      --remote-write.client-tls-cert=""
-                                 TLS Certificates to use to identify this client
-                                 to the server.
-      --remote-write.client-tls-key=""
-                                 TLS Key for the client's certificate.
       --[no-]remote-write.client-tls-secure
                                  Use TLS when talking to the other receivers.
       --[no-]remote-write.client-tls-skip-verify
                                  Disable TLS certificate verification when
                                  talking to the other receivers i.e self signed,
                                  signed by fake CA.
+      --remote-write.client-tls-cert=""
+                                 TLS Certificates to use to identify this client
+                                 to the server.
+      --remote-write.client-tls-key=""
+                                 TLS Key for the client's certificate.
       --remote-write.client-tls-ca=""
                                  TLS CA Certificates to use to verify servers.
       --remote-write.client-server-name=""
                                  Server name to verify the hostname
                                  on the returned TLS certificates. See
                                  https://tools.ietf.org/html/rfc4366#section-3.1
+      --receive.grpc-compression=snappy
+                                 Compression algorithm to use for gRPC requests
+                                 to other receivers. Must be one of: snappy,
+                                 none
+      --receive.grpc-service-config=<content>
+                                 gRPC service configuration file
+                                 or content in JSON format. See
+                                 https://github.com/grpc/grpc/blob/master/doc/service_config.md
       --tsdb.path="./data"       Data directory of TSDB.
       --label=key="value" ...    External labels to announce. This flag will be
                                  removed in the future when handling multiple
@@ -562,10 +570,6 @@ Flags:
       --receive.forward.async-workers=5
                                  Number of concurrent workers processing
                                  forwarding of remote-write requests.
-      --receive.grpc-compression=snappy
-                                 Compression algorithm to use for gRPC requests
-                                 to other receivers. Must be one of: snappy,
-                                 none
       --receive.replication-factor=1
                                  How many times to replicate incoming write
                                  requests.
@@ -575,10 +579,6 @@ Flags:
                                  capnproto
       --receive.capnproto-address="0.0.0.0:19391"
                                  Address for the Cap'n Proto server.
-      --receive.grpc-service-config=<content>
-                                 gRPC service configuration file
-                                 or content in JSON format. See
-                                 https://github.com/grpc/grpc/blob/master/doc/service_config.md
       --receive.relabel-config-file=<file-path>
                                  Path to YAML file that contains relabeling
                                  configuration.

--- a/pkg/extgrpc/client.go
+++ b/pkg/extgrpc/client.go
@@ -78,33 +78,87 @@ func (c *nonPoolingCodec) Marshal(v any) (mem.BufferSlice, error) {
 	return mem.BufferSlice{mem.NewBuffer(&bufExact, pool)}, nil
 }
 
-// EndpointGroupGRPCOpts creates gRPC dial options for connecting to endpoint groups.
+// DefaultServiceConfig is the default gRPC service config applied to all client connections.
+// It enables round-robin load balancing and retries on transient UNAVAILABLE errors.
 // For details on retry capabilities, see https://github.com/grpc/proposal/blob/master/A6-client-retries.md#retry-policy-capabilities
-func EndpointGroupGRPCOpts(serviceConfig string) []grpc.DialOption {
-	if serviceConfig == "" {
-		serviceConfig = `
-{
-  "loadBalancingPolicy":"round_robin",
-  "retryPolicy": {
-    "maxAttempts": 3,
-    "initialBackoff": "0.1s",
-    "backoffMultiplier": 2,
-    "retryableStatusCodes": [
-  	  "UNAVAILABLE"
-    ]
+const DefaultServiceConfig = `{
+  "loadBalancingPolicy": "round_robin",
+  "methodConfig": [{
+    "name": [{}],
+    "retryPolicy": {
+      "maxAttempts": 3,
+      "initialBackoff": "0.1s",
+      "maxBackoff": "1s",
+      "backoffMultiplier": 2,
+      "retryableStatusCodes": ["UNAVAILABLE"]
+    }
+  }],
+  "retryThrottling": {
+    "maxTokens": 10,
+    "tokenRatio": 0.1
   }
 }`
-	}
 
-	return []grpc.DialOption{
-		grpc.WithDefaultServiceConfig(serviceConfig),
-		grpc.WithDisableServiceConfig(),
-		grpc.WithKeepaliveParams(keepalive.ClientParameters{Time: 10 * time.Second, Timeout: 5 * time.Second}),
+// StoreClientGRPCOption is a functional option for StoreClientGRPCOpts.
+type StoreClientGRPCOption func(*storeClientGRPCOpts)
+
+type storeClientGRPCOpts struct {
+	serviceConfig string
+	secure        bool
+	skipVerify    bool
+	cert          string
+	key           string
+	caCert        string
+	serverName    string
+	compression   string
+}
+
+// WithTLS enables TLS for the gRPC client connection.
+// Presence of this option implies secure=true.
+// Empty cert/key/caCert/serverName values are valid and result in TLS with system CA pool.
+func WithTLS(cert, key, caCert, serverName string, skipVerify bool) StoreClientGRPCOption {
+	return func(o *storeClientGRPCOpts) {
+		o.secure = true
+		o.cert = cert
+		o.key = key
+		o.caCert = caCert
+		o.serverName = serverName
+		o.skipVerify = skipVerify
+	}
+}
+
+// WithServiceConfig overrides the default gRPC service config. No-op if empty.
+func WithServiceConfig(serviceConfig string) StoreClientGRPCOption {
+	return func(o *storeClientGRPCOpts) {
+		if serviceConfig != "" {
+			o.serviceConfig = serviceConfig
+		}
+	}
+}
+
+// WithCompression enables gRPC compression with the given algorithm. No-op if empty or "none".
+func WithCompression(compression string) StoreClientGRPCOption {
+	return func(o *storeClientGRPCOpts) {
+		if compression != "" && compression != "none" {
+			o.compression = compression
+		}
 	}
 }
 
 // StoreClientGRPCOpts creates gRPC dial options for connecting to a store client.
-func StoreClientGRPCOpts(logger log.Logger, reg prometheus.Registerer, tracer opentracing.Tracer, secure, skipVerify bool, cert, key, caCert, serverName string) ([]grpc.DialOption, error) {
+// By default, DefaultServiceConfig is applied and connections are insecure.
+// Use WithTLS, WithServiceConfig, and WithCompression to customize.
+func StoreClientGRPCOpts(logger log.Logger, reg prometheus.Registerer, tracer opentracing.Tracer, options ...StoreClientGRPCOption) ([]grpc.DialOption, error) {
+	o := &storeClientGRPCOpts{}
+	for _, opt := range options {
+		opt(o)
+	}
+
+	serviceConfig := o.serviceConfig
+	if serviceConfig == "" {
+		serviceConfig = DefaultServiceConfig
+	}
+
 	grpcMets := grpc_prometheus.NewClientMetrics(
 		grpc_prometheus.WithClientHandlingTimeHistogram(grpc_prometheus.WithHistogramOpts(
 			&prometheus.HistogramOpts{
@@ -131,18 +185,23 @@ func StoreClientGRPCOpts(logger log.Logger, reg prometheus.Registerer, tracer op
 			tracing.StreamClientInterceptor(tracer),
 		),
 		grpc.WithKeepaliveParams(keepalive.ClientParameters{Time: 10 * time.Second, Timeout: 5 * time.Second}),
+		grpc.WithDefaultServiceConfig(serviceConfig),
+		grpc.WithDisableServiceConfig(),
+	}
+	if o.compression != "" {
+		dialOpts = append(dialOpts, grpc.WithDefaultCallOptions(grpc.UseCompressor(o.compression)))
 	}
 	if reg != nil {
 		reg.MustRegister(grpcMets)
 	}
 
-	if !secure {
+	if !o.secure {
 		return append(dialOpts, grpc.WithTransportCredentials(insecure.NewCredentials())), nil
 	}
 
 	level.Info(logger).Log("msg", "enabling client to server TLS")
 
-	tlsCfg, err := tls.NewClientConfig(logger, cert, key, caCert, serverName, skipVerify)
+	tlsCfg, err := tls.NewClientConfig(logger, o.cert, o.key, o.caCert, o.serverName, o.skipVerify)
 	if err != nil {
 		return nil, err
 	}

--- a/test/e2e/info_api_test.go
+++ b/test/e2e/info_api_test.go
@@ -71,21 +71,21 @@ func TestInfo(t *testing.T) {
 	expected := map[string][]query.EndpointStatus{
 		"sidecar": {
 			{
-				Name:      "e2e-test-info-sidecar-alone1:9091",
+				Name:      "passthrough:///e2e-test-info-sidecar-alone1:9091",
 				LabelSets: []labels.Labels{labels.FromStrings("prometheus", "prom-alone1", "replica", "0")},
 			},
 			{
-				Name:      "e2e-test-info-sidecar-alone2:9091",
+				Name:      "passthrough:///e2e-test-info-sidecar-alone2:9091",
 				LabelSets: []labels.Labels{labels.FromStrings("prometheus", "prom-alone2", "replica", "0")},
 			},
 			{
-				Name:      "e2e-test-info-sidecar-alone3:9091",
+				Name:      "passthrough:///e2e-test-info-sidecar-alone3:9091",
 				LabelSets: []labels.Labels{labels.FromStrings("prometheus", "prom-alone3", "replica", "0")},
 			},
 		},
 		"store": {
 			{
-				Name:      "e2e-test-info-store-gw-1:9091",
+				Name:      "passthrough:///e2e-test-info-store-gw-1:9091",
 				LabelSets: []labels.Labels{},
 			},
 		},


### PR DESCRIPTION
The endpoint group service config is genuienly useful for all grpc connections. The difference is in the resolver - for groups it will resolve on its own and loadbalnace between the backends for non-groups we use the passthrough resolver which then will loadbalnace between one backend which should be same behavior as today - in turn we get retries on UNAVAILABLE which is still useful.
This also unifies the dial option construction which makes it easier to reason about.
I also took the liberty to clean up some related stuff.

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
