### PR TITLE
ci: pin remaining GitHub Actions to commit hashes

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -132,9 +132,9 @@ jobs:
     name: Check misspelled words
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - name: Run codespell
-        uses: codespell-project/actions-codespell@v2
+        uses: codespell-project/actions-codespell@8f01853be192eb0f849a5c7d721450e7a467c579 # v2.2
         with:
           check_filenames: false
           check_hidden: true
@@ -155,7 +155,7 @@ jobs:
         run: docker save thanos | gzip > /tmp/thanos-e2e.tar.gz
 
       - name: Upload image artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: thanos-e2e-image
           path: /tmp/thanos-e2e.tar.gz
@@ -190,7 +190,7 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
 
       - name: Download e2e image artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: thanos-e2e-image
           path: /tmp


### PR DESCRIPTION
## What

Pin the four remaining mutable version-tag action references in `go.yaml` to exact commit SHAs with version comments:

| Action | Before | After |
|---|---|---|
| `actions/checkout` (codespell job) | `@v4` | `@692973e` (v4.1.7) |
| `codespell-project/actions-codespell` | `@v2` | `@8f01853` (v2.2) |
| `actions/upload-artifact` | `@v4` | `@ea165f8` (v4.6.2) |
| `actions/download-artifact` | `@v4` | `@d3f86a1` (v4.3.0) |

## Why

Mutable version tags can be silently overwritten - a compromised upstream release can swap a tag to point at malicious code. Pinning to a commit SHA gives a tamper-evident reference: the SHA is immutable, so any change to the action requires an explicit PR update here.

The other jobs in this file (`unit`, `cross-build`, `lint`, `stringlabels`, `e2e`) were already pinned. This brings the `codespell` and `build-e2e-image` jobs into the same posture.

## References

- GitHub docs: [Using third-party actions - Pinning to a commit SHA](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions)
- StepSecurity: Why pin GitHub Actions to commit SHAs