### PR TITLE
compact: Add flag to disable of directory marker objects during compaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 ### Added
 
 - [#8882](https://github.com/thanos-io/thanos/pull/8882) Receive: implement multi-tenant writes; greatly improves throughput when using the split tenant label functionality.
+- [#8980](https://github.com/thanos-io/thanos/pull/8980) Compact: add hidden `--compact.skip-delete-directory-markers` flag to disable removal of S3-style directory marker objects during block deletion.
 - [#8876](https://github.com/thanos-io/thanos/pull/8876): Query-Frontend: Reuse compatible lower-step query range cache entries by subsampling cached responses.
 
 ### Fixed

--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -175,6 +175,8 @@ func runCompact(
 	conf compactConfig,
 	flagsMap map[string]string,
 ) (rerr error) {
+	block.DeleteDirectoryMarkers = !conf.skipDeleteDirectoryMarkers
+
 	deleteDelay := time.Duration(conf.deleteDelay)
 	compactMetrics := newCompactMetrics(reg, deleteDelay)
 	downsampleMetrics := newDownsampleMetrics(reg)
@@ -737,6 +739,7 @@ type compactConfig struct {
 	progressCalculateInterval                      time.Duration
 	filterConf                                     *store.FilterConfig
 	disableAdminOperations                         bool
+	skipDeleteDirectoryMarkers                     bool
 }
 
 func (cc *compactConfig) registerFlag(cmd extkingpin.FlagClause) {
@@ -805,6 +808,10 @@ func (cc *compactConfig) registerFlag(cmd extkingpin.FlagClause) {
 		"Note that deleting blocks immediately can cause query failures, if store gateway still has the block loaded, "+
 		"or compactor is ignoring the deletion because it's compacting the block at the same time.").
 		Default("48h").SetValue(&cc.deleteDelay)
+
+	cmd.Flag("compact.skip-delete-directory-markers", "Disable removal of explicit directory marker objects (e.g. \"<block>/\", \"<block>/chunks/\") when deleting a block. "+
+		"Some S3-compatible object storages (e.g. seaweedfs, HCP) create these markers alongside block contents; most backends don't need this and can safely leave it disabled.").
+		Hidden().Default("false").BoolVar(&cc.skipDeleteDirectoryMarkers)
 
 	cmd.Flag("compact.enable-vertical-compaction", "Experimental. When set to true, compactor will allow overlaps and perform **irreversible** vertical compaction. See https://thanos.io/tip/components/compact.md/#vertical-compactions to read more. "+
 		"Please note that by default this uses a NAIVE algorithm for merging. If you need a different deduplication algorithm (e.g one that works well with Prometheus replicas), please set it via --deduplication.func."+

--- a/pkg/block/block.go
+++ b/pkg/block/block.go
@@ -194,6 +194,13 @@ func MarkForDeletion(ctx context.Context, logger log.Logger, bkt objstore.Bucket
 	return nil
 }
 
+// DeleteDirectoryMarkers controls whether Delete also removes the explicit
+// directory marker objects that some S3-compatible object storages (e.g. seaweedfs, HCP)
+// create alongside block contents. It is exposed as a package variable, set once at
+// startup from a CLI flag, so it can be disabled on backends where the extra delete
+// calls are unnecessary or undesired.
+var DeleteDirectoryMarkers = true
+
 // Delete removes directory that is meant to be block directory.
 // NOTE: Always prefer this method for deleting blocks.
 //   - We have to delete block's files in the certain order (meta.json first and deletion-mark.json last)
@@ -242,14 +249,16 @@ func Delete(ctx context.Context, logger log.Logger, bkt objstore.Bucket, id ulid
 
 	// Some object storages represent directories as explicit empty objects.
 	// We try to delete the directory marker objects themselves after all their contents are removed.
-	directoryMarkerPaths := []string{
-		path.Join(id.String(), ChunksDirname) + objstore.DirDelim,
-		id.String() + objstore.DirDelim,
-	}
+	if DeleteDirectoryMarkers {
+		directoryMarkerPaths := []string{
+			path.Join(id.String(), ChunksDirname) + objstore.DirDelim,
+			id.String() + objstore.DirDelim,
+		}
 
-	for _, p := range directoryMarkerPaths {
-		if err := bkt.Delete(ctx, p); err != nil && !bkt.IsObjNotFoundErr(err) {
-			level.Debug(logger).Log("msg", "failed to delete directory marker object", "dir", p, "err", err)
+		for _, p := range directoryMarkerPaths {
+			if err := bkt.Delete(ctx, p); err != nil && !bkt.IsObjNotFoundErr(err) {
+				level.Debug(logger).Log("msg", "failed to delete directory marker object", "dir", p, "err", err)
+			}
 		}
 	}
 


### PR DESCRIPTION
* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Add a hidden flag to disable deleting directory markers.
Slightly reduces delete calls to cloud storage, and prevents deletion errors from showing whilst attempting to delete non-existent objects

## Verification

<!-- How you tested it? How do you know it works? -->

Testing it now