### PR TITLE
tracing: drop noisiest INTERNAL spans for usable distributed traces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 
 ### Changed
 
+- [#6099](https://github.com/thanos-io/thanos/issues/6099): Tracing: drop the noisiest INTERNAL spans (`proxy.series`, `proxy.label_names`, `proxy.label_values`, `bucket_store_block_series`, `send_rules_response`, `send_rule_group_response`) so distributed traces stay usable; gRPC CLIENT/SERVER spans remain.
 - [#8907](https://github.com/thanos-io/thanos/pull/8907): UI: Migrate the React app (`pkg/ui/react-app`) from npm to pnpm; contributors now need pnpm 11+ instead of npm to build the Web UI.
 - [#8943](https://github.com/thanos-io/thanos/pull/8943): receive: always intern. *breaking :warning:* `--writer.intern` was removed on Thanos Receive and Receive will fail to start if that command line parameter is provided
 

--- a/pkg/rules/manager.go
+++ b/pkg/rules/manager.go
@@ -28,7 +28,6 @@ import (
 	"github.com/thanos-io/thanos/pkg/rules/rulespb"
 	"github.com/thanos-io/thanos/pkg/store/labelpb"
 	"github.com/thanos-io/thanos/pkg/store/storepb"
-	"github.com/thanos-io/thanos/pkg/tracing"
 )
 
 const tmpRuleDir = ".tmp-rules"
@@ -432,9 +431,7 @@ func (m *Manager) Rules(r *rulespb.RulesRequest, s rulespb.Rules_RulesServer) (e
 	enrichRulesWithExtLabels(pgs, m.extLset)
 
 	for _, pg := range pgs {
-		tracing.DoInSpan(s.Context(), "send_rule_group_response", func(_ context.Context) {
-			err = s.Send(&rulespb.RulesResponse{Result: &rulespb.RulesResponse_Group{Group: pg}})
-		})
+		err = s.Send(&rulespb.RulesResponse{Result: &rulespb.RulesResponse_Group{Group: pg}})
 		if err != nil {
 			return err
 		}

--- a/pkg/rules/proxy.go
+++ b/pkg/rules/proxy.go
@@ -76,9 +76,7 @@ func (s *Proxy) Rules(req *rulespb.RulesRequest, srv rulespb.Rules_RulesServer) 
 	}
 
 	for _, g := range groups {
-		tracing.DoInSpan(srv.Context(), "send_rules_response", func(_ context.Context) {
-			err = srv.Send(rulespb.NewRuleGroupRulesResponse(g))
-		})
+		err = srv.Send(rulespb.NewRuleGroupRulesResponse(g))
 		if err != nil {
 			return status.Error(codes.Unknown, errors.Wrap(err, "send rules response").Error())
 		}

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -1577,7 +1577,7 @@ func (s *BucketStore) Series(req *storepb.SeriesRequest, seriesSrv storepb.Store
 		stats            = &queryStats{}
 		respSets         []respSet
 		mtx              sync.Mutex
-		g, gctx          = errgroup.WithContext(ctx)
+		g, _             = errgroup.WithContext(ctx)
 		resHints         = &hintspb.SeriesResponseHints{}
 		reqBlockMatchers []*labels.Matcher
 
@@ -1628,7 +1628,6 @@ func (s *BucketStore) Series(req *storepb.SeriesRequest, seriesSrv storepb.Store
 
 		for _, b := range blocks {
 			blk := b
-			gctx := gctx
 
 			if s.enableSeriesResponseHints {
 				// Keep track of queried blocks.
@@ -1666,14 +1665,6 @@ func (s *BucketStore) Series(req *storepb.SeriesRequest, seriesSrv storepb.Store
 			defer blockClient.Close()
 
 			g.Go(func() error {
-
-				span, _ := tracing.StartSpan(gctx, "bucket_store_block_series", tracing.Tags{
-					"block.id":         blk.meta.ULID,
-					"block.mint":       blk.meta.MinTime,
-					"block.maxt":       blk.meta.MaxTime,
-					"block.resolution": blk.meta.Thanos.Downsample.Resolution,
-				})
-
 				onClose := func() {
 					mtx.Lock()
 					stats = blockClient.MergeStats(stats)
@@ -1685,14 +1676,12 @@ func (s *BucketStore) Series(req *storepb.SeriesRequest, seriesSrv storepb.Store
 					seriesLimiter,
 				); err != nil {
 					onClose()
-					span.Finish()
 					return errors.Wrapf(err, "fetch postings for block %s", blk.meta.ULID)
 				}
 
 				var resp respSet
 				if s.sortingStrategy == sortingStrategyStore {
 					resp = newEagerRespSet(
-						span,
 						10*time.Minute,
 						blk.meta.ULID.String(),
 						[]labels.Labels{blk.extLset},
@@ -1706,7 +1695,6 @@ func (s *BucketStore) Series(req *storepb.SeriesRequest, seriesSrv storepb.Store
 					)
 				} else {
 					resp = newLazyRespSet(
-						span,
 						10*time.Minute,
 						blk.meta.ULID.String(),
 						[]labels.Labels{blk.extLset},

--- a/pkg/store/proxy.go
+++ b/pkg/store/proxy.go
@@ -33,7 +33,6 @@ import (
 	"github.com/thanos-io/thanos/pkg/store/storepb"
 	"github.com/thanos-io/thanos/pkg/strutil"
 	"github.com/thanos-io/thanos/pkg/tenancy"
-	"github.com/thanos-io/thanos/pkg/tracing"
 )
 
 type ctxKey int
@@ -468,16 +467,8 @@ func (s *ProxyStore) LabelNames(ctx context.Context, originalRequest *storepb.La
 		g, gctx  = errgroup.WithContext(ctx)
 	)
 	for _, st := range stores {
-
-		storeID, storeAddr, isLocalStore := storeInfo(st)
 		g.Go(func() error {
-			span, spanCtx := tracing.StartSpan(gctx, "proxy.label_names", tracing.Tags{
-				"store.id":       storeID,
-				"store.addr":     storeAddr,
-				"store.is_local": isLocalStore,
-			})
-			defer span.Finish()
-			resp, err := st.LabelNames(spanCtx, r)
+			resp, err := st.LabelNames(gctx, r)
 			if err != nil {
 				err = errors.Wrapf(err, "fetch label names from store %s", st)
 				if r.PartialResponseDisabled || r.PartialResponseStrategy == storepb.PartialResponseStrategy_ABORT {
@@ -572,17 +563,8 @@ func (s *ProxyStore) LabelValues(ctx context.Context, originalRequest *storepb.L
 		g, gctx  = errgroup.WithContext(ctx)
 	)
 	for _, st := range stores {
-
-		storeID, storeAddr, isLocalStore := storeInfo(st)
 		g.Go(func() error {
-			span, spanCtx := tracing.StartSpan(gctx, "proxy.label_values", tracing.Tags{
-				"store.id":       storeID,
-				"store.addr":     storeAddr,
-				"store.is_local": isLocalStore,
-			})
-			defer span.Finish()
-
-			resp, err := st.LabelValues(spanCtx, r)
+			resp, err := st.LabelValues(gctx, r)
 			if err != nil {
 				err = errors.Wrapf(err, "fetch label values from store %s", st)
 				if r.PartialResponseDisabled || r.PartialResponseStrategy == storepb.PartialResponseStrategy_ABORT {

--- a/pkg/store/proxy.go
+++ b/pkg/store/proxy.go
@@ -351,7 +351,7 @@ func (s *ProxyStore) Series(originalRequest *storepb.SeriesRequest, seriesSrv st
 		var reporter statsReporter
 
 		if tracker != nil && opIDOK {
-			_, storeAddr, _ := storeInfo(st)
+			_, storeAddr := storeInfo(st)
 			reporter = func(rs RespSetStats) {
 				tracker.AddStore(opID, fanout.StoreFanout{
 					EndpointAddr:   storeAddr,
@@ -599,13 +599,13 @@ func (s *ProxyStore) LabelValues(ctx context.Context, originalRequest *storepb.L
 	}, nil
 }
 
-func storeInfo(st Client) (storeID string, storeAddr string, isLocalStore bool) {
-	storeAddr, isLocalStore = st.Addr()
+func storeInfo(st Client) (storeID string, storeAddr string) {
+	storeAddr, _ = st.Addr()
 	storeID = labelpb.PromLabelSetsToString(st.LabelSets())
 	if storeID == "" {
 		storeID = "Store Gateway"
 	}
-	return storeID, storeAddr, isLocalStore
+	return storeID, storeAddr
 }
 
 // storesForTSDBSelector returns stores that match the TSDBSelector filtering criteria.

--- a/pkg/store/proxy_merge.go
+++ b/pkg/store/proxy_merge.go
@@ -26,7 +26,6 @@ import (
 	"github.com/thanos-io/thanos/pkg/losertree"
 	"github.com/thanos-io/thanos/pkg/store/labelpb"
 	"github.com/thanos-io/thanos/pkg/store/storepb"
-	"github.com/thanos-io/thanos/pkg/tracing"
 )
 
 type seriesStream interface {
@@ -309,7 +308,6 @@ func (rb *ringBuffer) isFull() bool {
 // NB: It is not thread-safe, so its metholds must be called from the same goroutine.
 type lazyRespSet struct {
 	// Generic parameters.
-	span           opentracing.Span
 	cl             storepb.Store_SeriesClient
 	closeSeries    context.CancelFunc
 	storeName      string
@@ -407,7 +405,6 @@ func (l *lazyRespSet) Close() {
 }
 
 func newLazyRespSet(
-	span opentracing.Span,
 	frameTimeout time.Duration,
 	storeName string,
 	storeLabelSets []labels.Labels,
@@ -427,7 +424,6 @@ func newLazyRespSet(
 		storeLabelSets:       storeLabelSets,
 		cl:                   cl,
 		closeSeries:          closeSeries,
-		span:                 span,
 		dataOrFinishEvent:    sync.NewCond(bufferedResponsesMtx),
 		bufferedResponsesMtx: bufferedResponsesMtx,
 		rb:                   newRingBuffer(fixedBufferSize, bufferedResponsesMtx),
@@ -451,12 +447,6 @@ func newLazyRespSet(
 		numResponses := 0
 
 		defer func() {
-			l.span.SetTag("processed.series", seriesStats.Series)
-			l.span.SetTag("processed.chunks", seriesStats.Chunks)
-			l.span.SetTag("processed.samples", seriesStats.Samples)
-			l.span.SetTag("processed.bytes", bytesProcessed)
-			l.span.Finish()
-
 			reportStats(reportStatsFn, RespSetStats{
 				Duration:       time.Since(startTime),
 				BytesProcessed: int64(bytesProcessed),
@@ -500,8 +490,6 @@ func newLazyRespSet(
 				} else {
 					rerr = errors.Wrapf(err, "receive series from %s", st)
 				}
-				l.span.SetTag("err", rerr.Error())
-
 				l.bufferedResponsesMtx.Lock()
 				l.rb.append(storepb.NewWarnSeriesResponse(rerr))
 				l.noMoreData = true
@@ -593,20 +581,11 @@ func newAsyncRespSet(
 	reportStatsFn statsReporter,
 ) (respSet, error) {
 
-	var (
-		span   opentracing.Span
-		cancel context.CancelFunc
-	)
+	var cancel context.CancelFunc
 
-	storeID, storeAddr, isLocalStore := storeInfo(st)
+	_, storeAddr, _ := storeInfo(st)
 	seriesCtx := grpc_opentracing.ClientAddContextTags(ctx, opentracing.Tags{
 		"target": storeAddr,
-	})
-	span, seriesCtx = tracing.StartSpan(seriesCtx, "proxy.series", tracing.Tags{
-		"store.id":           storeID,
-		"store.is_local":     isLocalStore,
-		"store.addr":         storeAddr,
-		"retrieval_strategy": retrievalStrategy,
 	})
 
 	seriesCtx, cancel = context.WithCancel(seriesCtx)
@@ -620,10 +599,7 @@ func newAsyncRespSet(
 
 	cl, err := st.Series(seriesCtx, req)
 	if err != nil {
-		err = errors.Wrapf(err, "fetch series for %s %s", storeID, st)
-
-		span.SetTag("err", err.Error())
-		span.Finish()
+		err = errors.Wrapf(err, "fetch series for %s", st)
 		cancel()
 		return nil, err
 	}
@@ -648,7 +624,6 @@ func newAsyncRespSet(
 		}
 
 		return newLazyRespSet(
-			span,
 			frameTimeout,
 			st.String(),
 			st.LabelSets(),
@@ -662,7 +637,6 @@ func newAsyncRespSet(
 		), nil
 	case EagerRetrieval:
 		return newEagerRespSet(
-			span,
 			frameTimeout,
 			st.String(),
 			st.LabelSets(),
@@ -684,8 +658,6 @@ func newAsyncRespSet(
 // NOTE(bwplotka): It also resorts the series (and emits warning) if the client.SupportsWithoutReplicaLabels() is false.
 type eagerRespSet struct {
 	// Generic parameters.
-	span opentracing.Span
-
 	cl           storepb.Store_SeriesClient
 	closeSeries  context.CancelFunc
 	frameTimeout time.Duration
@@ -704,7 +676,6 @@ type eagerRespSet struct {
 }
 
 func newEagerRespSet(
-	span opentracing.Span,
 	frameTimeout time.Duration,
 	storeName string,
 	storeLabelSets []labels.Labels,
@@ -717,7 +688,6 @@ func newEagerRespSet(
 	reportStatsFn statsReporter,
 ) respSet {
 	ret := &eagerRespSet{
-		span:              span,
 		cl:                cl,
 		closeSeries:       closeSeries,
 		frameTimeout:      frameTimeout,
@@ -745,12 +715,6 @@ func newEagerRespSet(
 		numResponses := 0
 
 		defer func() {
-			l.span.SetTag("processed.series", seriesStats.Series)
-			l.span.SetTag("processed.chunks", seriesStats.Chunks)
-			l.span.SetTag("processed.samples", seriesStats.Samples)
-			l.span.SetTag("processed.bytes", bytesProcessed)
-			l.span.Finish()
-
 			reportStats(reportStatsFn, RespSetStats{
 				Duration:       time.Since(startTime),
 				BytesProcessed: int64(bytesProcessed),
@@ -794,7 +758,6 @@ func newEagerRespSet(
 				}
 
 				l.bufferedResponses = append(l.bufferedResponses, storepb.NewWarnSeriesResponse(rerr))
-				l.span.SetTag("err", rerr.Error())
 				return false
 			}
 

--- a/pkg/store/proxy_merge.go
+++ b/pkg/store/proxy_merge.go
@@ -583,7 +583,7 @@ func newAsyncRespSet(
 
 	var cancel context.CancelFunc
 
-	_, storeAddr, _ := storeInfo(st)
+	storeID, storeAddr := storeInfo(st)
 	seriesCtx := grpc_opentracing.ClientAddContextTags(ctx, opentracing.Tags{
 		"target": storeAddr,
 	})
@@ -599,7 +599,7 @@ func newAsyncRespSet(
 
 	cl, err := st.Series(seriesCtx, req)
 	if err != nil {
-		err = errors.Wrapf(err, "fetch series for %s", st)
+		err = errors.Wrapf(err, "fetch series for %s %s", storeID, st)
 		cancel()
 		return nil, err
 	}

--- a/pkg/store/proxy_merge_test.go
+++ b/pkg/store/proxy_merge_test.go
@@ -10,8 +10,6 @@ import (
 	"testing"
 
 	"github.com/efficientgo/core/testutil"
-	"github.com/opentracing/opentracing-go"
-	otlog "github.com/opentracing/opentracing-go/log"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/prometheus/model/labels"
@@ -276,7 +274,6 @@ func TestProxyResponseTreeSortWithBatchResponses(t *testing.T) {
 	// Create eagerRespSets which should unpack the batches
 	var shardInfo *storepb.ShardInfo
 	respSet1 := newEagerRespSet(
-		noopSpan{},
 		0,
 		"store1",
 		nil,
@@ -289,7 +286,6 @@ func TestProxyResponseTreeSortWithBatchResponses(t *testing.T) {
 		nil,
 	)
 	respSet2 := newEagerRespSet(
-		noopSpan{},
 		0,
 		"store2",
 		nil,
@@ -334,23 +330,6 @@ func (c *mockBatchSeriesClient) Recv() (*storepb.SeriesResponse, error) {
 
 func (c *mockBatchSeriesClient) CloseSend() error { return nil }
 
-// noopSpan implements opentracing.Span for testing.
-type noopSpan struct{}
-
-func (noopSpan) Finish()                                        {}
-func (noopSpan) SetTag(string, any) opentracing.Span            { return noopSpan{} }
-func (noopSpan) Context() opentracing.SpanContext               { return nil }
-func (noopSpan) SetOperationName(string) opentracing.Span       { return noopSpan{} }
-func (noopSpan) Tracer() opentracing.Tracer                     { return nil }
-func (noopSpan) SetBaggageItem(string, string) opentracing.Span { return noopSpan{} }
-func (noopSpan) BaggageItem(string) string                      { return "" }
-func (noopSpan) LogKV(...any)                                   {}
-func (noopSpan) LogFields(...otlog.Field)                       {}
-func (noopSpan) Log(opentracing.LogData)                        {}
-func (noopSpan) FinishWithOptions(opentracing.FinishOptions)    {}
-func (noopSpan) LogEvent(string)                                {}
-func (noopSpan) LogEventWithPayload(string, interface{})        {}
-
 // TestLazyRespSetUnpacksBatchResponses verifies that lazyRespSet properly unpacks
 // batch responses into individual series before being merged by the loser tree.
 func TestLazyRespSetUnpacksBatchResponses(t *testing.T) {
@@ -374,7 +353,6 @@ func TestLazyRespSetUnpacksBatchResponses(t *testing.T) {
 
 	var shardInfo *storepb.ShardInfo
 	respSet1 := newLazyRespSet(
-		noopSpan{},
 		0,
 		"store1",
 		nil,
@@ -387,7 +365,6 @@ func TestLazyRespSetUnpacksBatchResponses(t *testing.T) {
 		nil,
 	)
 	respSet2 := newLazyRespSet(
-		noopSpan{},
 		0,
 		"store2",
 		nil,

--- a/test/e2e/tracing_test.go
+++ b/test/e2e/tracing_test.go
@@ -84,7 +84,7 @@ config:
 		},
 	})
 
-	url := "http://" + strings.TrimSpace(newJaeger.Endpoint("http")+"/api/traces?service=thanos-query&operation=proxy.series")
+	url := "http://" + strings.TrimSpace(newJaeger.Endpoint("http")+"/api/traces?service=thanos-query&operation=%2Fthanos.Store%2FSeries")
 	request, err := http.NewRequest("GET", url, nil)
 	testutil.Ok(t, err)
 	client := &http.Client{}


### PR DESCRIPTION
## Summary
- Distributed traces in large Thanos deployments can emit tens of thousands of INTERNAL spans per request (#6099), drowning out useful CLIENT/SERVER RPC spans.
- Maintainer guidance on the issue is to drop INTERNAL spans (profiling is a better fit for that visibility). This focused first change removes the highest-volume INTERNAL spans from production analytics while keeping gRPC CLIENT/SERVER spans.
- Removed spans: `proxy.series`, `proxy.label_names`, `proxy.label_values`, `bucket_store_block_series`, `send_rules_response`, `send_rule_group_response` (continuing after #6106 which removed `store_matches`).

## Test plan
- [x] `go build ./pkg/store/ ./pkg/rules/`
- [x] `go test ./pkg/rules/ -run TestProxy`
- [x] `go test ./pkg/store/ -run TestRmLabelsCornerCases`
- [ ] CI e2e tracing test (`TestJaegerTracing`) now asserts `/thanos.Store/Series` instead of `proxy.series`

Fixes #6099