### PR TITLE
block: fix incorrect log messages in pkg/block

### DIFF
--- a/pkg/block/block.go
+++ b/pkg/block/block.go
@@ -418,7 +418,7 @@ func MarkForNoDownsample(ctx context.Context, logger log.Logger, bkt objstore.Bu
 		return errors.Wrapf(err, "check exists %s in bucket", m)
 	}
 	if noDownsampleMarkExists {
-		level.Warn(logger).Log("msg", "requested to mark for no deletion, but file already exists; this should not happen; investigate", "err", errors.Errorf("file %s already exists in bucket", m))
+		level.Warn(logger).Log("msg", "requested to mark for no downsampling, but file already exists; this should not happen; investigate", "err", errors.Errorf("file %s already exists in bucket", m))
 		return nil
 	}
 	noDownsampleMark, err := json.Marshal(metadata.NoDownsampleMark{

--- a/pkg/block/writer.go
+++ b/pkg/block/writer.go
@@ -71,7 +71,7 @@ func NewDiskWriter(ctx context.Context, logger log.Logger, bDir string) (_ *Disk
 		if err != nil {
 			err = tsdb_errors.NewMulti(err, tsdb_errors.CloseAll(d.closers)).Err()
 			if err := os.RemoveAll(bTmp); err != nil {
-				level.Error(logger).Log("msg", "removed tmp folder after failed compaction", "err", err.Error())
+				level.Error(logger).Log("msg", "failed to remove tmp folder after failed compaction", "err", err.Error())
 			}
 		}
 	}()
@@ -105,7 +105,7 @@ func (d *DiskWriter) Flush() (_ tsdb.BlockStats, err error) {
 		if err != nil {
 			err = tsdb_errors.NewMulti(err, tsdb_errors.CloseAll(d.closers)).Err()
 			if err := os.RemoveAll(d.bTmp); err != nil {
-				level.Error(d.logger).Log("msg", "removed tmp folder failed after block(s) write", "err", err.Error())
+				level.Error(d.logger).Log("msg", "failed to remove tmp folder after block(s) write", "err", err.Error())
 			}
 		}
 	}()


### PR DESCRIPTION
* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

Three operator-facing log messages in `pkg/block` stated the wrong thing:

- `MarkForNoDownsample` (`block.go`) logged `"requested to mark for no deletion ..."` when the no-downsample mark file already exists. This is the no-downsample path (function name, doc comment, the marshalled `metadata.NoDownsampleMark`, and the success log on the next branch all confirm it), so it now says `"no downsampling"`, matching the correct sibling logs in `MarkForDeletion` ("no deletion") and `MarkForNoCompact` ("no compaction").
- The cleanup defers in `NewDiskWriter` and `DiskWriter.Flush` (`writer.go`) only run when `os.RemoveAll` fails, yet logged `"removed tmp folder ..."` (and a garbled `"removed tmp folder failed ..."`). They now log `"failed to remove tmp folder ..."`, which reflects what actually happened.

No logic, fields, or behavior change; message strings only.

## Verification

- `go build ./cmd/thanos` - OK.
- `go test ./pkg/block/ -run TestMarkForNoDownsample -count=1` - PASS. The "no-downsample mark already" subtest exercises the corrected `block.go` branch.
- `gofmt`, `go vet`, `golangci-lint` (pinned v2.4.0) - clean.
