### PR TITLE
receive: ignore lost+found directory when scanning tenant dirs

### DIFF
--- a/pkg/receive/multitsdb.go
+++ b/pkg/receive/multitsdb.go
@@ -403,6 +403,17 @@ func (m *MultiTSDB) initTSDBIfNeeded(tenantID string, t *tenant) error {
 
 const compactionDelayPercentBlockLength = 10
 
+// lostFoundDir is the directory name that ext4 (and some other filesystems)
+// create automatically at the root of every partition. When a receiver's
+// --tsdb.path points directly at a mount point, the directory scan in Open()
+// and RemoveLockFilesIfAny() would otherwise treat it as a tenant name and
+// attempt to open or clean a TSDB for it, producing spurious errors on
+// startup. A name-based skip is the simplest cross-platform fix; checking the
+// inode or filesystem type would require platform-specific syscalls and adds
+// complexity without meaningful safety benefit, since a tenant legitimately
+// named "lost+found" is not a realistic concern.
+const lostFoundDir = "lost+found"
+
 // generateCompactionDelay() generates a time.Duration of up to compactionDelayPercentBlockLength% of the block range. Used to stagger compactions & uploads.
 func (t *tenant) generateCompactionDelay() time.Duration {
 	return time.Duration(rand.Int63n((t.maxBlockDuration*compactionDelayPercentBlockLength)/100)) * time.Millisecond
@@ -626,7 +637,7 @@ func (t *MultiTSDB) Open() error {
 		if !f.IsDir() {
 			continue
 		}
-		if f.Name() == "lost+found" {
+		if f.Name() == lostFoundDir {
 			continue
 		}
 
@@ -813,7 +824,7 @@ func (t *MultiTSDB) RemoveLockFilesIfAny() error {
 		if !fi.IsDir() {
 			continue
 		}
-		if fi.Name() == "lost+found" {
+		if fi.Name() == lostFoundDir {
 			continue
 		}
 		if err := os.Remove(filepath.Join(t.defaultTenantDataDir(fi.Name()), "lock")); err != nil {

--- a/pkg/receive/multitsdb.go
+++ b/pkg/receive/multitsdb.go
@@ -626,6 +626,9 @@ func (t *MultiTSDB) Open() error {
 		if !f.IsDir() {
 			continue
 		}
+		if f.Name() == "lost+found" {
+			continue
+		}
 
 		g.Go(func() error {
 			_, err := t.getOrLoadTenant(f.Name())
@@ -808,6 +811,9 @@ func (t *MultiTSDB) RemoveLockFilesIfAny() error {
 	merr := errutil.MultiError{}
 	for _, fi := range fis {
 		if !fi.IsDir() {
+			continue
+		}
+		if fi.Name() == "lost+found" {
 			continue
 		}
 		if err := os.Remove(filepath.Join(t.defaultTenantDataDir(fi.Name()), "lock")); err != nil {

--- a/pkg/receive/multitsdb_test.go
+++ b/pkg/receive/multitsdb_test.go
@@ -170,6 +170,22 @@ func TestMultiTSDB(t *testing.T) {
 		testMulitTSDBSeries(t, m)
 	})
 
+	t.Run("open ignores lost+found directory", func(t *testing.T) {
+		lostFound := filepath.Join(dir, "lost+found")
+		testutil.Ok(t, os.MkdirAll(lostFound, 0750))
+
+		m := NewMultiTSDB(dir, logger, prometheus.NewRegistry(), &tsdb.Options{
+			MinBlockDuration:  (2 * time.Hour).Milliseconds(),
+			MaxBlockDuration:  (2 * time.Hour).Milliseconds(),
+			RetentionDuration: (6 * time.Hour).Milliseconds(),
+			NoLockfile:        true,
+		}, labels.FromStrings("replica", "01"), "tenant_id", nil, false, false, metadata.NoneFunc, WithGCImmediately())
+		defer m.Close()
+
+		testutil.Ok(t, m.Open())
+		testutil.Equals(t, (*tenant)(nil), m.testGetTenant("lost+found"))
+	})
+
 	t.Run("flush with one sample produces a block", func(t *testing.T) {
 		const testTenant = "test_tenant"
 		m := NewMultiTSDB(dir, logger, prometheus.NewRegistry(), &tsdb.Options{


### PR DESCRIPTION
## What

Skip any directory named `lost+found` when `MultiTSDB.Open()` and
`MultiTSDB.RemoveLockFilesIfAny()` scan the data directory for tenants.

## Why

The ext4 filesystem creates a `lost+found` directory at the root of
every partition. When a receiver's `--tsdb.path` is the filesystem
mount point, both scan loops treat `lost+found` as a tenant name and
attempt to open or clean a TSDB for it, producing spurious errors on
startup.

A name-based skip is the simplest cross-platform fix. Checking the
inode or filesystem type would require platform-specific syscalls and
adds complexity without meaningful safety benefit, since a tenant
legitimately named `lost+found` is not a realistic concern.

## Test

`TestMultiTSDB/open_ignores_lost+found_directory` creates a `lost+found`
directory in the data dir, calls `Open()`, and asserts no tenant was
registered for that name.

Fixes #8798