### PR TITLE
fix(receive): validate tenant label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ It is recommend to upgrade the storage components first (Receive, Store, etc.) a
 - [#8128](https://github.com/thanos-io/thanos/issues/8128): Query-Frontend: Fix panic in `AnalyzesMerge` caused by indexing the wrong slice variable, leading to an out-of-range access when merging more than two query analyses.
 - [#8720](https://github.com/thanos-io/thanos/issues/8720): Receive: Fix 503 errors during restarts in some cases.
 - [#8799](https://github.com/thanos-io/thanos/pull/8799): *: Set a `KeepaliveEnforcementPolicy` with `MinTime: 10s` on all gRPC servers, matching the client keepalive interval.
+- [#8806](https://github.com/thanos-io/thanos/pull/8806): Receive: Validate tenant IDs extracted from split-tenant labels to prevent path traversal.
 
 ### Added
 

--- a/pkg/receive/handler.go
+++ b/pkg/receive/handler.go
@@ -87,6 +87,8 @@ var (
 	errBadReplica  = errors.New("request replica exceeds receiver replication factor")
 	errNotReady    = errors.New("target not ready")
 	errUnavailable = errors.New("target not available")
+
+	errValidation = errors.New("validation error")
 )
 
 type WriteableStoreAsyncClient interface {
@@ -640,6 +642,8 @@ func (h *Handler) receiveHTTP(w http.ResponseWriter, r *http.Request) {
 			responseStatusCode = http.StatusConflict
 		case errBadReplica:
 			responseStatusCode = http.StatusBadRequest
+		case errValidation:
+			responseStatusCode = http.StatusBadRequest
 		default:
 			level.Error(tLogger).Log("err", err, "msg", "internal server error")
 			responseStatusCode = http.StatusInternalServerError
@@ -907,6 +911,9 @@ func (h *Handler) distributeTimeseriesToReplicas(
 
 			tenantLabel := lbls.Get(h.splitTenantLabelName)
 			if tenantLabel != "" {
+				if err := tenancy.IsTenantValid(tenantLabel); err != nil {
+					return nil, nil, errors.Wrap(errValidation, err.Error())
+				}
 				tenant = tenantLabel
 
 				newLabels := labels.NewBuilder(lbls)

--- a/pkg/receive/handler_test.go
+++ b/pkg/receive/handler_test.go
@@ -1043,6 +1043,81 @@ func TestReceiveWriteRequestLimits(t *testing.T) {
 	}
 }
 
+func TestReceiveTenantValidation(t *testing.T) {
+	t.Parallel()
+
+	const tenantLabelName = "thanos_tenant_id"
+
+	for _, tc := range []struct {
+		name         string
+		tenantHeader string
+		tenantLabel  string
+		status       int
+	}{
+		{
+			name:         "Tenant from label validation fails",
+			tenantHeader: "tenant-a",
+			tenantLabel:  "../malicious",
+			status:       http.StatusBadRequest,
+		},
+		{
+			name:         "Tenant from header validation fails",
+			tenantHeader: "../malicious",
+			status:       http.StatusBadRequest,
+		},
+		{
+			name:         "Valid tenant from header and label succeeds",
+			tenantHeader: "tenant-a",
+			tenantLabel:  "tenant-b",
+			status:       http.StatusOK,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+
+			appendables := []*fakeAppendable{
+				{
+					appender: newFakeAppender(nil, nil, nil),
+				},
+			}
+
+			handlers, _, closeFunc, err := newTestHandlerHashring(tc.name, appendables, 1, AlgorithmHashmod, false)
+			if err != nil {
+				t.Fatalf("unable to create test handler: %v", err)
+			}
+			defer func() {
+				testutil.Ok(t, closeFunc())
+				// Wait a few milliseconds for peer workers to process the queue.
+				time.AfterFunc(50*time.Millisecond, func() {
+					for _, h := range handlers {
+						h.Close()
+					}
+				})
+			}()
+
+			h := handlers[0]
+			h.splitTenantLabelName = tenantLabelName
+
+			wreq := &prompb.WriteRequest{
+				Timeseries: []prompb.TimeSeries{
+					{
+						Labels: []labelpb.ZLabel{
+							{Name: "__name__", Value: "test_metric"},
+							{Name: tenantLabelName, Value: tc.tenantLabel},
+						},
+						Samples: []prompb.Sample{
+							{Value: 1, Timestamp: time.Now().UnixMilli()},
+						},
+					},
+				},
+			}
+
+			rec, err := makeRequest(h, tc.tenantHeader, wreq)
+			testutil.Ok(t, err)
+			testutil.Equals(t, tc.status, rec.Code)
+		})
+	}
+}
+
 // endpointHit is a helper to determine if a given endpoint in a hashring would be selected
 // for a given time series, tenant, and replication factor.
 func endpointHit(t *testing.T, h Hashring, rf uint64, endpoint, tenant string, timeSeries *prompb.TimeSeries) bool {
@@ -1431,17 +1506,17 @@ func TestIsTenantValid(t *testing.T) {
 		{
 			name:        "test malicious tenant",
 			tenant:      "/etc/foo",
-			expectedErr: errors.New("Tenant name not valid"),
+			expectedErr: errors.New("tenant name not valid"),
 		},
 		{
 			name:        "test malicious tenant going out of receiver directory",
 			tenant:      "./../../hacker_dir",
-			expectedErr: errors.New("Tenant name not valid"),
+			expectedErr: errors.New("tenant name not valid"),
 		},
 		{
 			name:        "test slash-only tenant",
 			tenant:      "///",
-			expectedErr: errors.New("Tenant name not valid"),
+			expectedErr: errors.New("tenant name not valid"),
 		},
 		{
 			name:   "test default tenant",

--- a/pkg/tenancy/tenancy.go
+++ b/pkg/tenancy/tenancy.go
@@ -40,7 +40,7 @@ const (
 
 func IsTenantValid(tenant string) error {
 	if tenant != path.Base(tenant) {
-		return errors.New("Tenant name not valid")
+		return errors.New("tenant name not valid")
 	}
 	return nil
 }


### PR DESCRIPTION
* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

When `--receive.split-tenant-label-name` is configured, tenant IDs extracted from labels are now validated against IsTenantValid() as done for  HTTP header and certificate-based tenants.
                                                        
  - `pkg/receive/handler.go`: validate tenant IDs extracted from labels, matching the existing validation applied to HTTP header tenants.
  - `test/e2e/receive_test.go`: Add `TestReceivePathTraversal` with subtests verifying both HTTP header and           
  label-based path traversal attempts are rejected.

## Verification
- all unit tests pass
- e2e test `TestReceivePathTraversal` confirms labels like `../mal-path` are now rejected
