### PR TITLE
receive: fix write_samples metric help typo

### DIFF
--- a/pkg/receive/handler.go
+++ b/pkg/receive/handler.go
@@ -254,7 +254,7 @@ func NewHandler(logger log.Logger, o *Options) *Handler {
 				Namespace: "thanos",
 				Subsystem: "receive",
 				Name:      "write_samples",
-				Help:      "The number of sampled received in the incoming write requests.",
+				Help:      "The number of samples received in the incoming write requests.",
 				Buckets:   []float64{10, 50, 100, 500, 1000, 5000, 10000},
 			}, []string{"code", "tenant"},
 		),


### PR DESCRIPTION
* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

The `thanos_receive_write_samples` histogram help read "The number of sampled received in the incoming write requests." Fix the typo "sampled" -> "samples" so it reads "The number of samples received...", matching the sibling `write_timeseries` help just above it and the value it actually counts (`stats.totalSamples`).

Add a small colocated test (`TestHandlerWriteMetricsHelp`) asserting the help text for both `write_samples` and `write_timeseries`.

## Verification

- `go build ./cmd/thanos` passes.
- `go test ./pkg/receive/ -run TestHandlerWriteMetricsHelp -count=1` passes.
- `gofmt -l` clean and `go vet ./pkg/receive/` clean on both files.
- Mutation check: re-introducing the typo makes the new test fail; reverting makes it pass, confirming the test actually guards the help string.
