### PR TITLE
ci: align Go version to 1.26.x across all workflows

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -44,7 +44,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
       with:
-        go-version: 1.22.x
+        go-version: 1.26.x
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/mixin.yaml
+++ b/.github/workflows/mixin.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
         with:
-          go-version: 1.22.x
+          go-version: 1.26.x
 
       - name: Generate
         run: make examples
@@ -37,7 +37,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
         with:
-          go-version: 1.22.x
+          go-version: 1.26.x
 
       - name: Format
         run: |


### PR DESCRIPTION
## Summary

- `codeql-analysis.yml` and `mixin.yaml` were pinned to Go `1.22.x` while `go.yaml` (the primary workflow) uses `1.26.x`, which also matches the `go.mod` directive (`go 1.26.0`).
- Inconsistent toolchain versions across jobs can cause different lint, vet, and build results - a failure in CodeQL or mixin that passes the main workflow (or vice versa) becomes hard to diagnose.
- Aligns all three workflows to `1.26.x`.

## Test plan

- [ ] CodeQL analysis workflow builds successfully with Go 1.26.x.
- [ ] Mixin generate and lint jobs pass with Go 1.26.x.