### PR TITLE
receive: don't abort OTLP sum conversion on zero start timestamp

### DIFF
--- a/pkg/receive/otlptranslator/number_data_points.go
+++ b/pkg/receive/otlptranslator/number_data_points.go
@@ -105,7 +105,7 @@ func (c *PrometheusConverter) addSumNumberDataPoints(ctx context.Context, dataPo
 		if settings.ExportCreatedMetric && metric.Sum().IsMonotonic() {
 			startTimestamp := pt.StartTimestamp()
 			if startTimestamp == 0 {
-				return nil
+				continue
 			}
 
 			createdLabels := make([]labelpb.ZLabel, len(lbls))

--- a/pkg/receive/otlptranslator/number_data_points_test.go
+++ b/pkg/receive/otlptranslator/number_data_points_test.go
@@ -204,6 +204,49 @@ func TestPrometheusConverter_addSumNumberDataPoints(t *testing.T) {
 			},
 		},
 		{
+			name: "monotonic cumulative sum with missing start time on first point still converts later points",
+			metric: func() pmetric.Metric {
+				metric := pmetric.NewMetric()
+				metric.SetName("test_sum")
+				metric.SetEmptySum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+				metric.SetEmptySum().SetIsMonotonic(true)
+
+				dpNoStart := metric.Sum().DataPoints().AppendEmpty()
+				dpNoStart.SetDoubleValue(1)
+				dpNoStart.SetTimestamp(ts)
+
+				dpWithStart := metric.Sum().DataPoints().AppendEmpty()
+				dpWithStart.SetDoubleValue(2)
+				dpWithStart.SetTimestamp(ts + 1)
+				dpWithStart.SetStartTimestamp(ts)
+
+				return metric
+			},
+			want: func() map[uint64]*prompb.TimeSeries {
+				labels := []labelpb.ZLabel{
+					{Name: model.MetricNameLabel, Value: "test_sum"},
+				}
+				createdLabels := []labelpb.ZLabel{
+					{Name: model.MetricNameLabel, Value: "test_sum" + createdSuffix},
+				}
+				return map[uint64]*prompb.TimeSeries{
+					timeSeriesSignature(labels): {
+						Labels: labels,
+						Samples: []prompb.Sample{
+							{Value: 1, Timestamp: convertTimeStamp(ts)},
+							{Value: 2, Timestamp: convertTimeStamp(ts + 1)},
+						},
+					},
+					timeSeriesSignature(createdLabels): {
+						Labels: createdLabels,
+						Samples: []prompb.Sample{
+							{Value: float64(convertTimeStamp(ts)), Timestamp: convertTimeStamp(ts + 1)},
+						},
+					},
+				}
+			},
+		},
+		{
 			name: "non-monotonic cumulative sum with start time",
 			metric: func() pmetric.Metric {
 				metric := pmetric.NewMetric()


### PR DESCRIPTION
* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

In `pkg/receive/otlptranslator`, `addSumNumberDataPoints` iterates over every data point of a sum metric. Inside that per-data-point loop, the `ExportCreatedMetric` branch returned from the whole function when a monotonic sum point had a zero start timestamp.

Because the return sits inside the loop, a single point with a missing start timestamp abandons the whole metric: the samples and exemplars of every later data point in that same metric are silently dropped, so the produced `TimeSeries` is incomplete.

This changes that return to `continue`, so only the offending point's created-series emission is skipped while its own sample (already appended just above, before the guard) is kept and the loop proceeds to the remaining points. That guard-and-continue behavior matches what the sibling created-series paths in the same package already do for histograms and summaries, which guard with `startTimestamp != 0` and never early-return. The sum path was the lone outlier.

This file is a vendored copy of the OpenTelemetry collector-contrib `prometheusremotewrite` translation. Upstream collector-contrib has since removed the entire `ExportCreatedMetric` created-series block from `addSumNumberDataPoints` on main, so Thanos's copy is stale and still carries the latent loop-abandonment. Keeping the block and fixing the abort with `continue` is the smallest corrective change and preserves the created-series behavior that PR #8766 wants to enable.

Reachability: Thanos's own remote-write handler does not set `ExportCreatedMetric` today, so this branch is currently dormant in the default path. It is reachable through the exported translator `Settings`, and PR #8766 would turn it on. This fix is therefore a latent-correctness fix and a good companion to #8766.

## Verification

- Added a colocated regression subtest in `pkg/receive/otlptranslator/number_data_points_test.go`: a monotonic cumulative sum with two data points where the first has no start timestamp and the second has a start timestamp, converted with `Settings{ExportCreatedMetric: true}`. It asserts both samples are present plus the second point's `_created` series.
- Confirmed red -> green: with the original return the new subtest fails; with `continue` it passes.
- `go test ./pkg/receive/otlptranslator/ -tags=slicelabels -run TestPrometheusConverter_addSumNumberDataPoints -count=1 -v` -> PASS.
- `go test ./pkg/receive/otlptranslator/ -tags=slicelabels -race -count=1` -> ok.
- `go test ./pkg/receive/otlptranslator/ -tags=slicelabels -count=1` -> ok.
- `gofmt -l` on both changed files -> clean; `go vet -tags=slicelabels ./pkg/receive/otlptranslator/` -> clean.
- `go build ./cmd/thanos` -> OK.
