### PR TITLE
compact: halt instead of crash-looping when a block's index file is missing after download

### DIFF
--- a/docs/components/receive.md
+++ b/docs/components/receive.md
@@ -372,7 +372,7 @@ Please see the metric `thanos_receive_forward_delay_seconds` to see if you need 
 
 The following formula is used for calculating quorum:
 
-```go mdox-exec="sed -n '1288,1298p' pkg/receive/handler.go"
+```go mdox-exec="sed -n '1333,1343p' pkg/receive/handler.go"
 // writeQuorum returns minimum number of replicas that has to confirm write success before claiming replication success.
 func (h *Handler) writeQuorum() int {
 	// NOTE(GiedriusS): this is here because otherwise RF=2 doesn't make sense as all writes

--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -1227,7 +1227,17 @@ func (cg *Group) compact(ctx context.Context, dir string, planner Planner, comp 
 					stats, e = block.GatherIndexHealthStats(ctx, cg.logger, filepath.Join(bdir, block.IndexFilename), meta.MinTime, meta.MaxTime)
 					return e
 				}, opentracing.Tags{"block.id": meta.ULID}); err != nil {
-					return errors.Wrapf(err, "gather index issues for block %s", bdir)
+					if errors.Is(err, context.Canceled) {
+						// Context was canceled, e.g. because a sibling block in this
+						// compaction batch already failed, or on shutdown; do not mask
+						// that with a halt error.
+						return errors.Wrapf(err, "gather index issues for block %s", bdir)
+					}
+					// The index of this block could not be read locally after a successful
+					// download (e.g. missing/corrupted index, likely from an aborted upload).
+					// Retrying will not fix this, so halt for investigation instead of
+					// crash-looping the whole process. See #5363.
+					return halt(errors.Wrapf(err, "gather index issues for block %s", bdir))
 				}
 
 				if err := stats.CriticalErr(); err != nil {

--- a/pkg/compact/compact_test.go
+++ b/pkg/compact/compact_test.go
@@ -867,7 +867,8 @@ func TestGroupCompactHaltsOnMissingIndex(t *testing.T) {
 	// Only upload meta.json, simulating an aborted upload that never wrote the index file.
 	testutil.Ok(t, bkt.Upload(ctx, path.Join(id.String(), metadata.MetaFilename), &buf))
 
-	counter := prometheus.NewCounter(prometheus.CounterOpts{})
+	reg := prometheus.NewRegistry()
+	counter := promauto.With(reg).NewCounter(prometheus.CounterOpts{Name: "test_metric_for_missing_index"})
 	cg, err := NewGroup(
 		logger,
 		bkt,

--- a/pkg/compact/compact_test.go
+++ b/pkg/compact/compact_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/tsdb"
 	"github.com/thanos-io/objstore"
 
@@ -820,4 +821,70 @@ func TestCompactExtensions(t *testing.T) {
 			testutil.Assert(t, len(groups) > 0)
 		})
 	}
+}
+
+type fakePlanner struct {
+	metas []*metadata.Meta
+}
+
+func (p fakePlanner) Plan(context.Context, []*metadata.Meta, chan error, any) ([]*metadata.Meta, error) {
+	return p.metas, nil
+}
+
+type fakeCompactor struct{}
+
+func (fakeCompactor) Compact(string, []string, []*tsdb.Block) ([]ulid.ULID, error) {
+	return nil, errors.New("unexpected call to Compact")
+}
+
+func (fakeCompactor) CompactWithBlockPopulator(string, []string, []*tsdb.Block, tsdb.BlockPopulator) ([]ulid.ULID, error) {
+	return nil, errors.New("unexpected call to CompactWithBlockPopulator")
+}
+
+// TestGroupCompactHaltsOnMissingIndex ensures that a block whose index file is
+// missing from the bucket (e.g. left behind by an aborted upload, see #5363)
+// halts the compactor for investigation instead of returning a plain error
+// that would otherwise crash the whole process and trigger an endless
+// restart loop on every subsequent run.
+func TestGroupCompactHaltsOnMissingIndex(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	logger := log.NewNopLogger()
+	bkt := objstore.NewInMemBucket()
+
+	id := ulid.MustNew(1, nil)
+	meta := &metadata.Meta{
+		BlockMeta: tsdb.BlockMeta{
+			ULID:    id,
+			MinTime: 0,
+			MaxTime: 10,
+			Version: metadata.TSDBVersion1,
+		},
+	}
+	var buf bytes.Buffer
+	testutil.Ok(t, json.NewEncoder(&buf).Encode(meta))
+	// Only upload meta.json, simulating an aborted upload that never wrote the index file.
+	testutil.Ok(t, bkt.Upload(ctx, path.Join(id.String(), metadata.MetaFilename), &buf))
+
+	counter := prometheus.NewCounter(prometheus.CounterOpts{})
+	cg, err := NewGroup(
+		logger,
+		bkt,
+		"group-key",
+		labels.EmptyLabels(),
+		0,
+		false,
+		false,
+		counter, counter, counter, counter, counter, counter, counter, counter,
+		metadata.NoneFunc,
+		1,
+		1,
+	)
+	testutil.Ok(t, err)
+	testutil.Ok(t, cg.AppendMeta(meta))
+
+	_, _, err = cg.compact(ctx, t.TempDir(), fakePlanner{metas: cg.metasByMinTime}, fakeCompactor{}, DefaultBlockDeletableChecker{}, DefaultCompactionLifecycleCallback{}, make(chan error, 1))
+	testutil.NotOk(t, err)
+	testutil.Assert(t, IsHaltError(err), "expected a halt error for a block with a missing index file, got: %v", err)
 }


### PR DESCRIPTION
Fixes #5363

Motivation:
When gathering index health stats for a block fails after that block was
already downloaded successfully (e.g. because the block in object storage
is missing its index file, commonly left behind by an aborted/partial
upload), Group.compact() returned a plain wrapped error. That error is
neither a HaltError nor a RetryError, so it propagates out of the
`--wait` loop in cmd/thanos/compact.go and causes the compact command to
exit non-zero. Under a container orchestrator with a restart-always
policy this results in an endless crash-restart loop, since the same
corrupted block will fail again on every restart. This has been reported
repeatedly on #5363 since 2022, most recently in 2025-11-12.

Approach:
Wrap this specific error with the existing halt() helper, the same
mechanism already used for other permanently-fatal per-block issues
(e.g. stats.CriticalErr() a few lines below). With --debug.halt-on-error
(the default), a HaltError keeps the process alive, sets the
thanos_compact_halted gauge to 1, and stops further compaction instead
of exiting, so operators can alert on thanos_compact_halted instead of
the process being killed and restarted indefinitely. Retrying a missing
local index file would never succeed anyway, so halting for
investigation is strictly better than crash-looping.

One case is excluded: if the underlying error is context.Canceled, it is
left as a plain error rather than a halt. In Group.compact()'s
errgroup-based concurrent download/verify loop, such a cancellation is
only observed here because a sibling block's goroutine already failed
(or the process is shutting down); that sibling's own error should
decide the halt/retry outcome, not this goroutine's fallout from it.

Impact: this does not change behavior for any other error path in
Group.compact() (e.g. stats.CriticalErr(), OutOfOrderChunksErr(),
download errors) - it only changes the classification of errors
returned by GatherIndexHealthStats itself. Before this change, a
compactor hitting this specific error would exit and be restarted by
the orchestrator forever with no persisted signal; after this change,
the same corrupted block still blocks that compactor's progress (this
was already true before the fix) but the process now halts cleanly with
thanos_compact_halted=1 instead of crash-looping.

Validation:
Added TestGroupCompactHaltsOnMissingIndex in pkg/compact/compact_test.go,
which builds a Group backed by an in-memory bucket containing only a
block's meta.json (no index file, simulating an aborted upload) and
asserts that Group.compact() now returns a HaltError. Verified the test
fails with the pre-fix code, reproducing the exact "open index file: ...
no such file or directory" error from the issue reports.

  go build ./...
  go test ./pkg/compact/... -run TestGroupCompactHaltsOnMissingIndex -v

Both passed. Also ran the full `go test ./pkg/compact/...` suite; the
only failures observed (TestSyncer_GarbageCollect_e2e cloud-provider
subtests requiring credentials, TestGroupCompactE2E/TestGroupKey
flakiness) are pre-existing on unmodified main and reproduce identically
without this change.

Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>
