### PR TITLE
docs: upgrade http links to https in docs and source comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 NOTE: As semantic versioning states all 0.y.z releases can contain breaking changes in API (flags, grpc API, any backward compatibility)
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -10,4 +10,4 @@ Project maintainers who do not follow or enforce the Code of Conduct in good fai
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant](http://contributor-covenant.org), version 1.4, available at [http://contributor-covenant.org/version/1/4](http://contributor-covenant.org/version/1/4/)
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 1.4, available at [https://www.contributor-covenant.org/version/1/4](https://www.contributor-covenant.org/version/1/4/)

--- a/docs/contributing/coding-style-guide.md
+++ b/docs/contributing/coding-style-guide.md
@@ -273,7 +273,7 @@ func copyIntoSliceAndMap(biggy []string) (a []string, b map[string]struct{})
 
 To extend the above point, there are cases where you don't need to allocate new space in memory all the time. If you repeat the certain operation on slices sequentially and you just release the array on every iteration, it's reasonable to reuse the underlying array for those. This can give quite enormous gains for critical paths. Unfortunately, currently there is no way to reuse the underlying array for maps.
 
-NOTE: Why you cannot just allocate slice and release and in new iteration allocate and release again etc? Go should know it has available space and just reuses that no? (: Well, it's not that easy. TL;DR is that Go Garbage Collection runs periodically or on certain cases (big heap), but definitely not on every iteration of your loop (that would be super slow). Read more in details [here](http://web.archive.org/web/20220511045405/https://about.sourcegraph.com/go/gophercon-2018-allocator-wrestling/).
+NOTE: Why you cannot just allocate slice and release and in new iteration allocate and release again etc? Go should know it has available space and just reuses that no? (: Well, it's not that easy. TL;DR is that Go Garbage Collection runs periodically or on certain cases (big heap), but definitely not on every iteration of your loop (that would be super slow). Read more in details [here](https://web.archive.org/web/20220511045405/https://about.sourcegraph.com/go/gophercon-2018-allocator-wrestling/).
 
 <table>
 <tbody>

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -2,9 +2,9 @@
 
 This page describes the release cadence and process for Thanos project.
 
-We use [Semantic Versioning](http://semver.org/).
+We use [Semantic Versioning](https://semver.org/).
 
-NOTE: As [Semantic Versioning](http://semver.org/spec/v2.0.0.html) states all 0.y.z releases can contain breaking changes in API (flags, grpc API, any backward compatibility)
+NOTE: As [Semantic Versioning](https://semver.org/spec/v2.0.0.html) states all 0.y.z releases can contain breaking changes in API (flags, grpc API, any backward compatibility)
 
 ## Cadence
 
@@ -165,6 +165,6 @@ Feel free to mimic following PR: https://github.com/thanos-io/thanos/pull/3861
 
 The following changes to the above procedures apply:
 
-* In line with [Semantic Versioning](http://semver.org/), append something like `-rc.0` to the version (with the corresponding changes to the tag name, the release name etc.).
+* In line with [Semantic Versioning](https://semver.org/), append something like `-rc.0` to the version (with the corresponding changes to the tag name, the release name etc.).
 * Tick the `This is a pre-release` box when drafting the release in the GitHub UI.
 * Still update `CHANGELOG.md`, but when you cut the final release later, merge all the changes from the pre-releases into the one final update.

--- a/mixin/README.md
+++ b/mixin/README.md
@@ -2,19 +2,19 @@
 
 > Note that everything is experimental and may change significantly at any time. Also it still has missing alert and dashboard definitions for certain components, e.g. rule and sidecar. Please feel free to contribute.
 
-This directory contains extensible and customizable monitoring definitions for Thanos. [Grafana](http://grafana.com/) dashboards, and [Prometheus rules](https://prometheus.io/docs/prometheus/latest/configuration/recording_rules/) combined with documentation and scripts to provide easy monitoring experience for Thanos.
+This directory contains extensible and customizable monitoring definitions for Thanos. [Grafana](https://grafana.com/) dashboards, and [Prometheus rules](https://prometheus.io/docs/prometheus/latest/configuration/recording_rules/) combined with documentation and scripts to provide easy monitoring experience for Thanos.
 
 You can find more about monitoring-mixins in [the design document](https://github.com/monitoring-mixins/docs/blob/master/design.pdf), and you can check out other examples like [Prometheus Mixin](https://github.com/prometheus/prometheus/tree/master/documentation/prometheus-mixin).
 
-The content of this project is written in [jsonnet](http://jsonnet.org/). This project could both be described as a package as well as a library.
+The content of this project is written in [jsonnet](https://jsonnet.org/). This project could both be described as a package as well as a library.
 
 ## Requirements
 
 ### jsonnet
 
-The content of this project consists of a set of [jsonnet](http://jsonnet.org/) files making up a library to be consumed.
+The content of this project consists of a set of [jsonnet](https://jsonnet.org/) files making up a library to be consumed.
 
-We recommend to use [go-jsonnet](https://github.com/google/go-jsonnet). It's an implementation of [Jsonnet](http://jsonnet.org/) in pure Go. It is feature complete but is not as heavily exercised as the [Jsonnet C++ implementation](https://github.com/google/jsonnet).
+We recommend to use [go-jsonnet](https://github.com/google/go-jsonnet). It's an implementation of [Jsonnet](https://jsonnet.org/) in pure Go. It is feature complete but is not as heavily exercised as the [Jsonnet C++ implementation](https://github.com/google/jsonnet).
 
 To install:
 

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -81,7 +81,7 @@ const (
 	// without downloading them. Please take a look at https://github.com/prometheus/tsdb/pull/397 to know
 	// where this number comes from. Long story short: TSDB is made in such a way, and it is made in such a way
 	// because you barely get any improvements in compression when the number of samples is beyond this.
-	// Take a look at Figure 6 in this whitepaper http://www.vldb.org/pvldb/vol8/p1816-teller.pdf.
+	// Take a look at Figure 6 in this whitepaper https://www.vldb.org/pvldb/vol8/p1816-teller.pdf.
 	MaxSamplesPerChunk = 120
 	// EstimatedMaxChunkSize is average max of chunk size. This can be exceeded though in very rare (valid) cases.
 	EstimatedMaxChunkSize  = 16000

--- a/pkg/tracing/tracing_middleware/doc.go
+++ b/pkg/tracing/tracing_middleware/doc.go
@@ -23,7 +23,7 @@ not have the appropriate requests propagated.
 All server-side spans are tagged with grpc_ctxtags information.
 
 For more information see:
-http://opentracing.io/documentation/
+https://opentracing.io/documentation/
 https://github.com/opentracing/specification/blob/master/semantic_conventions.md
 */
 package tracing_middleware


### PR DESCRIPTION
## Summary

Several documentation files and source code comments reference URLs over plain `http://` that point to sites which have supported `https://` for years. Insecure links can trigger browser security warnings and fail automated link-checkers that enforce HTTPS.

This PR upgrades all such links found across docs and source comments:

| File | Link |
|---|---|
| `CHANGELOG.md` | `keepachangelog.com`, `semver.org` |
| `CODE_OF_CONDUCT.md` | `contributor-covenant.org` |
| `docs/release-process.md` | `semver.org` (3 occurrences) |
| `docs/contributing/coding-style-guide.md` | `web.archive.org` |
| `mixin/README.md` | `grafana.com`, `jsonnet.org` (3 occurrences) |
| `pkg/store/bucket.go` | `www.vldb.org` (TSDB whitepaper link in comment) |
| `pkg/tracing/tracing_middleware/doc.go` | `opentracing.io` |

**Intentionally excluded:**
- Apache License 2.0 headers - canonical license text uses `http://`, changing it is non-standard.
- `http://alert.thanos.io` in `docs/components/rule.md` - this is an intentional CLI example showing an alertmanager endpoint format, not a documentation link.


## Test plan

- [ ] `make check-docs` passes.
- [ ] No functional change - documentation and comments only.