### PR TITLE
store: fix run-on sentence in request-samples flag help

### DIFF
--- a/docs/components/query.md
+++ b/docs/components/query.md
@@ -677,7 +677,7 @@ Flags:
                                  exceeded. 0 means no limit.
       --store.limits.request-samples=0
                                  The maximum samples allowed for a single
-                                 Series request, The Series call fails if
+                                 Series request. The Series call fails if
                                  this limit is exceeded. 0 means no limit.
                                  NOTE: For efficiency the limit is internally
                                  implemented as 'chunks limit' considering each

--- a/docs/components/receive.md
+++ b/docs/components/receive.md
@@ -465,7 +465,7 @@ Flags:
                                  exceeded. 0 means no limit.
       --store.limits.request-samples=0
                                  The maximum samples allowed for a single
-                                 Series request, The Series call fails if
+                                 Series request. The Series call fails if
                                  this limit is exceeded. 0 means no limit.
                                  NOTE: For efficiency the limit is internally
                                  implemented as 'chunks limit' considering each

--- a/docs/components/rule.md
+++ b/docs/components/rule.md
@@ -463,7 +463,7 @@ Flags:
                                  exceeded. 0 means no limit.
       --store.limits.request-samples=0
                                  The maximum samples allowed for a single
-                                 Series request, The Series call fails if
+                                 Series request. The Series call fails if
                                  this limit is exceeded. 0 means no limit.
                                  NOTE: For efficiency the limit is internally
                                  implemented as 'chunks limit' considering each

--- a/docs/components/sidecar.md
+++ b/docs/components/sidecar.md
@@ -240,7 +240,7 @@ Flags:
                                  exceeded. 0 means no limit.
       --store.limits.request-samples=0
                                  The maximum samples allowed for a single
-                                 Series request, The Series call fails if
+                                 Series request. The Series call fails if
                                  this limit is exceeded. 0 means no limit.
                                  NOTE: For efficiency the limit is internally
                                  implemented as 'chunks limit' considering each

--- a/docs/components/store.md
+++ b/docs/components/store.md
@@ -118,7 +118,7 @@ Flags:
                                  exceeded. 0 means no limit.
       --store.limits.request-samples=0
                                  The maximum samples allowed for a single
-                                 Series request, The Series call fails if
+                                 Series request. The Series call fails if
                                  this limit is exceeded. 0 means no limit.
                                  NOTE: For efficiency the limit is internally
                                  implemented as 'chunks limit' considering each

--- a/pkg/store/limiter.go
+++ b/pkg/store/limiter.go
@@ -112,7 +112,7 @@ type SeriesSelectLimits struct {
 
 func (l *SeriesSelectLimits) RegisterFlags(cmd extkingpin.FlagClause) {
 	cmd.Flag("store.limits.request-series", "The maximum series allowed for a single Series request. The Series call fails if this limit is exceeded. 0 means no limit.").Default("0").Uint64Var(&l.SeriesPerRequest)
-	cmd.Flag("store.limits.request-samples", "The maximum samples allowed for a single Series request, The Series call fails if this limit is exceeded. 0 means no limit. NOTE: For efficiency the limit is internally implemented as 'chunks limit' considering each chunk contains a maximum of 120 samples.").Default("0").Uint64Var(&l.SamplesPerRequest)
+	cmd.Flag("store.limits.request-samples", "The maximum samples allowed for a single Series request. The Series call fails if this limit is exceeded. 0 means no limit. NOTE: For efficiency the limit is internally implemented as 'chunks limit' considering each chunk contains a maximum of 120 samples.").Default("0").Uint64Var(&l.SamplesPerRequest)
 }
 
 var _ storepb.StoreServer = &limitedStoreServer{}


### PR DESCRIPTION
* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

The `--store.limits.request-samples` flag help joined two sentences with a comma instead of a period:

```
The maximum samples allowed for a single Series request, The Series call fails
if this limit is exceeded. ...
```

The immediately adjacent flag `--store.limits.request-series`, defined one line above in the same `RegisterFlags`, already uses a period in the identical phrasing ("... a single Series request. The Series call fails ..."), so the intended punctuation is unambiguous. This changes the stray comma to a period in `pkg/store/limiter.go` and regenerates the five component docs that embed the flag help (store, sidecar, query, receive, rule).

No flag name, default, or behavior changes; this is help-text wording only.

## Verification

- `go build ./cmd/thanos` passes.
- `./thanos store --help` now renders "... a single Series request. The Series call fails ...", matching the regenerated docs.
- `go test ./pkg/store/ -run TestLimiter -count=1` passes (no test asserts the help text; the limiter logic is unchanged).
- `gofmt -l pkg/store/limiter.go` and `go vet ./pkg/store/` are clean.
