### PR TITLE
compactv2: propagate series set error in RelabelModifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#8932](https://github.com/thanos-io/thanos/pull/8932): Store: Return the series set error from `TSDBStore.LabelValues` instead of an empty response.
 - [#8967](https://github.com/thanos-io/thanos/pull/8967): Query: Enforce store request series and samples limits for batched series responses.
 - [#8970](https://github.com/thanos-io/thanos/pull/8970): clientconfig: Fix TLS client permanently failing with `unable to use specified CA cert: none configured` after cert/key file rotation, since `TLSRoundTripperSettings.CA` was never populated.
+- [#8937](https://github.com/thanos-io/thanos/pull/8937): Compact: Fix `tools bucket rewrite` silently writing a block with missing data when the source series set fails during relabeling.
 
 ### Changed
 

--- a/pkg/compactv2/modifiers.go
+++ b/pkg/compactv2/modifiers.go
@@ -430,6 +430,9 @@ func (d *RelabelModifier) Modify(_ index.StringIter, set storage.ChunkSeriesSet,
 			}
 		}
 	}
+	if err := set.Err(); err != nil {
+		return errorOnlyStringIter{err}, nil
+	}
 
 	symbolsSlice := make([]string, 0, len(symbols))
 	for s := range symbols {


### PR DESCRIPTION
`thanos tools bucket rewrite --rewrite.to-relabel-config` can write a block that is missing data and report success while doing it.

`RelabelModifier.Modify` drains the source `ChunkSeriesSet` into maps and builds a new `listChunkSeriesSet` from what it collected, but it never checks `set.Err()`. `Next()` returns false on failure as well as on completion, so if reading the source block fails partway through, the loop simply ends and `Modify` returns a normal looking result holding only the series it read before the failure. The caller then writes that out as the new block.

Three things in the same package suggest this is an oversight rather than intentional:

- the same function already checks the inner chunk iterator in two places, and returns `errorOnlyStringIter` when it fails
- `DeletionModifier` propagates the source error through `delModifierSeriesSet.Err()`, which forwards `d.ChunkSeriesSet.Err()`. `RelabelModifier` cannot rely on that because it returns a brand new set, so it has to check explicitly
- the dry run path in `compactor.go` does check `set.Err()`, so a dry run surfaces the failure today while the actual rewrite does not

Fixes #8933

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

- pkg/compactv2/modifiers.go: return the series set error from `RelabelModifier.Modify`, reusing the `errorOnlyStringIter` path the function already uses for chunk iterator errors.

## Verification

`go build` passes on `pkg/compactv2`. `go vet` reports only two pre-existing `stdmethods` warnings on lines this change does not touch.
