### PR TITLE
receive: only start CapNProto server when replication-protocol is cap…

### DIFF
--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -552,7 +552,7 @@ func runReceive(
 		}
 	}
 
-	{
+	if receive.ReplicationProtocol(conf.replicationProtocol) == receive.CapNProtoReplication {
 		capNProtoWriter := receive.NewCapNProtoWriter(logger, dbs, &receive.CapNProtoWriterOptions{
 			TooFarInFutureTimeWindow: int64(time.Duration(*conf.tsdbTooFarInFutureTimeWindow)),
 		})


### PR DESCRIPTION
Previously the CapNProto writer, handler, listener, and server were always initialized on startup regardless of --receive.replication-protocol, wasting resources and starting an unused listener when protobuf replication was configured. This wraps that block so it only runs when the CapNProto protocol is actually selected.

Fixes #8093

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes
- Wrapped the CapNProto writer/handler/listener/server initialization in `runReceive` (cmd/thanos/receive.go) with a check on `conf.replicationProtocol`, so it only starts when `--receive.replication-protocol=capnproto` is set.

## Verification
- `go build ./cmd/thanos/...` succeeds
- `go vet ./cmd/thanos/...` reports no issues
- Confirmed accepted flag values via `./thanos receive --help`