### PR TITLE
block: fix GatherIndexHealthStats postings walk error check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 ### Fixed
 
 - [#8881](https://github.com/thanos-io/thanos/pull/8881): Receive: Fix routing receivers crashing with `mkdir ./data: read-only file system` on startup by gating data directory setup on `enableIngestion`, since routing receivers don't write local TSDB data.
+- [#8890](https://github.com/thanos-io/thanos/pull/8890): block: fix GatherIndexHealthStats postings walk error check to prevent swallowing an error.
 - [#8889](https://github.com/thanos-io/thanos/pull/8889): Query: Return an error if Querier doesn't have any registered endpoints and partial response is disabled.
 
 ### Changed

--- a/pkg/block/index.go
+++ b/pkg/block/index.go
@@ -373,7 +373,7 @@ func GatherIndexHealthStats(ctx context.Context, logger log.Logger, fn string, m
 			seriesLifeDurationWithoutSingleSampleSeries.Add(seriesLifeTimeMs)
 		}
 	}
-	if p.Err() != nil {
+	if err := p.Err(); err != nil {
 		return stats, errors.Wrap(err, "walk postings")
 	}
 


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->


* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Fixes an error check in `GatherIndexHealthStats`. `p.Err()` gets checked, but `err` gets wrapped, which would return a `nil` err.

For context I originally found this in https://github.com/grafana/mimir/pull/15895 and I'm reflecting the change here due to provenance.

## Verification

None
