### PR TITLE
receive: avoid pruning panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 
 ### Fixed
 
+- [#8990](https://github.com/thanos-io/thanos/pull/8990): Receive: Avoid a panic when pruning starts before a tenant TSDB is ready.
 - [#8968](https://github.com/thanos-io/thanos/pull/8968): *: Bump `google.golang.org/grpc` to v1.82.1 to fix GHSA-hrxh-6v49-42gf (CVSS 8.6): HTTP/2 Rapid Reset DoS bypass, xDS RBAC authorization bypass, and NOT-rule panic.
 - [#8900](https://github.com/thanos-io/thanos/pull/8900): UI: Fix web UI static assets (JS/CSS) returning 404 on Windows by using slash-separated paths for the embedded file system.
 - [#8935](https://github.com/thanos-io/thanos/pull/8935): Receive: remove redundant tl.Set() while building a Capnp WriteRequest.

--- a/pkg/receive/multitsdb.go
+++ b/pkg/receive/multitsdb.go
@@ -343,7 +343,11 @@ func (t *tenant) shouldBeMarkedInactive() bool {
 	// NOTE(GiedriusS): it could also happen that compaction is failing and it is not producing new blocks.
 	// But if compaction is failing then that probably also means that the storage layer is hosed
 	// and if that is the case then we cannot do anything about it anyway.
-	head := t.tsdb.Head()
+	db := t.readyS.Get()
+	if db == nil {
+		return false
+	}
+	head := db.Head()
 	if head.MaxTime() < 0 {
 		return false
 	}

--- a/pkg/receive/multitsdb_test.go
+++ b/pkg/receive/multitsdb_test.go
@@ -708,6 +708,43 @@ func TestMultiTSDBAddNewTenant(t *testing.T) {
 	}
 }
 
+func TestMultiTSDBPruneSkipsUnreadyTenant(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	maxBlockDuration := (2 * time.Hour).Milliseconds()
+	retentionDuration := (6 * time.Hour).Milliseconds()
+	m := NewMultiTSDB(
+		openTestRoot(t, dir),
+		log.NewNopLogger(),
+		prometheus.NewRegistry(),
+		&tsdb.Options{
+			MinBlockDuration:  maxBlockDuration,
+			MaxBlockDuration:  maxBlockDuration,
+			RetentionDuration: retentionDuration,
+		},
+		labels.FromStrings("replica", "test"),
+		"tenant_id",
+		nil,
+		false,
+		false,
+		metadata.NoneFunc,
+	)
+
+	const tenantID = "unready-tenant"
+	tenant := newTenant(log.NewNopLogger(), retentionDuration, maxBlockDuration, tenantID)
+	m.addTenantLocked(tenantID, tenant)
+	t.Cleanup(func() {
+		m.mtx.Lock()
+		m.removeTenantUnlocked(tenantID)
+		m.mtx.Unlock()
+		m.Close()
+	})
+
+	testutil.Ok(t, m.Prune(context.Background()))
+	testutil.Equals(t, false, tenant.readOnly.Load())
+}
+
 func TestAlignedHeadFlush(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
* [x] I added CHANGELOG entry for this change.

## Changes

Skip pruning until the tenant TSDB is ready.

## Verification

`go test -tags slicelabels -race ./pkg/receive`