### PR TITLE
receive: Preserve upload on shutdown behaviour

### DIFF
--- a/Dockerfile.multi-stage
+++ b/Dockerfile.multi-stage
@@ -1,6 +1,6 @@
 # By default we pin to amd64 sha. Use make docker to automatically adjust for arm64 versions.
 ARG BASE_DOCKER_SHA="14d68ca3d69fceaa6224250c83d81d935c053fb13594c811038c461194599973"
-FROM golang:1.26.4-alpine3.20 as builder
+FROM golang:1.26.4-alpine3.24 as builder
 
 WORKDIR $GOPATH/src/github.com/thanos-io/thanos
 # Change in the docker context invalidates the cache so to leverage docker

--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -721,8 +721,6 @@ func startTSDBAndUpload(g *run.Group,
 	// TSDBs reload logic, listening on hashring changes.
 	cancel := make(chan struct{})
 	g.Add(func() error {
-		defer close(uploadC)
-
 		// Before quitting, ensure the WAL is flushed and the DBs are closed.
 		defer func() {
 			level.Info(logger).Log("msg", "shutting down storage")
@@ -730,6 +728,11 @@ func startTSDBAndUpload(g *run.Group,
 				level.Error(logger).Log("err", err, "msg", "failed to flush storage")
 			} else {
 				level.Info(logger).Log("msg", "storage is flushed successfully")
+			}
+			close(uploadC)
+			// Wait for upload to finish before closing dbs.
+			if upload {
+				<-uploadDone
 			}
 			dbs.Close()
 			level.Info(logger).Log("msg", "storage is closed")
@@ -811,6 +814,8 @@ func startTSDBAndUpload(g *run.Group,
 					runutil.CloseWithLogOnErr(logger, bkt, "bucket client")
 				}()
 
+				defer close(uploadDone)
+
 				// Before quitting, ensure all blocks are uploaded.
 				defer func() {
 					<-uploadC // Closed by storage routine when it's done.
@@ -825,8 +830,6 @@ func startTSDBAndUpload(g *run.Group,
 					cancel()
 					level.Info(logger).Log("msg", "the final cut block was uploaded", "uploaded", uploaded)
 				}()
-
-				defer close(uploadDone)
 
 				for {
 					select {

--- a/test/e2e/e2ethanos/services.go
+++ b/test/e2e/e2ethanos/services.go
@@ -607,6 +607,7 @@ type ReceiveBuilder struct {
 	nativeHistograms      bool
 	labels                []string
 	tenantSplitLabel      string
+	objStoreConfig        *client.BucketConfig
 }
 
 func NewReceiveBuilder(e e2e.Environment, name string) *ReceiveBuilder {
@@ -685,6 +686,11 @@ func (r *ReceiveBuilder) WithValidationEnabled(limit int, metaMonitoring string,
 
 func (r *ReceiveBuilder) WithNativeHistograms() *ReceiveBuilder {
 	r.nativeHistograms = true
+	return r
+}
+
+func (r *ReceiveBuilder) WithObjStoreConfig(config client.BucketConfig) *ReceiveBuilder {
+	r.objStoreConfig = &config
 	return r
 }
 
@@ -794,6 +800,14 @@ func (r *ReceiveBuilder) Init() *e2eobs.Observable {
 
 	if r.nativeHistograms {
 		args["--tsdb.enable-native-histograms"] = ""
+	}
+
+	if r.objStoreConfig != nil {
+		bktConfigBytes, err := yaml.Marshal(r.objStoreConfig)
+		if err != nil {
+			return &e2eobs.Observable{Runnable: e2e.NewFailedRunnable(r.Name(), errors.Wrapf(err, "generate objstore config: %v", r.objStoreConfig))}
+		}
+		args["--objstore.config"] = string(bktConfigBytes)
 	}
 
 	return e2eobs.AsObservable(r.f.Init(wrapWithDefaults(e2e.StartOptions{

--- a/test/e2e/receive_test.go
+++ b/test/e2e/receive_test.go
@@ -34,6 +34,10 @@ import (
 
 	"github.com/efficientgo/core/testutil"
 
+	"github.com/thanos-io/objstore"
+	"github.com/thanos-io/objstore/client"
+	"github.com/thanos-io/objstore/providers/s3"
+
 	"github.com/thanos-io/thanos/pkg/exemplars/exemplarspb"
 	"github.com/thanos-io/thanos/pkg/promclient"
 	"github.com/thanos-io/thanos/pkg/receive"
@@ -1394,4 +1398,60 @@ func TestReceiveWithRelabelConfigSmoke(t *testing.T) {
 		e2emon.WithLabelMatchers(matchers.MustNewMatcher(matchers.MatchEqual, "tenant", "default-tenant")),
 		e2emon.WaitMissingMetrics(),
 	))
+}
+
+func TestReceiveUploadOnShutdown(t *testing.T) {
+	t.Parallel()
+
+	e, err := e2e.NewDockerEnvironment("receive-u-s")
+	testutil.Ok(t, err)
+	t.Cleanup(e2ethanos.CleanScenario(t, e))
+
+	const bucket = "receive-upload-shutdown-test"
+	m := e2edb.NewMinio(e, "thanos-minio", bucket, e2edb.WithMinioTLS())
+	testutil.Ok(t, e2e.StartAndWaitReady(m))
+
+	bktConfig := client.BucketConfig{
+		Type:   objstore.S3,
+		Config: e2ethanos.NewS3Config(bucket, m.InternalEndpoint("http"), m.InternalDir()),
+	}
+
+	i := e2ethanos.NewReceiveBuilder(e, "ingestor").
+		WithIngestionEnabled().
+		WithObjStoreConfig(bktConfig).
+		Init()
+	testutil.Ok(t, e2e.StartAndWaitReady(i))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	t.Cleanup(cancel)
+
+	require.NoError(t, runutil.RetryWithLog(logkit.NewLogfmtLogger(os.Stdout), 1*time.Second, ctx.Done(), func() error {
+		return storeWriteRequest(ctx, "http://"+i.Endpoint("remote-write")+"/api/v1/receive", &prompb.WriteRequest{
+			Timeseries: []prompb.TimeSeries{
+				{
+					Labels: []prompb.Label{
+						{Name: "__name__", Value: "upload_test_metric"},
+						{Name: "foo", Value: "bar"},
+					},
+					Samples: []prompb.Sample{
+						{Value: 1, Timestamp: time.Now().UnixMilli()},
+					},
+				},
+			},
+		})
+	}))
+
+	testutil.Ok(t, i.Stop())
+
+	l := logkit.NewLogfmtLogger(os.Stdout)
+	bkt, err := s3.NewBucketWithConfig(l,
+		e2ethanos.NewS3Config(bucket, m.Endpoint("http"), m.Dir()), "test-verify", nil)
+	testutil.Ok(t, err)
+
+	var blockCount int
+	testutil.Ok(t, bkt.Iter(ctx, "", func(_ string) error {
+		blockCount++
+		return nil
+	}))
+	require.Greater(t, blockCount, 0, "expected at least one block uploaded to object storage after receiver shutdown")
 }


### PR DESCRIPTION

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->
On previous versions receive was always uploading blocks on shutdown.

In v0.42 this behaviour changed. Due to the order of defers in the TSDB and upload goroutines, we call dbs.Flush() and dbs.Close(), ahead of unblocking uploadC channel. Which means that when SyncAllTenants runs, it runs with nil shippers. We also seem to be closing uploadDone channel before uploads have finished in the upload goroutine.



* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes


This commit addresses this, and reinstates the upload on shutdown behaviour, by modifying TSDB goroutine to call dbs.Flush(), and close uploadC, and then waiting for the uploads to finish via uploadDone, before final dbs.Close().

## Verification

<!-- How you tested it? How do you know it works? -->
