### PR TITLE
 receive: fix router mode crash on startup when trying to create the data dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 
 ### Fixed
 
+- Receive: Fix routing receivers crashing with `mkdir ./data: read-only file system` on startup by gating data directory setup on `enableIngestion`, since routing receivers don't write local TSDB data.
+
 ### Changed
 
 ## [v0.42.0-rc.0](https://github.com/thanos-io/thanos/tree/release-0.42) - 2026 06 23 (in progress)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 
 ### Fixed
 
-- Receive: Fix routing receivers crashing with `mkdir ./data: read-only file system` on startup by gating data directory setup on `enableIngestion`, since routing receivers don't write local TSDB data.
+- [#8881](https://github.com/thanos-io/thanos/pull/8881): Receive: Fix routing receivers crashing with `mkdir ./data: read-only file system` on startup by gating data directory setup on `enableIngestion`, since routing receivers don't write local TSDB data.
 
 ### Changed
 

--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -206,18 +206,21 @@ func runReceive(
 		}
 	}
 
-	if err := os.MkdirAll(conf.dataDir, 0o755); err != nil {
-		return errors.Wrapf(err, "create data dir in %v", conf.dataDir)
-	}
+	var dataDir *os.Root
+	if enableIngestion {
+		if err := os.MkdirAll(conf.dataDir, 0o755); err != nil {
+			return errors.Wrapf(err, "create data dir in %v", conf.dataDir)
+		}
 
-	dataDir, err := os.OpenRoot(conf.dataDir)
-	if err != nil {
-		return errors.Wrap(err, "open storage dir")
-	}
+		dataDir, err = os.OpenRoot(conf.dataDir)
+		if err != nil {
+			return errors.Wrap(err, "open storage dir")
+		}
 
-	// Create TSDB for the default tenant.
-	if err := createDefautTenantTSDB(logger, conf.defaultTenantID, dataDir); err != nil {
-		return errors.Wrapf(err, "create default tenant tsdb in %v", conf.dataDir)
+		// Create TSDB for the default tenant.
+		if err := createDefautTenantTSDB(logger, conf.defaultTenantID, dataDir); err != nil {
+			return errors.Wrapf(err, "create default tenant tsdb in %v", conf.dataDir)
+		}
 	}
 
 	relabelConfig, err := conf.relabelCfg.RelabelConfig(nil)


### PR DESCRIPTION
* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

#8797 accidentally made routing receivers try to create a data directory causing it to crash on startup with the error `caller=main.go:143 level=error err="mkdir ./data: read-only file system\ncreate data dir in ./data` 

Routing receivers don't ingest locally so they don't need one. This change gates the data directory setup (`os.MkdirAll`, `os.OpenRoot`, and `createDefautTenantTSDB`) on `enableIngestion` to fix it and restore the behavior of `v0.41.0` where the routing receivers do not create or require the data dir.

## Verification

I tested this by reproducing the issue in our development environment. The routing receivers crash on startup with the following error:

```
ts=2026-06-25T19:11:58.23588627Z caller=main.go:143 level=error err="mkdir ./data: read-only file system\ncreate data dir in ./data\nmain.runReceive\n\t/app/cmd/thanos/receive.go:210\nmain.registerReceive.func1\n\t/app/cmd/thanos/receive.go:109\nmain.main\n\t/app/cmd/thanos/main.go:141\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:290\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_amd64.s:1771\npreparing receive command failed\nmain.main\n\t/app/cmd/thanos/main.go:143\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:290\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_amd64.s:1771"
```

I then updated the routing receiver to this new build with the fix and it started successfully.
