### PR TITLE
Return an errof if we have no stores at all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 ### Fixed
 
 - [#8881](https://github.com/thanos-io/thanos/pull/8881): Receive: Fix routing receivers crashing with `mkdir ./data: read-only file system` on startup by gating data directory setup on `enableIngestion`, since routing receivers don't write local TSDB data.
+- [#8889](https://github.com/thanos-io/thanos/pull/8889): Query: Return an error if Querier doesn't have any registered endpoints and partial response is disabled.
 
 ### Changed
 

--- a/pkg/store/proxy.go
+++ b/pkg/store/proxy.go
@@ -48,6 +48,11 @@ const StoreMatcherKey = ctxKey(0)
 // This can happen with Query servers trees and external labels.
 var ErrorNoStoresMatched = errors.New("No StoreAPIs matched for this query")
 
+// ErrorNoStoresAvailable is returned if we have an empty list of stores.
+// This happens either when we didn't yet complete any discovery
+// or when all stores disappear suddenly.
+var ErrorNoStoresAvailable = errors.New("No StoreAPIs available")
+
 // Client holds meta information about a store.
 type Client interface {
 	// StoreClient to access the store.
@@ -198,7 +203,7 @@ func NewProxyStore(
 }
 
 func (s *ProxyStore) LabelSet() []labelpb.ZLabelSet {
-	stores := s.storesForTSDBSelector()
+	stores := s.storesForTSDBSelector(s.stores())
 	if len(stores) == 0 {
 		// We always want to enforce announcing the subset of data that
 		// selector-labels represents. If no stores match the filter,
@@ -246,7 +251,7 @@ func (s *ProxyStore) LabelSet() []labelpb.ZLabelSet {
 }
 
 func (s *ProxyStore) TimeRange() (int64, int64) {
-	stores := s.storesForTSDBSelector()
+	stores := s.storesForTSDBSelector(s.stores())
 	if len(stores) == 0 {
 		return math.MinInt64, math.MaxInt64
 	}
@@ -266,7 +271,7 @@ func (s *ProxyStore) TimeRange() (int64, int64) {
 }
 
 func (s *ProxyStore) TSDBInfos() []infopb.TSDBInfo {
-	stores := s.storesForTSDBSelector()
+	stores := s.storesForTSDBSelector(s.stores())
 	infos := make([]infopb.TSDBInfo, 0)
 	for _, st := range stores {
 		infos = append(infos, st.TSDBInfos()...)
@@ -309,7 +314,14 @@ func (s *ProxyStore) Series(originalRequest *storepb.SeriesRequest, seriesSrv st
 	ctx = metadata.AppendToOutgoingContext(ctx, tenancy.DefaultTenantHeader, tenant)
 	level.Debug(s.logger).Log("msg", "Tenant info in Series()", "tenant", tenant)
 
-	stores, storeLabelSets, storeDebugMsgs := s.matchingStores(ctx, originalRequest.MinTime, originalRequest.MaxTime, matchers)
+	// There are no stores registered at all and partial results are disabled, return an error.
+	stores := s.stores()
+	if originalRequest.PartialResponseDisabled && len(stores) == 0 {
+		level.Debug(reqLogger).Log("err", ErrorNoStoresAvailable)
+		return ErrorNoStoresAvailable
+	}
+
+	stores, storeLabelSets, storeDebugMsgs := s.matchingStores(ctx, stores, originalRequest.MinTime, originalRequest.MaxTime, matchers)
 	if len(stores) == 0 {
 		level.Debug(reqLogger).Log("err", ErrorNoStoresMatched, "stores", strings.Join(storeDebugMsgs, ";"))
 		return nil
@@ -433,7 +445,7 @@ func (s *ProxyStore) LabelNames(ctx context.Context, originalRequest *storepb.La
 	ctx = metadata.AppendToOutgoingContext(ctx, tenancy.DefaultTenantHeader, tenant)
 	level.Debug(s.logger).Log("msg", "Tenant info in LabelNames()", "tenant", tenant)
 
-	stores, storeLabelSets, storeDebugMsgs := s.matchingStores(ctx, originalRequest.Start, originalRequest.End, matchers)
+	stores, storeLabelSets, storeDebugMsgs := s.matchingStores(ctx, s.stores(), originalRequest.Start, originalRequest.End, matchers)
 	if len(stores) == 0 {
 		level.Debug(reqLogger).Log("err", ErrorNoStoresMatched, "stores", strings.Join(storeDebugMsgs, ";"))
 		return &storepb.LabelNamesResponse{}, nil
@@ -536,7 +548,7 @@ func (s *ProxyStore) LabelValues(ctx context.Context, originalRequest *storepb.L
 	ctx = metadata.AppendToOutgoingContext(ctx, tenancy.DefaultTenantHeader, tenant)
 	level.Debug(reqLogger).Log("msg", "Tenant info in LabelValues()", "tenant", tenant)
 
-	stores, storeLabelSets, storeDebugMsgs := s.matchingStores(ctx, originalRequest.Start, originalRequest.End, matchers)
+	stores, storeLabelSets, storeDebugMsgs := s.matchingStores(ctx, s.stores(), originalRequest.Start, originalRequest.End, matchers)
 	if len(stores) == 0 {
 		level.Debug(reqLogger).Log("err", ErrorNoStoresMatched, "stores", strings.Join(storeDebugMsgs, ";"))
 		return &storepb.LabelValuesResponse{}, nil
@@ -617,9 +629,9 @@ func storeInfo(st Client) (storeID string, storeAddr string, isLocalStore bool) 
 // storesForTSDBSelector returns stores that match the TSDBSelector filtering criteria.
 // This centralizes the TSDBSelector filtering logic used across all ProxyStore methods
 // for cases where we don't need additional matchers or time range filtering.
-func (s *ProxyStore) storesForTSDBSelector() []Client {
+func (s *ProxyStore) storesForTSDBSelector(stores []Client) []Client {
 	var filteredStores []Client
-	for _, st := range s.stores() {
+	for _, st := range stores {
 		matches, _ := s.tsdbSelector.MatchLabelSets(st.LabelSets()...)
 		if matches {
 			filteredStores = append(filteredStores, st)
@@ -630,13 +642,13 @@ func (s *ProxyStore) storesForTSDBSelector() []Client {
 
 // TODO: consider moving the following functions into something like "pkg/pruneutils" since it is also used for exemplars.
 
-func (s *ProxyStore) matchingStores(ctx context.Context, minTime, maxTime int64, matchers []*labels.Matcher) ([]Client, []labels.Labels, []string) {
+func (s *ProxyStore) matchingStores(ctx context.Context, allStores []Client, minTime, maxTime int64, matchers []*labels.Matcher) ([]Client, []labels.Labels, []string) {
 	var (
 		stores         []Client
 		storeLabelSets []labels.Labels
 		storeDebugMsgs []string
 	)
-	for _, st := range s.storesForTSDBSelector() {
+	for _, st := range s.storesForTSDBSelector(allStores) {
 		// We might be able to skip the store if its meta information indicates it cannot have series matching our query.
 		if ok, reason := storeMatches(ctx, s.debugLogging, st, minTime, maxTime, matchers...); !ok {
 			if s.debugLogging {

--- a/pkg/store/proxy_test.go
+++ b/pkg/store/proxy_test.go
@@ -113,6 +113,16 @@ func TestProxyStore_Series(t *testing.T) {
 			expectedWarningsLen: 0, // No store matched for this query.
 		},
 		{
+			title: "no storeAPI available with partial response disabled",
+			req: &storepb.SeriesRequest{
+				MinTime:                 1,
+				MaxTime:                 300,
+				Matchers:                []storepb.LabelMatcher{{Name: "a", Value: "a", Type: storepb.LabelMatcher_EQ}},
+				PartialResponseDisabled: true,
+			},
+			expectedErr: ErrorNoStoresAvailable, // No stored registered at all.
+		},
+		{
 			title: "no storeAPI available for 301-302 time range",
 			storeAPIs: []Client{
 				&storetestutil.TestClient{


### PR DESCRIPTION
If the querier receives a query but it has an empty list of stores, and partial response is disabled, then we should error out. We either:
- didn't finish discovery yet - although querier would be marked as not-ready, so it shouldn't receive requests (unless sender doesn't check for ready status)
- all stores are simply gone and discovery doesn't return these - could be problem with discovery, could be that all stores disappeared

If there are no stores at all and partial response is disabled then it's unlikely that the user wants 200 OK here. This can be bogus config or some operational issue, either way querier with no stores is not a valid querier and so shouldn't pretend that it's giving back a legitimate response.

I didn't want to check store count by doing second stores() call, because the list of stores could change between these stores() calls and so if we had:

if len(s.stores()) == 0 {...}

followed by another call to s.stores() then the first call might get non-empty list while the second call might return empty list. Having a single call to stores() here requires a small refactoring to avoid calling stores() inside functions we call, so stores list is passed around.

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
