### PR TITLE
receive: validate remote write v2 symbol references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 
 ### Fixed
 
+- [#8976](https://github.com/thanos-io/thanos/pull/8976): Receive: Reject remote write v2 requests whose `labels_refs` fall outside the symbols table instead of panicking the request goroutine.
 - [#8968](https://github.com/thanos-io/thanos/pull/8968): *: Bump `google.golang.org/grpc` to v1.82.1 to fix GHSA-hrxh-6v49-42gf (CVSS 8.6): HTTP/2 Rapid Reset DoS bypass, xDS RBAC authorization bypass, and NOT-rule panic.
 - [#8900](https://github.com/thanos-io/thanos/pull/8900): UI: Fix web UI static assets (JS/CSS) returning 404 on Windows by using slash-separated paths for the embedded file system.
 - [#8935](https://github.com/thanos-io/thanos/pull/8935): Receive: remove redundant tl.Set() while building a Capnp WriteRequest.

--- a/docs/components/receive.md
+++ b/docs/components/receive.md
@@ -372,7 +372,7 @@ Please see the metric `thanos_receive_forward_delay_seconds` to see if you need 
 
 The following formula is used for calculating quorum:
 
-```go mdox-exec="sed -n '1333,1343p' pkg/receive/handler.go"
+```go mdox-exec="sed -n '1357,1367p' pkg/receive/handler.go"
 // writeQuorum returns minimum number of replicas that has to confirm write success before claiming replication success.
 func (h *Handler) writeQuorum() int {
 	// NOTE(GiedriusS): this is here because otherwise RF=2 doesn't make sense as all writes

--- a/pkg/receive/handler.go
+++ b/pkg/receive/handler.go
@@ -552,7 +552,31 @@ func determineRWVersion(r *http.Request) (int, error) {
 	return 0, fmt.Errorf("required headers Content-Type and/or X-Prometheus-Remote-Write-Version not found")
 }
 
-func translateV2ToV1(w writev2.Request) *prompb.WriteRequest {
+// desymbolizeLabels resolves label references against a remote write v2 symbols
+// table. Both the references and the table are taken straight off the wire, so
+// a reference that does not address the table is a malformed request rather
+// than an internal error. Mirrors the invariants Prometheus enforces in
+// prompb/io/prometheus/write/v2.desymbolizeLabels.
+func desymbolizeLabels(symbols []string, refs []uint32) ([]labelpb.ZLabel, error) {
+	if len(refs)%2 != 0 {
+		return nil, fmt.Errorf("invalid labels_refs length %d: must be a multiple of two", len(refs))
+	}
+
+	lbls := make([]labelpb.ZLabel, 0, len(refs)/2)
+	for i := 0; i < len(refs); i += 2 {
+		nameRef, valueRef := refs[i], refs[i+1]
+		if int(nameRef) >= len(symbols) || int(valueRef) >= len(symbols) {
+			return nil, fmt.Errorf("labels_refs %d (name) %d (value) outside of symbols table (size %d)", nameRef, valueRef, len(symbols))
+		}
+		lbls = append(lbls, labelpb.ZLabel{
+			Name:  symbols[nameRef],
+			Value: symbols[valueRef],
+		})
+	}
+	return lbls, nil
+}
+
+func translateV2ToV1(w writev2.Request) (*prompb.WriteRequest, error) {
 	// TODO(GiedriusS): somehow ensure programmatically that all fields are set and we don't miss anything.
 	out := &prompb.WriteRequest{
 		Timeseries: make([]prompb.TimeSeries, 0, len(w.Timeseries)),
@@ -561,13 +585,11 @@ func translateV2ToV1(w writev2.Request) *prompb.WriteRequest {
 	for _, t := range w.Timeseries {
 		v1Ts := prompb.TimeSeries{}
 
-		v1Ts.Labels = make([]labelpb.ZLabel, 0, len(t.LabelsRefs)/2)
-		for i := 0; i+1 < len(t.LabelsRefs); i += 2 {
-			v1Ts.Labels = append(v1Ts.Labels, labelpb.ZLabel{
-				Name:  w.Symbols[t.LabelsRefs[i]],
-				Value: w.Symbols[t.LabelsRefs[i+1]],
-			})
+		lbls, err := desymbolizeLabels(w.Symbols, t.LabelsRefs)
+		if err != nil {
+			return nil, err
 		}
+		v1Ts.Labels = lbls
 
 		if len(t.Samples) > 0 {
 			v1Ts.Samples = make([]prompb.Sample, 0, len(t.Samples))
@@ -582,18 +604,15 @@ func translateV2ToV1(w writev2.Request) *prompb.WriteRequest {
 		if len(t.Exemplars) > 0 {
 			v1Ts.Exemplars = make([]prompb.Exemplar, 0, len(t.Exemplars))
 			for _, e := range t.Exemplars {
-				v1Exemplar := prompb.Exemplar{
+				exLbls, err := desymbolizeLabels(w.Symbols, e.LabelsRefs)
+				if err != nil {
+					return nil, err
+				}
+				v1Ts.Exemplars = append(v1Ts.Exemplars, prompb.Exemplar{
 					Value:     e.Value,
 					Timestamp: e.Timestamp,
-					Labels:    make([]labelpb.ZLabel, 0, len(e.LabelsRefs)/2),
-				}
-				for i := 0; i+1 < len(e.LabelsRefs); i += 2 {
-					v1Exemplar.Labels = append(v1Exemplar.Labels, labelpb.ZLabel{
-						Name:  w.Symbols[e.LabelsRefs[i]],
-						Value: w.Symbols[e.LabelsRefs[i+1]],
-					})
-				}
-				v1Ts.Exemplars = append(v1Ts.Exemplars, v1Exemplar)
+					Labels:    exLbls,
+				})
 			}
 		}
 
@@ -635,7 +654,7 @@ func translateV2ToV1(w writev2.Request) *prompb.WriteRequest {
 
 		out.Timeseries = append(out.Timeseries, v1Ts)
 	}
-	return out
+	return out, nil
 }
 
 func translateV2SpansToV1(spans []writev2.BucketSpan) []prompb.BucketSpan {
@@ -656,7 +675,12 @@ func (h *Handler) handleV2HTTP(ctx context.Context, w http.ResponseWriter, r *ht
 		return
 	}
 
-	translatedReq := translateV2ToV1(wreq)
+	translatedReq, err := translateV2ToV1(wreq)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
 	if err := h.handleV1HTTP(ctx, w, r, translatedReq, tLogger, tenantHTTP, requestLimiter); err != nil {
 		return
 	}

--- a/pkg/receive/translate_v2_test.go
+++ b/pkg/receive/translate_v2_test.go
@@ -1,0 +1,87 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package receive
+
+import (
+	"testing"
+
+	"github.com/efficientgo/core/testutil"
+
+	writev2 "github.com/thanos-io/thanos/pkg/store/storepb/prompb/io/prometheus/write/v2"
+)
+
+// TestTranslateV2ToV1SymbolRefs covers label references that do not address a
+// valid entry in the request's symbols table. Both the references and the table
+// arrive from the remote write client, so a mismatch has to be reported rather
+// than indexed blindly.
+func TestTranslateV2ToV1SymbolRefs(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		req  writev2.Request
+	}{
+		{
+			name: "series label ref past end of symbols",
+			req: writev2.Request{
+				Symbols:    []string{"", "__name__"},
+				Timeseries: []writev2.TimeSeries{{LabelsRefs: []uint32{1, 99}}},
+			},
+		},
+		{
+			name: "exemplar label ref past end of symbols",
+			req: writev2.Request{
+				Symbols: []string{"", "__name__", "thanos_v2_translate_test"},
+				Timeseries: []writev2.TimeSeries{
+					{
+						LabelsRefs: []uint32{1, 2},
+						Exemplars:  []writev2.Exemplar{{LabelsRefs: []uint32{1, 42}}},
+					},
+				},
+			},
+		},
+		{
+			name: "empty symbols table",
+			req: writev2.Request{
+				Timeseries: []writev2.TimeSeries{{LabelsRefs: []uint32{0, 1}}},
+			},
+		},
+		{
+			name: "odd number of label refs",
+			req: writev2.Request{
+				Symbols:    []string{"", "__name__"},
+				Timeseries: []writev2.TimeSeries{{LabelsRefs: []uint32{1}}},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := translateV2ToV1(tc.req)
+			testutil.NotOk(t, err)
+		})
+	}
+}
+
+func TestTranslateV2ToV1(t *testing.T) {
+	req := writev2.Request{
+		Symbols: []string{"", "__name__", "thanos_v2_translate_test", "trace_id", "abc"},
+		Timeseries: []writev2.TimeSeries{
+			{
+				LabelsRefs: []uint32{1, 2},
+				Samples:    []writev2.Sample{{Value: 1.5, Timestamp: 10}},
+				Exemplars:  []writev2.Exemplar{{LabelsRefs: []uint32{3, 4}, Value: 2.5, Timestamp: 20}},
+			},
+		},
+	}
+
+	out, err := translateV2ToV1(req)
+	testutil.Ok(t, err)
+	testutil.Equals(t, 1, len(out.Timeseries))
+
+	ts := out.Timeseries[0]
+	testutil.Equals(t, "__name__", ts.Labels[0].Name)
+	testutil.Equals(t, "thanos_v2_translate_test", ts.Labels[0].Value)
+	testutil.Equals(t, 1, len(ts.Samples))
+	testutil.Equals(t, 1.5, ts.Samples[0].Value)
+	testutil.Equals(t, 1, len(ts.Exemplars))
+	testutil.Equals(t, "trace_id", ts.Exemplars[0].Labels[0].Name)
+	testutil.Equals(t, "abc", ts.Exemplars[0].Labels[0].Value)
+}


### PR DESCRIPTION
## Changes

`translateV2ToV1` resolves remote write v2 label references by indexing the request's
symbols table directly:

```go
Name:  w.Symbols[t.LabelsRefs[i]],
Value: w.Symbols[t.LabelsRefs[i+1]],
```

Both the references and the table come from the client, so a payload whose
`labels_refs` point past the end of `symbols` panics the request goroutine with an
index out of range. Same pattern for exemplar refs. `handleV2HTTP` unmarshals and
calls the translation with no validation in between, so any v2 client can trigger it.
`net/http` recovers the panic per connection, so the process survives, but the
request is dropped and a stack trace is logged.

Prometheus enforces two invariants when desymbolizing and returns an error for
either — `labels_refs` must have even length, and every reference must address the
table (`prompb/io/prometheus/write/v2.desymbolizeLabels`). The v2 to v1 translation
reimplemented that lookup without them.

- Add `desymbolizeLabels` with both checks and use it for series and exemplar labels.
- `translateV2ToV1` returns an error; `handleV2HTTP` maps it to 400.

Odd-length `labels_refs` previously dropped the trailing element silently; it is now
a 400, matching Prometheus.

## Verification

Without the fix, a ref past the end panics:

```
--- FAIL: TestReproSymbolOutOfRange (0.00s)
panic: runtime error: index out of range [99] with length 2 [recovered, repanicked]
	pkg/receive/handler.go:568
```

`translateV2ToV1` had no unit test, which is why this went unnoticed; the new file
covers the happy path and four malformed-reference cases.

`go test -tags slicelabels -race ./pkg/receive/` passes and matches the baseline
(`ok`, 166s). `golangci-lint run --build-tags=slicelabels ./pkg/receive/...` reports
nothing for the changed or added files; the package's existing goconst findings are
unchanged.

* [x] I added CHANGELOG entry for this change.
