### PR TITLE
docs: fix wrong --query.tenant-header flag name in query tenancy section

### DIFF
--- a/docs/components/query.md
+++ b/docs/components/query.md
@@ -285,7 +285,7 @@ Tenant information is captured in relevant Thanos exported metrics in the Querie
 
 ### Tenant Enforcement
 
-Enforcement of tenancy can be enabled using `--query.enforce-tenancy`. If enabled, queries will only fetch series containing a specific matcher, while evaluating PromQL expressions. The matcher label name is `--query.tenant-label-name` and the matcher value matches the tenant, as sent to the querier in the HTTP header configured with `--query-tenant-header`. This functionality requires that metrics are injected with a tenant label when ingested into Thanos. This can be done for example by enabling tenancy in the Thanos Receive component.
+Enforcement of tenancy can be enabled using `--query.enforce-tenancy`. If enabled, queries will only fetch series containing a specific matcher, while evaluating PromQL expressions. The matcher label name is `--query.tenant-label-name` and the matcher value matches the tenant, as sent to the querier in the HTTP header configured with `--query.tenant-header`. This functionality requires that metrics are injected with a tenant label when ingested into Thanos. This can be done for example by enabling tenancy in the Thanos Receive component.
 
 In case of nested Thanos Query components, it's important to note that tenancy enforcement will only occur in the querier which the initial request is sent to, the layered queriers will not perform any enforcement.
 


### PR DESCRIPTION
In the Querier tenancy docs, the enforcement paragraph refers to the tenant header flag as `--query-tenant-header` (all dashes), but the registered flag is `--query.tenant-header` (dotted, `cmd/thanos/query.go`). The paragraph immediately above already uses the correct `--query.tenant-header`, so acting on the enforcement paragraph as written points at a flag that does not exist. This fixes the single inconsistent reference.

Docs only.