### PR TITLE
e2e: tweak flaky test parameters

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -141,12 +141,33 @@ jobs:
           skip: ./pkg/ui/*,./pkg/store/6545postingsrepro,./internal/*,./mixin/vendor/*,./.bingo/*,go.mod,go.sum
           ignore_words_list: intrumentation,mmaped,nd,ot,re-use,ser,serie,sme,sudu,tast,te,ans
 
+  build-e2e-image:
+    runs-on: ubuntu-24.04
+    name: Build e2e Docker image
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+      - name: Build e2e Docker image
+        run: make docker-e2e
+
+      - name: Export image
+        run: docker save thanos | gzip > /tmp/thanos-e2e.tar.gz
+
+      - name: Upload image artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: thanos-e2e-image
+          path: /tmp/thanos-e2e.tar.gz
+          retention-days: 1
+
   e2e:
+    needs: build-e2e-image
     strategy:
       fail-fast: false
       matrix:
-        parallelism: [16]
-        index: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
+        parallelism: [8]
+        index: [0, 1, 2, 3, 4, 5, 6, 7]
     runs-on: ubuntu-24.04
     name: Thanos end-to-end tests
     env:
@@ -168,5 +189,14 @@ jobs:
             ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
 
+      - name: Download e2e image artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: thanos-e2e-image
+          path: /tmp
+
+      - name: Load e2e Docker image
+        run: docker load < /tmp/thanos-e2e.tar.gz
+
       - name: Run e2e docker-based tests
-        run: make test-e2e GH_PARALLEL=${{ matrix.parallelism }} GH_INDEX=${{ matrix.index }}
+        run: make test-e2e SKIP_DOCKER_BUILD=1 GH_PARALLEL=${{ matrix.parallelism }} GH_INDEX=${{ matrix.index }}

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -145,8 +145,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        parallelism: [8]
-        index: [0, 1, 2, 3, 4, 5, 6, 7]
+        parallelism: [16]
+        index: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
     runs-on: ubuntu-24.04
     name: Thanos end-to-end tests
     env:

--- a/Makefile
+++ b/Makefile
@@ -335,7 +335,7 @@ test-local-short:
 
 .PHONY: test-e2e
 test-e2e: ## Runs all Thanos e2e docker-based e2e tests from test/e2e. Required access to docker daemon.
-test-e2e: docker-e2e $(GOTESPLIT)
+test-e2e: $(if $(SKIP_DOCKER_BUILD),,docker-e2e) $(GOTESPLIT)
 	@echo ">> cleaning docker environment."
 	@docker system prune -f --volumes
 	@echo ">> cleaning e2e test garbage."

--- a/test/e2e/query_frontend_test.go
+++ b/test/e2e/query_frontend_test.go
@@ -1101,7 +1101,7 @@ func TestQueryFrontendAnalyze(t *testing.T) {
 func TestQueryFrontendReadyOnlyIfDownstreamIsAvailable(t *testing.T) {
 	t.Parallel()
 
-	e, err := e2e.NewDockerEnvironment("qfe-analyze")
+	e, err := e2e.NewDockerEnvironment("qfe-analyzeds")
 	testutil.Ok(t, err)
 	t.Cleanup(e2ethanos.CleanScenario(t, e))
 

--- a/test/e2e/receive_test.go
+++ b/test/e2e/receive_test.go
@@ -901,11 +901,11 @@ test_metric{a="2", b="2"} 1`)
 				MetricCount:    "10",
 				SeriesCount:    "1",
 				MetricInterval: "3600",
-				SeriesInterval: "30",
-				ValueInterval:  "30",
+				SeriesInterval: "5",
+				ValueInterval:  "5",
 
 				RemoteURL:           e2ethanos.RemoteWriteEndpoint(ingestor1.InternalEndpoint("remote-write")),
-				RemoteWriteInterval: "30s",
+				RemoteWriteInterval: "5s",
 				RemoteBatchSize:     "10",
 				RemoteRequestCount:  "5",
 
@@ -923,7 +923,7 @@ test_metric{a="2", b="2"} 1`)
 				ValueInterval:  "3600",
 
 				RemoteURL:           e2ethanos.RemoteWriteEndpoint(ingestor1.InternalEndpoint("remote-write")),
-				RemoteWriteInterval: "30s",
+				RemoteWriteInterval: "5s",
 				RemoteBatchSize:     "5",
 				RemoteRequestCount:  "5",
 
@@ -937,11 +937,11 @@ test_metric{a="2", b="2"} 1`)
 				MetricCount:    "10",
 				SeriesCount:    "1",
 				MetricInterval: "3600",
-				SeriesInterval: "30",
-				ValueInterval:  "30",
+				SeriesInterval: "5",
+				ValueInterval:  "5",
 
 				RemoteURL:           e2ethanos.RemoteWriteEndpoint(ingestor1.InternalEndpoint("remote-write")),
-				RemoteWriteInterval: "30s",
+				RemoteWriteInterval: "5s",
 				RemoteBatchSize:     "10",
 				RemoteRequestCount:  "5",
 
@@ -952,7 +952,7 @@ test_metric{a="2", b="2"} 1`)
 
 		// Here, 4/5 requests are failed due to limiting as we ingest one initial request.
 		// 4 limited requests belong to the exceed-tenant.
-		testutil.Ok(t, i1Runnable.WaitSumMetricsWithOptions(e2emon.Equals(4), []string{"thanos_receive_head_series_limited_requests_total"}, e2emon.WithWaitBackoff(&backoff.Config{Min: 1 * time.Second, Max: 10 * time.Minute, MaxRetries: 200}), e2emon.WaitMissingMetrics()))
+		testutil.Ok(t, i1Runnable.WaitSumMetricsWithOptions(e2emon.Equals(4), []string{"thanos_receive_head_series_limited_requests_total"}, e2emon.WithWaitBackoff(&backoff.Config{Min: 1 * time.Second, Max: 30 * time.Second, MaxRetries: 200}), e2emon.WaitMissingMetrics()))
 
 		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
 		t.Cleanup(cancel)

--- a/test/e2e/receive_test.go
+++ b/test/e2e/receive_test.go
@@ -901,11 +901,11 @@ test_metric{a="2", b="2"} 1`)
 				MetricCount:    "10",
 				SeriesCount:    "1",
 				MetricInterval: "3600",
-				SeriesInterval: "5",
-				ValueInterval:  "5",
+				SeriesInterval: "30",
+				ValueInterval:  "30",
 
 				RemoteURL:           e2ethanos.RemoteWriteEndpoint(ingestor1.InternalEndpoint("remote-write")),
-				RemoteWriteInterval: "5s",
+				RemoteWriteInterval: "30s",
 				RemoteBatchSize:     "10",
 				RemoteRequestCount:  "5",
 
@@ -937,11 +937,11 @@ test_metric{a="2", b="2"} 1`)
 				MetricCount:    "10",
 				SeriesCount:    "1",
 				MetricInterval: "3600",
-				SeriesInterval: "5",
-				ValueInterval:  "5",
+				SeriesInterval: "30",
+				ValueInterval:  "30",
 
 				RemoteURL:           e2ethanos.RemoteWriteEndpoint(ingestor1.InternalEndpoint("remote-write")),
-				RemoteWriteInterval: "5s",
+				RemoteWriteInterval: "30s",
 				RemoteBatchSize:     "10",
 				RemoteRequestCount:  "5",
 

--- a/test/e2e/receive_test.go
+++ b/test/e2e/receive_test.go
@@ -1305,12 +1305,12 @@ func TestReceiveCpnpDelayed(t *testing.T) {
 		},
 	}
 
-	r := e2ethanos.NewReceiveBuilder(e, "router").UseCapnpReplication().WithRouting(2, h).WithArtificialDelay(20 * time.Second).Init()
+	r := e2ethanos.NewReceiveBuilder(e, "router").UseCapnpReplication().WithRouting(2, h).WithArtificialDelay(2 * time.Second).Init()
 	testutil.Ok(t, e2e.StartAndWaitReady(r))
 
 	ts := time.Now()
 
-	for i := range 1000 {
+	for i := range 20 {
 		t.Log("writing a request:", i, time.Now().UnixMilli())
 
 		require.NoError(t, runutil.RetryWithLog(logkit.NewLogfmtLogger(os.Stdout), 1*time.Second, make(<-chan struct{}), func() error {


### PR DESCRIPTION
- Do not wait 10 full minutes
- Write more often
- Build e2e image once instead of in each job (8x)

Maybe this will help reduce flakiness.
