### PR TITLE
ci: add Dockerfile lint job using hadolint

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -141,6 +141,29 @@ jobs:
           skip: ./pkg/ui/*,./pkg/store/6545postingsrepro,./internal/*,./mixin/vendor/*,./.bingo/*,go.mod,go.sum
           ignore_words_list: intrumentation,mmaped,nd,ot,re-use,ser,serie,sme,sudu,tast,te,ans
 
+  dockerfile-lint:
+    runs-on: ubuntu-latest
+    name: Lint Dockerfiles
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - name: Lint Dockerfile
+        uses: hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5 # v3.3.0
+        with:
+          dockerfile: Dockerfile
+      - name: Lint Dockerfile.multi-stage
+        uses: hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5 # v3.3.0
+        with:
+          dockerfile: Dockerfile.multi-stage
+      - name: Lint Dockerfile.multi-arch
+        uses: hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5 # v3.3.0
+        with:
+          dockerfile: Dockerfile.multi-arch
+      - name: Lint Dockerfile.e2e-tests
+        uses: hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5 # v3.3.0
+        with:
+          dockerfile: Dockerfile.e2e-tests
+
   build-e2e-image:
     runs-on: ubuntu-24.04
     name: Build e2e Docker image

--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,0 +1,4 @@
+ignore:
+  # Dockerfile.multi-stage installs alpine-sdk in a build stage; pinning an
+  # exact apk package version is not practical here.
+  - DL3018


### PR DESCRIPTION
## Summary

- The repo has four Dockerfiles (`Dockerfile`, `Dockerfile.multi-stage`, `Dockerfile.multi-arch`, `Dockerfile.e2e-tests`) but none were validated in CI.
- Syntax errors or best-practice violations in any of them would only surface at build or release time.
- Adds a `dockerfile-lint` job to `go.yaml` that runs [hadolint](https://github.com/hadolint/hadolint) against all four files on every push and pull request.

## Test plan

- [ ] `dockerfile-lint` job passes in CI for all four Dockerfiles.
- [ ] Any intentional hadolint rule suppressions (e.g. `# hadolint ignore=DL3008`) are added inline if needed.