### PR TITLE
fix(store): release label values read lock

### DIFF
--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -2142,6 +2142,7 @@ func (s *BucketStore) LabelValues(ctx context.Context, req *storepb.LabelValuesR
 		if !hasMetricNameEqMatcher && len(reqSeriesMatchersNoExtLabels) > 0 && !b.extLset.Has(req.Label) {
 			m, err := labels.NewMatcher(labels.MatchNotEqual, req.Label, "")
 			if err != nil {
+				s.mtx.RUnlock()
 				return nil, status.Error(codes.InvalidArgument, err.Error())
 			}
 


### PR DESCRIPTION
## Summary
- Release BucketStore read lock before returning from LabelValues matcher creation error path.
- Fixes GCL1001 report for s.mtx RLock without matching RUnlock.

## Root cause
LabelValues acquires s.mtx.RLock before iterating blocks, then can return early if labels.NewMatcher fails while the read lock is still held.

## Validation
- git diff --check
- gofmt -w pkg/store/bucket.go

## Local check notes
- golangci-lint run ./... --timeout=300s fails on existing unrelated goconst/staticcheck/unparam findings outside this change.
- golangci-lint run ./pkg/store --timeout=300s fails on existing unrelated goconst findings.
- go test ./pkg/store and go test ./pkg/store -run 'Test.*LabelValues' fail locally under go1.26.4 darwin/arm64 with runtime OOM/segfault in existing test setup paths.