### PR TITLE
fix(store): close response body and finish span on unsupported content type

### DIFF
--- a/pkg/store/prometheus.go
+++ b/pkg/store/prometheus.go
@@ -214,6 +214,8 @@ func (p *PrometheusStore) Series(r *storepb.SeriesRequest, seriesSrv storepb.Sto
 	}
 
 	if !strings.HasPrefix(contentType, "application/x-streamed-protobuf; proto=prometheus.ChunkedReadResponse") {
+		runutil.CloseWithLogOnErr(p.logger, httpResp.Body, "unsupported content type response body")
+		queryPrometheusSpan.Finish()
 		return errors.Errorf("not supported remote read content type: %s", contentType)
 	}
 	return p.handleStreamedPrometheusResponse(s, shardMatcher, httpResp, queryPrometheusSpan, extLset, enableChunkHashCalculation, extLsetToRemove)


### PR DESCRIPTION
## Summary
- Fix HTTP response body and tracing span leak when Prometheus returns unexpected content type

## Bug
In `PrometheusStore.Series`, when the remote read response returns a content type that is neither `application/x-protobuf` nor `application/x-streamed-protobuf`, the error path returns without closing `httpResp.Body` or finishing `queryPrometheusSpan`. Both success paths correctly handle cleanup.

## Fix
Add `runutil.CloseWithLogOnErr` for the response body and `queryPrometheusSpan.Finish()` before the error return.
