### PR TITLE
build: remove DOCKER_CLI_EXPERIMENTAL from docker-manifest target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -234,8 +234,8 @@ docker-e2e:
 .PHONY: docker-manifest
 docker-manifest:
 	@echo ">> creating and pushing manifest"
-	@DOCKER_CLI_EXPERIMENTAL=enabled docker manifest create -a "$(DOCKER_IMAGE_REPO):$(DOCKER_IMAGE_TAG)" $(foreach ARCH,$(DOCKER_ARCHS),$(DOCKER_IMAGE_REPO)-linux-$(ARCH):$(DOCKER_IMAGE_TAG))
-	@DOCKER_CLI_EXPERIMENTAL=enabled docker manifest push "$(DOCKER_IMAGE_REPO):$(DOCKER_IMAGE_TAG)"
+	@docker manifest create -a "$(DOCKER_IMAGE_REPO):$(DOCKER_IMAGE_TAG)" $(foreach ARCH,$(DOCKER_ARCHS),$(DOCKER_IMAGE_REPO)-linux-$(ARCH):$(DOCKER_IMAGE_TAG))
+	@docker manifest push "$(DOCKER_IMAGE_REPO):$(DOCKER_IMAGE_TAG)"
 
 .PHONY: docker-push $(PUSH_DOCKER_ARCHS)
 docker-push: ## Pushes Thanos docker image build to "$(DOCKER_IMAGE_REPO):$(DOCKER_IMAGE_TAG)".


### PR DESCRIPTION
## Summary

- `docker manifest` has been stable since Docker 20.10 (December 2020) and does not require `DOCKER_CLI_EXPERIMENTAL=enabled` anymore.
- The flag is a no-op on any Docker version that CI actually runs, but it visually signals that the feature is experimental, which is misleading.
- Removes the prefix from both `docker manifest create` and `docker manifest push` in the `docker-manifest` Makefile target.

## Test plan

- [ ] `make docker-manifest` succeeds without the flag on a modern Docker version.