### PR TITLE
receive: implement multi-tenant writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 
 ### Added
 
+- [#8882](https://github.com/thanos-io/thanos/pull/8882) Receive: implement multi-tenant writes; greatly improves throughput when using the split tenant label functionality.
+
 ### Fixed
 
 ### Changed

--- a/docs/components/receive.md
+++ b/docs/components/receive.md
@@ -372,7 +372,7 @@ Please see the metric `thanos_receive_forward_delay_seconds` to see if you need 
 
 The following formula is used for calculating quorum:
 
-```go mdox-exec="sed -n '1077,1087p' pkg/receive/handler.go"
+```go mdox-exec="sed -n '1122,1132p' pkg/receive/handler.go"
 // writeQuorum returns minimum number of replicas that has to confirm write success before claiming replication success.
 func (h *Handler) writeQuorum() int {
 	// NOTE(GiedriusS): this is here because otherwise RF=2 doesn't make sense as all writes

--- a/pkg/receive/handler.go
+++ b/pkg/receive/handler.go
@@ -632,7 +632,12 @@ func (h *Handler) receiveHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	responseStatusCode := http.StatusOK
-	tenantStats, err := h.handleRequest(ctx, rep, tenantHTTP, &wreq)
+	tenantStats, err := h.handleRequest(ctx, rep, []wreqTenantTuple{
+		{
+			tenant: tenantHTTP,
+			wreq:   &wreq,
+		},
+	})
 	if err != nil {
 		level.Debug(tLogger).Log("msg", "failed to handle request", "err", err.Error())
 		switch errors.Cause(err) {
@@ -666,8 +671,8 @@ type requestStats struct {
 
 type tenantRequestStats map[string]requestStats
 
-func (h *Handler) handleRequest(ctx context.Context, rep uint64, tenantHTTP string, wreq *prompb.WriteRequest) (tenantRequestStats, error) {
-	tLogger := log.With(h.logger, "tenantHTTP", tenantHTTP)
+func (h *Handler) handleRequest(ctx context.Context, rep uint64, data []wreqTenantTuple) (tenantRequestStats, error) {
+	tLogger := h.logger
 
 	// This replica value is used to detect cycles in cyclic topologies.
 	// A non-zero value indicates that the request has already been replicated by a previous receive instance.
@@ -695,7 +700,7 @@ func (h *Handler) handleRequest(ctx context.Context, rep uint64, tenantHTTP stri
 	// Forward any time series as necessary. All time series
 	// destined for the local node will be written to the receiver.
 	// Time series will be replicated as necessary.
-	return h.forward(ctx, tenantHTTP, r, wreq)
+	return h.forward(ctx, r, data)
 }
 
 // forward accepts a write request, batches its time series by
@@ -706,7 +711,7 @@ func (h *Handler) handleRequest(ctx context.Context, rep uint64, tenantHTTP stri
 // unless the request needs to be replicated.
 // The function only returns when all requests have finished
 // or the context is canceled.
-func (h *Handler) forward(ctx context.Context, tenantHTTP string, r replica, wreq *prompb.WriteRequest) (tenantRequestStats, error) {
+func (h *Handler) forward(ctx context.Context, r replica, data []wreqTenantTuple) (tenantRequestStats, error) {
 	span, ctx := tracing.StartSpan(ctx, "receive_fanout_forward")
 	defer span.Finish()
 
@@ -720,8 +725,7 @@ func (h *Handler) forward(ctx context.Context, tenantHTTP string, r replica, wre
 	}
 
 	params := remoteWriteParams{
-		tenant:            tenantHTTP,
-		writeRequest:      wreq,
+		data:              data,
 		replicas:          replicas,
 		alreadyReplicated: r.replicated,
 	}
@@ -730,10 +734,26 @@ func (h *Handler) forward(ctx context.Context, tenantHTTP string, r replica, wre
 }
 
 type remoteWriteParams struct {
-	tenant            string
-	writeRequest      *prompb.WriteRequest
+	data              []wreqTenantTuple
 	replicas          []uint64
 	alreadyReplicated bool
+}
+
+func (p *remoteWriteParams) tenantLogTags() []any {
+	if len(p.data) == 1 {
+		return []any{"tenant", p.data[0].tenant}
+	}
+
+	var sb strings.Builder
+
+	for i, d := range p.data {
+		fmt.Fprintf(&sb, "%s", d.tenant)
+		if i < len(p.data) {
+			fmt.Fprintf(&sb, ",")
+		}
+	}
+
+	return []any{"tenants", sb.String()}
 }
 
 func (h *Handler) gatherWriteStats(rf int, writes map[endpointReplica]map[string]trackedSeries) tenantRequestStats {
@@ -787,13 +807,13 @@ func (h *Handler) fanoutForward(ctx context.Context, params remoteWriteParams) (
 		}
 	}()
 
-	logTags := []any{"tenant", params.tenant}
+	logTags := params.tenantLogTags()
 	if id, ok := middleware.RequestIDFromContext(ctx); ok {
 		logTags = append(logTags, "request-id", id)
 	}
 	requestLogger := log.With(h.logger, logTags...)
 
-	writes, err := h.distributeTimeseriesToReplicas(params.tenant, params.replicas, params.writeRequest.Timeseries)
+	writes, err := h.distributeTimeseriesToReplicas(params.replicas, params.data)
 	if err != nil {
 		level.Error(requestLogger).Log("msg", "failed to distribute timeseries to replicas", "err", err)
 		return stats, err
@@ -836,13 +856,17 @@ func (h *Handler) fanoutForward(ctx context.Context, params remoteWriteParams) (
 	// failureThreshold is the number of failures after which a series can no
 	// longer reach the success threshold. For RF=3 and successThreshold=2 this is 2.
 	failureThreshold := len(params.replicas) - successThreshold + 1
-	successes := make([]int, len(params.writeRequest.Timeseries))
-	failures := make([]int, len(params.writeRequest.Timeseries))
+	var numSeries int
+	for _, tup := range params.data {
+		numSeries += len(tup.wreq.Timeseries)
+	}
+	successes := make([]int, numSeries)
+	failures := make([]int, numSeries)
 	// conflictFailures tracks how many replicas returned a permanent conflict for
 	// each series. When conflictFailures[i] >= failureThreshold the series can
 	// never reach quorum regardless of retries.
-	conflictFailures := make([]int, len(params.writeRequest.Timeseries))
-	seriesErrs := newReplicationErrors(successThreshold, len(params.writeRequest.Timeseries))
+	conflictFailures := make([]int, numSeries)
+	seriesErrs := newReplicationErrors(successThreshold, numSeries)
 	for {
 		select {
 		case <-ctx.Done():
@@ -888,59 +912,63 @@ func (h *Handler) fanoutForward(ctx context.Context, params remoteWriteParams) (
 }
 
 func (h *Handler) distributeTimeseriesToReplicas(
-	tenantHTTP string,
 	replicas []uint64,
-	timeseries []prompb.TimeSeries,
+	data []wreqTenantTuple,
 ) (map[endpointReplica]map[string]trackedSeries, error) {
 	h.mtx.RLock()
 	defer h.mtx.RUnlock()
 	writes := make(map[endpointReplica]map[string]trackedSeries)
-	for tsIndex, ts := range timeseries {
-		var tenant = tenantHTTP
+	seriesID := -1
+	for _, tup := range data {
+		for _, ts := range tup.wreq.Timeseries {
+			seriesID++
+			var tenant = tup.tenant
 
-		if h.splitTenantLabelName != "" {
-			lbls := labelpb.ZLabelsToPromLabels(ts.Labels)
+			if h.splitTenantLabelName != "" {
+				lbls := labelpb.ZLabelsToPromLabels(ts.Labels)
 
-			tenantLabel := lbls.Get(h.splitTenantLabelName)
-			if tenantLabel != "" {
-				if err := tenancy.IsTenantValid(tenantLabel); err != nil {
-					return nil, errors.Wrap(errValidation, err.Error())
-				}
-				tenant = tenantLabel
+				tenantLabel := lbls.Get(h.splitTenantLabelName)
+				if tenantLabel != "" {
+					if err := tenancy.IsTenantValid(tenantLabel); err != nil {
+						return nil, errors.Wrap(errValidation, err.Error())
+					}
+					tenant = tenantLabel
 
-				newLabels := labels.NewBuilder(lbls)
-				newLabels.Del(h.splitTenantLabelName)
+					newLabels := labels.NewBuilder(lbls)
+					newLabels.Del(h.splitTenantLabelName)
 
-				ts.Labels = labelpb.ZLabelsFromPromLabels(
-					newLabels.Labels(),
-				)
-			}
-		}
-
-		for _, rn := range replicas {
-			endpoint, err := h.hashring.GetN(tenant, &ts, rn)
-			if err != nil {
-				return nil, err
-			}
-			endpointReplica := endpointReplica{endpoint: endpoint, replica: rn}
-
-			writeableSeries, ok := writes[endpointReplica]
-			if !ok {
-				writes[endpointReplica] = map[string]trackedSeries{
-					tenant: {
-						seriesIDs:  make([]int, 0),
-						timeSeries: make([]prompb.TimeSeries, 0),
-					},
+					ts.Labels = labelpb.ZLabelsFromPromLabels(
+						newLabels.Labels(),
+					)
 				}
 			}
-			tenantSeries := writeableSeries[tenant]
 
-			tenantSeries.timeSeries = append(tenantSeries.timeSeries, ts)
-			tenantSeries.seriesIDs = append(tenantSeries.seriesIDs, tsIndex)
+			for _, rn := range replicas {
+				endpoint, err := h.hashring.GetN(tenant, &ts, rn)
+				if err != nil {
+					return nil, err
+				}
+				endpointReplica := endpointReplica{endpoint: endpoint, replica: rn}
 
-			writes[endpointReplica][tenant] = tenantSeries
+				writeableSeries, ok := writes[endpointReplica]
+				if !ok {
+					writes[endpointReplica] = map[string]trackedSeries{
+						tenant: {
+							seriesIDs:  make([]int, 0),
+							timeSeries: make([]prompb.TimeSeries, 0),
+						},
+					}
+				}
+				tenantSeries := writeableSeries[tenant]
+
+				tenantSeries.timeSeries = append(tenantSeries.timeSeries, ts)
+				tenantSeries.seriesIDs = append(tenantSeries.seriesIDs, seriesID)
+
+				writes[endpointReplica][tenant] = tenantSeries
+			}
 		}
 	}
+
 	return writes, nil
 }
 
@@ -957,27 +985,20 @@ func (h *Handler) sendWrites(
 	writes map[endpointReplica]map[string]trackedSeries,
 	responses chan writeResponse,
 ) {
-	type deferredWrite struct {
-		tenant           string
-		writeDestination endpointReplica
-		trackedSeries    trackedSeries
-	}
-	var deferred []deferredWrite
+	var deferred []endpointReplica
 
 	for writeDestination := range writes {
-		for tenant, trackedSeries := range writes[writeDestination] {
-			wg.Add(1)
-			if !h.tryWrite(ctx, tenant, writeDestination, trackedSeries, params.alreadyReplicated, responses, wg) {
-				wg.Done()
-				deferred = append(deferred, deferredWrite{tenant, writeDestination, trackedSeries})
-			}
+		wg.Add(1)
+		if !h.tryWrite(ctx, writes[writeDestination], writeDestination, params.alreadyReplicated, responses, wg) {
+			wg.Done()
+			deferred = append(deferred, writeDestination)
 		}
 	}
 
 	// Second pass: blocking submission for any peer whose pool was saturated during the first pass.
-	for _, d := range deferred {
+	for _, writeDestination := range deferred {
 		wg.Add(1)
-		h.sendWrite(ctx, d.tenant, d.writeDestination, d.trackedSeries, params.alreadyReplicated, responses, wg)
+		h.sendWrite(ctx, writes[writeDestination], writeDestination, params.alreadyReplicated, responses, wg)
 	}
 }
 
@@ -986,12 +1007,12 @@ func (h *Handler) sendWrites(
 // responses and wg.Done called — callers must check for nil before proceeding.
 func (h *Handler) prepareRemoteWrite(
 	ctx context.Context,
-	tenant string,
+	writes map[string]trackedSeries,
 	er endpointReplica,
-	ts trackedSeries,
 	alreadyReplicated bool,
 	responses chan writeResponse,
 	wg *sync.WaitGroup,
+	allIDs []int,
 ) (WriteableStoreAsyncClient, *storepb.WriteRequest, func(error)) {
 	endpoint := er.endpoint
 	cl, err := h.peers.getConnection(ctx, endpoint)
@@ -999,16 +1020,24 @@ func (h *Handler) prepareRemoteWrite(
 		if errors.Is(err, errUnavailable) {
 			err = errors.Wrapf(errUnavailable, "backing off forward request for endpoint %v", er)
 		}
-		responses <- newWriteResponse(ts.seriesIDs, err, er)
+
+		responses <- newWriteResponse(allIDs, err, er)
 		wg.Done()
 		return nil, nil, nil
 	}
 
+	dataTuples := make([]storepb.TimeSeriesTenantTuple, 0, len(writes))
+	for wTenant, ts := range writes {
+		dataTuples = append(dataTuples, storepb.TimeSeriesTenantTuple{
+			Timeseries: ts.timeSeries,
+			Tenant:     wTenant,
+		})
+	}
+
 	// Replica is 1-indexed on the wire; 0 indicates un-replicated.
 	req := &storepb.WriteRequest{
-		Timeseries: ts.timeSeries,
-		Tenant:     tenant,
-		Replica:    int64(er.replica + 1),
+		TimeseriesTenantData: dataTuples,
+		Replica:              int64(er.replica + 1),
 	}
 	cb := func(err error) {
 		if err == nil {
@@ -1041,18 +1070,26 @@ func (h *Handler) prepareRemoteWrite(
 // pool accepts the work.
 func (h *Handler) sendWrite(
 	ctx context.Context,
-	tenant string,
+	writes map[string]trackedSeries,
 	er endpointReplica,
-	ts trackedSeries,
 	alreadyReplicated bool,
 	responses chan writeResponse,
 	wg *sync.WaitGroup,
 ) {
-	cl, req, cb := h.prepareRemoteWrite(ctx, tenant, er, ts, alreadyReplicated, responses, wg)
+	var totalIDs int
+	for _, ts := range writes {
+		totalIDs += len(ts.seriesIDs)
+	}
+	allIDs := make([]int, 0, totalIDs)
+	for _, ts := range writes {
+		allIDs = append(allIDs, ts.seriesIDs...)
+	}
+
+	cl, req, cb := h.prepareRemoteWrite(ctx, writes, er, alreadyReplicated, responses, wg, allIDs)
 	if cl == nil {
 		return
 	}
-	cl.RemoteWriteAsync(ctx, req, er, ts.seriesIDs, responses, cb)
+	cl.RemoteWriteAsync(ctx, req, er, allIDs, responses, cb)
 }
 
 // tryWrite is the non-blocking counterpart of sendRemoteWrite. It returns false when the
@@ -1060,18 +1097,26 @@ func (h *Handler) sendWrite(
 // wg.Done is NOT called on a false return — the caller must not have called wg.Add before checking.
 func (h *Handler) tryWrite(
 	ctx context.Context,
-	tenant string,
+	writes map[string]trackedSeries,
 	er endpointReplica,
-	ts trackedSeries,
 	alreadyReplicated bool,
 	responses chan writeResponse,
 	wg *sync.WaitGroup,
 ) bool {
-	cl, req, cb := h.prepareRemoteWrite(ctx, tenant, er, ts, alreadyReplicated, responses, wg)
+	var totalIDs int
+	for _, ts := range writes {
+		totalIDs += len(ts.seriesIDs)
+	}
+	allIDs := make([]int, 0, totalIDs)
+	for _, ts := range writes {
+		allIDs = append(allIDs, ts.seriesIDs...)
+	}
+
+	cl, req, cb := h.prepareRemoteWrite(ctx, writes, er, alreadyReplicated, responses, wg, allIDs)
 	if cl == nil {
 		return true
 	}
-	return cl.TryRemoteWriteAsync(ctx, req, er, ts.seriesIDs, responses, cb)
+	return cl.TryRemoteWriteAsync(ctx, req, er, allIDs, responses, cb)
 }
 
 // writeQuorum returns minimum number of replicas that has to confirm write success before claiming replication success.
@@ -1103,37 +1148,78 @@ func canReturnEarly(successes, conflictFailures []int, successThreshold, failure
 	return true
 }
 
+type wreqTenantTuple struct {
+	wreq   *prompb.WriteRequest
+	tenant string
+}
+
 // RemoteWrite implements the gRPC remote write handler for storepb.WriteableStore.
 func (h *Handler) RemoteWrite(ctx context.Context, r *storepb.WriteRequest) (*storepb.WriteResponse, error) {
 	span, ctx := tracing.StartSpan(ctx, "receive_grpc")
 	defer span.Finish()
 
-	h.pendingWriteRequests.Set(float64(h.pendingWriteRequestsCounter.Add(1)))
-	defer h.pendingWriteRequestsCounter.Add(-1)
+	h.pendingWriteRequests.Set(float64(h.pendingWriteRequestsCounter.Inc()))
+	defer h.pendingWriteRequestsCounter.Dec()
+
+	data := make([]wreqTenantTuple, 0, len(r.TimeseriesTenantData))
+	for _, ts := range r.TimeseriesTenantData {
+		data = append(data, wreqTenantTuple{
+			wreq: &prompb.WriteRequest{
+				Timeseries: ts.Timeseries,
+			},
+			tenant: ts.Tenant,
+		})
+	}
+	if len(data) == 0 {
+		data = append(data, wreqTenantTuple{
+			wreq: &prompb.WriteRequest{
+				Timeseries: r.Timeseries,
+			},
+			tenant: r.Tenant,
+		})
+	}
 
 	// Fast path for IngestorOnly mode: write directly to local TSDB.
 	// This skips distributeTimeseriesToReplicas and sendLocalWrite since
 	// the Router already determined this data belongs to this node.
 	if h.receiverMode == IngestorOnly {
-		err := h.writer.Write(ctx, r.Tenant, r.Timeseries)
-		if err != nil {
-			level.Debug(h.logger).Log("msg", "failed to write to local TSDB", "err", err)
-		}
-		switch cause := errors.Cause(err); cause {
-		case nil:
-			return &storepb.WriteResponse{}, nil
-		default:
-			if isNotReady(cause) {
-				return nil, status.Error(codes.Unavailable, err.Error())
+		var errs = make([]error, 0, len(data))
+		for _, di := range data {
+			err := h.writer.Write(ctx, di.tenant, di.wreq.Timeseries)
+			if err != nil {
+				level.Debug(h.logger).Log("msg", "failed to write to local TSDB", "err", err, "tenant", di.tenant)
+
+				errs = append(errs, fmt.Errorf("writing %s data to local TSDB: %w", di.tenant, err))
 			}
-			if isConflict(cause) {
-				return nil, status.Error(codes.AlreadyExists, err.Error())
-			}
-			return nil, status.Error(codes.Internal, err.Error())
 		}
+
+		if len(errs) > 0 {
+			returnErr := errs[0]
+			err := errors.Unwrap(returnErr)
+
+			if len(errs) > 1 {
+				returnErr = fmt.Errorf("got %d errors while writing to multiple tenants, first one: %w", len(errs), returnErr)
+			}
+
+			switch cause := errors.Cause(err); cause {
+			case nil:
+				panic("BUG: errors.Cause returned nil on a non-nil error")
+			default:
+				if isNotReady(cause) {
+					return nil, status.Error(codes.Unavailable, returnErr.Error())
+				}
+				if isConflict(cause) {
+					return nil, status.Error(codes.AlreadyExists, returnErr.Error())
+				}
+				return nil, status.Error(codes.Internal, returnErr.Error())
+			}
+		}
+
+		return &storepb.WriteResponse{}, nil
+
 	}
 
-	_, err := h.handleRequest(ctx, uint64(r.Replica), r.Tenant, &prompb.WriteRequest{Timeseries: r.Timeseries})
+	_, err := h.handleRequest(ctx, uint64(r.Replica), data)
 	if err != nil {
 		level.Debug(h.logger).Log("msg", "failed to handle request", "err", err)
 	}
@@ -1616,8 +1702,14 @@ func (lw *localAsyncWriter) Close() error {
 }
 
 func (lw *localAsyncWriter) RemoteWrite(ctx context.Context, in *storepb.WriteRequest, opts ...grpc.CallOption) (*storepb.WriteResponse, error) {
-	if err := lw.w.Write(ctx, in.Tenant, in.Timeseries); err != nil {
-		return nil, errors.Wrap(err, "writing locally")
+	if len(in.TimeseriesTenantData) == 0 {
+		panic("BUG: localAsyncWriter.RemoteWrite called without TimeseriesTenantData")
+	}
+
+	for _, ts := range in.TimeseriesTenantData {
+		if err := lw.w.Write(ctx, ts.Tenant, ts.Timeseries); err != nil {
+			return nil, errors.Wrap(err, "writing locally")
+		}
 	}
 
 	return &storepb.WriteResponse{}, nil

--- a/pkg/receive/handler_localwrite_test.go
+++ b/pkg/receive/handler_localwrite_test.go
@@ -6,6 +6,7 @@ package receive
 import (
 	"context"
 	"net/http"
+	"sync"
 	"testing"
 	"time"
 
@@ -13,7 +14,9 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
 
+	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
 
 	"github.com/thanos-io/thanos/pkg/extkingpin"
@@ -26,7 +29,7 @@ import (
 // newLocalWriteHandler builds a Handler backed by the *real* peerGroup (not the
 // fakePeersGroup used elsewhere in the tests) so that the local write path goes
 // through localAsyncWriter.
-func newLocalWriteHandler(t *testing.T, rf uint64, endpoints []Endpoint, apps []*fakeAppendable) *Handler {
+func newLocalWriteHandler(t *testing.T, endpoints []Endpoint, apps []*fakeAppendable) *Handler {
 	t.Helper()
 	require.Len(t, apps, 1, "only the local appendable is wired; remote nodes are not dialable in this test")
 
@@ -37,7 +40,7 @@ func newLocalWriteHandler(t *testing.T, rf uint64, endpoints []Endpoint, apps []
 	h := NewHandler(logger, &Options{
 		TenantHeader:        tenancy.DefaultTenantHeader,
 		ReplicaHeader:       DefaultReplicaHeader,
-		ReplicationFactor:   rf,
+		ReplicationFactor:   1,
 		ForwardTimeout:      5 * time.Minute,
 		Endpoint:            endpoints[0].Address,
 		Writer:              NewWriter(logger, newFakeTenantAppendable(apps[0]), &WriterOptions{}),
@@ -46,7 +49,7 @@ func newLocalWriteHandler(t *testing.T, rf uint64, endpoints []Endpoint, apps []
 	})
 
 	cfg := []HashringConfig{{Hashring: "test", Endpoints: endpoints}}
-	hashring, err := NewMultiHashring(AlgorithmHashmod, rf, cfg, prometheus.NewRegistry())
+	hashring, err := NewMultiHashring(AlgorithmHashmod, 1, cfg, prometheus.NewRegistry())
 	require.NoError(t, err)
 	h.Hashring(hashring)
 
@@ -63,8 +66,9 @@ func TestLocalAsyncWriterRemoteWritePersists(t *testing.T) {
 
 	series := makeSeriesWithValues(5)
 	resp, err := lw.RemoteWrite(context.Background(), &storepb.WriteRequest{
-		Tenant:     "tenant-a",
-		Timeseries: series,
+		TimeseriesTenantData: []storepb.TimeSeriesTenantTuple{
+			{Tenant: "tenant-a", Timeseries: series},
+		},
 	})
 	require.NoError(t, err)
 	require.NotNil(t, resp, "RemoteWrite must return a non-nil response on success")
@@ -87,8 +91,9 @@ func TestLocalAsyncWriterRemoteWritePropagatesError(t *testing.T) {
 	lw := &localAsyncWriter{w: w}
 
 	_, err := lw.RemoteWrite(context.Background(), &storepb.WriteRequest{
-		Tenant:     "tenant-a",
-		Timeseries: makeSeriesWithValues(1),
+		TimeseriesTenantData: []storepb.TimeSeriesTenantTuple{
+			{Tenant: "tenant-a", Timeseries: makeSeriesWithValues(1)},
+		},
 	})
 	require.Error(t, err)
 }
@@ -100,7 +105,7 @@ func TestLocalAsyncWriterRemoteWritePropagatesError(t *testing.T) {
 func TestReceiveLocalWritePersistsEndToEnd(t *testing.T) {
 	fa := newFakeAppender(nil, nil, nil)
 	app := &fakeAppendable{appender: fa}
-	h := newLocalWriteHandler(t, 1, []Endpoint{newUniqueEndpoint()}, []*fakeAppendable{app})
+	h := newLocalWriteHandler(t, []Endpoint{newUniqueEndpoint()}, []*fakeAppendable{app})
 	defer h.Close()
 
 	series := makeSeriesWithValues(10)
@@ -122,7 +127,7 @@ func TestReceiveLocalWriteReportsFailureWhenLocalWriteFails(t *testing.T) {
 		appender:    newFakeAppender(nil, nil, nil),
 		appenderErr: func() error { return errors.New("appender unavailable") },
 	}
-	h := newLocalWriteHandler(t, 1, []Endpoint{newUniqueEndpoint()}, []*fakeAppendable{app})
+	h := newLocalWriteHandler(t, []Endpoint{newUniqueEndpoint()}, []*fakeAppendable{app})
 	defer h.Close()
 
 	rec, err := makeRequest(h, "tenant-a", &prompb.WriteRequest{Timeseries: makeSeriesWithValues(3)})
@@ -141,10 +146,104 @@ func TestReceiveLocalWriteConflictReturns409(t *testing.T) {
 	app := &fakeAppendable{
 		appender: newFakeAppender(func() error { return storage.ErrOutOfBounds }, nil, nil),
 	}
-	h := newLocalWriteHandler(t, 1, []Endpoint{newUniqueEndpoint()}, []*fakeAppendable{app})
+	h := newLocalWriteHandler(t, []Endpoint{newUniqueEndpoint()}, []*fakeAppendable{app})
 	defer h.Close()
 
 	rec, err := makeRequest(h, "tenant-a", &prompb.WriteRequest{Timeseries: makeSeriesWithValues(3)})
 	require.NoError(t, err)
 	require.Equalf(t, http.StatusConflict, rec.Code, "local conflict should map to 409; body: %s", rec.Body.String())
+}
+
+// recordingWriteClient wraps a localAsyncWriter and records every WriteRequest it
+// receives, so a test can assert how many writes the fanout collapsed into and
+// which tenant data each carried.
+type recordingWriteClient struct {
+	lw   *localAsyncWriter
+	mu   sync.Mutex
+	reqs []*storepb.WriteRequest
+}
+
+func (c *recordingWriteClient) RemoteWrite(ctx context.Context, in *storepb.WriteRequest, opts ...grpc.CallOption) (*storepb.WriteResponse, error) {
+	c.mu.Lock()
+	c.reqs = append(c.reqs, in)
+	c.mu.Unlock()
+	return c.lw.RemoteWrite(ctx, in, opts...)
+}
+
+func (c *recordingWriteClient) RemoteWriteAsync(ctx context.Context, in *storepb.WriteRequest, er endpointReplica, seriesIDs []int, responses chan writeResponse, cb func(error)) {
+	_, err := c.RemoteWrite(ctx, in)
+	responses <- writeResponse{er: er, err: err, seriesIDs: seriesIDs}
+	cb(err)
+}
+
+func (c *recordingWriteClient) TryRemoteWriteAsync(ctx context.Context, in *storepb.WriteRequest, er endpointReplica, seriesIDs []int, responses chan writeResponse, cb func(error)) bool {
+	c.RemoteWriteAsync(ctx, in, er, seriesIDs, responses, cb)
+	return true
+}
+
+func (c *recordingWriteClient) Close() error { return nil }
+
+// singleClientPeers is a peersContainer that hands the same client to every
+// endpoint, letting a test observe the writes a handler emits.
+type singleClientPeers struct{ c WriteableStoreAsyncClient }
+
+func (p *singleClientPeers) getConnection(context.Context, Endpoint) (WriteableStoreAsyncClient, error) {
+	return p.c, nil
+}
+func (p *singleClientPeers) close(Endpoint) error         { return nil }
+func (p *singleClientPeers) markPeerUnavailable(Endpoint) {}
+func (p *singleClientPeers) markPeerAvailable(Endpoint)   {}
+func (p *singleClientPeers) reset()                       {}
+func (p *singleClientPeers) Close() error                 { return nil }
+
+// TestReceiveMultiTenantSplitWritesOnce drives a single remote-write request
+// whose series belong to two tenants (resolved via the split-tenant label)
+// through the handler and asserts the fanout splits the data per tenant but
+// emits exactly one write to the destination carrying both tenants.
+func TestReceiveMultiTenantSplitWritesOnce(t *testing.T) {
+	const tenantLabel = "thanos_tenant_id"
+
+	fa := newFakeAppender(nil, nil, nil)
+	app := &fakeAppendable{appender: fa}
+	h := newLocalWriteHandler(t, []Endpoint{newUniqueEndpoint()}, []*fakeAppendable{app})
+	defer h.Close()
+
+	h.splitTenantLabelName = tenantLabel
+	rec := &recordingWriteClient{lw: &localAsyncWriter{w: h.writer}}
+	h.peers = &singleClientPeers{c: rec}
+
+	mkSeries := func(tenant, metric string, val float64) prompb.TimeSeries {
+		return prompb.TimeSeries{
+			Labels:  labelpb.ZLabelsFromPromLabels(labels.FromStrings("__name__", metric, tenantLabel, tenant)),
+			Samples: []prompb.Sample{{Value: val, Timestamp: 10}},
+		}
+	}
+
+	wreq := &prompb.WriteRequest{Timeseries: []prompb.TimeSeries{
+		mkSeries("tenant-a", "metric_a", 1),
+		mkSeries("tenant-b", "metric_b", 2),
+		mkSeries("tenant-a", "metric_c", 3),
+	}}
+
+	httpRec, err := makeRequest(h, "default", wreq)
+	require.NoError(t, err)
+	require.Equalf(t, http.StatusOK, httpRec.Code, "unexpected status; body: %s", httpRec.Body.String())
+
+	require.Len(t, rec.reqs, 1)
+
+	gotByTenant := map[string][]string{}
+	for _, tup := range rec.reqs[0].TimeseriesTenantData {
+		for _, ts := range tup.Timeseries {
+			lset := labelpb.ZLabelsToPromLabels(ts.Labels)
+			require.Empty(t, lset.Get(tenantLabel), "split tenant label must be stripped from forwarded series")
+			gotByTenant[tup.Tenant] = append(gotByTenant[tup.Tenant], lset.Get("__name__"))
+		}
+	}
+	require.Len(t, gotByTenant, 2)
+	require.ElementsMatch(t, []string{"metric_a", "metric_c"}, gotByTenant["tenant-a"])
+	require.ElementsMatch(t, []string{"metric_b"}, gotByTenant["tenant-b"])
+
+	for _, metric := range []string{"metric_a", "metric_b", "metric_c"} {
+		require.Lenf(t, fa.Get(labels.FromStrings("__name__", metric)), 1, "series %s was not persisted exactly once", metric)
+	}
 }

--- a/pkg/receive/handler_otlp.go
+++ b/pkg/receive/handler_otlp.go
@@ -129,7 +129,12 @@ func (h *Handler) receiveOTLPHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	responseStatusCode := http.StatusOK
-	tenantStats, err := h.handleRequest(ctx, rep, tenant, &wreq)
+	tenantStats, err := h.handleRequest(ctx, rep, []wreqTenantTuple{
+		{
+			tenant: tenant,
+			wreq:   &wreq,
+		},
+	})
 	if err != nil {
 		level.Debug(tLogger).Log("msg", "failed to handle request", "err", err.Error())
 		switch errors.Cause(err) {

--- a/pkg/receive/handler_test.go
+++ b/pkg/receive/handler_test.go
@@ -241,8 +241,14 @@ type localTestWriter struct {
 func (w *localTestWriter) Close() error { return nil }
 
 func (w *localTestWriter) RemoteWrite(ctx context.Context, in *storepb.WriteRequest, _ ...grpc.CallOption) (*storepb.WriteResponse, error) {
-	if err := w.h.writer.Write(ctx, in.Tenant, in.Timeseries); err != nil {
-		return nil, errors.Wrap(err, "writing locally")
+	if len(in.TimeseriesTenantData) == 0 {
+		panic("BUG: localTestWriter.RemoteWrite called without TimeseriesTenantData")
+	}
+
+	for _, ts := range in.TimeseriesTenantData {
+		if err := w.h.writer.Write(ctx, ts.Tenant, ts.Timeseries); err != nil {
+			return nil, errors.Wrap(err, "writing locally")
+		}
 	}
 	return &storepb.WriteResponse{}, nil
 }
@@ -2149,14 +2155,20 @@ func TestDistributeSeries(t *testing.T) {
 	h.Hashring(hr)
 
 	writes, err := h.distributeTimeseriesToReplicas(
-		"foo",
 		[]uint64{0},
-		[]prompb.TimeSeries{
+		[]wreqTenantTuple{
 			{
-				Labels: labelpb.ZLabelsFromPromLabels(labels.FromStrings("a", "b", tenantIDLabelName, "bar")),
-			},
-			{
-				Labels: labelpb.ZLabelsFromPromLabels(labels.FromStrings("b", "a", tenantIDLabelName, "boo")),
+				tenant: "foo",
+				wreq: &prompb.WriteRequest{
+					Timeseries: []prompb.TimeSeries{
+						{
+							Labels: labelpb.ZLabelsFromPromLabels(labels.FromStrings("a", "b", tenantIDLabelName, "bar")),
+						},
+						{
+							Labels: labelpb.ZLabelsFromPromLabels(labels.FromStrings("b", "a", tenantIDLabelName, "boo")),
+						},
+					},
+				},
 			},
 		},
 	)
@@ -2262,14 +2274,19 @@ func TestHandlerFlippingHashrings(t *testing.T) {
 				return
 			}
 
-			_, err := h.handleRequest(ctx, 0, "test", &prompb.WriteRequest{
-				Timeseries: []prompb.TimeSeries{
-					{
-						Labels: labelpb.ZLabelsFromPromLabels(labels.FromStrings("foo", "bar")),
-						Samples: []prompb.Sample{
+			_, err := h.handleRequest(ctx, 0, []wreqTenantTuple{
+				{
+					tenant: "test",
+					wreq: &prompb.WriteRequest{
+						Timeseries: []prompb.TimeSeries{
 							{
-								Timestamp: time.Now().Unix(),
-								Value:     123,
+								Labels: labelpb.ZLabelsFromPromLabels(labels.FromStrings("foo", "bar")),
+								Samples: []prompb.Sample{
+									{
+										Timestamp: time.Now().Unix(),
+										Value:     123,
+									},
+								},
 							},
 						},
 					},

--- a/pkg/receive/receive_test.go
+++ b/pkg/receive/receive_test.go
@@ -899,12 +899,12 @@ func TestSendRemoteWriteMarksPeerUnavailableOnAnyError(t *testing.T) {
 
 			cl.sendUnavailable = sendUnavailable
 
-			h.sendWrite(ctx, "tenant-a", endpointReplica{
-				endpoint: endpoint,
-				replica:  0,
-			}, trackedSeries{
+			h.sendWrite(ctx, map[string]trackedSeries{"tenant-a": {
 				seriesIDs:  []int{0},
 				timeSeries: []prompb.TimeSeries{{}},
+			}}, endpointReplica{
+				endpoint: endpoint,
+				replica:  0,
 			}, false, responses, &wg)
 
 			wg.Wait()


### PR DESCRIPTION
Add a wreqTenantTuple that allows populating multiple writes in the handler function. Pass it around everywhere. Take use of the new fields that allow putting more than one tenant + set of timeseries.

This finally finishes implementing multi-tenant writes -- greatly improves throughput in the case of "split tenant label" functionality.
