### PR TITLE
fix(store): release label values read lock

### DIFF
--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -2142,6 +2142,7 @@ func (s *BucketStore) LabelValues(ctx context.Context, req *storepb.LabelValuesR
 		if !hasMetricNameEqMatcher && len(reqSeriesMatchersNoExtLabels) > 0 && !b.extLset.Has(req.Label) {
 			m, err := labels.NewMatcher(labels.MatchNotEqual, req.Label, "")
 			if err != nil {
+				s.mtx.RUnlock()
 				return nil, status.Error(codes.InvalidArgument, err.Error())
 			}
 


### PR DESCRIPTION
## Summary
- Release BucketStore read lock before returning from the LabelValues matcher creation error path.
- Fixes a lock leak reported by [goconcurrencylint](https://github.com/sanbricio/goconcurrencylint): GCL1001, s.mtx is rlocked but not runlocked.

## Root cause
LabelValues acquires s.mtx.RLock before iterating blocks, then can return early if labels.NewMatcher fails before the final s.mtx.RUnlock runs.

## Validation
- gofmt -w pkg/store/bucket.go
- git diff --check