### PR TITLE
rule: do not close data dir on boot

### DIFF
--- a/cmd/thanos/rule.go
+++ b/cmd/thanos/rule.go
@@ -891,18 +891,10 @@ func runRule(
 		}
 		bkt = objstoretracing.WrapWithTraces(objstore.WrapWithMetrics(bkt, extprom.WrapRegistererWithPrefix("thanos_", reg), bkt.Name()))
 
-		// Ensure we close up everything properly.
-		defer func() {
-			if err != nil {
-				runutil.CloseWithLogOnErr(logger, bkt, "bucket client")
-			}
-		}()
-
 		dataDir, err := os.OpenRoot(conf.dataDir)
 		if err != nil {
 			return errors.Wrap(err, "open data dir")
 		}
-		defer runutil.CloseWithLogOnErr(logger, dataDir, "data dir")
 
 		s := shipper.New(
 			bkt,
@@ -922,7 +914,6 @@ func runRule(
 
 		g.Add(func() error {
 			defer runutil.CloseWithLogOnErr(logger, bkt, "bucket client")
-
 			return runutil.Repeat(30*time.Second, ctx.Done(), func() error {
 				if _, err := s.Sync(ctx); err != nil {
 					level.Warn(logger).Log("err", err)
@@ -931,6 +922,9 @@ func runRule(
 			})
 		}, func(error) {
 			cancel()
+
+			runutil.CloseWithLogOnErr(logger, bkt, "bucket client")
+			runutil.CloseWithLogOnErr(logger, dataDir, "data dir")
 		})
 	} else {
 		level.Info(logger).Log("msg", "no supported bucket was configured, uploads will be disabled")

--- a/test/e2e/compatibility_test.go
+++ b/test/e2e/compatibility_test.go
@@ -210,7 +210,7 @@ func TestAlertCompliance(t *testing.T) {
 			WithResendDelay("1m").
 			WithEvalInterval("1m").
 			WithReplicaLabel("").
-			InitTSDB(filepath.Join(rFuture.InternalDir(), "rules"), []clientconfig.Config{
+			InitTSDB(filepath.Join(rFuture.InternalDir(), rulesSubDir), []clientconfig.Config{
 				{
 					HTTPConfig: clientconfig.HTTPConfig{
 						EndpointsConfig: clientconfig.HTTPEndpointsConfig{
@@ -235,8 +235,8 @@ func TestAlertCompliance(t *testing.T) {
 		{
 			var stdout bytes.Buffer
 			testutil.Ok(t, compliance.Exec(e2e.NewCommand("cat", "/rules.yaml"), e2e.WithExecOptionStdout(&stdout)))
-			testutil.Ok(t, os.MkdirAll(filepath.Join(ruler.Dir(), "rules"), os.ModePerm))
-			testutil.Ok(t, os.WriteFile(filepath.Join(ruler.Dir(), "rules", "rules.yaml"), stdout.Bytes(), os.ModePerm))
+			testutil.Ok(t, os.MkdirAll(filepath.Join(ruler.Dir(), rulesSubDir), os.ModePerm))
+			testutil.Ok(t, os.WriteFile(filepath.Join(ruler.Dir(), rulesSubDir, "rules.yaml"), stdout.Bytes(), os.ModePerm))
 
 			// Reload ruler.
 			resp, err := http.Post("http://"+ruler.Endpoint("http")+"/-/reload", "", nil)
@@ -294,7 +294,7 @@ func TestAlertCompliance(t *testing.T) {
 			WithEvalInterval("1m").
 			WithReplicaLabel("").
 			WithRestoreIgnoredLabels("tenant_id").
-			InitStateless(filepath.Join(rFuture.InternalDir(), "rules"), []clientconfig.Config{
+			InitStateless(filepath.Join(rFuture.InternalDir(), rulesSubDir), []clientconfig.Config{
 				{
 					HTTPConfig: clientconfig.HTTPConfig{
 						EndpointsConfig: clientconfig.HTTPEndpointsConfig{
@@ -315,8 +315,8 @@ func TestAlertCompliance(t *testing.T) {
 		{
 			var stdout bytes.Buffer
 			testutil.Ok(t, compliance.Exec(e2e.NewCommand("cat", "/rules.yaml"), e2e.WithExecOptionStdout(&stdout)))
-			testutil.Ok(t, os.MkdirAll(filepath.Join(ruler.Dir(), "rules"), os.ModePerm))
-			testutil.Ok(t, os.WriteFile(filepath.Join(ruler.Dir(), "rules", "rules.yaml"), stdout.Bytes(), os.ModePerm))
+			testutil.Ok(t, os.MkdirAll(filepath.Join(ruler.Dir(), rulesSubDir), os.ModePerm))
+			testutil.Ok(t, os.WriteFile(filepath.Join(ruler.Dir(), rulesSubDir, "rules.yaml"), stdout.Bytes(), os.ModePerm))
 
 			// Reload ruler.
 			resp, err := http.Post("http://"+ruler.Endpoint("http")+"/-/reload", "", nil)

--- a/test/e2e/e2ethanos/services.go
+++ b/test/e2e/e2ethanos/services.go
@@ -816,6 +816,7 @@ type RulerBuilder struct {
 	forGracePeriod       string
 	restoreIgnoredLabels []string
 	nativeHistograms     bool
+	objStoreConfig       *client.BucketConfig
 }
 
 // NewRulerBuilder is a Ruler future that allows extra configuration before initialization.
@@ -868,6 +869,11 @@ func (r *RulerBuilder) WithRestoreIgnoredLabels(labels ...string) *RulerBuilder 
 
 func (r *RulerBuilder) WithNativeHistograms() *RulerBuilder {
 	r.nativeHistograms = true
+	return r
+}
+
+func (r *RulerBuilder) WithObjStoreConfig(config client.BucketConfig) *RulerBuilder {
+	r.objStoreConfig = &config
 	return r
 }
 
@@ -940,6 +946,14 @@ func (r *RulerBuilder) initRule(internalRuleDir string, queryCfg []clientconfig.
 
 	if r.nativeHistograms {
 		ruleArgs["--tsdb.enable-native-histograms"] = ""
+	}
+
+	if r.objStoreConfig != nil {
+		bktConfigBytes, err := yaml.Marshal(r.objStoreConfig)
+		if err != nil {
+			return &e2eobs.Observable{Runnable: e2e.NewFailedRunnable(r.Name(), errors.Wrapf(err, "generate objstore config: %v", r.objStoreConfig))}
+		}
+		ruleArgs["--objstore.config"] = string(bktConfigBytes)
 	}
 
 	args := e2e.BuildArgs(ruleArgs)

--- a/test/e2e/native_histograms_test.go
+++ b/test/e2e/native_histograms_test.go
@@ -346,7 +346,6 @@ func TestRuleNativeHistograms(t *testing.T) {
 	t.Cleanup(cancel)
 
 	rFuture := e2ethanos.NewRulerBuilder(e, "1")
-	rulesSubDir := "rules"
 	rulesPath := filepath.Join(rFuture.Dir(), rulesSubDir)
 	testutil.Ok(t, os.MkdirAll(rulesPath, os.ModePerm))
 
@@ -405,7 +404,6 @@ func TestRuleNativeHistogramsTSDB(t *testing.T) {
 	t.Cleanup(cancel)
 
 	rFuture := e2ethanos.NewRulerBuilder(e, "1").WithNativeHistograms()
-	rulesSubDir := "rules"
 	rulesPath := filepath.Join(rFuture.Dir(), rulesSubDir)
 	testutil.Ok(t, os.MkdirAll(rulesPath, os.ModePerm))
 

--- a/test/e2e/rule_test.go
+++ b/test/e2e/rule_test.go
@@ -16,12 +16,15 @@ import (
 	"time"
 
 	"github.com/efficientgo/e2e"
+	e2edb "github.com/efficientgo/e2e/db"
 	e2emon "github.com/efficientgo/e2e/monitoring"
 	e2eobs "github.com/efficientgo/e2e/observable"
 	common_cfg "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/discovery/targetgroup"
+	"github.com/thanos-io/objstore"
+	"github.com/thanos-io/objstore/client"
 	"github.com/thanos-io/thanos/pkg/errors"
 	"gopkg.in/yaml.v2"
 
@@ -33,6 +36,8 @@ import (
 	"github.com/thanos-io/thanos/pkg/runutil"
 	"github.com/thanos-io/thanos/test/e2e/e2ethanos"
 )
+
+const rulesSubDir = "rules"
 
 const (
 	testAlertRuleAbortOnPartialResponse = `
@@ -328,7 +333,7 @@ func TestRule(t *testing.T) {
 	queryTargetsSubDir := filepath.Join("rules_query_targets")
 	testutil.Ok(t, os.MkdirAll(filepath.Join(rFuture.Dir(), queryTargetsSubDir), os.ModePerm))
 
-	rulesSubDir := filepath.Join("rules")
+	rulesSubDir := filepath.Join(rulesSubDir)
 	rulesPath := filepath.Join(rFuture.Dir(), rulesSubDir)
 	testutil.Ok(t, os.MkdirAll(rulesPath, os.ModePerm))
 	createRuleFiles(t, rulesPath)
@@ -567,7 +572,7 @@ func TestRule_KeepFiringFor(t *testing.T) {
 	queryTargetsSubDir := filepath.Join("rules_query_targets")
 	testutil.Ok(t, os.MkdirAll(filepath.Join(rFuture.Dir(), queryTargetsSubDir), os.ModePerm))
 
-	rulesSubDir := filepath.Join("rules")
+	rulesSubDir := filepath.Join(rulesSubDir)
 	rulesPath := filepath.Join(rFuture.Dir(), rulesSubDir)
 	testutil.Ok(t, os.MkdirAll(rulesPath, os.ModePerm))
 	createRuleFile(t, filepath.Join(rulesPath, "alert_keep_firing_for.yaml"), testAlertRuleKeepFiringFor)
@@ -679,7 +684,6 @@ func TestRule_CanRemoteWriteData(t *testing.T) {
 	t.Cleanup(cancel)
 
 	rFuture := e2ethanos.NewRulerBuilder(e, "1")
-	rulesSubDir := "rules"
 	rulesPath := filepath.Join(rFuture.Dir(), rulesSubDir)
 	testutil.Ok(t, os.MkdirAll(rulesPath, os.ModePerm))
 
@@ -755,6 +759,41 @@ func TestRule_CanRemoteWriteData(t *testing.T) {
 	})
 }
 
+func TestRule_CanShipBlocks(t *testing.T) {
+	t.Parallel()
+
+	e, err := e2e.NewDockerEnvironment("rule-shipper")
+	testutil.Ok(t, err)
+	t.Cleanup(e2ethanos.CleanScenario(t, e))
+
+	const bucket = "rule-shipper-test"
+	m := e2edb.NewMinio(e, "minio", bucket, e2edb.WithMinioTLS())
+	testutil.Ok(t, e2e.StartAndWaitReady(m))
+
+	rFuture := e2ethanos.NewRulerBuilder(e, "1")
+
+	rulesPath := filepath.Join(rFuture.Dir(), rulesSubDir)
+	testutil.Ok(t, os.MkdirAll(rulesPath, os.ModePerm))
+	createRuleFile(t, filepath.Join(rulesPath, "rules-0.yaml"), testRuleRecordAbsentMetric)
+
+	r := rFuture.WithObjStoreConfig(client.BucketConfig{
+		Type:   objstore.S3,
+		Config: e2ethanos.NewS3Config(bucket, m.InternalEndpoint("http"), m.InternalDir()),
+	}).InitTSDB(filepath.Join(rFuture.InternalDir(), rulesSubDir), []clientconfig.Config{
+		{
+			HTTPConfig: clientconfig.HTTPConfig{
+				EndpointsConfig: clientconfig.HTTPEndpointsConfig{
+					StaticAddresses: []string{"localhost:9090"},
+					Scheme:          "http",
+				},
+			},
+		},
+	})
+	testutil.Ok(t, e2e.StartAndWaitReady(r))
+
+	testutil.Ok(t, r.WaitSumMetricsWithOptions(e2emon.GreaterOrEqual(1), []string{"thanos_shipper_dir_syncs_total"}, e2emon.WaitMissingMetrics()))
+}
+
 func TestStatelessRulerAlertStateRestore(t *testing.T) {
 	t.Parallel()
 
@@ -775,7 +814,6 @@ func TestStatelessRulerAlertStateRestore(t *testing.T) {
 	q := e2ethanos.NewQuerierBuilder(e, "1", receiver.InternalEndpoint("grpc")).
 		WithReplicaLabels("replica", "receive").Init()
 	testutil.Ok(t, e2e.StartAndWaitReady(q))
-	rulesSubDir := "rules"
 	var rulers []*e2eobs.Observable
 	for i := 1; i <= 2; i++ {
 		rFuture := e2ethanos.NewRulerBuilder(e, fmt.Sprintf("%d", i))

--- a/test/e2e/rules_api_test.go
+++ b/test/e2e/rules_api_test.go
@@ -38,7 +38,7 @@ func TestRulesAPI_Fanout(t *testing.T) {
 	qBuilder := e2ethanos.NewQuerierBuilder(e, "query")
 
 	// Use querier work dir for shared resources (easiest to obtain).
-	promRulesSubDir := filepath.Join("rules")
+	promRulesSubDir := filepath.Join(rulesSubDir)
 	testutil.Ok(t, os.MkdirAll(filepath.Join(qBuilder.Dir(), promRulesSubDir), os.ModePerm))
 	// Create the abort_on_partial_response alert for Prometheus.
 	// We don't create the warn_on_partial_response alert as Prometheus has strict yaml unmarshalling.


### PR DESCRIPTION
The currently happens on main/rc:

```
22:58:18 rule-1: ts=2026-06-29T19:58:18.003294856Z caller=log.go:168 name=rule-1 level=warn component=rules err="open dir: openat .: file already closed"
```

We accidentally introduced this footgun - the function only adds actors to the main run group so we must not do the deferred close here because otherwise it just closes the *os.Root on boot.

The closing of the bucket is just dead code that suffers from a similar issue - the err captured is always nil and later on it is shadowed.