### PR TITLE
receive: implement cpnp multi-tenant writes

### DIFF
--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -554,7 +554,7 @@ func runReceive(
 		capNProtoWriter := receive.NewCapNProtoWriter(logger, dbs, &receive.CapNProtoWriterOptions{
 			TooFarInFutureTimeWindow: int64(time.Duration(*conf.tsdbTooFarInFutureTimeWindow)),
 		})
-		handler := receive.NewCapNProtoHandler(logger, capNProtoWriter)
+		handler := receive.NewCapNProtoHandler(reg, logger, capNProtoWriter)
 		listener, err := net.Listen("tcp", conf.replicationAddr)
 		if err != nil {
 			return err

--- a/pkg/receive/capnp_server.go
+++ b/pkg/receive/capnp_server.go
@@ -12,6 +12,8 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 
 	"github.com/thanos-io/thanos/pkg/receive/writecapnp"
 )
@@ -55,30 +57,93 @@ func (c *CapNProtoServer) Shutdown() {
 type CapNProtoHandler struct {
 	writer *CapNProtoWriter
 	logger log.Logger
+
+	handledTotal  prometheus.Counter
+	writesByShape *prometheus.CounterVec
 }
 
-func NewCapNProtoHandler(logger log.Logger, writer *CapNProtoWriter) *CapNProtoHandler {
-	return &CapNProtoHandler{logger: logger, writer: writer}
+const (
+	capnpShapeSingleTenant = "single_tenant"
+	capnpShapeMultiTenant  = "multi_tenant"
+)
+
+func NewCapNProtoHandler(reg prometheus.Registerer, logger log.Logger, writer *CapNProtoWriter) *CapNProtoHandler {
+	handledTotal := promauto.With(reg).NewCounter(prometheus.CounterOpts{
+		Name: "thanos_receive_capnproto_handled_total",
+		Help: "Total number of handled CapNProto requests.",
+	})
+	writesByShape := promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+		Name: "thanos_receive_capnproto_writes_total",
+		Help: "Total number of CapNProto write requests broken down by tenant payload shape.",
+	}, []string{"shape"})
+	writesByShape.WithLabelValues(capnpShapeSingleTenant)
+	writesByShape.WithLabelValues(capnpShapeMultiTenant)
+
+	return &CapNProtoHandler{
+		handledTotal:  handledTotal,
+		writesByShape: writesByShape,
+		logger:        logger,
+		writer:        writer,
+	}
 }
 
 func (c CapNProtoHandler) Write(ctx context.Context, call writecapnp.Writer_write) error {
+	c.handledTotal.Inc()
+
 	call.Go()
 	wr, err := call.Args().Wr()
 	if err != nil {
 		return err
 	}
-	t, err := wr.Tenant()
-	if err != nil {
-		return err
-	}
-	req, err := writecapnp.NewRequest(wr)
-	if err != nil {
-		return err
-	}
-	defer req.Close()
 
 	var errs writeErrors
-	errs.Add(c.writer.Write(ctx, t, req))
+
+	if wr.HasTimeSeries() {
+		c.writesByShape.WithLabelValues(capnpShapeSingleTenant).Inc()
+
+		t, err := wr.Tenant()
+		if err != nil {
+			return err
+		}
+
+		req, err := writecapnp.NewSingleTenantRequest(wr, t)
+		if err != nil {
+			return err
+		}
+
+		errs.Add(c.writer.Write(ctx, req))
+		errs.Add(req.Close())
+	} else {
+		c.writesByShape.WithLabelValues(capnpShapeMultiTenant).Inc()
+
+		data, err := wr.Data()
+		if err != nil {
+			return err
+		}
+
+		symTable, err := wr.Symbols()
+		if err != nil {
+			return err
+		}
+
+		for i := 0; i < data.Len(); i++ {
+			d := data.At(i)
+
+			tenant, err := d.Tenant()
+			if err != nil {
+				return err
+			}
+
+			req, err := writecapnp.NewRequest(d, symTable, tenant)
+			if err != nil {
+				return err
+			}
+
+			errs.Add(c.writer.Write(ctx, req))
+			errs.Add(req.Close())
+		}
+	}
+
 	if err := errs.ErrOrNil(); err != nil {
 		level.Debug(c.logger).Log("msg", "failed to handle request", "err", err)
 		result, allocErr := call.AllocResults()

--- a/pkg/receive/capnp_server.go
+++ b/pkg/receive/capnp_server.go
@@ -13,7 +13,6 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 
 	"github.com/thanos-io/thanos/pkg/receive/writecapnp"
 )
@@ -57,39 +56,16 @@ func (c *CapNProtoServer) Shutdown() {
 type CapNProtoHandler struct {
 	writer *CapNProtoWriter
 	logger log.Logger
-
-	handledTotal  prometheus.Counter
-	writesByShape *prometheus.CounterVec
 }
 
-const (
-	capnpShapeSingleTenant = "single_tenant"
-	capnpShapeMultiTenant  = "multi_tenant"
-)
-
 func NewCapNProtoHandler(reg prometheus.Registerer, logger log.Logger, writer *CapNProtoWriter) *CapNProtoHandler {
-	handledTotal := promauto.With(reg).NewCounter(prometheus.CounterOpts{
-		Name: "thanos_receive_capnproto_handled_total",
-		Help: "Total number of handled CapNProto requests.",
-	})
-	writesByShape := promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
-		Name: "thanos_receive_capnproto_writes_total",
-		Help: "Total number of CapNProto write requests broken down by tenant payload shape.",
-	}, []string{"shape"})
-	writesByShape.WithLabelValues(capnpShapeSingleTenant)
-	writesByShape.WithLabelValues(capnpShapeMultiTenant)
-
 	return &CapNProtoHandler{
-		handledTotal:  handledTotal,
-		writesByShape: writesByShape,
-		logger:        logger,
-		writer:        writer,
+		logger: logger,
+		writer: writer,
 	}
 }
 
 func (c CapNProtoHandler) Write(ctx context.Context, call writecapnp.Writer_write) error {
-	c.handledTotal.Inc()
-
 	call.Go()
 	wr, err := call.Args().Wr()
 	if err != nil {
@@ -99,8 +75,6 @@ func (c CapNProtoHandler) Write(ctx context.Context, call writecapnp.Writer_writ
 	var errs writeErrors
 
 	if wr.HasTimeSeries() {
-		c.writesByShape.WithLabelValues(capnpShapeSingleTenant).Inc()
-
 		t, err := wr.Tenant()
 		if err != nil {
 			return err
@@ -114,8 +88,6 @@ func (c CapNProtoHandler) Write(ctx context.Context, call writecapnp.Writer_writ
 		errs.Add(c.writer.Write(ctx, req))
 		errs.Add(req.Close())
 	} else {
-		c.writesByShape.WithLabelValues(capnpShapeMultiTenant).Inc()
-
 		data, err := wr.Data()
 		if err != nil {
 			return err

--- a/pkg/receive/capnproto_server_bench_test.go
+++ b/pkg/receive/capnproto_server_bench_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/go-kit/log"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/test/bufconn"
 
@@ -53,7 +54,7 @@ func BenchmarkCapNProtoServer_SingleConcurrentClient(b *testing.B) {
 			&CapNProtoWriterOptions{},
 		)
 		listener = bufconn.Listen(1024)
-		handler  = NewCapNProtoHandler(log.NewNopLogger(), writer)
+		handler  = NewCapNProtoHandler(prometheus.NewRegistry(), log.NewNopLogger(), writer)
 		srv      = NewCapNProtoServer(listener, handler, log.NewNopLogger())
 	)
 	go func() {

--- a/pkg/receive/capnproto_server_test.go
+++ b/pkg/receive/capnproto_server_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/go-kit/log"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/test/bufconn"
 
@@ -32,7 +33,7 @@ func TestCapNProtoServer_SingleConcurrentClient(t *testing.T) {
 			&CapNProtoWriterOptions{},
 		)
 		listener = bufconn.Listen(1024)
-		handler  = NewCapNProtoHandler(log.NewNopLogger(), writer)
+		handler  = NewCapNProtoHandler(prometheus.NewRegistry(), log.NewNopLogger(), writer)
 		srv      = NewCapNProtoServer(listener, handler, log.NewNopLogger())
 	)
 	go func() {
@@ -62,7 +63,7 @@ func TestCapNProtoServer_MultipleConcurrentClients(t *testing.T) {
 			&CapNProtoWriterOptions{},
 		)
 		listener = bufconn.Listen(1024)
-		handler  = NewCapNProtoHandler(log.NewNopLogger(), writer)
+		handler  = NewCapNProtoHandler(prometheus.NewRegistry(), log.NewNopLogger(), writer)
 		srv      = NewCapNProtoServer(listener, handler, log.NewNopLogger())
 	)
 	go func() {

--- a/pkg/receive/capnproto_writer.go
+++ b/pkg/receive/capnproto_writer.go
@@ -40,10 +40,10 @@ func NewCapNProtoWriter(logger log.Logger, multiTSDB TenantStorage, opts *CapNPr
 	}
 }
 
-func (r *CapNProtoWriter) Write(ctx context.Context, tenantID string, wreq *writecapnp.Request) error {
-	tLogger := log.With(r.logger, "tenant", tenantID)
+func (r *CapNProtoWriter) Write(ctx context.Context, wreq *writecapnp.Request) error {
+	tLogger := log.With(r.logger, "tenant", wreq.Tenant)
 
-	s, err := r.multiTSDB.TenantAppendable(tenantID)
+	s, err := r.multiTSDB.TenantAppendable(wreq.Tenant)
 	if err != nil {
 		return errors.Wrap(err, "get tenant appendable")
 	}

--- a/pkg/receive/capnproto_writer_test.go
+++ b/pkg/receive/capnproto_writer_test.go
@@ -57,11 +57,17 @@ func TestCapNProtoWriter_Write(t *testing.T) {
 	capnpReq, err := writecapnp.Build(tenancy.DefaultTenant, timeseries)
 	require.NoError(t, err)
 
-	wr, err := writecapnp.NewRequest(capnpReq)
+	syms, err := capnpReq.Symbols()
+	require.NoError(t, err)
+
+	data, err := capnpReq.Data()
+	require.NoError(t, err)
+
+	wr, err := writecapnp.NewRequest(data.At(0), syms, tenancy.DefaultTenant)
 	require.NoError(t, err)
 
 	// Write the request
-	err = writer.Write(context.Background(), tenancy.DefaultTenant, wr)
+	err = writer.Write(context.Background(), wr)
 	require.NoError(t, err)
 
 	require.NotNil(t, app)
@@ -185,9 +191,15 @@ func TestCapNProtoWriter_ValidateExemplarLabels(t *testing.T) {
 					capnpReq, err := writecapnp.Build(tenancy.DefaultTenant, req.Timeseries)
 					testutil.Ok(t, err)
 
-					wr, err := writecapnp.NewRequest(capnpReq)
+					syms, err := capnpReq.Symbols()
 					testutil.Ok(t, err)
-					err = w.Write(context.Background(), tenancy.DefaultTenant, wr)
+
+					data, err := capnpReq.Data()
+					testutil.Ok(t, err)
+
+					wr, err := writecapnp.NewRequest(data.At(0), syms, tenancy.DefaultTenant)
+					testutil.Ok(t, err)
+					err = w.Write(context.Background(), wr)
 
 					if testData.expectedErr == nil || idx < len(testData.reqs)-1 {
 						testutil.Ok(t, err)

--- a/pkg/receive/capnproto_writer_test.go
+++ b/pkg/receive/capnproto_writer_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"testing"
 
+	"capnproto.org/go/capnp/v3"
 	"github.com/efficientgo/core/testutil"
 	"github.com/pkg/errors"
 	"github.com/prometheus/prometheus/model/labels"
@@ -17,6 +18,22 @@ import (
 	"github.com/thanos-io/thanos/pkg/store/storepb/prompb"
 	"github.com/thanos-io/thanos/pkg/tenancy"
 )
+
+// newOldFormatWrite builds a request in the deprecated format where the tenant and
+// time series list are set directly on the WriteRequest instead of in the data tuples.
+func newOldFormatWrite(t *testing.T, tenant string, tsreq []prompb.TimeSeries) *writecapnp.Request {
+	arena := capnp.SingleSegment(nil)
+	_, seg, err := capnp.NewMessage(arena)
+	require.NoError(t, err)
+
+	wr, err := writecapnp.NewRootWriteRequest(seg)
+	require.NoError(t, err)
+	require.NoError(t, writecapnp.BuildIntoSingleTenantWriteRequest(wr, tenant, tsreq))
+
+	req, err := writecapnp.NewSingleTenantRequest(wr, tenant)
+	require.NoError(t, err)
+	return req
+}
 
 func TestCapNProtoWriter_Write(t *testing.T) {
 	t.Parallel()
@@ -53,7 +70,6 @@ func TestCapNProtoWriter_Write(t *testing.T) {
 		},
 	}
 
-	// Create capnproto request
 	capnpReq, err := writecapnp.Build(tenancy.DefaultTenant, timeseries)
 	require.NoError(t, err)
 
@@ -122,6 +138,12 @@ func TestCapNProtoWriter_Write(t *testing.T) {
 
 	require.Equal(t, "xyz789", secondLabels["trace_id"], "Second exemplar trace_id should match")
 	require.Equal(t, "uvw012", secondLabels["span_id"], "Second exemplar span_id should match")
+
+	// A request in the deprecated format should still create the tenant.
+	oldReq := newOldFormatWrite(t, "old-format-tenant", timeseries)
+	require.NoError(t, writer.Write(context.Background(), oldReq))
+	require.NoError(t, oldReq.Close())
+	require.NotNil(t, m.testGetTenant("old-format-tenant"), "old format write should create the tenant")
 }
 
 func TestCapNProtoWriter_ValidateExemplarLabels(t *testing.T) {

--- a/pkg/receive/handler_test.go
+++ b/pkg/receive/handler_test.go
@@ -294,7 +294,7 @@ func newTestHandlerHashring(
 			writer := NewCapNProtoWriter(logger, newFakeTenantAppendable(appendables[i]), nil)
 			var (
 				listener = bufconn.Listen(1024)
-				handler  = NewCapNProtoHandler(log.NewNopLogger(), writer)
+				handler  = NewCapNProtoHandler(prometheus.NewRegistry(), log.NewNopLogger(), writer)
 			)
 			srv := NewCapNProtoServer(listener, handler, log.NewNopLogger())
 			client := writecapnp.NewRemoteWriteClient(listener, logger)

--- a/pkg/receive/writecapnp/client.go
+++ b/pkg/receive/writecapnp/client.go
@@ -19,6 +19,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/thanos-io/thanos/pkg/store/storepb"
+	"github.com/thanos-io/thanos/pkg/symboltable"
 )
 
 type Dialer interface {
@@ -99,7 +100,54 @@ func (r *RemoteWriteClient) writeWithReconnect(ctx context.Context, numReconnect
 		if err != nil {
 			return err
 		}
-		return BuildInto(wr, in.Tenant, in.Timeseries)
+
+		if len(in.TimeseriesTenantData) == 0 {
+			if err := BuildIntoSingleTenantWriteRequest(wr, in.Tenant, in.Timeseries); err != nil {
+				return err
+			}
+			if err := params.SetWr(wr); err != nil {
+				return err
+			}
+
+			return nil
+		}
+
+		sym, err := wr.NewSymbols()
+		if err != nil {
+			return err
+		}
+
+		tl, err := NewTimeSeriesTenantTuple_List(wr.Segment(), int32(len(in.TimeseriesTenantData)))
+		if err != nil {
+			return err
+		}
+
+		builder := symboltable.NewBuilder()
+
+		for i, d := range in.TimeseriesTenantData {
+			ttl := tl.At(i)
+			if err := BuildInto(&ttl, d.Tenant, d.Timeseries, builder); err != nil {
+				return err
+			}
+
+			if err := tl.Set(i, ttl); err != nil {
+				return err
+			}
+		}
+
+		if err := marshalSymbols(builder, sym); err != nil {
+			return err
+		}
+
+		if err := wr.SetData(tl); err != nil {
+			return err
+		}
+
+		if err := params.SetWr(wr); err != nil {
+			return err
+		}
+
+		return nil
 	})
 	defer release()
 

--- a/pkg/receive/writecapnp/marshal.go
+++ b/pkg/receive/writecapnp/marshal.go
@@ -41,13 +41,63 @@ func Build(tenant string, tsreq []prompb.TimeSeries) (WriteRequest, error) {
 	if err != nil {
 		return WriteRequest{}, err
 	}
-	if err := BuildInto(wr, tenant, tsreq); err != nil {
+	sym, err := wr.NewSymbols()
+	if err != nil {
+		return WriteRequest{}, err
+	}
+	builder := symboltable.NewBuilder()
+
+	t, err := NewTimeSeriesTenantTuple_List(seg, 1)
+	if err != nil {
+		return WriteRequest{}, err
+	}
+	if err := wr.SetData(t); err != nil {
+		return WriteRequest{}, err
+	}
+	ttd := t.At(0)
+	if err := BuildInto(&ttd, tenant, tsreq, builder); err != nil {
+		return WriteRequest{}, err
+	}
+	if err := marshalSymbols(builder, sym); err != nil {
 		return WriteRequest{}, err
 	}
 	return wr, nil
 }
 
-func BuildInto(wr WriteRequest, tenant string, tsreq []prompb.TimeSeries) error {
+func BuildInto(wr *TimeSeriesTenantTuple, tenant string, tsreq []prompb.TimeSeries, builder *symboltable.Builder) error {
+	if err := wr.SetTenant(tenant); err != nil {
+		return errors.Wrap(err, "set tenant")
+	}
+
+	series, err := wr.NewTimeSeries(int32(len(tsreq)))
+	if err != nil {
+		return err
+	}
+	for i, ts := range tsreq {
+		tsc := series.At(i)
+
+		lblsc, err := tsc.NewLabels(int32(len(ts.Labels)))
+		if err != nil {
+			return errors.Wrap(err, "new labels")
+		}
+		if err := marshalLabels(lblsc, ts.Labels, builder); err != nil {
+			return errors.Wrap(err, "marshal labels")
+		}
+		if err := marshalSamples(tsc, ts.Samples); err != nil {
+			return errors.Wrap(err, "marshal samples")
+		}
+		if err := marshalHistograms(tsc, ts.Histograms); err != nil {
+			return errors.Wrap(err, "marshal histograms")
+		}
+		if err := marshalExemplars(tsc, ts.Exemplars, builder); err != nil {
+			return errors.Wrap(err, "marshal exemplars")
+		}
+	}
+
+	return nil
+}
+
+func BuildIntoSingleTenantWriteRequest(wr WriteRequest, tenant string, tsreq []prompb.TimeSeries) error {
 	if err := wr.SetTenant(tenant); err != nil {
 		return errors.Wrap(err, "set tenant")
 	}
@@ -224,7 +274,7 @@ func marshalExemplars(ts TimeSeries, pbExemplars []prompb.Exemplar, symbols *sym
 	if err != nil {
 		return err
 	}
-	for i := range pbExemplars {
+	for i := 0; i < len(pbExemplars); i++ {
 		ex := exemplars.At(i)
 
 		lbls, err := ex.NewLabels(int32(len(pbExemplars[i].Labels)))

--- a/pkg/receive/writecapnp/marshal_bench_test.go
+++ b/pkg/receive/writecapnp/marshal_bench_test.go
@@ -132,13 +132,25 @@ func BenchmarkMarshalWriteRequest(b *testing.B) {
 			wr, err := ReadRootWriteRequest(msg)
 			require.NoError(b, err)
 
-			var ts Series
-			iter, err := NewRequest(wr)
+			symTable, err := wr.Symbols()
 			require.NoError(b, err)
-			for iter.Next() {
-				require.NoError(b, iter.At(&ts))
+
+			data, err := wr.Data()
+			require.NoError(b, err)
+
+			var ts Series
+			for i := 0; i < data.Len(); i++ {
+				d := data.At(i)
+				tenant, err := d.Tenant()
+				require.NoError(b, err)
+
+				iter, err := NewRequest(d, symTable, tenant)
+				require.NoError(b, err)
+				for iter.Next() {
+					require.NoError(b, iter.At(&ts))
+				}
+				iter.Close()
 			}
-			iter.Close()
 		}
 	})
 }

--- a/pkg/receive/writecapnp/marshal_test.go
+++ b/pkg/receive/writecapnp/marshal_test.go
@@ -83,11 +83,20 @@ func TestMarshalWriteRequest(t *testing.T) {
 	wr, err := ReadRootWriteRequest(msg)
 	require.NoError(t, err)
 
-	tenant, err := wr.Tenant()
+	syms, err := wr.Symbols()
+	require.NoError(t, err)
+
+	data, err := wr.Data()
+	require.NoError(t, err)
+	require.Equal(t, 1, data.Len())
+
+	tuple := data.At(0)
+
+	tenant, err := tuple.Tenant()
 	require.NoError(t, err)
 	require.Equal(t, wreq.Tenant, tenant)
 
-	series, err := wr.TimeSeries()
+	series, err := tuple.TimeSeries()
 	require.NoError(t, err)
 	require.Equal(t, len(wreq.Timeseries), series.Len())
 
@@ -95,7 +104,7 @@ func TestMarshalWriteRequest(t *testing.T) {
 		i      int
 		actual Series
 	)
-	request, err := NewRequest(wr)
+	request, err := NewRequest(tuple, syms, tenant)
 	require.NoError(t, err)
 	for request.Next() {
 		require.NoError(t, request.At(&actual))
@@ -178,11 +187,20 @@ func TestMarshalWithMultipleHistogramSeries(t *testing.T) {
 	wr, err := ReadRootWriteRequest(msg)
 	require.NoError(t, err)
 
-	tenant, err := wr.Tenant()
+	syms, err := wr.Symbols()
+	require.NoError(t, err)
+
+	data, err := wr.Data()
+	require.NoError(t, err)
+	require.Equal(t, 1, data.Len())
+
+	tuple := data.At(0)
+
+	tenant, err := tuple.Tenant()
 	require.NoError(t, err)
 	require.Equal(t, wreq.Tenant, tenant)
 
-	series, err := wr.TimeSeries()
+	series, err := tuple.TimeSeries()
 	require.NoError(t, err)
 	require.Equal(t, len(wreq.Timeseries), series.Len())
 	var (
@@ -191,7 +209,7 @@ func TestMarshalWithMultipleHistogramSeries(t *testing.T) {
 		readHistograms      []*histogram.Histogram
 		readFloatHistograms []*histogram.FloatHistogram
 	)
-	request, err := NewRequest(wr)
+	request, err := NewRequest(tuple, syms, tenant)
 	require.NoError(t, err)
 
 	for request.Next() {

--- a/pkg/receive/writecapnp/write_request.go
+++ b/pkg/receive/writecapnp/write_request.go
@@ -37,14 +37,12 @@ type Request struct {
 	symbols *[]string
 	builder labels.ScratchBuilder
 	series  TimeSeries_List
+
+	Tenant string
 }
 
-func NewRequest(wr WriteRequest) (*Request, error) {
+func NewRequest(wr TimeSeriesTenantTuple, symTable Symbols, tenant string) (*Request, error) {
 	ts, err := wr.TimeSeries()
-	if err != nil {
-		return nil, err
-	}
-	symTable, err := wr.Symbols()
 	if err != nil {
 		return nil, err
 	}
@@ -75,6 +73,7 @@ func NewRequest(wr WriteRequest) (*Request, error) {
 		symbols: strings,
 		series:  ts,
 		builder: labels.NewScratchBuilder(8),
+		Tenant:  tenant,
 	}, nil
 }
 
@@ -268,4 +267,44 @@ func (s *Request) readExemplar(symbols *[]string, e Exemplar) (exemplar.Exemplar
 func (s *Request) Close() error {
 	symbolsPool.Put(s.symbols)
 	return nil
+}
+
+func NewSingleTenantRequest(wr WriteRequest, tenant string) (*Request, error) {
+	ts, err := wr.TimeSeries()
+	if err != nil {
+		return nil, err
+	}
+	symTable, err := wr.Symbols()
+	if err != nil {
+		return nil, err
+	}
+	data, err := symTable.Data()
+	if err != nil {
+		return nil, err
+	}
+	offsets, err := symTable.Offsets()
+	if err != nil {
+		return nil, err
+	}
+
+	strings, _ := symbolsPool.Get(offsets.Len())
+	start := uint32(0)
+	for i := 0; i < offsets.Len(); i++ {
+		end := offsets.At(i)
+		if start == end {
+			*strings = append(*strings, "")
+		} else {
+			b := data[start:end]
+			*strings = append(*strings, unsafe.String(&b[0], len(b)))
+		}
+		start = end
+	}
+
+	return &Request{
+		i:       -1,
+		symbols: strings,
+		series:  ts,
+		builder: labels.NewScratchBuilder(8),
+		Tenant:  tenant,
+	}, nil
 }

--- a/pkg/receive/writecapnp/write_request_test.go
+++ b/pkg/receive/writecapnp/write_request_test.go
@@ -33,7 +33,10 @@ func TestNewRequest(t *testing.T) {
 	require.NoError(t, symbols.SetOffsets(list))
 	require.NoError(t, wr.SetSymbols(symbols))
 
-	req, err := NewRequest(wr)
+	tuples, err := NewTimeSeriesTenantTuple_List(seg, 1)
+	require.NoError(t, err)
+
+	req, err := NewRequest(tuples.At(0), symbols, "test-tenant")
 	require.NoError(t, err)
 
 	require.Equal(t, "foo", (*req.symbols)[0])

--- a/pkg/receive/writer_test.go
+++ b/pkg/receive/writer_test.go
@@ -399,9 +399,15 @@ func TestWriter(t *testing.T) {
 					capnpReq, err := writecapnp.Build(tenancy.DefaultTenant, req.Timeseries)
 					testutil.Ok(t, err)
 
-					wr, err := writecapnp.NewRequest(capnpReq)
+					syms, err := capnpReq.Symbols()
 					testutil.Ok(t, err)
-					err = w.Write(context.Background(), tenancy.DefaultTenant, wr)
+
+					data, err := capnpReq.Data()
+					testutil.Ok(t, err)
+
+					wr, err := writecapnp.NewRequest(data.At(0), syms, tenancy.DefaultTenant)
+					testutil.Ok(t, err)
+					err = w.Write(context.Background(), wr)
 
 					// We expect no error on any request except the last one
 					// which may error (and in that case we assert on it).


### PR DESCRIPTION
Add a cpnp implementation that handles multi-tenant writes. Both single-tenant and multi-tenant writes are supported so should be safe to merge - the senders only send single tenant writes ATM.
