### PR TITLE
ci: add path filters to skip CI on unrelated changes

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -6,6 +6,12 @@ on:
       - main
     tags:
   pull_request:
+    paths:
+      - 'docs/**'
+      - 'website/**'
+      - '*.md'
+      - 'CONTRIBUTING.md'
+      - '.github/workflows/docs.yaml'
 
 permissions:  
   contents: read

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -6,6 +6,14 @@ on:
       - main
     tags:
   pull_request:
+    paths:
+      - '**.go'
+      - 'go.mod'
+      - 'go.sum'
+      - 'Makefile'
+      - '.bingo/**'
+      - 'Dockerfile*'
+      - '.github/workflows/go.yaml'
 
 permissions:  
   contents: read

--- a/.github/workflows/mixin.yaml
+++ b/.github/workflows/mixin.yaml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    paths:
+      - 'mixin/**'
+      - '.github/workflows/mixin.yaml'
 
 permissions:  
   contents: read

--- a/.github/workflows/react.yml
+++ b/.github/workflows/react.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
   pull_request:
+    paths:
+      - 'pkg/ui/**'
+      - '.github/workflows/react.yml'
 
 permissions:  
   contents: read


### PR DESCRIPTION
## Summary

Every PR currently triggers all workflows regardless of what files changed. A documentation fix kicks off the full Go build, lint, unit tests, and all 8 e2e shards - spending ~30 minutes of runner time for a change that cannot affect Go behaviour.

Adds `paths:` filters to the `pull_request:` trigger of each workflow so a run is only started when a relevant file changes:

| Workflow | Triggers on |
|---|---|
| `go.yaml` | `**.go`, `go.mod`, `go.sum`, `Makefile`, `.bingo/**`, `Dockerfile*`, `go.yaml` itself |
| `react.yml` | `pkg/ui/**`, `react.yml` itself |
| `docs.yaml` | `docs/**`, `website/**`, `*.md`, `CONTRIBUTING.md`, `docs.yaml` itself |
| `mixin.yaml` | `mixin/**`, `mixin.yaml` itself |

Pushes to `main` remain unrestricted - no path filter is applied there, so merge-commit CI always runs fully.


## Test plan

- [ ] A PR that only modifies `docs/` does not trigger `go.yaml` or `react.yml`.
- [ ] A PR that only modifies `pkg/ui/` does not trigger `go.yaml`.
- [ ] A PR that modifies a `.go` file triggers `go.yaml` as expected.
- [ ] A push to `main` triggers all workflows regardless of changed files.