### PR TITLE
ci: add concurrency groups to cancel stale workflow runs

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -7,8 +7,12 @@ on:
     tags:
   pull_request:
 
-permissions:  
+permissions:
   contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   check:

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -7,8 +7,12 @@ on:
     tags:
   pull_request:
 
-permissions:  
+permissions:
   contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   unit:

--- a/.github/workflows/mixin.yaml
+++ b/.github/workflows/mixin.yaml
@@ -6,8 +6,12 @@ on:
   pull_request:
     branches: [main]
 
-permissions:  
+permissions:
   contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   build:

--- a/.github/workflows/react.yml
+++ b/.github/workflows/react.yml
@@ -6,8 +6,12 @@ on:
       - main
   pull_request:
 
-permissions:  
+permissions:
   contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   build:


### PR DESCRIPTION
## Summary

- Without concurrency groups, every push to a PR queues a new workflow run while the previous ones keep running. On a busy PR with several fixup commits this wastes significant CI minutes and produces interleaved, confusing results.
- Adds a top-level `concurrency` block to `go.yaml`, `react.yml`, `docs.yaml`, and `mixin.yaml`.
- Groups runs by `workflow + ref` so each branch/PR has at most one active run per workflow at a time.
- Sets `cancel-in-progress: true` for all refs except `main`, so merge-commit runs are always recorded in full.


## Test plan

- [ ] Push two commits to a PR in quick succession and verify the first run is cancelled when the second starts.
- [ ] Verify pushes to `main` are not cancelled.