### PR TITLE
*: add CLI argument to configure TLS curves for gRPC servers + remote-write receiver's server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ It is recommend to upgrade the storage components first (Receive, Store, etc.) a
 - [#8691](https://github.com/thanos-io/thanos/pull/8691): Compactor: remove the directory marker objects for some s3 compatible object stores
 - [#8730](https://github.com/thanos-io/thanos/pull/8730): *: add `--grpc-server-tls-ciphers` to configure cipher suites for gRPC servers.
 - [#8730](https://github.com/thanos-io/thanos/pull/8730): Receive: add `--remote-write.server-tls-ciphers` to configure cipher suites for the HTTP server.
+- [#8770](https://github.com/thanos-io/thanos/pull/8770): *: add `--grpc-server-tls-curves` to configure curves for gRPC servers.
+- [#8770](https://github.com/thanos-io/thanos/pull/8770): Receive: add `--remote-write.server-tls-curves` to configure curves for the HTTP server.
 
 ### Changed
 

--- a/cmd/thanos/config.go
+++ b/cmd/thanos/config.go
@@ -36,6 +36,7 @@ type grpcConfig struct {
 	tlsSrvClientCA   string
 	tlsMinVersion    string
 	tlsCiphers       []string
+	tlsCurves        []string
 	gracePeriod      time.Duration
 	maxConnectionAge time.Duration
 }
@@ -59,6 +60,9 @@ func (gc *grpcConfig) registerFlag(cmd extkingpin.FlagClause) *grpcConfig {
 	cmd.Flag("grpc-server-tls-ciphers",
 		"TLS cipher suites for gRPC server (repeatable). If not specified, the default Go cipher suites are used. See https://pkg.go.dev/crypto/tls#pkg-constants for valid values.").
 		StringsVar(&gc.tlsCiphers)
+	cmd.Flag("grpc-server-tls-curves",
+		"TLS curves for gRPC server (repeatable). If not specified, the default Go curves are used. Valid values: CurveP256, CurveP384, CurveP521, X25519.").
+		StringsVar(&gc.tlsCurves)
 	cmd.Flag("grpc-server-max-connection-age", "The grpc server max connection age. This controls how often to re-establish connections and redo TLS handshakes.").
 		Default("60m").DurationVar(&gc.maxConnectionAge)
 	cmd.Flag("grpc-grace-period",

--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -595,7 +595,7 @@ func runQuery(
 	}
 	// Start query (proxy) gRPC StoreAPI.
 	{
-		tlsCfg, err := tls.NewServerConfig(log.With(logger, "protocol", "gRPC"), grpcServerConfig.tlsSrvCert, grpcServerConfig.tlsSrvKey, grpcServerConfig.tlsSrvClientCA, grpcServerConfig.tlsMinVersion, grpcServerConfig.tlsCiphers)
+		tlsCfg, err := tls.NewServerConfig(log.With(logger, "protocol", "gRPC"), grpcServerConfig.tlsSrvCert, grpcServerConfig.tlsSrvKey, grpcServerConfig.tlsSrvClientCA, grpcServerConfig.tlsMinVersion, grpcServerConfig.tlsCiphers, grpcServerConfig.tlsCurves)
 		if err != nil {
 			return errors.Wrap(err, "setup gRPC server")
 		}

--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -153,7 +153,7 @@ func runReceive(
 		}
 	}
 
-	rwTLSConfig, err := tls.NewServerConfig(log.With(logger, "protocol", "HTTP"), conf.rwServerCert, conf.rwServerKey, conf.rwServerClientCA, conf.rwServerTlsMinVersion, conf.rwServerTlsCiphers)
+	rwTLSConfig, err := tls.NewServerConfig(log.With(logger, "protocol", "HTTP"), conf.rwServerCert, conf.rwServerKey, conf.rwServerClientCA, conf.rwServerTlsMinVersion, conf.rwServerTlsCiphers, conf.rwServerTlsCurves)
 	if err != nil {
 		return err
 	}
@@ -346,7 +346,7 @@ func runReceive(
 
 	level.Debug(logger).Log("msg", "setting up gRPC server")
 	{
-		tlsCfg, err := tls.NewServerConfig(log.With(logger, "protocol", "gRPC"), conf.grpcConfig.tlsSrvCert, conf.grpcConfig.tlsSrvKey, conf.grpcConfig.tlsSrvClientCA, conf.grpcConfig.tlsMinVersion, conf.grpcConfig.tlsCiphers)
+		tlsCfg, err := tls.NewServerConfig(log.With(logger, "protocol", "gRPC"), conf.grpcConfig.tlsSrvCert, conf.grpcConfig.tlsSrvKey, conf.grpcConfig.tlsSrvClientCA, conf.grpcConfig.tlsMinVersion, conf.grpcConfig.tlsCiphers, conf.grpcConfig.tlsCurves)
 		if err != nil {
 			return errors.Wrap(err, "setup gRPC server")
 		}
@@ -852,6 +852,7 @@ type receiveConfig struct {
 	rwClientSkipVerify    bool
 	rwServerTlsMinVersion string
 	rwServerTlsCiphers    []string
+	rwServerTlsCurves     []string
 
 	dataDir   string
 	labelStrs []string
@@ -939,6 +940,8 @@ func (rc *receiveConfig) registerFlag(cmd extkingpin.FlagClause) {
 	cmd.Flag("remote-write.server-tls-min-version", "TLS version for the HTTP server, leave blank to default to TLS 1.3, allow values: [\"1.0\", \"1.1\", \"1.2\", \"1.3\"]").Default("1.3").StringVar(&rc.rwServerTlsMinVersion)
 
 	cmd.Flag("remote-write.server-tls-ciphers", "TLS cipher suites for the HTTP server (repeatable). If not specified, the default Go cipher suites are used. See https://pkg.go.dev/crypto/tls#pkg-constants for valid values.").StringsVar(&rc.rwServerTlsCiphers)
+
+	cmd.Flag("remote-write.server-tls-curves", "TLS curves for the HTTP server (repeatable). If not specified, the default Go curves are used. Valid values: CurveP256, CurveP384, CurveP521, X25519.").StringsVar(&rc.rwServerTlsCurves)
 
 	cmd.Flag("remote-write.client-tls-cert", "TLS Certificates to use to identify this client to the server.").Default("").StringVar(&rc.rwClientCert)
 

--- a/cmd/thanos/rule.go
+++ b/cmd/thanos/rule.go
@@ -735,7 +735,7 @@ func runRule(
 	)
 
 	// Start gRPC server.
-	tlsCfg, err := tls.NewServerConfig(log.With(logger, "protocol", "gRPC"), conf.grpc.tlsSrvCert, conf.grpc.tlsSrvKey, conf.grpc.tlsSrvClientCA, conf.grpc.tlsMinVersion, conf.grpc.tlsCiphers)
+	tlsCfg, err := tls.NewServerConfig(log.With(logger, "protocol", "gRPC"), conf.grpc.tlsSrvCert, conf.grpc.tlsSrvKey, conf.grpc.tlsSrvClientCA, conf.grpc.tlsMinVersion, conf.grpc.tlsCiphers, conf.grpc.tlsCurves)
 	if err != nil {
 		return errors.Wrap(err, "setup gRPC server")
 	}

--- a/cmd/thanos/sidecar.go
+++ b/cmd/thanos/sidecar.go
@@ -317,7 +317,7 @@ func runSidecar(
 		}
 
 		tlsCfg, err := tls.NewServerConfig(log.With(logger, "protocol", "gRPC"),
-			conf.grpc.tlsSrvCert, conf.grpc.tlsSrvKey, conf.grpc.tlsSrvClientCA, conf.grpc.tlsMinVersion, conf.grpc.tlsCiphers)
+			conf.grpc.tlsSrvCert, conf.grpc.tlsSrvKey, conf.grpc.tlsSrvClientCA, conf.grpc.tlsMinVersion, conf.grpc.tlsCiphers, conf.grpc.tlsCurves)
 		if err != nil {
 			return errors.Wrap(err, "setup gRPC server")
 		}

--- a/cmd/thanos/store.go
+++ b/cmd/thanos/store.go
@@ -555,7 +555,7 @@ func runStore(
 
 	// Start query (proxy) gRPC StoreAPI.
 	{
-		tlsCfg, err := tls.NewServerConfig(log.With(logger, "protocol", "gRPC"), conf.grpcConfig.tlsSrvCert, conf.grpcConfig.tlsSrvKey, conf.grpcConfig.tlsSrvClientCA, conf.grpcConfig.tlsMinVersion, conf.grpcConfig.tlsCiphers)
+		tlsCfg, err := tls.NewServerConfig(log.With(logger, "protocol", "gRPC"), conf.grpcConfig.tlsSrvCert, conf.grpcConfig.tlsSrvKey, conf.grpcConfig.tlsSrvClientCA, conf.grpcConfig.tlsMinVersion, conf.grpcConfig.tlsCiphers, conf.grpcConfig.tlsCurves)
 		if err != nil {
 			return errors.Wrap(err, "setup gRPC server")
 		}

--- a/docs/components/query.md
+++ b/docs/components/query.md
@@ -352,6 +352,11 @@ Flags:
                                  the default Go cipher suites are used.
                                  See https://pkg.go.dev/crypto/tls#pkg-constants
                                  for valid values.
+      --grpc-server-tls-curves=GRPC-SERVER-TLS-CURVES ...
+                                 TLS curves for gRPC server (repeatable). If
+                                 not specified, the default Go curves are used.
+                                 Valid values: CurveP256, CurveP384, CurveP521,
+                                 X25519.
       --grpc-server-max-connection-age=60m
                                  The grpc server max connection age. This
                                  controls how often to re-establish connections

--- a/docs/components/receive.md
+++ b/docs/components/receive.md
@@ -448,6 +448,11 @@ Flags:
                                  the default Go cipher suites are used.
                                  See https://pkg.go.dev/crypto/tls#pkg-constants
                                  for valid values.
+      --grpc-server-tls-curves=GRPC-SERVER-TLS-CURVES ...
+                                 TLS curves for gRPC server (repeatable). If
+                                 not specified, the default Go curves are used.
+                                 Valid values: CurveP256, CurveP384, CurveP521,
+                                 X25519.
       --grpc-server-max-connection-age=60m
                                  The grpc server max connection age. This
                                  controls how often to re-establish connections
@@ -487,6 +492,11 @@ Flags:
                                  the default Go cipher suites are used.
                                  See https://pkg.go.dev/crypto/tls#pkg-constants
                                  for valid values.
+      --remote-write.server-tls-curves=REMOTE-WRITE.SERVER-TLS-CURVES ...
+                                 TLS curves for the HTTP server (repeatable). If
+                                 not specified, the default Go curves are used.
+                                 Valid values: CurveP256, CurveP384, CurveP521,
+                                 X25519.
       --remote-write.client-tls-cert=""
                                  TLS Certificates to use to identify this client
                                  to the server.

--- a/docs/components/rule.md
+++ b/docs/components/rule.md
@@ -322,6 +322,11 @@ Flags:
                                  the default Go cipher suites are used.
                                  See https://pkg.go.dev/crypto/tls#pkg-constants
                                  for valid values.
+      --grpc-server-tls-curves=GRPC-SERVER-TLS-CURVES ...
+                                 TLS curves for gRPC server (repeatable). If
+                                 not specified, the default Go curves are used.
+                                 Valid values: CurveP256, CurveP384, CurveP521,
+                                 X25519.
       --grpc-server-max-connection-age=60m
                                  The grpc server max connection age. This
                                  controls how often to re-establish connections

--- a/docs/components/sidecar.md
+++ b/docs/components/sidecar.md
@@ -148,6 +148,11 @@ Flags:
                                  the default Go cipher suites are used.
                                  See https://pkg.go.dev/crypto/tls#pkg-constants
                                  for valid values.
+      --grpc-server-tls-curves=GRPC-SERVER-TLS-CURVES ...
+                                 TLS curves for gRPC server (repeatable). If
+                                 not specified, the default Go curves are used.
+                                 Valid values: CurveP256, CurveP384, CurveP521,
+                                 X25519.
       --grpc-server-max-connection-age=60m
                                  The grpc server max connection age. This
                                  controls how often to re-establish connections

--- a/docs/components/store.md
+++ b/docs/components/store.md
@@ -101,6 +101,11 @@ Flags:
                                  the default Go cipher suites are used.
                                  See https://pkg.go.dev/crypto/tls#pkg-constants
                                  for valid values.
+      --grpc-server-tls-curves=GRPC-SERVER-TLS-CURVES ...
+                                 TLS curves for gRPC server (repeatable). If
+                                 not specified, the default Go curves are used.
+                                 Valid values: CurveP256, CurveP384, CurveP521,
+                                 X25519.
       --grpc-server-max-connection-age=60m
                                  The grpc server max connection age. This
                                  controls how often to re-establish connections

--- a/pkg/tls/options.go
+++ b/pkg/tls/options.go
@@ -20,7 +20,7 @@ import (
 )
 
 // NewServerConfig provides new server TLS configuration.
-func NewServerConfig(logger log.Logger, certPath, keyPath, clientCA, tlsMinVersion string, ciphers []string) (*tls.Config, error) {
+func NewServerConfig(logger log.Logger, certPath, keyPath, clientCA, tlsMinVersion string, ciphers []string, curves []string) (*tls.Config, error) {
 	if keyPath == "" && certPath == "" {
 		if clientCA != "" {
 			return nil, errors.New("when a client CA is used a server key and certificate must also be provided")
@@ -50,6 +50,12 @@ func NewServerConfig(logger log.Logger, certPath, keyPath, clientCA, tlsMinVersi
 		return nil, err
 	}
 	tlsCfg.CipherSuites = cipherSuiteIDs
+
+	curveIDs, err := getCurveIDs(curves)
+	if err != nil {
+		return nil, err
+	}
+	tlsCfg.CurvePreferences = curveIDs
 
 	// Certificate is loaded during server startup to check for any errors.
 	certificate, err := tls.LoadX509KeyPair(certPath, keyPath)
@@ -230,17 +236,49 @@ func getCipherSuiteIDs(ciphers []string) ([]uint16, error) {
 	for _, cs := range supported {
 		cipherMap[cs.Name] = cs.ID
 	}
+	validNames := make([]string, 0, len(cipherMap))
+	for n := range cipherMap {
+		validNames = append(validNames, n)
+	}
+	sort.Strings(validNames)
 
 	ids := make([]uint16, 0, len(ciphers))
 	for _, name := range ciphers {
 		id, ok := cipherMap[name]
 		if !ok {
-			validNames := make([]string, 0, len(cipherMap))
-			for n := range cipherMap {
-				validNames = append(validNames, n)
-			}
-			sort.Strings(validNames)
 			return nil, errors.New(fmt.Sprintf("invalid cipher suite: %s, valid values are %s", name, strings.Join(validNames, ", ")))
+		}
+		ids = append(ids, id)
+	}
+	return ids, nil
+}
+
+func getCurveIDs(curves []string) ([]tls.CurveID, error) {
+	if len(curves) == 0 {
+		return nil, nil
+	}
+
+	// Manual mapping since crypto/tls doesn't provide enumeration
+	curveMap := map[string]tls.CurveID{
+		"CurveP256":          tls.CurveP256,
+		"CurveP384":          tls.CurveP384,
+		"CurveP521":          tls.CurveP521,
+		"X25519":             tls.X25519,
+		"X25519MLKEM768":     tls.X25519MLKEM768,
+		"SecP256r1MLKEM768":  tls.SecP256r1MLKEM768,
+		"SecP384r1MLKEM1024": tls.SecP384r1MLKEM1024,
+	}
+	validNames := make([]string, 0, len(curveMap))
+	for n := range curveMap {
+		validNames = append(validNames, n)
+	}
+	sort.Strings(validNames)
+
+	ids := make([]tls.CurveID, 0, len(curves))
+	for _, name := range curves {
+		id, ok := curveMap[name]
+		if !ok {
+			return nil, errors.New(fmt.Sprintf("invalid curve: %s, valid values are %s", name, strings.Join(validNames, ", ")))
 		}
 		ids = append(ids, id)
 	}

--- a/pkg/tls/options_test.go
+++ b/pkg/tls/options_test.go
@@ -84,6 +84,78 @@ func TestGetCipherSuiteIDs(t *testing.T) {
 	}
 }
 
+func TestGetCurveIDs(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       []string
+		wantIDs     []tls.CurveID
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:    "empty input returns nil",
+			input:   []string{},
+			wantIDs: nil,
+		},
+		{
+			name:    "nil input returns nil",
+			input:   nil,
+			wantIDs: nil,
+		},
+		{
+			name:    "single valid curve",
+			input:   []string{"X25519"},
+			wantIDs: []tls.CurveID{tls.X25519},
+		},
+		{
+			name:    "multiple valid curves preserves order",
+			input:   []string{"CurveP384", "X25519"},
+			wantIDs: []tls.CurveID{tls.CurveP384, tls.X25519},
+		},
+		{
+			name:    "all valid curves",
+			input:   []string{"CurveP256", "CurveP384", "CurveP521", "X25519"},
+			wantIDs: []tls.CurveID{tls.CurveP256, tls.CurveP384, tls.CurveP521, tls.X25519},
+		},
+		{
+			name:    "duplicate curve returns duplicate IDs",
+			input:   []string{"CurveP256", "CurveP256"},
+			wantIDs: []tls.CurveID{tls.CurveP256, tls.CurveP256},
+		},
+		{
+			name:        "unknown curve returns error",
+			input:       []string{"INVALID_CURVE"},
+			wantErr:     true,
+			errContains: "INVALID_CURVE",
+		},
+		{
+			name:        "error message contains valid curve names",
+			input:       []string{"BAD_CURVE"},
+			wantErr:     true,
+			errContains: "CurveP256",
+		},
+		{
+			name:        "valid curve followed by invalid returns error",
+			input:       []string{"X25519", "UNKNOWN"},
+			wantErr:     true,
+			errContains: "UNKNOWN",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ids, err := getCurveIDs(tc.input)
+			if tc.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.errContains)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantIDs, ids)
+		})
+	}
+}
+
 func TestTlsOptions(t *testing.T) {
 	var tests = []struct {
 		input  string

--- a/test/e2e/tls_test.go
+++ b/test/e2e/tls_test.go
@@ -55,7 +55,7 @@ func TestGRPCServerCertAutoRotate(t *testing.T) {
 	genCerts(t, certSrv, keySrv, caClt)
 	genCerts(t, certClt, keyClt, caSrv)
 
-	configSrv, err := thTLS.NewServerConfig(logger, certSrv, keySrv, caSrv, tlsMinVersion, nil)
+	configSrv, err := thTLS.NewServerConfig(logger, certSrv, keySrv, caSrv, tlsMinVersion, nil, nil)
 	testutil.Ok(t, err)
 
 	srv := grpc.NewServer(grpc.KeepaliveParams(keepalive.ServerParameters{MaxConnectionAge: 1 * time.Millisecond}), grpc.Creds(credentials.NewTLS(configSrv)))
@@ -117,7 +117,7 @@ func TestGRPCServerTLSCiphersAndVersions(t *testing.T) {
 	genCerts(t, certSrv, keySrv, caClt)
 	genCerts(t, certClt, keyClt, caSrv)
 
-	configSrv, err := thTLS.NewServerConfig(logger, certSrv, keySrv, caSrv, tlsMinVersion, []string{"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256", "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"})
+	configSrv, err := thTLS.NewServerConfig(logger, certSrv, keySrv, caSrv, tlsMinVersion, []string{"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256", "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"}, nil)
 	testutil.Ok(t, err)
 
 	srv := grpc.NewServer(grpc.KeepaliveParams(keepalive.ServerParameters{MaxConnectionAge: 1 * time.Millisecond}), grpc.Creds(credentials.NewTLS(configSrv)))
@@ -186,6 +186,83 @@ func TestGRPCServerTLSCiphersAndVersions(t *testing.T) {
 		// Configure TLS version 1.1 only.
 		configClt.MinVersion = tls.VersionTLS11
 		configClt.MaxVersion = tls.VersionTLS11
+
+		conn, err := grpc.NewClient(addr, grpc.WithConnectParams(grpc.ConnectParams{MinConnectTimeout: 1 * time.Minute}), grpc.WithTransportCredentials(credentials.NewTLS(configClt)))
+		testutil.Ok(t, err)
+		defer func() {
+			testutil.Ok(t, conn.Close())
+		}()
+		clt := pb.NewEchoClient(conn)
+
+		// Check a bad state.
+		_, err = clt.UnaryEcho(context.Background(), &pb.EchoRequest{Message: expMessage})
+		testutil.NotOk(t, err)
+	})
+}
+
+func TestGRPCServerTLSCurves(t *testing.T) {
+	defer leaktest.CheckTimeout(t, 10*time.Second)() // To see whether any goroutines leaked.
+
+	logger := log.NewLogfmtLogger(os.Stderr)
+	expMessage := "hello world"
+
+	tmpDirClt := t.TempDir()
+	caClt := filepath.Join(tmpDirClt, "ca")
+	certClt := filepath.Join(tmpDirClt, "cert")
+	keyClt := filepath.Join(tmpDirClt, "key")
+
+	tmpDirSrv := t.TempDir()
+	caSrv := filepath.Join(tmpDirSrv, "ca")
+	certSrv := filepath.Join(tmpDirSrv, "cert")
+	keySrv := filepath.Join(tmpDirSrv, "key")
+	tlsMinVersion := "1.2"
+
+	genCerts(t, certSrv, keySrv, caClt)
+	genCerts(t, certClt, keyClt, caSrv)
+
+	configSrv, err := thTLS.NewServerConfig(logger, certSrv, keySrv, caSrv, tlsMinVersion, nil, []string{"X25519", "CurveP521"})
+	testutil.Ok(t, err)
+
+	srv := grpc.NewServer(grpc.KeepaliveParams(keepalive.ServerParameters{MaxConnectionAge: 1 * time.Millisecond}), grpc.Creds(credentials.NewTLS(configSrv)))
+
+	pb.RegisterEchoServer(srv, &ecServer{})
+	p, err := e2eutil.FreePort()
+	testutil.Ok(t, err)
+	addr := fmt.Sprint("localhost:", p)
+	lis, err := net.Listen("tcp", addr)
+	testutil.Ok(t, err)
+
+	go func() {
+		testutil.Ok(t, srv.Serve(lis))
+	}()
+	defer func() { srv.Stop() }()
+	time.Sleep(50 * time.Millisecond) // Wait for the server to start.
+
+	t.Run("compatible configurations", func(t *testing.T) {
+		// Setup the connection and the client.
+		configClt, err := thTLS.NewClientConfig(logger, certClt, keyClt, caClt, serverName, false)
+		testutil.Ok(t, err)
+
+		configClt.CurvePreferences = []tls.CurveID{tls.CurveP521}
+
+		conn, err := grpc.NewClient(addr, grpc.WithConnectParams(grpc.ConnectParams{MinConnectTimeout: 1 * time.Minute}), grpc.WithTransportCredentials(credentials.NewTLS(configClt)))
+		testutil.Ok(t, err)
+		defer func() {
+			testutil.Ok(t, conn.Close())
+		}()
+		clt := pb.NewEchoClient(conn)
+
+		// Check a good state.
+		resp, err := clt.UnaryEcho(context.Background(), &pb.EchoRequest{Message: expMessage})
+		testutil.Ok(t, err)
+		testutil.Equals(t, expMessage, resp.Message)
+	})
+
+	t.Run("curves mismatch", func(t *testing.T) {
+		configClt, err := thTLS.NewClientConfig(logger, certClt, keyClt, caClt, serverName, false)
+		testutil.Ok(t, err)
+
+		configClt.CurvePreferences = []tls.CurveID{tls.CurveP256}
 
 		conn, err := grpc.NewClient(addr, grpc.WithConnectParams(grpc.ConnectParams{MinConnectTimeout: 1 * time.Minute}), grpc.WithTransportCredentials(credentials.NewTLS(configClt)))
 		testutil.Ok(t, err)
@@ -294,6 +371,6 @@ func TestInvalidCertAndKey(t *testing.T) {
 	keySrv := filepath.Join(tmpDirSrv, "key")
 	tlsMinVersion := "1.3"
 	// Certificate and key are not present in the above path
-	_, err := thTLS.NewServerConfig(logger, certSrv, keySrv, caSrv, tlsMinVersion, nil)
+	_, err := thTLS.NewServerConfig(logger, certSrv, keySrv, caSrv, tlsMinVersion, nil, nil)
 	testutil.NotOk(t, err)
 }


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [X] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Closes #8685

* Extend NewServerConfig() to configure TLS curves
* Add `--grpc-server-tls-curves` CLI argument to configure gRPC servers.
* Add `--remote-write.server-tls-curves` CLI arguments to configure the remote-write receiver server.

## Verification

Unit + end-to-end tests added.
