### PR TITLE
receive: pool slices/maps in hot path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -118,6 +118,7 @@ require (
 require (
 	github.com/VictoriaMetrics/easyproto v1.1.3
 	github.com/alecthomas/kingpin/v2 v2.4.0
+	github.com/colega/zeropool v0.0.0-20230505084239-6fb4a4f75381
 	github.com/oklog/ulid/v2 v2.1.1
 	github.com/prometheus/otlptranslator v1.0.0
 	github.com/tjhop/slog-gokit v0.1.4

--- a/go.sum
+++ b/go.sum
@@ -703,6 +703,8 @@ github.com/cncf/xds/go v0.0.0-20230310173818-32f1caf87195/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2 h1:aBangftG7EVZoUb69Os8IaYg++6uMOdKK83QtkkvJik=
 github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2/go.mod h1:qwXFYgsP6T7XnJtbKlf1HP8AjxZZyzxMmc+Lq5GjlU4=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
+github.com/colega/zeropool v0.0.0-20230505084239-6fb4a4f75381 h1:d5EKgQfRQvO97jnISfR89AiCCCJMwMFoSxUiU0OGCRU=
+github.com/colega/zeropool v0.0.0-20230505084239-6fb4a4f75381/go.mod h1:OU76gHeRo8xrzGJU3F3I1CqX1ekM8dfJw0+wPeMwnp0=
 github.com/containerd/errdefs v1.0.0 h1:tg5yIfIlQIrxYtu9ajqY42W3lpS19XqdxRQeEwYG8PI=
 github.com/containerd/errdefs v1.0.0/go.mod h1:+YBYIdtsnF4Iw6nWZhJcqGSg/dwvV7tyJ/kCkyJ2k+M=
 github.com/containerd/errdefs/pkg v0.3.0 h1:9IKJ06FvyNlexW690DXuQNx2KA2cUJXx151Xdx3ZPPE=

--- a/pkg/receive/handler.go
+++ b/pkg/receive/handler.go
@@ -21,6 +21,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/colega/zeropool"
+
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/gogo/protobuf/proto"
@@ -153,6 +155,24 @@ type Handler struct {
 	pendingWriteRequestsCounter atomic.Int32
 
 	Limiter *Limiter
+
+	seriesIDsPool     zeropool.Pool[[]int]
+	timeSeriesPool    zeropool.Pool[[]prompb.TimeSeries]
+	distributeMapPool zeropool.Pool[map[endpointReplica]map[string]trackedSeries]
+	trackedSeries     zeropool.Pool[map[string]trackedSeries]
+	intScratchPool    zeropool.Pool[[]int]
+}
+
+// getIntScratch returns a zeroed []int of length n from intScratchPool.
+// clear is required: reslicing a pooled slice back up exposes stale values.
+func (h *Handler) getIntScratch(n int) []int {
+	s := h.intScratchPool.Get()
+	if cap(s) < n {
+		return make([]int, n)
+	}
+	s = s[:n]
+	clear(s)
+	return s
 }
 
 func NewHandler(logger log.Logger, o *Options) *Handler {
@@ -984,7 +1004,6 @@ func (h *Handler) fanoutForward(ctx context.Context, params remoteWriteParams) (
 		level.Error(requestLogger).Log("msg", "failed to distribute timeseries to replicas", "err", err)
 		return stats, err
 	}
-
 	stats = h.gatherWriteStats(len(params.replicas), writes)
 
 	// Prepare a buffered channel to receive the responses from the local and remote writes. Remote writes will all go
@@ -1012,6 +1031,19 @@ func (h *Handler) fanoutForward(ctx context.Context, params remoteWriteParams) (
 					level.Debug(requestLogger).Log("msg", "request failed, but not needed to achieve quorum", "err", resp.err)
 				}
 			}
+
+			for _, er := range writes {
+				for _, v := range er {
+					h.seriesIDsPool.Put(v.seriesIDs[:0])
+					h.timeSeriesPool.Put(v.timeSeries[:0])
+				}
+
+				clear(er)
+				h.trackedSeries.Put(er)
+			}
+
+			clear(writes)
+			h.distributeMapPool.Put(writes)
 		}()
 	}()
 
@@ -1026,12 +1058,17 @@ func (h *Handler) fanoutForward(ctx context.Context, params remoteWriteParams) (
 	for _, tup := range params.data {
 		numSeries += len(tup.wreq.Timeseries)
 	}
-	successes := make([]int, numSeries)
-	failures := make([]int, numSeries)
+	successes := h.getIntScratch(numSeries)
+	failures := h.getIntScratch(numSeries)
 	// conflictFailures tracks how many replicas returned a permanent conflict for
 	// each series. When conflictFailures[i] >= failureThreshold the series can
 	// never reach quorum regardless of retries.
-	conflictFailures := make([]int, numSeries)
+	conflictFailures := h.getIntScratch(numSeries)
+	defer func() {
+		h.intScratchPool.Put(successes[:0])
+		h.intScratchPool.Put(failures[:0])
+		h.intScratchPool.Put(conflictFailures[:0])
+	}()
 	seriesErrs := newReplicationErrors(successThreshold, numSeries)
 	for {
 		select {
@@ -1083,7 +1120,11 @@ func (h *Handler) distributeTimeseriesToReplicas(
 ) (map[endpointReplica]map[string]trackedSeries, error) {
 	h.mtx.RLock()
 	defer h.mtx.RUnlock()
-	writes := make(map[endpointReplica]map[string]trackedSeries)
+	writes := h.distributeMapPool.Get()
+	if writes == nil {
+		writes = make(map[endpointReplica]map[string]trackedSeries)
+	}
+
 	seriesID := -1
 	for _, tup := range data {
 		for _, ts := range tup.wreq.Timeseries {
@@ -1118,12 +1159,16 @@ func (h *Handler) distributeTimeseriesToReplicas(
 
 				writeableSeries, ok := writes[endpointReplica]
 				if !ok {
-					writes[endpointReplica] = map[string]trackedSeries{
-						tenant: {
-							seriesIDs:  make([]int, 0),
-							timeSeries: make([]prompb.TimeSeries, 0),
-						},
+					writeableSeries = h.trackedSeries.Get()
+					if writeableSeries == nil {
+						writeableSeries = make(map[string]trackedSeries)
 					}
+
+					writeableSeries[tenant] = trackedSeries{
+						seriesIDs:  h.seriesIDsPool.Get(),
+						timeSeries: h.timeSeriesPool.Get(),
+					}
+					writes[endpointReplica] = writeableSeries
 				}
 				tenantSeries := writeableSeries[tenant]
 

--- a/pkg/receive/handler_test.go
+++ b/pkg/receive/handler_test.go
@@ -2184,6 +2184,45 @@ func TestDistributeSeries(t *testing.T) {
 	require.Equal(t, map[string]struct{}{"bar": {}, "boo": {}}, hr.seenTenants)
 }
 
+type nopPeerClient struct{}
+
+func (nopPeerClient) RemoteWrite(context.Context, *storepb.WriteRequest, ...grpc.CallOption) (*storepb.WriteResponse, error) {
+	return &storepb.WriteResponse{}, nil
+}
+
+func (nopPeerClient) Close() error { return nil }
+
+func BenchmarkFanoutForward(b *testing.B) {
+	h := NewHandler(nil, &Options{
+		ReplicationFactor: 1,
+		ForwardTimeout:    time.Minute,
+	})
+	b.Cleanup(h.Close)
+
+	endpoint := Endpoint{Address: "http://localhost:9090"}
+	hashring, err := newSimpleHashring([]Endpoint{endpoint})
+	require.NoError(b, err)
+	h.peers = &fakePeersGroup{clients: map[Endpoint]*peerWorker{
+		endpoint: newPeerWorker(nopPeerClient{}, prometheus.NewHistogram(prometheus.HistogramOpts{}), 1, 0),
+	}}
+	h.Hashring(hashring)
+
+	params := remoteWriteParams{
+		data: []wreqTenantTuple{{
+			tenant: "bench",
+			wreq:   &prompb.WriteRequest{Timeseries: makeSeriesWithValues(1000)},
+		}},
+		replicas: []uint64{0},
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		_, err := h.fanoutForward(b.Context(), params)
+		require.NoError(b, err)
+	}
+}
+
 func TestHandlerSplitTenantLabelLocalWrite(t *testing.T) {
 	const tenantIDLabelName = "thanos_tenant_id"
 


### PR DESCRIPTION
On the router, I noticed that this function allocates a lot. Pool the slices and the map to reduce allocs. I opted to have two []int pools because they will typically have different sizes and plus one has fixed sizes whereas the other can be different depending on the inputs.

Diff:
```
goos: linux
goarch: amd64
pkg: github.com/thanos-io/thanos/pkg/receive
cpu: Intel(R) Core(TM) Ultra 7 165H
                 │ fanout_forward_before │        fanout_forward_after         │
                 │        sec/op         │   sec/op     vs base                │
FanoutForward-22             474.3µ ± 5%   399.4µ ± 2%  -15.80% (p=0.000 n=10)

                 │ fanout_forward_before │         fanout_forward_after         │
                 │         B/op          │     B/op      vs base                │
FanoutForward-22            440.0Ki ± 0%   173.5Ki ± 4%  -60.58% (p=0.000 n=10)

                 │ fanout_forward_before │        fanout_forward_after        │
                 │       allocs/op       │  allocs/op   vs base               │
FanoutForward-22             2.061k ± 0%   2.034k ± 0%  -1.33% (p=0.000 n=10)
```
