### PR TITLE
receive: enable ExportCreatedMetric in OTLP translator

### DIFF
--- a/pkg/receive/handler_otlp.go
+++ b/pkg/receive/handler_otlp.go
@@ -161,6 +161,10 @@ func (h *Handler) convertToPrometheusFormat(ctx context.Context, pmetrics pmetri
 		AddMetricSuffixes:         true,
 		DisableTargetInfo:         !h.options.OtlpEnableTargetInfo,
 		PromoteResourceAttributes: h.options.OtlpResourceAttributes,
+		// ExportCreatedMetric preserves StartTimeUnixNano from OTLP as a
+		// _created timestamp, enabling correct counter reset detection by
+		// downstream Prometheus-compatible systems.
+		ExportCreatedMetric: true,
 	}
 
 	annots, err := converter.FromMetrics(ctx, pmetrics, settings)


### PR DESCRIPTION
## What does this do?

Without `ExportCreatedMetric`, the `StartTimeUnixNano` field on OTLP counters and histograms was silently dropped during translation to Prometheus remote write. This breaks counter reset detection for downstream systems that rely on the `_created` timestamp to distinguish a genuine counter reset from a fresh series.

Setting `ExportCreatedMetric: true` in `otlptranslator.Settings` causes the translator to emit a `<metric>_created` series carrying the `StartTimeUnixNano` value, matching the behaviour described in the [Prometheus exposition format spec](https://github.com/prometheus/OpenMetrics/blob/main/specification/OpenMetrics.md#created-timestamps).

Fixes #8637

## Checklist

- [x] `go test ./pkg/receive/` passes
- [x] `gofmt` clean
- [x] Pre-existing failure in `pkg/receive/writecapnp` is unrelated (also fails on unmodified `main`)

Signed-off-by: Ali <alliasgher123@gmail.com>