### PR TITLE
*: publish coverage data

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,16 @@
+codecov:
+  require_ci_to_pass: false
+
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true
+
+ignore:
+  - "**/*.pb.go"
+  - "**/*.pb.gw.go"
+  - "internal/cortex"

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -41,7 +41,15 @@ jobs:
       - name: Add GOBIN to path
         run: echo "/tmp/.bin" >> $GITHUB_PATH
       - name: Run unit tests
-        run: make test
+        run: make test-coverage
+
+      - name: Upload coverage data
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-unit
+          path: .coverage
+          include-hidden-files: true
+          retention-days: 1
 
   cross-build-check:
     runs-on: ubuntu-latest
@@ -149,7 +157,7 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
       - name: Build e2e Docker image
-        run: make docker-e2e
+        run: make docker-e2e E2E_GOFLAGS=-cover
 
       - name: Export image
         run: docker save thanos | gzip > /tmp/thanos-e2e.tar.gz
@@ -200,3 +208,43 @@ jobs:
 
       - name: Run e2e docker-based tests
         run: make test-e2e SKIP_DOCKER_BUILD=1 GH_PARALLEL=${{ matrix.parallelism }} GH_INDEX=${{ matrix.index }}
+        env:
+          THANOS_E2E_GOCOVERDIR: ${{ github.workspace }}/.coverage/e2e
+
+      - name: Upload coverage data
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-e2e-${{ matrix.index }}
+          path: .coverage
+          include-hidden-files: true
+          retention-days: 1
+
+  coverage:
+    needs: [unit, e2e]
+    runs-on: ubuntu-latest
+    name: Merge unit+e2e coverage and upload to Codecov
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+      - name: Install Go.
+        uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
+        with:
+          go-version: 1.26.x
+
+      - name: Download coverage data
+        uses: actions/download-artifact@v4
+        with:
+          pattern: coverage-*
+          path: .coverage
+          merge-multiple: true
+
+      - name: Merge coverage profiles
+        run: make coverage-report
+
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: .coverage/coverage.txt
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,9 @@ examples/interactive/e2e_*
 # Ignore benchmarks dir.
 benchmarks/
 
+# Ignore coverage data.
+/.coverage
+
 # Ignore promu artifacts.
 /.build
 /.release

--- a/Dockerfile.e2e-tests
+++ b/Dockerfile.e2e-tests
@@ -1,11 +1,13 @@
 # Taking a non-alpine image for e2e tests so that cgo can be enabled for the race detector.
 FROM golang:1.26.4 as builder
 
+ARG GOFLAGS=""
+
 WORKDIR $GOPATH/src/github.com/thanos-io/thanos
 
 COPY . $GOPATH/src/github.com/thanos-io/thanos
 
-RUN CGO_ENABLED=1 go build -tags slicelabels -o $GOBIN/thanos -race ./cmd/thanos
+RUN CGO_ENABLED=1 GOFLAGS="$GOFLAGS" go build -tags slicelabels -o $GOBIN/thanos -race ./cmd/thanos
 # -----------------------------------------------------------------------------
 
 FROM golang:1.26.4

--- a/Makefile
+++ b/Makefile
@@ -229,7 +229,7 @@ $(TEST_DOCKER_ARCHS): docker-test-%:
 docker-e2e: ## Builds 'thanos' docker for e2e tests
 docker-e2e:
 	@echo ">> building docker image 'thanos' with Dockerfile.e2e-tests"
-	@docker build -f Dockerfile.e2e-tests -t "thanos" .
+	@docker build --build-arg GOFLAGS="$(E2E_GOFLAGS)" -f Dockerfile.e2e-tests -t "thanos" .
 
 # docker-manifest push docker manifest to support multiple architectures.
 .PHONY: docker-manifest
@@ -320,7 +320,7 @@ test: export THANOS_TEST_ALERTMANAGER_PATH= $(ALERTMANAGER)
 test: check-git install-tool-deps
 	@echo ">> install thanos GOOPTS=${GOOPTS}"
 	@echo ">> running unit tests (without /test/e2e). Do export THANOS_TEST_OBJSTORE_SKIP=GCS,S3,AZURE,SWIFT,COS,ALIYUNOSS,BOS,OCI,OBS if you want to skip e2e tests against all real store buckets. Current value: ${THANOS_TEST_OBJSTORE_SKIP}"
-	@go test $(SHORT) -tags slicelabels -race -timeout 15m $(shell go list ./... | grep -v /vendor/ | grep -v /test/e2e);
+	@go test $(SHORT) $(if $(TEST_GOCOVERDIR),-cover) -tags slicelabels -race -timeout 15m $(shell go list ./... | grep -v /vendor/ | grep -v /test/e2e) $(if $(TEST_GOCOVERDIR),-args -test.gocoverdir=$(TEST_GOCOVERDIR));
 
 .PHONY: test-local
 test-local: ## Runs test excluding tests for ALL  object storage integrations.
@@ -333,6 +333,19 @@ test-local-short: ## Runs test excluding tests for ALL  object storage integrati
 test-local-short: export THANOS_TEST_OBJSTORE_SKIP=GCS,S3,AZURE,SWIFT,COS,ALIYUNOSS,BOS,OCI,OBS
 test-local-short:
 	$(MAKE) test SHORT="-short"
+
+COVERAGE_DIR ?= $(shell pwd)/.coverage
+
+.PHONY: test-coverage
+test-coverage: ## Runs unit tests as `test`, emitting binary coverage data to $(COVERAGE_DIR)/unit.
+	@mkdir -p $(COVERAGE_DIR)/unit
+	@$(MAKE) test TEST_GOCOVERDIR=$(COVERAGE_DIR)/unit
+
+.PHONY: coverage-report
+coverage-report: ## Merges all binary coverage data under $(COVERAGE_DIR) into $(COVERAGE_DIR)/coverage.txt (Go text profile).
+	@echo ">> merging coverage data from $(COVERAGE_DIR)"
+	@go tool covdata textfmt -i=$$(find $(COVERAGE_DIR) -name 'covmeta.*' -exec dirname {} \; | sort -u | paste -sd, -) -o $(COVERAGE_DIR)/coverage.txt
+	@echo ">> wrote $(COVERAGE_DIR)/coverage.txt"
 
 .PHONY: test-e2e
 test-e2e: ## Runs all Thanos e2e docker-based e2e tests from test/e2e. Required access to docker daemon.
@@ -360,6 +373,12 @@ test-e2e-local: ## Runs all thanos e2e tests locally.
 test-e2e-local: export THANOS_TEST_OBJSTORE_SKIP=GCS,S3,AZURE,SWIFT,COS,ALIYUNOSS,BOS,OCI,OBS
 test-e2e-local:
 	$(MAKE) test-e2e
+
+.PHONY: test-e2e-coverage
+test-e2e-coverage: ## Runs e2e tests with a coverage-instrumented Thanos image, emitting binary coverage data to $(COVERAGE_DIR)/e2e.
+test-e2e-coverage: export THANOS_E2E_GOCOVERDIR=$(COVERAGE_DIR)/e2e
+test-e2e-coverage:
+	$(MAKE) test-e2e E2E_GOFLAGS=-cover
 
 .PHONY: quickstart
 quickstart: ## Installs and runs a quickstart example of thanos.

--- a/test/e2e/e2ethanos/services.go
+++ b/test/e2e/e2ethanos/services.go
@@ -51,6 +51,15 @@ func wrapWithDefaults(opt e2e.StartOptions) e2e.StartOptions {
 	if opt.WaitReadyBackoff == nil {
 		opt.WaitReadyBackoff = &defaultBackoffConfig
 	}
+	// Coverage data must be written outside the environment's shared dir as that is removed on Close().
+	if dir := os.Getenv("THANOS_E2E_GOCOVERDIR"); dir != "" {
+		_ = os.MkdirAll(dir, 0750)
+		if opt.EnvVars == nil {
+			opt.EnvVars = map[string]string{}
+		}
+		opt.EnvVars["GOCOVERDIR"] = dir
+		opt.Volumes = append(opt.Volumes, dir+":"+dir+":z")
+	}
 	return opt
 }
 
@@ -1158,13 +1167,11 @@ func NewQueryFrontend(e e2e.Environment, name, downstreamURL string, config quer
 
 	return e2eobs.AsObservable(e.Runnable(fmt.Sprintf("query-frontend-%s", name)).
 		WithPorts(map[string]int{"http": 8080}).
-		Init(e2e.StartOptions{
-			Image:            DefaultImage(),
-			Command:          e2e.NewCommand("query-frontend", e2e.BuildArgs(flags)...),
-			Readiness:        e2e.NewHTTPReadinessProbe("http", "/-/ready", 200, 200),
-			User:             strconv.Itoa(os.Getuid()),
-			WaitReadyBackoff: &defaultBackoffConfig,
-		}), "http")
+		Init(wrapWithDefaults(e2e.StartOptions{
+			Image:     DefaultImage(),
+			Command:   e2e.NewCommand("query-frontend", e2e.BuildArgs(flags)...),
+			Readiness: e2e.NewHTTPReadinessProbe("http", "/-/ready", 200, 200),
+		})), "http")
 }
 
 func NewReverseProxy(e e2e.Environment, name, tenantID, target string) *e2eobs.Observable {
@@ -1441,12 +1448,10 @@ func NewToolsBucketDownsample(e e2e.Environment, name string, bucketConfig clien
 	})...)
 
 	return e2eobs.AsObservable(f.Init(
-		e2e.StartOptions{
-			Image:            DefaultImage(),
-			Command:          e2e.NewCommand("tools", args...),
-			User:             strconv.Itoa(os.Getuid()),
-			Readiness:        e2e.NewHTTPReadinessProbe("http", "/-/ready", 200, 200),
-			WaitReadyBackoff: &defaultBackoffConfig,
-		},
+		wrapWithDefaults(e2e.StartOptions{
+			Image:     DefaultImage(),
+			Command:   e2e.NewCommand("tools", args...),
+			Readiness: e2e.NewHTTPReadinessProbe("http", "/-/ready", 200, 200),
+		}),
 	), "http")
 }


### PR DESCRIPTION
Combine e2e and unit tests coverage data, and publish it to codecov so that it would be possible to have increased confidence before merging changes. It would enable to see at a glance whether important lines in new/changed lines are covered.
