### PR TITLE
query: enforce store limits for batched series responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#8900](https://github.com/thanos-io/thanos/pull/8900): UI: Fix web UI static assets (JS/CSS) returning 404 on Windows by using slash-separated paths for the embedded file system.
 - [#8935](https://github.com/thanos-io/thanos/pull/8935): Receive: remove redundant tl.Set() while building a Capnp WriteRequest.
 - [#8932](https://github.com/thanos-io/thanos/pull/8932): Store: Return the series set error from `TSDBStore.LabelValues` instead of an empty response.
+- [#8967](https://github.com/thanos-io/thanos/pull/8967): Query: Enforce store request series and samples limits for batched series responses.
 
 ### Changed
 

--- a/pkg/store/limiter.go
+++ b/pkg/store/limiter.go
@@ -167,15 +167,26 @@ func newLimitedServer(upstream storepb.Store_SeriesServer, seriesLimiter SeriesL
 }
 
 func (i *limitedServer) Send(response *storepb.SeriesResponse) error {
-	series := response.GetSeries()
-	if series == nil {
+	var seriesCount, chunksCount uint64
+	if series := response.GetSeries(); series != nil {
+		seriesCount = 1
+		chunksCount = uint64(len(series.Chunks))
+	} else if batch := response.GetBatch(); batch != nil {
+		for _, series := range batch.Series {
+			if series == nil {
+				continue
+			}
+			seriesCount++
+			chunksCount += uint64(len(series.Chunks))
+		}
+	} else {
 		return i.Store_SeriesServer.Send(response)
 	}
 
-	if err := i.seriesLimiter.Reserve(1); err != nil {
+	if err := i.seriesLimiter.Reserve(seriesCount); err != nil {
 		return errors.Wrapf(err, "failed to send series")
 	}
-	if err := i.samplesLimiter.Reserve(uint64(len(series.Chunks) * MaxSamplesPerChunk)); err != nil {
+	if err := i.samplesLimiter.Reserve(chunksCount * MaxSamplesPerChunk); err != nil {
 		return errors.Wrapf(err, "failed to send samples")
 	}
 

--- a/pkg/store/limiter_test.go
+++ b/pkg/store/limiter_test.go
@@ -47,6 +47,13 @@ func TestRateLimitedServer(t *testing.T) {
 		storeSeriesResponse(t, labels.FromStrings("series", "2"), makeSamples(numSamples)),
 		storeSeriesResponse(t, labels.FromStrings("series", "3"), makeSamples(numSamples)),
 	}
+	batchedSeries := []*storepb.SeriesResponse{
+		storepb.NewBatchResponse([]*storepb.Series{
+			series[0].GetSeries(),
+			series[1].GetSeries(),
+			series[2].GetSeries(),
+		}),
+	}
 	tests := []struct {
 		name   string
 		limits SeriesSelectLimits
@@ -79,6 +86,23 @@ func TestRateLimitedServer(t *testing.T) {
 			err:    "failed to send series: limit 2 violated (got 3)",
 		},
 		{
+			name: "batched series below limit",
+			limits: SeriesSelectLimits{
+				SeriesPerRequest:  3,
+				SamplesPerRequest: uint64(3 * MaxSamplesPerChunk),
+			},
+			series: batchedSeries,
+		},
+		{
+			name: "batched series over limit",
+			limits: SeriesSelectLimits{
+				SeriesPerRequest:  2,
+				SamplesPerRequest: 0,
+			},
+			series: batchedSeries,
+			err:    "failed to send series: limit 2 violated (got 3)",
+		},
+		{
 			name: "chunks below limit",
 			limits: SeriesSelectLimits{
 				SeriesPerRequest:  0,
@@ -94,6 +118,15 @@ func TestRateLimitedServer(t *testing.T) {
 			},
 			series: series,
 			err:    "failed to send samples: limit 50 violated (got 120)",
+		},
+		{
+			name: "batched chunks over limit",
+			limits: SeriesSelectLimits{
+				SeriesPerRequest:  0,
+				SamplesPerRequest: uint64(2 * MaxSamplesPerChunk),
+			},
+			series: batchedSeries,
+			err:    "failed to send samples: limit 240 violated (got 360)",
 		},
 	}
 	for _, test := range tests {

--- a/pkg/store/limiter_test.go
+++ b/pkg/store/limiter_test.go
@@ -5,6 +5,7 @@ package store
 
 import (
 	"context"
+	"errors"
 	"io"
 	"testing"
 	"time"
@@ -50,9 +51,13 @@ func TestRateLimitedServer(t *testing.T) {
 	batchedSeries := []*storepb.SeriesResponse{
 		storepb.NewBatchResponse([]*storepb.Series{
 			series[0].GetSeries(),
+			nil,
 			series[1].GetSeries(),
 			series[2].GetSeries(),
 		}),
+	}
+	nonSeriesResponses := []*storepb.SeriesResponse{
+		storepb.NewWarnSeriesResponse(errors.New("warning")),
 	}
 	tests := []struct {
 		name   string
@@ -92,6 +97,14 @@ func TestRateLimitedServer(t *testing.T) {
 				SamplesPerRequest: uint64(3 * MaxSamplesPerChunk),
 			},
 			series: batchedSeries,
+		},
+		{
+			name: "non-series responses bypass limits",
+			limits: SeriesSelectLimits{
+				SeriesPerRequest:  1,
+				SamplesPerRequest: 1,
+			},
+			series: nonSeriesResponses,
 		},
 		{
 			name: "batched series over limit",


### PR DESCRIPTION
* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

- Update the query store limiter to count series and chunks in batched `SeriesResponse` messages.
- Add regression coverage for accepted and rejected batched series and sample limits.

Fixes #8964

## Verification

- Confirmed the new batched limit regressions fail without the production change and pass with it.
- `make go-format FILES_TO_FMT='pkg/store/limiter.go pkg/store/limiter_test.go'`
- `go vet ./pkg/store`
- `go test -tags=slicelabels ./pkg/store -run '^(TestLimiter|TestRateLimitedServer)$' -count=1`
- `go test -tags=slicelabels -race ./pkg/store -run '^(TestLimiter|TestRateLimitedServer)$' -count=1`
- `go test -tags=stringlabels ./pkg/store -run '^TestRateLimitedServer$' -count=1`
- `go test -tags=slicelabels ./pkg/store -run '^$' -count=1`

The complete `pkg/store` suite was also attempted on macOS arm64 with Go 1.26.5. Unrelated existing TSDB and generated protobuf tests crash inside the Go runtime. The same crash reproduces on an untouched `main` worktree. The full Linux suite will run in CI.