### PR TITLE
receive/store: reduce some allocs

### DIFF
--- a/pkg/filter/cuckoo.go
+++ b/pkg/filter/cuckoo.go
@@ -28,7 +28,7 @@ func (f *CuckooMetricNameStoreFilter) Matches(matchers []*labels.Matcher) bool {
 
 	for _, m := range matchers {
 		if m.Type == labels.MatchEqual && m.Name == labels.MetricName {
-			return f.filter.Lookup([]byte(m.Value))
+			return f.filter.Lookup(unsafe.Slice(unsafe.StringData(m.Value), len(m.Value)))
 		}
 	}
 

--- a/pkg/receive/multitsdb.go
+++ b/pkg/receive/multitsdb.go
@@ -267,7 +267,7 @@ func (l *localClient) Matches(matchers []*labels.Matcher) bool {
 }
 
 func (l *localClient) LabelSets() []labels.Labels {
-	return labelpb.ZLabelSetsToPromLabelSets(l.store.LabelSet()...)
+	return l.store.ExtLabelSets()
 }
 
 func (l *localClient) TimeRange() (mint int64, maxt int64) {

--- a/pkg/store/proxy.go
+++ b/pkg/store/proxy.go
@@ -713,7 +713,7 @@ func storeMatchDebugMetadata(s Client, debugLogging bool, storeDebugMatchers [][
 
 	match := false
 	for _, sm := range storeDebugMatchers {
-		match = match || LabelSetsMatch(sm, labels.FromStrings("__address__", addr))
+		match = match || matchersMatchAddress(sm, addr)
 	}
 	if !match {
 		const s string = "__address__ does not match debug store metadata matchers"
@@ -723,6 +723,18 @@ func storeMatchDebugMetadata(s Client, debugLogging bool, storeDebugMatchers [][
 		return false, s
 	}
 	return true, ""
+}
+
+// matchersMatchAddress reports whether the matchers match a label set that only
+// contains __address__=addr. It mirrors LabelSetsMatch for that single synthetic
+// label without allocating a labels.Labels for every store on every request.
+func matchersMatchAddress(matchers []*labels.Matcher, addr string) bool {
+	for _, m := range matchers {
+		if m.Name == "__address__" && !m.Matches(addr) {
+			return false
+		}
+	}
+	return true
 }
 
 // LabelSetsMatch returns false if all label-sets do not match the matchers (aka: OR is between all label-sets).

--- a/pkg/store/tsdb.go
+++ b/pkg/store/tsdb.go
@@ -72,7 +72,7 @@ type TSDBStore struct {
 	maxBytesPerFrame int
 	matcherCache     storecache.MatchersCache
 
-	extLset                labels.Labels
+	extLsetAsLabelSets     []labels.Labels
 	startStoreFilterUpdate bool
 	storeFilter            filter.StoreFilter
 	mtx                    sync.RWMutex
@@ -110,13 +110,13 @@ func NewTSDBStore(
 	}
 
 	st := &TSDBStore{
-		logger:           logger,
-		db:               db,
-		component:        component,
-		extLset:          extLset,
-		maxBytesPerFrame: RemoteReadFrameLimit,
-		storeFilter:      filter.AllowAllStoreFilter{},
-		close:            func() {},
+		logger:             logger,
+		db:                 db,
+		component:          component,
+		extLsetAsLabelSets: []labels.Labels{extLset},
+		maxBytesPerFrame:   RemoteReadFrameLimit,
+		storeFilter:        filter.AllowAllStoreFilter{},
+		close:              func() {},
 		buffers: sync.Pool{New: func() any {
 			b := make([]byte, 0, initialBufSize)
 			return &b
@@ -167,14 +167,23 @@ func (s *TSDBStore) SetExtLset(extLset labels.Labels) {
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
 
-	s.extLset = extLset
+	s.extLsetAsLabelSets = []labels.Labels{extLset}
 }
 
 func (s *TSDBStore) getExtLset() labels.Labels {
 	s.mtx.RLock()
 	defer s.mtx.RUnlock()
 
-	return s.extLset
+	return s.extLsetAsLabelSets[0]
+}
+
+// ExtLabelSets returns the external labels exposed by this store as a slice of
+// label sets. Read-only.
+func (s *TSDBStore) ExtLabelSets() []labels.Labels {
+	s.mtx.RLock()
+	defer s.mtx.RUnlock()
+
+	return s.extLsetAsLabelSets
 }
 
 func (s *TSDBStore) LabelSet() []labelpb.ZLabelSet {
@@ -300,7 +309,7 @@ func (s *TSDBStore) Series(r *storepb.SeriesRequest, seriesSrv storepb.Store_Ser
 	for _, lbl := range r.WithoutReplicaLabels {
 		extLsetToRemove[lbl] = struct{}{}
 	}
-	finalExtLset := rmLabels(s.extLset.Copy(), extLsetToRemove)
+	finalExtLset := rmLabels(s.extLsetAsLabelSets[0].Copy(), extLsetToRemove)
 
 	// Stream at most one series per frame; series may be split over multiple frames according to maxBytesInFrame.
 	for set.Next() {


### PR DESCRIPTION
From production profiles - allocate in advance where needed, avoid casts, or avoid allocating in general.
