### PR TITLE
extgrpc: pool results on stringlabels

### DIFF
--- a/pkg/extgrpc/client.go
+++ b/pkg/extgrpc/client.go
@@ -38,18 +38,17 @@ func (n *nonPoolingCodec) Name() string {
 	return "proto"
 }
 
-var nopPool = mem.NopBufferPool{}
-
 func (n *nonPoolingCodec) Unmarshal(data mem.BufferSlice, v any) error {
 	gmsg, ok := v.(gogoMsg)
 	if !ok {
 		return n.CodecV2.Unmarshal(data, v)
 	}
 
-	// TODO(GiedriusS): we use unsafe code around labels so we cannot use pooling here.
-	buf := data.MaterializeToBuffer(nopPool)
-
-	return gmsg.Unmarshal(buf.ReadOnlyData())
+	buf, free := materializeForUnmarshal(data)
+	if free != nil {
+		defer free()
+	}
+	return gmsg.Unmarshal(buf)
 }
 
 type gogoMsg interface {

--- a/pkg/extgrpc/codec_slicelabels.go
+++ b/pkg/extgrpc/codec_slicelabels.go
@@ -1,0 +1,15 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+//go:build slicelabels
+
+package extgrpc
+
+import "google.golang.org/grpc/mem"
+
+var nopPool = mem.NopBufferPool{}
+
+func materializeForUnmarshal(data mem.BufferSlice) ([]byte, func()) {
+	buf := data.MaterializeToBuffer(nopPool)
+	return buf.ReadOnlyData(), nil
+}

--- a/pkg/extgrpc/codec_stringlabels.go
+++ b/pkg/extgrpc/codec_stringlabels.go
@@ -1,0 +1,13 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+//go:build !slicelabels
+
+package extgrpc
+
+import "google.golang.org/grpc/mem"
+
+func materializeForUnmarshal(data mem.BufferSlice) ([]byte, func()) {
+	buf := data.MaterializeToBuffer(mem.DefaultBufferPool())
+	return buf.ReadOnlyData(), buf.Free
+}


### PR DESCRIPTION
On stringlabels we want to have pooling from the get go. Make this change behind a tag. Using tags will allow us to delete slicelabels cleanly if everything is OK.
