### PR TITLE
fix: replace errors.New(fmt.Sprintf(...)) with errors.Errorf(...)

### DIFF
--- a/pkg/block/index.go
+++ b/pkg/block/index.go
@@ -119,14 +119,14 @@ func (i HealthStats) Issue347OutsideChunksErr() error {
 
 func (i HealthStats) OutOfOrderChunksErr() error {
 	if i.OutOfOrderChunks > 0 {
-		return errors.New(fmt.Sprintf(
+		return errors.Errorf(
 			"%d/%d series have an average of %.3f out-of-order chunks: "+
 				"%.3f of these are exact duplicates (in terms of data and time range)",
 			i.OutOfOrderSeries,
 			i.TotalSeries,
 			float64(i.OutOfOrderChunks)/float64(i.OutOfOrderSeries),
 			float64(i.DuplicatedChunks)/float64(i.OutOfOrderChunks),
-		))
+		)
 	}
 	return nil
 }

--- a/pkg/store/recover.go
+++ b/pkg/store/recover.go
@@ -4,7 +4,6 @@
 package store
 
 import (
-	"fmt"
 	"runtime"
 
 	"github.com/go-kit/log"
@@ -45,7 +44,7 @@ func (r *recoverableStoreServer) recover(srv storepb.Store_SeriesServer) {
 			level.Error(r.logger).Log("err", err)
 		}
 	default:
-		if err := srv.Send(storepb.NewWarnSeriesResponse(errors.New(fmt.Sprintf("unknown error while processing Series: %v", e)))); err != nil {
+		if err := srv.Send(storepb.NewWarnSeriesResponse(errors.Errorf("unknown error while processing Series: %v", e))); err != nil {
 			level.Error(r.logger).Log("err", err)
 		}
 	}

--- a/pkg/tls/options.go
+++ b/pkg/tls/options.go
@@ -263,7 +263,7 @@ func getCipherSuiteIDs(ciphers []string) ([]uint16, error) {
 	for _, name := range ciphers {
 		id, ok := cipherMap[name]
 		if !ok {
-			return nil, errors.New(fmt.Sprintf("invalid cipher suite: %s, valid values are %s", name, strings.Join(validNames, ", ")))
+			return nil, errors.Errorf("invalid cipher suite: %s, valid values are %s", name, strings.Join(validNames, ", "))
 		}
 		ids = append(ids, id)
 	}
@@ -295,7 +295,7 @@ func getCurveIDs(curves []string) ([]tls.CurveID, error) {
 	for _, name := range curves {
 		id, ok := curveMap[name]
 		if !ok {
-			return nil, errors.New(fmt.Sprintf("invalid curve: %s, valid values are %s", name, strings.Join(validNames, ", ")))
+			return nil, errors.Errorf("invalid curve: %s, valid values are %s", name, strings.Join(validNames, ", "))
 		}
 		ids = append(ids, id)
 	}
@@ -314,7 +314,7 @@ func GetTlsVersion(tlsMinVersion string) (uint16, error) {
 	}
 
 	if _, ok := validOption.tlsOption[tlsMinVersion]; !ok {
-		return 0, errors.New(fmt.Sprintf("invalid TLS version: %s, valid values are %s", tlsMinVersion, validOption.joinString()))
+		return 0, errors.Errorf("invalid TLS version: %s, valid values are %s", tlsMinVersion, validOption.joinString())
 	}
 
 	return validOption.tlsOption[tlsMinVersion], nil


### PR DESCRIPTION
\`github.com/pkg/errors\` already provides \`errors.Errorf\` which accepts a format string directly. Three places in \`pkg/store\`, \`pkg/block\`, and \`pkg/tls\` were wrapping it unnecessarily with \`errors.New(fmt.Sprintf(...))\`.

The \`fmt\` import in \`pkg/store/recover.go\` becomes unused after the change and is removed.

Self-found.