### PR TITLE
receive: fix a few bugs

### DIFF
--- a/pkg/receive/head_series_limiter.go
+++ b/pkg/receive/head_series_limiter.go
@@ -20,6 +20,8 @@ import (
 	"github.com/thanos-io/thanos/pkg/promclient"
 )
 
+const tenantLabel = "tenant"
+
 // headSeriesLimit implements headSeriesLimiter interface.
 type headSeriesLimit struct {
 	mtx                    sync.RWMutex
@@ -47,13 +49,13 @@ func NewHeadSeriesLimit(w WriteLimitsConfig, registerer prometheus.Registerer, l
 			prometheus.GaugeOpts{
 				Name: "thanos_receive_head_series_limit",
 				Help: "The configured limit for active (head) series of tenants.",
-			}, []string{"tenant"},
+			}, []string{tenantLabel},
 		),
 		limitedRequests: promauto.With(registerer).NewCounterVec(
 			prometheus.CounterOpts{
 				Name: "thanos_receive_head_series_limited_requests_total",
 				Help: "The total number of remote write requests that have been dropped due to active series limiting.",
-			}, []string{"tenant"},
+			}, []string{tenantLabel},
 		),
 		metaMonitoringErr: promauto.With(registerer).NewCounter(
 			prometheus.CounterOpts{
@@ -120,9 +122,9 @@ func (h *headSeriesLimit) QueryMetaMonitoring(ctx context.Context) error {
 	// Construct map of tenant name and current head series.
 	for _, e := range vectorRes {
 		for k, v := range e.Metric {
-			if k == "tenant" {
+			if k == tenantLabel {
 				h.tenantCurrentSeriesMap[string(v)] = float64(e.Value)
-				level.Debug(h.logger).Log("msg", "tenant value queried", "tenant", string(v), "value", e.Value)
+				level.Debug(h.logger).Log("msg", "tenant value queried", tenantLabel, string(v), "value", e.Value)
 			}
 		}
 	}
@@ -162,7 +164,7 @@ func (h *headSeriesLimit) isUnderLimit(tenant string) (bool, error) {
 	}
 
 	if v >= float64(limit) {
-		level.Error(h.logger).Log("msg", "tenant above limit", "tenant", tenant, "currentSeries", v, "limit", limit)
+		level.Error(h.logger).Log("msg", "tenant above limit", tenantLabel, tenant, "currentSeries", v, "limit", limit)
 		h.limitedRequests.WithLabelValues(tenant).Inc()
 		return false, nil
 	}

--- a/pkg/receive/multitsdb.go
+++ b/pkg/receive/multitsdb.go
@@ -576,6 +576,10 @@ func (t *tenant) close(cd closeDelete) {
 	t.closeOnce.Do(func() {
 		close(t.doneC)
 
+		if t.reg != nil {
+			t.reg.UnregisterAll()
+		}
+
 		// NOTE(GiedriusS): on paper, we could Close() again but the TSDB's Close() function is not idempotent.
 		// If storage starts erroring out then we are hosed anyway, so just log an error.
 		if err := t.tsdb.Close(); err != nil {
@@ -637,9 +641,6 @@ func (t *tenant) set(storeTSDB *store.TSDBStore, tenantTSDB *tsdb.DB, ship *ship
 func (t *tenant) setComponents(storeTSDB *store.TSDBStore, ship *shipper.Shipper, exemplarsTSDB *exemplars.TSDB, tenantTSDB *tsdb.DB, reg *UnRegisterer) {
 	if storeTSDB == nil && t.storeTSDB != nil {
 		t.storeTSDB.Close()
-	}
-	if reg == nil && t.reg != nil {
-		t.reg.UnregisterAll()
 	}
 	t.storeTSDB = storeTSDB
 	t.reg = reg
@@ -935,7 +936,8 @@ func (t *MultiTSDB) TenantStats(limit int, statsByLabelName string, tenantIDs ..
 
 func (t *MultiTSDB) startTSDB(logger log.Logger, tenantID string, tenant *tenant) error {
 	reg := prometheus.WrapRegistererWith(prometheus.Labels{"tenant": tenantID}, t.reg)
-	reg = NewUnRegisterer(reg)
+	unreg := NewUnRegisterer(reg)
+	reg = unreg
 
 	initialLset := labelpb.ExtendSortedLabels(t.labels, labels.FromStrings(t.tenantLabelName, tenantID))
 	lset := t.extractTenantsLabels(tenantID, initialLset)
@@ -1004,6 +1006,7 @@ func (t *MultiTSDB) startTSDB(logger log.Logger, tenantID string, tenant *tenant
 		nil,
 	)
 	if err != nil {
+		unreg.UnregisterAll()
 		t.removeTenantLocked(tenantID)
 		return err
 	}
@@ -1018,6 +1021,9 @@ func (t *MultiTSDB) startTSDB(logger log.Logger, tenantID string, tenant *tenant
 		// shipDataDir must be closed together with tenant
 		shipDataDir, err := os.OpenRoot(dataDir)
 		if err != nil {
+			s.Close()
+			unreg.UnregisterAll()
+			t.removeTenantLocked(tenantID)
 			return err
 		}
 		ship = shipper.New(
@@ -1269,7 +1275,6 @@ func (u *UnRegisterer) MustRegister(cs ...prometheus.Collector) {
 			panic(err)
 		}
 	}
-	u.collectors = append(u.collectors, cs...)
 }
 
 // extractTenantsLabels extracts tenant's external labels from hashring configs.

--- a/pkg/receive/multitsdb_test.go
+++ b/pkg/receive/multitsdb_test.go
@@ -549,6 +549,67 @@ func TestMultiTSDBRecreatePrunedTenant(t *testing.T) {
 
 }
 
+// tenantMetricCount returns how many gathered metric series carry the
+// tenant="<tenant>" label that startTSDB attaches to a tenant's TSDB metrics.
+func tenantMetricCount(t *testing.T, g prometheus.Gatherer, tenant string) int {
+	t.Helper()
+	mfs, err := g.Gather()
+	testutil.Ok(t, err)
+	count := 0
+	for _, mf := range mfs {
+		for _, metric := range mf.GetMetric() {
+			for _, lp := range metric.GetLabel() {
+				if lp.GetName() == "tenant" && lp.GetValue() == tenant {
+					count++
+				}
+			}
+		}
+	}
+	return count
+}
+
+// TestMultiTSDBPruneUnregistersMetrics verifies that pruning (deleting) a tenant
+// unregisters all of its TSDB metric collectors. Otherwise scrapes keep
+// collecting dynamic gauges (e.g. the chunks_head directory size) against a data
+// directory that has been removed, logging errors such as
+// "lstat .../chunks_head: no such file or directory".
+func TestMultiTSDBPruneUnregistersMetrics(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		dir := t.TempDir()
+
+		reg := prometheus.NewRegistry()
+		m := NewMultiTSDB(openTestRoot(t, dir), log.NewLogfmtLogger(os.Stderr), reg,
+			&tsdb.Options{
+				MinBlockDuration:  (2 * time.Hour).Milliseconds(),
+				MaxBlockDuration:  (2 * time.Hour).Milliseconds(),
+				RetentionDuration: (6 * time.Hour).Milliseconds(),
+			},
+			labels.FromStrings("replica", "test"),
+			"tenant_id",
+			nil,
+			false,
+			false,
+			metadata.NoneFunc,
+			WithGCImmediately(),
+		)
+		defer m.Close()
+
+		testutil.Ok(t, appendSample(m, "foo", time.UnixMilli(int64(10))))
+		testutil.Assert(t, tenantMetricCount(t, reg, "foo") > 0, "tenant TSDB metrics should be registered")
+
+		time.Sleep(5 * time.Hour)
+		synctest.Wait()
+		testutil.Ok(t, m.Prune(context.Background()))
+		testutil.Equals(t, 0, len(m.TSDBLocalClients()))
+
+		// All per-tenant collectors must be gone and gathering must not error
+		// even though the tenant's data directory was removed.
+		testutil.Equals(t, 0, tenantMetricCount(t, reg, "foo"))
+		_, err := reg.Gather()
+		testutil.Ok(t, err)
+	})
+}
+
 // synctest.Test controls fake time so t.Parallel() is not used.
 func TestPeriodicHeadCompaction(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {

--- a/pkg/receive/multitsdb_test.go
+++ b/pkg/receive/multitsdb_test.go
@@ -521,7 +521,8 @@ func TestMultiTSDBRecreatePrunedTenant(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		dir := t.TempDir()
 
-		m := NewMultiTSDB(openTestRoot(t, dir), log.NewLogfmtLogger(os.Stderr), prometheus.NewRegistry(),
+		reg := prometheus.NewRegistry()
+		m := NewMultiTSDB(openTestRoot(t, dir), log.NewLogfmtLogger(os.Stderr), reg,
 			&tsdb.Options{
 				MinBlockDuration:  (2 * time.Hour).Milliseconds(),
 				MaxBlockDuration:  (2 * time.Hour).Milliseconds(),
@@ -538,10 +539,14 @@ func TestMultiTSDBRecreatePrunedTenant(t *testing.T) {
 		defer m.Close()
 
 		testutil.Ok(t, appendSample(m, "foo", time.UnixMilli(int64(10))))
+		testutil.Assert(t, tenantMetricCount(t, reg, "foo") > 0, "tenant TSDB metrics should be registered")
 		time.Sleep(5 * time.Hour)
 		synctest.Wait()
 		testutil.Ok(t, m.Prune(context.Background()))
 		testutil.Equals(t, 0, len(m.TSDBLocalClients()))
+		testutil.Assert(t, tenantMetricCount(t, reg, "foo") == 0, "tenant TSDB metrics should be not registered")
+		_, err := reg.Gather()
+		testutil.Ok(t, err)
 
 		testutil.Ok(t, appendSample(m, "foo", time.UnixMilli(int64(10))))
 		testutil.Equals(t, 1, len(m.TSDBLocalClients()))
@@ -566,48 +571,6 @@ func tenantMetricCount(t *testing.T, g prometheus.Gatherer, tenant string) int {
 		}
 	}
 	return count
-}
-
-// TestMultiTSDBPruneUnregistersMetrics verifies that pruning (deleting) a tenant
-// unregisters all of its TSDB metric collectors. Otherwise scrapes keep
-// collecting dynamic gauges (e.g. the chunks_head directory size) against a data
-// directory that has been removed, logging errors such as
-// "lstat .../chunks_head: no such file or directory".
-func TestMultiTSDBPruneUnregistersMetrics(t *testing.T) {
-	synctest.Test(t, func(t *testing.T) {
-		dir := t.TempDir()
-
-		reg := prometheus.NewRegistry()
-		m := NewMultiTSDB(openTestRoot(t, dir), log.NewLogfmtLogger(os.Stderr), reg,
-			&tsdb.Options{
-				MinBlockDuration:  (2 * time.Hour).Milliseconds(),
-				MaxBlockDuration:  (2 * time.Hour).Milliseconds(),
-				RetentionDuration: (6 * time.Hour).Milliseconds(),
-			},
-			labels.FromStrings("replica", "test"),
-			"tenant_id",
-			nil,
-			false,
-			false,
-			metadata.NoneFunc,
-			WithGCImmediately(),
-		)
-		defer m.Close()
-
-		testutil.Ok(t, appendSample(m, "foo", time.UnixMilli(int64(10))))
-		testutil.Assert(t, tenantMetricCount(t, reg, "foo") > 0, "tenant TSDB metrics should be registered")
-
-		time.Sleep(5 * time.Hour)
-		synctest.Wait()
-		testutil.Ok(t, m.Prune(context.Background()))
-		testutil.Equals(t, 0, len(m.TSDBLocalClients()))
-
-		// All per-tenant collectors must be gone and gathering must not error
-		// even though the tenant's data directory was removed.
-		testutil.Equals(t, 0, tenantMetricCount(t, reg, "foo"))
-		_, err := reg.Gather()
-		testutil.Ok(t, err)
-	})
 }
 
 // synctest.Test controls fake time so t.Parallel() is not used.

--- a/pkg/receive/writecapnp/write_request.go
+++ b/pkg/receive/writecapnp/write_request.go
@@ -55,7 +55,10 @@ func NewRequest(wr TimeSeriesTenantTuple, symTable Symbols, tenant string) (*Req
 		return nil, err
 	}
 
-	strings, _ := symbolsPool.Get(offsets.Len())
+	strings, err := symbolsPool.Get(offsets.Len())
+	if err != nil {
+		return nil, err
+	}
 	start := uint32(0)
 	for i := 0; i < offsets.Len(); i++ {
 		end := offsets.At(i)


### PR DESCRIPTION
- Properly call closers when an error occurs
- Do not append to the collectors slice in the unregisterer because the other method does that already
