### PR TITLE
receive: Stricter tenant validation

### DIFF
--- a/pkg/receive/handler_test.go
+++ b/pkg/receive/handler_test.go
@@ -1581,6 +1581,26 @@ func TestIsTenantValid(t *testing.T) {
 			name:   "test valid tenant",
 			tenant: "foo",
 		},
+		{
+			name:        "test malicious tenant with ..",
+			tenant:      "..",
+			expectedErr: errors.New("tenant name not valid"),
+		},
+		{
+			name:        "test malicious tenant with .",
+			tenant:      ".",
+			expectedErr: errors.New("tenant name not valid"),
+		},
+		{
+			name:        "test malicious tenant with /",
+			tenant:      "/",
+			expectedErr: errors.New("tenant name not valid"),
+		},
+		{
+			name:        "test malicious tenant ./",
+			tenant:      "./",
+			expectedErr: errors.New("tenant name not valid"),
+		},
 	} {
 		t.Run(tcase.name, func(t *testing.T) {
 			err := tenancy.IsTenantValid(tcase.tenant)

--- a/pkg/tenancy/tenancy.go
+++ b/pkg/tenancy/tenancy.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"net/http"
 	"path"
+	"path/filepath"
 
 	"github.com/pkg/errors"
 	"github.com/prometheus-community/prom-label-proxy/injectproxy"
@@ -39,7 +40,7 @@ const (
 )
 
 func IsTenantValid(tenant string) error {
-	if tenant != path.Base(tenant) {
+	if !filepath.IsLocal(tenant) || tenant != path.Base(tenant) || tenant == "." {
 		return errors.New("tenant name not valid")
 	}
 	return nil


### PR DESCRIPTION
This commit adds better methods of validating tenant names such as
filepath.IsLocal.

I believe this topic was brought up a few times previously, via reports.
I don't think this is a critical issue, as Thanos already does not ship
any auth flows OOTB, and it is left up to the user.

IMO, exposing Thanos remote write endpoints publicly and allowing
arbitary tenant names, is not a reasonable route.

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->
This commit adds better methods of validating tenant names such as filepath.IsLocal.


## Verification

<!-- How you tested it? How do you know it works? -->
