### PR TITLE
receiver: ignore lost+found directory during tenant discovery

### DIFF
--- a/pkg/receive/multitsdb.go
+++ b/pkg/receive/multitsdb.go
@@ -623,6 +623,9 @@ func (t *MultiTSDB) Open() error {
 
 	var g errgroup.Group
 	for _, f := range files {
+		if f.Name() == "lost+found" {
+			continue
+		}
 		if !f.IsDir() {
 			continue
 		}
@@ -807,6 +810,9 @@ func (t *MultiTSDB) RemoveLockFilesIfAny() error {
 
 	merr := errutil.MultiError{}
 	for _, fi := range fis {
+		if fi.Name() == "lost+found" {
+			continue
+		}
 		if !fi.IsDir() {
 			continue
 		}

--- a/pkg/receive/multitsdb_test.go
+++ b/pkg/receive/multitsdb_test.go
@@ -1020,3 +1020,38 @@ func TestMultiTSDBDoesNotReturnPrunedTenants(t *testing.T) {
 
 	wg.Wait()
 }
+
+func TestMultiTSDBIgnoresLostFoundDirectory(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	// Create lost+found directory
+	lostFoundDir := filepath.Join(dir, "lost+found")
+	require.NoError(t, os.Mkdir(lostFoundDir, 0750))
+
+	// Create a default tenant directory to ensure the TSDB initializes correctly
+	defaultTenantDir := filepath.Join(dir, "default-tenant")
+	require.NoError(t, os.Mkdir(defaultTenantDir, 0750))
+
+	logger := log.NewLogfmtLogger(os.Stderr)
+
+	m := NewMultiTSDB(dir, logger, prometheus.NewRegistry(), &tsdb.Options{
+		MinBlockDuration:  (2 * time.Hour).Milliseconds(),
+		MaxBlockDuration:  (2 * time.Hour).Milliseconds(),
+		RetentionDuration: (6 * time.Hour).Milliseconds(),
+	}, labels.FromStrings("replica", "test"), "tenant_id", objstore.NewInMemBucket(), false, false, metadata.NoneFunc)
+	t.Cleanup(func() {
+		m.Close()
+	})
+
+	require.NoError(t, m.Open())
+
+	// Verify lost+found is not treated as a tenant
+	m.mtx.RLock()
+	defer m.mtx.RUnlock()
+
+	for tenantID := range m.tenants {
+		require.NotEqual(t, "lost+found", tenantID, "lost+found should be ignored and not treated as a tenant")
+	}
+}


### PR DESCRIPTION
Closes #8798

## What changed

The receiver now ignores the `lost+found` directory when scanning for tenants. Previously, it would treat this directory as a tenant and create TSDB files within it, which is incorrect.

Changes made:
1. Added checks in `MultiTSDB.Open()` to skip the `lost+found` directory
2. Added checks in `MultiTSDB.RemoveLockFilesIfAny()` to skip the `lost+found` directory
3. Added a unit test `TestMultiTSDBIgnoresLostFoundDirectory` to verify the fix

## Testing
- [x] Unit test added to verify lost+found is ignored
- [ ] Existing test suite passes
- [ ] Follows CONTRIBUTING.md style guidelines