### PR TITLE
receive: make tests faster

### DIFF
--- a/pkg/receive/capnproto_server_test.go
+++ b/pkg/receive/capnproto_server_test.go
@@ -41,7 +41,7 @@ func TestCapNProtoServer_SingleConcurrentClient(t *testing.T) {
 	}()
 	defer srv.Shutdown()
 
-	for range 1000 {
+	for range 200 {
 		client := writecapnp.NewRemoteWriteClient(listener, log.NewLogfmtLogger(os.Stdout))
 		_, err := client.RemoteWrite(context.Background(), &storepb.WriteRequest{
 			Tenant: "default",
@@ -71,7 +71,7 @@ func TestCapNProtoServer_MultipleConcurrentClients(t *testing.T) {
 	}()
 	defer srv.Shutdown()
 
-	for range 1000 {
+	for range 200 {
 		client := writecapnp.NewRemoteWriteClient(listener, log.NewLogfmtLogger(os.Stdout))
 		_, err := client.RemoteWrite(context.Background(), &storepb.WriteRequest{
 			Tenant: "default",

--- a/pkg/receive/handler_localwrite_test.go
+++ b/pkg/receive/handler_localwrite_test.go
@@ -59,6 +59,8 @@ func newLocalWriteHandler(t *testing.T, endpoints []Endpoint, apps []*fakeAppend
 // TestLocalAsyncWriterRemoteWritePersists ensures localAsyncWriter actually
 // writes the request to the underlying TSDB.
 func TestLocalAsyncWriterRemoteWritePersists(t *testing.T) {
+	t.Parallel()
+
 	fa := newFakeAppender(nil, nil, nil)
 	app := &fakeAppendable{appender: fa}
 	w := NewWriter(log.NewNopLogger(), newFakeTenantAppendable(app), &WriterOptions{})
@@ -83,6 +85,8 @@ func TestLocalAsyncWriterRemoteWritePersists(t *testing.T) {
 // surfaces as an error to the caller. A no-op RemoteWrite would mask backend
 // errors and make the handler return a success code while losing data.
 func TestLocalAsyncWriterRemoteWritePropagatesError(t *testing.T) {
+	t.Parallel()
+
 	app := &fakeAppendable{
 		appender:    newFakeAppender(nil, nil, nil),
 		appenderErr: func() error { return errors.New("appender unavailable") },
@@ -103,6 +107,8 @@ func TestLocalAsyncWriterRemoteWritePropagatesError(t *testing.T) {
 // the real local-write path (peerGroup.getConnection -> localAsyncWriter) that
 // the existing test harness mocks away.
 func TestReceiveLocalWritePersistsEndToEnd(t *testing.T) {
+	t.Parallel()
+
 	fa := newFakeAppender(nil, nil, nil)
 	app := &fakeAppendable{appender: fa}
 	h := newLocalWriteHandler(t, []Endpoint{newUniqueEndpoint()}, []*fakeAppendable{app})
@@ -123,6 +129,8 @@ func TestReceiveLocalWritePersistsEndToEnd(t *testing.T) {
 // promise of the commit: when the local write fails the handler must return a
 // non-2xx status instead of pretending the write succeeded.
 func TestReceiveLocalWriteReportsFailureWhenLocalWriteFails(t *testing.T) {
+	t.Parallel()
+
 	app := &fakeAppendable{
 		appender:    newFakeAppender(nil, nil, nil),
 		appenderErr: func() error { return errors.New("appender unavailable") },
@@ -143,6 +151,8 @@ func TestReceiveLocalWriteReportsFailureWhenLocalWriteFails(t *testing.T) {
 // lost and the handler degrades the response to 503. Wrapping with errors.Wrap
 // instead preserves the Cause() chain that writeErrors/isConflict rely on.
 func TestReceiveLocalWriteConflictReturns409(t *testing.T) {
+	t.Parallel()
+
 	app := &fakeAppendable{
 		appender: newFakeAppender(func() error { return storage.ErrOutOfBounds }, nil, nil),
 	}
@@ -201,6 +211,8 @@ func (p *singleClientPeers) Close() error                 { return nil }
 // through the handler and asserts the fanout splits the data per tenant but
 // emits exactly one write to the destination carrying both tenants.
 func TestReceiveMultiTenantSplitWritesOnce(t *testing.T) {
+	t.Parallel()
+
 	const tenantLabel = "thanos_tenant_id"
 
 	fa := newFakeAppender(nil, nil, nil)

--- a/pkg/receive/handler_otlp_test.go
+++ b/pkg/receive/handler_otlp_test.go
@@ -18,6 +18,8 @@ import (
 )
 
 func TestOTLPWriteHandler(t *testing.T) {
+	t.Parallel()
+
 	exportRequest := generateOTLPWriteRequest()
 
 	buf, err := exportRequest.MarshalProto()

--- a/pkg/receive/handler_test.go
+++ b/pkg/receive/handler_test.go
@@ -926,7 +926,7 @@ func TestReceiveSaturatedPoolRF2(t *testing.T) {
 
 		// NOTE(GiedriusS): waiting until the best-effort writers are done
 		// because the waiting is happening in a goroutine.
-		require.NoError(t, runutil.Retry(1*time.Second, t.Context().Done(), func() error {
+		require.NoError(t, runutil.Retry(10*time.Millisecond, t.Context().Done(), func() error {
 			laggyPool := fakePeers.clients[endpoints[1]].wp
 
 			r := laggyPool.TryGo(func() {})
@@ -1473,7 +1473,7 @@ func benchmarkHandlerMultiTSDBReceiveRemoteWrite(b testutil.TB) {
 				ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 				defer cancel()
 
-				testutil.Ok(b, runutil.Retry(1*time.Second, ctx.Done(), func() error {
+				testutil.Ok(b, runutil.Retry(10*time.Millisecond, ctx.Done(), func() error {
 					_, err = app.Appender(ctx)
 					return err
 				}))
@@ -1500,7 +1500,7 @@ func benchmarkHandlerMultiTSDBReceiveRemoteWrite(b testutil.TB) {
 				ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 				defer cancel()
 
-				testutil.Ok(b, runutil.Retry(1*time.Second, ctx.Done(), func() error {
+				testutil.Ok(b, runutil.Retry(10*time.Millisecond, ctx.Done(), func() error {
 					_, err = app.Appender(ctx)
 					return err
 				}))
@@ -2224,6 +2224,8 @@ func BenchmarkFanoutForward(b *testing.B) {
 }
 
 func TestHandlerSplitTenantLabelLocalWrite(t *testing.T) {
+	t.Parallel()
+
 	const tenantIDLabelName = "thanos_tenant_id"
 
 	appendable := &fakeAppendable{

--- a/pkg/receive/hashring_test.go
+++ b/pkg/receive/hashring_test.go
@@ -340,6 +340,7 @@ func TestKetamaHashringIncreaseAtEnd(t *testing.T) {
 	initialRing := []Endpoint{{Address: "node-1"}, {Address: "node-2"}, {Address: "node-3"}}
 	initialAssignments, err := assignSeries(series, initialRing)
 	require.NoError(t, err)
+	initialSets := seriesSets(initialAssignments)
 
 	resizedRing := []Endpoint{{Address: "node-1"}, {Address: "node-2"}, {Address: "node-3"}, {Address: "node-4"}, {Address: "node-5"}}
 	reassignments, err := assignSeries(series, resizedRing)
@@ -348,7 +349,7 @@ func TestKetamaHashringIncreaseAtEnd(t *testing.T) {
 	// Assert that the initial nodes have no new keys after increasing the ring size
 	for _, node := range initialRing {
 		for _, ts := range reassignments[node.Address] {
-			foundInInitialAssignment := findSeries(initialAssignments, node.Address, ts)
+			foundInInitialAssignment := findSeries(initialSets, node.Address, ts)
 			require.True(t, foundInInitialAssignment, "node %s contains new series after resizing", node)
 		}
 	}
@@ -362,6 +363,7 @@ func TestKetamaHashringIncreaseInMiddle(t *testing.T) {
 	initialRing := []Endpoint{{Address: "node-1"}, {Address: "node-3"}}
 	initialAssignments, err := assignSeries(series, initialRing)
 	require.NoError(t, err)
+	initialSets := seriesSets(initialAssignments)
 
 	resizedRing := []Endpoint{{Address: "node-1"}, {Address: "node-2"}, {Address: "node-3"}}
 	reassignments, err := assignSeries(series, resizedRing)
@@ -370,7 +372,7 @@ func TestKetamaHashringIncreaseInMiddle(t *testing.T) {
 	// Assert that the initial nodes have no new keys after increasing the ring size
 	for _, node := range initialRing {
 		for _, ts := range reassignments[node.Address] {
-			foundInInitialAssignment := findSeries(initialAssignments, node.Address, ts)
+			foundInInitialAssignment := findSeries(initialSets, node.Address, ts)
 			require.True(t, foundInInitialAssignment, "node %s contains new series after resizing", node)
 		}
 	}
@@ -389,6 +391,7 @@ func TestKetamaHashringReplicationConsistency(t *testing.T) {
 	initialRing := []Endpoint{{Address: "node-1"}, {Address: "node-4"}, {Address: "node-5"}}
 	initialAssignments, err := assignReplicatedSeries(series, initialRing, 2)
 	require.NoError(t, err)
+	initialSets := seriesSets(initialAssignments)
 
 	resizedRing := []Endpoint{{Address: "node-4"}, {Address: "node-3"}, {Address: "node-1"}, {Address: "node-2"}, {Address: "node-5"}}
 	reassignments, err := assignReplicatedSeries(series, resizedRing, 2)
@@ -397,7 +400,7 @@ func TestKetamaHashringReplicationConsistency(t *testing.T) {
 	// Assert that the initial nodes have no new keys after increasing the ring size
 	for _, node := range initialRing {
 		for _, ts := range reassignments[node.Address] {
-			foundInInitialAssignment := findSeries(initialAssignments, node.Address, ts)
+			foundInInitialAssignment := findSeries(initialSets, node.Address, ts)
 			require.True(t, foundInInitialAssignment, "node %s contains new series after resizing", node)
 		}
 	}
@@ -447,6 +450,7 @@ func TestKetamaHashringReplicationConsistencyWithAZs(t *testing.T) {
 
 			initialAssignments, err := assignReplicatedSeries(series, tt.initialRing, tt.replicas)
 			require.NoError(t, err)
+			initialSets := seriesSets(initialAssignments)
 
 			reassignments, err := assignReplicatedSeries(series, tt.resizedRing, tt.replicas)
 			require.NoError(t, err)
@@ -454,7 +458,7 @@ func TestKetamaHashringReplicationConsistencyWithAZs(t *testing.T) {
 			// Assert that the initial nodes have no new keys after increasing the ring size
 			for _, node := range tt.initialRing {
 				for _, ts := range reassignments[node.Address] {
-					foundInInitialAssignment := findSeries(initialAssignments, node.Address, ts)
+					foundInInitialAssignment := findSeries(initialSets, node.Address, ts)
 					require.True(t, foundInInitialAssignment, "node %s contains new series after resizing", node)
 				}
 			}
@@ -878,20 +882,29 @@ func makeSeries() []prompb.TimeSeries {
 	return series
 }
 
-func findSeries(initialAssignments map[string][]prompb.TimeSeries, node string, newSeries prompb.TimeSeries) bool {
-	for _, oldSeries := range initialAssignments[node] {
-		l1 := labelpb.ZLabelsToPromLabels(newSeries.Labels)
-		l2 := labelpb.ZLabelsToPromLabels(oldSeries.Labels)
-		if labels.Equal(l1, l2) {
-			return true
-		}
+func seriesSet(series []prompb.TimeSeries) map[string]struct{} {
+	set := make(map[string]struct{}, len(series))
+	for _, ts := range series {
+		set[labelpb.ZLabelsToPromLabels(ts.Labels).String()] = struct{}{}
 	}
+	return set
+}
 
-	return false
+func findSeries(initialAssignments map[string]map[string]struct{}, node string, newSeries prompb.TimeSeries) bool {
+	_, ok := initialAssignments[node][labelpb.ZLabelsToPromLabels(newSeries.Labels).String()]
+	return ok
+}
+
+func seriesSets(assignments map[string][]prompb.TimeSeries) map[string]map[string]struct{} {
+	sets := make(map[string]map[string]struct{}, len(assignments))
+	for node, series := range assignments {
+		sets[node] = seriesSet(series)
+	}
+	return sets
 }
 
 func assignSeries(series []prompb.TimeSeries, nodes []Endpoint) (map[string][]prompb.TimeSeries, error) {
-	return assignReplicatedSeries(series, nodes, 0)
+	return assignReplicatedSeries(series, nodes, 1)
 }
 
 func assignReplicatedSeries(series []prompb.TimeSeries, nodes []Endpoint, replicas uint64) (map[string][]prompb.TimeSeries, error) {
@@ -954,6 +967,8 @@ func TestShuffleShardHashringStability(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
 			// Create initial endpoints
 			initialEndpoints := make([]Endpoint, tc.initialNodes)
 			for i := 0; i < tc.initialNodes; i++ {
@@ -1016,7 +1031,7 @@ func getTenantNodes(t *testing.T, ring *shuffleShardHashring, tenant string, sha
 	t.Helper()
 	nodes := make(map[string]struct{})
 
-	for i := 0; i < 1000; i++ {
+	for i := 0; i < 200; i++ {
 		ts := &prompb.TimeSeries{
 			Labels: []labelpb.ZLabel{
 				{Name: "series", Value: fmt.Sprintf("%d", i)},

--- a/pkg/receive/multitsdb_test.go
+++ b/pkg/receive/multitsdb_test.go
@@ -77,7 +77,7 @@ func TestMultiTSDB(t *testing.T) {
 		defer cancel()
 
 		var a storage.Appender
-		testutil.Ok(t, runutil.Retry(1*time.Second, ctx.Done(), func() error {
+		testutil.Ok(t, runutil.Retry(10*time.Millisecond, ctx.Done(), func() error {
 			a, err = app.Appender(context.Background())
 			return err
 		}))
@@ -112,7 +112,7 @@ func TestMultiTSDB(t *testing.T) {
 		app, err = m.TenantAppendable("bar")
 		testutil.Ok(t, err)
 
-		testutil.Ok(t, runutil.Retry(1*time.Second, ctx.Done(), func() error {
+		testutil.Ok(t, runutil.Retry(10*time.Millisecond, ctx.Done(), func() error {
 			a, err = app.Appender(context.Background())
 			return err
 		}))
@@ -162,7 +162,7 @@ func TestMultiTSDB(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
 
-		testutil.Ok(t, runutil.Retry(1*time.Second, ctx.Done(), func() error {
+		testutil.Ok(t, runutil.Retry(10*time.Millisecond, ctx.Done(), func() error {
 			_, err := app.Appender(context.Background())
 			return err
 		}))
@@ -518,15 +518,18 @@ func TestMultiTSDBPrune(t *testing.T) {
 }*/
 
 func TestMultiTSDBRecreatePrunedTenant(t *testing.T) {
+	t.Parallel()
+
 	synctest.Test(t, func(t *testing.T) {
 		dir := t.TempDir()
 
 		reg := prometheus.NewRegistry()
 		m := NewMultiTSDB(openTestRoot(t, dir), log.NewLogfmtLogger(os.Stderr), reg,
 			&tsdb.Options{
-				MinBlockDuration:  (2 * time.Hour).Milliseconds(),
-				MaxBlockDuration:  (2 * time.Hour).Milliseconds(),
-				RetentionDuration: (6 * time.Hour).Milliseconds(),
+				MinBlockDuration:    (2 * time.Hour).Milliseconds(),
+				MaxBlockDuration:    (2 * time.Hour).Milliseconds(),
+				RetentionDuration:   (6 * time.Hour).Milliseconds(),
+				BlockReloadInterval: 1 * time.Hour,
 			},
 			labels.FromStrings("replica", "test"),
 			"tenant_id",
@@ -575,6 +578,8 @@ func tenantMetricCount(t *testing.T, g prometheus.Gatherer, tenant string) int {
 
 // synctest.Test controls fake time so t.Parallel() is not used.
 func TestPeriodicHeadCompaction(t *testing.T) {
+	t.Parallel()
+
 	synctest.Test(t, func(t *testing.T) {
 		dir := t.TempDir()
 
@@ -586,6 +591,7 @@ func TestPeriodicHeadCompaction(t *testing.T) {
 				MaxBlockDuration:     maxBlockDuration,
 				RetentionDuration:    (24 * time.Hour).Milliseconds(),
 				OutOfOrderTimeWindow: (4 * time.Hour).Milliseconds(),
+				BlockReloadInterval:  time.Hour,
 			},
 			labels.FromStrings("replica", "test"),
 			"tenant_id",
@@ -662,7 +668,7 @@ func TestMultiTSDBAddNewTenant(t *testing.T) {
 	}
 
 	t.Parallel()
-	const iterations = 10
+	const iterations = 3
 	// This test detects race conditions, so we run it multiple times to increase the chance of catching the issue.
 	for i := range iterations {
 		t.Run(fmt.Sprintf("iteration-%d", i), func(t *testing.T) {
@@ -945,7 +951,7 @@ func appendSampleWithLabels(m *MultiTSDB, tenant string, lbls labels.Labels, tim
 	}
 
 	var a storage.Appender
-	if err := runutil.Retry(1*time.Second, ctx.Done(), func() error {
+	if err := runutil.Retry(10*time.Millisecond, ctx.Done(), func() error {
 		a, err = app.Appender(ctx)
 		return err
 	}); err != nil {
@@ -1011,7 +1017,7 @@ func BenchmarkMultiTSDB(b *testing.B) {
 	defer cancel()
 
 	var a storage.Appender
-	testutil.Ok(b, runutil.Retry(1*time.Second, ctx.Done(), func() error {
+	testutil.Ok(b, runutil.Retry(10*time.Millisecond, ctx.Done(), func() error {
 		a, err = app.Appender(context.Background())
 		return err
 	}))
@@ -1111,7 +1117,7 @@ func TestMultiTSDBDoesNotReturnPrunedTenants(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
-	const iterations = 200
+	const iterations = 50
 
 	wg := sync.WaitGroup{}
 	wg.Go(func() {

--- a/pkg/receive/writer_test.go
+++ b/pkg/receive/writer_test.go
@@ -468,7 +468,7 @@ func setupMultitsdb(t *testing.T, maxExemplars int64) (log.Logger, *MultiTSDB, A
 	app, err := m.TenantAppendable(tenancy.DefaultTenant)
 	testutil.Ok(t, err)
 
-	testutil.Ok(t, runutil.Retry(1*time.Second, ctx.Done(), func() error {
+	testutil.Ok(t, runutil.Retry(10*time.Millisecond, ctx.Done(), func() error {
 		_, err = app.Appender(context.Background())
 		return err
 	}))
@@ -533,7 +533,7 @@ func benchmarkWriter(b *testing.B, labelsNum int, seriesNum int, generateHistogr
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	testutil.Ok(b, runutil.Retry(1*time.Second, ctx.Done(), func() error {
+	testutil.Ok(b, runutil.Retry(10*time.Millisecond, ctx.Done(), func() error {
 		_, err = app.Appender(context.Background())
 		return err
 	}))

--- a/pkg/store/bucket_e2e_test.go
+++ b/pkg/store/bucket_e2e_test.go
@@ -194,8 +194,7 @@ func prepareStoreWithTestBlocks(t testing.TB, dir string, bkt objstore.Bucket, m
 	defer cancel()
 
 	// Check if the blocks are being loaded.
-	start := time.Now()
-	time.Sleep(time.Second * 1)
+	start := time.Now().Truncate(time.Second)
 	testutil.Ok(t, store.SyncBlocks(ctx))
 
 	// Get the value of the metric 'thanos_bucket_store_blocks_last_loaded_timestamp_seconds' to capture the timestamp of the last loaded block.

--- a/pkg/store/bucket_test.go
+++ b/pkg/store/bucket_test.go
@@ -1380,7 +1380,7 @@ func TestBucketSeries(t *testing.T) {
 	t.Parallel()
 
 	tb := testutil.NewTB(t)
-	storetestutil.RunSeriesInterestingCases(tb, 200e3, 200e3, func(t testutil.TB, samplesPerSeries, series int) {
+	storetestutil.RunSeriesInterestingCases(tb, 50e3, 50e3, func(t testutil.TB, samplesPerSeries, series int) {
 		benchBucketSeries(t, chunkenc.ValFloat, false, false, samplesPerSeries, series, 1)
 	})
 }
@@ -1394,7 +1394,7 @@ func TestBucketSeriesLazyExpandedPostings(t *testing.T) {
 	t.Parallel()
 
 	tb := testutil.NewTB(t)
-	storetestutil.RunSeriesInterestingCases(tb, 200e3, 200e3, func(t testutil.TB, samplesPerSeries, series int) {
+	storetestutil.RunSeriesInterestingCases(tb, 50e3, 50e3, func(t testutil.TB, samplesPerSeries, series int) {
 		benchBucketSeries(t, chunkenc.ValFloat, false, true, samplesPerSeries, series, 1)
 	})
 }
@@ -1408,7 +1408,7 @@ func TestBucketHistogramSeries(t *testing.T) {
 	t.Parallel()
 
 	tb := testutil.NewTB(t)
-	storetestutil.RunSeriesInterestingCases(tb, 200e3, 200e3, func(t testutil.TB, samplesPerSeries, series int) {
+	storetestutil.RunSeriesInterestingCases(tb, 50e3, 50e3, func(t testutil.TB, samplesPerSeries, series int) {
 		benchBucketSeries(t, chunkenc.ValHistogram, false, false, samplesPerSeries, series, 1)
 	})
 }
@@ -1422,7 +1422,7 @@ func TestBucketFloatHistogramSeries(t *testing.T) {
 	t.Parallel()
 
 	tb := testutil.NewTB(t)
-	storetestutil.RunSeriesInterestingCases(tb, 200e3, 200e3, func(t testutil.TB, samplesPerSeries, series int) {
+	storetestutil.RunSeriesInterestingCases(tb, 50e3, 50e3, func(t testutil.TB, samplesPerSeries, series int) {
 		benchBucketSeries(t, chunkenc.ValFloatHistogram, false, false, samplesPerSeries, series, 1)
 	})
 }
@@ -1436,7 +1436,7 @@ func TestBucketSkipChunksSeries(t *testing.T) {
 	t.Parallel()
 
 	tb := testutil.NewTB(t)
-	storetestutil.RunSeriesInterestingCases(tb, 200e3, 200e3, func(t testutil.TB, samplesPerSeries, series int) {
+	storetestutil.RunSeriesInterestingCases(tb, 50e3, 50e3, func(t testutil.TB, samplesPerSeries, series int) {
 		benchBucketSeries(t, chunkenc.ValFloat, true, false, samplesPerSeries, series, 1)
 	})
 }

--- a/pkg/store/postings_codec_test.go
+++ b/pkg/store/postings_codec_test.go
@@ -54,7 +54,7 @@ func TestStreamedSnappyMaximumDecodedLen(t *testing.T) {
 		testutil.Assert(t, maxLen == 100)
 	})
 	t.Run("random", func(t *testing.T) {
-		for i := 10000; i < 30000; i++ {
+		for i := 10000; i < 30000; i += 100 {
 			b := make([]byte, i)
 			_, err := crand.Read(b)
 			testutil.Ok(t, err)
@@ -95,7 +95,7 @@ func TestDiffVarintCodec(t *testing.T) {
 		testutil.Ok(t, h.Close())
 	}()
 
-	appendTestData(t, h.Appender(context.Background()), 1e6)
+	appendTestData(t, h.Appender(context.Background()), 1e5)
 
 	idx, err := h.Index()
 	testutil.Ok(t, err)

--- a/pkg/store/proxy_test.go
+++ b/pkg/store/proxy_test.go
@@ -2119,7 +2119,7 @@ func TestProxySeries(t *testing.T) {
 	t.Parallel()
 
 	tb := testutil.NewTB(t)
-	storetestutil.RunSeriesInterestingCases(tb, 200e3, 200e3, func(t testutil.TB, samplesPerSeries, series int) {
+	storetestutil.RunSeriesInterestingCases(tb, 50e3, 50e3, func(t testutil.TB, samplesPerSeries, series int) {
 		benchProxySeries(t, samplesPerSeries, series)
 	})
 }


### PR DESCRIPTION
Make time.Sleep() faster in synctest; add t.Parallel() to more places; memoize some searches; make intervals tighter.
