### PR TITLE
ci: add explicit timeout-minutes to all workflow jobs

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -13,6 +13,7 @@ permissions:
 jobs:
   check:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     name: Documentation check
     env:
       GOBIN: /tmp/.bin

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -13,6 +13,7 @@ permissions:
 jobs:
   unit:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     name: Thanos unit tests
     env:
       THANOS_TEST_OBJSTORE_SKIP: GCS,S3,AZURE,COS,ALIYUNOSS,BOS,OCI,OBS,SWIFT
@@ -45,6 +46,7 @@ jobs:
 
   cross-build-check:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     name: Go build for different platforms
     env:
       GOBIN: /tmp/.bin
@@ -72,6 +74,7 @@ jobs:
 
   build-stringlabels:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     name: Go build with -tags=stringlabels
     env:
       GOBIN: /tmp/.bin
@@ -99,6 +102,7 @@ jobs:
 
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     name: Linters (Static Analysis) for Go
     env:
       GOBIN: /tmp/.bin
@@ -129,6 +133,7 @@ jobs:
 
   codespell:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     name: Check misspelled words
     steps:
       - name: Checkout code
@@ -143,6 +148,7 @@ jobs:
 
   build-e2e-image:
     runs-on: ubuntu-24.04
+    timeout-minutes: 15
     name: Build e2e Docker image
     steps:
       - name: Checkout code
@@ -169,6 +175,7 @@ jobs:
         parallelism: [8]
         index: [0, 1, 2, 3, 4, 5, 6, 7]
     runs-on: ubuntu-24.04
+    timeout-minutes: 30
     name: Thanos end-to-end tests
     env:
       GOBIN: /tmp/.bin

--- a/.github/workflows/mixin.yaml
+++ b/.github/workflows/mixin.yaml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout code
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
@@ -29,6 +30,7 @@ jobs:
 
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     name: Linters (Static Analysis) for Jsonnet (mixin)
     steps:
       - name: Checkout code

--- a/.github/workflows/react.yml
+++ b/.github/workflows/react.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     strategy:
       matrix:
         node: [ '14' ]


### PR DESCRIPTION
## Summary

Without job-level timeouts a hung or runaway job can hold a GitHub Actions runner for up to 6 hours (the platform default), blocking other work and inflating costs. We hit the impact of this directly - the `TestReceive/multitenant_active_series_limiting` e2e test consumed the runner until the global Go test `-timeout 10m` fired, with no safety net above that at the job level.

Adds `timeout-minutes` to every job across `go.yaml`, `react.yml`, `docs.yaml`, and `mixin.yaml`. Values are set conservatively above observed p95 durations from recent CI runs:

| Job | Timeout | Observed |
|---|---|---|
| unit tests | 30 min | ~17 min |
| cross-build | 20 min | ~14 min |
| stringlabels build | 10 min | ~3 min |
| lint | 15 min | ~6 min |
| codespell | 5 min | <1 min |
| build-e2e-image | 15 min | ~4 min |
| e2e (per shard) | 30 min | ~7 min typical, ~15 min worst |
| react | 15 min | ~2 min |
| docs | 15 min | ~6 min |
| mixin build/lint | 10 min | <1 min |


## Test plan

- [ ] All jobs complete within their timeout on a normal run.
- [ ] A deliberately hung job is killed at the timeout rather than running for hours.