### PR TITLE
fix: adding required permissions to top level and jobs in the workflow

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -20,14 +20,15 @@ on:
   schedule:
     - cron: '30 12 * * 1'
 
-permissions:  
-  contents: read
-  security-events: write
+permissions: {}
 
 jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
Currently the score for the Token Permissions is 9 because a few top level permissions and a job level permission are missing in the workflows. With this change, the score will improve to 10, since the workflow jobs will run with the minimal permissions. The PR retains conditions like `write` only at the job level, where it is necessary.

Fixes #8771

* [ ] ~I added CHANGELOG entry for this change.~
* [x] Change is not relevant to the end user.

## Changes

- Added top-level `permissions: contents: read` to workflows that were missing it (`docs.yaml`, `go.yaml`, `mixin.yaml`, `react.yml`, `container-version.yaml`, `codeql-analysis.yml`).
- Tightened `security-events: write` in `codeql-analysis.yml` by moving it to the job level where it is required, keeping the top level minimal.
- Scoped the `contents: write` permission in `container-version.yaml` to only the job that requires it, keeping the top level minimal.

## Verification

- This is a CI-only change affecting GitHub Actions workflow permissions.
- Verified each workflow still has the permissions required for its jobs (read access for checkout, `security-events: write` for CodeQL upload at the job level, `contents: write` for the container version job that needs it).
- Re-running OSSF Scorecard's Token-Permissions check against the updated workflows should report score 10.
