### PR TITLE
rule: add external labels to alert instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ It is recommend to upgrade the storage components first (Receive, Store, etc.) a
 
 ### Fixed
 
+- [#7327](https://github.com/thanos-io/thanos/issues/7327): Rule: Add external labels to the individual alert instances returned over the Rules API. Previously Thanos enriched the alerting rule definition labels with external labels but not the active alert instances, so alerts surfaced via the sidecar Rules API were missing external labels such as `cluster`/`replica`.
 - [#8702](https://github.com/thanos-io/thanos/issues/8702): Query: Fix exemplar proxy stripping external label matchers in multi-tier query topologies. In Query A → Query B → Sidecar setups, external label matchers are now preserved when forwarding to downstream Query nodes so they can route to the correct stores.
 - [#8726](https://github.com/thanos-io/thanos/pull/8726): *: Bump `thanos-community/grpc-go` fork to fix CVE-2026-33186 (CVSS 9.1), an authorization bypass via malformed `:path` headers that could bypass path-based "deny" rules in `grpc/authz` interceptors.
 - [#8714](https://github.com/thanos-io/thanos/pull/8714): Tracing: Fix `tls_config` fields (`ca_file`, `cert_file`, `key_file`) being silently ignored when using the OTLP gRPC exporter. Previously, deployments using a private CA or mTLS client certificates had to work around this via `OTEL_EXPORTER_OTLP_CERTIFICATE` and related environment variables.

--- a/pkg/rules/prometheus.go
+++ b/pkg/rules/prometheus.go
@@ -58,6 +58,15 @@ func enrichRulesWithExtLabels(groups []*rulespb.RuleGroup, extLset labels.Labels
 	for _, g := range groups {
 		for _, r := range g.Rules {
 			r.SetLabels(labelpb.ExtendSortedLabels(r.GetLabels(), extLset))
+
+			// Prometheus does not add external labels to the individual alert
+			// instances either, so enrich those too.
+			if a := r.GetAlert(); a != nil {
+				for _, ai := range a.Alerts {
+					ai.Labels = labelpb.ZLabelSet{Labels: labelpb.ZLabelsFromPromLabels(
+						labelpb.ExtendSortedLabels(ai.Labels.PromLabels(), extLset))}
+				}
+			}
 		}
 	}
 }

--- a/pkg/rules/prometheus_test.go
+++ b/pkg/rules/prometheus_test.go
@@ -16,8 +16,34 @@ import (
 
 	"github.com/efficientgo/core/testutil"
 	"github.com/thanos-io/thanos/pkg/promclient"
+	"github.com/thanos-io/thanos/pkg/rules/rulespb"
+	"github.com/thanos-io/thanos/pkg/store/labelpb"
 	"github.com/thanos-io/thanos/pkg/testutil/e2eutil"
 )
+
+func TestEnrichRulesWithExtLabels(t *testing.T) {
+	extLset := labels.FromStrings("cluster", "prod", "replica", "0")
+
+	groups := []*rulespb.RuleGroup{{
+		Rules: []*rulespb.Rule{
+			rulespb.NewAlertingRule(&rulespb.Alert{
+				Name:   "TestAlert",
+				Labels: labelpb.ZLabelSet{Labels: labelpb.ZLabelsFromPromLabels(labels.FromStrings("severity", "page"))},
+				Alerts: []*rulespb.AlertInstance{
+					{Labels: labelpb.ZLabelSet{Labels: labelpb.ZLabelsFromPromLabels(labels.FromStrings("instance", "a"))}},
+				},
+			}),
+		},
+	}}
+
+	enrichRulesWithExtLabels(groups, extLset)
+
+	alert := groups[0].Rules[0].GetAlert()
+	// The rule definition labels are enriched with the external labels.
+	testutil.Equals(t, labels.FromStrings("cluster", "prod", "replica", "0", "severity", "page"), alert.Labels.PromLabels())
+	// The individual alert instances are enriched too (the bug fixed in #7327).
+	testutil.Equals(t, labels.FromStrings("cluster", "prod", "instance", "a", "replica", "0"), alert.Alerts[0].Labels.PromLabels())
+}
 
 func TestPrometheus_Rules_e2e(t *testing.T) {
 	p, err := e2eutil.NewPrometheus()


### PR DESCRIPTION
Fixes #7327

`enrichRulesWithExtLabels` enriched the alerting rule *definition* labels with the configured external labels, but not the individual active alert instances (`Alert.Alerts[].Labels`). As a result, alerts surfaced over the sidecar Rules API were missing external labels such as `cluster`/`replica`, even though those labels appeared on the rule and on metrics (the symptom reported in #7327, confirmed by several users).

This extends the shared helper to also enrich each alert instance's labels using the existing `ExtendSortedLabels` helper. `ExtendSortedLabels` keeps already-present labels, so the Thanos Ruler/Manager path (whose instances may already carry these labels) is unaffected and the operation is idempotent.

Added a unit test (`TestEnrichRulesWithExtLabels`) asserting both the rule definition labels and the alert instance labels are enriched.

- [x] CHANGELOG entry added under Unreleased > Fixed.
