### PR TITLE
fix(rule): enable grpc client flags for ruler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ It is recommend to upgrade the storage components first (Receive, Store, etc.) a
 - [#8770](https://github.com/thanos-io/thanos/pull/8770): Receive: add `--remote-write.server-tls-curves` to configure curves for the HTTP server.
 - [#8808](https://github.com/thanos-io/thanos/pull/8808): ruler, sidecar: Add TSDB stats endpoint to gRPC server.
 - [#8594](https://github.com/thanos-io/thanos/pull/8594): Query: Support per endpoint TLS configuration.
+- [#8807](https://github.com/thanos-io/thanos/pull/8807): Rule: enable grpc client flags
 
 ### Changed
 

--- a/cmd/thanos/rule.go
+++ b/cmd/thanos/rule.go
@@ -86,10 +86,11 @@ import (
 )
 
 type ruleConfig struct {
-	http    httpConfig
-	grpc    grpcConfig
-	web     webConfig
-	shipper shipperConfig
+	http       httpConfig
+	grpc       grpcConfig
+	grpcClient grpcClientConfig
+	web        webConfig
+	shipper    shipperConfig
 
 	query              queryConfig
 	queryConfigYAML    []byte
@@ -127,6 +128,7 @@ type Expression struct {
 func (rc *ruleConfig) registerFlag(cmd extkingpin.FlagClause) {
 	rc.http.registerFlag(cmd)
 	rc.grpc.registerFlag(cmd)
+	rc.grpcClient.registerFlag(cmd)
 	rc.web.registerFlag(cmd)
 	rc.shipper.registerFlag(cmd)
 	rc.query.registerFlag(cmd)
@@ -418,22 +420,33 @@ func runRule(
 	}
 
 	if len(grpcEndpoints) > 0 {
-		dialOpts, err := extgrpc.StoreClientGRPCOpts(
+		dialOpts, err := conf.grpcClient.dialOptions(logger, reg, tracer)
+		if err != nil {
+			return err
+		}
+
+		tlsDialOpts, err := extgrpc.StoreClientTLSCredentials(
 			logger,
-			reg,
-			tracer,
+			conf.grpcClient.secure,
+			conf.grpcClient.skipVerify,
+			conf.grpcClient.cert,
+			conf.grpcClient.key,
+			conf.grpcClient.caCert,
+			conf.grpcClient.serverName,
+			conf.grpcClient.minTLSVersion,
 		)
 		if err != nil {
 			return err
 		}
 
-		tlsDialOpts, err := extgrpc.StoreClientTLSCredentials(logger, false, false, "", "", "", "", "")
-		if err != nil {
-			return err
+		grpcTLSConfig := &tlsConfig{
+			Enabled:                  &conf.grpcClient.secure,
+			InsecureSkipVerification: &conf.grpcClient.skipVerify,
+			CertFile:                 &conf.grpcClient.cert,
+			KeyFile:                  &conf.grpcClient.key,
+			CAFile:                   &conf.grpcClient.caCert,
+			MinVersion:               &conf.grpcClient.minTLSVersion,
 		}
-
-		// No TLS config for rule component
-		noTLSConfig := &tlsConfig{}
 
 		grpcEndpointSet, err = setupEndpointSet(
 			g,
@@ -454,9 +467,9 @@ func runRule(
 			5*time.Second,
 			conf.evalInterval,
 			dialOpts,
-			noTLSConfig,
+			grpcTLSConfig,
 			tlsDialOpts,
-			"", // no global compression
+			conf.grpcClient.compression,
 			[]string{},
 		)
 		if err != nil {

--- a/docs/components/receive.md
+++ b/docs/components/receive.md
@@ -373,17 +373,17 @@ Please see the metric `thanos_receive_forward_delay_seconds` to see if you need 
 The following formula is used for calculating quorum:
 
 ```go mdox-exec="sed -n '1123,1133p' pkg/receive/handler.go"
-// writeQuorum returns minimum number of replicas that has to confirm write success before claiming replication success.
-func (h *Handler) writeQuorum() int {
-	// NOTE(GiedriusS): this is here because otherwise RF=2 doesn't make sense as all writes
-	// would need to succeed all the time. Another way to think about it is when migrating
-	// from a Sidecar based setup with 2 Prometheus nodes to a Receiver setup, we want to
-	// keep the same guarantees.
-	if h.options.ReplicationFactor == 2 {
-		return 1
+	tenant string,
+	er endpointReplica,
+	ts trackedSeries,
+	alreadyReplicated bool,
+	responses chan writeResponse,
+	wg *sync.WaitGroup,
+) bool {
+	cl, req, cb := h.prepareRemoteWrite(ctx, tenant, er, ts, alreadyReplicated, responses, wg)
+	if cl == nil {
+		return true
 	}
-	return int((h.options.ReplicationFactor / 2) + 1)
-}
 ```
 
 So, if the replication factor is 2 then at least one write must succeed. With RF=3, two writes must succeed, and so on.

--- a/docs/components/rule.md
+++ b/docs/components/rule.md
@@ -333,6 +333,32 @@ Flags:
                                  and redo TLS handshakes.
       --grpc-grace-period=2m     Time to wait after an interrupt received for
                                  GRPC Server.
+      --[no-]grpc-client-tls-secure
+                                 Deprecated after v0.43.0: Use TLS when talking
+                                 to the gRPC server
+      --[no-]grpc-client-tls-skip-verify
+                                 Deprecated after v0.43.0: Disable TLS
+                                 certificate verification i.e self signed,
+                                 signed by fake CA
+      --grpc-client-tls-cert=""  Deprecated after v0.43.0: TLS Certificates to
+                                 use to identify this client to the server
+      --grpc-client-tls-key=""   Deprecated after v0.43.0: TLS Key for the
+                                 client's certificate
+      --grpc-client-tls-ca=""    Deprecated after v0.43.0: TLS CA Certificates
+                                 to use to verify gRPC servers
+      --grpc-client-server-name=""
+                                 Deprecated after v0.43.0: Server
+                                 name to verify the hostname on the
+                                 returned gRPC certificates. See
+                                 https://tools.ietf.org/html/rfc4366#section-3.1
+      --grpc-compression=none    Deprecated after v0.43.0: Compression algorithm
+                                 to use for gRPC requests to other clients.
+                                 Must be one of: snappy, none
+      --grpc-client-tls-min-version=1.3
+                                 Deprecated after v0.43.0: TLS supported
+                                 minimum version for gRPC client. If no version
+                                 is specified, it'll default to 1.3. Allowed
+                                 values: ["1.0", "1.1", "1.2", "1.3"]
       --web.route-prefix=""      Prefix for API and UI endpoints. This allows
                                  thanos UI to be served on a sub-path. This
                                  option is analogous to --web.route-prefix of


### PR DESCRIPTION
Ruler talks over gRPC but it doesn't enable client flags, so one cannot configure (for example) custom CA certs if required. Enable client flags.

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
