### PR TITLE
fix(store): correct estimated-max-chunk-size default in flag help

### DIFF
--- a/cmd/thanos/store.go
+++ b/cmd/thanos/store.go
@@ -169,7 +169,7 @@ func (sc *storeConfig) registerFlag(cmd extkingpin.FlagClause) {
 	cmd.Flag("debug.estimated-max-series-size", "Estimated max series size. Setting a value might result in over fetching data while a small value might result in data refetch. Default value is 64KB.").
 		Hidden().Default(strconv.Itoa(store.EstimatedMaxSeriesSize)).Uint64Var(&sc.estimatedMaxSeriesSize)
 
-	cmd.Flag("debug.estimated-max-chunk-size", "Estimated max chunk size. Setting a value might result in over fetching data while a small value might result in data refetch. Default value is 16KiB.").
+	cmd.Flag("debug.estimated-max-chunk-size", "Estimated max chunk size. Setting a value might result in over fetching data while a small value might result in data refetch. Default value is 16000.").
 		Hidden().Default(strconv.Itoa(store.EstimatedMaxChunkSize)).Uint64Var(&sc.estimatedMaxChunkSize)
 
 	sc.filterConf = &store.FilterConfig{}


### PR DESCRIPTION

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

The hidden `--debug.estimated-max-chunk-size` store flag advertised a default of
`16KiB` in its help text, but its registered default is
`store.EstimatedMaxChunkSize`, which is `16000` bytes (`16KiB` would be `16384`).
This corrects the help string to say `16000` so it matches the actual default.

For contrast, the sibling flag `--debug.estimated-max-series-size` is already
consistent: it says `64KB` and its constant `store.EstimatedMaxSeriesSize` is
`64 * 1024`.

```diff
- ... Default value is 16KiB.
+ ... Default value is 16000.
```

I used the literal `16000` (rather than an approximation like `~16KB`) so the
help matches `strconv.Itoa(store.EstimatedMaxChunkSize)` exactly. The constant is
not a power of two, and this is also how the value is already described elsewhere
(the CHANGELOG for #2956 refers to "chunks bigger than 16000 bytes").

There is no behavior change: only the help string is corrected, the backing
constant is untouched.

## Verification

- `go build ./cmd/thanos ./pkg/store` passes; `gofmt -l cmd/thanos/store.go` is
  clean; `go vet ./cmd/thanos` is clean.
- Built the binary and confirmed it no longer emits `16KiB` and now emits `16000`
  for this flag's default.
- The flag is `Hidden()`, so it is not rendered into `--help`/`--help-long` or
  into any generated flag table under `docs/`; there is nothing to regenerate and
  `check-docs` is unaffected (no `docs/` file references this flag or the old
  string).
