### PR TITLE
query: suppress plan is not a logicalplan.Node errors

### DIFF
--- a/pkg/api/query/querypb/plan.go
+++ b/pkg/api/query/querypb/plan.go
@@ -4,7 +4,6 @@
 package querypb
 
 import (
-	"github.com/pkg/errors"
 	"github.com/thanos-io/promql-engine/api"
 	"github.com/thanos-io/promql-engine/logicalplan"
 )
@@ -12,7 +11,7 @@ import (
 func NewJSONEncodedPlan(plan api.RemoteQuery) (*QueryPlan, error) {
 	node, ok := plan.(logicalplan.Node)
 	if !ok {
-		return nil, errors.New("plan is not a logicalplan.Node")
+		return nil, nil
 	}
 	bytes, err := logicalplan.Marshal(node)
 	if err != nil {


### PR DESCRIPTION
This failed cast is not really an error and it floods logs with message when using Ruler with gRPC queries.

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
