### PR TITLE
compactor: retry block.Delete on transient errors during cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ It is recommend to upgrade the storage components first (Receive, Store, etc.) a
 - [#8799](https://github.com/thanos-io/thanos/pull/8799): *: Set a `KeepaliveEnforcementPolicy` with `MinTime: 10s` on all gRPC servers, matching the client keepalive interval.
 - [#8806](https://github.com/thanos-io/thanos/pull/8806): Receive: Validate tenant IDs extracted from split-tenant labels to prevent path traversal.
 - [#8810](https://github.com/thanos-io/thanos/pull/8810): Ruler: correctly pass query partial response for gRPC.
+- [#TBD](https://github.com/thanos-io/thanos/pull/TBD): Compactor: Retry block deletion on transient object-store errors during cleanup.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ It is recommend to upgrade the storage components first (Receive, Store, etc.) a
 - [#8799](https://github.com/thanos-io/thanos/pull/8799): *: Set a `KeepaliveEnforcementPolicy` with `MinTime: 10s` on all gRPC servers, matching the client keepalive interval.
 - [#8806](https://github.com/thanos-io/thanos/pull/8806): Receive: Validate tenant IDs extracted from split-tenant labels to prevent path traversal.
 - [#8810](https://github.com/thanos-io/thanos/pull/8810): Ruler: correctly pass query partial response for gRPC.
-- [#TBD](https://github.com/thanos-io/thanos/pull/TBD): Compactor: Retry block deletion on transient object-store errors during cleanup.
+- [#8838](https://github.com/thanos-io/thanos/pull/8838): Compactor: Retry block deletion on transient object-store errors during cleanup.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ It is recommend to upgrade the storage components first (Receive, Store, etc.) a
 
 - [#8670](https://github.com/thanos-io/thanos/pull/8670): Receive: *breaking :warning:* removed `--shipper.ignore-unequal-block-size`. TSDB now delays compaction until blocks have been uploaded by the shipper, allowing compaction while uploading without risking data loss.
 - [#8802](https://github.com/thanos-io/thanos/pull/8802): Cache: add `SendToReplicas` option while initializing Rueidis client to allow sending read-only requests to Redis replica instances.
-- [#8839](https://github.com/thanos-io/thanos/pull/8839): Store: *breaking :warning:* removed `--debug.advertise-compatibility-label`. Stores now don't advertise `@thanos_compatibility_store_type=store` external label by default, breaking compatibility with Thanos Query before v0.8.0. 
+- [#8839](https://github.com/thanos-io/thanos/pull/8839): Store: *breaking :warning:* removed `--debug.advertise-compatibility-label`. Stores now don't advertise `@thanos_compatibility_store_type=store` external label by default, breaking compatibility with Thanos Query before v0.8.0.
 
 ### Removed
 

--- a/pkg/compact/blocks_cleaner.go
+++ b/pkg/compact/blocks_cleaner.go
@@ -20,6 +20,8 @@ import (
 	"github.com/thanos-io/thanos/pkg/errutil"
 )
 
+const deleteBlockMaxAttempts = 3
+
 // BlocksCleaner is a struct that deletes blocks from bucket which are marked for deletion.
 type BlocksCleaner struct {
 	logger                   log.Logger
@@ -65,7 +67,7 @@ func (s *BlocksCleaner) DeleteMarkedBlocks(ctx context.Context) (map[ulid.ULID]s
 					return
 				}
 				if time.Since(time.Unix(deletionMark.DeletionTime, 0)).Seconds() > s.deleteDelay.Seconds() {
-					if err := block.Delete(ctx, s.logger, s.bkt, deletionMark.ID); err != nil {
+					if err := s.deleteBlockWithRetry(ctx, deletionMark.ID); err != nil {
 						s.blockCleanupFailures.Inc()
 						merr.Add(errors.Wrap(err, "delete block"))
 						continue
@@ -94,4 +96,27 @@ func (s *BlocksCleaner) DeleteMarkedBlocks(ctx context.Context) (map[ulid.ULID]s
 
 	level.Info(s.logger).Log("msg", "cleaning of blocks marked for deletion done")
 	return deletedBlocks, merr.Err()
+}
+
+func (s *BlocksCleaner) deleteBlockWithRetry(ctx context.Context, id ulid.ULID) error {
+	var err error
+	for attempt := range deleteBlockMaxAttempts {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		err = block.Delete(ctx, s.logger, s.bkt, id)
+		if err == nil {
+			return nil
+		}
+		if attempt == deleteBlockMaxAttempts-1 {
+			break
+		}
+		level.Warn(s.logger).Log("msg", "delete block failed, retrying", "block", id, "attempt", attempt+1, "err", err)
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(time.Second << attempt): // exponential backoff
+		}
+	}
+	return err
 }

--- a/pkg/compact/blocks_cleaner_test.go
+++ b/pkg/compact/blocks_cleaner_test.go
@@ -1,0 +1,135 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package compact
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/oklog/ulid/v2"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	promtest "github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/thanos-io/objstore"
+
+	"github.com/efficientgo/core/testutil"
+
+	"github.com/thanos-io/thanos/pkg/block"
+	"github.com/thanos-io/thanos/pkg/block/metadata"
+)
+
+type flakyDeleteBucket struct {
+	objstore.Bucket
+	failuresBeforeSuccess int32
+	deletesFailed         atomic.Int32
+}
+
+func (b *flakyDeleteBucket) Delete(ctx context.Context, name string) error {
+	if b.deletesFailed.Load() < b.failuresBeforeSuccess {
+		b.deletesFailed.Add(1)
+		return errors.New("simulated transient object-store error")
+	}
+	return b.Bucket.Delete(ctx, name)
+}
+
+func uploadFakeBlock(t *testing.T, ctx context.Context, bkt objstore.Bucket, id ulid.ULID) {
+	t.Helper()
+
+	var meta metadata.Meta
+	meta.Version = metadata.TSDBVersion1
+	meta.ULID = id
+	meta.Thanos.Labels = map[string]string{"replica": "test"}
+
+	var metaBuf bytes.Buffer
+	testutil.Ok(t, meta.Write(&metaBuf))
+	testutil.Ok(t, bkt.Upload(ctx, id.String()+"/"+metadata.MetaFilename, &metaBuf))
+
+	testutil.Ok(t, bkt.Upload(ctx, id.String()+"/chunks/000001", bytes.NewReader([]byte{0, 1, 2, 3})))
+}
+
+func TestBlocksCleaner_DeleteMarkedBlocks_RetriesTransientDeleteFailures(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	id := ulid.MustNew(uint64(time.Now().Add(-2*time.Hour).Unix()*1000), nil)
+
+	mb := objstore.NewInMemBucket()
+	bkt := objstore.WithNoopInstr(mb)
+	uploadFakeBlock(t, ctx, bkt, id)
+
+	logger := log.NewNopLogger()
+
+	markCounter := promauto.With(nil).NewCounter(prometheus.CounterOpts{Name: "test_block_marked"})
+	testutil.Ok(t, block.MarkForDeletion(ctx, logger, bkt, id, "test", markCounter))
+
+	// Fail 2 times before succeeding.
+	flaky := &flakyDeleteBucket{Bucket: bkt, failuresBeforeSuccess: 2}
+
+	df := block.NewIgnoreDeletionMarkFilter(logger, bkt, 48*time.Hour, 32)
+	testutil.Ok(t, df.Filter(ctx, map[ulid.ULID]*metadata.Meta{id: nil}, nil, nil))
+
+	cleanedMetric := promauto.With(nil).NewCounter(prometheus.CounterOpts{Name: "test_blocks_cleaned"})
+	failedMetric := promauto.With(nil).NewCounter(prometheus.CounterOpts{Name: "test_block_cleanup_failures"})
+	cleaner := NewBlocksCleaner(logger, flaky, df, 0*time.Second, cleanedMetric, failedMetric)
+
+	deleted, err := cleaner.DeleteMarkedBlocks(ctx)
+	testutil.Ok(t, err)
+	testutil.Equals(t, 1, len(deleted))
+
+	testutil.Equals(t, 1.0, promtest.ToFloat64(cleanedMetric))
+	testutil.Equals(t, 0.0, promtest.ToFloat64(failedMetric))
+	testutil.Equals(t, int32(2), flaky.deletesFailed.Load())
+
+	exists, err := bkt.Exists(ctx, id.String()+"/"+metadata.MetaFilename)
+	testutil.Ok(t, err)
+	testutil.Equals(t, false, exists)
+}
+
+// persistentlyFailingBucket fails every Delete call.
+type persistentlyFailingBucket struct {
+	objstore.Bucket
+}
+
+func (b *persistentlyFailingBucket) Delete(_ context.Context, _ string) error {
+	return errors.New("persistent object-store error")
+}
+
+func TestBlocksCleaner_DeleteMarkedBlocks_PersistentFailureStillReturnsError(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	id := ulid.MustNew(uint64(time.Now().Add(-2*time.Hour).Unix()*1000), nil)
+
+	mb := objstore.NewInMemBucket()
+	bkt := objstore.WithNoopInstr(mb)
+	uploadFakeBlock(t, ctx, bkt, id)
+
+	logger := log.NewNopLogger()
+
+	markCounter := promauto.With(nil).NewCounter(prometheus.CounterOpts{Name: "test_block_marked_2"})
+	testutil.Ok(t, block.MarkForDeletion(ctx, logger, bkt, id, "test", markCounter))
+
+	failing := &persistentlyFailingBucket{Bucket: bkt}
+
+	df := block.NewIgnoreDeletionMarkFilter(logger, bkt, 48*time.Hour, 32)
+	testutil.Ok(t, df.Filter(ctx, map[ulid.ULID]*metadata.Meta{id: nil}, nil, nil))
+
+	cleanedMetric := promauto.With(nil).NewCounter(prometheus.CounterOpts{Name: "test_blocks_cleaned_2"})
+	failedMetric := promauto.With(nil).NewCounter(prometheus.CounterOpts{Name: "test_block_cleanup_failures_2"})
+	cleaner := NewBlocksCleaner(logger, failing, df, 0*time.Second, cleanedMetric, failedMetric)
+
+	_, err := cleaner.DeleteMarkedBlocks(ctx)
+	testutil.NotOk(t, err)
+	testutil.Equals(t, 0.0, promtest.ToFloat64(cleanedMetric))
+	testutil.Equals(t, 1.0, promtest.ToFloat64(failedMetric))
+}

--- a/pkg/compact/blocks_cleaner_test.go
+++ b/pkg/compact/blocks_cleaner_test.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -17,6 +16,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	promtest "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/thanos-io/objstore"
+	"go.uber.org/atomic"
 
 	"github.com/efficientgo/core/testutil"
 


### PR DESCRIPTION
A single transient error from the object store during cleanup propagates up to `runCompact` and crashes the compactor. GCS in particular returns occasional 5xx that are documented as transient and expected to be retried client-side.

Wrap `block.Delete` in a small bounded retry (3 attempts with exponential backoff). The block is already marked for deletion when this runs, so retrying is safe. Persistent errors still surface via the existing multi-error after the retry budget is exhausted.

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

- Add a bounded retry around the inner `block.Delete` call in `BlocksCleaner.DeleteMarkedBlocks`. 3 attempts with exponential backoff (1s, 2s).
- Persistent errors are still collected into the existing `SyncMultiError` and returned to the caller, so real failures continue to surface.
- Add two unit tests in `pkg/compact/blocks_cleaner_test.go`:
   - `TestBlocksCleaner_DeleteMarkedBlocks_RetriesTransientDeleteFailures` — wraps the in-mem bucket so the first two `Delete` calls fail; asserts cleanup succeeds, `blocksCleaned == 1`, `blockCleanupFailures == 0`.
  - `TestBlocksCleaner_DeleteMarkedBlocks_PersistentFailureStillReturnsError` — wraps the bucket so every `Delete` fails; asserts the error is still returned, `blocksCleaned == 0`, `blockCleanupFailures == 1`.

## Verification

Reproduced in production with Thanos v0.37.1 against GCS. The failing stack shows

```
level=warn msg="changing probe status" status=not-ready reason="cleaning marked blocks: delete block: googleapi: Error
  503: We encountered an internal error. Please try again., backendError"
  level=error err="googleapi: Error 503: ...\ndelete block\ngithub.com/thanos-io/thanos/pkg/compact.(*BlocksCleaner).Del
  eteMarkedBlocks\n\t.../pkg/compact/blocks_cleaner.go:51\nmain.runCompact.func6\n\t.../cmd/thanos/compact.go:445\n..."
```

During the cleanup pass runs, the compactor hits a transient 5xx on one delete from GCS and then exits the process.

Tested locally:

  - `go test -v -count=1 -run 'TestBlocksCleaner_DeleteMarkedBlocks' ./pkg/compact/` — both new tests pass
  - `go test -count=1 -run '^(TestBlocksCleaner|TestBestEffort|TestGetLastModifiedTime|TestCompactExtensions)'
  ./pkg/compact/` tests pass
