### PR TITLE
ui: route partial-response localStorage through a shared accessor

### DIFF
--- a/pkg/ui/react-app/src/hooks/useLocalStorage.tsx
+++ b/pkg/ui/react-app/src/hooks/useLocalStorage.tsx
@@ -1,12 +1,29 @@
 import { Dispatch, SetStateAction, useEffect, useState } from 'react';
 
+// split out so class components (which can't use hooks) can still go through
+// a shared accessor instead of touching localStorage directly
+export function getStorageItem<S>(localStorageKey: string, initialState: S): S {
+  try {
+    return JSON.parse(localStorage.getItem(localStorageKey) || JSON.stringify(initialState));
+  } catch {
+    // a foreign or corrupted value under this key shouldn't crash the caller
+    return initialState;
+  }
+}
+
+export function setStorageItem<S>(localStorageKey: string, value: S): void {
+  localStorage.setItem(localStorageKey, JSON.stringify(value));
+}
+
+export function hasStorageItem(localStorageKey: string): boolean {
+  return localStorage.getItem(localStorageKey) !== null;
+}
+
 export function useLocalStorage<S>(localStorageKey: string, initialState: S): [S, Dispatch<SetStateAction<S>>] {
-  const localStorageState = JSON.parse(localStorage.getItem(localStorageKey) || JSON.stringify(initialState));
-  const [value, setValue] = useState(localStorageState);
+  const [value, setValue] = useState(getStorageItem(localStorageKey, initialState));
 
   useEffect(() => {
-    const serializedState = JSON.stringify(value);
-    localStorage.setItem(localStorageKey, serializedState);
+    setStorageItem(localStorageKey, value);
   }, [localStorageKey, value]);
 
   return [value, setValue];

--- a/pkg/ui/react-app/src/pages/graph/Panel.tsx
+++ b/pkg/ui/react-app/src/pages/graph/Panel.tsx
@@ -32,6 +32,7 @@ import PathPrefixProps from '../../types/PathPrefixProps';
 import { QueryParams } from '../../types/types';
 import { parseDuration } from '../../utils';
 import { defaultTenant, tenantHeader, displayTenantBox } from '../../thanos/config';
+import { getStorageItem, setStorageItem, hasStorageItem } from '../../hooks/useLocalStorage';
 
 export interface PanelProps {
   id: string;
@@ -217,12 +218,11 @@ class Panel extends Component<PanelProps & PathPrefixProps, PanelState> {
 
   componentDidMount(): void {
     this.executeQuery();
-    const storedValue = localStorage.getItem('usePartialResponse');
-    if (storedValue !== null) {
+    if (hasStorageItem('usePartialResponse')) {
       // Set the default value in state and local storage
       this.setOptions({ usePartialResponse: true });
       this.props.onUsePartialResponseChange(true);
-      localStorage.setItem('usePartialResponse', JSON.stringify(true));
+      setStorageItem('usePartialResponse', true);
     }
   }
 
@@ -414,15 +414,15 @@ class Panel extends Component<PanelProps & PathPrefixProps, PanelState> {
   handleChangePartialResponse = (event: React.ChangeEvent<HTMLInputElement>): void => {
     let newValue = event.target.checked;
 
-    const storedValue = localStorage.getItem('usePartialResponse');
+    const storedValue = getStorageItem<boolean | null>('usePartialResponse', null);
 
-    if (storedValue === 'true') {
+    if (storedValue === true) {
       newValue = true;
     }
     this.setOptions({ usePartialResponse: newValue });
     this.props.onUsePartialResponseChange(newValue);
 
-    localStorage.setItem('usePartialResponse', JSON.stringify(event.target.checked));
+    setStorageItem('usePartialResponse', event.target.checked);
   };
 
   handleStoreMatchChange = (selectedStores: any): void => {

--- a/pkg/ui/react-app/src/pages/graph/PanelList.tsx
+++ b/pkg/ui/react-app/src/pages/graph/PanelList.tsx
@@ -10,7 +10,7 @@ import { Store } from '../../thanos/pages/stores/store';
 import { FlagMap } from '../flags/Flags';
 import { generateID, decodePanelOptionsFromQueryString, encodePanelOptionsToQueryString, callAll } from '../../utils';
 import { useFetch } from '../../hooks/useFetch';
-import { useLocalStorage } from '../../hooks/useLocalStorage';
+import { useLocalStorage, setStorageItem } from '../../hooks/useLocalStorage';
 import { withStatusIndicator } from '../../components/withStatusIndicator';
 
 export type PanelMeta = { key: string; options: PanelOptions; id: string };
@@ -100,7 +100,7 @@ export const PanelListContent: FC<PanelListProps> = ({
     ]);
   };
   const handleUsePartialResponseChange = (value: boolean): void => {
-    localStorage.setItem('usePartialResponse', JSON.stringify(value));
+    setStorageItem('usePartialResponse', value);
   };
 
   return (


### PR DESCRIPTION
* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

Every localStorage read/write in the React app goes through the `useLocalStorage` hook, except the `usePartialResponse` key in `Panel.tsx` and `PanelList.tsx`, which touch `localStorage` directly. `Panel` is a class component and can't call the hook, which is why it bypassed it.

I pulled the raw operations out into three plain functions in `useLocalStorage.tsx` — `getStorageItem`, `setStorageItem`, `hasStorageItem` — so both hook and non-hook callers go through the same accessor. `useLocalStorage` becomes a thin wrapper over them, and I routed the three bypass sites through them instead of touching `localStorage` directly. After this, no raw `localStorage.` access remains in the app outside that one module.

I intended this as a read/write refactor with no behavior change, so I checked the full git history of the key: it has only ever been written as `JSON.stringify(<boolean>)` since it was introduced, so under normal use the stored value is always `"true"`, `"false"`, or absent.

One thing I want to flag: routing reads through `JSON.parse` (which the old raw-string comparison didn't do) would throw on a non-JSON value. I confirmed that can't happen through app code, only via manual localStorage tampering or corruption — but to keep the old "never crashes on a bad value" behavior, I added a try/catch in `getStorageItem` that falls back to the initial value on a parse error, the same approach jaeger-ui uses for this. I used `hasStorageItem` (no parsing) for the `componentDidMount` existence check to keep exact parity there.

One residual I'll disclose: `handleChangePartialResponse` now parses via the typed accessor, so a whitespace-padded value like `"  true  "` would parse to `true` where the old `=== 'true'` didn't match. No app code has ever produced such a value, and closing it fully would mean abandoning the typed accessor for that one read, which didn't seem worth it — happy to change that if you'd prefer.

## Verification

I verified behavior parity empirically across every value the key could hold before settling on this shape. `make react-app-lint` and `make react-app-test` both pass (260 tests).
