### PR TITLE
ci: add workflow_dispatch to allow manual CI triggering

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -6,6 +6,7 @@ on:
       - main
     tags:
   pull_request:
+  workflow_dispatch:
 
 permissions:  
   contents: read

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -6,6 +6,7 @@ on:
       - main
     tags:
   pull_request:
+  workflow_dispatch:
 
 permissions:  
   contents: read

--- a/.github/workflows/mixin.yaml
+++ b/.github/workflows/mixin.yaml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 permissions:  
   contents: read

--- a/.github/workflows/react.yml
+++ b/.github/workflows/react.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
   pull_request:
+  workflow_dispatch:
 
 permissions:  
   contents: read


### PR DESCRIPTION
## Summary

Currently only `container-version.yaml` supports manual triggering via the GitHub Actions UI. The four main workflows (`go`, `react`, `docs`, `mixin`) can only run on `push` or `pull_request` events.

This is a real friction point - when a flaky e2e test fails on a PR, the only way to retry CI today is to push a dummy/amended commit, which pollutes the commit history (we had to do exactly this on PR #8775 where `TestReceive/multitenant_active_series_limiting` timed out due to CI load, not a code bug).

Adding `workflow_dispatch:` to all four workflows lets any maintainer or contributor trigger a re-run directly from the **Actions** tab without touching the branch.


## Test plan

- [ ] Navigate to Actions tab, select the `go` workflow, and confirm "Run workflow" button is available.
- [ ] Trigger a manual run and confirm all jobs execute normally.