### PR TITLE
e2eutil: return real error on postings walk failure

### DIFF
--- a/pkg/testutil/e2eutil/prometheus.go
+++ b/pkg/testutil/e2eutil/prometheus.go
@@ -718,7 +718,7 @@ func gatherMaxSeriesSize(ctx context.Context, fn string) (int64, error) {
 		}
 		prevId = id
 	}
-	if p.Err() != nil {
+	if err := p.Err(); err != nil {
 		return 0, errors.Wrap(err, "walk postings")
 	}
 


### PR DESCRIPTION
gatherMaxSeriesSize checks p.Err() after walking the postings but wraps the
stale err from the earlier r.Postings call, not p.Err(). That err is always
nil here, and errors.Wrap(nil, ...) returns nil, so a postings walk failure is
dropped and the function returns a max series size of 0 with no error.

Same bug as #8890, in the remaining occurrence.

Fixes #8924

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

- pkg/testutil/e2eutil/prometheus.go: wrap p.Err() instead of the stale err in gatherMaxSeriesSize.

## Verification

go build and go vet pass on the package. Fix mirrors #8890.
