### PR TITLE
receive: detach exemplar labels from the protobuf receive buffer to fix unbounded memory / OOM

### DIFF
--- a/pkg/receive/writer.go
+++ b/pkg/receive/writer.go
@@ -143,6 +143,7 @@ func (r *Writer) Write(ctx context.Context, tenantID string, wreq []prompb.TimeS
 		// We drop the exemplars in case the series doesn't exist.
 		if ref != 0 && len(t.Exemplars) > 0 {
 			for _, ex := range t.Exemplars {
+				labelpb.ReAllocZLabelsStrings(&ex.Labels)
 				exLset := labelpb.ZLabelsToPromLabels(ex.Labels)
 				exLogger := log.With(tLogger, "exemplarLset", exLset, "exemplar", ex.String())
 


### PR DESCRIPTION
**What**

Copies exemplar labels out of the (zero-copy) protobuf receive buffer before they're appended to TSDB, mirroring what's already done for series labels a few lines above.

**Why**

Series labels are detached via `labelpb.ReAllocZLabelsStrings`, but exemplar labels were passed straight through the unsafe `ZLabelsToPromLabels` alias into `AppendExemplar`. Because the TSDB exemplar ring stores labels by reference, every stored exemplar kept its entire source receive buffer alive against GC for as long as it stayed in the ring. Under exemplar-heavy remote-write (high-cardinality `trace_id`/`span_id`) the receive ingestor's memory grew without bound and OOM'd; adding memory only delayed it.

Full diagnosis, pprof, and measurements are in #8923: at `--tsdb.max-exemplars=100000`, ~20.7k stored exemplars pinned ~2.5 GB of `mem.NopBufferPool` receive buffers (~122 KB each); lowering the ring dropped RSS proportionally. This is the standard remote-write (gRPC) counterpart to #8486, which fixed the same class of retention on the Cap'n Proto path.

**Changes**

- `pkg/receive/writer.go`: `labelpb.ReAllocZLabelsStrings(&ex.Labels)` in the exemplar loop.
- `pkg/receive/writer_exemplar_test.go`: regression test — backs exemplar labels with a mutable buffer, writes, scribbles the buffer, asserts the stored labels survive. Fails without the fix, passes with it.
- `CHANGELOG.md`: entry under Unreleased → Fixed.

**Verification**

- `go test -tags slicelabels -run TestWriter ./pkg/receive/` passes (existing exemplar cases + new test).
- Confirmed the new test fails on `main` without the change.
- `go build -tags slicelabels ./cmd/thanos` succeeds.

Fixes #8923
