### PR TITLE
ci: upgrade Node.js from 14 to 20 in react workflow

### DIFF
--- a/.github/workflows/react.yml
+++ b/.github/workflows/react.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [ '14' ]
+        node: [ '20' ]
     name: React UI test on Node ${{ matrix.node }}
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary

- Node.js 14 reached end-of-life on April 30, 2023 and no longer receives security patches or bug fixes.
- Bumps the `node` matrix entry in `.github/workflows/react.yml` from `14` to `20` (current LTS).

## Test plan

- [ ] React workflow runs successfully on Node 20.
- [ ] `make check-react-app` and `make react-app-test` pass.