### PR TITLE
receive: Fix non-retryable quorum failures returning 5xx

### DIFF
--- a/pkg/receive/handler.go
+++ b/pkg/receive/handler.go
@@ -87,7 +87,6 @@ var (
 	errBadReplica  = errors.New("request replica exceeds receiver replication factor")
 	errNotReady    = errors.New("target not ready")
 	errUnavailable = errors.New("target not available")
-	errInternal    = errors.New("internal error")
 )
 
 type WriteableStoreAsyncClient interface {
@@ -838,6 +837,10 @@ func (h *Handler) fanoutForward(ctx context.Context, params remoteWriteParams) (
 	failureThreshold := len(params.replicas) - successThreshold + 1
 	successes := make([]int, len(params.writeRequest.Timeseries))
 	failures := make([]int, len(params.writeRequest.Timeseries))
+	// conflictFailures tracks how many replicas returned a permanent conflict for
+	// each series. When conflictFailures[i] >= failureThreshold the series can
+	// never reach quorum regardless of retries.
+	conflictFailures := make([]int, len(params.writeRequest.Timeseries))
 	seriesErrs := newReplicationErrors(successThreshold, len(params.writeRequest.Timeseries))
 	for {
 		select {
@@ -854,9 +857,13 @@ func (h *Handler) fanoutForward(ctx context.Context, params remoteWriteParams) (
 			}
 
 			if resp.err != nil {
+				isConflictErr := isConflict(errors.Cause(resp.err))
 				for _, seriesID := range resp.seriesIDs {
 					seriesErrs[seriesID].Add(resp.err)
 					failures[seriesID]++
+					if isConflictErr {
+						conflictFailures[seriesID]++
+					}
 				}
 			} else {
 				for _, seriesID := range resp.seriesIDs {
@@ -864,7 +871,7 @@ func (h *Handler) fanoutForward(ctx context.Context, params remoteWriteParams) (
 				}
 			}
 
-			if canReturnEarly(successes, failures, successThreshold, failureThreshold) {
+			if canReturnEarly(successes, conflictFailures, successThreshold, failureThreshold) {
 				var hadErrors bool
 				for i, seriesErr := range seriesErrs {
 					if failures[i] >= failureThreshold {
@@ -1132,12 +1139,17 @@ func (h *Handler) writeQuorum() int {
 	return int((h.options.ReplicationFactor / 2) + 1)
 }
 
-// canReturnEarly returns true when every series in the request has a
-// determined outcome: either it reached the success threshold or it accumulated
-// enough failures that reaching the success threshold is no longer possible.
-func canReturnEarly(successes, failures []int, successThreshold, failureThreshold int) bool {
+// canReturnEarly returns true when every series has a determined outcome.
+// A series is determined when it either reached the success threshold, or its
+// conflict failure count reached the failure threshold meaning it can never
+// reach quorum even if every remaining non-conflict replica succeeds.
+//
+// Non-conflict failures do not trigger early return, we must wait
+// for all replica responses so we can count total conflicts accurately and
+// decide whether the request is permanently failed (409) or retryable (503).
+func canReturnEarly(successes, conflictFailures []int, successThreshold, failureThreshold int) bool {
 	for i := range successes {
-		if successes[i] < successThreshold && failures[i] < failureThreshold {
+		if successes[i] < successThreshold && conflictFailures[i] < failureThreshold {
 			return false
 		}
 	}
@@ -1408,11 +1420,17 @@ type replicationErrors struct {
 	threshold int
 }
 
-// Cause extracts a sentinel error with the highest occurrence that
-// has happened more than the given threshold.
-// If no single error has occurred more than the threshold, but the
-// total number of errors meets the threshold,
-// replicationErr will return errInternal.
+// Cause extracts the sentinel error that best describes the replication outcome.
+//
+// If one error type appears at least threshold times it is returned directly
+// (a conflict-dominated series can never succeed).
+//
+// Otherwise, if total errors meet the threshold but no single type dominates,
+// the series failed quorum due to a mix of error types.
+//
+// Because canReturnEarly only fires early when conflict failures alone reach
+// the threshold, reaching this fallback guarantees that conflict_count < failureThreshold,
+// the request could succeed on retry once transient failures resolve.
 func (es *replicationErrors) Cause() error {
 	if len(es.errs) == 0 {
 		return errorSet{}
@@ -1439,7 +1457,9 @@ func (es *replicationErrors) Cause() error {
 	}
 
 	if len(es.errs) >= es.threshold {
-		return errInternal
+		// conflict count is below the threshold so retry may
+		// succeed once transient replicas recover.
+		return errUnavailable
 	}
 
 	return nil

--- a/pkg/receive/handler_test.go
+++ b/pkg/receive/handler_test.go
@@ -338,7 +338,7 @@ func testReceiveQuorum(t *testing.T, hashringAlgo HashringAlgorithm, withConsist
 		},
 		{
 			name:              "size 1 commit error",
-			status:            http.StatusInternalServerError,
+			status:            http.StatusServiceUnavailable,
 			replicationFactor: 1,
 			wreq:              wreq,
 			appendables: []*fakeAppendable{
@@ -408,7 +408,7 @@ func testReceiveQuorum(t *testing.T, hashringAlgo HashringAlgorithm, withConsist
 		},
 		{
 			name:              "size 3 commit error",
-			status:            http.StatusInternalServerError,
+			status:            http.StatusServiceUnavailable,
 			replicationFactor: 1,
 			wreq:              wreq,
 			appendables: []*fakeAppendable{
@@ -425,7 +425,7 @@ func testReceiveQuorum(t *testing.T, hashringAlgo HashringAlgorithm, withConsist
 		},
 		{
 			name:              "size 3 commit error with replication",
-			status:            http.StatusInternalServerError,
+			status:            http.StatusServiceUnavailable,
 			replicationFactor: 3,
 			wreq:              wreq,
 			appendables: []*fakeAppendable{
@@ -442,7 +442,7 @@ func testReceiveQuorum(t *testing.T, hashringAlgo HashringAlgorithm, withConsist
 		},
 		{
 			name:              "size 3 appender error with replication",
-			status:            http.StatusInternalServerError,
+			status:            http.StatusServiceUnavailable,
 			replicationFactor: 3,
 			wreq:              wreq,
 			appendables: []*fakeAppendable{
@@ -563,8 +563,28 @@ func testReceiveQuorum(t *testing.T, hashringAlgo HashringAlgorithm, withConsist
 			},
 		},
 		{
+			// cce: two permanent conflicts + one generic error. Even if the
+			// error node recovers, the best possible outcome is 1 success +
+			// 2 conflicts which cannot reach quorum of 2. Must return 409.
+			name:              "size 3 with replication two conflicts and one commit error",
+			status:            http.StatusConflict,
+			replicationFactor: 3,
+			wreq:              wreq,
+			appendables: []*fakeAppendable{
+				{
+					appender: newFakeAppender(conflictErrFn, nil, nil),
+				},
+				{
+					appender: newFakeAppender(conflictErrFn, nil, nil),
+				},
+				{
+					appender: newFakeAppender(nil, commitErrFn, nil),
+				},
+			},
+		},
+		{
 			name:              "size 3 with replication one conflict and one commit error",
-			status:            http.StatusInternalServerError,
+			status:            http.StatusServiceUnavailable,
 			replicationFactor: 3,
 			wreq:              wreq,
 			appendables: []*fakeAppendable{
@@ -581,7 +601,7 @@ func testReceiveQuorum(t *testing.T, hashringAlgo HashringAlgorithm, withConsist
 		},
 		{
 			name:              "size 3 with replication two commit errors",
-			status:            http.StatusInternalServerError,
+			status:            http.StatusServiceUnavailable,
 			replicationFactor: 3,
 			wreq:              wreq,
 			appendables: []*fakeAppendable{
@@ -624,7 +644,7 @@ func testReceiveQuorum(t *testing.T, hashringAlgo HashringAlgorithm, withConsist
 		},
 		{
 			name:              "size 6 with replication 3 one commit and two conflict error",
-			status:            http.StatusConflict,
+			status:            http.StatusServiceUnavailable,
 			replicationFactor: 3,
 			wreq:              wreq,
 			appendables: []*fakeAppendable{
@@ -709,12 +729,6 @@ func testReceiveQuorum(t *testing.T, hashringAlgo HashringAlgorithm, withConsist
 					rec, err := makeRequest(handler, tenant, tc.wreq)
 					if err != nil {
 						t.Fatalf("handler %d: unexpectedly failed making HTTP request: %v", i+1, err)
-					}
-					// TODO(GiedriusS): fix this for gRPC replication too.
-					if capnpReplication {
-						if rec.Code == 503 {
-							rec.Code = 500
-						}
 					}
 					if rec.Code != tc.status {
 						t.Errorf("handler %d: got unexpected HTTP status code: expected %d, got %d; body: %s", i+1, tc.status, rec.Code, rec.Body.String())


### PR DESCRIPTION
RW replication seems to return 5xx for requests that can never succeed on retry, causing prometheus to retry indefinitely.

For example on rf=3, quorum=2, with the 3 nodes, in a 2 conflict + 1 err case (cce) the correct response should be 409 not 500.

The code is tricky but I think it happens when, `canReturnEarly` fires as soon as any two failures arrive, but this meant for a cce case if it got errors in the order of conflict, error, conflict, it would fire after the second transient error and return 5xx, but the request can actually never succeed.

This commit addresses this issue by tracking conflict failures separately from other failures. So canReturnEarly only returns early on successes reaching success threshold i.e quorum, or when conflict counts reach failure threshold.

It also changes errInternal to errUnavailble, so that error tracking in split mode is actually accurate semantically, instead of falling back to default or unknown error cases all the time (also removes similar TODO for it in test).

Addresses https://github.com/thanos-io/thanos/issues/8727

I could be very wrong here, trying to work through this code manually, and I think this is current flow, but feel free to correct me if I'm wrong 🙂 
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
