### PR TITLE
docs: update Go minimum version requirement to 1.26.x

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,7 @@ The following section explains various suggestions and procedures to note during
 
 * It is strongly recommended that you use Linux distributions systems or macOS for development.
 * Running [WSL 2 (on Windows)](https://learn.microsoft.com/en-us/windows/wsl/) is also possible. Note that if during development you run a local Kubernetes cluster and have a Service with `service.spec.sessionAffinity: ClientIP`, it will break things until it's removed[^windows_xt_recent].
-* Go 1.22.x or higher.
+* Go 1.26.x or higher.
 * Docker (to run e2e tests)
 * For React UI, you will need a working NodeJS environment and the npm package manager to compile the Web UI assets.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -40,7 +40,7 @@ Thanos can **not** be downloaded nor installed via the `go get` or `go install` 
 
 Thanos uses the directive *replace*. The reason is to provide a way to unblock ourselves promptly while also being flexible in the packages that we (re)use. Support for `go install` is not likely at this point.
 
-If you want to build Thanos from source you would need a working installation of the Go 1.18+ [toolchain](https://github.com/golang/tools) (`GOPATH`, `PATH=${GOPATH}/bin:${PATH}`). Next one should make a clone of our repository:
+If you want to build Thanos from source you would need a working installation of the Go 1.26+ [toolchain](https://github.com/golang/tools) (`GOPATH`, `PATH=${GOPATH}/bin:${PATH}`). Next one should make a clone of our repository:
 
 ```
 git clone git@github.com:thanos-io/thanos.git


### PR DESCRIPTION
## Summary

- `CONTRIBUTING.md` listed `Go 1.22.x or higher` as the minimum requirement.
- `docs/getting-started.md` listed `Go 1.18+`.
- Both are stale: `go.mod` specifies `go 1.26.0` and all main CI jobs run `1.26.x`.
- Updates both files to reflect the actual minimum version.

## Test plan

- [ ] No functional changes - documentation only.