### PR TITLE
docs: replace the removed --store flag with --endpoint

### DIFF
--- a/docs/components/rule.md
+++ b/docs/components/rule.md
@@ -96,7 +96,7 @@ labels:
   [ <labelname>: <labelvalue> ]
 ```
 
-Note: If you make use of recording rules, make sure that you expose your Ruler instance as a store in the Thanos Querier so that the new time series can be queried as part of Thanos Query. One of the ways you can do this is by adding a new `--store <thanos-ruler-ip>` command-line argument to the Thanos Query command.
+Note: If you make use of recording rules, make sure that you expose your Ruler instance as a store in the Thanos Querier so that the new time series can be queried as part of Thanos Query. One of the ways you can do this is by adding a new `--endpoint <thanos-ruler-ip>` command-line argument to the Thanos Query command.
 
 ### Alerting Rules
 

--- a/docs/operating/cross-cluster-tls-communication.md
+++ b/docs/operating/cross-cluster-tls-communication.md
@@ -23,7 +23,7 @@ Envoy can be implemented as a sidecar container (example shown here) within the 
 - Configure an envoy sidecar container to the Thanos Querier pod (unfortunately this also isn't supported by a lot of Thanos charts) an example pod config is below (see `deployment.yaml`)
 - Make sure that the envoy sidecar has the correct certificates (using a mounted secret) and a valid configuration (using a mounted configmap) an example envoy config is below (`envoy.yaml`)
 - Configure a service for the envoy sidecar an example service is shown below (`service.yaml`) you may have another service already for local cluster access (for Thanos Ruler or Grafana etc.)
-- Point the querier at the service and the correct port an example `--store ` field is below (`thanos-querier args`)
+- Point the querier at the service and the correct port an example `--endpoint` field is below (`thanos-querier args`)
 - Make sure your remote cluster has TLS setup and an appropriate HTTP2 supported ingress, example below `ingress.yaml`
 
 ### Observer Cluster: Querier with Envoy `deployment.yaml`
@@ -32,7 +32,7 @@ Envoy can be implemented as a sidecar container (example shown here) within the 
 - `[service-name]` is the name of the envoy service
 - `[namespace]` is the name of the envoy service namespace
 
-You may need to change cluster.local depending on your cluster domain. The `--store` entries for thanos storegateway etc. may be named different in your setup
+You may need to change cluster.local depending on your cluster domain. The `--endpoint` entries for thanos storegateway etc. may be named different in your setup
 
 ```yaml
 kind: Deployment


### PR DESCRIPTION
## Changes

The legacy endpoint flags were removed in #7890. From the changelog:

> Query,Ruler: *breaking :warning:* deprecated `--store.sd-file` and `--store.sd-interval` to be replaced with `--endpoint.sd-config` and `--endpoint-sd-config-reload-interval`; removed legacy flags to pass endpoints `--store`, `--metadata`, `--rule`, `--exemplar`.

Two documentation pages still instruct users to pass `--store` to Thanos Query:

- `docs/components/rule.md` — "adding a new `--store <thanos-ruler-ip>` command-line argument to the Thanos Query command"
- `docs/operating/cross-cluster-tls-communication.md` — twice in the prose describing the querier arguments

The second page is internally inconsistent: the prose says `--store`, while the `deployment.yaml` example further down the same page already passes `--endpoint=dnssrv+...`. A reader who follows the prose gets an unknown flag error on start.

Both are changed to `--endpoint`, which is what `docs/quick-tutorial.md` and the YAML examples already use. Documentation only, no code changes.

## Verification

- `--store` is no longer registered in `cmd/thanos/query.go`; only the namespaced `--store.response-timeout`, `--store.sd-dns-interval`, `--store.sd-dns-resolver`, `--store.unhealthy-timeout`, `--store.sd-files` and `--store.sd-interval` flags remain, and none of them accepts an endpoint address.
- Remaining occurrences of `--store` under `docs/proposals-*` are left untouched, since those are historical design documents.