### PR TITLE
ruler: correctly pass query partial response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ It is recommend to upgrade the storage components first (Receive, Store, etc.) a
 - [#8720](https://github.com/thanos-io/thanos/issues/8720): Receive: Fix 503 errors during restarts in some cases.
 - [#8799](https://github.com/thanos-io/thanos/pull/8799): *: Set a `KeepaliveEnforcementPolicy` with `MinTime: 10s` on all gRPC servers, matching the client keepalive interval.
 - [#8806](https://github.com/thanos-io/thanos/pull/8806): Receive: Validate tenant IDs extracted from split-tenant labels to prevent path traversal.
+- [#8810](https://github.com/thanos-io/thanos/pull/8810): Ruler: correctly pass query partial response for gRPC.
 
 ### Added
 

--- a/cmd/thanos/rule.go
+++ b/cmd/thanos/rule.go
@@ -1011,7 +1011,9 @@ func queryFuncCreator(
 			if grpcEndpointSet != nil {
 				queryAPIClients := grpcEndpointSet.GetQueryAPIClients()
 				for _, i := range rand.Perm(len(queryAPIClients)) {
-					e := query.NewRemoteEngine(logger, queryAPIClients[i], query.Opts{})
+					e := query.NewRemoteEngine(logger, queryAPIClients[i], query.Opts{
+						PartialResponse: partialResponseStrategy == storepb.PartialResponseStrategy_WARN,
+					})
 					expr, err := extpromql.ParseExpr(qs)
 					if err != nil {
 						level.Error(logger).Log("err", err, "query", qs)


### PR DESCRIPTION
Ruler doesn't set PartialResponse for gRPC clients, so it's always false. It only sets it for HTTP clients.
>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
