### PR TITLE
fix(receive): guard peerGroup.reset with p.m mutex

### DIFF
--- a/pkg/receive/handler.go
+++ b/pkg/receive/handler.go
@@ -1804,6 +1804,9 @@ func (p *peerGroup) isPeerUp(addr Endpoint) bool {
 }
 
 func (p *peerGroup) reset() {
+	p.m.Lock()
+	defer p.m.Unlock()
+
 	p.expBackoff.Reset()
 	p.peerStates = make(map[Endpoint]*retryState)
 }

--- a/pkg/receive/handler_test.go
+++ b/pkg/receive/handler_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/go-kit/log"
 	"github.com/gogo/protobuf/proto"
 	"github.com/golang/snappy"
+	"github.com/jpillora/backoff"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
@@ -2317,5 +2318,55 @@ func TestHandlerFlippingHashrings(t *testing.T) {
 
 	<-time.After(1 * time.Second)
 	cancel()
+	wg.Wait()
+}
+
+// TestPeerGroupResetRace exercises peerGroup.reset() (called on the hashring
+// reload path under Handler.mtx) concurrently with the p.m-guarded accessors
+// that in-flight forward callbacks use (markPeerUnavailable, markPeerAvailable,
+// isPeerUp). reset() must take p.m or it races the peerStates map and
+// expBackoff. Run with -race to catch the regression.
+func TestPeerGroupResetRace(t *testing.T) {
+	t.Parallel()
+
+	endpoint := Endpoint{Address: "http://localhost:9090"}
+	p := &peerGroup{
+		peerStates: make(map[Endpoint]*retryState),
+		expBackoff: backoff.Backoff{
+			Factor: 2,
+			Min:    100 * time.Millisecond,
+			Max:    30 * time.Second,
+			Jitter: true,
+		},
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(4)
+
+	go func() {
+		defer wg.Done()
+		for range 1000 {
+			p.reset()
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for range 1000 {
+			p.markPeerUnavailable(endpoint)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for range 1000 {
+			p.markPeerAvailable(endpoint)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for range 1000 {
+			p.isPeerUp(endpoint)
+		}
+	}()
+
 	wg.Wait()
 }


### PR DESCRIPTION
## Summary

Guard `peerGroup.reset()` with the peer group mutex before it resets peer backoff
state and replaces the `peerStates` map.

All other accessors for those fields (`markPeerAvailable`,
`markPeerUnavailableUnlocked`, and `isPeerUp`) already use `p.m`. During a
hashring reload, `reset()` can run while in-flight forwarding callbacks are still
checking or updating peer state, so using the same mutex keeps the reset path
consistent with the rest of the peer group state handling.

This also adds a race regression test that exercises `reset()` concurrently with
peer availability updates and reads.

## Testing

- `go test ./pkg/receive/ -tags=slicelabels -race -run TestPeerGroupResetRace -count=1`
- `go test ./pkg/receive/ -tags=slicelabels -run TestPeerGroupResetRace -count=1`
- `go build ./cmd/thanos`
