### PR TITLE
store: check series set error in TSDBStore.LabelValues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 
 - [#8900](https://github.com/thanos-io/thanos/pull/8900): UI: Fix web UI static assets (JS/CSS) returning 404 on Windows by using slash-separated paths for the embedded file system.
 - [#8935](https://github.com/thanos-io/thanos/pull/8935): Receive: remove redundant tl.Set() while building a Capnp WriteRequest.
+- [#8932](https://github.com/thanos-io/thanos/pull/8932): Store: Return the series set error from `TSDBStore.LabelValues` instead of an empty response.
 
 ### Changed
 

--- a/pkg/store/tsdb.go
+++ b/pkg/store/tsdb.go
@@ -482,6 +482,9 @@ func (s *TSDBStore) LabelValues(ctx context.Context, r *storepb.LabelValuesReque
 		for set.Next() {
 			return &storepb.LabelValuesResponse{Values: []string{val}}, nil
 		}
+		if err := set.Err(); err != nil {
+			return nil, status.Error(codes.Internal, err.Error())
+		}
 		return &storepb.LabelValuesResponse{}, nil
 	}
 


### PR DESCRIPTION
TSDBStore.LabelValues selects series to decide whether an external label has a
value but never checks set.Err(). ChunkSeriesSet.Next() returns false on failure
as well as on completion, so a failed select is returned as an empty successful
response instead of an error.

TSDBStore.Series in the same file already checks set.Err() after the same
q.Select call.

Fixes #8931

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

- pkg/store/tsdb.go: return the series set error in LabelValues.

## Verification

go build and go vet pass on pkg/store.
