### PR TITLE
Add missing partial response stategy check

### DIFF
--- a/pkg/api/query/grpc_test.go
+++ b/pkg/api/query/grpc_test.go
@@ -53,11 +53,12 @@ func TestGRPCQueryAPIWithQueryPlan(t *testing.T) {
 	testutil.Ok(t, err)
 
 	rangeRequest := &querypb.QueryRangeRequest{
-		Query:            "metric",
-		StartTimeSeconds: 0,
-		IntervalSeconds:  10,
-		EndTimeSeconds:   300,
-		QueryPlan:        &querypb.QueryPlan{Encoding: &querypb.QueryPlan_Json{Json: planBytes}},
+		Query:                 "metric",
+		StartTimeSeconds:      0,
+		IntervalSeconds:       10,
+		EndTimeSeconds:        300,
+		EnablePartialResponse: true,
+		QueryPlan:             &querypb.QueryPlan{Encoding: &querypb.QueryPlan_Json{Json: planBytes}},
 	}
 
 	srv := newQueryRangeServer(context.Background())
@@ -70,9 +71,10 @@ func TestGRPCQueryAPIWithQueryPlan(t *testing.T) {
 	testutil.Ok(t, err)
 
 	instantRequest := &querypb.QueryRequest{
-		Query:          "metric",
-		TimeoutSeconds: 60,
-		QueryPlan:      &querypb.QueryPlan{Encoding: &querypb.QueryPlan_Json{Json: planBytes}},
+		Query:                 "metric",
+		TimeoutSeconds:        60,
+		EnablePartialResponse: true,
+		QueryPlan:             &querypb.QueryPlan{Encoding: &querypb.QueryPlan_Json{Json: planBytes}},
 	}
 	instSrv := newQueryServer(context.Background())
 	err = api.Query(instantRequest, instSrv)
@@ -170,6 +172,7 @@ func (qs queryCreatorStub) makeInstantQuery(
 ) (res promql.Query, err error) {
 	return queryStub{err: qs.err, warns: qs.warns, result: qs.result}, nil
 }
+
 func (qs queryCreatorStub) makeRangeQuery(
 	ctx context.Context,
 	t PromqlEngineType,

--- a/pkg/query/query_test.go
+++ b/pkg/query/query_test.go
@@ -102,7 +102,7 @@ func TestQuerier_Proxy(t *testing.T) {
 				nil,
 				nil,
 				0,
-				false,
+				true,
 				false,
 				nil,
 				NoopSeriesStatsReporter,

--- a/pkg/store/proxy.go
+++ b/pkg/store/proxy.go
@@ -316,7 +316,7 @@ func (s *ProxyStore) Series(originalRequest *storepb.SeriesRequest, seriesSrv st
 
 	// There are no stores registered at all and partial results are disabled, return an error.
 	stores := s.stores()
-	if originalRequest.PartialResponseDisabled && len(stores) == 0 {
+	if len(stores) == 0 && (originalRequest.PartialResponseDisabled || originalRequest.PartialResponseStrategy == storepb.PartialResponseStrategy_ABORT) {
 		level.Debug(reqLogger).Log("err", ErrorNoStoresAvailable)
 		return ErrorNoStoresAvailable
 	}

--- a/pkg/store/proxy_test.go
+++ b/pkg/store/proxy_test.go
@@ -123,6 +123,16 @@ func TestProxyStore_Series(t *testing.T) {
 			expectedErr: ErrorNoStoresAvailable, // No stored registered at all.
 		},
 		{
+			title: "no storeAPI available with abort partial response strategy",
+			req: &storepb.SeriesRequest{
+				MinTime:                 1,
+				MaxTime:                 300,
+				Matchers:                []storepb.LabelMatcher{{Name: "a", Value: "a", Type: storepb.LabelMatcher_EQ}},
+				PartialResponseStrategy: storepb.PartialResponseStrategy_ABORT,
+			},
+			expectedErr: ErrorNoStoresAvailable, // No stored registered at all.
+		},
+		{
 			title: "no storeAPI available for 301-302 time range",
 			storeAPIs: []Client{
 				&storetestutil.TestClient{


### PR DESCRIPTION
In https://github.com/thanos-io/thanos/pull/8889 we've added a check on the number of stores registered, also guarded on partial response, but it seems that there are two ways partial response is signaled to the engine:
- PartialResponseDisabled == false
- PartialResponseStrategy == PartialResponseStrategy_WARN

Original PR only uses first, but not the second. Also check second field.

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
