### PR TITLE
cmd/thanos: reuse helper

### DIFF
--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -213,12 +213,7 @@ func runCompact(
 	}
 	insBkt := objstoretracing.WrapWithTraces(objstore.WrapWithMetrics(bkt, extprom.WrapRegistererWithPrefix("thanos_", reg), bkt.Name()))
 
-	relabelContentYaml, err := conf.selectorRelabelConf.Content()
-	if err != nil {
-		return errors.Wrap(err, "get content of relabel configuration")
-	}
-
-	relabelConfig, err := block.ParseRelabelConfig(relabelContentYaml, block.SelectorSupportedRelabelActions)
+	relabelConfig, err := conf.selectorRelabel.RelabelConfig(block.SelectorSupportedRelabelActions)
 	if err != nil {
 		return err
 	}
@@ -730,7 +725,7 @@ type compactConfig struct {
 	compactBlocksFetchConcurrency                  int
 	deleteDelay                                    model.Duration
 	dedupReplicaLabels                             []string
-	selectorRelabelConf                            extflag.PathOrContent
+	selectorRelabel                                *relabelCfg
 	disableWeb                                     bool
 	webConf                                        webConfig
 	label                                          string
@@ -849,7 +844,7 @@ func (cc *compactConfig) registerFlag(cmd extkingpin.FlagClause) {
 
 	cmd.Flag("web.disable", "Disable Block Viewer UI.").Default("false").BoolVar(&cc.disableWeb)
 
-	cc.selectorRelabelConf = *extkingpin.RegisterSelectorRelabelFlags(cmd)
+	cc.selectorRelabel = &relabelCfg{PathOrContent: extkingpin.RegisterSelectorRelabelFlags(cmd)}
 
 	cc.webConf.registerFlag(cmd)
 

--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -31,8 +31,8 @@ import (
 	"github.com/thanos-io/objstore/client"
 	objstoretracing "github.com/thanos-io/objstore/tracing/opentracing"
 	"google.golang.org/grpc"
-	"gopkg.in/yaml.v2"
 
+	"github.com/thanos-io/thanos/pkg/block"
 	"github.com/thanos-io/thanos/pkg/block/metadata"
 	"github.com/thanos-io/thanos/pkg/component"
 	"github.com/thanos-io/thanos/pkg/compressutil"
@@ -220,7 +220,7 @@ func runReceive(
 		return errors.Wrapf(err, "create default tenant tsdb in %v", conf.dataDir)
 	}
 
-	relabelConfig, err := conf.relabelCfg.RelabelConfig()
+	relabelConfig, err := conf.relabelCfg.RelabelConfig(nil)
 	if err != nil {
 		return errors.Wrap(err, "get relabel configuration")
 	}
@@ -958,22 +958,12 @@ type relabelCfg struct {
 	*extflag.PathOrContent
 }
 
-func (r *relabelCfg) RelabelConfig() ([]*relabel.Config, error) {
+func (r *relabelCfg) RelabelConfig(supportedActions map[relabel.Action]struct{}) ([]*relabel.Config, error) {
 	relabelContentYaml, err := r.Content()
 	if err != nil {
 		return []*relabel.Config{}, errors.Wrap(err, "get content of relabel configuration")
 	}
-	var relabelConfig []*relabel.Config
-	if err := yaml.Unmarshal(relabelContentYaml, &relabelConfig); err != nil {
-		return []*relabel.Config{}, errors.Wrap(err, "parse relabel configuration")
-	}
-	for _, cfg := range relabelConfig {
-		if err := cfg.Validate(model.LegacyValidation); err != nil {
-			return []*relabel.Config{}, errors.Wrap(err, "invalid relabel config")
-		}
-	}
-
-	return relabelConfig, nil
+	return block.ParseRelabelConfig(relabelContentYaml, supportedActions)
 }
 
 func (rc *receiveConfig) registerFlag(cmd extkingpin.FlagClause) {

--- a/cmd/thanos/store.go
+++ b/cmd/thanos/store.go
@@ -89,7 +89,7 @@ type storeConfig struct {
 	blockSyncConcurrency          int
 	blockMetaFetchConcurrency     int
 	filterConf                    *store.FilterConfig
-	selectorRelabelConf           extflag.PathOrContent
+	selectorRelabel               *relabelCfg
 	consistencyDelay              commonmodel.Duration
 	ignoreDeletionMarksDelay      commonmodel.Duration
 	disableWeb                    bool
@@ -180,7 +180,7 @@ func (sc *storeConfig) registerFlag(cmd extkingpin.FlagClause) {
 	cmd.Flag("max-time", "End of time range limit to serve. Thanos Store will serve only blocks, which happened earlier than this value. Option can be a constant time in RFC3339 format or time duration relative to current time, such as -1d or 2h45m. Valid duration units are ms, s, m, h, d, w, y.").
 		Default("9999-12-31T23:59:59Z").SetValue(&sc.filterConf.MaxTime)
 
-	sc.selectorRelabelConf = *extkingpin.RegisterSelectorRelabelFlags(cmd)
+	sc.selectorRelabel = &relabelCfg{PathOrContent: extkingpin.RegisterSelectorRelabelFlags(cmd)}
 
 	cmd.Flag("store.index-header-posting-offsets-in-mem-sampling", "Controls what is the ratio of postings offsets store will hold in memory. "+
 		"Larger value will keep less offsets, which will increase CPU cycles needed for query touching those postings. It's meant for setups that want low baseline memory pressure and where less traffic is expected. "+
@@ -348,12 +348,7 @@ func runStore(
 		}
 	}
 
-	relabelContentYaml, err := conf.selectorRelabelConf.Content()
-	if err != nil {
-		return errors.Wrap(err, "get content of relabel configuration")
-	}
-
-	relabelConfig, err := block.ParseRelabelConfig(relabelContentYaml, block.SelectorSupportedRelabelActions)
+	relabelConfig, err := conf.selectorRelabel.RelabelConfig(block.SelectorSupportedRelabelActions)
 	if err != nil {
 		return err
 	}

--- a/cmd/thanos/tools_bucket.go
+++ b/cmd/thanos/tools_bucket.go
@@ -111,11 +111,11 @@ type bucketVerifyConfig struct {
 }
 
 type bucketLsConfig struct {
-	output              string
-	excludeDelete       bool
-	selectorRelabelConf extflag.PathOrContent
-	filterConf          *store.FilterConfig
-	timeout             time.Duration
+	output          string
+	excludeDelete   bool
+	selectorRelabel *relabelCfg
+	filterConf      *store.FilterConfig
+	timeout         time.Duration
 }
 
 type bucketWebConfig struct {
@@ -187,7 +187,8 @@ func (tbc *bucketVerifyConfig) registerBucketVerifyFlag(cmd extkingpin.FlagClaus
 }
 
 func (tbc *bucketLsConfig) registerBucketLsFlag(cmd extkingpin.FlagClause) *bucketLsConfig {
-	tbc.selectorRelabelConf = *extkingpin.RegisterSelectorRelabelFlags(cmd)
+	tbc.selectorRelabel = &relabelCfg{PathOrContent: extkingpin.RegisterSelectorRelabelFlags(cmd)}
+
 	tbc.filterConf = &store.FilterConfig{}
 
 	cmd.Flag("output", "Optional format in which to print each block's information. Options are 'json', 'wide' or a custom template.").
@@ -438,12 +439,7 @@ func registerBucketLs(app extkingpin.AppClause, objStoreConfig *extflag.PathOrCo
 			level.Warn(logger).Log("msg", "Timeout less than 1m could lead to frequent failures")
 		}
 
-		relabelContentYaml, err := tbc.selectorRelabelConf.Content()
-		if err != nil {
-			return errors.Wrap(err, "get content of relabel configuration")
-		}
-
-		relabelConfig, err := block.ParseRelabelConfig(relabelContentYaml, block.SelectorSupportedRelabelActions)
+		relabelConfig, err := tbc.selectorRelabel.RelabelConfig(block.SelectorSupportedRelabelActions)
 		if err != nil {
 			return err
 		}
@@ -612,7 +608,7 @@ func registerBucketWeb(app extkingpin.AppClause, objStoreConfig *extflag.PathOrC
 		Default("0000-01-01T00:00:00Z").SetValue(&filterConf.MinTime)
 	cmd.Flag("max-time", "End of time range limit to serve. Thanos tool bucket web will serve only blocks, which happened earlier than this value. Option can be a constant time in RFC3339 format or time duration relative to current time, such as -1d or 2h45m. Valid duration units are ms, s, m, h, d, w, y.").
 		Default("9999-12-31T23:59:59Z").SetValue(&filterConf.MaxTime)
-	selectorRelabelConf := *extkingpin.RegisterSelectorRelabelFlags(cmd)
+	selectorRelabelConf := &relabelCfg{extkingpin.RegisterSelectorRelabelFlags(cmd)}
 
 	cmd.Setup(func(g *run.Group, logger log.Logger, reg *prometheus.Registry, tracer opentracing.Tracer, _ <-chan struct{}, _ bool) error {
 		comp := component.Bucket
@@ -694,12 +690,7 @@ func registerBucketWeb(app extkingpin.AppClause, objStoreConfig *extflag.PathOrC
 			level.Warn(logger).Log("msg", "Refresh interval should be at least 2 times the timeout")
 		}
 
-		relabelContentYaml, err := selectorRelabelConf.Content()
-		if err != nil {
-			return errors.Wrap(err, "get content of relabel configuration")
-		}
-
-		relabelConfig, err := block.ParseRelabelConfig(relabelContentYaml, block.SelectorSupportedRelabelActions)
+		relabelConfig, err := selectorRelabelConf.RelabelConfig(block.SelectorSupportedRelabelActions)
 		if err != nil {
 			return err
 		}
@@ -844,19 +835,14 @@ func registerBucketCleanup(app extkingpin.AppClause, objStoreConfig *extflag.Pat
 	tbc := &bucketCleanupConfig{}
 	tbc.registerBucketCleanupFlag(cmd)
 
-	selectorRelabelConf := extkingpin.RegisterSelectorRelabelFlags(cmd)
+	selectorRelabelConf := &relabelCfg{extkingpin.RegisterSelectorRelabelFlags(cmd)}
 	cmd.Setup(func(g *run.Group, logger log.Logger, reg *prometheus.Registry, _ opentracing.Tracer, _ <-chan struct{}, _ bool) error {
 		confContentYaml, err := objStoreConfig.Content()
 		if err != nil {
 			return err
 		}
 
-		relabelContentYaml, err := selectorRelabelConf.Content()
-		if err != nil {
-			return errors.Wrap(err, "get content of relabel configuration")
-		}
-
-		relabelConfig, err := block.ParseRelabelConfig(relabelContentYaml, block.SelectorSupportedRelabelActions)
+		relabelConfig, err := selectorRelabelConf.RelabelConfig(block.SelectorSupportedRelabelActions)
 		if err != nil {
 			return err
 		}
@@ -1367,7 +1353,7 @@ func registerBucketRetention(app extkingpin.AppClause, objStoreConfig *extflag.P
 	tbc := &bucketRetentionConfig{}
 	tbc.registerBucketRetentionFlag(cmd)
 
-	selectorRelabelConf := extkingpin.RegisterSelectorRelabelFlags(cmd)
+	selectorRelabelConf := &relabelCfg{extkingpin.RegisterSelectorRelabelFlags(cmd)}
 	cmd.Flag("retention.resolution-raw",
 		"How long to retain raw samples in bucket. Setting this to 0d will retain samples of this resolution forever").
 		Default("0d").SetValue(&retentionRaw)
@@ -1397,12 +1383,7 @@ func registerBucketRetention(app extkingpin.AppClause, objStoreConfig *extflag.P
 			return err
 		}
 
-		relabelContentYaml, err := selectorRelabelConf.Content()
-		if err != nil {
-			return errors.Wrap(err, "get content of relabel configuration")
-		}
-
-		relabelConfig, err := block.ParseRelabelConfig(relabelContentYaml, block.SelectorSupportedRelabelActions)
+		relabelConfig, err := selectorRelabelConf.RelabelConfig(block.SelectorSupportedRelabelActions)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Relabel configs are read from more places so let's use the same helpers everywhere.
