### PR TITLE
receive: fix (some) 500 errors during lag increase

### DIFF
--- a/docs/components/receive.md
+++ b/docs/components/receive.md
@@ -372,7 +372,7 @@ Please see the metric `thanos_receive_forward_delay_seconds` to see if you need 
 
 The following formula is used for calculating quorum:
 
-```go mdox-exec="sed -n '1067,1078p' pkg/receive/handler.go"
+```go mdox-exec="sed -n '1123,1133p' pkg/receive/handler.go"
 // writeQuorum returns minimum number of replicas that has to confirm write success before claiming replication success.
 func (h *Handler) writeQuorum() int {
 	// NOTE(GiedriusS): this is here because otherwise RF=2 doesn't make sense as all writes
@@ -384,7 +384,6 @@ func (h *Handler) writeQuorum() int {
 	}
 	return int((h.options.ReplicationFactor / 2) + 1)
 }
-
 ```
 
 So, if the replication factor is 2 then at least one write must succeed. With RF=3, two writes must succeed, and so on.

--- a/pkg/pool/worker_pool.go
+++ b/pkg/pool/worker_pool.go
@@ -20,6 +20,9 @@ type WorkerPool interface {
 	// Returns ctx.Err() if the context is canceled before a worker slot is available.
 	Go(ctx context.Context, work Work) error
 
+	// TryGo submits work without blocking. Returns false if the pool is at capacity.
+	TryGo(work Work) bool
+
 	// Close cancels all workers and waits for them to finish.
 	Close()
 
@@ -68,6 +71,16 @@ func (p *workerPool) Go(ctx context.Context, work Work) error {
 		return nil
 	case <-ctx.Done():
 		return ctx.Err()
+	}
+}
+
+func (p *workerPool) TryGo(work Work) bool {
+	p.Init()
+	select {
+	case p.workCh <- work:
+		return true
+	default:
+		return false
 	}
 }
 

--- a/pkg/receive/config.go
+++ b/pkg/receive/config.go
@@ -69,7 +69,7 @@ type Endpoint struct {
 	AZ               string `json:"az"`
 }
 
-func (e *Endpoint) String() string {
+func (e Endpoint) String() string {
 	return fmt.Sprintf("addr: %s, capnp_addr: %s, az: %s", e.Address, e.CapNProtoAddress, e.AZ)
 }
 

--- a/pkg/receive/handler.go
+++ b/pkg/receive/handler.go
@@ -93,6 +93,9 @@ var (
 type WriteableStoreAsyncClient interface {
 	storepb.WriteableStoreClient
 	RemoteWriteAsync(context.Context, *storepb.WriteRequest, endpointReplica, []int, chan writeResponse, func(error))
+	// TryRemoteWriteAsync submits the request without blocking. Returns false if the peer's
+	// worker pool is at capacity; the caller should fall back to RemoteWriteAsync.
+	TryRemoteWriteAsync(context.Context, *storepb.WriteRequest, endpointReplica, []int, chan writeResponse, func(error)) bool
 }
 
 // Options for the web Handler.
@@ -957,13 +960,31 @@ func (h *Handler) sendWrites(
 		}(writeDestination)
 	}
 
-	// Do the writes to remote nodes. Run them all in parallel.
+	// First pass: submit to remote nodes non-blocking so that peers with available pool
+	// capacity (typically the fast ones) all get in flight before we stall on any saturated peer.
+	// This lets quorum be reached—and the HTTP response returned—without waiting for a slow peer's
+	// worker pool to drain.
+	type deferredRemote struct {
+		tenant           string
+		writeDestination endpointReplica
+		trackedSeries    trackedSeries
+	}
+	var deferred []deferredRemote
+
 	for writeDestination := range remoteWrites {
 		for tenant, trackedSeries := range remoteWrites[writeDestination] {
 			wg.Add(1)
-
-			h.sendRemoteWrite(ctx, tenant, writeDestination, trackedSeries, params.alreadyReplicated, responses, wg)
+			if !h.tryRemoteWrite(ctx, tenant, writeDestination, trackedSeries, params.alreadyReplicated, responses, wg) {
+				wg.Done()
+				deferred = append(deferred, deferredRemote{tenant, writeDestination, trackedSeries})
+			}
 		}
+	}
+
+	// Second pass: blocking submission for any peer whose pool was saturated during the first pass.
+	for _, d := range deferred {
+		wg.Add(1)
+		h.sendRemoteWrite(ctx, d.tenant, d.writeDestination, d.trackedSeries, params.alreadyReplicated, responses, wg)
 	}
 }
 
@@ -1006,38 +1027,36 @@ func (h *Handler) sendLocalWrite(
 
 }
 
-// sendRemoteWrite sends a write request to the remote node. It takes care of checking whether the endpoint is up or not
-// in the peerGroup, correctly marking them as up or down when appropriate.
-// The responses are sent to the responses channel.
-func (h *Handler) sendRemoteWrite(
+// prepareRemoteWrite resolves the peer connection, builds the WriteRequest, and constructs the
+// completion callback. Returns (nil, nil, nil) when a connection error has already been written to
+// responses and wg.Done called — callers must check for nil before proceeding.
+func (h *Handler) prepareRemoteWrite(
 	ctx context.Context,
 	tenant string,
-	endpointReplica endpointReplica,
-	trackedSeries trackedSeries,
+	er endpointReplica,
+	ts trackedSeries,
 	alreadyReplicated bool,
 	responses chan writeResponse,
 	wg *sync.WaitGroup,
-) {
-	endpoint := endpointReplica.endpoint
+) (WriteableStoreAsyncClient, *storepb.WriteRequest, func(error)) {
+	endpoint := er.endpoint
 	cl, err := h.peers.getConnection(ctx, endpoint)
 	if err != nil {
 		if errors.Is(err, errUnavailable) {
-			err = errors.Wrapf(errUnavailable, "backing off forward request for endpoint %v", endpointReplica)
+			err = errors.Wrapf(errUnavailable, "backing off forward request for endpoint %v", er)
 		}
-		responses <- newWriteResponse(trackedSeries.seriesIDs, err, endpointReplica)
+		responses <- newWriteResponse(ts.seriesIDs, err, er)
 		wg.Done()
-		return
+		return nil, nil, nil
 	}
 
-	// This is called "real" because it's 1-indexed.
-	realReplicationIndex := int64(endpointReplica.replica + 1)
-	// Actually make the request against the endpoint we determined should handle these time series.
-	cl.RemoteWriteAsync(ctx, &storepb.WriteRequest{
-		Timeseries: trackedSeries.timeSeries,
+	// Replica is 1-indexed on the wire; 0 indicates un-replicated.
+	req := &storepb.WriteRequest{
+		Timeseries: ts.timeSeries,
 		Tenant:     tenant,
-		// Increment replica since on-the-wire format is 1-indexed and 0 indicates un-replicated.
-		Replica: realReplicationIndex,
-	}, endpointReplica, trackedSeries.seriesIDs, responses, func(err error) {
+		Replica:    int64(er.replica + 1),
+	}
+	cb := func(err error) {
 		if err == nil {
 			h.forwardRequests.WithLabelValues(labelSuccess).Inc()
 			if !alreadyReplicated {
@@ -1052,16 +1071,53 @@ func (h *Handler) sendRemoteWrite(
 					h.replications.WithLabelValues(labelError).Inc()
 				}
 			}
-
 			// Check if peer connection is unavailable, update the peer state to avoid spamming that peer.
 			if st, ok := status.FromError(err); ok {
 				if st.Code() == codes.Unavailable {
-					h.peers.markPeerUnavailable(endpointReplica.endpoint)
+					h.peers.markPeerUnavailable(er.endpoint)
 				}
 			}
 		}
 		wg.Done()
-	})
+	}
+	return cl, req, cb
+}
+
+// sendRemoteWrite sends a write request to the remote node. It blocks until the peer's worker
+// pool accepts the work.
+func (h *Handler) sendRemoteWrite(
+	ctx context.Context,
+	tenant string,
+	er endpointReplica,
+	ts trackedSeries,
+	alreadyReplicated bool,
+	responses chan writeResponse,
+	wg *sync.WaitGroup,
+) {
+	cl, req, cb := h.prepareRemoteWrite(ctx, tenant, er, ts, alreadyReplicated, responses, wg)
+	if cl == nil {
+		return
+	}
+	cl.RemoteWriteAsync(ctx, req, er, ts.seriesIDs, responses, cb)
+}
+
+// tryRemoteWrite is the non-blocking counterpart of sendRemoteWrite. It returns false when the
+// peer's worker pool is at capacity; the caller should then fall back to sendRemoteWrite.
+// wg.Done is NOT called on a false return — the caller must not have called wg.Add before checking.
+func (h *Handler) tryRemoteWrite(
+	ctx context.Context,
+	tenant string,
+	er endpointReplica,
+	ts trackedSeries,
+	alreadyReplicated bool,
+	responses chan writeResponse,
+	wg *sync.WaitGroup,
+) bool {
+	cl, req, cb := h.prepareRemoteWrite(ctx, tenant, er, ts, alreadyReplicated, responses, wg)
+	if cl == nil {
+		return true
+	}
+	return cl.TryRemoteWriteAsync(ctx, req, er, ts.seriesIDs, responses, cb)
 }
 
 // writeQuorum returns minimum number of replicas that has to confirm write success before claiming replication success.
@@ -1472,9 +1528,9 @@ type peersContainer interface {
 	io.Closer
 }
 
-func (p *peerWorker) RemoteWriteAsync(ctx context.Context, req *storepb.WriteRequest, er endpointReplica, seriesIDs []int, responseWriter chan writeResponse, cb func(error)) {
+func (p *peerWorker) buildWork(ctx context.Context, req *storepb.WriteRequest, er endpointReplica, seriesIDs []int, responseWriter chan writeResponse, cb func(error)) pool.Work {
 	now := time.Now()
-	if err := p.wp.Go(ctx, func() {
+	return func() {
 		if p.maxArtificialDelay > 0 {
 			var randDuration = time.Duration(rand.Int63n(int64(p.maxArtificialDelay)))
 			if randDuration < 1*time.Second {
@@ -1505,7 +1561,11 @@ func (p *peerWorker) RemoteWriteAsync(ctx context.Context, req *storepb.WriteReq
 			"endpoint": er.endpoint,
 			"replica":  er.replica,
 		})
-	}); err != nil {
+	}
+}
+
+func (p *peerWorker) RemoteWriteAsync(ctx context.Context, req *storepb.WriteRequest, er endpointReplica, seriesIDs []int, responseWriter chan writeResponse, cb func(error)) {
+	if err := p.wp.Go(ctx, p.buildWork(ctx, req, er, seriesIDs, responseWriter, cb)); err != nil {
 		tracing.DoInSpan(ctx, "receive_forward", func(ctx context.Context) {
 			sp := trace.SpanFromContext(ctx)
 			sp.SetAttributes(attribute.Bool("error", true))
@@ -1521,6 +1581,10 @@ func (p *peerWorker) RemoteWriteAsync(ctx context.Context, req *storepb.WriteReq
 			"replica":  er.replica,
 		})
 	}
+}
+
+func (p *peerWorker) TryRemoteWriteAsync(ctx context.Context, req *storepb.WriteRequest, er endpointReplica, seriesIDs []int, responseWriter chan writeResponse, cb func(error)) bool {
+	return p.wp.TryGo(p.buildWork(ctx, req, er, seriesIDs, responseWriter, cb))
 }
 
 type peerGroup struct {

--- a/pkg/receive/handler_test.go
+++ b/pkg/receive/handler_test.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"go.uber.org/atomic"
@@ -791,6 +792,92 @@ func TestReceiveQuorumKetama(t *testing.T) {
 	}
 }
 
+// TestReceiveSaturatedPoolRF2 verifies that with replication factor 2 (quorum=1)
+// writes don't block when one peer's worker pool is saturated.
+func TestReceiveSaturatedPoolRF2(t *testing.T) {
+	t.Parallel()
+
+	fakePeers := &fakePeersGroup{clients: map[Endpoint]*peerWorker{}}
+	limiter, err := NewLimiter(extkingpin.NewNopConfig(), nil, RouterIngestor, log.NewNopLogger(), 1*time.Second)
+	require.NoError(t, err)
+
+	app := &fakeAppendable{
+		appender: newFakeAppender(nil, nil, nil),
+	}
+
+	h := NewHandler(log.NewNopLogger(), &Options{
+		ReplicationFactor: 2,
+		ForwardTimeout:    100 * time.Second,
+		Writer:            NewWriter(log.NewNopLogger(), newFakeTenantAppendable(app), &WriterOptions{}),
+		Limiter:           limiter,
+		Endpoint:          newUniqueEndpoint().String(),
+	})
+
+	endpoints := []Endpoint{
+		{
+			Address: newUniqueEndpoint().String(),
+		},
+		{
+			Address: newUniqueEndpoint().String(),
+		},
+	}
+
+	cfg := []HashringConfig{{
+		Hashring:  "test",
+		Endpoints: endpoints,
+	}}
+
+	hashring, err := NewMultiHashring(AlgorithmHashmod, 2, cfg, prometheus.NewRegistry())
+	require.NoError(t, err)
+
+	h.Hashring(hashring)
+	h.peers = fakePeers
+
+	synctest.Test(t, func(t *testing.T) {
+		t.Cleanup(func() { require.NoError(t, fakePeers.Close()) })
+
+		fakePeers.clients[endpoints[0]] = newPeerWorker(
+			&alwaysSucceedClient{},
+			prometheus.NewHistogram(prometheus.HistogramOpts{}),
+			1, 0,
+		)
+
+		fakePeers.clients[endpoints[1]] = newPeerWorker(
+			&alwaysSucceedClient{},
+			prometheus.NewHistogram(prometheus.HistogramOpts{}),
+			1, 30*time.Second,
+		)
+
+		wreq := &storepb.WriteRequest{Timeseries: makeSeriesWithValues(1)}
+		go func() {
+			for range 500 {
+				_, err := h.RemoteWrite(t.Context(), wreq)
+				require.NoError(t, err)
+			}
+		}()
+
+		_, err := h.RemoteWrite(t.Context(), wreq)
+		require.NoError(t, err)
+
+		time.Sleep(10 * time.Minute)
+		synctest.Wait()
+
+		// NOTE(GiedriusS): waiting until the best-effort writers are done
+		// because the waiting is happening in a goroutine.
+		require.NoError(t, runutil.Retry(1*time.Second, t.Context().Done(), func() error {
+			laggyPool := fakePeers.clients[endpoints[1]].wp
+
+			r := laggyPool.TryGo(func() {})
+			if !r {
+				return fmt.Errorf("pool still busy")
+			}
+
+			return nil
+		}))
+	})
+
+}
+
 func TestReceiveWithConsistencyDelayHashmod(t *testing.T) {
 	if testing.
 		Short() {
@@ -957,6 +1044,14 @@ func endpointHit(t *testing.T, h Hashring, rf uint64, endpoint, tenant string, t
 	return false
 }
 
+type alwaysSucceedClient struct{}
+
+func (a *alwaysSucceedClient) RemoteWrite(_ context.Context, _ *storepb.WriteRequest, _ ...grpc.CallOption) (*storepb.WriteResponse, error) {
+	return &storepb.WriteResponse{}, nil
+}
+
+func (a *alwaysSucceedClient) Close() error { return nil }
+
 // cycleErrors returns an error generator that cycles through every given error.
 func cycleErrors(errs []error) func() error {
 	var mu sync.Mutex
@@ -1019,6 +1114,11 @@ func (f *fakeRemoteWriteGRPCServer) RemoteWriteAsync(ctx context.Context, in *st
 		seriesIDs: seriesIDs,
 	}
 	cb(err)
+}
+
+func (f *fakeRemoteWriteGRPCServer) TryRemoteWriteAsync(ctx context.Context, in *storepb.WriteRequest, er endpointReplica, seriesIDs []int, responses chan writeResponse, cb func(error)) bool {
+	f.RemoteWriteAsync(ctx, in, er, seriesIDs, responses, cb)
+	return true
 }
 
 func (f *fakeRemoteWriteGRPCServer) Close() error { return nil }

--- a/pkg/receive/receive_test.go
+++ b/pkg/receive/receive_test.go
@@ -968,4 +968,9 @@ func (s *stubAsyncClient) RemoteWriteAsync(ctx context.Context, in *storepb.Writ
 	cb(err)
 }
 
+func (s *stubAsyncClient) TryRemoteWriteAsync(ctx context.Context, in *storepb.WriteRequest, er endpointReplica, seriesIDs []int, responses chan writeResponse, cb func(error)) bool {
+	s.RemoteWriteAsync(ctx, in, er, seriesIDs, responses, cb)
+	return true
+}
+
 func (s *stubAsyncClient) Close() error { return nil }


### PR DESCRIPTION
workpool.Go() can hang and when we run multiple of them in a loop, a laggy ingester node can bring down the whole ingestion pipeline until it is removed from the hashring automatically.

This change reworks how sending requests works: first try to queue work as much as possible, and only then if some are left run the deferred ones. This makes sure that we can still reach quorum even if one or more nodes have slow writes.

An alternative design would be to cancel the context as soon as quorum is reached but that would mean that the we would never try to do the actual writes if some ingester is lagging thus reducing reliability.

Add test to cover this case.
