### PR TITLE
Fix head block bound drift in multitsdb compaction 

### DIFF
--- a/docs/components/receive.md
+++ b/docs/components/receive.md
@@ -372,7 +372,7 @@ Please see the metric `thanos_receive_forward_delay_seconds` to see if you need 
 
 The following formula is used for calculating quorum:
 
-```go mdox-exec="sed -n '1123,1133p' pkg/receive/handler.go"
+```go mdox-exec="sed -n '1137,1147p' pkg/receive/handler.go"
 // writeQuorum returns minimum number of replicas that has to confirm write success before claiming replication success.
 func (h *Handler) writeQuorum() int {
 	// NOTE(GiedriusS): this is here because otherwise RF=2 doesn't make sense as all writes

--- a/pkg/receive/multitsdb.go
+++ b/pkg/receive/multitsdb.go
@@ -432,18 +432,34 @@ func (t *tenant) startPeriodicHeadCompaction() {
 		if head.MinTime() < 0 {
 			return nil
 		}
-		sinceOldestDataMillis := time.Since(time.UnixMilli(head.MinTime())).Milliseconds()
 
-		// NOTE(GiedriusS): this is what Prometheus does. 0.5 is an extra appending window.
+		// Wall-clock time determines whether the head is old enough to compact,
+		// ensuring tenants that stopped receiving samples still get flushed.
+		// The head's data span (MaxTime - MinTime) determines how many blocks
+		// to produce, compacting until the span drops below the threshold.
 		compactionThreshold := int64(1.5 * float64(t.maxBlockDuration))
-		if sinceOldestDataMillis > compactionThreshold {
+		sinceOldestSampleMs := time.Since(time.UnixMilli(head.MinTime())).Milliseconds()
+		if sinceOldestSampleMs <= compactionThreshold {
+			return nil
+		}
+
+		for {
+			select {
+			case <-t.doneC:
+				return nil
+			default:
+			}
+
 			if err := t.compactHead(db); err != nil {
 				return fmt.Errorf("compact head: %w", err)
 			}
 			t.lastSuccessfulHeadCompaction.Store(time.Now().UnixNano())
-		}
 
-		return nil
+			head = db.Head()
+			if head.MaxTime()-head.MinTime() <= compactionThreshold {
+				return nil
+			}
+		}
 	}
 
 	compactionDelay := t.generateCompactionDelay()

--- a/pkg/receive/multitsdb.go
+++ b/pkg/receive/multitsdb.go
@@ -420,8 +420,7 @@ func (t *tenant) generateCompactionDelay() time.Duration {
 }
 
 func (t *tenant) startPeriodicHeadCompaction() {
-	// NOTE(GiedriusS): from the old cmd/thanos/receive.go.
-	var interval = 2 * time.Duration(t.maxBlockDuration) * time.Millisecond
+	var interval = time.Duration(t.maxBlockDuration) * time.Millisecond
 
 	doIter := func() error {
 		db := t.readyS.Get()

--- a/pkg/receive/multitsdb_test.go
+++ b/pkg/receive/multitsdb_test.go
@@ -541,6 +541,71 @@ func TestMultiTSDBRecreatePrunedTenant(t *testing.T) {
 
 }
 
+// synctest.Test controls fake time so t.Parallel() is not used.
+func TestPeriodicHeadCompaction(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		dir := t.TempDir()
+
+		maxBlockDuration := (2 * time.Hour).Milliseconds()
+
+		m := NewMultiTSDB(dir, log.NewLogfmtLogger(os.Stderr), prometheus.NewRegistry(),
+			&tsdb.Options{
+				MinBlockDuration:  maxBlockDuration,
+				MaxBlockDuration:  maxBlockDuration,
+				RetentionDuration: (24 * time.Hour).Milliseconds(),
+			},
+			labels.FromStrings("replica", "test"),
+			"tenant_id",
+			nil,
+			false,
+			false,
+			metadata.NoneFunc,
+			WithGCImmediately(),
+		)
+		defer m.Close()
+
+		// Write 10 hours of samples upfront, simulating a large head
+		// backlog (e.g. WAL replay after a long downtime).
+		now := time.Now()
+		for step := time.Duration(0); step <= 10*time.Hour; step += time.Minute {
+			testutil.Ok(t, appendSample(m, "test-tenant", now.Add(step)))
+		}
+
+		tenant := m.testGetTenant("test-tenant")
+		db := tenant.readyStorage().Get()
+		testutil.Assert(t, db != nil, "TSDB should be initialized")
+
+		// Precondition: head must contain the full 10h of data before
+		// we advance time, otherwise the test could pass vacuously.
+		headSpanBefore := db.Head().MaxTime() - db.Head().MinTime()
+		testutil.Assert(t, headSpanBefore >= (10*time.Hour).Milliseconds(),
+			"precondition: head should span at least 10h, got %dms", headSpanBefore)
+
+		// Advance time to let the periodic compaction ticker fire.
+		// The ticker interval is 2*maxBlockDuration (4h) with a random
+		// initial delay up to 10% of maxBlockDuration (~12min). After
+		// 8h, 1-2 ticks will have fired. A correct implementation
+		// should drain the full backlog within a single tick.
+		time.Sleep(8 * time.Hour)
+		synctest.Wait()
+
+		head := db.Head()
+		headSpanMs := head.MaxTime() - head.MinTime()
+		maxAcceptableHeadSpanMs := 2 * maxBlockDuration
+
+		testutil.Assert(t, headSpanMs <= maxAcceptableHeadSpanMs,
+			"head span is %dms, expected at most %dms",
+			headSpanMs, maxAcceptableHeadSpanMs)
+
+		// 10h of data with 2h blocks should produce at least 3 on-disk
+		// blocks. The exact count depends on the random compaction delay
+		// and how many ticks fired within the 8h window.
+		testutil.Assert(t, len(db.Blocks()) >= 3,
+			"expected at least 3 blocks, got %d",
+			len(db.Blocks()))
+	})
+}
+
 func TestMultiTSDBAddNewTenant(t *testing.T) {
 	if testing.
 		Short() {


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ x ] Change is not relevant to the end user.

## Changes
* [Adding loop until the head's data span drops below the compaction threshold instead, and check doneC between iterations so shutdown isn't blocked by a large backlog.](https://github.com/thanos-io/thanos/pull/8809/changes/61e2077c122b8bef2fdf51a21aec20d39e7ed158)
* [Updating periodic head compaction interval to run based on the maxBlockDuration, and not 2x the maxBlockDuration. This keeps the head and WAL in line with the maxBlockDuration under normal operatiion](https://github.com/thanos-io/thanos/pull/8809/changes/b3eed71299db0c75567997f739755ff91ab3be05)

## Why? 
 The refactor in [57a2770](https://github.com/thanos-io/thanos/pull/8704/changes#diff-61eda56d07cd51eb9fde89c6bd9f1fe7e260edb05eb8fb4c1c81aa258f034331R413) ("receive/multitsdb: refactor inner workings") disabled TSDB's built-in auto-compaction and replaced it with a manual `startPeriodicHeadCompaction()` loop inside multitsdb.

 This introduced a regression: assuming a default `MaxBlockDuration` of 2h (or any for that matter), the compaction ticker fires every `2*MaxBlockDuration = 4h`. Each tick, `compactHead()` only flushes one block-aligned 2h range from the back of the head:

```go
     blockAlignedMint := mint - (mint % t.maxBlockDuration)  // align to block boundary
     maxt := blockAlignedMint + t.maxBlockDuration - 1       // mint + 2h
```

Since 4h of data accumulates between ticks but only 2h is compacted per tick, the head grows by ~2h every cycle. This causes:

 * Linear growth of WAL size (truncation only happens after head compaction)
 * Linear growth of head chunks (data stays in-memory instead of being
   flushed to on-disk blocks)
 * Compaction/truncation interval effectively doubling from ~2h to ~4h

 Added: test simulates 12h of continuous writes that the head span stays bounded at <= 2 block ranges (4h) and that at least 4 on-disk blocks are produced. First commit introduces it and should currently fails, confirming the regression.

## Verification

[Adding unit test to capture head-bound compaction drift.](https://github.com/thanos-io/thanos/pull/8809/changes/986ec4963c2d2b5286b67d53f36722af1d613044)


# Note
OOO Sample ingestion + WLB compaction is also impacted by the disabling of autocompaction. Would like some guidance from Thanos Maintainers on how best to address this either we: 
* Add WLB compaction as part of multitsdb periodic compaction
* Revert back to autocompaction w/ mtx on upstream. (I worry that we have some edgecases with autocompaction that we have potentially not addressed). 
