### PR TITLE
docs: fix writeQuorum snippet line range in receive.md

### DIFF
--- a/docs/components/receive.md
+++ b/docs/components/receive.md
@@ -372,7 +372,7 @@ Please see the metric `thanos_receive_forward_delay_seconds` to see if you need 
 
 The following formula is used for calculating quorum:
 
-```go mdox-exec="sed -n '1288,1298p' pkg/receive/handler.go"
+```go mdox-exec="sed -n '1333,1343p' pkg/receive/handler.go"
 // writeQuorum returns minimum number of replicas that has to confirm write success before claiming replication success.
 func (h *Handler) writeQuorum() int {
 	// NOTE(GiedriusS): this is here because otherwise RF=2 doesn't make sense as all writes


### PR DESCRIPTION
## Changes

The `Documentation check` CI job has been failing on `main` since 2026-07-21 (see e.g. [this run on main](https://github.com/thanos-io/thanos/actions/runs/29836241449/job/88653199795)), which also fails the check for every open PR.

**Cause:** the Quorum section of `docs/components/receive.md` embeds the `writeQuorum` function with a fixed line range:

```
mdox-exec="sed -n '1288,1298p' pkg/receive/handler.go"
```

A recent change to `pkg/receive/handler.go` shifted the function from line 1288 to 1333, so `make check-docs` now wants to replace the quorum snippet with unrelated code that happens to live at the old range.

**Fix:** update the range to the function's current location (`1333,1343`). The rendered snippet content is unchanged — `writeQuorum` itself did not change, it only moved.

## Verification

`sed -n '1333,1343p' pkg/receive/handler.go` matches the committed snippet byte-for-byte.