### PR TITLE
receiver, compactor, sidecar: use os.Root API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ It is recommend to upgrade the storage components first (Receive, Store, etc.) a
 - [#8770](https://github.com/thanos-io/thanos/pull/8770): *: add `--grpc-server-tls-curves` to configure curves for gRPC servers.
 - [#8770](https://github.com/thanos-io/thanos/pull/8770): Receive: add `--remote-write.server-tls-curves` to configure curves for the HTTP server.
 - [#8808](https://github.com/thanos-io/thanos/pull/8808): ruler, sidecar: Add TSDB stats endpoint to gRPC server.
+- [#8797](https://github.com/thanos-io/thanos/pull/8797): Receive, Compact, Sidecar: Use `os.Root` API to confine filesystem access to the service data directory.
 - [#8594](https://github.com/thanos-io/thanos/pull/8594): Query: Support per endpoint TLS configuration.
 
 ### Changed

--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -206,8 +206,18 @@ func runReceive(
 		}
 	}
 
+	// TODO(guidonguido): check that. Do we need to create the default storage dir?
+	if err := os.MkdirAll(conf.dataDir, 0o755); err != nil {
+		return errors.Wrapf(err, "create data dir in %v", conf.dataDir)
+	}
+
+	dataDir, err := os.OpenRoot(conf.dataDir)
+	if err != nil {
+		return errors.Wrap(err, "open storage dir")
+	}
+
 	// Create TSDB for the default tenant.
-	if err := createDefautTenantTSDB(logger, conf.dataDir, conf.defaultTenantID); err != nil {
+	if err := createDefautTenantTSDB(logger, conf.defaultTenantID, dataDir); err != nil {
 		return errors.Wrapf(err, "create default tenant tsdb in %v", conf.dataDir)
 	}
 
@@ -232,7 +242,7 @@ func runReceive(
 	multiTSDBOptions = append(multiTSDBOptions, receive.WithUploadConcurrency(conf.uploadConcurrency))
 
 	dbs := receive.NewMultiTSDB(
-		conf.dataDir,
+		dataDir,
 		logger,
 		reg,
 		tsdbOpts,
@@ -842,23 +852,17 @@ func startTSDBAndUpload(g *run.Group,
 	return nil
 }
 
-func createDefautTenantTSDB(logger log.Logger, dataDir, defaultTenantID string) error {
-	defaultTenantDataDir := path.Join(dataDir, defaultTenantID)
+func createDefautTenantTSDB(logger log.Logger, defaultTenantID string, dataDir *os.Root) error {
 
-	if _, err := os.Stat(defaultTenantDataDir); !os.IsNotExist(err) {
+	if _, err := dataDir.Stat(defaultTenantID); !os.IsNotExist(err) {
 		level.Info(logger).Log("msg", "default tenant data dir already present, will not create")
-		return nil
-	}
-
-	if _, err := os.Stat(dataDir); os.IsNotExist(err) {
-		level.Info(logger).Log("msg", "no existing storage found, not creating default tenant data dir")
 		return nil
 	}
 
 	level.Info(logger).Log("msg", "default tenant data dir not found, creating", "defaultTenantID", defaultTenantID)
 
-	if err := os.MkdirAll(defaultTenantDataDir, 0750); err != nil {
-		return errors.Wrapf(err, "create default tenant data dir: %v", defaultTenantDataDir)
+	if err := dataDir.MkdirAll(defaultTenantID, 0750); err != nil {
+		return errors.Wrapf(err, "create default tenant data dir: %v", path.Join(dataDir.Name(), defaultTenantID))
 	}
 
 	return nil

--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -206,7 +206,6 @@ func runReceive(
 		}
 	}
 
-	// TODO(guidonguido): check that. Do we need to create the default storage dir?
 	if err := os.MkdirAll(conf.dataDir, 0o755); err != nil {
 		return errors.Wrapf(err, "create data dir in %v", conf.dataDir)
 	}
@@ -853,7 +852,6 @@ func startTSDBAndUpload(g *run.Group,
 }
 
 func createDefautTenantTSDB(logger log.Logger, defaultTenantID string, dataDir *os.Root) error {
-
 	if _, err := dataDir.Stat(defaultTenantID); !os.IsNotExist(err) {
 		level.Info(logger).Log("msg", "default tenant data dir already present, will not create")
 		return nil

--- a/cmd/thanos/rule.go
+++ b/cmd/thanos/rule.go
@@ -902,7 +902,7 @@ func runRule(
 		if err != nil {
 			return errors.Wrap(err, "open data dir")
 		}
-		defer dataDir.Close()
+		defer runutil.CloseWithLogOnErr(logger, dataDir, "data dir")
 
 		s := shipper.New(
 			bkt,

--- a/cmd/thanos/rule.go
+++ b/cmd/thanos/rule.go
@@ -898,9 +898,15 @@ func runRule(
 			}
 		}()
 
+		dataDir, err := os.OpenRoot(conf.dataDir)
+		if err != nil {
+			return errors.Wrap(err, "open data dir")
+		}
+		defer dataDir.Close()
+
 		s := shipper.New(
 			bkt,
-			conf.dataDir,
+			dataDir,
 			shipper.WithLogger(logger),
 			shipper.WithRegisterer(reg),
 			shipper.WithSource(metadata.RulerSource),

--- a/cmd/thanos/sidecar.go
+++ b/cmd/thanos/sidecar.go
@@ -461,7 +461,7 @@ func runSidecar(
 			if err != nil {
 				return errors.Wrap(err, "opening tsdb directory")
 			}
-			defer dataDir.Close()
+			defer runutil.CloseWithLogOnErr(logger, dataDir, "tsdb directory")
 
 			s := shipper.New(
 				bkt,

--- a/cmd/thanos/sidecar.go
+++ b/cmd/thanos/sidecar.go
@@ -9,6 +9,7 @@ import (
 	"math"
 	"net/http"
 	"net/url"
+	"os"
 	"path/filepath"
 	"sync"
 	"time"
@@ -456,9 +457,15 @@ func runSidecar(
 				return errors.Wrapf(err, "aborting as no external labels found after waiting %s", promReadyTimeout)
 			}
 
+			dataDir, err := os.OpenRoot(conf.tsdb.path)
+			if err != nil {
+				return errors.Wrap(err, "opening tsdb directory")
+			}
+			defer dataDir.Close()
+
 			s := shipper.New(
 				bkt,
-				conf.tsdb.path,
+				dataDir,
 				shipper.WithLogger(logger),
 				shipper.WithRegisterer(reg),
 				shipper.WithSource(metadata.SidecarSource),

--- a/cmd/thanos/tools_bucket.go
+++ b/cmd/thanos/tools_bucket.go
@@ -1505,9 +1505,15 @@ func registerBucketUploadBlocks(app extkingpin.AppClause, objStoreConfig *extfla
 
 		bkt = objstoretracing.WrapWithTraces(objstore.WrapWithMetrics(bkt, extprom.WrapRegistererWithPrefix("thanos_", reg), bkt.Name()))
 
+		tbcDir, err := os.OpenRoot(tbc.path)
+		if err != nil {
+			return errors.Wrap(err, "unable to open tbc directory")
+		}
+		defer tbcDir.Close()
+
 		s := shipper.New(
 			bkt,
-			tbc.path,
+			tbcDir,
 			shipper.WithLogger(logger),
 			shipper.WithRegisterer(reg),
 			shipper.WithSource(metadata.BucketUploadSource),

--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -910,10 +910,11 @@ type Compactor interface {
 
 // Compact plans and runs a single compaction against the group. The compacted result
 // is uploaded into the bucket the blocks were retrieved from.
-func (cg *Group) Compact(ctx context.Context, dir string, planner Planner, comp Compactor, blockDeletableChecker BlockDeletableChecker, compactionLifecycleCallback CompactionLifecycleCallback) (shouldRerun bool, compIDs []ulid.ULID, rerr error) {
+func (cg *Group) Compact(ctx context.Context, dir *os.Root, planner Planner, comp Compactor, blockDeletableChecker BlockDeletableChecker, compactionLifecycleCallback CompactionLifecycleCallback) (shouldRerun bool, compIDs []ulid.ULID, rerr error) {
 	cg.compactionRunsStarted.Inc()
 
-	subDir := filepath.Join(dir, cg.Key())
+	subPath := cg.Key()
+	subDir := filepath.Join(dir.Name(), subPath)
 
 	defer func() {
 		// Leave the compact directory for inspection if it is a halt error
@@ -921,12 +922,12 @@ func (cg *Group) Compact(ctx context.Context, dir string, planner Planner, comp 
 		if rerr != nil {
 			return
 		}
-		if err := os.RemoveAll(subDir); err != nil {
+		if err := dir.RemoveAll(subPath); err != nil {
 			level.Error(cg.logger).Log("msg", "failed to remove compaction group work directory", "path", subDir, "err", err)
 		}
 	}()
 
-	if err := os.MkdirAll(subDir, 0750); err != nil {
+	if err := dir.MkdirAll(subPath, 0750); err != nil {
 		return false, nil, errors.Wrap(err, "create compaction group dir")
 	}
 
@@ -1481,7 +1482,16 @@ func NewBucketCompactorWithCheckerAndCallback(
 
 // Compact runs compaction over bucket.
 func (c *BucketCompactor) Compact(ctx context.Context) (rerr error) {
+	if err := os.MkdirAll(c.compactDir, 0750); err != nil {
+		return errors.Wrap(err, "create compact root directory")
+	}
+	dir, err := os.OpenRoot(c.compactDir)
+	if err != nil {
+		return errors.Wrap(err, "open compact root directory")
+	}
+
 	defer func() {
+		dir.Close()
 		// Do not remove the compactDir if an error has occurred
 		// because potentially on the next run we would not have to download
 		// everything again.
@@ -1510,7 +1520,7 @@ func (c *BucketCompactor) Compact(ctx context.Context) (rerr error) {
 		for i := 0; i < c.concurrency; i++ {
 			wg.Go(func() {
 				for g := range groupChan {
-					shouldRerunGroup, _, err := g.Compact(workCtx, c.compactDir, c.planner, c.comp, c.blockDeletableChecker, c.compactionLifecycleCallback)
+					shouldRerunGroup, _, err := g.Compact(workCtx, dir, c.planner, c.comp, c.blockDeletableChecker, c.compactionLifecycleCallback)
 					if err == nil {
 						if shouldRerunGroup {
 							mtx.Lock()

--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -1491,7 +1491,7 @@ func (c *BucketCompactor) Compact(ctx context.Context) (rerr error) {
 	}
 
 	defer func() {
-		dir.Close()
+		runutil.CloseWithLogOnErr(c.logger, dir, "compact root directory")
 		// Do not remove the compactDir if an error has occurred
 		// because potentially on the next run we would not have to download
 		// everything again.

--- a/pkg/receive/handler_test.go
+++ b/pkg/receive/handler_test.go
@@ -1322,7 +1322,7 @@ func benchmarkHandlerMultiTSDBReceiveRemoteWrite(b testutil.TB) {
 
 	logger := log.NewNopLogger()
 	m := NewMultiTSDB(
-		dir, logger, reg, &tsdb.Options{
+		openTestRoot(b, dir), logger, reg, &tsdb.Options{
 			MinBlockDuration:  int64(2 * time.Hour / time.Millisecond),
 			MaxBlockDuration:  int64(2 * time.Hour / time.Millisecond),
 			RetentionDuration: int64(6 * time.Hour / time.Millisecond),

--- a/pkg/receive/multitsdb.go
+++ b/pkg/receive/multitsdb.go
@@ -9,7 +9,6 @@ import (
 	"math/rand"
 	"os"
 	"path"
-	"path/filepath"
 	"slices"
 	"sort"
 	"sync"
@@ -53,7 +52,7 @@ type TSDBStats interface {
 }
 
 type MultiTSDB struct {
-	dataDir         string
+	dataDir         *os.Root
 	logger          log.Logger
 	reg             prometheus.Registerer
 	tsdbOpts        *tsdb.Options
@@ -152,7 +151,7 @@ Invariants:
 - Any object storage operations must not block reading or writing new samples.
 */
 func NewMultiTSDB(
-	dataDir string,
+	dataDir *os.Root,
 	l log.Logger,
 	reg prometheus.Registerer,
 	tsdbOpts *tsdb.Options,
@@ -638,11 +637,13 @@ func (t *tenant) setComponents(storeTSDB *store.TSDBStore, ship *shipper.Shipper
 }
 
 func (t *MultiTSDB) Open() error {
-	if err := os.MkdirAll(t.dataDir, 0750); err != nil {
+	dir, err := t.dataDir.Open(".")
+	if err != nil {
 		return err
 	}
+	defer dir.Close()
 
-	files, err := os.ReadDir(t.dataDir)
+	files, err := dir.ReadDir(-1)
 	if err != nil {
 		return err
 	}
@@ -721,6 +722,7 @@ func (t *MultiTSDB) Close() {
 	for _, tenant := range t.tenants {
 		tenant.close(KEEP_DATA)
 	}
+	t.dataDir.Close()
 }
 
 func (t *MultiTSDB) maybeDeleteTenant(tenant *tenant) {
@@ -826,7 +828,13 @@ func (t *MultiTSDB) SyncAllTenants(ctx context.Context) (int, error) {
 }
 
 func (t *MultiTSDB) RemoveLockFilesIfAny() error {
-	fis, err := os.ReadDir(t.dataDir)
+	dir, err := t.dataDir.Open(".")
+	if err != nil {
+		return err
+	}
+	defer dir.Close()
+
+	fis, err := dir.ReadDir(-1)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil
@@ -842,7 +850,7 @@ func (t *MultiTSDB) RemoveLockFilesIfAny() error {
 		if fi.Name() == lostFoundDir {
 			continue
 		}
-		if err := os.Remove(filepath.Join(t.defaultTenantDataDir(fi.Name()), "lock")); err != nil {
+		if err := t.dataDir.Remove(path.Join(fi.Name(), "lock")); err != nil {
 			if os.IsNotExist(err) {
 				continue
 			}
@@ -919,7 +927,8 @@ func (t *MultiTSDB) startTSDB(logger log.Logger, tenantID string, tenant *tenant
 
 	initialLset := labelpb.ExtendSortedLabels(t.labels, labels.FromStrings(t.tenantLabelName, tenantID))
 	lset := t.extractTenantsLabels(tenantID, initialLset)
-	dataDir := t.defaultTenantDataDir(tenantID)
+
+	dataDir := path.Join(t.dataDir.Name(), tenantID)
 
 	level.Info(logger).Log("msg", "opening TSDB")
 
@@ -974,6 +983,7 @@ func (t *MultiTSDB) startTSDB(logger log.Logger, tenantID string, tenant *tenant
 	// We don't do scrapes ourselves so this only gives us a performance penalty.
 	opts.IsolationDisabled = true
 
+	// TODO(guidonguido): open creates a new Dir with no check on the path
 	s, err := tsdb.Open(
 		dataDir,
 		logutil.GoKitLogToSlog(logger),
@@ -1018,10 +1028,6 @@ func (t *MultiTSDB) startTSDB(logger log.Logger, tenantID string, tenant *tenant
 	t.addTenantLocked(tenantID, tenant) // need to update the client list once store is ready & client != nil
 	level.Info(logger).Log("msg", "TSDB is now ready")
 	return nil
-}
-
-func (t *MultiTSDB) defaultTenantDataDir(tenantID string) string {
-	return path.Join(t.dataDir, tenantID)
 }
 
 func (t *MultiTSDB) getOrLoadTenant(tenantID string) (*tenant, error) {

--- a/pkg/receive/multitsdb.go
+++ b/pkg/receive/multitsdb.go
@@ -17,6 +17,7 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/oklog/ulid/v2"
+	"github.com/thanos-io/thanos/pkg/runutil"
 
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
@@ -728,7 +729,7 @@ func (t *MultiTSDB) Close() {
 	for _, tenant := range t.tenants {
 		tenant.close(KEEP_DATA)
 	}
-	t.dataDir.Close()
+	runutil.CloseWithLogOnErr(t.logger, t.dataDir, "mtsdb data dir")
 }
 
 func (t *MultiTSDB) maybeDeleteTenant(tenant *tenant) {

--- a/pkg/receive/multitsdb.go
+++ b/pkg/receive/multitsdb.go
@@ -582,6 +582,12 @@ func (t *tenant) close(cd closeDelete) {
 			}
 		}
 
+		if t.ship != nil {
+			if err := t.ship.Close(); err != nil {
+				level.Error(t.logger).Log("msg", "failed closing tenant's shipper", "tenant", t.tenantName, "err", err)
+			}
+		}
+
 		t.readyS.set(nil)
 		t.setComponents(nil, nil, nil, nil, nil)
 	})
@@ -1003,9 +1009,14 @@ func (t *MultiTSDB) startTSDB(logger log.Logger, tenantID string, tenant *tenant
 
 	var ship *shipper.Shipper
 	if t.bucket != nil {
+		// shipDataDir must be closed together with tenant
+		shipDataDir, err := os.OpenRoot(dataDir)
+		if err != nil {
+			return err
+		}
 		ship = shipper.New(
 			t.bucket,
-			dataDir,
+			shipDataDir,
 			shipper.WithLogger(logger),
 			shipper.WithRegisterer(reg),
 			shipper.WithSource(metadata.ReceiveSource),

--- a/pkg/receive/multitsdb_test.go
+++ b/pkg/receive/multitsdb_test.go
@@ -41,6 +41,14 @@ import (
 	"github.com/thanos-io/thanos/pkg/store/storepb"
 )
 
+func openTestRoot(t testing.TB, dir string) *os.Root {
+	t.Helper()
+	root, err := os.OpenRoot(dir)
+	testutil.Ok(t, err)
+	t.Cleanup(func() { root.Close() })
+	return root
+}
+
 func TestMultiTSDB(t *testing.T) {
 	t.Parallel()
 
@@ -49,7 +57,7 @@ func TestMultiTSDB(t *testing.T) {
 	logger := log.NewLogfmtLogger(os.Stderr)
 
 	t.Run("run fresh", func(t *testing.T) {
-		m := NewMultiTSDB(dir, logger, prometheus.NewRegistry(), &tsdb.Options{
+		m := NewMultiTSDB(openTestRoot(t, dir), logger, prometheus.NewRegistry(), &tsdb.Options{
 			MinBlockDuration:      (2 * time.Hour).Milliseconds(),
 			MaxBlockDuration:      (2 * time.Hour).Milliseconds(),
 			RetentionDuration:     (6 * time.Hour).Milliseconds(),
@@ -129,7 +137,7 @@ func TestMultiTSDB(t *testing.T) {
 	})
 	t.Run("run on existing storage", func(t *testing.T) {
 		m := NewMultiTSDB(
-			dir, logger, prometheus.NewRegistry(), &tsdb.Options{
+			openTestRoot(t, dir), logger, prometheus.NewRegistry(), &tsdb.Options{
 				MinBlockDuration:  (2 * time.Hour).Milliseconds(),
 				MaxBlockDuration:  (2 * time.Hour).Milliseconds(),
 				RetentionDuration: (6 * time.Hour).Milliseconds(),
@@ -174,7 +182,7 @@ func TestMultiTSDB(t *testing.T) {
 		lostFound := filepath.Join(dir, "lost+found")
 		testutil.Ok(t, os.MkdirAll(lostFound, 0750))
 
-		m := NewMultiTSDB(dir, logger, prometheus.NewRegistry(), &tsdb.Options{
+		m := NewMultiTSDB(openTestRoot(t, dir), logger, prometheus.NewRegistry(), &tsdb.Options{
 			MinBlockDuration:  (2 * time.Hour).Milliseconds(),
 			MaxBlockDuration:  (2 * time.Hour).Milliseconds(),
 			RetentionDuration: (6 * time.Hour).Milliseconds(),
@@ -188,7 +196,7 @@ func TestMultiTSDB(t *testing.T) {
 
 	t.Run("flush with one sample produces a block", func(t *testing.T) {
 		const testTenant = "test_tenant"
-		m := NewMultiTSDB(dir, logger, prometheus.NewRegistry(), &tsdb.Options{
+		m := NewMultiTSDB(openTestRoot(t, dir), logger, prometheus.NewRegistry(), &tsdb.Options{
 			MinBlockDuration:  (2 * time.Hour).Milliseconds(),
 			MaxBlockDuration:  (2 * time.Hour).Milliseconds(),
 			RetentionDuration: (6 * time.Hour).Milliseconds(),
@@ -453,7 +461,7 @@ func TestMultiTSDBPrune(t *testing.T) {
 			dir := t.TempDir()
 
 			synctest.Test(t, func(t *testing.T) {
-				m := NewMultiTSDB(dir, log.NewLogfmtLogger(os.Stderr), prometheus.NewRegistry(),
+				m := NewMultiTSDB(openTestRoot(t, dir), log.NewLogfmtLogger(os.Stderr), prometheus.NewRegistry(),
 					&tsdb.Options{
 						MinBlockDuration:  (2 * time.Hour).Milliseconds(),
 						MaxBlockDuration:  (2 * time.Hour).Milliseconds(),
@@ -513,7 +521,7 @@ func TestMultiTSDBRecreatePrunedTenant(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		dir := t.TempDir()
 
-		m := NewMultiTSDB(dir, log.NewLogfmtLogger(os.Stderr), prometheus.NewRegistry(),
+		m := NewMultiTSDB(openTestRoot(t, dir), log.NewLogfmtLogger(os.Stderr), prometheus.NewRegistry(),
 			&tsdb.Options{
 				MinBlockDuration:  (2 * time.Hour).Milliseconds(),
 				MaxBlockDuration:  (2 * time.Hour).Milliseconds(),
@@ -548,7 +556,7 @@ func TestPeriodicHeadCompaction(t *testing.T) {
 
 		maxBlockDuration := (2 * time.Hour).Milliseconds()
 
-		m := NewMultiTSDB(dir, log.NewLogfmtLogger(os.Stderr), prometheus.NewRegistry(),
+		m := NewMultiTSDB(openTestRoot(t, dir), log.NewLogfmtLogger(os.Stderr), prometheus.NewRegistry(),
 			&tsdb.Options{
 				MinBlockDuration:  maxBlockDuration,
 				MaxBlockDuration:  maxBlockDuration,
@@ -618,7 +626,7 @@ func TestMultiTSDBAddNewTenant(t *testing.T) {
 	for i := range iterations {
 		t.Run(fmt.Sprintf("iteration-%d", i), func(t *testing.T) {
 			dir := t.TempDir()
-			m := NewMultiTSDB(dir, log.NewNopLogger(), prometheus.NewRegistry(),
+			m := NewMultiTSDB(openTestRoot(t, dir), log.NewNopLogger(), prometheus.NewRegistry(),
 				&tsdb.Options{
 					MinBlockDuration:  (2 * time.Hour).Milliseconds(),
 					MaxBlockDuration:  (2 * time.Hour).Milliseconds(),
@@ -694,7 +702,7 @@ func TestAlignedHeadFlush(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			dir := t.TempDir()
 
-			m := NewMultiTSDB(dir, log.NewNopLogger(), prometheus.NewRegistry(),
+			m := NewMultiTSDB(openTestRoot(t, dir), log.NewNopLogger(), prometheus.NewRegistry(),
 				&tsdb.Options{
 					MinBlockDuration:  (2 * time.Hour).Milliseconds(),
 					MaxBlockDuration:  (2 * time.Hour).Milliseconds(),
@@ -722,7 +730,7 @@ func TestAlignedHeadFlush(t *testing.T) {
 			var shippedBlocks int
 			var maxts []int64
 			testutil.Ok(t, test.bucket.Iter(context.Background(), "", func(s string) error {
-				meta, err := metadata.ReadFromDir(path.Join(m.dataDir, "test-tenant", s))
+				meta, err := metadata.ReadFromDir(path.Join(m.dataDir.Name(), "test-tenant", s))
 				testutil.Ok(t, err)
 
 				maxts = append(maxts, meta.MaxTime)
@@ -769,7 +777,7 @@ func TestMultiTSDBStats(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			dir := t.TempDir()
 
-			m := NewMultiTSDB(dir, log.NewNopLogger(), prometheus.NewRegistry(),
+			m := NewMultiTSDB(openTestRoot(t, dir), log.NewNopLogger(), prometheus.NewRegistry(),
 				&tsdb.Options{
 					MinBlockDuration:  (2 * time.Hour).Milliseconds(),
 					MaxBlockDuration:  (2 * time.Hour).Milliseconds(),
@@ -801,7 +809,7 @@ func TestMultiTSDBWithNilStore(t *testing.T) {
 
 	dir := t.TempDir()
 
-	m := NewMultiTSDB(dir, log.NewNopLogger(), prometheus.NewRegistry(),
+	m := NewMultiTSDB(openTestRoot(t, dir), log.NewNopLogger(), prometheus.NewRegistry(),
 		&tsdb.Options{
 			MinBlockDuration:  (2 * time.Hour).Milliseconds(),
 			MaxBlockDuration:  (2 * time.Hour).Milliseconds(),
@@ -844,7 +852,7 @@ func TestProxyLabelValues(t *testing.T) {
 
 	dir := t.TempDir()
 	m := NewMultiTSDB(
-		dir, nil, prometheus.NewRegistry(), &tsdb.Options{
+		openTestRoot(t, dir), nil, prometheus.NewRegistry(), &tsdb.Options{
 			RetentionDuration: 10 * time.Minute.Milliseconds(),
 			MinBlockDuration:  5 * time.Minute.Milliseconds(),
 			MaxBlockDuration:  5 * time.Minute.Milliseconds(),
@@ -938,7 +946,7 @@ func queryLabelValues(ctx context.Context, m *MultiTSDB) error {
 func BenchmarkMultiTSDB(b *testing.B) {
 	dir := b.TempDir()
 
-	m := NewMultiTSDB(dir, log.NewNopLogger(), prometheus.NewRegistry(), &tsdb.Options{
+	m := NewMultiTSDB(openTestRoot(b, dir), log.NewNopLogger(), prometheus.NewRegistry(), &tsdb.Options{
 		MinBlockDuration:  (2 * time.Hour).Milliseconds(),
 		MaxBlockDuration:  (2 * time.Hour).Milliseconds(),
 		RetentionDuration: (6 * time.Hour).Milliseconds(),
@@ -1050,7 +1058,7 @@ func TestMultiTSDBDoesNotReturnPrunedTenants(t *testing.T) {
 
 	dir := t.TempDir()
 
-	m := NewMultiTSDB(dir, log.NewNopLogger(), prometheus.NewRegistry(), &tsdb.Options{
+	m := NewMultiTSDB(openTestRoot(t, dir), log.NewNopLogger(), prometheus.NewRegistry(), &tsdb.Options{
 		MinBlockDuration:  (2 * time.Hour).Milliseconds(),
 		MaxBlockDuration:  (2 * time.Hour).Milliseconds(),
 		RetentionDuration: (6 * time.Hour).Milliseconds(),

--- a/pkg/receive/multitsdb_test.go
+++ b/pkg/receive/multitsdb_test.go
@@ -1037,7 +1037,7 @@ func TestMultiTSDBDoesNotDeleteNotUploadedBlocks(t *testing.T) {
 
 		tenant.ship = shipper.New(
 			nil,
-			td,
+			openTestRoot(t, td),
 			shipper.WithLogger(log.NewNopLogger()),
 			shipper.WithSource(metadata.BucketUploadSource),
 			shipper.WithHashFunc(metadata.NoneFunc),

--- a/pkg/receive/receive_test.go
+++ b/pkg/receive/receive_test.go
@@ -213,7 +213,7 @@ func TestAddingExternalLabelsForTenants(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			m := initializeMultiTSDB(t.TempDir())
+			m := initializeMultiTSDB(t, t.TempDir())
 
 			err := m.SetHashringConfig(tc.cfg)
 			require.NoError(t, err)
@@ -296,7 +296,7 @@ func TestLabelSetsOfTenantsWhenAddingTenants(t *testing.T) {
 	}
 
 	t.Run("Adding tenants", func(t *testing.T) {
-		m := initializeMultiTSDB(t.TempDir())
+		m := initializeMultiTSDB(t, t.TempDir())
 
 		err := m.SetHashringConfig(initialConfig)
 		require.NoError(t, err)
@@ -540,7 +540,7 @@ func TestLabelSetsOfTenantsWhenChangingLabels(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			m := initializeMultiTSDB(t.TempDir())
+			m := initializeMultiTSDB(t, t.TempDir())
 
 			err := m.SetHashringConfig(initialConfig)
 			require.NoError(t, err)
@@ -714,7 +714,7 @@ func TestAddingLabelsWhenTenantAppearsInMultipleHashrings(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			m := initializeMultiTSDB(t.TempDir())
+			m := initializeMultiTSDB(t, t.TempDir())
 
 			err := m.SetHashringConfig(initialConfig)
 			require.NoError(t, err)
@@ -787,7 +787,7 @@ func TestReceiverLabelsNotOverwrittenByExternalLabels(t *testing.T) {
 	}
 
 	t.Run("Receiver's labels not overwritten by external labels", func(t *testing.T) {
-		m := initializeMultiTSDB(t.TempDir())
+		m := initializeMultiTSDB(t, t.TempDir())
 
 		err := m.SetHashringConfig(cfg)
 		require.NoError(t, err)
@@ -821,10 +821,10 @@ func TestReceiverLabelsNotOverwrittenByExternalLabels(t *testing.T) {
 	})
 }
 
-func initializeMultiTSDB(dir string) *MultiTSDB {
+func initializeMultiTSDB(t testing.TB, dir string) *MultiTSDB {
 	var bucket objstore.Bucket
 
-	m := NewMultiTSDB(dir, log.NewNopLogger(), prometheus.NewRegistry(),
+	m := NewMultiTSDB(openTestRoot(t, dir), log.NewNopLogger(), prometheus.NewRegistry(),
 		&tsdb.Options{
 			MinBlockDuration:  (2 * time.Hour).Milliseconds(),
 			MaxBlockDuration:  (2 * time.Hour).Milliseconds(),

--- a/pkg/receive/writer_test.go
+++ b/pkg/receive/writer_test.go
@@ -436,7 +436,7 @@ func setupMultitsdb(t *testing.T, maxExemplars int64) (log.Logger, *MultiTSDB, A
 	dir := t.TempDir()
 	logger := log.NewNopLogger()
 
-	m := NewMultiTSDB(dir, logger, prometheus.NewRegistry(), &tsdb.Options{
+	m := NewMultiTSDB(openTestRoot(t, dir), logger, prometheus.NewRegistry(), &tsdb.Options{
 		MinBlockDuration:      (2 * time.Hour).Milliseconds(),
 		MaxBlockDuration:      (2 * time.Hour).Milliseconds(),
 		RetentionDuration:     (6 * time.Hour).Milliseconds(),
@@ -501,7 +501,7 @@ func benchmarkWriter(b *testing.B, labelsNum int, seriesNum int, generateHistogr
 	dir := b.TempDir()
 	logger := log.NewNopLogger()
 
-	m := NewMultiTSDB(dir, logger, prometheus.NewRegistry(), &tsdb.Options{
+	m := NewMultiTSDB(openTestRoot(b, dir), logger, prometheus.NewRegistry(), &tsdb.Options{
 		MinBlockDuration:      (2 * time.Hour).Milliseconds(),
 		MaxBlockDuration:      (2 * time.Hour).Milliseconds(),
 		RetentionDuration:     (6 * time.Hour).Milliseconds(),

--- a/pkg/shipper/shipper.go
+++ b/pkg/shipper/shipper.go
@@ -75,7 +75,7 @@ func newMetrics(reg prometheus.Registerer) *metrics {
 // them to a remote data store.
 type Shipper struct {
 	logger           log.Logger
-	dir              string
+	dir              *os.Root
 	metrics          *metrics
 	bucket           objstore.Bucket
 	source           metadata.SourceType
@@ -204,7 +204,7 @@ func applyOptions(opts []Option) *shipperOptions {
 // New creates a new shipper that detects new TSDB blocks in dir and uploads them to
 // remote if necessary. It attaches the Thanos metadata section in each meta JSON file.
 // If uploadCompacted is enabled, it also uploads compacted blocks which are already in filesystem.
-func New(bucket objstore.Bucket, dir string, opts ...Option) *Shipper {
+func New(bucket objstore.Bucket, dir *os.Root, opts ...Option) *Shipper {
 	options := applyOptions(opts)
 
 	return &Shipper{
@@ -219,7 +219,7 @@ func New(bucket objstore.Bucket, dir string, opts ...Option) *Shipper {
 		uploadCompacted:        options.uploadCompacted,
 		hashFunc:               options.hashFunc,
 		uploadConcurrency:      options.uploadConcurrency,
-		metadataFilePath:       filepath.Join(dir, filepath.Clean(options.metaFileName)),
+		metadataFilePath:       filepath.Join(dir.Name(), filepath.Clean(options.metaFileName)),
 	}
 }
 
@@ -228,6 +228,11 @@ func (s *Shipper) SetLabels(lbls labels.Labels) {
 	defer s.mtx.Unlock()
 
 	s.labels = func() labels.Labels { return lbls }
+}
+
+// Close releases the os.Root directory handle held by the shipper.
+func (s *Shipper) Close() error {
+	return s.dir.Close()
 }
 
 type lazyOverlapChecker struct {
@@ -475,23 +480,24 @@ func (s *Shipper) upload(ctx context.Context, meta *metadata.Meta) error {
 
 	// We hard-link the files into a temporary upload directory so we are not affected
 	// by other operations happening against the TSDB directory.
-	updir := filepath.Join(s.dir, "thanos", "upload", meta.ULID.String())
+	updir := filepath.Join("thanos", "upload", meta.ULID.String())
 
 	// Remove updir just in case.
-	if err := os.RemoveAll(updir); err != nil {
+	if err := s.dir.RemoveAll(updir); err != nil {
 		return errors.Wrap(err, "clean upload directory")
 	}
-	if err := os.MkdirAll(updir, 0750); err != nil {
+	if err := s.dir.MkdirAll(updir, 0750); err != nil {
 		return errors.Wrap(err, "create upload dir")
 	}
 	defer func() {
-		if err := os.RemoveAll(updir); err != nil {
+		if err := s.dir.RemoveAll(updir); err != nil {
 			level.Error(s.logger).Log("msg", "failed to clean upload directory", "err", err)
 		}
 	}()
 
-	dir := filepath.Join(s.dir, meta.ULID.String())
-	if err := hardlinkBlock(dir, updir); err != nil {
+	absUpdir := filepath.Join(s.dir.Name(), updir)
+	dir := filepath.Join(s.dir.Name(), meta.ULID.String())
+	if err := hardlinkBlock(dir, absUpdir); err != nil {
 		return errors.Wrap(err, "hard link block")
 	}
 	// Attach current labels and write a new meta file with Thanos extensions.
@@ -501,24 +507,32 @@ func (s *Shipper) upload(ctx context.Context, meta *metadata.Meta) error {
 		})
 	}
 	meta.Thanos.Source = s.source
-	meta.Thanos.SegmentFiles = block.GetSegmentFiles(updir)
-	if err := meta.WriteToDir(s.logger, updir); err != nil {
+	meta.Thanos.SegmentFiles = block.GetSegmentFiles(absUpdir)
+	if err := meta.WriteToDir(s.logger, absUpdir); err != nil {
 		return errors.Wrap(err, "write meta file")
 	}
 	var uploadOptions []objstore.UploadOption
 	if s.uploadConcurrency > 0 {
 		uploadOptions = append(uploadOptions, objstore.WithUploadConcurrency(s.uploadConcurrency))
 	}
-	return block.Upload(ctx, s.logger, s.bucket, updir, s.hashFunc, uploadOptions...)
+	return block.Upload(ctx, s.logger, s.bucket, absUpdir, s.hashFunc, uploadOptions...)
 }
 
 // blockMetasFromOldest returns the block meta of each block found in dir
 // sorted by minTime asc.
 func (s *Shipper) blockMetasFromOldest() (metas []*metadata.Meta, failedBlocks []string, _ error) {
-	fis, err := os.ReadDir(s.dir)
+
+	dir, err := s.dir.Open(".")
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "open dir")
+	}
+	defer dir.Close()
+
+	fis, err := dir.ReadDir(-1)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "read dir")
 	}
+
 	names := make([]string, 0, len(fis))
 	for _, fi := range fis {
 		names = append(names, fi.Name())
@@ -527,9 +541,9 @@ func (s *Shipper) blockMetasFromOldest() (metas []*metadata.Meta, failedBlocks [
 		if _, ok := block.IsBlockDir(n); !ok {
 			continue
 		}
-		dir := filepath.Join(s.dir, n)
+		dir := filepath.Join(s.dir.Name(), n)
 
-		fi, err := os.Stat(dir)
+		fi, err := s.dir.Stat(n)
 		if err != nil {
 			if s.skipCorruptedBlocks {
 				level.Error(s.logger).Log("msg", "stat block", "err", err, "block", dir)

--- a/pkg/shipper/shipper.go
+++ b/pkg/shipper/shipper.go
@@ -526,7 +526,7 @@ func (s *Shipper) blockMetasFromOldest() (metas []*metadata.Meta, failedBlocks [
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "open dir")
 	}
-	defer dir.Close()
+	defer runutil.CloseWithLogOnErr(s.logger, dir, "shipper dir")
 
 	fis, err := dir.ReadDir(-1)
 	if err != nil {

--- a/pkg/shipper/shipper_e2e_test.go
+++ b/pkg/shipper/shipper_e2e_test.go
@@ -62,7 +62,7 @@ func TestShipper_SyncBlocks_e2e(t *testing.T) {
 		extLset := labels.FromStrings("prometheus", "prom-1")
 		shipper := New(
 			metricsBucket,
-			dir,
+			openTestRoot(t, dir),
 			WithLogger(log.NewLogfmtLogger(os.Stderr)),
 			WithSource(metadata.TestSource),
 			WithHashFunc(metadata.NoneFunc),
@@ -233,7 +233,7 @@ func TestShipper_SyncBlocksWithMigrating_e2e(t *testing.T) {
 
 		shipper := New(
 			bkt,
-			dir,
+			openTestRoot(t, dir),
 			WithLogger(log.NewLogfmtLogger(os.Stderr)),
 			WithSource(metadata.TestSource),
 			WithHashFunc(metadata.NoneFunc),
@@ -386,7 +386,7 @@ func TestShipper_SyncOverlapBlocks_e2e(t *testing.T) {
 	// Here, the allowOutOfOrderUploads flag is set to true, which allows blocks with overlaps to be uploaded.
 	shipper := New(
 		bkt,
-		dir,
+		openTestRoot(t, dir),
 		WithLogger(log.NewLogfmtLogger(os.Stderr)),
 		WithSource(metadata.TestSource),
 		WithHashFunc(metadata.NoneFunc),

--- a/pkg/shipper/shipper_test.go
+++ b/pkg/shipper/shipper_test.go
@@ -28,6 +28,14 @@ import (
 	"github.com/thanos-io/thanos/pkg/block/metadata"
 )
 
+func openTestRoot(t testing.TB, dir string) *os.Root {
+	t.Helper()
+	root, err := os.OpenRoot(dir)
+	testutil.Ok(t, err)
+	t.Cleanup(func() { root.Close() })
+	return root
+}
+
 func TestIterBlockMetas(t *testing.T) {
 	dir := t.TempDir()
 
@@ -66,7 +74,7 @@ func TestIterBlockMetas(t *testing.T) {
 
 	shipper := New(
 		nil,
-		dir,
+		openTestRoot(t, dir),
 		WithSource(metadata.TestSource),
 		WithHashFunc(metadata.NoneFunc),
 	)
@@ -108,7 +116,7 @@ func TestIterBlockMetasWhenMissingMeta(t *testing.T) {
 
 	shipper := New(
 		nil,
-		dir,
+		openTestRoot(t, dir),
 		WithSource(metadata.TestSource),
 		WithHashFunc(metadata.NoneFunc),
 		WithSkipCorruptedBlocks(true),
@@ -148,7 +156,7 @@ func BenchmarkIterBlockMetas(b *testing.B) {
 
 	shipper := New(
 		nil,
-		dir,
+		openTestRoot(b, dir),
 		WithSource(metadata.TestSource),
 		WithHashFunc(metadata.NoneFunc),
 	)
@@ -163,7 +171,7 @@ func TestShipperAddsSegmentFiles(t *testing.T) {
 	lbls := labels.FromStrings("test", "test")
 	s := New(
 		inmemory,
-		dir,
+		openTestRoot(t, dir),
 		WithRegisterer(metrics),
 		WithSource(metadata.TestSource),
 		WithHashFunc(metadata.NoneFunc),
@@ -214,7 +222,7 @@ func TestShipperSkipCorruptedBlocks(t *testing.T) {
 	lbls := labels.FromStrings("test", "test")
 	s := New(
 		inmemory,
-		dir,
+		openTestRoot(t, dir),
 		WithRegisterer(metrics),
 		WithSource(metadata.TestSource),
 		WithHashFunc(metadata.NoneFunc),
@@ -271,7 +279,7 @@ func TestShipperNotSkipCorruptedBlocks(t *testing.T) {
 	lbls := labels.FromStrings("test", "test")
 	s := New(
 		inmemory,
-		dir,
+		openTestRoot(t, dir),
 		WithRegisterer(metrics),
 		WithSource(metadata.TestSource),
 		WithHashFunc(metadata.NoneFunc),
@@ -334,7 +342,7 @@ func TestShipperExistingThanosLabels(t *testing.T) {
 	lbls := labels.FromStrings("test", "test")
 	s := New(
 		inmemory,
-		dir,
+		openTestRoot(t, dir),
 		WithSource(metadata.TestSource),
 		WithHashFunc(metadata.NoneFunc),
 		WithLabels(func() labels.Labels { return lbls }),


### PR DESCRIPTION
* [x] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

Fixes #8103 

## Issue
Current os filesystem access methods do not prevent accidental path traversal access, so directory operations based on user input may access unintended paths.

## Changes
Force the use of os.Root to confine access to subdirectories only to the root working folder of the specific service.

## Approach
__Receiver, Sidecar__: long-lived os.Root. The data directory persists for the entire service lifetime, so the Root is stored in the owning struct.
__Compactor__: transient os.Root. The compaction dir is fully removed after each compaction iteration, so the Root dir is opened on-demand.

## Analysis
__Receiver__: real protection from user input, since the tenants directory paths are retrieved from the tenant IDs, derived either from HTTP Header, TLS cert or **metric label**.

__Compactor__: no path is composed from user input. The change only prevents accidental use on the codebase side.

__Sidecar__: as compactor.
