### PR TITLE
*: publish optional distroless container images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 
 ### Added
 
+- [#8973](https://github.com/thanos-io/thanos/pull/8973): Build and publish optional distroless container images with the `-distroless` tag suffix.
 - [#8882](https://github.com/thanos-io/thanos/pull/8882) Receive: implement multi-tenant writes; greatly improves throughput when using the split tenant label functionality.
 - [#8876](https://github.com/thanos-io/thanos/pull/8876): Query-Frontend: Reuse compatible lower-step query range cache entries by subsampling cached responses.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@
 ARG BASE_DOCKER_SHA="14d68ca3d69fceaa6224250c83d81d935c053fb13594c811038c461194599973"
 FROM quay.io/prometheus/busybox@sha256:${BASE_DOCKER_SHA}
 LABEL maintainer="The Thanos Authors"
+LABEL io.thanos.image.variant="busybox"
 
 RUN adduser \
     -D `#Dont assign a password` \

--- a/Dockerfile.distroless
+++ b/Dockerfile.distroless
@@ -1,0 +1,12 @@
+FROM gcr.io/distroless/static-debian13:nonroot@sha256:f9f84bd968430d7d35e8e6d55c40efb0b980829ec42920a49e60e65eac0d83fc
+# The base image runs as the nonroot user (UID/GID 65532).
+
+LABEL maintainer="The Thanos Authors"
+LABEL io.thanos.image.variant="distroless"
+
+ARG ARCH="amd64"
+ARG OS="linux"
+
+COPY .build/${OS}-${ARCH}/thanos /bin/thanos
+
+ENTRYPOINT [ "/bin/thanos" ]

--- a/Dockerfile.multi-arch
+++ b/Dockerfile.multi-arch
@@ -3,6 +3,7 @@ ARG BASE_DOCKER_SHA="97a9aacc097e5dbdec33b0d671adea0785e76d26ff2b979ee28570baf6a
 
 FROM quay.io/prometheus/busybox@sha256:${BASE_DOCKER_SHA}
 LABEL maintainer="The Thanos Authors"
+LABEL io.thanos.image.variant="busybox"
 
 ARG ARCH="amd64"
 ARG OS="linux"

--- a/Makefile
+++ b/Makefile
@@ -214,16 +214,27 @@ docker-multi-stage:
 .PHONY: docker-build $(BUILD_DOCKER_ARCHS)
 docker-build: $(BUILD_DOCKER_ARCHS)
 $(BUILD_DOCKER_ARCHS): docker-build-%:
-	@docker build -t "thanos-linux-$*" \
-  --build-arg BASE_DOCKER_SHA="$($*)" \
-  --build-arg ARCH="$*" \
-  -f Dockerfile.multi-arch .
+	@for variant in busybox distroless; do \
+		dockerfile="Dockerfile.multi-arch"; \
+		suffix=""; \
+		if [ "$$variant" = "distroless" ]; then \
+			dockerfile="Dockerfile.distroless"; \
+			suffix="-distroless"; \
+		fi; \
+		echo ">> building $$variant image for linux/$*"; \
+		docker build --platform="linux/$*" -t "thanos-linux-$*$$suffix" \
+			--build-arg BASE_DOCKER_SHA="$($*)" \
+			--build-arg ARCH="$*" \
+			-f "$$dockerfile" . || exit 1; \
+	done
 
 .PHONY: docker-test $(TEST_DOCKER_ARCHS)
 docker-test: $(TEST_DOCKER_ARCHS)
 $(TEST_DOCKER_ARCHS): docker-test-%:
-	@echo ">> testing image"
-	@docker run "thanos-linux-$*" --help
+	@for suffix in "" "-distroless"; do \
+		echo ">> testing thanos-linux-$*$$suffix"; \
+		docker run --rm "thanos-linux-$*$$suffix" --help || exit 1; \
+	done
 
 .PHONY: docker-e2e
 docker-e2e: ## Builds 'thanos' docker for e2e tests
@@ -234,17 +245,21 @@ docker-e2e:
 # docker-manifest push docker manifest to support multiple architectures.
 .PHONY: docker-manifest
 docker-manifest:
-	@echo ">> creating and pushing manifest"
-	@DOCKER_CLI_EXPERIMENTAL=enabled docker manifest create -a "$(DOCKER_IMAGE_REPO):$(DOCKER_IMAGE_TAG)" $(foreach ARCH,$(DOCKER_ARCHS),$(DOCKER_IMAGE_REPO)-linux-$(ARCH):$(DOCKER_IMAGE_TAG))
-	@DOCKER_CLI_EXPERIMENTAL=enabled docker manifest push "$(DOCKER_IMAGE_REPO):$(DOCKER_IMAGE_TAG)"
+	@for suffix in "" "-distroless"; do \
+		echo ">> creating and pushing$$suffix manifest"; \
+		DOCKER_CLI_EXPERIMENTAL=enabled docker manifest create -a "$(DOCKER_IMAGE_REPO):$(DOCKER_IMAGE_TAG)$$suffix" $(foreach ARCH,$(DOCKER_ARCHS),$(DOCKER_IMAGE_REPO)-linux-$(ARCH):$(DOCKER_IMAGE_TAG)$$suffix) || exit 1; \
+		DOCKER_CLI_EXPERIMENTAL=enabled docker manifest push "$(DOCKER_IMAGE_REPO):$(DOCKER_IMAGE_TAG)$$suffix" || exit 1; \
+	done
 
 .PHONY: docker-push $(PUSH_DOCKER_ARCHS)
 docker-push: ## Pushes Thanos docker image build to "$(DOCKER_IMAGE_REPO):$(DOCKER_IMAGE_TAG)".
 docker-push: $(PUSH_DOCKER_ARCHS)
 $(PUSH_DOCKER_ARCHS): docker-push-%:
-	@echo ">> pushing image"
-	@docker tag "thanos-linux-$*" "$(DOCKER_IMAGE_REPO)-linux-$*:$(DOCKER_IMAGE_TAG)"
-	@docker push "$(DOCKER_IMAGE_REPO)-linux-$*:$(DOCKER_IMAGE_TAG)"
+	@for suffix in "" "-distroless"; do \
+		echo ">> pushing thanos-linux-$*$$suffix"; \
+		docker tag "thanos-linux-$*$$suffix" "$(DOCKER_IMAGE_REPO)-linux-$*:$(DOCKER_IMAGE_TAG)$$suffix" || exit 1; \
+		docker push "$(DOCKER_IMAGE_REPO)-linux-$*:$(DOCKER_IMAGE_TAG)$$suffix" || exit 1; \
+	done
 
 .PHONY: docs
 docs: ## Generates docs for all thanos commands, localise links, ensure GitHub format.


### PR DESCRIPTION
* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

- Add a pinned `static-debian13:nonroot` image variant for Thanos.
- Build and smoke-test both BusyBox and distroless images for every supported release architecture.
- Publish multi-architecture distroless manifests with a `-distroless` tag suffix while keeping the existing BusyBox tags unchanged.
- Add image variant labels so operators can distinguish the two image types.

## Verification

- `git diff --check`
- GNU Make dry-runs for the build, push, and manifest targets.
- Built and ran the BusyBox and distroless `linux/amd64` images using the checksum-verified v0.42.4 release binary.
- Built and ran the distroless `linux/arm64` image under emulation and confirmed its architecture, non-root UID (`65532`), variant label, and Thanos version output.
- Confirmed the pinned distroless manifest includes `amd64`, `arm64`, and `ppc64le` images.

Fixes #8961.

### AI assistance disclosure

I used an AI coding assistant to inspect the existing container release flow and draft the initial patch. I reviewed every changed line, corrected the cross-architecture platform handling, and performed the verification listed above. I am responsible for and can explain the submitted changes.