### PR TITLE
docs: align Go version prerequisite with go.mod

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,7 @@ The following section explains various suggestions and procedures to note during
 
 * It is strongly recommended that you use Linux distributions systems or macOS for development.
 * Running [WSL 2 (on Windows)](https://learn.microsoft.com/en-us/windows/wsl/) is also possible. Note that if during development you run a local Kubernetes cluster and have a Service with `service.spec.sessionAffinity: ClientIP`, it will break things until it's removed[^windows_xt_recent].
-* Go 1.22.x or higher.
+* Go 1.26.x or higher.
 * Docker (to run e2e tests)
 * For React UI, you will need a working NodeJS environment and the [pnpm](https://pnpm.io/) package manager to compile the Web UI assets.
 


### PR DESCRIPTION
* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

`go.mod` requires `go 1.26.0`, but the prerequisites in `CONTRIBUTING.md` still tell new
contributors to install Go 1.22.x. Following the guide as written and running `make build`
fails immediately:

```
go: go.mod requires go >= 1.26.0 (running go 1.25.0; GOTOOLCHAIN=go1.25.0)
```

One line changed:

* `CONTRIBUTING.md`: `Go 1.22.x or higher` -> `Go 1.26.x or higher`, matching `go.mod`.

### Relation to other open PRs

The same Go version drift shows up in a few other places, all of which are already covered
by open PRs. This PR deliberately does **not** duplicate them, so it should not conflict
with either:

| Location | Covered by |
| --- | --- |
| `docs/getting-started.md` (Go 1.18+) | #8733 |
| `docs/contributing/how-to-change-go-version.md` checklist | #8733 |
| `.github/workflows/codeql-analysis.yml`, `.github/workflows/mixin.yaml` | #8734 |
| **`CONTRIBUTING.md` prerequisites** | **not covered — this PR** |

`CONTRIBUTING.md` is the one place none of them touch, and it is the first thing a new
contributor reads, which is how I ran into it.

## Verification

* `make build` and `make docs` pass with Go 1.26; `make docs` produces no diff beyond the
  single intended line.
* Checked the change against `go.mod` (`go 1.26.0`) and against the files listed in
  `docs/contributing/how-to-change-go-version.md` — `.promu.yml`, `.circleci/config.yml`,
  `Dockerfile.e2e-tests`, `.github/workflows/go.yaml` and `.github/workflows/docs.yaml` are
  all already on 1.26.
* `git diff upstream/main` touches `CONTRIBUTING.md` only.
