### PR TITLE
ruler: speed up remote_write

### DIFF
--- a/cmd/thanos/rule.go
+++ b/cmd/thanos/rule.go
@@ -503,6 +503,11 @@ func runRule(
 		if err != nil {
 			return errors.Wrap(err, "start remote write agent db")
 		}
+		// We need to call SetWriteNotified() so that agendDB gets notified about every write.
+		// Without it we fallback to polling, which pulls new samples to write every 15s.
+		// If we don't call SetWriteNotified() we'll have up to 15s lag between rule evaluation
+		// and samples being sent over via remote_write.
+		agentDB.SetWriteNotified(remoteStore)
 		fanoutStore := storage.NewFanout(slogger, agentDB, remoteStore)
 		appendable = fanoutStore
 		// Use a separate queryable to restore the ALERTS firing states.


### PR DESCRIPTION
Call SetWriteNotified() on Ruler agent.DB, without it we fallback to poll. See:

- https://github.com/prometheus/prometheus/blob/v3.13.1/tsdb/agent/db.go#L371-L375
- https://github.com/prometheus/prometheus/blob/v3.13.1/tsdb/wlog/watcher.go#L461

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [X] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
