### PR TITLE
reloader: watch parent directory to survive atomic config replace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#8932](https://github.com/thanos-io/thanos/pull/8932): Store: Return the series set error from `TSDBStore.LabelValues` instead of an empty response.
 - [#8967](https://github.com/thanos-io/thanos/pull/8967): Query: Enforce store request series and samples limits for batched series responses.
 - [#8970](https://github.com/thanos-io/thanos/pull/8970): clientconfig: Fix TLS client permanently failing with `unable to use specified CA cert: none configured` after cert/key file rotation, since `TLSRoundTripperSettings.CA` was never populated.
+- [#8873](https://github.com/thanos-io/thanos/pull/8873): Rule: Log PromQL info annotations (e.g. "metric might not be a counter") at debug level instead of warn, to avoid log spam on every rule evaluation.
+- [#8874](https://github.com/thanos-io/thanos/pull/8874): Reloader: Watch the parent directory of the config file instead of the file itself, so reload is no longer missed after the file is replaced atomically (e.g. ConfigMap mounts, editors using temp-file-and-rename).
 
 ### Changed
 

--- a/pkg/reloader/reloader.go
+++ b/pkg/reloader/reloader.go
@@ -803,9 +803,15 @@ func (w *watcher) addDirectory(name string) error {
 	return w.addPath(name)
 }
 
+// addFile watches the parent directory of name, rather than name itself, so
+// that the watch survives the file being atomically replaced (e.g. via a
+// temp-file-and-rename, which is how ConfigMap-mounted files and many editors
+// update files in place). Watching the file's inode directly would otherwise
+// stop receiving events once the inode is replaced.
 func (w *watcher) addFile(name string) error {
-	w.watchedDirs[filepath.Dir(name)] = struct{}{}
-	return w.addPath(name)
+	dir := filepath.Dir(name)
+	w.watchedDirs[dir] = struct{}{}
+	return w.addPath(dir)
 }
 
 func (w *watcher) run(ctx context.Context) {

--- a/pkg/reloader/reloader_test.go
+++ b/pkg/reloader/reloader_test.go
@@ -207,6 +207,89 @@ config:
 	testutil.Ok(t, os.Unsetenv("TEST_RELOADER_THANOS_ENV2"))
 }
 
+// TestReloader_ConfigApplyAtomicReplace ensures that a reload is triggered
+// even when the config file is replaced atomically (temp-file-then-rename),
+// which is how ConfigMap-mounted files and many editors update files in
+// place. Watching the file's inode directly (rather than its parent
+// directory) would stop receiving events once the original inode is gone.
+func TestReloader_ConfigApplyAtomicReplace(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+	defer cancel()
+
+	l, err := net.Listen("tcp", "localhost:0")
+	testutil.Ok(t, err)
+
+	reloads := &atomic.Value{}
+	reloads.Store(0)
+	srv := &http.Server{}
+	srv.Handler = http.HandlerFunc(func(resp http.ResponseWriter, _ *http.Request) {
+		reloads.Store(reloads.Load().(int) + 1) // The only writer.
+		resp.WriteHeader(http.StatusOK)
+	})
+	go func() { _ = srv.Serve(l) }()
+	defer func() { testutil.Ok(t, srv.Close()) }()
+
+	reloadURL, err := url.Parse(fmt.Sprintf("http://%s", l.Addr().String()))
+	testutil.Ok(t, err)
+
+	dir := t.TempDir()
+	input := filepath.Join(dir, "cfg.yaml")
+
+	testutil.Ok(t, os.WriteFile(input, []byte("a: 1\n"), os.ModePerm))
+
+	reloader := New(nil, nil, &Options{
+		ReloadURL:     reloadURL,
+		CfgFile:       input,
+		WatchInterval: 9999 * time.Hour, // Disable interval to test watch logic only.
+		RetryInterval: 100 * time.Millisecond,
+		DelayInterval: 1 * time.Millisecond,
+	})
+
+	rctx, cancel2 := context.WithCancel(ctx)
+	g := sync.WaitGroup{}
+	g.Go(func() {
+		testutil.Ok(t, reloader.Watch(rctx))
+	})
+
+	// Replace the config file atomically (write to a temp file in the same
+	// directory, then rename over the target) twice. A single replacement can
+	// still produce a trailing inotify event on a dying file-level watch (e.g.
+	// a REMOVE event for the old inode), so it isn't enough to distinguish a
+	// watch that survives replacement from one that doesn't: only the *second*
+	// replacement reliably tells them apart, since by then a file-level watch
+	// has gone fully dead while a directory-level watch keeps working.
+	replacements := 0
+Outer:
+	for {
+		select {
+		case <-ctx.Done():
+			break Outer
+		case <-time.After(300 * time.Millisecond):
+		}
+
+		rel := reloads.Load().(int)
+		if rel == replacements+1 && replacements < 2 {
+			replacements++
+			tmp := filepath.Join(dir, fmt.Sprintf("cfg.yaml.tmp%d", replacements))
+			testutil.Ok(t, os.WriteFile(tmp, []byte(fmt.Sprintf("a: %d\n", replacements+1)), os.ModePerm))
+			testutil.Ok(t, os.Rename(tmp, input))
+		} else if rel >= 3 {
+			break
+		}
+	}
+	cancel2()
+	g.Wait()
+
+	testutil.Equals(t, 2, replacements)
+	testutil.Assert(t, reloads.Load().(int) >= 3, "expected a reload after each of the two atomic replacements, got %d reloads", reloads.Load().(int))
+}
+
 func TestReloader_ConfigRollback(t *testing.T) {
 	if testing.
 		Short() {


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

- `watcher.addFile` watched the config file's path directly via `fsnotify.Watcher.Add(name)`. On Linux (inotify), this watches the file's inode. When the file is replaced atomically (temp-file-then-rename — how ConfigMap-mounted files and many editors update files in place), the original inode is gone and the watch dies with no further events, exactly as documented in [fsnotify's README](https://github.com/fsnotify/fsnotify/blob/a9bc2e01792f868516acf80817f7d7d7b3315409/README.md?plain=1#L128) (linked from #8127).
- Changed `addFile` to watch the file's **parent directory** instead, mirroring the existing `addDirectory` (already used for `CfgDirs`/`WatchedDirs`). The existing event filter in `watcher.run` already matches on `filepath.Dir(event.Name)`, so no other changes were needed.

## Verification

- Added `TestReloader_ConfigApplyAtomicReplace`, which replaces the watched config file atomically (write-to-temp + rename) **twice** in a row and asserts a reload follows each replacement.
  - A single atomic replace isn't enough to distinguish correct behavior from the bug: on Linux, the dying file-level watch still emits one trailing `IN_IGNORED`/remove-ish event before going dead, which is enough to trigger one reload even with the bug present. Only the *second* replacement reliably tells a directory-level watch (survives) apart from a file-level watch (now silently dead).
  - **Note on local verification**: I ran this locally on macOS, where fsnotify's kqueue backend has its own built-in compatibility shim (`sendCreateIfNew` in `backend_kqueue.go`) that re-establishes a file-level watch when it detects a new file reappearing at the same path — so the bug doesn't reproduce on macOS regardless of this fix. I confirmed by reading both backends (`backend_inotify.go` has no equivalent re-add logic) that this is Linux-specific, which matches the project's actual CI platform (`ubuntu-latest`) and the original reporter's environment.
- `go test ./pkg/reloader/...`: all tests pass except the two already self-marked `t.Skip("Flaky")` (`TestReloader_ConfigDirApply`, `TestReloader_ConfigDirApplyBasedOnWatchInterval`) and `TestReloader_DirectoriesApply`, which I confirmed fails identically on `main` without this change (pre-existing flakiness, already tracked by #8114/#8115 with open PRs against it) — unrelated to this change.
- `make go-lint` passes with 0 issues.

Closes #8127
