### PR TITLE
*: add --auto-gomemlimit.refresh-interval flag to periodically refresh GOMEMLIMIT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 ### Added
 
 - [#8882](https://github.com/thanos-io/thanos/pull/8882) Receive: implement multi-tenant writes; greatly improves throughput when using the split tenant label functionality.
+- [#8906](https://github.com/thanos-io/thanos/pull/8906) *: Add `--auto-gomemlimit.refresh-interval` flag to periodically refresh GOMEMLIMIT from the detected container or system memory limit, so in-place container memory resizes are picked up. Defaults to `0` (no refresh, previous behavior).
 - [#8876](https://github.com/thanos-io/thanos/pull/8876): Query-Frontend: Reuse compatible lower-step query range cache entries by subsampling cached responses.
 
 ### Fixed

--- a/cmd/thanos/config.go
+++ b/cmd/thanos/config.go
@@ -347,6 +347,7 @@ func parseFlagLabels(s []string) (labels.Labels, error) {
 type goMemLimitConfig struct {
 	enableAutoGoMemlimit bool
 	memlimitRatio        float64
+	memlimitRefresh      time.Duration
 }
 
 func (gml *goMemLimitConfig) registerFlag(cmd extkingpin.FlagClause) *goMemLimitConfig {
@@ -357,6 +358,10 @@ func (gml *goMemLimitConfig) registerFlag(cmd extkingpin.FlagClause) *goMemLimit
 	cmd.Flag("auto-gomemlimit.ratio",
 		"The ratio of reserved GOMEMLIMIT memory to the detected maximum container or system memory.").
 		Default("0.9").FloatVar(&gml.memlimitRatio)
+
+	cmd.Flag("auto-gomemlimit.refresh-interval",
+		"Interval at which the detected maximum container or system memory is refreshed and GOMEMLIMIT is reapplied if it has changed. Useful when the container memory limit can be resized in place. 0 disables refreshing.").
+		Default("0").DurationVar(&gml.memlimitRefresh)
 
 	return gml
 }
@@ -371,6 +376,10 @@ func configureGoAutoMemLimit(common goMemLimitConfig) (int64, error) {
 		return limits, errors.New("--auto-gomemlimit.ratio must be greater than 0 and less than or equal to 1.")
 	}
 
+	if common.memlimitRefresh < 0 {
+		return limits, errors.New("--auto-gomemlimit.refresh-interval must be greater than or equal to 0.")
+	}
+
 	if common.enableAutoGoMemlimit {
 		limits, err = memlimit.SetGoMemLimitWithOpts(
 			memlimit.WithRatio(common.memlimitRatio),
@@ -380,6 +389,7 @@ func configureGoAutoMemLimit(common goMemLimitConfig) (int64, error) {
 					memlimit.FromSystem,
 				),
 			),
+			memlimit.WithRefreshInterval(common.memlimitRefresh),
 		)
 		if err != nil {
 			return -1, errors.Wrap(err, "Failed to set GOMEMLIMIT automatically")

--- a/cmd/thanos/config_test.go
+++ b/cmd/thanos/config_test.go
@@ -1,0 +1,61 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/efficientgo/core/testutil"
+)
+
+func TestConfigureGoAutoMemLimitValidation(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name    string
+		config  goMemLimitConfig
+		wantErr bool
+	}{
+		{
+			name:    "disabled with defaults",
+			config:  goMemLimitConfig{enableAutoGoMemlimit: false, memlimitRatio: 0.9},
+			wantErr: false,
+		},
+		{
+			name:    "ratio zero",
+			config:  goMemLimitConfig{memlimitRatio: 0.0},
+			wantErr: true,
+		},
+		{
+			name:    "ratio negative",
+			config:  goMemLimitConfig{memlimitRatio: -0.5},
+			wantErr: true,
+		},
+		{
+			name:    "ratio greater than one",
+			config:  goMemLimitConfig{memlimitRatio: 1.1},
+			wantErr: true,
+		},
+		{
+			name:    "refresh interval negative",
+			config:  goMemLimitConfig{memlimitRatio: 0.9, memlimitRefresh: -time.Second},
+			wantErr: true,
+		},
+		{
+			name:    "disabled with refresh interval set",
+			config:  goMemLimitConfig{enableAutoGoMemlimit: false, memlimitRatio: 0.9, memlimitRefresh: time.Minute},
+			wantErr: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := configureGoAutoMemLimit(tc.config)
+			if tc.wantErr {
+				testutil.NotOk(t, err)
+			} else {
+				testutil.Ok(t, err)
+			}
+		})
+	}
+}

--- a/docs/components/compact.md
+++ b/docs/components/compact.md
@@ -303,6 +303,12 @@ Flags:
       --auto-gomemlimit.ratio=0.9
                                 The ratio of reserved GOMEMLIMIT memory to the
                                 detected maximum container or system memory.
+      --auto-gomemlimit.refresh-interval=0
+                                Interval at which the detected maximum container
+                                or system memory is refreshed and GOMEMLIMIT
+                                is reapplied if it has changed. Useful when the
+                                container memory limit can be resized in place.
+                                0 disables refreshing.
       --http-address="0.0.0.0:10902"
                                 Listen host:port for HTTP endpoints.
       --http-grace-period=2m    Time to wait after an interrupt received for

--- a/docs/components/query-frontend.md
+++ b/docs/components/query-frontend.md
@@ -225,6 +225,12 @@ Flags:
       --auto-gomemlimit.ratio=0.9
                                The ratio of reserved GOMEMLIMIT memory to the
                                detected maximum container or system memory.
+      --auto-gomemlimit.refresh-interval=0
+                               Interval at which the detected maximum container
+                               or system memory is refreshed and GOMEMLIMIT
+                               is reapplied if it has changed. Useful when the
+                               container memory limit can be resized in place.
+                               0 disables refreshing.
       --http-address="0.0.0.0:10902"
                                Listen host:port for HTTP endpoints.
       --http-grace-period=2m   Time to wait after an interrupt received for HTTP

--- a/docs/components/query.md
+++ b/docs/components/query.md
@@ -380,6 +380,12 @@ Flags:
       --auto-gomemlimit.ratio=0.9
                                  The ratio of reserved GOMEMLIMIT memory to the
                                  detected maximum container or system memory.
+      --auto-gomemlimit.refresh-interval=0
+                                 Interval at which the detected maximum
+                                 container or system memory is refreshed and
+                                 GOMEMLIMIT is reapplied if it has changed.
+                                 Useful when the container memory limit can be
+                                 resized in place. 0 disables refreshing.
       --http-address="0.0.0.0:10902"
                                  Listen host:port for HTTP endpoints.
       --http-grace-period=2m     Time to wait after an interrupt received for

--- a/docs/components/receive.md
+++ b/docs/components/receive.md
@@ -418,6 +418,12 @@ Flags:
       --auto-gomemlimit.ratio=0.9
                                  The ratio of reserved GOMEMLIMIT memory to the
                                  detected maximum container or system memory.
+      --auto-gomemlimit.refresh-interval=0
+                                 Interval at which the detected maximum
+                                 container or system memory is refreshed and
+                                 GOMEMLIMIT is reapplied if it has changed.
+                                 Useful when the container memory limit can be
+                                 resized in place. 0 disables refreshing.
       --http-address="0.0.0.0:10902"
                                  Listen host:port for HTTP endpoints.
       --http-grace-period=2m     Time to wait after an interrupt received for

--- a/docs/components/rule.md
+++ b/docs/components/rule.md
@@ -292,6 +292,12 @@ Flags:
       --auto-gomemlimit.ratio=0.9
                                  The ratio of reserved GOMEMLIMIT memory to the
                                  detected maximum container or system memory.
+      --auto-gomemlimit.refresh-interval=0
+                                 Interval at which the detected maximum
+                                 container or system memory is refreshed and
+                                 GOMEMLIMIT is reapplied if it has changed.
+                                 Useful when the container memory limit can be
+                                 resized in place. 0 disables refreshing.
       --http-address="0.0.0.0:10902"
                                  Listen host:port for HTTP endpoints.
       --http-grace-period=2m     Time to wait after an interrupt received for

--- a/docs/components/sidecar.md
+++ b/docs/components/sidecar.md
@@ -118,6 +118,12 @@ Flags:
       --auto-gomemlimit.ratio=0.9
                                  The ratio of reserved GOMEMLIMIT memory to the
                                  detected maximum container or system memory.
+      --auto-gomemlimit.refresh-interval=0
+                                 Interval at which the detected maximum
+                                 container or system memory is refreshed and
+                                 GOMEMLIMIT is reapplied if it has changed.
+                                 Useful when the container memory limit can be
+                                 resized in place. 0 disables refreshing.
       --http-address="0.0.0.0:10902"
                                  Listen host:port for HTTP endpoints.
       --http-grace-period=2m     Time to wait after an interrupt received for

--- a/docs/components/store.md
+++ b/docs/components/store.md
@@ -71,6 +71,12 @@ Flags:
       --auto-gomemlimit.ratio=0.9
                                  The ratio of reserved GOMEMLIMIT memory to the
                                  detected maximum container or system memory.
+      --auto-gomemlimit.refresh-interval=0
+                                 Interval at which the detected maximum
+                                 container or system memory is refreshed and
+                                 GOMEMLIMIT is reapplied if it has changed.
+                                 Useful when the container memory limit can be
+                                 resized in place. 0 disables refreshing.
       --http-address="0.0.0.0:10902"
                                  Listen host:port for HTTP endpoints.
       --http-grace-period=2m     Time to wait after an interrupt received for

--- a/docs/components/tools.md
+++ b/docs/components/tools.md
@@ -34,6 +34,12 @@ Flags:
       --auto-gomemlimit.ratio=0.9
                            The ratio of reserved GOMEMLIMIT memory to the
                            detected maximum container or system memory.
+      --auto-gomemlimit.refresh-interval=0
+                           Interval at which the detected maximum container
+                           or system memory is refreshed and GOMEMLIMIT
+                           is reapplied if it has changed. Useful when the
+                           container memory limit can be resized in place.
+                           0 disables refreshing.
 
 Subcommands:
 tools bucket verify [<flags>]
@@ -165,6 +171,12 @@ Flags:
       --auto-gomemlimit.ratio=0.9
                            The ratio of reserved GOMEMLIMIT memory to the
                            detected maximum container or system memory.
+      --auto-gomemlimit.refresh-interval=0
+                           Interval at which the detected maximum container
+                           or system memory is refreshed and GOMEMLIMIT
+                           is reapplied if it has changed. Useful when the
+                           container memory limit can be resized in place.
+                           0 disables refreshing.
       --objstore.config-file=<file-path>
                            Path to YAML file that contains object
                            store configuration. See format details:
@@ -274,6 +286,12 @@ Flags:
       --auto-gomemlimit.ratio=0.9
                                 The ratio of reserved GOMEMLIMIT memory to the
                                 detected maximum container or system memory.
+      --auto-gomemlimit.refresh-interval=0
+                                Interval at which the detected maximum container
+                                or system memory is refreshed and GOMEMLIMIT
+                                is reapplied if it has changed. Useful when the
+                                container memory limit can be resized in place.
+                                0 disables refreshing.
       --objstore.config-file=<file-path>
                                 Path to YAML file that contains object
                                 store configuration. See format details:
@@ -400,6 +418,12 @@ Flags:
       --auto-gomemlimit.ratio=0.9
                            The ratio of reserved GOMEMLIMIT memory to the
                            detected maximum container or system memory.
+      --auto-gomemlimit.refresh-interval=0
+                           Interval at which the detected maximum container
+                           or system memory is refreshed and GOMEMLIMIT
+                           is reapplied if it has changed. Useful when the
+                           container memory limit can be resized in place.
+                           0 disables refreshing.
       --objstore.config-file=<file-path>
                            Path to YAML file that contains object
                            store configuration. See format details:
@@ -486,6 +510,12 @@ Flags:
       --auto-gomemlimit.ratio=0.9
                              The ratio of reserved GOMEMLIMIT memory to the
                              detected maximum container or system memory.
+      --auto-gomemlimit.refresh-interval=0
+                             Interval at which the detected maximum container
+                             or system memory is refreshed and GOMEMLIMIT
+                             is reapplied if it has changed. Useful when the
+                             container memory limit can be resized in place.
+                             0 disables refreshing.
       --objstore.config-file=<file-path>
                              Path to YAML file that contains object
                              store configuration. See format details:
@@ -570,6 +600,12 @@ Flags:
       --auto-gomemlimit.ratio=0.9
                              The ratio of reserved GOMEMLIMIT memory to the
                              detected maximum container or system memory.
+      --auto-gomemlimit.refresh-interval=0
+                             Interval at which the detected maximum container
+                             or system memory is refreshed and GOMEMLIMIT
+                             is reapplied if it has changed. Useful when the
+                             container memory limit can be resized in place.
+                             0 disables refreshing.
       --objstore.config-file=<file-path>
                              Path to YAML file that contains object
                              store configuration. See format details:
@@ -635,6 +671,12 @@ Flags:
       --auto-gomemlimit.ratio=0.9
                               The ratio of reserved GOMEMLIMIT memory to the
                               detected maximum container or system memory.
+      --auto-gomemlimit.refresh-interval=0
+                              Interval at which the detected maximum container
+                              or system memory is refreshed and GOMEMLIMIT
+                              is reapplied if it has changed. Useful when the
+                              container memory limit can be resized in place.
+                              0 disables refreshing.
       --objstore.config-file=<file-path>
                               Path to YAML file that contains object
                               store configuration. See format details:
@@ -770,6 +812,12 @@ Flags:
       --auto-gomemlimit.ratio=0.9
                               The ratio of reserved GOMEMLIMIT memory to the
                               detected maximum container or system memory.
+      --auto-gomemlimit.refresh-interval=0
+                              Interval at which the detected maximum container
+                              or system memory is refreshed and GOMEMLIMIT
+                              is reapplied if it has changed. Useful when the
+                              container memory limit can be resized in place.
+                              0 disables refreshing.
       --objstore.config-file=<file-path>
                               Path to YAML file that contains object
                               store configuration. See format details:
@@ -878,6 +926,12 @@ Flags:
       --auto-gomemlimit.ratio=0.9
                            The ratio of reserved GOMEMLIMIT memory to the
                            detected maximum container or system memory.
+      --auto-gomemlimit.refresh-interval=0
+                           Interval at which the detected maximum container
+                           or system memory is refreshed and GOMEMLIMIT
+                           is reapplied if it has changed. Useful when the
+                           container memory limit can be resized in place.
+                           0 disables refreshing.
       --objstore.config-file=<file-path>
                            Path to YAML file that contains object
                            store configuration. See format details:
@@ -961,6 +1015,12 @@ Flags:
       --auto-gomemlimit.ratio=0.9
                             The ratio of reserved GOMEMLIMIT memory to the
                             detected maximum container or system memory.
+      --auto-gomemlimit.refresh-interval=0
+                            Interval at which the detected maximum container
+                            or system memory is refreshed and GOMEMLIMIT
+                            is reapplied if it has changed. Useful when the
+                            container memory limit can be resized in place.
+                            0 disables refreshing.
       --objstore.config-file=<file-path>
                             Path to YAML file that contains object
                             store configuration. See format details:
@@ -971,7 +1031,7 @@ Flags:
                             object store configuration. See format details:
                             https://thanos.io/tip/thanos/storage.md/#configuration
       --id=ID ...           ID (ULID) of the blocks for rewrite (repeated flag).
-      --tmp.dir="/tmp/thanos-rewrite"
+      --tmp.dir="/var/folders/h1/nkyfc5zj2zlbylk9sbw1m_100000gn/T/thanos-rewrite"
                             Working directory for temporary files
       --[no-]dry-run        Prints the series changes instead of doing them.
                             Defaults to true, for user to double check. (:
@@ -1042,6 +1102,12 @@ Flags:
       --auto-gomemlimit.ratio=0.9
                                The ratio of reserved GOMEMLIMIT memory to the
                                detected maximum container or system memory.
+      --auto-gomemlimit.refresh-interval=0
+                               Interval at which the detected maximum container
+                               or system memory is refreshed and GOMEMLIMIT
+                               is reapplied if it has changed. Useful when the
+                               container memory limit can be resized in place.
+                               0 disables refreshing.
       --objstore.config-file=<file-path>
                                Path to YAML file that contains object
                                store configuration. See format details:
@@ -1109,6 +1175,12 @@ Flags:
       --auto-gomemlimit.ratio=0.9
                            The ratio of reserved GOMEMLIMIT memory to the
                            detected maximum container or system memory.
+      --auto-gomemlimit.refresh-interval=0
+                           Interval at which the detected maximum container
+                           or system memory is refreshed and GOMEMLIMIT
+                           is reapplied if it has changed. Useful when the
+                           container memory limit can be resized in place.
+                           0 disables refreshing.
       --rules=RULES ...    The rule files glob to check (repeated).
 
 ```

--- a/docs/components/tools.md
+++ b/docs/components/tools.md
@@ -1031,7 +1031,7 @@ Flags:
                             object store configuration. See format details:
                             https://thanos.io/tip/thanos/storage.md/#configuration
       --id=ID ...           ID (ULID) of the blocks for rewrite (repeated flag).
-      --tmp.dir="/var/folders/h1/nkyfc5zj2zlbylk9sbw1m_100000gn/T/thanos-rewrite"
+      --tmp.dir="/tmp/thanos-rewrite"
                             Working directory for temporary files
       --[no-]dry-run        Prints the series changes instead of doing them.
                             Defaults to true, for user to double check. (:


### PR DESCRIPTION
* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Add `--auto-gomemlimit.refresh-interval` flag (default `0` = disabled, current
behavior). When set, it is passed to `memlimit.WithRefreshInterval(...)`, so
the cgroup memory limit is periodically re-read and GOMEMLIMIT reapplied if it
changed. The vendored automemlimit v0.7.5 already supports this — no dependency
changes.

## Motivation

GOMEMLIMIT is set only once at startup. With Kubernetes VPA in-place pod
resizing, the container memory limit can change without a restart: after a
decrease the GC still targets the old limit and the container gets OOM-killed,
after an increase the new memory is never used. The Go runtime itself does not
track cgroup memory limits (container-awareness in Go 1.25+ covers GOMAXPROCS
only), so a periodic refresh is needed.

## Verification

- New unit test `TestConfigureGoAutoMemLimitValidation` (flag validation).
- `go build`, `go vet`, `go test -short ./cmd/thanos/` pass.
- Verified end-to-end on local Kubernetes v1.36 with in-place pod resize
  (`kubectl patch --subresource resize`, `resizePolicy: NotRequired`), running
  `thanos query --enable-auto-gomemlimit --auto-gomemlimit.refresh-interval=5s`
  with a 512Mi limit:
  - startup: `go_gc_gomemlimit_bytes = 483183820` (0.9 × 512Mi)
  - resize to 1Gi: metric updated to `966367641` (0.9 × 1Gi) within the refresh interval
  - resize down to 640Mi: metric updated to `603979776` (0.9 × 640Mi)
  - zero container restarts throughout.
