### PR TITLE
ci: replace deprecated git.io shortlink in CodeQL workflow

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -63,7 +63,7 @@ jobs:
       uses: github/codeql-action/autobuild@fca7ace96b7d713c7035871441bd52efbe39e27e # v3.28.19
 
     # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 https://git.io/JvXDl
+    # 📚 https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
 
     # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
     #    and modify them (or add more) to build your code if your project


### PR DESCRIPTION
## What

Replace a deprecated `git.io` shortlink in `.github/workflows/codeql-analysis.yml` with the canonical URL it resolves to.

```diff
-    # 📚 https://git.io/JvXDl
+    # 📚 https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
```

## Why

GitHub deprecated and shut down the git.io URL shortener in April 2022. The shortlink still redirects for now but is not guaranteed to remain operational. Using the direct docs.github.com URL makes the reference self-contained and permanently readable.

## References

- GitHub deprecation notice: https://github.blog/changelog/2022-04-25-git-io-deprecation/