### PR TITLE
receive: remove separation between remote/local

### DIFF
--- a/docs/components/receive.md
+++ b/docs/components/receive.md
@@ -372,7 +372,7 @@ Please see the metric `thanos_receive_forward_delay_seconds` to see if you need 
 
 The following formula is used for calculating quorum:
 
-```go mdox-exec="sed -n '1137,1147p' pkg/receive/handler.go"
+```go mdox-exec="sed -n '1077,1087p' pkg/receive/handler.go"
 // writeQuorum returns minimum number of replicas that has to confirm write success before claiming replication success.
 func (h *Handler) writeQuorum() int {
 	// NOTE(GiedriusS): this is here because otherwise RF=2 doesn't make sense as all writes

--- a/pkg/receive/handler.go
+++ b/pkg/receive/handler.go
@@ -194,6 +194,8 @@ func NewHandler(logger log.Logger, o *Options) *Handler {
 				}, []string{"worker"},
 			),
 			workers,
+			o.Endpoint,
+			o.Writer,
 			o.MaxArtificialDelay,
 			o.ReplicationProtocol,
 			o.DialOpts...),
@@ -734,28 +736,26 @@ type remoteWriteParams struct {
 	alreadyReplicated bool
 }
 
-func (h *Handler) gatherWriteStats(rf int, writes ...map[endpointReplica]map[string]trackedSeries) tenantRequestStats {
+func (h *Handler) gatherWriteStats(rf int, writes map[endpointReplica]map[string]trackedSeries) tenantRequestStats {
 	var stats = make(tenantRequestStats)
 
-	for _, write := range writes {
-		for er := range write {
-			for tenant, series := range write[er] {
-				samples := 0
+	for er := range writes {
+		for tenant, series := range writes[er] {
+			samples := 0
 
-				for _, ts := range series.timeSeries {
-					samples += len(ts.Samples)
-				}
+			for _, ts := range series.timeSeries {
+				samples += len(ts.Samples)
+			}
 
-				if st, ok := stats[tenant]; ok {
-					st.timeseries += len(series.timeSeries)
-					st.totalSamples += samples
+			if st, ok := stats[tenant]; ok {
+				st.timeseries += len(series.timeSeries)
+				st.totalSamples += samples
 
-					stats[tenant] = st
-				} else {
-					stats[tenant] = requestStats{
-						timeseries:   len(series.timeSeries),
-						totalSamples: samples,
-					}
+				stats[tenant] = st
+			} else {
+				stats[tenant] = requestStats{
+					timeseries:   len(series.timeSeries),
+					totalSamples: samples,
 				}
 			}
 		}
@@ -793,29 +793,26 @@ func (h *Handler) fanoutForward(ctx context.Context, params remoteWriteParams) (
 	}
 	requestLogger := log.With(h.logger, logTags...)
 
-	localWrites, remoteWrites, err := h.distributeTimeseriesToReplicas(params.tenant, params.replicas, params.writeRequest.Timeseries)
+	writes, err := h.distributeTimeseriesToReplicas(params.tenant, params.replicas, params.writeRequest.Timeseries)
 	if err != nil {
 		level.Error(requestLogger).Log("msg", "failed to distribute timeseries to replicas", "err", err)
 		return stats, err
 	}
 
-	stats = h.gatherWriteStats(len(params.replicas), localWrites, remoteWrites)
+	stats = h.gatherWriteStats(len(params.replicas), writes)
 
 	// Prepare a buffered channel to receive the responses from the local and remote writes. Remote writes will all go
 	// asynchronously and with this capacity we will never block on writing to the channel.
 	var maxBufferedResponses int
-	for er := range localWrites {
-		maxBufferedResponses += len(localWrites[er])
-	}
-	for er := range remoteWrites {
-		maxBufferedResponses += len(remoteWrites[er])
+	for er := range writes {
+		maxBufferedResponses += len(writes[er])
 	}
 
 	responses := make(chan writeResponse, maxBufferedResponses)
 	wg := sync.WaitGroup{}
 
 	go func() {
-		h.sendWrites(ctx, &wg, params, localWrites, remoteWrites, responses)
+		h.sendWrites(ctx, &wg, params, writes, responses)
 		wg.Wait()
 		close(responses)
 	}()
@@ -890,19 +887,14 @@ func (h *Handler) fanoutForward(ctx context.Context, params remoteWriteParams) (
 	}
 }
 
-// distributeTimeseriesToReplicas distributes the given timeseries from the tenant to different endpoints in a manner
-// that achieves the replication factor indicated by replicas.
-// The first return value are the series that should be written to the local node. The second return value are the
-// series that should be written to remote nodes.
 func (h *Handler) distributeTimeseriesToReplicas(
 	tenantHTTP string,
 	replicas []uint64,
 	timeseries []prompb.TimeSeries,
-) (map[endpointReplica]map[string]trackedSeries, map[endpointReplica]map[string]trackedSeries, error) {
+) (map[endpointReplica]map[string]trackedSeries, error) {
 	h.mtx.RLock()
 	defer h.mtx.RUnlock()
-	remoteWrites := make(map[endpointReplica]map[string]trackedSeries)
-	localWrites := make(map[endpointReplica]map[string]trackedSeries)
+	writes := make(map[endpointReplica]map[string]trackedSeries)
 	for tsIndex, ts := range timeseries {
 		var tenant = tenantHTTP
 
@@ -912,7 +904,7 @@ func (h *Handler) distributeTimeseriesToReplicas(
 			tenantLabel := lbls.Get(h.splitTenantLabelName)
 			if tenantLabel != "" {
 				if err := tenancy.IsTenantValid(tenantLabel); err != nil {
-					return nil, nil, errors.Wrap(errValidation, err.Error())
+					return nil, errors.Wrap(errValidation, err.Error())
 				}
 				tenant = tenantLabel
 
@@ -928,16 +920,13 @@ func (h *Handler) distributeTimeseriesToReplicas(
 		for _, rn := range replicas {
 			endpoint, err := h.hashring.GetN(tenant, &ts, rn)
 			if err != nil {
-				return nil, nil, err
+				return nil, err
 			}
 			endpointReplica := endpointReplica{endpoint: endpoint, replica: rn}
-			var writeDestination = remoteWrites
-			if endpoint.HasAddress(h.options.Endpoint) {
-				writeDestination = localWrites
-			}
-			writeableSeries, ok := writeDestination[endpointReplica]
+
+			writeableSeries, ok := writes[endpointReplica]
 			if !ok {
-				writeDestination[endpointReplica] = map[string]trackedSeries{
+				writes[endpointReplica] = map[string]trackedSeries{
 					tenant: {
 						seriesIDs:  make([]int, 0),
 						timeSeries: make([]prompb.TimeSeries, 0),
@@ -949,10 +938,14 @@ func (h *Handler) distributeTimeseriesToReplicas(
 			tenantSeries.timeSeries = append(tenantSeries.timeSeries, ts)
 			tenantSeries.seriesIDs = append(tenantSeries.seriesIDs, tsIndex)
 
-			writeDestination[endpointReplica][tenant] = tenantSeries
+			writes[endpointReplica][tenant] = tenantSeries
 		}
 	}
-	return localWrites, remoteWrites, nil
+	return writes, nil
+}
+
+func isLocalEndpoint(e Endpoint, localEndpoint string) bool {
+	return e.HasAddress(localEndpoint)
 }
 
 // sendWrites sends the local and remote writes to execute concurrently, controlling them through the provided sync.WaitGroup.
@@ -961,36 +954,22 @@ func (h *Handler) sendWrites(
 	ctx context.Context,
 	wg *sync.WaitGroup,
 	params remoteWriteParams,
-	localWrites map[endpointReplica]map[string]trackedSeries,
-	remoteWrites map[endpointReplica]map[string]trackedSeries,
+	writes map[endpointReplica]map[string]trackedSeries,
 	responses chan writeResponse,
 ) {
-	// Do the writes to the local node first. This should be easy and fast.
-	for writeDestination := range localWrites {
-		func(writeDestination endpointReplica) {
-			for tenant, trackedSeries := range localWrites[writeDestination] {
-				h.sendLocalWrite(ctx, writeDestination, tenant, trackedSeries, responses)
-			}
-		}(writeDestination)
-	}
-
-	// First pass: submit to remote nodes non-blocking so that peers with available pool
-	// capacity (typically the fast ones) all get in flight before we stall on any saturated peer.
-	// This lets quorum be reached—and the HTTP response returned—without waiting for a slow peer's
-	// worker pool to drain.
-	type deferredRemote struct {
+	type deferredWrite struct {
 		tenant           string
 		writeDestination endpointReplica
 		trackedSeries    trackedSeries
 	}
-	var deferred []deferredRemote
+	var deferred []deferredWrite
 
-	for writeDestination := range remoteWrites {
-		for tenant, trackedSeries := range remoteWrites[writeDestination] {
+	for writeDestination := range writes {
+		for tenant, trackedSeries := range writes[writeDestination] {
 			wg.Add(1)
-			if !h.tryRemoteWrite(ctx, tenant, writeDestination, trackedSeries, params.alreadyReplicated, responses, wg) {
+			if !h.tryWrite(ctx, tenant, writeDestination, trackedSeries, params.alreadyReplicated, responses, wg) {
 				wg.Done()
-				deferred = append(deferred, deferredRemote{tenant, writeDestination, trackedSeries})
+				deferred = append(deferred, deferredWrite{tenant, writeDestination, trackedSeries})
 			}
 		}
 	}
@@ -998,47 +977,8 @@ func (h *Handler) sendWrites(
 	// Second pass: blocking submission for any peer whose pool was saturated during the first pass.
 	for _, d := range deferred {
 		wg.Add(1)
-		h.sendRemoteWrite(ctx, d.tenant, d.writeDestination, d.trackedSeries, params.alreadyReplicated, responses, wg)
+		h.sendWrite(ctx, d.tenant, d.writeDestination, d.trackedSeries, params.alreadyReplicated, responses, wg)
 	}
-}
-
-// sendLocalWrite sends a write request to the local node.
-// The responses are sent to the responses channel.
-func (h *Handler) sendLocalWrite(
-	ctx context.Context,
-	writeDestination endpointReplica,
-	tenantHTTP string,
-	trackedSeries trackedSeries,
-	responses chan<- writeResponse,
-) {
-	span, tracingCtx := tracing.StartSpan(ctx, "receive_local_tsdb_write")
-	defer span.Finish()
-	span.SetTag("endpoint", writeDestination.endpoint)
-	span.SetTag("replica", writeDestination.replica)
-
-	tenantSeriesMapping := map[string][]prompb.TimeSeries{}
-	for _, ts := range trackedSeries.timeSeries {
-		var tenant = tenantHTTP
-		if h.splitTenantLabelName != "" {
-			lbls := labelpb.ZLabelsToPromLabels(ts.Labels)
-			if tnt := lbls.Get(h.splitTenantLabelName); tnt != "" {
-				tenant = tnt
-			}
-		}
-		tenantSeriesMapping[tenant] = append(tenantSeriesMapping[tenant], ts)
-	}
-
-	for tenant, series := range tenantSeriesMapping {
-		err := h.writer.Write(tracingCtx, tenant, series)
-		if err != nil {
-			span.SetTag("error", true)
-			span.SetTag("error.msg", err.Error())
-			responses <- newWriteResponse(trackedSeries.seriesIDs, err, writeDestination)
-			return
-		}
-	}
-	responses <- newWriteResponse(trackedSeries.seriesIDs, nil, writeDestination)
-
 }
 
 // prepareRemoteWrite resolves the peer connection, builds the WriteRequest, and constructs the
@@ -1097,9 +1037,9 @@ func (h *Handler) prepareRemoteWrite(
 	return cl, req, cb
 }
 
-// sendRemoteWrite sends a write request to the remote node. It blocks until the peer's worker
+// sendWrite sends a write request to the remote node. It blocks until the peer's worker
 // pool accepts the work.
-func (h *Handler) sendRemoteWrite(
+func (h *Handler) sendWrite(
 	ctx context.Context,
 	tenant string,
 	er endpointReplica,
@@ -1115,10 +1055,10 @@ func (h *Handler) sendRemoteWrite(
 	cl.RemoteWriteAsync(ctx, req, er, ts.seriesIDs, responses, cb)
 }
 
-// tryRemoteWrite is the non-blocking counterpart of sendRemoteWrite. It returns false when the
+// tryWrite is the non-blocking counterpart of sendRemoteWrite. It returns false when the
 // peer's worker pool is at capacity; the caller should then fall back to sendRemoteWrite.
 // wg.Done is NOT called on a false return — the caller must not have called wg.Add before checking.
-func (h *Handler) tryRemoteWrite(
+func (h *Handler) tryWrite(
 	ctx context.Context,
 	tenant string,
 	er endpointReplica,
@@ -1527,6 +1467,8 @@ func newPeerGroup(
 	backoff backoff.Backoff,
 	forwardDelay *prometheus.HistogramVec,
 	asyncForwardWorkersCount uint,
+	localEndpoint string,
+	writer *Writer,
 	maxArtificialDelay time.Duration,
 	replicationProtocol ReplicationProtocol,
 	dialOpts ...grpc.DialOption,
@@ -1543,6 +1485,8 @@ func newPeerGroup(
 		maxArtificialDelay:       maxArtificialDelay,
 		asyncForwardWorkersCount: asyncForwardWorkersCount,
 		replicationProtocol:      replicationProtocol,
+		localEndpoint:            localEndpoint,
+		writer:                   writer,
 	}
 }
 
@@ -1624,6 +1568,8 @@ type peerGroup struct {
 	asyncForwardWorkersCount uint
 	replicationProtocol      ReplicationProtocol
 	maxArtificialDelay       time.Duration
+	localEndpoint            string
+	writer                   *Writer
 
 	m sync.RWMutex
 
@@ -1661,6 +1607,22 @@ func (p *peerGroup) close(endpoint Endpoint) error {
 	return nil
 }
 
+type localAsyncWriter struct {
+	w *Writer
+}
+
+func (lw *localAsyncWriter) Close() error {
+	return nil
+}
+
+func (lw *localAsyncWriter) RemoteWrite(ctx context.Context, in *storepb.WriteRequest, opts ...grpc.CallOption) (*storepb.WriteResponse, error) {
+	if err := lw.w.Write(ctx, in.Tenant, in.Timeseries); err != nil {
+		return nil, errors.Wrap(err, "writing locally")
+	}
+
+	return &storepb.WriteResponse{}, nil
+}
+
 func (p *peerGroup) getConnection(ctx context.Context, endpoint Endpoint) (WriteableStoreAsyncClient, error) {
 	if !p.isPeerUp(endpoint) {
 		return nil, errUnavailable
@@ -1685,20 +1647,26 @@ func (p *peerGroup) getConnection(ctx context.Context, endpoint Endpoint) (Write
 	p.conns.Inc()
 
 	var client peerClient
-	switch p.replicationProtocol {
-	case CapNProtoReplication:
-		client = writecapnp.NewRemoteWriteClient(writecapnp.NewTCPDialer(endpoint.CapNProtoAddress), p.logger)
-
-	case ProtobufReplication:
-		conn, err := p.dialer(endpoint.Address, p.dialOpts...)
-		if err != nil {
-			p.markPeerUnavailableUnlocked(endpoint)
-			dialError := errors.Wrap(err, "failed to dial peer")
-			return nil, errors.Wrap(dialError, errUnavailable.Error())
+	if isLocalEndpoint(endpoint, p.localEndpoint) {
+		client = &localAsyncWriter{
+			w: p.writer,
 		}
-		client = newProtobufPeer(conn)
-	default:
-		return nil, errors.Errorf("unknown replication protocol %v", p.replicationProtocol)
+	} else {
+		switch p.replicationProtocol {
+		case CapNProtoReplication:
+			client = writecapnp.NewRemoteWriteClient(writecapnp.NewTCPDialer(endpoint.CapNProtoAddress), p.logger)
+
+		case ProtobufReplication:
+			conn, err := p.dialer(endpoint.Address, p.dialOpts...)
+			if err != nil {
+				p.markPeerUnavailableUnlocked(endpoint)
+				dialError := errors.Wrap(err, "failed to dial peer")
+				return nil, errors.Wrap(dialError, errUnavailable.Error())
+			}
+			client = newProtobufPeer(conn)
+		default:
+			return nil, errors.Errorf("unknown replication protocol %v", p.replicationProtocol)
+		}
 	}
 
 	var delay time.Duration

--- a/pkg/receive/handler_localwrite_test.go
+++ b/pkg/receive/handler_localwrite_test.go
@@ -1,0 +1,150 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package receive
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+
+	"github.com/prometheus/prometheus/storage"
+
+	"github.com/thanos-io/thanos/pkg/extkingpin"
+	"github.com/thanos-io/thanos/pkg/store/labelpb"
+	"github.com/thanos-io/thanos/pkg/store/storepb"
+	"github.com/thanos-io/thanos/pkg/store/storepb/prompb"
+	"github.com/thanos-io/thanos/pkg/tenancy"
+)
+
+// newLocalWriteHandler builds a Handler backed by the *real* peerGroup (not the
+// fakePeersGroup used elsewhere in the tests) so that the local write path goes
+// through localAsyncWriter.
+func newLocalWriteHandler(t *testing.T, rf uint64, endpoints []Endpoint, apps []*fakeAppendable) *Handler {
+	t.Helper()
+	require.Len(t, apps, 1, "only the local appendable is wired; remote nodes are not dialable in this test")
+
+	logger := log.NewNopLogger()
+	limiter, err := NewLimiter(extkingpin.NewNopConfig(), nil, RouterIngestor, log.NewNopLogger(), 1*time.Second)
+	require.NoError(t, err)
+
+	h := NewHandler(logger, &Options{
+		TenantHeader:        tenancy.DefaultTenantHeader,
+		ReplicaHeader:       DefaultReplicaHeader,
+		ReplicationFactor:   rf,
+		ForwardTimeout:      5 * time.Minute,
+		Endpoint:            endpoints[0].Address,
+		Writer:              NewWriter(logger, newFakeTenantAppendable(apps[0]), &WriterOptions{}),
+		Limiter:             limiter,
+		ReplicationProtocol: ProtobufReplication,
+	})
+
+	cfg := []HashringConfig{{Hashring: "test", Endpoints: endpoints}}
+	hashring, err := NewMultiHashring(AlgorithmHashmod, rf, cfg, prometheus.NewRegistry())
+	require.NoError(t, err)
+	h.Hashring(hashring)
+
+	return h
+}
+
+// TestLocalAsyncWriterRemoteWritePersists ensures localAsyncWriter actually
+// writes the request to the underlying TSDB.
+func TestLocalAsyncWriterRemoteWritePersists(t *testing.T) {
+	fa := newFakeAppender(nil, nil, nil)
+	app := &fakeAppendable{appender: fa}
+	w := NewWriter(log.NewNopLogger(), newFakeTenantAppendable(app), &WriterOptions{})
+	lw := &localAsyncWriter{w: w}
+
+	series := makeSeriesWithValues(5)
+	resp, err := lw.RemoteWrite(context.Background(), &storepb.WriteRequest{
+		Tenant:     "tenant-a",
+		Timeseries: series,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp, "RemoteWrite must return a non-nil response on success")
+
+	for _, ts := range series {
+		lset := labelpb.ZLabelsToPromLabels(ts.Labels)
+		require.Lenf(t, fa.Get(lset), len(ts.Samples), "series %s was not persisted locally", lset.String())
+	}
+}
+
+// TestLocalAsyncWriterRemoteWritePropagatesError ensures a local write failure
+// surfaces as an error to the caller. A no-op RemoteWrite would mask backend
+// errors and make the handler return a success code while losing data.
+func TestLocalAsyncWriterRemoteWritePropagatesError(t *testing.T) {
+	app := &fakeAppendable{
+		appender:    newFakeAppender(nil, nil, nil),
+		appenderErr: func() error { return errors.New("appender unavailable") },
+	}
+	w := NewWriter(log.NewNopLogger(), newFakeTenantAppendable(app), &WriterOptions{})
+	lw := &localAsyncWriter{w: w}
+
+	_, err := lw.RemoteWrite(context.Background(), &storepb.WriteRequest{
+		Tenant:     "tenant-a",
+		Timeseries: makeSeriesWithValues(1),
+	})
+	require.Error(t, err)
+}
+
+// TestReceiveLocalWritePersistsEndToEnd drives a full HTTP remote-write request
+// through a single-node receiver whose only hashring member is itself. This is
+// the real local-write path (peerGroup.getConnection -> localAsyncWriter) that
+// the existing test harness mocks away.
+func TestReceiveLocalWritePersistsEndToEnd(t *testing.T) {
+	fa := newFakeAppender(nil, nil, nil)
+	app := &fakeAppendable{appender: fa}
+	h := newLocalWriteHandler(t, 1, []Endpoint{newUniqueEndpoint()}, []*fakeAppendable{app})
+	defer h.Close()
+
+	series := makeSeriesWithValues(10)
+	rec, err := makeRequest(h, "tenant-a", &prompb.WriteRequest{Timeseries: series})
+	require.NoError(t, err)
+	require.Equalf(t, http.StatusOK, rec.Code, "unexpected status; body: %s", rec.Body.String())
+
+	for _, ts := range series {
+		lset := labelpb.ZLabelsToPromLabels(ts.Labels)
+		require.Lenf(t, fa.Get(lset), len(ts.Samples), "series %s was not persisted locally", lset.String())
+	}
+}
+
+// TestReceiveLocalWriteReportsFailureWhenLocalWriteFails verifies the headline
+// promise of the commit: when the local write fails the handler must return a
+// non-2xx status instead of pretending the write succeeded.
+func TestReceiveLocalWriteReportsFailureWhenLocalWriteFails(t *testing.T) {
+	app := &fakeAppendable{
+		appender:    newFakeAppender(nil, nil, nil),
+		appenderErr: func() error { return errors.New("appender unavailable") },
+	}
+	h := newLocalWriteHandler(t, 1, []Endpoint{newUniqueEndpoint()}, []*fakeAppendable{app})
+	defer h.Close()
+
+	rec, err := makeRequest(h, "tenant-a", &prompb.WriteRequest{Timeseries: makeSeriesWithValues(3)})
+	require.NoError(t, err)
+	require.NotEqualf(t, http.StatusOK, rec.Code, "local write failed but handler returned OK; body: %s", rec.Body.String())
+}
+
+// TestReceiveLocalWriteConflictReturns409 verifies a conflict from the local TSDB
+// (e.g. an out-of-bounds sample) is surfaced as HTTP 409, not 503. localAsyncWriter
+// wraps the writer error with fmt.Errorf("writing locally: %w", err); the status
+// classifier resolves the cause with errors.Cause (github.com/pkg/errors), which
+// follows Cause() but NOT the %w chain of fmt.Errorf, so the conflict sentinel is
+// lost and the handler degrades the response to 503. Wrapping with errors.Wrap
+// instead preserves the Cause() chain that writeErrors/isConflict rely on.
+func TestReceiveLocalWriteConflictReturns409(t *testing.T) {
+	app := &fakeAppendable{
+		appender: newFakeAppender(func() error { return storage.ErrOutOfBounds }, nil, nil),
+	}
+	h := newLocalWriteHandler(t, 1, []Endpoint{newUniqueEndpoint()}, []*fakeAppendable{app})
+	defer h.Close()
+
+	rec, err := makeRequest(h, "tenant-a", &prompb.WriteRequest{Timeseries: makeSeriesWithValues(3)})
+	require.NoError(t, err)
+	require.Equalf(t, http.StatusConflict, rec.Code, "local conflict should map to 409; body: %s", rec.Body.String())
+}

--- a/pkg/receive/handler_test.go
+++ b/pkg/receive/handler_test.go
@@ -229,6 +229,24 @@ func (g *fakePeersGroup) getConnection(_ context.Context, endpoint Endpoint) (Wr
 
 var _ = (peersContainer)(&fakePeersGroup{})
 
+// localTestWriter mirrors production's localAsyncWriter (writes straight to the
+// local TSDB, wrapping errors with errors.Wrap so conflict classification works)
+// but resolves the handler's writer at call time. Some tests swap handler.writer
+// after the harness is built (e.g. the MultiTSDB benchmark), and the old local
+// write path read h.writer dynamically, so we preserve that behavior here.
+type localTestWriter struct {
+	h *Handler
+}
+
+func (w *localTestWriter) Close() error { return nil }
+
+func (w *localTestWriter) RemoteWrite(ctx context.Context, in *storepb.WriteRequest, _ ...grpc.CallOption) (*storepb.WriteResponse, error) {
+	if err := w.h.writer.Write(ctx, in.Tenant, in.Timeseries); err != nil {
+		return nil, errors.Wrap(err, "writing locally")
+	}
+	return &storepb.WriteResponse{}, nil
+}
+
 func newTestHandlerHashring(
 	debugName string,
 	appendables []*fakeAppendable,
@@ -241,9 +259,6 @@ func newTestHandlerHashring(
 		handlers []*Handler
 		wOpts    = &WriterOptions{}
 	)
-	fakePeers := &fakePeersGroup{
-		clients: map[Endpoint]*peerWorker{},
-	}
 
 	var (
 		closers = make([]func() error, 0)
@@ -251,6 +266,14 @@ func newTestHandlerHashring(
 		logger, _  = logging.NewLogger("debug", "logfmt", debugName)
 		limiter, _ = NewLimiter(extkingpin.NewNopConfig(), nil, RouterIngestor, log.NewNopLogger(), 1*time.Second)
 	)
+
+	// remoteClients models delivery of a write to the handler that owns an
+	// endpoint. It is only ever used by *other* handlers: a handler's own
+	// endpoint is served by a local writer below (mirroring production's
+	// localAsyncWriter), so that local writes terminate at the TSDB instead of
+	// looping back into the same handler's worker pool and deadlocking.
+	endpoints := make([]Endpoint, len(appendables))
+	remoteClients := make(map[Endpoint]*peerWorker, len(appendables))
 	for i := range appendables {
 		h := NewHandler(logger, &Options{
 			TenantHeader:      tenancy.DefaultTenantHeader,
@@ -261,9 +284,9 @@ func newTestHandlerHashring(
 			Limiter:           limiter,
 		})
 		handlers = append(handlers, h)
-		h.peers = fakePeers
 		endpoint := newUniqueEndpoint()
 		h.options.Endpoint = endpoint.Address
+		endpoints[i] = endpoint
 		cfg[0].Endpoints = append(cfg[0].Endpoints, endpoint)
 
 		var peer *peerWorker
@@ -284,8 +307,23 @@ func newTestHandlerHashring(
 		} else {
 			peer = newPeerWorker(&fakeRemoteWriteGRPCServer{h: h}, prometheus.NewHistogram(prometheus.HistogramOpts{}), 1, 0)
 		}
-		fakePeers.clients[endpoint] = peer
+		remoteClients[endpoint] = peer
 	}
+
+	// Give each handler its own peers view: its own endpoint resolves to a local
+	// writer, every other endpoint resolves to the shared remote-delivery worker.
+	for i, h := range handlers {
+		clients := make(map[Endpoint]*peerWorker, len(endpoints))
+		for j, endpoint := range endpoints {
+			if i == j {
+				clients[endpoint] = newPeerWorker(&localTestWriter{h: h}, prometheus.NewHistogram(prometheus.HistogramOpts{}), 1, 0)
+			} else {
+				clients[endpoint] = remoteClients[endpoint]
+			}
+		}
+		h.peers = &fakePeersGroup{clients: clients}
+	}
+
 	// Use hashmod as default.
 	if hashringAlgo == "" {
 		hashringAlgo = AlgorithmHashmod
@@ -736,34 +774,31 @@ func testReceiveQuorum(t *testing.T, hashringAlgo HashringAlgorithm, withConsist
 				}
 			}
 
-			if withConsistencyDelay {
-				time.Sleep(50 * time.Millisecond)
-			}
+			// Replicas beyond quorum are written best-effort and land asynchronously
+			// after the HTTP response returns, so poll until every fake DB holds the
+			// expected number of samples rather than checking exactly once.
+			verify := func() error {
+				var errs []error
+				for _, ts := range tc.wreq.Timeseries {
+					lset := labelpb.ZLabelsToPromLabels(ts.Labels)
+					for j, a := range tc.appendables {
+						got := uint64(len(a.appender.(*fakeAppender).Get(lset)))
+						hit := a.appenderErr == nil && endpointHit(t, hashring, tc.replicationFactor, handlers[j].options.Endpoint, tenant, &ts)
+						if withConsistencyDelay && tc.status == http.StatusOK {
+							var expected int
+							if hit {
+								// We have len(handlers) copies of each sample because the test case
+								// is run once for each handler and they all use the same appender.
+								expected = len(handlers) * len(ts.Samples)
+							}
+							if uint64(expected) != got {
+								errs = append(errs, fmt.Errorf("handler: %d, labels %q: expected %d samples, got %d", j, lset.String(), expected, got))
+							}
+							continue
+						}
 
-			// Test that each time series is stored
-			// the correct amount of times in each fake DB.
-			for _, ts := range tc.wreq.Timeseries {
-				lset := labelpb.ZLabelsToPromLabels(ts.Labels)
-				for j, a := range tc.appendables {
-					if withConsistencyDelay && tc.status == http.StatusOK {
-						var expected int
-						n := a.appender.(*fakeAppender).Get(lset)
-						got := uint64(len(n))
-						if a.appenderErr == nil && endpointHit(t, hashring, tc.replicationFactor, handlers[j].options.Endpoint, tenant, &ts) {
-							// We have len(handlers) copies of each sample because the test case
-							// is run once for each handler and they all use the same appender.
-							expected = len(handlers) * len(ts.Samples)
-						}
-						if uint64(expected) != got {
-							t.Errorf("handler: %d, labels %q: expected %d samples, got %d", j, lset.String(), expected, got)
-						}
-					} else {
 						var expectedMin int
-						n := a.appender.(*fakeAppender).Get(lset)
-						got := uint64(len(n))
-						if a.appenderErr == nil && endpointHit(t, hashring, tc.replicationFactor, handlers[j].options.Endpoint, tenant, &ts) {
-							// We have len(handlers) copies of each sample because the test case
-							// is run once for each handler and they all use the same appender.
+						if hit {
 							expectedMin = int((tc.replicationFactor/2)+1) * len(ts.Samples)
 							if tc.randomNode {
 								expectedMin = len(ts.Samples)
@@ -776,11 +811,17 @@ func testReceiveQuorum(t *testing.T, hashringAlgo HashringAlgorithm, withConsist
 							}
 						}
 						if uint64(expectedMin) > got {
-							t.Errorf("handler: %d, labels %q: expected minimum of %d samples, got %d", j, lset.String(), expectedMin, got)
+							errs = append(errs, fmt.Errorf("handler: %d, labels %q: expected minimum of %d samples, got %d", j, lset.String(), expectedMin, got))
 						}
 					}
-
 				}
+				return goerrors.Join(errs...)
+			}
+
+			verifyCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			if err := runutil.Retry(50*time.Millisecond, verifyCtx.Done(), verify); err != nil {
+				t.Error(err)
 			}
 		})
 	}
@@ -1315,6 +1356,9 @@ func benchmarkHandlerMultiTSDBReceiveRemoteWrite(b testutil.TB) {
 	}
 	defer func() {
 		testutil.Ok(b, closeFunc())
+		for _, h := range handlers {
+			h.Close()
+		}
 	}()
 	handler := handlers[0]
 
@@ -2104,7 +2148,7 @@ func TestDistributeSeries(t *testing.T) {
 	hr := &hashringSeenTenants{Hashring: hashring}
 	h.Hashring(hr)
 
-	_, remote, err := h.distributeTimeseriesToReplicas(
+	writes, err := h.distributeTimeseriesToReplicas(
 		"foo",
 		[]uint64{0},
 		[]prompb.TimeSeries{
@@ -2117,12 +2161,12 @@ func TestDistributeSeries(t *testing.T) {
 		},
 	)
 	require.NoError(t, err)
-	require.Len(t, remote, 1)
-	require.Len(t, remote[endpointReplica{endpoint: endpoint, replica: 0}]["bar"].timeSeries, 1)
-	require.Len(t, remote[endpointReplica{endpoint: endpoint, replica: 0}]["boo"].timeSeries, 1)
+	require.Len(t, writes, 1)
+	require.Len(t, writes[endpointReplica{endpoint: endpoint, replica: 0}]["bar"].timeSeries, 1)
+	require.Len(t, writes[endpointReplica{endpoint: endpoint, replica: 0}]["boo"].timeSeries, 1)
 
-	require.Equal(t, 1, labelpb.ZLabelsToPromLabels(remote[endpointReplica{endpoint: endpoint, replica: 0}]["bar"].timeSeries[0].Labels).Len())
-	require.Equal(t, 1, labelpb.ZLabelsToPromLabels(remote[endpointReplica{endpoint: endpoint, replica: 0}]["boo"].timeSeries[0].Labels).Len())
+	require.Equal(t, 1, labelpb.ZLabelsToPromLabels(writes[endpointReplica{endpoint: endpoint, replica: 0}]["bar"].timeSeries[0].Labels).Len())
+	require.Equal(t, 1, labelpb.ZLabelsToPromLabels(writes[endpointReplica{endpoint: endpoint, replica: 0}]["boo"].timeSeries[0].Labels).Len())
 
 	require.Equal(t, map[string]struct{}{"bar": {}, "boo": {}}, hr.seenTenants)
 }
@@ -2146,6 +2190,9 @@ func TestHandlerSplitTenantLabelLocalWrite(t *testing.T) {
 			&WriterOptions{},
 		),
 	})
+	// Local writes now flow through the peer worker pool, so the handler must be
+	// closed to stop its workers.
+	t.Cleanup(h.Close)
 
 	// initialize hashring with a single local endpoint matching the handler endpoint to force
 	// using local write

--- a/pkg/receive/receive_test.go
+++ b/pkg/receive/receive_test.go
@@ -899,7 +899,7 @@ func TestSendRemoteWriteMarksPeerUnavailableOnAnyError(t *testing.T) {
 
 			cl.sendUnavailable = sendUnavailable
 
-			h.sendRemoteWrite(ctx, "tenant-a", endpointReplica{
+			h.sendWrite(ctx, "tenant-a", endpointReplica{
 				endpoint: endpoint,
 				replica:  0,
 			}, trackedSeries{


### PR DESCRIPTION
Use the same peer groups/workers infra that we already have also for local writes - this makes the handler work properly (i.e. return with a "good" status code, etc.) when local writes are lagging.

Brain-coded the main logic, generated tests using a clanker.