### PR TITLE
query-frontend: optionally expose HTTP API over gRPC via httpgrpc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ It is recommend to upgrade the storage components first (Receive, Store, etc.) a
 
 ### Added
 
+- [#7905](https://github.com/thanos-io/thanos/issues/7905): Query-Frontend: optionally expose the HTTP API over gRPC via the httpgrpc protocol. Enable by setting `--grpc-address`; disabled by default.
 - [#8691](https://github.com/thanos-io/thanos/pull/8691): Compactor: remove the directory marker objects for some s3 compatible object stores
 - [#8730](https://github.com/thanos-io/thanos/pull/8730): *: add `--grpc-server-tls-ciphers` to configure cipher suites for gRPC servers.
 - [#8730](https://github.com/thanos-io/thanos/pull/8730): Receive: add `--remote-write.server-tls-ciphers` to configure cipher suites for the HTTP server.

--- a/cmd/thanos/config.go
+++ b/cmd/thanos/config.go
@@ -43,9 +43,15 @@ type grpcConfig struct {
 }
 
 func (gc *grpcConfig) registerFlag(cmd extkingpin.FlagClause) *grpcConfig {
+	return gc.registerFlagWithDefaultAddress(cmd, "0.0.0.0:10901")
+}
+
+// registerFlagWithDefaultAddress registers gRPC server flags with a configurable default bind address.
+// Use an empty string as defaultAddr to disable the gRPC server by default.
+func (gc *grpcConfig) registerFlagWithDefaultAddress(cmd extkingpin.FlagClause, defaultAddr string) *grpcConfig {
 	cmd.Flag("grpc-address",
 		"Listen ip:port address for gRPC endpoints (StoreAPI). Make sure this address is routable from other components.").
-		Default("0.0.0.0:10901").StringVar(&gc.bindAddress)
+		Default(defaultAddr).StringVar(&gc.bindAddress)
 	cmd.Flag("grpc-server-tls-cert",
 		"TLS Certificate for gRPC server, leave blank to disable TLS").
 		Default("").StringVar(&gc.tlsSrvCert)

--- a/cmd/thanos/query_frontend.go
+++ b/cmd/thanos/query_frontend.go
@@ -20,7 +20,10 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/thanos-io/promql-engine/execution/parse"
+	"github.com/weaveworks/common/httpgrpc"
+	httpgrpcserver "github.com/weaveworks/common/httpgrpc/server"
 	"github.com/weaveworks/common/user"
+	"google.golang.org/grpc"
 	"gopkg.in/yaml.v2"
 
 	cortexfrontend "github.com/thanos-io/thanos/internal/cortex/frontend"
@@ -37,15 +40,18 @@ import (
 	"github.com/thanos-io/thanos/pkg/prober"
 	"github.com/thanos-io/thanos/pkg/queryfrontend"
 	"github.com/thanos-io/thanos/pkg/runutil"
+	grpcserver "github.com/thanos-io/thanos/pkg/server/grpc"
 	httpserver "github.com/thanos-io/thanos/pkg/server/http"
 	"github.com/thanos-io/thanos/pkg/server/http/middleware"
 	"github.com/thanos-io/thanos/pkg/tenancy"
+	"github.com/thanos-io/thanos/pkg/tls"
 	"github.com/thanos-io/thanos/pkg/tracing"
 )
 
 type queryFrontendConfig struct {
 	queryfrontend.Config
 	http           httpConfig
+	grpc           grpcConfig
 	webDisableCORS bool
 	orgIdHeaders   []string
 }
@@ -69,6 +75,7 @@ func registerQueryFrontend(app *extkingpin.App) {
 	}
 
 	cfg.http.registerFlag(cmd)
+	cfg.grpc.registerFlagWithDefaultAddress(cmd, "")
 
 	cmd.Flag("web.disable-cors", "Whether to disable CORS headers to be set by Thanos. By default Thanos sets CORS headers to be allowed by all.").
 		Default("false").BoolVar(&cfg.webDisableCORS)
@@ -355,6 +362,29 @@ func runQueryFrontend(
 	logMiddleware := logging.NewHTTPServerMiddleware(logger, httpLogOpts...)
 	ins := extpromhttp.NewTenantInstrumentationMiddleware(cfg.TenantHeader, cfg.DefaultTenant, reg, nil)
 
+	instr := func(f http.HandlerFunc) http.HandlerFunc {
+		hf := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			orgId := extractOrgId(cfg, r)
+			name := "query-frontend"
+			if !cfg.webDisableCORS {
+				api.SetCORS(w)
+			}
+			middleware.RequestID(
+				tracing.HTTPMiddleware(
+					tracer,
+					name,
+					logger,
+					ins.NewHandler(
+						name,
+						logMiddleware.HTTPMiddleware(name, f),
+					),
+					// Cortex frontend middlewares require orgID.
+				),
+			).ServeHTTP(w, r.WithContext(user.InjectOrgID(r.Context(), orgId)))
+		})
+		return hf
+	}
+
 	// Start metrics HTTP server.
 	{
 		srv := httpserver.New(logger, reg, comp, httpProbe,
@@ -363,28 +393,6 @@ func runQueryFrontend(
 			httpserver.WithTLSConfig(cfg.http.tlsConfig),
 		)
 
-		instr := func(f http.HandlerFunc) http.HandlerFunc {
-			hf := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				orgId := extractOrgId(cfg, r)
-				name := "query-frontend"
-				if !cfg.webDisableCORS {
-					api.SetCORS(w)
-				}
-				middleware.RequestID(
-					tracing.HTTPMiddleware(
-						tracer,
-						name,
-						logger,
-						ins.NewHandler(
-							name,
-							logMiddleware.HTTPMiddleware(name, f),
-						),
-						// Cortex frontend middlewares require orgID.
-					),
-				).ServeHTTP(w, r.WithContext(user.InjectOrgID(r.Context(), orgId)))
-			})
-			return hf
-		}
 		srv.Handle("/", instr(handler.ServeHTTP))
 
 		g.Add(func() error {
@@ -396,6 +404,40 @@ func runQueryFrontend(
 			defer statusProber.NotHealthy(err)
 
 			srv.Shutdown(err)
+		})
+	}
+
+	// Optionally start a gRPC server exposing the HTTP API over the httpgrpc protocol.
+	// Enabled only when --grpc-address is non-empty (disabled by default).
+	if cfg.grpc.bindAddress != "" {
+		tlsCfg, err := tls.NewServerConfig(log.With(logger, "protocol", "gRPC"),
+			cfg.grpc.tlsSrvCert, cfg.grpc.tlsSrvKey, cfg.grpc.tlsSrvClientCA,
+			cfg.grpc.tlsMinVersion, cfg.grpc.tlsCiphers, cfg.grpc.tlsCurves)
+		if err != nil {
+			return errors.Wrap(err, "setup gRPC server")
+		}
+
+		httpgrpcSrv := httpgrpcserver.NewServer(instr(handler.ServeHTTP))
+
+		grpcProbe := prober.NewGRPC()
+		s := grpcserver.New(logger, reg, tracer, nil, nil, comp, grpcProbe,
+			grpcserver.WithServer(func(srv *grpc.Server) {
+				httpgrpc.RegisterHTTPServer(srv, httpgrpcSrv)
+			}),
+			grpcserver.WithListen(cfg.grpc.bindAddress),
+			grpcserver.WithGracePeriod(cfg.grpc.gracePeriod),
+			grpcserver.WithMaxConnAge(cfg.grpc.maxConnectionAge),
+			grpcserver.WithTLSConfig(tlsCfg),
+		)
+
+		g.Add(func() error {
+			grpcProbe.Healthy()
+			grpcProbe.Ready()
+			return s.ListenAndServe()
+		}, func(err error) {
+			grpcProbe.NotReady(err)
+			grpcProbe.NotHealthy(err)
+			s.Shutdown(err)
 		})
 	}
 

--- a/docs/components/query-frontend.md
+++ b/docs/components/query-frontend.md
@@ -218,7 +218,7 @@ Flags:
                                  (mutually exclusive). Content of YAML file
                                  with tracing configuration. See format details:
                                  https://thanos.io/tip/thanos/tracing.md/#configuration
-      --[no-]enable-auto-gomemlimi
+      --[no-]enable-auto-gomemlimit
                                  Enable go runtime to automatically limit memory
                                  consumption.
       --auto-gomemlimit.ratio=0.9
@@ -240,9 +240,9 @@ Flags:
                                  disable TLS
       --grpc-server-tls-client-ca=""
                                  TLS CA to verify clients against. If no
-                                 client CA is specified, there is no clien
+                                 client CA is specified, there is no client
                                  verification on server side. (tls.NoClientCert)
-      --grpc-server-tls-min-version="1.3"
+      --grpc-server-tls-min-version=1.3
                                  TLS supported minimum version for gRPC server.
                                  If no version is specified, it'll default to
                                  1.3. Allowed values: ["1.0", "1.1", "1.2",
@@ -270,7 +270,7 @@ Flags:
       --[no-]query-range.align-range-with-step
                                  Mutate incoming queries to align their
                                  start and end with their step for better
-                                 cache-ability. Note: Grafana dashboards do tha
+                                 cache-ability. Note: Grafana dashboards do that
                                  by default.
       --[no-]query-range.request-downsampled
                                  Make additional query for downsampled data in
@@ -286,7 +286,7 @@ Flags:
                                  interval in query-range.horizontal-shards
                                  requests of equal range. Using
                                  this parameter is not allowed with
-                                 query-range.split-interval. One should also se
+                                 query-range.split-interval. One should also set
                                  query-range.split-min-horizontal-shards to a
                                  value greater than 1 to enable splitting.
       --query-range.max-split-interval=0
@@ -303,7 +303,7 @@ Flags:
                                  range request; beyond this, the downstream
                                  error is returned.
       --query.max-retries-per-request=5
-                                 Maximum number of retries for a single instan
+                                 Maximum number of retries for a single instant
                                  query request; beyond this, the downstream
                                  error is returned.
       --[no-]query-frontend.enable-x-functions
@@ -323,7 +323,7 @@ Flags:
                                  scheduled in parallel by the Frontend.
       --query-range.response-cache-max-freshness=1m
                                  Most recent allowed cacheable result for query
-                                 range requests, to prevent caching very recen
+                                 range requests, to prevent caching very recent
                                  results that might still be in flux.
       --[no-]query-range.partial-response
                                  Enable partial response for query range
@@ -336,7 +336,7 @@ Flags:
       --query-range.response-cache-config=<content>
                                  Alternative to
                                  'query-range.response-cache-config-file' flag
-                                 (mutually exclusive). Content of YAML file tha
+                                 (mutually exclusive). Content of YAML file that
                                  contains response cache configuration.
       --labels.split-interval=24h
                                  Split labels requests by an interval and
@@ -352,7 +352,7 @@ Flags:
                                  scheduled in parallel by the Frontend.
       --labels.response-cache-max-freshness=1m
                                  Most recent allowed cacheable result for
-                                 labels requests, to prevent caching very recen
+                                 labels requests, to prevent caching very recent
                                  results that might still be in flux.
       --[no-]labels.partial-response
                                  Enable partial response for labels requests
@@ -368,7 +368,7 @@ Flags:
       --labels.response-cache-config=<content>
                                  Alternative to
                                  'labels.response-cache-config-file' flag
-                                 (mutually exclusive). Content of YAML file tha
+                                 (mutually exclusive). Content of YAML file that
                                  contains response cache configuration.
       --cache-compression-type=""
                                  Use compression in results cache.
@@ -381,7 +381,7 @@ Flags:
                                  Path to YAML file that contains downstream
                                  tripper configuration. If your downstream URL
                                  is localhost or 127.0.0.1 then it is highly
-                                 recommended to increase max_idle_conns_per_hos
+                                 recommended to increase max_idle_conns_per_host
                                  to at least 100.
       --query-frontend.downstream-tripper-config=<content>
                                  Alternative to
@@ -390,7 +390,7 @@ Flags:
                                  that contains downstream tripper configuration.
                                  If your downstream URL is localhost or
                                  127.0.0.1 then it is highly recommended to
-                                 increase max_idle_conns_per_host to at leas
+                                 increase max_idle_conns_per_host to at least
                                  100.
       --[no-]query-frontend.compress-responses
                                  Compress HTTP responses.
@@ -434,7 +434,7 @@ Flags:
                                  https://thanos.io/tip/thanos/logging.md/#configuration
       --request.logging-config=<content>
                                  Alternative to 'request.logging-config-file'
-                                 flag (mutually exclusive). Conten
+                                 flag (mutually exclusive). Content
                                  of YAML file with request logging
                                  configuration. See format details:
                                  https://thanos.io/tip/thanos/logging.md/#configuration

--- a/docs/components/query-frontend.md
+++ b/docs/components/query-frontend.md
@@ -7,8 +7,8 @@ Query Frontend is fully stateless and horizontally scalable.
 Example command to run Query Frontend:
 
 ```bash
-thanos query-frontend \
-    --http-address     "0.0.0.0:9090" \
+thanos query-frontend
+    --http-address     "0.0.0.0:9090"
     --query-frontend.downstream-url="<thanos-querier>:<querier-http-port>"
 ```
 
@@ -187,8 +187,8 @@ You can find the default values [here](https://github.com/thanos-io/thanos/blob/
 If downstream queriers need basic authentication to access, we can run query-frontend:
 
 ```bash
-thanos query-frontend \
-    --http-address     "0.0.0.0:9090" \
+thanos query-frontend
+    --http-address     "0.0.0.0:9090"
     --query-frontend.forward-header "Authorization"
     --query-frontend.downstream-url="<thanos-querier>:<querier-http-port>"
 ```
@@ -203,198 +203,240 @@ improve query parallelization and caching.
 
 
 Flags:
-  -h, --[no-]help              Show context-sensitive help (also try --help-long
-                               and --help-man).
-      --[no-]version           Show application version.
-      --log.level=info         Log filtering level.
-      --log.format=logfmt      Log format to use. Possible options: logfmt,
-                               json or journald.
+  -h, --[no-]help                Show context-sensitive help (also try
+                                 --help-long and --help-man).
+      --[no-]version             Show application version.
+      --log.level=info           Log filtering level.
+      --log.format=logfmt        Log format to use. Possible options: logfmt,
+                                 json or journald.
       --tracing.config-file=<file-path>
-                               Path to YAML file with tracing
-                               configuration. See format details:
-                               https://thanos.io/tip/thanos/tracing.md/#configuration
+                                 Path to YAML file with tracing
+                                 configuration. See format details:
+                                 https://thanos.io/tip/thanos/tracing.md/#configuration
       --tracing.config=<content>
-                               Alternative to 'tracing.config-file' flag
-                               (mutually exclusive). Content of YAML file
-                               with tracing configuration. See format details:
-                               https://thanos.io/tip/thanos/tracing.md/#configuration
-      --[no-]enable-auto-gomemlimit
-                               Enable go runtime to automatically limit memory
-                               consumption.
+                                 Alternative to 'tracing.config-file' flag
+                                 (mutually exclusive). Content of YAML file
+                                 with tracing configuration. See format details:
+                                 https://thanos.io/tip/thanos/tracing.md/#configuration
+      --[no-]enable-auto-gomemlimi
+                                 Enable go runtime to automatically limit memory
+                                 consumption.
       --auto-gomemlimit.ratio=0.9
-                               The ratio of reserved GOMEMLIMIT memory to the
-                               detected maximum container or system memory.
+                                 The ratio of reserved GOMEMLIMIT memory to the
+                                 detected maximum container or system memory.
       --http-address="0.0.0.0:10902"
-                               Listen host:port for HTTP endpoints.
-      --http-grace-period=2m   Time to wait after an interrupt received for HTTP
-                               Server.
-      --http.config=""         [EXPERIMENTAL] Path to the configuration file
-                               that can enable TLS or authentication for all
-                               HTTP endpoints.
-      --[no-]web.disable-cors  Whether to disable CORS headers to be set by
-                               Thanos. By default Thanos sets CORS headers to be
-                               allowed by all.
+                                 Listen host:port for HTTP endpoints.
+      --http-grace-period=2m     Time to wait after an interrupt received for
+                                 HTTP Server.
+      --http.config=""           [EXPERIMENTAL] Path to the configuration file
+                                 that can enable TLS or authentication for all
+                                 HTTP endpoints.
+      --grpc-address=""          Listen ip:port address for gRPC endpoints
+                                 (StoreAPI). Make sure this address is routable
+                                 from other components.
+      --grpc-server-tls-cert=""  TLS Certificate for gRPC server, leave blank to
+                                 disable TLS
+      --grpc-server-tls-key=""   TLS Key for the gRPC server, leave blank to
+                                 disable TLS
+      --grpc-server-tls-client-ca=""
+                                 TLS CA to verify clients against. If no
+                                 client CA is specified, there is no clien
+                                 verification on server side. (tls.NoClientCert)
+      --grpc-server-tls-min-version="1.3"
+                                 TLS supported minimum version for gRPC server.
+                                 If no version is specified, it'll default to
+                                 1.3. Allowed values: ["1.0", "1.1", "1.2",
+                                 "1.3"]
+      --grpc-server-tls-ciphers=GRPC-SERVER-TLS-CIPHERS ...
+                                 TLS cipher suites for gRPC server
+                                 (repeatable). If not specified,
+                                 the default Go cipher suites are used.
+                                 See https://pkg.go.dev/crypto/tls#pkg-constants
+                                 for valid values.
+      --grpc-server-tls-curves=GRPC-SERVER-TLS-CURVES ...
+                                 TLS curves for gRPC server (repeatable). If
+                                 not specified, the default Go curves are used.
+                                 Valid values: CurveP256, CurveP384, CurveP521,
+                                 X25519.
+      --grpc-server-max-connection-age=60m
+                                 The grpc server max connection age. This
+                                 controls how often to re-establish connections
+                                 and redo TLS handshakes.
+      --grpc-grace-period=2m     Time to wait after an interrupt received for
+                                 GRPC Server.
+      --[no-]web.disable-cors    Whether to disable CORS headers to be set by
+                                 Thanos. By default Thanos sets CORS headers to
+                                 be allowed by all.
       --[no-]query-range.align-range-with-step
-                               Mutate incoming queries to align their start and
-                               end with their step for better cache-ability.
-                               Note: Grafana dashboards do that by default.
+                                 Mutate incoming queries to align their
+                                 start and end with their step for better
+                                 cache-ability. Note: Grafana dashboards do tha
+                                 by default.
       --[no-]query-range.request-downsampled
-                               Make additional query for downsampled data in
-                               case of empty or incomplete response to range
-                               request.
+                                 Make additional query for downsampled data in
+                                 case of empty or incomplete response to range
+                                 request.
       --query-range.split-interval=24h
-                               Split query range requests by an interval and
-                               execute in parallel, it should be greater than
-                               0 when query-range.response-cache-config is
-                               configured.
+                                 Split query range requests by an interval and
+                                 execute in parallel, it should be greater than
+                                 0 when query-range.response-cache-config is
+                                 configured.
       --query-range.min-split-interval=0
-                               Split query range requests above this interval
-                               in query-range.horizontal-shards requests of
-                               equal range. Using this parameter is not allowed
-                               with query-range.split-interval. One should also
-                               set query-range.split-min-horizontal-shards to a
-                               value greater than 1 to enable splitting.
+                                 Split query range requests above this
+                                 interval in query-range.horizontal-shards
+                                 requests of equal range. Using
+                                 this parameter is not allowed with
+                                 query-range.split-interval. One should also se
+                                 query-range.split-min-horizontal-shards to a
+                                 value greater than 1 to enable splitting.
       --query-range.max-split-interval=0
-                               Split query range below this interval in
-                               query-range.horizontal-shards. Queries with a
-                               range longer than this value will be split in
-                               multiple requests of this length.
+                                 Split query range below this interval in
+                                 query-range.horizontal-shards. Queries with a
+                                 range longer than this value will be split in
+                                 multiple requests of this length.
       --query-range.horizontal-shards=0
-                               Split queries in this many requests when query
-                               duration is below query-range.max-split-interval.
+                                 Split queries in this many requests
+                                 when query duration is below
+                                 query-range.max-split-interval.
       --query-range.max-retries-per-request=5
-                               Maximum number of retries for a single query
-                               range request; beyond this, the downstream error
-                               is returned.
+                                 Maximum number of retries for a single query
+                                 range request; beyond this, the downstream
+                                 error is returned.
       --query.max-retries-per-request=5
-                               Maximum number of retries for a single instant
-                               query request; beyond this, the downstream error
-                               is returned.
+                                 Maximum number of retries for a single instan
+                                 query request; beyond this, the downstream
+                                 error is returned.
       --[no-]query-frontend.enable-x-functions
-                               Enable experimental x-
-                               functions in query-frontend.
-                               --no-query-frontend.enable-x-functions for
-                               disabling.
-      --enable-feature= ...    Comma separated feature names to enable. Valid
-                               options for now: promql-experimental-functions
-                               (enables promql experimental functions in
-                               query-frontend)
+                                 Enable experimental x-
+                                 functions in query-frontend.
+                                 --no-query-frontend.enable-x-functions for
+                                 disabling.
+      --enable-feature= ...      Comma separated feature names to enable. Valid
+                                 options for now: promql-experimental-functions
+                                 (enables promql experimental functions in
+                                 query-frontend)
       --query-range.max-query-length=0
-                               Limit the query time range (end - start time) in
-                               the query-frontend, 0 disables it.
+                                 Limit the query time range (end - start time)
+                                 in the query-frontend, 0 disables it.
       --query-range.max-query-parallelism=14
-                               Maximum number of query range requests will be
-                               scheduled in parallel by the Frontend.
+                                 Maximum number of query range requests will be
+                                 scheduled in parallel by the Frontend.
       --query-range.response-cache-max-freshness=1m
-                               Most recent allowed cacheable result for query
-                               range requests, to prevent caching very recent
-                               results that might still be in flux.
+                                 Most recent allowed cacheable result for query
+                                 range requests, to prevent caching very recen
+                                 results that might still be in flux.
       --[no-]query-range.partial-response
-                               Enable partial response for query range requests
-                               if no partial_response param is specified.
-                               --no-query-range.partial-response for disabling.
+                                 Enable partial response for query range
+                                 requests if no partial_response param is
+                                 specified. --no-query-range.partial-response
+                                 for disabling.
       --query-range.response-cache-config-file=<file-path>
-                               Path to YAML file that contains response cache
-                               configuration.
+                                 Path to YAML file that contains response cache
+                                 configuration.
       --query-range.response-cache-config=<content>
-                               Alternative to
-                               'query-range.response-cache-config-file' flag
-                               (mutually exclusive). Content of YAML file that
-                               contains response cache configuration.
+                                 Alternative to
+                                 'query-range.response-cache-config-file' flag
+                                 (mutually exclusive). Content of YAML file tha
+                                 contains response cache configuration.
       --labels.split-interval=24h
-                               Split labels requests by an interval and execute
-                               in parallel, it should be greater than 0 when
-                               labels.response-cache-config is configured.
+                                 Split labels requests by an interval and
+                                 execute in parallel, it should be greater
+                                 than 0 when labels.response-cache-config is
+                                 configured.
       --labels.max-retries-per-request=5
-                               Maximum number of retries for a single
-                               label/series API request; beyond this, the
-                               downstream error is returned.
+                                 Maximum number of retries for a single
+                                 label/series API request; beyond this,
+                                 the downstream error is returned.
       --labels.max-query-parallelism=14
-                               Maximum number of labels requests will be
-                               scheduled in parallel by the Frontend.
+                                 Maximum number of labels requests will be
+                                 scheduled in parallel by the Frontend.
       --labels.response-cache-max-freshness=1m
-                               Most recent allowed cacheable result for labels
-                               requests, to prevent caching very recent results
-                               that might still be in flux.
+                                 Most recent allowed cacheable result for
+                                 labels requests, to prevent caching very recen
+                                 results that might still be in flux.
       --[no-]labels.partial-response
-                               Enable partial response for labels requests
-                               if no partial_response param is specified.
-                               --no-labels.partial-response for disabling.
+                                 Enable partial response for labels requests
+                                 if no partial_response param is specified.
+                                 --no-labels.partial-response for disabling.
       --labels.default-time-range=24h
-                               The default metadata time range duration for
-                               retrieving labels through Labels and Series API
-                               when the range parameters are not specified.
+                                 The default metadata time range duration for
+                                 retrieving labels through Labels and Series API
+                                 when the range parameters are not specified.
       --labels.response-cache-config-file=<file-path>
-                               Path to YAML file that contains response cache
-                               configuration.
+                                 Path to YAML file that contains response cache
+                                 configuration.
       --labels.response-cache-config=<content>
-                               Alternative to
-                               'labels.response-cache-config-file' flag
-                               (mutually exclusive). Content of YAML file that
-                               contains response cache configuration.
+                                 Alternative to
+                                 'labels.response-cache-config-file' flag
+                                 (mutually exclusive). Content of YAML file tha
+                                 contains response cache configuration.
       --cache-compression-type=""
-                               Use compression in results cache. Supported
-                               values are: 'snappy' and ” (disable compression).
+                                 Use compression in results cache.
+                                 Supported values are: 'snappy' and ” (disable
+                                 compression).
       --query-frontend.downstream-url="http://localhost:9090"
-                               URL of downstream Prometheus Query compatible
-                               API.
+                                 URL of downstream Prometheus Query compatible
+                                 API.
       --query-frontend.downstream-tripper-config-file=<file-path>
-                               Path to YAML file that contains downstream
-                               tripper configuration. If your downstream URL
-                               is localhost or 127.0.0.1 then it is highly
-                               recommended to increase max_idle_conns_per_host
-                               to at least 100.
+                                 Path to YAML file that contains downstream
+                                 tripper configuration. If your downstream URL
+                                 is localhost or 127.0.0.1 then it is highly
+                                 recommended to increase max_idle_conns_per_hos
+                                 to at least 100.
       --query-frontend.downstream-tripper-config=<content>
-                               Alternative to
-                               'query-frontend.downstream-tripper-config-file'
-                               flag (mutually exclusive). Content of YAML file
-                               that contains downstream tripper configuration.
-                               If your downstream URL is localhost or 127.0.0.1
-                               then it is highly recommended to increase
-                               max_idle_conns_per_host to at least 100.
+                                 Alternative to
+                                 'query-frontend.downstream-tripper-config-file'
+                                 flag (mutually exclusive). Content of YAML file
+                                 that contains downstream tripper configuration.
+                                 If your downstream URL is localhost or
+                                 127.0.0.1 then it is highly recommended to
+                                 increase max_idle_conns_per_host to at leas
+                                 100.
       --[no-]query-frontend.compress-responses
-                               Compress HTTP responses.
+                                 Compress HTTP responses.
       --query-frontend.log-queries-longer-than=0
-                               Log queries that are slower than the specified
-                               duration. Set to 0 to disable. Set to < 0 to
-                               enable on all queries.
+                                 Log queries that are slower than the specified
+                                 duration. Set to 0 to disable. Set to < 0 to
+                                 enable on all queries.
       --[no-]query-frontend.force-query-stats
-                               Enables query statistics for all queries and will
-                               export statistics as logs and service headers.
+                                 Enables query statistics for all queries and
+                                 will export statistics as logs and service
+                                 headers.
       --query-frontend.org-id-header=<http-header-name> ...
-                               Deprecation Warning - This flag
-                               will be soon deprecated in favor of
-                               query-frontend.tenant-header and both flags
-                               cannot be used at the same time. Request header
-                               names used to identify the source of slow queries
-                               (repeated flag). The values of the header will be
-                               added to the org id field in the slow query log.
-                               If multiple headers match the request, the first
-                               matching arg specified will take precedence.
-                               If no headers match 'anonymous' will be used.
+                                 Deprecation Warning - This flag
+                                 will be soon deprecated in favor of
+                                 query-frontend.tenant-header and both flags
+                                 cannot be used at the same time. Request header
+                                 names used to identify the source of slow
+                                 queries (repeated flag). The values of the
+                                 header will be added to the org id field in
+                                 the slow query log. If multiple headers match
+                                 the request, the first matching arg specified
+                                 will take precedence. If no headers match
+                                 'anonymous' will be used.
       --query-frontend.forward-header=<http-header-name> ...
-                               List of headers forwarded by the query-frontend
-                               to downstream queriers, default is empty
+                                 List of headers forwarded by the query-frontend
+                                 to downstream queriers, default is empty
       --query-frontend.vertical-shards=QUERY-FRONTEND.VERTICAL-SHARDS
-                               Number of shards to use when
-                               distributing shardable PromQL queries.
-                               For more details, you can refer to
-                               the Vertical query sharding proposal:
-                               https://thanos.io/tip/proposals-accepted/202205-vertical-query-sharding.md
+                                 Number of shards to use when
+                                 distributing shardable PromQL queries.
+                                 For more details, you can refer to
+                                 the Vertical query sharding proposal:
+                                 https://thanos.io/tip/proposals-accepted/202205-vertical-query-sharding.md
       --query-frontend.slow-query-logs-user-header=<http-header-name>
-                               Set the value of the field remote_user in the
-                               slow query logs to the value of the given HTTP
-                               header. Falls back to reading the user from the
-                               basic auth header.
+                                 Set the value of the field remote_user in the
+                                 slow query logs to the value of the given HTTP
+                                 header. Falls back to reading the user from the
+                                 basic auth header.
       --request.logging-config-file=<file-path>
-                               Path to YAML file with request logging
-                               configuration. See format details:
-                               https://thanos.io/tip/thanos/logging.md/#configuration
+                                 Path to YAML file with request logging
+                                 configuration. See format details:
+                                 https://thanos.io/tip/thanos/logging.md/#configuration
       --request.logging-config=<content>
-                               Alternative to 'request.logging-config-file'
-                               flag (mutually exclusive). Content
-                               of YAML file with request logging
-                               configuration. See format details:
-                               https://thanos.io/tip/thanos/logging.md/#configuration
+                                 Alternative to 'request.logging-config-file'
+                                 flag (mutually exclusive). Conten
+                                 of YAML file with request logging
+                                 configuration. See format details:
+                                 https://thanos.io/tip/thanos/logging.md/#configuration
 
 ```

--- a/docs/components/query-frontend.md
+++ b/docs/components/query-frontend.md
@@ -118,6 +118,7 @@ The default redis config is:
 type: REDIS
 config:
   addr: ""
+  prefix: ""
   username: ""
   password: ""
   db: 0

--- a/docs/components/store.md
+++ b/docs/components/store.md
@@ -456,6 +456,7 @@ The `redis` index cache allows to use [Redis](https://redis.io) as cache backend
 type: REDIS
 config:
   addr: ""
+  prefix: ""
   username: ""
   password: ""
   db: 0


### PR DESCRIPTION
Fixes #7905.

## What this does

Adds an opt-in gRPC server to the `query-frontend` component that exposes the existing HTTP API over the [httpgrpc](https://github.com/weaveworks/common/tree/main/httpgrpc) protocol. Disabled by default; enabled by setting `--grpc-address`.

## Why

Downstream components (e.g. a gateway or a scheduler) that already speak gRPC to other Thanos endpoints can reach the query-frontend without needing a separate HTTP connection, letting them reuse TLS configuration, service discovery, and load balancing already in place for gRPC traffic.

## How it works

When `--grpc-address` is non-empty, the query-frontend starts a standard Thanos gRPC server (reusing `grpcserver.New` and `tls.NewServerConfig`, same as sidecar/store/receive) and registers `httpgrpc.HTTPServer` on it. Incoming gRPC requests are forwarded to the same `instr` middleware chain used by the HTTP server, so orgID injection, CORS, tracing, and instrumentation apply identically over both transports.

```
--grpc-address=0.0.0.0:10901      # enable gRPC; empty = disabled (default)
--grpc-server-tls-cert=...        # optional mTLS
--grpc-server-tls-key=...
--grpc-server-tls-client-ca=...
--grpc-grace-period=2m
--grpc-server-max-connection-age=60m
```

## Changes

- `cmd/thanos/config.go`: refactored `registerFlag` to delegate to `registerFlagWithDefaultAddress(cmd, addr)` so the default bind address is configurable per binary.
- `cmd/thanos/query_frontend.go`: added `grpcConfig` field; registers gRPC flags with empty default; conditionally starts gRPC server block.
- `CHANGELOG.md`: added entry under `### Added`.

## Scope choices (feedback welcome)

- **Default disabled** — existing deployments are unaffected. Is this the right default?
- **gRPC health probe** is independent of the HTTP `/ready` probe. Should the gRPC probe be folded into `statusProber` so the HTTP ready endpoint reflects gRPC health as well?
- **No new e2e test** in this PR (the e2e framework would require a helper in `test/e2e/e2ethanos/services.go`). Happy to add a smoke test if preferred.

Signed-off-by: Oğulcan Aydoğan <ogulcanaydogan@gmail.com>