### PR TITLE
clientconfig: fix lost CA on TLS round-tripper rebuild

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#8935](https://github.com/thanos-io/thanos/pull/8935): Receive: remove redundant tl.Set() while building a Capnp WriteRequest.
 - [#8932](https://github.com/thanos-io/thanos/pull/8932): Store: Return the series set error from `TSDBStore.LabelValues` instead of an empty response.
 - [#8967](https://github.com/thanos-io/thanos/pull/8967): Query: Enforce store request series and samples limits for batched series responses.
+- [#8970](https://github.com/thanos-io/thanos/pull/8970): clientconfig: Fix TLS client permanently failing with `unable to use specified CA cert: none configured` after cert/key file rotation, since `TLSRoundTripperSettings.CA` was never populated.
 
 ### Changed
 

--- a/pkg/clientconfig/http.go
+++ b/pkg/clientconfig/http.go
@@ -202,7 +202,7 @@ func NewRoundTripperFromConfig(cfg config_util.HTTPClientConfig, transportConfig
 	}
 
 	rtConfig := config_util.TLSRoundTripperSettings{
-		Cert: config_util.NewFileSecret(cfg.TLSConfig.CAFile),
+		CA: config_util.NewFileSecret(cfg.TLSConfig.CAFile),
 	}
 	if len(cfg.TLSConfig.CertFile) > 0 {
 		rtConfig.Cert = config_util.NewFileSecret(cfg.TLSConfig.CertFile)

--- a/pkg/clientconfig/http_test.go
+++ b/pkg/clientconfig/http_test.go
@@ -4,7 +4,18 @@
 package clientconfig
 
 import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/efficientgo/core/testutil"
 )
@@ -91,5 +102,118 @@ func TestNewHTTPClientConfigFromYAML(t *testing.T) {
 
 			testutil.Ok(t, err)
 		})
+	}
+}
+
+func generateTestCA(t *testing.T) (certPEM []byte, cert *x509.Certificate, key *rsa.PrivateKey) {
+	t.Helper()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	testutil.Ok(t, err)
+
+	template := x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, &template, &template, &key.PublicKey, key)
+	testutil.Ok(t, err)
+
+	cert, err = x509.ParseCertificate(der)
+	testutil.Ok(t, err)
+
+	certPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	return certPEM, cert, key
+}
+
+func generateTestLeaf(t *testing.T, caCert *x509.Certificate, caKey *rsa.PrivateKey) (certPEM, keyPEM []byte) {
+	t.Helper()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	testutil.Ok(t, err)
+
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, &template, caCert, &key.PublicKey, caKey)
+	testutil.Ok(t, err)
+
+	certPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyPEM = pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)})
+	return certPEM, keyPEM
+}
+
+// TestNewHTTPClient_CertRotation checks that a client that specifies a cert, key, and CA
+// continues working after its cert/key files are updated.
+func TestNewHTTPClient_CertRotation(t *testing.T) {
+	caCertPEM, caCert, caKey := generateTestCA(t)
+
+	caPool := x509.NewCertPool()
+	testutil.Assert(t, caPool.AppendCertsFromPEM(caCertPEM))
+
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	server.TLS = new(tlsConfigForTest(t, caPool))
+	server.StartTLS()
+	defer server.Close()
+
+	dir := t.TempDir()
+	caFile := filepath.Join(dir, "ca.pem")
+	certFile := filepath.Join(dir, "client.crt")
+	keyFile := filepath.Join(dir, "client.key")
+
+	testutil.Ok(t, os.WriteFile(caFile, caCertPEM, 0o600))
+
+	certPEMv1, keyPEMv1 := generateTestLeaf(t, caCert, caKey)
+	testutil.Ok(t, os.WriteFile(certFile, certPEMv1, 0o600))
+	testutil.Ok(t, os.WriteFile(keyFile, keyPEMv1, 0o600))
+
+	client, err := NewHTTPClient(HTTPClientConfig{
+		TLSConfig: TLSConfig{
+			CAFile:             caFile,
+			CertFile:           certFile,
+			KeyFile:            keyFile,
+			InsecureSkipVerify: true,
+		},
+	}, "")
+	testutil.Ok(t, err)
+
+	resp, err := client.Get(server.URL)
+	testutil.Ok(t, err)
+	testutil.Equals(t, http.StatusOK, resp.StatusCode)
+	testutil.Ok(t, resp.Body.Close())
+
+	certPEMv2, keyPEMv2 := generateTestLeaf(t, caCert, caKey)
+	testutil.Ok(t, os.WriteFile(certFile, certPEMv2, 0o600))
+	testutil.Ok(t, os.WriteFile(keyFile, keyPEMv2, 0o600))
+
+	resp, err = client.Get(server.URL)
+	testutil.Ok(t, err)
+	testutil.Equals(t, http.StatusOK, resp.StatusCode)
+	testutil.Ok(t, resp.Body.Close())
+}
+
+func tlsConfigForTest(t *testing.T, clientCAs *x509.CertPool) tls.Config {
+	t.Helper()
+
+	_, serverCACert, serverCAKey := generateTestCA(t)
+	serverCertPEM, serverKeyPEM := generateTestLeaf(t, serverCACert, serverCAKey)
+	serverCert, err := tls.X509KeyPair(serverCertPEM, serverKeyPEM)
+	testutil.Ok(t, err)
+
+	return tls.Config{
+		Certificates: []tls.Certificate{serverCert},
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+		ClientCAs:    clientCAs,
 	}
 }


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

This fixes https://github.com/thanos-io/thanos/issues/8969 (see for full bug report) by unconditionally setting the CA on the round tripper config. 

## Verification

<!-- How you tested it? How do you know it works? -->
I've included a test that fails and reproduces the bug without this fix, and verified it works with the fix

Code on main that fails test
```
$ git diff
diff --git a/pkg/clientconfig/http.go b/pkg/clientconfig/http.go
index 93e81905..5c3f4038 100644
--- a/pkg/clientconfig/http.go
+++ b/pkg/clientconfig/http.go
@@ -202,7 +202,7 @@ func NewRoundTripperFromConfig(cfg config_util.HTTPClientConfig, transportConfig
        }

        rtConfig := config_util.TLSRoundTripperSettings{
-               CA: config_util.NewFileSecret(cfg.TLSConfig.CAFile),
+               Cert: config_util.NewFileSecret(cfg.TLSConfig.CAFile),
        }
        if len(cfg.TLSConfig.CertFile) > 0 {
                rtConfig.Cert = config_util.NewFileSecret(cfg.TLSConfig.CertFile)
```

Evidence it fails test
```
$ go test ./pkg/clientconfig/... -run TestNewHTTPClient_CertRotation
--- FAIL: TestNewHTTPClient_CertRotation (0.25s)
    http_test.go:201: http_test.go:201: ""

         unexpected error: Get "https://127.0.0.1:49253": unable to use specified CA cert: none configured

FAIL
FAIL	github.com/thanos-io/thanos/pkg/clientconfig	0.631s
FAIL
```