### PR TITLE
chore: move TLS config logs from info to debug

### DIFF
--- a/pkg/extgrpc/client.go
+++ b/pkg/extgrpc/client.go
@@ -144,7 +144,7 @@ func StoreClientTLSCredentials(logger log.Logger, secure, skipVerify bool, cert,
 		return grpc.WithTransportCredentials(insecure.NewCredentials()), nil
 	}
 
-	level.Info(logger).Log("msg", "enabling client to server TLS")
+	level.Debug(logger).Log("msg", "enabling client to server TLS")
 
 	tlsCfg, err := tls.NewClientConfig(logger, cert, key, caCert, serverName, skipVerify, minTLSVersion)
 	if err != nil {

--- a/pkg/tls/options.go
+++ b/pkg/tls/options.go
@@ -142,14 +142,14 @@ func NewClientConfig(logger log.Logger, cert, key, caCert, serverName string, sk
 		if !certPool.AppendCertsFromPEM(caPEM) {
 			return nil, errors.Wrap(err, "building client CA")
 		}
-		level.Info(logger).Log("msg", "TLS client using provided certificate pool")
+		level.Debug(logger).Log("msg", "TLS client using provided certificate pool")
 	} else {
 		var err error
 		certPool, err = x509.SystemCertPool()
 		if err != nil {
 			return nil, errors.Wrap(err, "reading system certificate pool")
 		}
-		level.Info(logger).Log("msg", "TLS client using system certificate pool")
+		level.Debug(logger).Log("msg", "TLS client using system certificate pool")
 	}
 
 	var (
@@ -162,7 +162,7 @@ func NewClientConfig(logger log.Logger, cert, key, caCert, serverName string, sk
 		if err != nil {
 			return nil, err
 		}
-		level.Info(logger).Log("msg", fmt.Sprintf("setting minimum TLS version to %s", minTLSVersion))
+		level.Debug(logger).Log("msg", fmt.Sprintf("setting minimum TLS version to %s", minTLSVersion))
 	}
 	tlsCfg := &tls.Config{
 		RootCAs:    certPool,
@@ -188,7 +188,7 @@ func NewClientConfig(logger log.Logger, cert, key, caCert, serverName string, sk
 		}
 		tlsCfg.GetClientCertificate = mngr.getClientCertificate
 
-		level.Info(logger).Log("msg", "TLS client authentication enabled")
+		level.Debug(logger).Log("msg", "TLS client authentication enabled")
 	}
 	return tlsCfg, nil
 }


### PR DESCRIPTION

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [X] Change is not relevant to the end user.

## Changes

This commit changes the log verbosity from info to debug for TLS client configuration setup.

Running a Thanos Query on the main branch with
`--endpoint.sd-config-file` instead of the legacy `--grpc-client*` arguments, log messages are emitted every 5 seconds (the interval at which the list of endpoints is refreshed):

```
ts=2026-06-15T14:47:46.913935863Z caller=client.go:147 level=info msg="enabling client to server TLS"
ts=2026-06-15T14:47:46.9141221Z caller=options.go:145 level=info msg="TLS client using provided certificate pool"
ts=2026-06-15T14:47:46.914143614Z caller=options.go:165 level=info msg="setting minimum TLS version to 1.3"
ts=2026-06-15T14:47:46.91415433Z caller=options.go:191 level=info msg="TLS client authentication enabled"
ts=2026-06-15T14:47:51.914025066Z caller=client.go:147 level=info msg="enabling client to server TLS"
ts=2026-06-15T14:47:51.914294263Z caller=options.go:145 level=info msg="TLS client using provided certificate pool"
ts=2026-06-15T14:47:51.91431529Z caller=options.go:165 level=info msg="setting minimum TLS version to 1.3"
ts=2026-06-15T14:47:51.914326314Z caller=options.go:191 level=info msg="TLS client authentication enabled"
ts=2026-06-15T14:47:56.913622829Z caller=client.go:147 level=info msg="enabling client to server TLS"
ts=2026-06-15T14:47:56.913977311Z caller=options.go:145 level=info msg="TLS client using provided certificate pool"
ts=2026-06-15T14:47:56.913995512Z caller=options.go:165 level=info msg="setting minimum TLS version to 1.3"
ts=2026-06-15T14:47:56.914006135Z caller=options.go:191 level=info msg="TLS client authentication enabled"
```

I think that it was introduced in #8594.

## Verification

I've verified manually.