### PR TITLE
reloader: make test more resilient

### DIFF
--- a/pkg/reloader/reloader_test.go
+++ b/pkg/reloader/reloader_test.go
@@ -32,6 +32,26 @@ func TestMain(m *testing.M) {
 	goleak.VerifyTestMain(m)
 }
 
+func waitFor(ctx context.Context, t *testing.T, what string, cond func() bool) {
+	t.Helper()
+
+	for !cond() {
+		select {
+		case <-ctx.Done():
+			t.Fatalf("Timeout waiting for %s", what)
+		case <-time.After(300 * time.Millisecond):
+		}
+	}
+}
+
+func readFile(t *testing.T, name string) string {
+	t.Helper()
+
+	b, err := os.ReadFile(name)
+	testutil.Ok(t, err)
+	return string(b)
+}
+
 func TestReloader_ConfigApply(t *testing.T) {
 	if testing.
 		Short() {
@@ -145,56 +165,40 @@ config:
 		testutil.Ok(t, reloader.Watch(rctx))
 	})
 
-	reloadsSeen := 0
-	attemptsCnt := 0
-Outer:
-	for {
-		select {
-		case <-ctx.Done():
-			break Outer
-		case <-time.After(300 * time.Millisecond):
-		}
-
-		rel := reloads.Load().(int)
-		reloadsSeen = rel
-
-		if reloadsSeen == 1 {
-			// Initial apply seen (without doing nothing).
-			f, err := os.ReadFile(output)
-			testutil.Ok(t, err)
-			testutil.Equals(t, `
+	waitFor(ctx, t, "initial config expansion", func() bool {
+		return readFile(t, output) == `
 config:
   a: 1
   b: 2
   c: 3
-`, string(f))
+`
+	})
 
-			// Change config, expect reload in another iteration.
-			testutil.Ok(t, os.WriteFile(input, []byte(`
+	// NOTE: os.WriteFile does a truncate + write so there could be more
+	// than 2 reloads.
+	testutil.Ok(t, os.WriteFile(input, []byte(`
 config:
   a: changed
   b: $(TEST_RELOADER_THANOS_ENV)
   c: $(TEST_RELOADER_THANOS_ENV2)
 `), os.ModePerm))
-		} else if reloadsSeen == 2 {
-			// Another apply, ensure we see change.
-			f, err := os.ReadFile(output)
-			testutil.Ok(t, err)
-			testutil.Equals(t, `
+	waitFor(ctx, t, "reload of the changed config", func() bool {
+		return reloads.Load().(int) >= 2 && readFile(t, output) == `
 config:
   a: changed
   b: 2
   c: 3
-`, string(f))
+`
+	})
 
-			// Change the mode so reloader can't read the file.
-			testutil.Ok(t, os.Chmod(input, os.ModeDir))
-			attemptsCnt++
-			// That was the second attempt to reload config. All good, break.
-			if attemptsCnt == 2 {
-				break
-			}
-		}
+	// Change the mode so reloader can't read the file. Two attempts have to fail
+	// without the reloader giving up.
+	for range 2 {
+		failuresSeen := promtest.ToFloat64(reloader.configApplyErrors)
+		testutil.Ok(t, os.Chmod(input, os.ModeDir))
+		waitFor(ctx, t, "failed apply of the unreadable config", func() bool {
+			return promtest.ToFloat64(reloader.configApplyErrors) > failuresSeen
+		})
 	}
 	cancel3()
 	g.Wait()
@@ -244,7 +248,7 @@ faulty_config:
 		f, err := os.ReadFile(output)
 		testutil.Ok(t, err)
 
-		if string(f) == string(faultyConfig) {
+		if string(f) != string(correctConfig) {
 			resp.WriteHeader(http.StatusServiceUnavailable)
 			return
 		}
@@ -277,45 +281,27 @@ faulty_config:
 		testutil.Ok(t, reloader.Watch(rctx))
 	})
 
-	reloadsSeen := 0
-	faulty := false
+	waitFor(ctx, t, "initial reload", func() bool {
+		return reloads.Load().(int) >= 1 && readFile(t, output) == string(correctConfig)
+	})
 
-	for {
-		select {
-		case <-ctx.Done():
-			t.Fatalf("Timeout with faulty = %t, reloadsSeen = %d", faulty, reloadsSeen)
-		case <-time.After(300 * time.Millisecond):
-		}
+	var curReloads = reloads.Load().(int)
 
-		rel := reloads.Load().(int)
-		reloadsSeen = rel
+	// Faulty config gets written out but its reload keeps failing.
+	testutil.Ok(t, os.WriteFile(input, faultyConfig, os.ModePerm))
+	waitFor(ctx, t, "faulty config to be written out", func() bool {
+		return readFile(t, output) == string(faultyConfig)
+	})
+	testutil.Equals(t, curReloads, reloads.Load().(int))
 
-		if reloadsSeen == 1 && !faulty {
-			// Initial apply seen (without doing anything).
-			f, err := os.ReadFile(output)
-			testutil.Ok(t, err)
-			testutil.Equals(t, string(correctConfig), string(f))
+	// Rollback to the previous config should trigger a successful reload.
+	testutil.Ok(t, os.WriteFile(input, correctConfig, os.ModePerm))
 
-			// Change to a faulty config
-			testutil.Ok(t, os.WriteFile(input, faultyConfig, os.ModePerm))
-			faulty = true
-		} else if reloadsSeen == 1 && faulty {
-			// Faulty config will trigger a reload, but reload failed
-			f, err := os.ReadFile(output)
-			testutil.Ok(t, err)
-			testutil.Equals(t, string(faultyConfig), string(f))
+	// os.WriteFile does a truncate + write so multiple reloads might be seen.
+	waitFor(ctx, t, "rollback reload", func() bool {
+		return reloads.Load().(int) >= curReloads+1 && readFile(t, output) == string(correctConfig)
+	})
 
-			// Rollback config
-			testutil.Ok(t, os.WriteFile(input, correctConfig, os.ModePerm))
-		} else if reloadsSeen >= 2 {
-			// Rollback to previous config should trigger a reload
-			f, err := os.ReadFile(output)
-			testutil.Ok(t, err)
-			testutil.Equals(t, string(correctConfig), string(f))
-
-			break
-		}
-	}
 	cancel2()
 	g.Wait()
 }


### PR DESCRIPTION
Make the test more resilient, hopefully. Reloads seen can jump by more than 1 after os.WriteFile because it does a truncate+write so inotify sees 2 in some cases.
