### PR TITLE
ci: delete runner caches when PR is closed

### DIFF
--- a/.github/workflows/cleanup-pr-caches.yaml
+++ b/.github/workflows/cleanup-pr-caches.yaml
@@ -1,0 +1,37 @@
+name: Cleanup PR Caches
+
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  cleanup:
+    name: Delete runner caches for closed PR
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      actions: write
+      contents: read
+    steps:
+      - name: Delete caches
+        run: |
+          REPO="${{ github.repository }}"
+          BRANCH="refs/pull/${{ github.event.pull_request.number }}/merge"
+          echo "Listing caches for branch: $BRANCH"
+          cache_ids=$(gh api --paginate \
+            -H "Accept: application/vnd.github+json" \
+            "/repos/$REPO/actions/caches?ref=$BRANCH&per_page=100" \
+            --jq '.actions_caches[].id')
+          if [ -z "$cache_ids" ]; then
+            echo "No caches found for this PR."
+            exit 0
+          fi
+          echo "Deleting caches..."
+          while IFS= read -r id; do
+            gh cache delete "$id" \
+              --repo "$REPO"
+            echo "Deleted cache ID: $id"
+          done <<< "$cache_ids"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What this does

Adds a workflow that deletes all GitHub Actions runner caches scoped to a PR's merge ref whenever that PR is closed (merged or abandoned).

## Why

GitHub Actions caches created during PR runs are scoped to `refs/pull/<N>/merge`. GitHub never automatically deletes them when a PR closes - they persist until the 10 GB per-repo cache limit is hit, at which point GitHub evicts caches in LRU order. This means active branches lose their caches because old merged PRs are holding the space.

This workflow runs on `pull_request: types: [closed]`, lists all caches for the closed PR via the GitHub REST API (paginated), and deletes each one immediately. The job only needs `actions: write` (job-level, not repo-level).

