### PR TITLE
fix(store): correct no-op slice element removal in matchesExternalLabels

### DIFF
--- a/pkg/exemplars/proxy.go
+++ b/pkg/exemplars/proxy.go
@@ -235,7 +235,7 @@ func matchesExternalLabels(ms []*labels.Matcher, externalLabels labels.Labels) (
 		extValue := externalLabels.Get(tm.Name)
 		if extValue == "" {
 			// Agnostic to external labels.
-			ms = append(ms[:i], ms[i:]...)
+			ms = append(ms[:i], ms[i+1:]...)
 			newMatchers = append(newMatchers, tm)
 			continue
 		}

--- a/pkg/store/prometheus.go
+++ b/pkg/store/prometheus.go
@@ -510,7 +510,7 @@ func matchesExternalLabels(ms []storepb.LabelMatcher, externalLabels labels.Labe
 		extValue := externalLabels.Get(tm.Name)
 		if extValue == "" {
 			// Agnostic to external labels.
-			tms = append(tms[:i], tms[i:]...)
+			tms = append(tms[:i], tms[i+1:]...)
 			newMatchers = append(newMatchers, tm)
 			continue
 		}


### PR DESCRIPTION
## Summary
- Fix no-op slice element removal in matchesExternalLabels in store and exemplars packages

## Bug
`append(tms[:i], tms[i:]...)` is a no-op — it reconstructs the same slice without removing element at index `i`. The correct expression is `append(tms[:i], tms[i+1:]...)`. This bug exists in both `pkg/store/prometheus.go` and `pkg/exemplars/proxy.go`.

## Fix
Change `tms[i:]...` to `tms[i+1:]...` in both files.
