### PR TITLE
indexheader: replace fixed sleep with require.Eventually in reader pool idle test

### DIFF
--- a/pkg/block/indexheader/reader_pool_test.go
+++ b/pkg/block/indexheader/reader_pool_test.go
@@ -115,8 +115,11 @@ func TestReaderPool_ShouldCloseIdleLazyReaders(t *testing.T) {
 	testutil.Equals(t, float64(1), promtestutil.ToFloat64(metrics.lazyReader.loadCount))
 	testutil.Equals(t, float64(0), promtestutil.ToFloat64(metrics.lazyReader.unloadCount))
 
-	// Wait enough time before checking it.
-	time.Sleep(idleTimeout * 2)
+	// Wait until the pool's background reaper (which runs every idleTimeout/10)
+	// has closed the idle reader, rather than sleeping for a fixed duration.
+	require.Eventually(t, func() bool {
+		return promtestutil.ToFloat64(metrics.lazyReader.unloadCount) == 1
+	}, 5*idleTimeout, idleTimeout/20)
 
 	// We expect the reader has been closed, but not released from the pool.
 	testutil.Assert(t, pool.isTracking(r.(*LazyBinaryReader)))


### PR DESCRIPTION
* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

`TestReaderPool_ShouldCloseIdleLazyReaders` waited for the pool's background
reaper to unload an idle reader with a fixed `time.Sleep(idleTimeout * 2)` (2s)
and then asserted `unloadCount == 1`.

The reaper goroutine ticks every `idleTimeout/10` and unloads a reader once it
has been idle for `idleTimeout`, so the unload is an asynchronous event. This
replaces the blind sleep with `require.Eventually` (testify is already imported
in this file), polling `unloadCount` until it reaches 1 with a generous 5×
`idleTimeout` cap and a short tick. The surrounding `loadCount`/`isTracking`
assertions are unchanged — they are stable at the moment the unload is observed.

Net effect: both a **speedup** (resolves in ~1s instead of a fixed 2s of dead
time) and a **de-flake** (a loaded CI runner where the reaper tick slips past
the fixed 2s window no longer fails a hard timing assertion). Test-only, no
production code touched.

## Verification

Ran the target test with the race detector, repeated to shake out flakiness:

```
go test -race -run TestReaderPool_ShouldCloseIdleLazyReaders -count=50 ./pkg/block/indexheader/
ok  github.com/thanos-io/thanos/pkg/block/indexheader  113.217s
```

50/50 passes, no data races. Timing comparison (`-count=10`, no race, same box):
old fixed-sleep 58.4s vs. poll 54.9s — the per-iteration sleep saving shows
through even though block setup dominates each iteration. `gofmt` clean.

---
for the record: authored with AI assistance, reviewed and verified by me.
