### PR TITLE
ci: skip broken pnpm 11.12.0

### DIFF
--- a/.github/workflows/react.yml
+++ b/.github/workflows/react.yml
@@ -22,7 +22,10 @@ jobs:
 
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
-          version: 11
+          # Exclude the broken pnpm 11.12.0 (self-installer crash, see
+          # https://github.com/pnpm/action-setup/issues/276) while still
+          # picking up future 11.x releases that fix it.
+          version: ">=11.0.0 <11.12.0 || >11.12.0 <12.0.0"
 
       - name: Install nodejs
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0


### PR DESCRIPTION
* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

Skips the broken pnpm 11.12.0 release in the React workflow.

pnpm 11.12.0 was released after #8907 merged. The existing `version: 11` configuration started resolving to it and now fails during `pnpm/action-setup`, before the React dependencies are installed, due to pnpm/action-setup#276.

Instead of pinning a stale exact version, this uses a semver range that excludes only 11.12.0 while staying on pnpm 11. This resolves to 11.11.0 today and will automatically pick up future pnpm 11 releases that fix the problem.

This mirrors the strategy used by prometheus/prometheus#19171.

## Verification

* The React workflow successfully installed pnpm 11.11.0 and passed in https://github.com/thanos-io/thanos/actions/runs/29140821662.
* `git diff --check` passes.
