### PR TITLE
query-frontend: avoid empty cache span events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 
 ### Fixed
 
+- [#8958](https://github.com/thanos-io/thanos/pull/8958): Query Frontend: Avoid invalid empty-name span events from cache instrumentation.
 - [#8900](https://github.com/thanos-io/thanos/pull/8900): UI: Fix web UI static assets (JS/CSS) returning 404 on Windows by using slash-separated paths for the embedded file system.
 - [#8935](https://github.com/thanos-io/thanos/pull/8935): Receive: remove redundant tl.Set() while building a Capnp WriteRequest.
 

--- a/internal/cortex/chunk/cache/instrumented.go
+++ b/internal/cortex/chunk/cache/instrumented.go
@@ -6,8 +6,6 @@ package cache
 import (
 	"context"
 
-	ot "github.com/opentracing/opentracing-go"
-	otlog "github.com/opentracing/opentracing-go/log"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	instr "github.com/weaveworks/common/instrument"
@@ -74,8 +72,6 @@ func (i *instrumentedCache) Store(ctx context.Context, keys []string, bufs [][]b
 
 	method := i.name + ".store"
 	_ = instr.CollectedRequest(ctx, method, i.requestDuration, instr.ErrorCode, func(ctx context.Context) error {
-		sp := ot.SpanFromContext(ctx)
-		sp.LogFields(otlog.Int("keys", len(keys)))
 		i.Cache.Store(ctx, keys, bufs)
 		return nil
 	})
@@ -90,11 +86,7 @@ func (i *instrumentedCache) Fetch(ctx context.Context, keys []string) ([]string,
 	)
 
 	_ = instr.CollectedRequest(ctx, method, i.requestDuration, instr.ErrorCode, func(ctx context.Context) error {
-		sp := ot.SpanFromContext(ctx)
-		sp.LogFields(otlog.Int("keys requested", len(keys)))
-
 		found, bufs, missing = i.Cache.Fetch(ctx, keys)
-		sp.LogFields(otlog.Int("keys found", len(found)), otlog.Int("keys missing", len(keys)-len(found)))
 		return nil
 	})
 

--- a/internal/cortex/chunk/cache/instrumented_test.go
+++ b/internal/cortex/chunk/cache/instrumented_test.go
@@ -1,0 +1,43 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package cache
+
+import (
+	"context"
+	"testing"
+
+	"github.com/opentracing/opentracing-go"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+	bridge "go.opentelemetry.io/otel/bridge/opentracing"
+	tracesdk "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+func TestInstrumentedCacheDoesNotEmitEmptySpanEvents(t *testing.T) {
+	recorder := tracetest.NewSpanRecorder()
+	provider := tracesdk.NewTracerProvider(tracesdk.WithSpanProcessor(recorder))
+	tracer, _ := bridge.NewTracerPair(provider.Tracer(""))
+	previousTracer := opentracing.GlobalTracer()
+	opentracing.SetGlobalTracer(tracer)
+	t.Cleanup(func() {
+		opentracing.SetGlobalTracer(previousTracer)
+		require.NoError(t, provider.Shutdown(context.Background()))
+	})
+
+	span := tracer.StartSpan("cache")
+	ctx := opentracing.ContextWithSpan(context.Background(), span)
+	c := Instrument("test", NewMockCache(), prometheus.NewRegistry())
+	c.Store(ctx, []string{"key"}, [][]byte{[]byte("value")})
+	c.Fetch(ctx, []string{"key", "missing"})
+	span.Finish()
+
+	recordedSpans := recorder.Ended()
+	require.NotEmpty(t, recordedSpans)
+	for _, recordedSpan := range recordedSpans {
+		for _, event := range recordedSpan.Events() {
+			require.NotEmpty(t, event.Name)
+		}
+	}
+}

--- a/internal/cortex/chunk/cache/instrumented_test.go
+++ b/internal/cortex/chunk/cache/instrumented_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) The Thanos Authors.
+// Copyright (c) The Cortex Authors.
 // Licensed under the Apache License 2.0.
 
 package cache


### PR DESCRIPTION
* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Remove cache OpenTracing field logs that the OpenTelemetry bridge converts into empty-name span events. Strict OTLP backends reject those events and can drop the affected spans. Existing cache request-duration, key, and hit/miss metrics are unchanged.

Fixes #8938

## Verification

- Reproduced before the fix with `go test ./internal/cortex/chunk/cache -run '^TestInstrumentedCacheDoesNotEmitEmptySpanEvents$' -count=1`: failed with 3 empty-name events.\n- `go test ./internal/cortex/chunk/cache -run '^TestInstrumentedCacheDoesNotEmitEmptySpanEvents$' -count=1`\n- `go test -race ./internal/cortex/chunk/cache -count=1`\n- `make build`\n- `make test-local` in Linux with Go 1.26\n- `make go-lint` in Linux with Go 1.26\n- `make react-app-lint`\n- `make shell-lint`