### PR TITLE
store: extract storeWarnOrErr helper for label fan-out error handling

### DIFF
--- a/pkg/store/proxy.go
+++ b/pkg/store/proxy.go
@@ -467,13 +467,13 @@ func (s *ProxyStore) LabelNames(ctx context.Context, originalRequest *storepb.La
 			defer span.Finish()
 			resp, err := st.LabelNames(spanCtx, r)
 			if err != nil {
-				err = errors.Wrapf(err, "fetch label names from store %s", st)
-				if r.PartialResponseDisabled || r.PartialResponseStrategy == storepb.PartialResponseStrategy_ABORT {
-					return err
+				warn, fatal := storeWarnOrErr("fetch label names", st, err, r.PartialResponseDisabled, r.PartialResponseStrategy)
+				if fatal != nil {
+					return fatal
 				}
 
 				mtx.Lock()
-				warnings = append(warnings, err.Error())
+				warnings = append(warnings, warn)
 				mtx.Unlock()
 				return nil
 			}
@@ -572,13 +572,13 @@ func (s *ProxyStore) LabelValues(ctx context.Context, originalRequest *storepb.L
 
 			resp, err := st.LabelValues(spanCtx, r)
 			if err != nil {
-				err = errors.Wrapf(err, "fetch label values from store %s", st)
-				if r.PartialResponseDisabled || r.PartialResponseStrategy == storepb.PartialResponseStrategy_ABORT {
-					return err
+				warn, fatal := storeWarnOrErr("fetch label values", st, err, r.PartialResponseDisabled, r.PartialResponseStrategy)
+				if fatal != nil {
+					return fatal
 				}
 
 				mtx.Lock()
-				warnings = append(warnings, err.Error())
+				warnings = append(warnings, warn)
 				mtx.Unlock()
 				return nil
 			}
@@ -603,6 +603,19 @@ func (s *ProxyStore) LabelValues(ctx context.Context, originalRequest *storepb.L
 		Values:   vals,
 		Warnings: warnings,
 	}, nil
+}
+
+// storeWarnOrErr annotates err with the operation and store, then decides how a
+// fan-out goroutine should surface it given the request's partial-response settings.
+// When partial responses are disabled or the strategy is ABORT it returns the
+// annotated error, signalling the caller to fail the whole request. Otherwise it
+// returns the error text as a warning to be appended to the response.
+func storeWarnOrErr(op string, st Client, err error, partialDisabled bool, strategy storepb.PartialResponseStrategy) (warning string, fatal error) {
+	err = errors.Wrapf(err, "%s from store %s", op, st)
+	if partialDisabled || strategy == storepb.PartialResponseStrategy_ABORT {
+		return "", err
+	}
+	return err.Error(), nil
 }
 
 func storeInfo(st Client) (storeID string, storeAddr string, isLocalStore bool) {


### PR DESCRIPTION
- [ ] I added CHANGELOG entry for this change.
- [x] Change is not relevant to the end user.

## Changes

`ProxyStore.LabelNames` and `ProxyStore.LabelValues` duplicated the same per-store error handling in their fan-out goroutines: wrap the error with the operation and store, then either fail the whole request or append a warning depending on the request's partial-response settings.

This extracts that decision into a small helper, `storeWarnOrErr`, which returns a `(warning, fatal)` pair so the two call sites read unambiguously.

No behavior change:
- The wrap format `"<op> from store <store>"` reproduces the original messages (`fetch label names from store ...` / `fetch label values from store ...`) exactly.
- The abort-vs-warn branch is identical to before.

`Series` is intentionally left as-is — its error path is synchronous (not in an errgroup), does not wrap with the store name today, and surfaces warnings over the response stream via `NewWarnSeriesResponse` rather than a warnings slice, so folding it in would change semantics rather than remove duplication.

## Verification

- `go build ./pkg/store/` and `go vet ./pkg/store/` are clean.
- `go test ./pkg/store/ -run 'TestProxyStore_LabelNames|TestProxyStore_LabelValues'` passes.