### PR TITLE
compact: share marker gathering filter logic

### DIFF
--- a/pkg/block/marker_filter.go
+++ b/pkg/block/marker_filter.go
@@ -1,0 +1,104 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package block
+
+import (
+	"context"
+	"sync"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/oklog/ulid/v2"
+	"github.com/pkg/errors"
+	"github.com/thanos-io/objstore"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/thanos-io/thanos/pkg/block/metadata"
+)
+
+// GatherMarkedBlocks reads one marker type for each provided block meta and
+// returns markers keyed by block ID. Missing and partially uploaded markers are
+// ignored, matching the behavior expected by metadata filters.
+func GatherMarkedBlocks[M metadata.Marker](
+	ctx context.Context,
+	logger log.Logger,
+	bkt objstore.InstrumentedBucketReader,
+	metas map[ulid.ULID]*metadata.Meta,
+	concurrency int,
+	newMarker func() M,
+	partialMarkerFilename string,
+	synced GaugeVec,
+	syncedLabel string,
+) (map[ulid.ULID]M, error) {
+	if concurrency < 1 {
+		concurrency = 1
+	}
+
+	markedBlocks := make(map[ulid.ULID]M)
+	var markedBlocksMtx sync.Mutex
+
+	// Make a copy of block IDs to check, in order to avoid concurrency issues
+	// between the scheduler and workers.
+	blockIDs := make([]ulid.ULID, 0, len(metas))
+	for id := range metas {
+		blockIDs = append(blockIDs, id)
+	}
+
+	var (
+		eg errgroup.Group
+		ch = make(chan ulid.ULID, concurrency)
+	)
+
+	for i := 0; i < concurrency; i++ {
+		eg.Go(func() error {
+			var lastErr error
+			for id := range ch {
+				marker := newMarker()
+				if err := metadata.ReadMarker(ctx, logger, bkt, id.String(), marker); err != nil {
+					if errors.Cause(err) == metadata.ErrorMarkerNotFound {
+						continue
+					}
+					if errors.Cause(err) == metadata.ErrorUnmarshalMarker {
+						level.Warn(logger).Log("msg", "found partial "+partialMarkerFilename+"; if we will see it happening often for the same block, consider manually deleting "+partialMarkerFilename+" from the object storage", "block", id, "err", err)
+						continue
+					}
+					// Remember the last error and continue draining the channel.
+					lastErr = err
+					continue
+				}
+
+				markedBlocksMtx.Lock()
+				markedBlocks[id] = marker
+				markedBlocksMtx.Unlock()
+				if synced != nil {
+					synced.WithLabelValues(syncedLabel).Inc()
+				}
+			}
+
+			return lastErr
+		})
+	}
+
+	// Workers scheduled, distribute blocks.
+	eg.Go(func() error {
+		defer close(ch)
+
+		for _, id := range blockIDs {
+			select {
+			case ch <- id:
+				// Nothing to do.
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
+
+		return nil
+	})
+
+	if err := eg.Wait(); err != nil {
+		return nil, err
+	}
+
+	return markedBlocks, nil
+}

--- a/pkg/block/marker_filter_test.go
+++ b/pkg/block/marker_filter_test.go
@@ -1,0 +1,55 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package block
+
+import (
+	"bytes"
+	"context"
+	"path"
+	"testing"
+
+	"github.com/efficientgo/core/testutil"
+	"github.com/go-kit/log"
+	"github.com/oklog/ulid/v2"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/thanos-io/objstore"
+
+	"github.com/thanos-io/thanos/pkg/block/metadata"
+)
+
+func TestGatherMarkedBlocks(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	logger := log.NewNopLogger()
+	bkt := objstore.NewInMemBucket()
+
+	ids := []ulid.ULID{
+		ulid.MustNew(1, nil),
+		ulid.MustNew(2, nil),
+		ulid.MustNew(3, nil),
+	}
+	metas := make(map[ulid.ULID]*metadata.Meta, len(ids))
+	for _, id := range ids {
+		metas[id] = &metadata.Meta{}
+	}
+
+	testutil.Ok(t, MarkForNoCompact(ctx, logger, bkt, ids[0], metadata.ManualNoCompactReason, "details", prometheus.NewCounter(prometheus.CounterOpts{})))
+	testutil.Ok(t, bkt.Upload(ctx, path.Join(ids[1].String(), metadata.NoCompactMarkFilename), bytes.NewBufferString("{")))
+
+	markedBlocks, err := GatherMarkedBlocks(
+		ctx,
+		logger,
+		objstore.WithNoopInstr(bkt),
+		metas,
+		2,
+		func() *metadata.NoCompactMark { return &metadata.NoCompactMark{} },
+		metadata.NoCompactMarkFilename,
+		nil,
+		MarkedForNoCompactionMeta,
+	)
+	testutil.Ok(t, err)
+	testutil.Equals(t, 1, len(markedBlocks))
+	testutil.Equals(t, metadata.ManualNoCompactReason, markedBlocks[ids[0]].Reason)
+}

--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -1662,68 +1662,18 @@ func (f *GatherNoCompactionMarkFilter) NoCompactMarkedBlocks() map[ulid.ULID]*me
 
 // Filter passes all metas, while gathering no compact markers.
 func (f *GatherNoCompactionMarkFilter) Filter(ctx context.Context, metas map[ulid.ULID]*metadata.Meta, synced block.GaugeVec, modified block.GaugeVec) error {
-	var localNoCompactMapMtx sync.Mutex
-
-	noCompactMarkedMap := make(map[ulid.ULID]*metadata.NoCompactMark)
-
-	// Make a copy of block IDs to check, in order to avoid concurrency issues
-	// between the scheduler and workers.
-	blockIDs := make([]ulid.ULID, 0, len(metas))
-	for id := range metas {
-		blockIDs = append(blockIDs, id)
-	}
-
-	var (
-		eg errgroup.Group
-		ch = make(chan ulid.ULID, f.concurrency)
+	noCompactMarkedMap, err := block.GatherMarkedBlocks(
+		ctx,
+		f.logger,
+		f.bkt,
+		metas,
+		f.concurrency,
+		func() *metadata.NoCompactMark { return &metadata.NoCompactMark{} },
+		metadata.NoCompactMarkFilename,
+		synced,
+		block.MarkedForNoCompactionMeta,
 	)
-
-	for i := 0; i < f.concurrency; i++ {
-		eg.Go(func() error {
-			var lastErr error
-			for id := range ch {
-				m := &metadata.NoCompactMark{}
-				// TODO(bwplotka): Hook up bucket cache here + reset API so we don't introduce API calls .
-				if err := metadata.ReadMarker(ctx, f.logger, f.bkt, id.String(), m); err != nil {
-					if errors.Cause(err) == metadata.ErrorMarkerNotFound {
-						continue
-					}
-					if errors.Cause(err) == metadata.ErrorUnmarshalMarker {
-						level.Warn(f.logger).Log("msg", "found partial no-compact-mark.json; if we will see it happening often for the same block, consider manually deleting no-compact-mark.json from the object storage", "block", id, "err", err)
-						continue
-					}
-					// Remember the last error and continue draining the channel.
-					lastErr = err
-					continue
-				}
-
-				localNoCompactMapMtx.Lock()
-				noCompactMarkedMap[id] = m
-				localNoCompactMapMtx.Unlock()
-				synced.WithLabelValues(block.MarkedForNoCompactionMeta).Inc()
-			}
-
-			return lastErr
-		})
-	}
-
-	// Workers scheduled, distribute blocks.
-	eg.Go(func() error {
-		defer close(ch)
-
-		for _, id := range blockIDs {
-			select {
-			case ch <- id:
-				// Nothing to do.
-			case <-ctx.Done():
-				return ctx.Err()
-			}
-		}
-
-		return nil
-	})
-
-	if err := eg.Wait(); err != nil {
+	if err != nil {
 		return errors.Wrap(err, "filter blocks marked for no compaction")
 	}
 

--- a/pkg/compact/compact_test.go
+++ b/pkg/compact/compact_test.go
@@ -552,6 +552,30 @@ func TestDownsampleProgressCalculate(t *testing.T) {
 	}
 }
 
+func TestGatherNoCompactionMarkFilter(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	logger := log.NewNopLogger()
+	bkt := objstore.NewInMemBucket()
+
+	markedID := ulid.MustNew(1, nil)
+	unmarkedID := ulid.MustNew(2, nil)
+	metas := map[ulid.ULID]*metadata.Meta{
+		markedID:   {},
+		unmarkedID: {},
+	}
+
+	testutil.Ok(t, block.MarkForNoCompact(ctx, logger, bkt, markedID, metadata.ManualNoCompactReason, "details", prometheus.NewCounter(prometheus.CounterOpts{})))
+
+	filter := NewGatherNoCompactionMarkFilter(logger, objstore.WithNoopInstr(bkt), 2)
+	testutil.Ok(t, filter.Filter(ctx, metas, nil, nil))
+
+	markedBlocks := filter.NoCompactMarkedBlocks()
+	testutil.Equals(t, 1, len(markedBlocks))
+	testutil.Equals(t, metadata.ManualNoCompactReason, markedBlocks[markedID].Reason)
+}
+
 func TestNoMarkFilterAtomic(t *testing.T) {
 	if testing.
 		Short() {

--- a/pkg/compact/downsample/downsample.go
+++ b/pkg/compact/downsample/downsample.go
@@ -26,7 +26,6 @@ import (
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
 	"github.com/prometheus/prometheus/tsdb/chunks"
 	"github.com/prometheus/prometheus/tsdb/index"
-	"golang.org/x/sync/errgroup"
 
 	"github.com/thanos-io/objstore"
 
@@ -1354,74 +1353,26 @@ func (f *GatherNoDownsampleMarkFilter) NoDownsampleMarkedBlocks() map[ulid.ULID]
 	return copiedNoDownsampleMarked
 }
 
-// TODO (@rohitkochhar): reduce code duplication here by combining
-// this code with that of GatherNoCompactionMarkFilter
 // Filter passes all metas, while gathering no downsample markers.
 func (f *GatherNoDownsampleMarkFilter) Filter(ctx context.Context, metas map[ulid.ULID]*metadata.Meta, synced block.GaugeVec, modified block.GaugeVec) error {
-	f.mtx.Lock()
-	f.noDownsampleMarkedMap = make(map[ulid.ULID]*metadata.NoDownsampleMark)
-	f.mtx.Unlock()
-
-	// Make a copy of block IDs to check, in order to avoid concurrency issues
-	// between the scheduler and workers.
-	blockIDs := make([]ulid.ULID, 0, len(metas))
-	for id := range metas {
-		blockIDs = append(blockIDs, id)
-	}
-
-	var (
-		eg errgroup.Group
-		ch = make(chan ulid.ULID, f.concurrency)
+	noDownsampleMarkedMap, err := block.GatherMarkedBlocks(
+		ctx,
+		f.logger,
+		f.bkt,
+		metas,
+		f.concurrency,
+		func() *metadata.NoDownsampleMark { return &metadata.NoDownsampleMark{} },
+		metadata.NoDownsampleMarkFilename,
+		synced,
+		block.MarkedForNoDownsampleMeta,
 	)
-
-	for i := 0; i < f.concurrency; i++ {
-		eg.Go(func() error {
-			var lastErr error
-			for id := range ch {
-				m := &metadata.NoDownsampleMark{}
-
-				if err := metadata.ReadMarker(ctx, f.logger, f.bkt, id.String(), m); err != nil {
-					if errors.Cause(err) == metadata.ErrorMarkerNotFound {
-						continue
-					}
-					if errors.Cause(err) == metadata.ErrorUnmarshalMarker {
-						level.Warn(f.logger).Log("msg", "found partial no-downsample-mark.json; if we will see it happening often for the same block, consider manually deleting no-downsample-mark.json from the object storage", "block", id, "err", err)
-						continue
-					}
-					// Remember the last error and continue draining the channel.
-					lastErr = err
-					continue
-				}
-
-				f.mtx.Lock()
-				f.noDownsampleMarkedMap[id] = m
-				f.mtx.Unlock()
-				synced.WithLabelValues(block.MarkedForNoDownsampleMeta).Inc()
-			}
-
-			return lastErr
-		})
-	}
-
-	// Workers scheduled, distribute blocks.
-	eg.Go(func() error {
-		defer close(ch)
-
-		for _, id := range blockIDs {
-			select {
-			case ch <- id:
-				// Nothing to do.
-			case <-ctx.Done():
-				return ctx.Err()
-			}
-		}
-
-		return nil
-	})
-
-	if err := eg.Wait(); err != nil {
+	if err != nil {
 		return errors.Wrap(err, "filter blocks marked for no downsample")
 	}
+
+	f.mtx.Lock()
+	f.noDownsampleMarkedMap = noDownsampleMarkedMap
+	f.mtx.Unlock()
 
 	return nil
 }

--- a/pkg/compact/downsample/downsample_test.go
+++ b/pkg/compact/downsample/downsample_test.go
@@ -14,7 +14,9 @@ import (
 	"github.com/go-kit/log"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/oklog/ulid/v2"
 	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/value"
@@ -26,6 +28,7 @@ import (
 	"github.com/prometheus/prometheus/tsdb/tombstones"
 	"github.com/prometheus/prometheus/tsdb/tsdbutil"
 	"github.com/stretchr/testify/require"
+	"github.com/thanos-io/objstore"
 
 	"github.com/efficientgo/core/testutil"
 
@@ -38,6 +41,30 @@ import (
 
 func TestMain(m *testing.M) {
 	custom.TolerantVerifyLeakMain(m)
+}
+
+func TestGatherNoDownsampleMarkFilter(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	logger := log.NewNopLogger()
+	bkt := objstore.NewInMemBucket()
+
+	markedID := ulid.MustNew(1, nil)
+	unmarkedID := ulid.MustNew(2, nil)
+	metas := map[ulid.ULID]*metadata.Meta{
+		markedID:   {},
+		unmarkedID: {},
+	}
+
+	testutil.Ok(t, block.MarkForNoDownsample(ctx, logger, bkt, markedID, metadata.ManualNoDownsampleReason, "details", prometheus.NewCounter(prometheus.CounterOpts{})))
+
+	filter := NewGatherNoDownsampleMarkFilter(logger, objstore.WithNoopInstr(bkt), 2)
+	testutil.Ok(t, filter.Filter(ctx, metas, nil, nil))
+
+	markedBlocks := filter.NoDownsampleMarkedBlocks()
+	testutil.Equals(t, 1, len(markedBlocks))
+	testutil.Equals(t, metadata.ManualNoDownsampleReason, markedBlocks[markedID].Reason)
 }
 
 func TestDownsampleNativeHistograms(t *testing.T) {


### PR DESCRIPTION
* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

Fixes #5962.

- Add a shared block marker-gathering helper for metadata filters that scan marker JSON files.
- Use it from the no-compact and no-downsample marker filters while keeping their typed accessors and error wrapping intact.
- Add focused tests for the shared helper and both component filter wrappers.

## Verification

- `go test -tags slicelabels ./pkg/block ./pkg/compact ./pkg/compact/downsample -run 'TestGatherMarkedBlocks|TestGatherNoCompactionMarkFilter|TestGatherNoDownsampleMarkFilter' -count=1`
- `THANOS_TEST_OBJSTORE_SKIP=GCS,S3,AZURE,SWIFT,COS,ALIYUNOSS,BOS,OCI,OBS go test -tags slicelabels ./pkg/block ./pkg/compact ./pkg/compact/downsample -count=1`
