### PR TITLE
Fix upload-blocks resource lifetime

### DIFF
--- a/cmd/thanos/tools_bucket.go
+++ b/cmd/thanos/tools_bucket.go
@@ -1482,15 +1482,14 @@ func registerBucketUploadBlocks(app extkingpin.AppClause, objStoreConfig *extfla
 		if err != nil {
 			return errors.Wrap(err, "unable to create bucket")
 		}
-		defer runutil.CloseWithLogOnErr(logger, bkt, "bucket client")
 
 		bkt = objstoretracing.WrapWithTraces(objstore.WrapWithMetrics(bkt, extprom.WrapRegistererWithPrefix("thanos_", reg), bkt.Name()))
 
 		tbcDir, err := os.OpenRoot(tbc.path)
 		if err != nil {
+			runutil.CloseWithLogOnErr(logger, bkt, "bucket client")
 			return errors.Wrap(err, "unable to open tbc directory")
 		}
-		defer tbcDir.Close()
 
 		s := shipper.New(
 			bkt,
@@ -1506,6 +1505,9 @@ func registerBucketUploadBlocks(app extkingpin.AppClause, objStoreConfig *extfla
 
 		ctx, cancel := context.WithCancel(context.Background())
 		g.Add(func() error {
+			defer runutil.CloseWithLogOnErr(logger, bkt, "bucket client")
+			defer runutil.CloseWithLogOnErr(logger, tbcDir, "tbc directory")
+
 			n, err := s.Sync(ctx)
 			if err != nil {
 				return errors.Wrap(err, "unable to sync blocks")

--- a/cmd/thanos/tools_bucket_test.go
+++ b/cmd/thanos/tools_bucket_test.go
@@ -1,0 +1,81 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/alecthomas/kingpin/v2"
+	"github.com/go-kit/log"
+	"github.com/oklog/run"
+	"github.com/opentracing/opentracing-go"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/prometheus/model/labels"
+
+	"github.com/efficientgo/core/testutil"
+
+	"github.com/thanos-io/thanos/pkg/block/metadata"
+	"github.com/thanos-io/thanos/pkg/compact/downsample"
+	"github.com/thanos-io/thanos/pkg/extkingpin"
+	"github.com/thanos-io/thanos/pkg/testutil/e2eutil"
+)
+
+func TestBucketUploadBlocksKeepsResourcesOpenDuringRun(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	blockDir := t.TempDir()
+	bucketDir := t.TempDir()
+
+	id, err := e2eutil.CreateBlock(
+		ctx,
+		blockDir,
+		[]labels.Labels{labels.FromStrings("__name__", "up", "job", "test")},
+		1,
+		0,
+		1000,
+		labels.EmptyLabels(),
+		downsample.ResLevel0,
+		metadata.NoneFunc,
+		nil,
+	)
+	testutil.Ok(t, err)
+
+	objstoreConfigPath := filepath.Join(t.TempDir(), "objstore.yml")
+	testutil.Ok(t, os.WriteFile(objstoreConfigPath, []byte(fmt.Sprintf(`type: FILESYSTEM
+config:
+  directory: %s
+`, bucketDir)), 0600))
+
+	app := extkingpin.NewApp(kingpin.New("test", "test"))
+	registerTools(app)
+
+	oldArgs := os.Args
+	os.Args = []string{
+		"test",
+		"tools",
+		"bucket",
+		"upload-blocks",
+		"--objstore.config-file=" + objstoreConfigPath,
+		"--path=" + blockDir,
+		`--label=tenant_id="example_tenant"`,
+	}
+	t.Cleanup(func() { os.Args = oldArgs })
+
+	cmd, setup := app.Parse()
+	testutil.Equals(t, "tools bucket upload-blocks", cmd)
+
+	var g run.Group
+	testutil.Ok(t, setup(&g, log.NewNopLogger(), prometheus.NewRegistry(), opentracing.NoopTracer{}, make(chan struct{}), false))
+	testutil.Ok(t, g.Run())
+
+	meta, err := metadata.ReadFromDir(filepath.Join(bucketDir, id.String()))
+	testutil.Ok(t, err)
+	testutil.Equals(t, "example_tenant", meta.Thanos.Labels["tenant_id"])
+}


### PR DESCRIPTION
## Summary
- keep upload-blocks bucket and local root resources open until the run actor finishes
- close the bucket client on the setup error path
- add a regression test that exercises the CLI setup/run boundary with a filesystem bucket

## Testing
- go test ./cmd/thanos