### PR TITLE
cache: Allow sending readonly requests to Redis replica instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ It is recommend to upgrade the storage components first (Receive, Store, etc.) a
 ### Changed
 
 - [#8670](https://github.com/thanos-io/thanos/pull/8670): Receive: *breaking :warning:* removed `--shipper.ignore-unequal-block-size`. TSDB now delays compaction until blocks have been uploaded by the shipper, allowing compaction while uploading without risking data loss.
+- [#8802](https://github.com/thanos-io/thanos/pull/8802): Cache: add `SendToReplicas` option while initializing Rueidis client to allow sending read-only requests to Redis replica instances.
 
 ### Removed
 

--- a/internal/cortex/chunk/cache/redis_client.go
+++ b/internal/cortex/chunk/cache/redis_client.go
@@ -60,6 +60,9 @@ func NewRedisClient(cfg *RedisConfig) (*RedisClient, error) {
 		Dialer:           net.Dialer{Timeout: cfg.Timeout},
 		ConnWriteTimeout: cfg.Timeout,
 		DisableCache:     true,
+		SendToReplicas: func(cmd rueidis.Completed) bool {
+			return cmd.IsReadOnly()
+		},
 	}
 	if cfg.EnableTLS {
 		clientOpts.TLSConfig = &tls.Config{InsecureSkipVerify: cfg.InsecureSkipVerify}

--- a/pkg/cacheutil/redis_client.go
+++ b/pkg/cacheutil/redis_client.go
@@ -211,6 +211,9 @@ func NewRedisClientWithConfig(logger log.Logger, name string, config RedisClient
 		ConnWriteTimeout:  config.WriteTimeout,
 		DisableCache:      clientSideCacheDisabled,
 		TLSConfig:         tlsConfig,
+		SendToReplicas: func(cmd rueidis.Completed) bool {
+			return cmd.IsReadOnly()
+		},
 	}
 
 	if config.MasterName != "" {


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.

## Changes

<!-- Enumerate changes you made -->
- Adds `SendToReplicas` to the Rueidis Cache Client (https://pkg.go.dev/github.com/redis/rueidis#ClientOption). Heavily reduced load on masters for our environment.

