### PR TITLE
docs(contributing): fix duplicate word and typo in contributing docs

### DIFF
--- a/docs/contributing/coding-style-guide.md
+++ b/docs/contributing/coding-style-guide.md
@@ -217,7 +217,7 @@ This is also why we recommend to scope errors if you can:
 	}
 ```
 
-While it's not yet configured, we might think consider not permitting variable shadowing with [`golang.org/x/tools/go/analysis/passes/shadow/cmd/shadow`](https://godoc.org/golang.org/x/tools/go/analysis/passes/shadow/cmd/shadow) in future. There was even Go 2 proposal for [disabling this in the language itself, but was rejected](https://github.com/golang/go/issues/21114):
+While it's not yet configured, we might consider not permitting variable shadowing with [`golang.org/x/tools/go/analysis/passes/shadow/cmd/shadow`](https://godoc.org/golang.org/x/tools/go/analysis/passes/shadow/cmd/shadow) in future. There was even Go 2 proposal for [disabling this in the language itself, but was rejected](https://github.com/golang/go/issues/21114):
 
 Similar to this problem is the package name shadowing. While it is less dangerous, it can cause similar issues, so avoid package shadowing if you can.
 

--- a/docs/contributing/committing.md
+++ b/docs/contributing/committing.md
@@ -2,7 +2,7 @@
 
 ## Prefer & run short tests
 
-Ideally, each test should be parallel i.e. not use any any shared state and run as fast as possible.
+Ideally, each test should be parallel i.e. not use any shared state and run as fast as possible.
 
 Consider using `synctest` to make the tests not timing dependent. If it is still not possible then please add this clause to your tests to skip them if `-short` is passed:
 


### PR DESCRIPTION
Signed-off-by: Akanksha Trehun <akankshatrehun@gmail.com>
