### PR TITLE
compact: remove dedup + hashmod footgun

### DIFF
--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -237,7 +237,7 @@ func runCompact(
 	duplicateBlocksFilter := block.NewDeduplicateFilter(conf.blockMetaFetchConcurrency)
 	noCompactMarkerFilter := compact.NewGatherNoCompactionMarkFilter(logger, insBkt, conf.blockMetaFetchConcurrency)
 	noDownsampleMarkerFilter := downsample.NewGatherNoDownsampleMarkFilter(logger, insBkt, conf.blockMetaFetchConcurrency)
-	labelShardedMetaFilter := block.NewLabelShardedMetaFilter(relabelConfig)
+	labelShardedMetaFilter := block.NewLabelShardedMetaFilter(relabelConfig, conf.dedupReplicaLabels...)
 	consistencyDelayMetaFilter := block.NewConsistencyDelayMetaFilter(logger, conf.consistencyDelay, extprom.WrapRegistererWithPrefix("thanos_", reg))
 	timePartitionMetaFilter := block.NewTimePartitionMetaFilter(conf.filterConf.MinTime, conf.filterConf.MaxTime)
 

--- a/docs/components/query-frontend.md
+++ b/docs/components/query-frontend.md
@@ -118,6 +118,7 @@ The default redis config is:
 type: REDIS
 config:
   addr: ""
+  prefix: ""
   username: ""
   password: ""
   db: 0

--- a/docs/components/store.md
+++ b/docs/components/store.md
@@ -456,6 +456,7 @@ The `redis` index cache allows to use [Redis](https://redis.io) as cache backend
 type: REDIS
 config:
   addr: ""
+  prefix: ""
   username: ""
   password: ""
   db: 0

--- a/pkg/block/fetcher.go
+++ b/pkg/block/fetcher.go
@@ -776,12 +776,24 @@ var _ MetadataFilter = &LabelShardedMetaFilter{}
 // LabelShardedMetaFilter represents struct that allows sharding.
 // Not go-routine safe.
 type LabelShardedMetaFilter struct {
-	relabelConfig []*relabel.Config
+	relabelConfig      []*relabel.Config
+	dedupReplicaLabels map[string]struct{}
 }
 
-// NewLabelShardedMetaFilter creates LabelShardedMetaFilter.
-func NewLabelShardedMetaFilter(relabelConfig []*relabel.Config) *LabelShardedMetaFilter {
-	return &LabelShardedMetaFilter{relabelConfig: relabelConfig}
+// NewLabelShardedMetaFilter creates LabelShardedMetaFilter. Dedup replica labels are here
+// to remove a footgun. For example, imagine that some tenant in Receiver is replicated to two
+// nodes (repllica factor of 2). There are also two Compactors where dedup replica labels are also
+// used in hashmod calculations to shard the work across two instances. Then, without this hashmod
+// separates two streams of the same (replicated) tenant_id data into multiple compactors. Later on, they
+// remove replica labels and then they get picked up by vertical compaction. This leads to a lot of extra
+// work and "error mark already exists". So, to remove this footgun we should just remove dedup replica
+// labels here.
+func NewLabelShardedMetaFilter(relabelConfig []*relabel.Config, dedupReplicaLabels ...string) *LabelShardedMetaFilter {
+	dedup := make(map[string]struct{}, len(dedupReplicaLabels))
+	for _, l := range dedupReplicaLabels {
+		dedup[l] = struct{}{}
+	}
+	return &LabelShardedMetaFilter{relabelConfig: relabelConfig, dedupReplicaLabels: dedup}
 }
 
 // Special label that will have an ULID of the meta.json being referenced to.
@@ -795,6 +807,9 @@ func (f *LabelShardedMetaFilter) Filter(_ context.Context, metas map[ulid.ULID]*
 		b.Set(BlockIDLabel, id.String())
 
 		for k, v := range m.Thanos.Labels {
+			if _, ok := f.dedupReplicaLabels[k]; ok {
+				continue
+			}
 			b.Set(k, v)
 		}
 

--- a/pkg/block/fetcher_test.go
+++ b/pkg/block/fetcher_test.go
@@ -405,6 +405,41 @@ func TestLabelShardedMetaFilter_Filter_Basic(t *testing.T) {
 
 }
 
+func TestLabelShardedMetaFilter_Filter_DedupReplicaLabel(t *testing.T) {
+	relabelContentYaml := `
+    - action: keep
+      regex: "r1"
+      source_labels:
+      - replica
+    `
+	relabelConfig, err := ParseRelabelConfig([]byte(relabelContentYaml), SelectorSupportedRelabelActions)
+	testutil.Ok(t, err)
+
+	metas := map[ulid.ULID]*metadata.Meta{
+		ULID(1): {Thanos: metadata.Thanos{Labels: map[string]string{"cluster": "A", "replica": "r1"}}},
+		ULID(2): {Thanos: metadata.Thanos{Labels: map[string]string{"cluster": "A", "replica": "r2"}}},
+	}
+	newInput := func() map[ulid.ULID]*metadata.Meta {
+		return map[ulid.ULID]*metadata.Meta{ULID(1): metas[ULID(1)], ULID(2): metas[ULID(2)]}
+	}
+
+	{
+		input := newInput()
+		m := newTestFetcherMetrics()
+		testutil.Ok(t, NewLabelShardedMetaFilter(relabelConfig).Filter(t.Context(), input, m.Synced, nil))
+		testutil.Equals(t, map[ulid.ULID]*metadata.Meta{ULID(1): metas[ULID(1)]}, input)
+		testutil.Equals(t, 1.0, promtest.ToFloat64(m.Synced.WithLabelValues(labelExcludedMeta)))
+	}
+
+	{
+		input := newInput()
+		m := newTestFetcherMetrics()
+		testutil.Ok(t, NewLabelShardedMetaFilter(relabelConfig, "replica").Filter(t.Context(), input, m.Synced, nil))
+		testutil.Equals(t, map[ulid.ULID]*metadata.Meta{}, input)
+		testutil.Equals(t, 2.0, promtest.ToFloat64(m.Synced.WithLabelValues(labelExcludedMeta)))
+	}
+}
+
 func TestLabelShardedMetaFilter_Filter_Hashmod(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()


### PR DESCRIPTION
From a recent fun adventure:
```
I think what happened is that multiple replicas (sets of receiver ext labels) of the same metrics streams were sharded to different compactors and then they removed replica labels -> those same overlaps were then picked up individually by each vertically compacting compactor -> they vertically compacted the same streams thus leading to "error mark already exists" error
```

So, let's just remove dedup replica from hashmod.
