### PR TITLE
cache: add redis key prefix support

### DIFF
--- a/pkg/cacheutil/redis_client.go
+++ b/pkg/cacheutil/redis_client.go
@@ -65,6 +65,9 @@ type RedisClientConfig struct {
 	// Addr specifies the addresses of redis server.
 	Addr string `yaml:"addr"`
 
+	// Prefix used for all redis keys (optional).
+	Prefix string `yaml:"prefix"`
+
 	// Use the specified Username to authenticate the current connection
 	// with one of the connections defined in the ACL list when connecting
 	// to a Redis 6.0 instance, or greater, that is using the Redis ACL system.
@@ -266,6 +269,7 @@ func NewRedisClientWithConfig(logger log.Logger, name string, config RedisClient
 
 // SetAsync implement RemoteCacheClient.
 func (c *RedisClient) SetAsync(key string, value []byte, ttl time.Duration) error {
+	key = c.addPrefix(key)
 	return c.p.EnqueueAsync(func() {
 		start := time.Now()
 		err := c.setAsyncCircuitBreaker.Execute(func() error {
@@ -288,7 +292,7 @@ func (c *RedisClient) SetMulti(data map[string][]byte, ttl time.Duration) {
 	sets := make(rueidis.Commands, 0, len(data))
 	ittl := int64(ttl.Seconds())
 	for k, v := range data {
-		sets = append(sets, c.client.B().Setex().Key(k).Seconds(ittl).Value(rueidis.BinaryString(v)).Build())
+		sets = append(sets, c.client.B().Setex().Key(c.addPrefix(k)).Seconds(ittl).Value(rueidis.BinaryString(v)).Build())
 	}
 	for _, resp := range c.client.DoMulti(context.Background(), sets...) {
 		if err := resp.Error(); err != nil {
@@ -305,7 +309,6 @@ func (c *RedisClient) GetMulti(ctx context.Context, keys []string) map[string][]
 		return nil
 	}
 	start := time.Now()
-	results := make(map[string][]byte, len(keys))
 
 	if c.config.ReadTimeout > 0 {
 		timeoutCtx, cancel := context.WithTimeout(ctx, c.config.ReadTimeout)
@@ -313,6 +316,20 @@ func (c *RedisClient) GetMulti(ctx context.Context, keys []string) map[string][]
 		ctx = timeoutCtx
 	}
 
+	var results map[string][]byte
+	if c.config.Prefix == "" {
+		results = c.getMulti(ctx, keys)
+	} else {
+		results = c.getMultiPrefixed(ctx, keys)
+	}
+
+	c.durationGetMulti.Observe(time.Since(start).Seconds())
+	return results
+}
+
+// getMulti fetches keys as-is.
+func (c *RedisClient) getMulti(ctx context.Context, keys []string) map[string][]byte {
+	results := make(map[string][]byte, len(keys))
 	// NOTE(GiedriusS): TTL is the default one in case PTTL fails. 8 hours should be good enough IMHO.
 	resps, err := rueidis.MGetCache(c.client, ctx, 8*time.Hour, keys)
 	if err != nil {
@@ -323,7 +340,20 @@ func (c *RedisClient) GetMulti(ctx context.Context, keys []string) map[string][]
 			results[key] = stringToBytes(val)
 		}
 	}
-	c.durationGetMulti.Observe(time.Since(start).Seconds())
+	return results
+}
+
+// getMultiPrefixed fetches keys with the configured prefix, mapping results back to the original keys.
+func (c *RedisClient) getMultiPrefixed(ctx context.Context, keys []string) map[string][]byte {
+	prefixedKeys := make([]string, len(keys))
+	for i, k := range keys {
+		prefixedKeys[i] = c.config.Prefix + k
+	}
+	prefixed := c.getMulti(ctx, prefixedKeys)
+	results := make(map[string][]byte, len(prefixed))
+	for k, v := range prefixed {
+		results[strings.TrimPrefix(k, c.config.Prefix)] = v
+	}
 	return results
 }
 
@@ -331,6 +361,13 @@ func (c *RedisClient) GetMulti(ctx context.Context, keys []string) map[string][]
 func (c *RedisClient) Stop() {
 	c.p.Stop()
 	c.client.Close()
+}
+
+func (c *RedisClient) addPrefix(key string) string {
+	if c.config.Prefix == "" {
+		return key
+	}
+	return c.config.Prefix + key
 }
 
 // stringToBytes converts string to byte slice (copied from vendor/github.com/go-redis/redis/v8/internal/util/unsafe.go).

--- a/pkg/cacheutil/redis_client_test.go
+++ b/pkg/cacheutil/redis_client_test.go
@@ -114,6 +114,15 @@ func TestRedisClient(t *testing.T) {
 				return cfg
 			},
 		},
+		{
+			name: "WithPrefix",
+			redisConfig: func() RedisClientConfig {
+				cfg := DefaultRedisClientConfig
+				cfg.Addr = s.Addr()
+				cfg.Prefix = "test-prefix:"
+				return cfg
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Basically https://github.com/thanos-io/thanos/pull/8617 but with my nit applied.

Closes #8617.
Closes #8608.
