### PR TITLE
docs: fix duplicated word in receive docs

### DIFF
--- a/docs/components/receive.md
+++ b/docs/components/receive.md
@@ -337,7 +337,7 @@ By default, all these limits are disabled.
 ### Remote write request gates
 
 The available request gates in Thanos Receive can be configured within the `global` key:
-- `max_concurrency`: the maximum amount of remote write requests that will be concurrently worked on. Any request request that would exceed this limit will be accepted, but wait until the gate allows it to be processed.
+- `max_concurrency`: the maximum amount of remote write requests that will be concurrently worked on. Any request that would exceed this limit will be accepted, but wait until the gate allows it to be processed.
 
 ## Active Series Limiting (experimental)
 


### PR DESCRIPTION
The Receive `max_concurrency` description reads "Any request request that would exceed this limit". Removed the duplicated "request".
