### PR TITLE
query-frontend: rename time_taken to time_taken_ms for slow queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ It is recommend to upgrade the storage components first (Receive, Store, etc.) a
 - [#8670](https://github.com/thanos-io/thanos/pull/8670): Receive: *breaking :warning:* removed `--shipper.ignore-unequal-block-size`. TSDB now delays compaction until blocks have been uploaded by the shipper, allowing compaction while uploading without risking data loss.
 - [#8802](https://github.com/thanos-io/thanos/pull/8802): Cache: add `SendToReplicas` option while initializing Rueidis client to allow sending read-only requests to Redis replica instances.
 - [#8839](https://github.com/thanos-io/thanos/pull/8839): Store: *breaking :warning:* removed `--debug.advertise-compatibility-label`. Stores now don't advertise `@thanos_compatibility_store_type=store` external label by default, breaking compatibility with Thanos Query before v0.8.0.
+- [#8831](https://github.com/thanos-io/thanos/pull/8830): Query-Frontend: change `time_taken` field to `time_taken_ms` for consistent JSON output for easier parsing by the log collector.
 
 ### Removed
 

--- a/internal/cortex/frontend/transport/handler.go
+++ b/internal/cortex/frontend/transport/handler.go
@@ -216,7 +216,7 @@ func (f *Handler) reportSlowQuery(
 		"path", r.URL.Path,
 		"remote_user", remoteUser,
 		"remote_addr", r.RemoteAddr,
-		"time_taken", queryResponseTime.String(),
+		"time_taken_ms", queryResponseTime.Milliseconds(),
 		"grafana_dashboard_uid", grafanaDashboardUID,
 		"grafana_panel_id", grafanaPanelID,
 		"trace_id", thanosTraceID,

--- a/internal/cortex/frontend/transport/handler_test.go
+++ b/internal/cortex/frontend/transport/handler_test.go
@@ -45,7 +45,7 @@ func TestHandler_SlowQueryLog(t *testing.T) {
 			url:  "/api/v1/query?query=absent(up)&start=1714262400&end=1714266000",
 			logParts: []string{
 				"slow query detected",
-				"time_taken=",
+				"time_taken_ms=",
 				"path=/api/v1/query",
 				"param_query=absent(up)",
 				"param_start=1714262400",
@@ -58,7 +58,7 @@ func TestHandler_SlowQueryLog(t *testing.T) {
 			url:  "/api/v1/series?match[]={__name__=~\"up\"}",
 			logParts: []string{
 				"slow query detected",
-				"time_taken=",
+				"time_taken_ms=",
 				"path=/api/v1/series",
 			},
 		},
@@ -67,7 +67,7 @@ func TestHandler_SlowQueryLog(t *testing.T) {
 			url:  "/api/v1/query_range?query=rate(http_requests_total[5m])&start=1714262400&end=1714266000&step=15",
 			logParts: []string{
 				"slow query detected",
-				"time_taken=",
+				"time_taken_ms=",
 				"path=/api/v1/query_range",
 				"param_query=rate(http_requests_total[5m])",
 				"param_start=1714262400",
@@ -80,7 +80,7 @@ func TestHandler_SlowQueryLog(t *testing.T) {
 			url:  "/external-prefix/api/v1/query?query=absent(up)&start=1714262400&end=1714266000",
 			logParts: []string{
 				"slow query detected",
-				"time_taken=",
+				"time_taken_ms=",
 				"path=/external-prefix/api/v1/query",
 				"param_query=absent(up)",
 				"param_start=1714262400",
@@ -155,7 +155,7 @@ func TestHandler_SlowQueryLogOnError(t *testing.T) {
 
 	// Verify slow query is logged even when round-tripper returns an error
 	require.Contains(t, logWriter.String(), "slow query detected")
-	require.Contains(t, logWriter.String(), "time_taken=")
+	require.Contains(t, logWriter.String(), "time_taken_ms=")
 	require.Contains(t, logWriter.String(), "path=/api/v1/query")
 	require.Contains(t, logWriter.String(), "param_query=up")
 	require.Contains(t, logWriter.String(), "test-trace-abc123")


### PR DESCRIPTION


<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.

## Changes

Rename time_taken field to time_taken_ms integer for easier filtering and sorting of the field, similar to #4509

Can merge into cortex repo if this goes well, not sure what is the process with the vendored code.

## Verification

`go test -v ./internal/cortex/...`
