### PR TITLE
fix double-allocation in capnp WriteRequest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 
 ### Fixed
 
+- [#8935](https://github.com/thanos-io/thanos/pull/8935): Receive: remove redundant tl.Set() while building a Capnp WriteRequest.
+
 ### Changed
 
 - [#8907](https://github.com/thanos-io/thanos/pull/8907): UI: Migrate the React app (`pkg/ui/react-app`) from npm to pnpm; contributors now need pnpm 11+ instead of npm to build the Web UI.

--- a/pkg/receive/writecapnp/client.go
+++ b/pkg/receive/writecapnp/client.go
@@ -129,10 +129,6 @@ func (r *RemoteWriteClient) writeWithReconnect(ctx context.Context, numReconnect
 			if err := BuildInto(&ttl, d.Tenant, d.Timeseries, builder); err != nil {
 				return err
 			}
-
-			if err := tl.Set(i, ttl); err != nil {
-				return err
-			}
 		}
 
 		if err := marshalSymbols(builder, sym); err != nil {

--- a/pkg/receive/writecapnp/self_set_bench_test.go
+++ b/pkg/receive/writecapnp/self_set_bench_test.go
@@ -1,0 +1,92 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package writecapnp
+
+import (
+	"fmt"
+	"testing"
+
+	"capnproto.org/go/capnp/v3"
+	"github.com/stretchr/testify/require"
+
+	"github.com/thanos-io/thanos/pkg/store/labelpb"
+	"github.com/thanos-io/thanos/pkg/store/storepb"
+	"github.com/thanos-io/thanos/pkg/store/storepb/prompb"
+	"github.com/thanos-io/thanos/pkg/symboltable"
+)
+
+// BenchmarkMultiTenantBuild builds a multi-tenant WriteRequest message the
+// same way RemoteWriteClient.writeWithReconnect does and reports its
+// marshaled size. The redundant_self_set variant additionally calls
+// tl.Set(i, ttl) after BuildInto, i.e. it copies each list element onto
+// itself: that deep-copies everything the element references into fresh
+// allocations and orphans the originals, which are still serialized -
+// doubling the message on the wire.
+func BenchmarkMultiTenantBuild(b *testing.B) {
+	const (
+		numTenants = 3
+		numSeries  = 100
+	)
+	tuples := make([]storepb.TimeSeriesTenantTuple, 0, numTenants)
+	for t := range numTenants {
+		series := make([]prompb.TimeSeries, 0, numSeries)
+		for s := range numSeries {
+			series = append(series, prompb.TimeSeries{
+				Labels: []labelpb.ZLabel{
+					{Name: "__name__", Value: "http_requests_total"},
+					{Name: "instance", Value: fmt.Sprintf("host-%d:9090", s)},
+					{Name: "job", Value: "api"},
+				},
+				Samples: []prompb.Sample{{Timestamp: int64(s), Value: float64(s)}},
+			})
+		}
+		tuples = append(tuples, storepb.TimeSeriesTenantTuple{
+			Tenant:     fmt.Sprintf("tenant-%d", t),
+			Timeseries: series,
+		})
+	}
+
+	for _, bench := range []struct {
+		name             string
+		redundantSelfSet bool
+	}{
+		{name: "in_place", redundantSelfSet: false},
+		{name: "redundant_self_set", redundantSelfSet: true},
+	} {
+		b.Run(bench.name, func(b *testing.B) {
+			var size int
+			for b.Loop() {
+				msg, seg, err := capnp.NewMessage(capnp.SingleSegment(nil))
+				require.NoError(b, err)
+
+				wr, err := NewRootWriteRequest(seg)
+				require.NoError(b, err)
+				sym, err := wr.NewSymbols()
+				require.NoError(b, err)
+				tl, err := NewTimeSeriesTenantTuple_List(wr.Segment(), int32(len(tuples)))
+				require.NoError(b, err)
+
+				builder := symboltable.NewBuilder()
+				for i, d := range tuples {
+					// At returns a view into the list's inline storage:
+					// BuildInto fills the element (and the objects it points
+					// to) in place.
+					ttl := tl.At(i)
+					require.NoError(b, BuildInto(&ttl, d.Tenant, d.Timeseries, builder))
+
+					if bench.redundantSelfSet {
+						require.NoError(b, tl.Set(i, ttl))
+					}
+				}
+				require.NoError(b, marshalSymbols(builder, sym))
+				require.NoError(b, wr.SetData(tl))
+
+				data, err := msg.Marshal()
+				require.NoError(b, err)
+				size = len(data)
+			}
+			b.ReportMetric(float64(size), "wire_bytes")
+		})
+	}
+}


### PR DESCRIPTION
After the version upgrade I have observed 1.5x transmitted bytes increase on router->ingester traffic using capnp RPC format.  Fable 5 was able to find this bug, tl.Set apparently allocates a garbage duplicate data structure which is encoded  in the request though it serves no purpose. BuildInto() does the job already. Also generate a benchmark using an LLM showcasing this behaviour.

## Benchmark
```bash
$ go test ./pkg/receive/writecapnp/ -run xxx -bench BenchmarkMultiTenantBuild -benchtime=100x
goos: linux
goarch: amd64
pkg: github.com/thanos-io/thanos/pkg/receive/writecapnp
cpu: AMD Ryzen 7 PRO 8840U w/ Radeon 780M Graphics
BenchmarkMultiTenantBuild/in_place-16                100            140415 ns/op             28272 wire_bytes
BenchmarkMultiTenantBuild/redundant_self_set-16                      100            253266 ns/op             54744 wire_bytes
PASS
ok      github.com/thanos-io/thanos/pkg/receive/writecapnp      0.049s
```
