### PR TITLE
receive: include native histograms in samples limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#6099](https://github.com/thanos-io/thanos/issues/6099): Tracing: drop the noisiest INTERNAL spans (`proxy.series`, `proxy.label_names`, `proxy.label_values`, `bucket_store_block_series`, `send_rules_response`, `send_rule_group_response`) so distributed traces stay usable; gRPC CLIENT/SERVER spans remain.
 - [#8907](https://github.com/thanos-io/thanos/pull/8907): UI: Migrate the React app (`pkg/ui/react-app`) from npm to pnpm; contributors now need pnpm 11+ instead of npm to build the Web UI.
 - [#8943](https://github.com/thanos-io/thanos/pull/8943): receive: always intern. *breaking :warning:* `--writer.intern` was removed on Thanos Receive and Receive will fail to start if that command line parameter is provided
+- [#7593](https://github.com/thanos-io/thanos/issues/7593): Receive: the per-request `samples` limit now also counts native histogram data points, not only float samples.
 
 ## [v0.42.4](https://github.com/thanos-io/thanos/tree/release-0.42) - 2026 07 30
 

--- a/pkg/receive/handler.go
+++ b/pkg/receive/handler.go
@@ -707,7 +707,7 @@ func (h *Handler) handleV1HTTP(ctx context.Context, w http.ResponseWriter, r *ht
 
 	totalSamples := 0
 	for _, timeseries := range wreq.Timeseries {
-		totalSamples += len(timeseries.Samples)
+		totalSamples += len(timeseries.Samples) + len(timeseries.Histograms)
 	}
 	if !requestLimiter.AllowSamples(tenantHTTP, int64(totalSamples)) {
 		http.Error(w, "too many samples", http.StatusRequestEntityTooLarge)

--- a/pkg/receive/handler_otlp.go
+++ b/pkg/receive/handler_otlp.go
@@ -81,7 +81,7 @@ func (h *Handler) receiveOTLPHTTP(w http.ResponseWriter, r *http.Request) {
 
 	totalSamples := 0
 	for _, ts := range metrics {
-		totalSamples += len(ts.Samples)
+		totalSamples += len(ts.Samples) + len(ts.Histograms)
 	}
 
 	if !requestLimiter.AllowSeries(tenant, int64(len(metrics))) {

--- a/pkg/receive/handler_test.go
+++ b/pkg/receive/handler_test.go
@@ -43,6 +43,7 @@ import (
 	"github.com/prometheus/prometheus/model/relabel"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb"
+	"github.com/prometheus/prometheus/tsdb/tsdbutil"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/test/bufconn"
@@ -974,10 +975,11 @@ func TestReceiveWriteRequestLimits(t *testing.T) {
 	t.Parallel()
 
 	for _, tc := range []struct {
-		name          string
-		status        int
-		amountSeries  int
-		amountSamples int
+		name             string
+		status           int
+		amountSeries     int
+		amountSamples    int
+		amountHistograms int
 	}{
 		{
 			name:         "Request above limit of series",
@@ -1000,6 +1002,15 @@ func TestReceiveWriteRequestLimits(t *testing.T) {
 			status:        http.StatusOK,
 			amountSeries:  10,
 			amountSamples: 2,
+		},
+		{
+			// Floats alone (10*10=100) stay under the 200 samples limit, but once
+			// native histograms (10*11=110) are also counted the total (210) exceeds it.
+			name:             "Request above limit of samples once native histograms are counted",
+			status:           http.StatusRequestEntityTooLarge,
+			amountSeries:     10,
+			amountSamples:    10,
+			amountHistograms: 11,
 		},
 		{
 			name:          "Request above body size limit",
@@ -1075,6 +1086,10 @@ func TestReceiveWriteRequestLimits(t *testing.T) {
 				for j := 0; j < tc.amountSamples; j += 1 {
 					sample := prompb.Sample{Value: float64(j), Timestamp: int64(j)}
 					series.Samples = append(series.Samples, sample)
+				}
+				for j := 0; j < tc.amountHistograms; j += 1 {
+					histogram := prompb.HistogramToHistogramProto(int64(j), tsdbutil.GenerateTestHistogram(int64(j)))
+					series.Histograms = append(series.Histograms, histogram)
 				}
 				wreq.Timeseries = append(wreq.Timeseries, series)
 			}


### PR DESCRIPTION
Fixes #7593

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

The Receive per-request `samples` limit only counted float samples when deciding whether to reject a write request as "too many samples". Native histogram data points were not counted, so a request could carry an unbounded number of native histograms without ever hitting the configured samples limit.

This changes the sample counting to also include native histograms:

- `pkg/receive/handler.go`: the Prometheus remote-write path now sums `len(timeseries.Samples) + len(timeseries.Histograms)` before calling `requestLimiter.AllowSamples(...)`.
- `pkg/receive/handler_otlp.go`: the OTLP path applies the same inclusion.

Scope is intentionally kept tight to the existing `samples` limit. The separate `total_histogram_samples` / total-buckets limits mentioned as larger alternatives in #7593 can be a follow-up.

## Verification

- `go build ./pkg/receive/...` passes.
- `go test ./pkg/receive/ -run TestReceiveWriteRequestLimits` passes, including a new sub-case `Request above limit of samples once native histograms are counted`: with a samples limit of 200, a request of 10 series × 10 float samples (100 total) stays under the limit on floats alone, but once 10 series × 11 native histograms (110) are also counted the total (210) exceeds the limit and the request is rejected with `413 Request Entity Too Large`. This fails without the change and passes with it.
- `gofmt` and `go vet ./pkg/receive/` are clean.
