### PR TITLE
queryfrontend: add other params to key

### DIFF
--- a/pkg/queryfrontend/cache.go
+++ b/pkg/queryfrontend/cache.go
@@ -5,6 +5,8 @@ package queryfrontend
 
 import (
 	"fmt"
+	"sort"
+	"strings"
 
 	"github.com/thanos-io/thanos/internal/cortex/querier/queryrange"
 	"github.com/thanos-io/thanos/pkg/compact/downsample"
@@ -22,7 +24,6 @@ func newThanosCacheKeyGenerator() thanosCacheKeyGenerator {
 }
 
 // GenerateCacheKey generates a cache key based on the Request and interval.
-// TODO(yeya24): Add other request params as request key.
 func (t thanosCacheKeyGenerator) GenerateCacheKey(userID string, r queryrange.Request) string {
 	if sr, ok := r.(SplitRequest); ok {
 		splitInterval := sr.GetSplitInterval().Milliseconds()
@@ -34,7 +35,10 @@ func (t thanosCacheKeyGenerator) GenerateCacheKey(userID string, r queryrange.Re
 			for ; i < len(t.resolutions) && t.resolutions[i] > tr.MaxSourceResolution; i++ {
 			}
 			shardInfoKey := generateShardInfoKey(tr)
-			return fmt.Sprintf("fe:%s:%s:%d:%d:%d:%d:%s:%d:%s", userID, tr.Query, tr.Step, splitInterval, currentInterval, i, shardInfoKey, tr.LookbackDelta, tr.Engine)
+			sort.Strings(tr.ReplicaLabels)
+			return fmt.Sprintf("fe:%s:%s:%d:%d:%d:%d:%s:%d:%s:%t:%s:%t",
+				userID, tr.Query, tr.Step, splitInterval, currentInterval, i, shardInfoKey,
+				tr.LookbackDelta, tr.Engine, tr.PartialResponse, strings.Join(tr.ReplicaLabels, ","), tr.Analyze)
 		case *ThanosLabelsRequest:
 			return fmt.Sprintf("fe:%s:%s:%s:%d:%d", userID, tr.Label, tr.Matchers, splitInterval, currentInterval)
 		case *ThanosSeriesRequest:

--- a/pkg/queryfrontend/cache_test.go
+++ b/pkg/queryfrontend/cache_test.go
@@ -30,7 +30,7 @@ func TestGenerateCacheKey(t *testing.T) {
 				Step:          60 * seconds,
 				SplitInterval: time.Hour,
 			},
-			expected: "fe::up:60000:3600000:0:2:-:0:",
+			expected: "fe::up:60000:3600000:0:2:-:0::false::false",
 		},
 		{
 			name: "10s step",
@@ -40,7 +40,7 @@ func TestGenerateCacheKey(t *testing.T) {
 				Step:          10 * seconds,
 				SplitInterval: time.Hour,
 			},
-			expected: "fe::up:10000:3600000:0:2:-:0:",
+			expected: "fe::up:10000:3600000:0:2:-:0::false::false",
 		},
 		{
 			name: "1m downsampling resolution",
@@ -51,7 +51,7 @@ func TestGenerateCacheKey(t *testing.T) {
 				MaxSourceResolution: 60 * seconds,
 				SplitInterval:       time.Hour,
 			},
-			expected: "fe::up:10000:3600000:0:2:-:0:",
+			expected: "fe::up:10000:3600000:0:2:-:0::false::false",
 		},
 		{
 			name: "5m downsampling resolution, different cache key",
@@ -62,7 +62,7 @@ func TestGenerateCacheKey(t *testing.T) {
 				MaxSourceResolution: 300 * seconds,
 				SplitInterval:       time.Hour,
 			},
-			expected: "fe::up:10000:3600000:0:1:-:0:",
+			expected: "fe::up:10000:3600000:0:1:-:0::false::false",
 		},
 		{
 			name: "1h downsampling resolution, different cache key",
@@ -73,7 +73,7 @@ func TestGenerateCacheKey(t *testing.T) {
 				MaxSourceResolution: hour,
 				SplitInterval:       time.Hour,
 			},
-			expected: "fe::up:10000:3600000:0:0:-:0:",
+			expected: "fe::up:10000:3600000:0:0:-:0::false::false",
 		},
 		{
 			name: "1h downsampling resolution with lookback delta",
@@ -85,7 +85,40 @@ func TestGenerateCacheKey(t *testing.T) {
 				LookbackDelta:       1000,
 				SplitInterval:       time.Hour,
 			},
-			expected: "fe::up:10000:3600000:0:0:-:1000:",
+			expected: "fe::up:10000:3600000:0:0:-:1000::false::false",
+		},
+		{
+			name: "partial response enabled, different cache key",
+			req: &ThanosQueryRangeRequest{
+				Query:           "up",
+				Start:           0,
+				Step:            60 * seconds,
+				SplitInterval:   time.Hour,
+				PartialResponse: true,
+			},
+			expected: "fe::up:60000:3600000:0:2:-:0::true::false",
+		},
+		{
+			name: "replica labels set, different cache key",
+			req: &ThanosQueryRangeRequest{
+				Query:         "up",
+				Start:         0,
+				Step:          60 * seconds,
+				SplitInterval: time.Hour,
+				ReplicaLabels: []string{"prometheus", "pod"},
+			},
+			expected: "fe::up:60000:3600000:0:2:-:0::false:pod,prometheus:false",
+		},
+		{
+			name: "analyze enabled, different cache key",
+			req: &ThanosQueryRangeRequest{
+				Query:         "up",
+				Start:         0,
+				Step:          60 * seconds,
+				SplitInterval: time.Hour,
+				Analyze:       true,
+			},
+			expected: "fe::up:60000:3600000:0:2:-:0::false::true",
 		},
 		{
 			name: "label names, no matcher",


### PR DESCRIPTION
Part of https://github.com/thanos-io/thanos/issues/8643. Remove a TODO -
pass other parameters to the key so that the key would encode all
information needed.

After this, I think we will be able to remove the protobuf step.

Signed-off-by: Giedrius Statkevičius <giedrius.statkevicius@vinted.com>
