### PR TITLE
docs: add v0.42 permalinks for tip-consistent doc URLs

### DIFF
--- a/website/hugo.yaml
+++ b/website/hugo.yaml
@@ -28,6 +28,7 @@ permalinks:
   # TODO(bwplotka): Move to mdox + fixes to ensure we don't need to manually do this.
   # For now we added few entries for advance.
   tip: "/:sections/:filename.md"
+  v0.42: "/:sections/:filename.md"
   v0.41: "/:sections/:filename.md"
   v0.40: "/:sections/:filename.md"
   v0.39: "/:sections/:filename.md"


### PR DESCRIPTION
## Summary
- Add `v0.42` to `website/hugo.yaml` permalinks so versioned docs use the same `/:sections/:filename.md` paths as `tip`.
- Without this entry, Hugo publishes v0.42 pages without the `.md` suffix, which breaks cross-version links and in-binary help URLs that include `.md` (as tip does).

Fixes #6889

## Test plan
- [ ] Confirm `website/hugo.yaml` lists `v0.42: "/:sections/:filename.md"` alongside other recent versions
- [ ] After site rebuild, `https://thanos.io/v0.42/.../*.md/` resolves the same way as tip
- [ ] Switching between tip and v0.42 in the version picker keeps doc paths consistent