### PR TITLE
receive: set NameValidationScheme on parsed relabel configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ It is recommend to upgrade the storage components first (Receive, Store, etc.) a
 
 ### Fixed
 
+- [#8823](https://github.com/thanos-io/thanos/issues/8823) Receive: fix panic "Invalid name validation scheme requested: unset" when using `--receive.relabel-config-file`
+
 ### Added
 
 ### Changed

--- a/pkg/receive/handler.go
+++ b/pkg/receive/handler.go
@@ -31,6 +31,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/prometheus/common/model"
 	"github.com/prometheus/common/route"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/relabel"
@@ -153,6 +154,12 @@ type Handler struct {
 func NewHandler(logger log.Logger, o *Options) *Handler {
 	if logger == nil {
 		logger = log.NewNopLogger()
+	}
+
+	for _, rc := range o.RelabelConfigs {
+		if rc.NameValidationScheme == model.UnsetValidation {
+			rc.NameValidationScheme = model.UTF8Validation
+		}
 	}
 
 	var registerer prometheus.Registerer = nil

--- a/pkg/receive/handler_test.go
+++ b/pkg/receive/handler_test.go
@@ -1715,6 +1715,54 @@ func TestRelabel(t *testing.T) {
 	}
 }
 
+// parseRelabelYAML is a helper that unmarshals a YAML relabel config.
+func parseRelabelYAML(t *testing.T, raw string) []*relabel.Config {
+	t.Helper()
+	var cfgs []*relabel.Config
+	require.NoError(t, yaml.Unmarshal([]byte(raw), &cfgs))
+	return cfgs
+}
+
+// relabelYAMLFixture is a replace-action config parsed from YAML.
+// NameValidationScheme will be zero (UnsetValidation) after unmarshaling.
+const relabelYAMLFixture = `
+- source_labels: [src]
+  regex: "(.+)"
+  target_label: dst
+  action: replace
+`
+
+func TestRelabelFromYAMLConfigPanicsWithoutFix(t *testing.T) {
+	t.Parallel()
+
+	cfgs := parseRelabelYAML(t, relabelYAMLFixture)
+	require.Equal(t, model.UnsetValidation, cfgs[0].NameValidationScheme)
+
+	// Without the fix: relabel.Process panics because NameValidationScheme is unset.
+	lbls := labels.FromStrings("__name__", "m", "src", "v")
+	require.Panics(t, func() {
+		relabel.Process(lbls, cfgs...)
+	})
+}
+
+func TestRelabelFromYAMLConfigWithFix(t *testing.T) {
+	t.Parallel()
+
+	cfgs := parseRelabelYAML(t, relabelYAMLFixture)
+
+	// NewHandler applies the fix.
+	h := NewHandler(nil, &Options{RelabelConfigs: cfgs})
+	require.Equal(t, model.UTF8Validation, h.options.RelabelConfigs[0].NameValidationScheme)
+
+	// With the fix: no panic, relabeling works.
+	lbls := labels.FromStrings("__name__", "m", "src", "v")
+	require.NotPanics(t, func() {
+		ret, keep := relabel.Process(lbls, h.options.RelabelConfigs...)
+		require.True(t, keep)
+		require.Equal(t, "v", ret.Get("dst"))
+	})
+}
+
 func TestGetStatsLimitParameter(t *testing.T) {
 	t.Parallel()
 

--- a/test/e2e/receive_test.go
+++ b/test/e2e/receive_test.go
@@ -1331,3 +1331,36 @@ func TestReceiveCpnpDelayed(t *testing.T) {
 
 	testutil.Ok(t, i1.WaitSumMetricsWithOptions(e2emon.Equals(0), []string{"prometheus_tsdb_blocks_loaded"}, e2emon.WithLabelMatchers(matchers.MustNewMatcher(matchers.MatchEqual, "tenant", "default-tenant")), e2emon.WaitMissingMetrics()))
 }
+
+// TestReceiveWithRelabelConfigSmoke tests that receive boots successfully
+// with --receive.relabel-config flag set. Regression test for issue #8823
+// where NameValidationScheme was not set on YAML-parsed relabel configs.
+func TestReceiveWithRelabelConfigSmoke(t *testing.T) {
+	t.Parallel()
+
+	e, err := e2e.NewDockerEnvironment("recv-relabel")
+	testutil.Ok(t, err)
+	t.Cleanup(e2ethanos.CleanScenario(t, e))
+
+	// Relabel config with replace action - this would panic without the fix
+	// because NameValidationScheme defaults to UnsetValidation when parsed from YAML.
+	relabelConfigs := []*relabel.Config{
+		{
+			SourceLabels: model.LabelNames{"src_label"},
+			Regex:        relabel.MustNewRegexp("(.+)"),
+			TargetLabel:  "dst_label",
+			Replacement:  "replaced_${1}",
+			Action:       relabel.Replace,
+		},
+	}
+
+	// Setup receive with relabel config - should boot without panic.
+	i := e2ethanos.NewReceiveBuilder(e, "ingestor").
+		WithIngestionEnabled().
+		WithRelabelConfigs(relabelConfigs).
+		Init()
+
+	// This will fail if receive panics during startup (issue #8823).
+	// StartAndWaitReady waits for the ready probe which confirms receive is healthy.
+	testutil.Ok(t, e2e.StartAndWaitReady(i))
+}


### PR DESCRIPTION
## Description

Fixes #8823

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

When relabel configs are loaded from YAML via `--receive.relabel-config-file`, the `NameValidationScheme` field defaults to `UnsetValidation` (zero value) because it is not present in user config files. This causes a panic in `relabel.Process` → `IsValidLabelName` when a `replace` action's regex matches.

- **`pkg/receive/handler.go`**: In `NewHandler`, set `NameValidationScheme = model.UTF8Validation` on any relabel config where it is unset.
- **`pkg/receive/handler_test.go`**: Two regression tests:
  - `TestRelabelFromYAMLConfigPanicsWithoutFix` — confirms YAML-parsed configs panic when calling `relabel.Process` directly (without `NewHandler`).
  - `TestRelabelFromYAMLConfigWithFix` — confirms `NewHandler` fixes the scheme and relabeling works without panic.

## Verification

```
$ go test -run "TestRelabelFromYAMLConfig" -v -count=1 ./pkg/receive/
--- PASS: TestRelabelFromYAMLConfigPanicsWithoutFix (0.00s)
--- PASS: TestRelabelFromYAMLConfigWithFix (0.00s)
PASS
```

Signed-off-by: Mario Apostolov <mario.apostolov@mariadb.com>