### PR TITLE
receive: always intern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 ### Changed
 
 - [#8907](https://github.com/thanos-io/thanos/pull/8907): UI: Migrate the React app (`pkg/ui/react-app`) from npm to pnpm; contributors now need pnpm 11+ instead of npm to build the Web UI.
+- [#8943](https://github.com/thanos-io/thanos/pull/8943): receive: always intern. *breaking :warning:* `--writer.intern` was removed on Thanos Receive and Receive will fail to start if that command line parameter is provided
 
 ## [v0.42.0](https://github.com/thanos-io/thanos/tree/release-0.42) - 2026 07 08
 

--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -253,7 +253,6 @@ func runReceive(
 		multiTSDBOptions...,
 	)
 	writer := receive.NewWriter(log.With(logger, "component", "receive-writer"), dbs, &receive.WriterOptions{
-		Intern:                   conf.writerInterning,
 		TooFarInFutureTimeWindow: int64(time.Duration(*conf.tsdbTooFarInFutureTimeWindow)),
 	})
 
@@ -927,7 +926,6 @@ type receiveConfig struct {
 
 	walCompression       bool
 	noLockFile           bool
-	writerInterning      bool
 	splitTenantLabelName string
 
 	hashFunc string
@@ -1110,10 +1108,6 @@ func (rc *receiveConfig) registerFlag(cmd extkingpin.FlagClause) {
 	cmd.Flag("tsdb.enable-native-histograms",
 		"(Deprecated) Enables the ingestion of native histograms. This flag is a no-op now and will be removed in the future. Native histogram ingestion is always enabled.").
 		Default("true").BoolVar(&rc.tsdbEnableNativeHistograms)
-
-	cmd.Flag("writer.intern",
-		"[EXPERIMENTAL] Enables string interning in receive writer, for more optimized memory usage.").
-		Default("false").Hidden().BoolVar(&rc.writerInterning)
 
 	cmd.Flag("hash-func", "Specify which hash function to use when calculating the hashes of produced files. If no function has been specified, it does not happen. This permits avoiding downloading some files twice albeit at some performance cost. Possible values are: \"\", \"SHA256\".").
 		Default("").EnumVar(&rc.hashFunc, "SHA256", "")

--- a/pkg/receive/writer.go
+++ b/pkg/receive/writer.go
@@ -51,7 +51,6 @@ func (ra *ReceiveAppender) Append(ref storage.SeriesRef, lset labels.Labels, t i
 }
 
 type WriterOptions struct {
-	Intern                   bool
 	TooFarInFutureTimeWindow int64 // Unit: nanoseconds
 }
 
@@ -114,7 +113,7 @@ func (r *Writer) Write(ctx context.Context, tenantID string, wreq []prompb.TimeS
 		if ref == 0 {
 			// If not, copy labels, as TSDB will hold those strings long term. Given no
 			// copy unmarshal we don't want to keep memory for whole protobuf, only for labels.
-			labelpb.ReAllocZLabelsStrings(&t.Labels, r.opts.Intern)
+			labelpb.ReAllocZLabelsStrings(&t.Labels)
 			lset = labelpb.ZLabelsToPromLabels(t.Labels)
 		}
 

--- a/pkg/receive/writer_test.go
+++ b/pkg/receive/writer_test.go
@@ -544,28 +544,14 @@ func benchmarkWriter(b *testing.B, labelsNum int, seriesNum int, generateHistogr
 		Timeseries: timeSeries,
 	}
 
-	b.Run("without interning", func(b *testing.B) {
-		w := NewWriter(logger, m, &WriterOptions{Intern: false})
+	w := NewWriter(logger, m, &WriterOptions{})
 
-		b.ReportAllocs()
-		b.ResetTimer()
+	b.ReportAllocs()
+	b.ResetTimer()
 
-		for b.Loop() {
-			testutil.Ok(b, w.Write(ctx, "foo", wreq.Timeseries))
-		}
-	})
-
-	b.Run("with interning", func(b *testing.B) {
-		w := NewWriter(logger, m, &WriterOptions{Intern: true})
-
-		b.ReportAllocs()
-		b.ResetTimer()
-
-		for b.Loop() {
-			testutil.Ok(b, w.Write(ctx, "foo", wreq.Timeseries))
-		}
-	})
-
+	for b.Loop() {
+		testutil.Ok(b, w.Write(ctx, "foo", wreq.Timeseries))
+	}
 }
 
 // generateLabelsAndSeries generates time series for benchmark with specified number of labels.

--- a/pkg/store/flushable.go
+++ b/pkg/store/flushable.go
@@ -76,7 +76,6 @@ func (r *resortingServer) Send(response *storepb.SeriesResponse) error {
 	}
 
 	series := response.GetSeries()
-	labelpb.ReAllocZLabelsStrings(&series.Labels, false)
 	r.series = append(r.series, series)
 	return nil
 }

--- a/pkg/store/labelpb/label.go
+++ b/pkg/store/labelpb/label.go
@@ -53,23 +53,15 @@ func ZLabelsToPromLabels(lset []ZLabel) labels.Labels {
 }
 
 // ReAllocAndInternZLabelsStrings re-allocates all underlying bytes for string, detaching it from bigger memory pool.
-// If `intern` is set to true, the method will use interning, i.e. reuse already allocated strings, to make the reallocation
-// method more efficient.
+// It interns the given strings - if they are already in memory, they do not get copied.
 //
 // This is primarily intended to be used before labels are written into TSDB which can hold label strings in the memory long term.
-func ReAllocZLabelsStrings(lset *[]ZLabel, intern bool) {
-	if intern {
-		for j, l := range *lset {
-			(*lset)[j].Name = unique.Make(l.Name).Value()
-			(*lset)[j].Value = unique.Make(l.Value).Value()
-		}
-		return
+func ReAllocZLabelsStrings(lset *[]ZLabel) {
+	for j, l := range *lset {
+		(*lset)[j].Name = unique.Make(l.Name).Value()
+		(*lset)[j].Value = unique.Make(l.Value).Value()
 	}
 
-	for j, l := range *lset {
-		(*lset)[j].Name = string(noAllocBytes(l.Name))
-		(*lset)[j].Value = string(noAllocBytes(l.Value))
-	}
 }
 
 // ZLabelSetsToPromLabelSets converts slice of labelpb.ZLabelSet to slice of Prometheus labels.

--- a/pkg/store/labelpb/label_test.go
+++ b/pkg/store/labelpb/label_test.go
@@ -37,37 +37,6 @@ func TestExtendLabels(t *testing.T) {
 	testInjectExtLabels(testutil.NewTB(t))
 }
 
-func BenchmarkRealloc(b *testing.B) {
-	lbls := ZLabelsFromPromLabels(labels.FromStrings(
-		"__name__", "container_cpu_usage_seconds_total",
-		"cluster", "prod-eu-west-1",
-		"container", "thanos-receive",
-		"cpu", "total",
-		"endpoint", "https-metrics",
-		"image", "quay.io/thanos/thanos:v0.35.0",
-		"instance", "10.128.4.231:10250",
-		"job", "kubelet",
-		"metrics_path", "/metrics/cadvisor",
-		"namespace", "monitoring",
-		"node", "ip-10-128-4-231.eu-west-1.compute.internal",
-		"pod", "thanos-receive-default-0",
-		"prometheus", "monitoring/k8s",
-		"prometheus_replica", "prometheus-k8s-0",
-		"service", "kubelet",
-	))
-	work := make([]ZLabel, len(lbls))
-
-	for _, intern := range []bool{false, true} {
-		b.Run(fmt.Sprintf("intern=%v", intern), func(b *testing.B) {
-			b.ReportAllocs()
-			for b.Loop() {
-				copy(work, lbls)
-				ReAllocZLabelsStrings(&work, intern)
-			}
-		})
-	}
-}
-
 func BenchmarkExtendLabels(b *testing.B) {
 	testInjectExtLabels(testutil.NewTB(b))
 }

--- a/pkg/store/labelpb/label_zlabel_test.go
+++ b/pkg/store/labelpb/label_zlabel_test.go
@@ -324,7 +324,7 @@ func benchmarkTransformWithAndWithoutCopy(b *testing.B, num int) {
 		b.ResetTimer()
 
 		for b.Loop() {
-			ReAllocZLabelsStrings(&lbls, true)
+			ReAllocZLabelsStrings(&lbls)
 			ret = ZLabelsToPromLabels(lbls)
 		}
 	})

--- a/pkg/store/prometheus.go
+++ b/pkg/store/prometheus.go
@@ -351,8 +351,10 @@ func (p *PrometheusStore) handleStreamedPrometheusResponse(
 				series.Chunks[i].Data = nil
 			}
 
+			lbls := labelpb.ZLabelsFromPromLabels(completeLabelset)
+			labelpb.ReAllocZLabelsStrings(&lbls)
 			r := storepb.NewSeriesResponse(&storepb.Series{
-				Labels: labelpb.ZLabelsFromPromLabels(completeLabelset),
+				Labels: lbls,
 				Chunks: thanosChks,
 			})
 			if err := s.Send(r); err != nil {
@@ -418,6 +420,10 @@ func (p *PrometheusStore) fetchSampledResponse(ctx context.Context, resp *http.R
 	}
 	if len(data.Results) != 1 {
 		return nil, errors.Errorf("unexpected result size %d", len(data.Results))
+	}
+
+	for _, ts := range data.Results[0].Timeseries {
+		labelpb.ReAllocZLabelsStrings(&ts.Labels)
 	}
 
 	return &data, nil


### PR DESCRIPTION
Interning is much faster with the unique package so remove "[EXPERIMENTAL]" and always do that. Remove one superfluous reallocation on the resorting path - SendMsg() in grpc-go synchronously prepares and marshals the response so I think it's not needed there. Move to where it matters - the Sidecar path. Sidecar reuses the buffer on each Next() so we need to detach the labels there as they get overwritten.
