### PR TITLE
scripts: remove deprecated GO111MODULE=on

### DIFF
--- a/scripts/genproto.sh
+++ b/scripts/genproto.sh
@@ -23,7 +23,7 @@ fi
 mkdir -p /tmp/protobin/
 cp ${PROTOC_GEN_GOGOFAST_BIN} /tmp/protobin/protoc-gen-gogofast
 PATH=${PATH}:/tmp/protobin
-GOGOPROTO_ROOT="$(GO111MODULE=on go list -modfile=.bingo/protoc-gen-gogofast.mod -f '{{ .Dir }}' -m github.com/gogo/protobuf)"
+GOGOPROTO_ROOT="$(go list -modfile=.bingo/protoc-gen-gogofast.mod -f '{{ .Dir }}' -m github.com/gogo/protobuf)"
 GOGOPROTO_PATH="${GOGOPROTO_ROOT}:${GOGOPROTO_ROOT}/protobuf"
 
 DIRS="store/storepb/ store/storepb/prompb/ store/labelpb rules/rulespb targets/targetspb store/hintspb queryfrontend metadata/metadatapb exemplars/exemplarspb info/infopb api/query/querypb status/statuspb"

--- a/scripts/insecure_grpcurl_series.sh
+++ b/scripts/insecure_grpcurl_series.sh
@@ -50,7 +50,7 @@ SERIES_REQUEST='{
   "skip_chunks": false
 }'
 
-GOGOPROTO_ROOT="$(GO111MODULE=on go list -f '{{ .Dir }}' -m github.com/gogo/protobuf)"
+GOGOPROTO_ROOT="$(go list -f '{{ .Dir }}' -m github.com/gogo/protobuf)"
 
 cd $DIR/../pkg/ || exit
 grpcurl \


### PR DESCRIPTION
## What

Remove the `GO111MODULE=on` inline prefix from two shell scripts:
- `scripts/genproto.sh`
- `scripts/insecure_grpcurl_series.sh`

## Why

`GO111MODULE` has been ignored since Go 1.21 - setting it has no effect. This repo declares `go 1.26.0` in `go.mod`, so the prefix is dead code in both scripts.

Module mode has been the default since Go 1.16, and the env var was fully deprecated in Go 1.21. Leaving it around creates a false impression that it is doing something.

## References

- Go 1.21 release notes: https://go.dev/doc/go1.21 (GO111MODULE deprecated)