### PR TITLE
receive: fix status code when conflicts fail quorum on even replication factors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 
 - [#8900](https://github.com/thanos-io/thanos/pull/8900): UI: Fix web UI static assets (JS/CSS) returning 404 on Windows by using slash-separated paths for the embedded file system.
 - [#8935](https://github.com/thanos-io/thanos/pull/8935): Receive: remove redundant tl.Set() while building a Capnp WriteRequest.
+- [#8946](https://github.com/thanos-io/thanos/pull/8946): Receive: Fix write requests returning `500` instead of `409`/`503` when a series fails quorum with an even replication factor. Duplicate writes were reported as retryable server errors, causing Prometheus remote write to retry indefinitely and scale up shards instead of backing off.
 
 ### Changed
 

--- a/docs/components/receive.md
+++ b/docs/components/receive.md
@@ -372,7 +372,7 @@ Please see the metric `thanos_receive_forward_delay_seconds` to see if you need 
 
 The following formula is used for calculating quorum:
 
-```go mdox-exec="sed -n '1333,1343p' pkg/receive/handler.go"
+```go mdox-exec="sed -n '1339,1349p' pkg/receive/handler.go"
 // writeQuorum returns minimum number of replicas that has to confirm write success before claiming replication success.
 func (h *Handler) writeQuorum() int {
 	// NOTE(GiedriusS): this is here because otherwise RF=2 doesn't make sense as all writes

--- a/pkg/receive/handler.go
+++ b/pkg/receive/handler.go
@@ -1069,7 +1069,13 @@ func (h *Handler) fanoutForward(ctx context.Context, params remoteWriteParams) (
 		h.intScratchPool.Put(failures[:0])
 		h.intScratchPool.Put(conflictFailures[:0])
 	}()
-	seriesErrs := newReplicationErrors(successThreshold, numSeries)
+	// A series error is only ever inspected once the series has already failed
+	// quorum, so the question replicationErrors.Cause answers is "did enough
+	// replicas fail with the same permanent cause to make this unretryable?".
+	// That makes failureThreshold the correct threshold: with successThreshold
+	// the counts can never be reached for even replication factors, where
+	// failureThreshold < successThreshold, and the cause stays undetermined.
+	seriesErrs := newReplicationErrors(failureThreshold, numSeries)
 	for {
 		select {
 		case <-ctx.Done():

--- a/pkg/receive/handler_test.go
+++ b/pkg/receive/handler_test.go
@@ -662,6 +662,102 @@ func testReceiveQuorum(t *testing.T, hashringAlgo HashringAlgorithm, withConsist
 			},
 		},
 		{
+			// With RF=2 the write quorum is 1, so a single successful write is
+			// enough and the conflict on the other replica must not surface.
+			name:              "size 2 with replication 2 and one conflict",
+			status:            http.StatusOK,
+			replicationFactor: 2,
+			wreq:              wreq,
+			appendables: []*fakeAppendable{
+				{
+					appender: newFakeAppender(conflictErrFn, nil, nil),
+				},
+				{
+					appender: newFakeAppender(nil, nil, nil),
+				},
+			},
+		},
+		{
+			// Both replicas permanently reject the sample, so no retry can ever
+			// reach the quorum of 1. Must be reported as a conflict, not as a
+			// retryable error.
+			name:              "size 2 with replication 2 and two conflicts",
+			status:            http.StatusConflict,
+			replicationFactor: 2,
+			wreq:              wreq,
+			appendables: []*fakeAppendable{
+				{
+					appender: newFakeAppender(conflictErrFn, nil, nil),
+				},
+				{
+					appender: newFakeAppender(conflictErrFn, nil, nil),
+				},
+			},
+		},
+		{
+			// One permanent conflict plus one transient failure. Once the
+			// transient replica recovers, 1 success reaches the quorum of 1, so
+			// the request is retryable and must not be reported as a conflict.
+			name:              "size 2 with replication 2 one conflict and one commit error",
+			status:            http.StatusServiceUnavailable,
+			replicationFactor: 2,
+			wreq:              wreq,
+			appendables: []*fakeAppendable{
+				{
+					appender: newFakeAppender(conflictErrFn, nil, nil),
+				},
+				{
+					appender: newFakeAppender(nil, commitErrFn, nil),
+				},
+			},
+		},
+		{
+			// With RF=4 the write quorum is 3, so two permanent conflicts already
+			// make the quorum unreachable no matter how often the client retries.
+			// This must be a conflict, mirroring "size 3 with replication and two
+			// conflicts" above.
+			name:              "size 4 with replication 4 and two conflicts",
+			status:            http.StatusConflict,
+			replicationFactor: 4,
+			wreq:              wreq,
+			appendables: []*fakeAppendable{
+				{
+					appender: newFakeAppender(conflictErrFn, nil, nil),
+				},
+				{
+					appender: newFakeAppender(conflictErrFn, nil, nil),
+				},
+				{
+					appender: newFakeAppender(nil, nil, nil),
+				},
+				{
+					appender: newFakeAppender(nil, nil, nil),
+				},
+			},
+		},
+		{
+			// Two transient failures also make the quorum of 3 unreachable, but
+			// a retry can still succeed, so this must be retryable.
+			name:              "size 4 with replication 4 and two commit errors",
+			status:            http.StatusServiceUnavailable,
+			replicationFactor: 4,
+			wreq:              wreq,
+			appendables: []*fakeAppendable{
+				{
+					appender: newFakeAppender(nil, commitErrFn, nil),
+				},
+				{
+					appender: newFakeAppender(nil, commitErrFn, nil),
+				},
+				{
+					appender: newFakeAppender(nil, nil, nil),
+				},
+				{
+					appender: newFakeAppender(nil, nil, nil),
+				},
+			},
+		},
+		{
 			name:              "size 6 with replication 3",
 			status:            http.StatusOK,
 			replicationFactor: 3,


### PR DESCRIPTION
## Changes

Fixes the long-standing `receive` bug where a write that is permanently rejected as a duplicate is reported as `500` instead of `409`.

### User impact

Prometheus remote write treats `5xx` as retryable and `409` as permanent. When a duplicate write comes back as `500`, the sender never drops the batch: it retries forever and, because the failures look like backpressure, it also keeps increasing the number of shards. That is the resharding loop described in #5407, where the reporter had to temporarily lower the replication factor to get the agents out of it. The same mismatch also turns transient replica failures into `500` instead of `503`.

### Root cause

Two of the causes originally suspected in the issue no longer apply on `main`, and I want to be explicit about that:

* The nested-multierror problem @phillebaba diagnosed is gone. `determineWriteErrorCause` and its "does not go deeper than the first multi error" limitation were removed in #5910, which replaced them with per-series error tracking.
* The RF=2 quorum concern @fpetkovski raised is also already handled: `writeQuorum()` special-cases `ReplicationFactor == 2` to `1`, so a single successful write is enough, matching the design doc.

What survived is a threshold that was not carried through that refactor. `fanoutForward` computes two different numbers:

```go
successThreshold := h.writeQuorum()
failureThreshold := len(params.replicas) - successThreshold + 1
```

A series error is collected once `failures[i] >= failureThreshold`, but the object that has to explain those errors is built with the *success* threshold:

```go
seriesErrs := newReplicationErrors(successThreshold, numSeries)
```

For odd replication factors the two numbers are equal, so this is invisible. For even replication factors `failureThreshold` is strictly smaller than the write quorum:

| RF | writeQuorum | failureThreshold |
|----|-------------|------------------|
| 1  | 1 | 1 |
| 2  | 1 | 2 |
| 3  | 2 | 2 |
| 4  | 3 | 2 |
| 5  | 3 | 3 |
| 6  | 4 | 3 |

So with RF=4, two conflicting replicas already make the quorum of 3 unreachable and the series error is collected, but `replicationErrors.Cause()` is then asked to find a cause that appears at least 3 times among 2 errors. It fails both its branches and returns `nil`, the cause stays undetermined, and `receiveHTTP` falls through to `default:` and answers `500`.

RF=2 has the same mismatch in the opposite direction: the threshold is `1` where failure requires `2`, so one conflict plus one transient failure was reported as a permanent `409` even though a retry could still reach the quorum of 1 once the transient replica recovers.

### Fix

Pass `failureThreshold`. `replicationErrors.Cause()` is only ever consulted for a series that has already failed quorum, so the question it answers is "did enough replicas fail with the same permanent cause to make this unretryable?" — and that is what `failureThreshold` measures. The existing doc comment on `Cause()` already describes it in those terms ("reaching this fallback guarantees that conflict_count < failureThreshold"); only the value being plumbed in was wrong.

### Tests

This is the main deliverable. @squat asked in the issue for explicit test cases in `handler_test.go` documenting the correct behaviour, and @fpetkovski expected a good enough test to catch this — the quorum table only covered replication factors 1, 3 and 5, so no even replication factor was exercised and neither direction of the mismatch was reachable.

Five cases added, covering RF=2 and RF=4. They run under both hashmod and ketama, with and without capnproto replication, and from the point of view of every node.

Before the one-line fix:

```
--- FAIL: .../size_2_with_replication_2_one_conflict_and_one_commit_error
    handler_test.go:875: handler 1: got unexpected HTTP status code: expected 503, got 409
--- FAIL: .../size_4_with_replication_4_and_two_conflicts
    handler_test.go:875: handler 1: got unexpected HTTP status code: expected 409, got 500
--- FAIL: .../size_4_with_replication_4_and_two_commit_errors
    handler_test.go:875: handler 1: got unexpected HTTP status code: expected 503, got 500
```

After:

```
--- PASS: .../size_2_with_replication_2_and_one_conflict
--- PASS: .../size_2_with_replication_2_and_two_conflicts
--- PASS: .../size_2_with_replication_2_one_conflict_and_one_commit_error
--- PASS: .../size_4_with_replication_4_and_two_conflicts
--- PASS: .../size_4_with_replication_4_and_two_commit_errors
```

The two RF=2 conflict-only cases already passed and are kept as regression guards for the `writeQuorum()` RF=2 carve-out. The expectations mirror the semantics the existing RF=3 cases already document: "size 3 with replication and two conflicts" is `409`, "size 3 with replication one conflict and one commit error" is `503`.

### On the quorum formula

@fpetkovski suggested the formula should be `(ReplicationFactor + 1) / 2`. I did not change it, for two reasons:

* `(RF/2)+1` plus the RF=2 carve-out already agrees with `(RF+1)/2` for RF=1, 2, 3, 5, 7. They differ only for even RF >= 4, where `(RF/2)+1` is a strict majority (3 of 4) and `(RF+1)/2` is not (2 of 4). Dropping below a strict majority would weaken the consistency guarantee, and the RF=2 case the design doc and the issue actually care about is already satisfied.
* It would only have hidden this bug rather than fixed it. `(RF+1)/2` happens to make `successThreshold <= failureThreshold` for every RF, so the undetermined-cause path would stop being reachable — but the threshold plumbing would still be wrong. Fixing the threshold is orthogonal and correct for every replication factor and for whichever formula is chosen later.

Happy to follow up on the formula separately if maintainers want to revisit it.

### Also

`docs/components/receive.md` embeds `writeQuorum()` through an `mdox-exec` fixed line range, which shifted with this change. Updated so the `Documentation check` job stays green (same failure mode as #8941). The rendered snippet content is unchanged.

## Verification

* `go test ./pkg/receive/... -tags slicelabels -count=1` — pass
* `go test ./pkg/receive/ -tags slicelabels -count=1 -race -run 'TestReceiveQuorum|TestReceiveSaturatedPoolRF2|TestReceiveWithConsistencyDelay|TestHandlerReceiveHTTP|TestDistributeSeries|TestHandlerEarlyStop'` — pass
* `go build ./cmd/thanos` — ok
* `gofmt -l pkg/receive/` — clean
* `sed -n '1339,1349p' pkg/receive/handler.go` matches the committed snippet byte-for-byte

Fixes #5407
