### PR TITLE
rule: log PromQL info annotations at debug instead of warn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#8932](https://github.com/thanos-io/thanos/pull/8932): Store: Return the series set error from `TSDBStore.LabelValues` instead of an empty response.
 - [#8967](https://github.com/thanos-io/thanos/pull/8967): Query: Enforce store request series and samples limits for batched series responses.
 - [#8970](https://github.com/thanos-io/thanos/pull/8970): clientconfig: Fix TLS client permanently failing with `unable to use specified CA cert: none configured` after cert/key file rotation, since `TLSRoundTripperSettings.CA` was never populated.
-- [#8229](https://github.com/thanos-io/thanos/issues/8229): Rule: Log PromQL info annotations (e.g. "metric might not be a counter") at debug level instead of warn, to avoid log spam on every rule evaluation.
+- [#8873](https://github.com/thanos-io/thanos/pull/8873): Rule: Log PromQL info annotations (e.g. "metric might not be a counter") at debug level instead of warn, to avoid log spam on every rule evaluation.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#8932](https://github.com/thanos-io/thanos/pull/8932): Store: Return the series set error from `TSDBStore.LabelValues` instead of an empty response.
 - [#8967](https://github.com/thanos-io/thanos/pull/8967): Query: Enforce store request series and samples limits for batched series responses.
 - [#8970](https://github.com/thanos-io/thanos/pull/8970): clientconfig: Fix TLS client permanently failing with `unable to use specified CA cert: none configured` after cert/key file rotation, since `TLSRoundTripperSettings.CA` was never populated.
+- [#8229](https://github.com/thanos-io/thanos/issues/8229): Rule: Log PromQL info annotations (e.g. "metric might not be a counter") at debug level instead of warn, to avoid log spam on every rule evaluation.
 
 ### Changed
 

--- a/cmd/thanos/rule.go
+++ b/cmd/thanos/rule.go
@@ -1155,7 +1155,11 @@ func filterOutPromQLWarnings(warns []string, logger log.Logger, query string) []
 	storeWarnings := make([]string, 0, len(warns))
 	for _, warn := range warns {
 		if extannotations.IsPromQLAnnotation(warn) {
-			level.Warn(logger).Log("warning", warn, "query", query)
+			if extannotations.IsPromQLInfoAnnotation(warn) {
+				level.Debug(logger).Log("warning", warn, "query", query)
+			} else {
+				level.Warn(logger).Log("warning", warn, "query", query)
+			}
 			continue
 		}
 		storeWarnings = append(storeWarnings, warn)

--- a/cmd/thanos/rule_test.go
+++ b/cmd/thanos/rule_test.go
@@ -4,6 +4,8 @@
 package main
 
 import (
+	"bytes"
+	"strings"
 	"testing"
 
 	"github.com/efficientgo/core/testutil"
@@ -157,4 +159,26 @@ func TestFilterOutPromQLWarnings(t *testing.T) {
 			testutil.Equals(t, tc.expected, output)
 		})
 	}
+}
+
+func TestFilterOutPromQLWarnings_LogLevel(t *testing.T) {
+	query := "foo"
+	expr, err := extpromql.ParseExpr(`rate(prometheus_build_info[5m])`)
+	testutil.Ok(t, err)
+	possibleCounterInfo := annotations.NewPossibleNonCounterInfo("foo", expr.PositionRange())
+	badBucketLabelWarning := annotations.NewBadBucketLabelWarning("foo", "0.99", expr.PositionRange())
+
+	t.Run("info annotation logs at debug", func(t *testing.T) {
+		var buf bytes.Buffer
+		logger := log.NewLogfmtLogger(&buf)
+		filterOutPromQLWarnings([]string{possibleCounterInfo.Error()}, logger, query)
+		testutil.Assert(t, strings.Contains(buf.String(), "level=debug"), "expected info annotation to be logged at debug level, got: %s", buf.String())
+	})
+
+	t.Run("warning annotation logs at warn", func(t *testing.T) {
+		var buf bytes.Buffer
+		logger := log.NewLogfmtLogger(&buf)
+		filterOutPromQLWarnings([]string{badBucketLabelWarning.Error()}, logger, query)
+		testutil.Assert(t, strings.Contains(buf.String(), "level=warn"), "expected warning annotation to be logged at warn level, got: %s", buf.String())
+	})
 }

--- a/pkg/extannotations/annotations.go
+++ b/pkg/extannotations/annotations.go
@@ -13,3 +13,10 @@ func IsPromQLAnnotation(s string) bool {
 	// We cannot use "errors.Is(w, annotations.PromQLInfo)" here because of gRPC so we use a string as argument
 	return strings.HasPrefix(s, annotations.PromQLInfo.Error()) || strings.HasPrefix(s, annotations.PromQLWarning.Error())
 }
+
+// IsPromQLInfoAnnotation returns true if the given annotation is a PromQL info
+// annotation (e.g. "metric might not be a counter"), as opposed to a PromQL warning.
+func IsPromQLInfoAnnotation(s string) bool {
+	// We cannot use "errors.Is(w, annotations.PromQLInfo)" here because of gRPC so we use a string as argument
+	return strings.HasPrefix(s, annotations.PromQLInfo.Error())
+}

--- a/pkg/extannotations/annotations_test.go
+++ b/pkg/extannotations/annotations_test.go
@@ -1,0 +1,42 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package extannotations
+
+import "testing"
+
+func TestIsPromQLAnnotation(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		s    string
+		want bool
+	}{
+		{"info annotation", "PromQL info: metric might not be a counter", true},
+		{"warning annotation", "PromQL warning: query timestamp out of bounds", true},
+		{"unrelated annotation", "store warning: some store warning", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsPromQLAnnotation(tc.s); got != tc.want {
+				t.Errorf("IsPromQLAnnotation(%q) = %v, want %v", tc.s, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsPromQLInfoAnnotation(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		s    string
+		want bool
+	}{
+		{"info annotation", "PromQL info: metric might not be a counter", true},
+		{"warning annotation", "PromQL warning: query timestamp out of bounds", false},
+		{"unrelated annotation", "store warning: some store warning", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsPromQLInfoAnnotation(tc.s); got != tc.want {
+				t.Errorf("IsPromQLInfoAnnotation(%q) = %v, want %v", tc.s, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

- `filterOutPromQLWarnings` in `cmd/thanos/rule.go` logged every PromQL annotation at `level.Warn`, including purely informational ones like "metric might not be a counter" (`annotations.PromQLInfo`). Since this runs on every rule evaluation cycle for any rule whose query triggers the heuristic, it produces continuous log spam (see #8229) rather than something an operator needs to act on.
- Added `IsPromQLInfoAnnotation` to `pkg/extannotations/annotations.go`, mirroring the existing `IsPromQLAnnotation` but checking only the `annotations.PromQLInfo` prefix.
- `filterOutPromQLWarnings` now logs info-type annotations at `level.Debug` and keeps true warning-type annotations (`annotations.PromQLWarning`) at `level.Warn`. Filtering behavior (which warnings get removed from the response) is unchanged — only the log level for info-type annotations changes.

## Verification

- Added `TestIsPromQLInfoAnnotation` (`pkg/extannotations/annotations_test.go`) covering info vs. warning vs. unrelated strings.
- Added `TestFilterOutPromQLWarnings_LogLevel` (`cmd/thanos/rule_test.go`), which captures logger output via `log.NewLogfmtLogger` and asserts info annotations produce `level=debug` while warning annotations produce `level=warn`.
- Existing `TestFilterOutPromQLWarnings` (filtering behavior) still passes unchanged.
- `make go-lint` passes with 0 issues.

Closes #8229
