### PR TITLE
queryfrontend: fix lower-step cache alignment

### DIFF
--- a/internal/cortex/querier/queryrange/results_cache.go
+++ b/internal/cortex/querier/queryrange/results_cache.go
@@ -278,8 +278,12 @@ func (s resultsCache) Do(ctx context.Context, r Request) (Response, error) {
 	} else {
 		cached, _, ok = s.getFirst(ctx, alternativeCacheKeys(s.generateAlternativeCacheKeys(tenantIDs, r), key))
 		if ok {
-			response, extents, err = s.handleHit(ctx, r, cached, maxCacheTime, extractMatchingStep)
-			writeBack = false
+			if covering, covered := findCoveringExtent(r, cached); covered {
+				response, extents, err = s.handleHit(ctx, r, []Extent{covering}, maxCacheTime, extractMatchingStep)
+				writeBack = false
+			} else {
+				ok = false
+			}
 		}
 		if !ok {
 			response, extents, err = s.handleMiss(ctx, r, maxCacheTime)
@@ -306,6 +310,15 @@ func (s resultsCache) generateAlternativeCacheKeys(tenantIDs []string, r Request
 		return nil
 	}
 	return splitter.GenerateCacheKeyAlternatives(tenant.JoinTenantIDs(tenantIDs), r)
+}
+
+func findCoveringExtent(r Request, extents []Extent) (Extent, bool) {
+	for _, extent := range extents {
+		if extent.Start <= r.GetStart() && extent.End >= r.GetEnd() {
+			return extent, true
+		}
+	}
+	return Extent{}, false
 }
 
 func alternativeCacheKeys(keys []string, primaryKey string) []string {

--- a/internal/cortex/querier/queryrange/results_cache_test.go
+++ b/internal/cortex/querier/queryrange/results_cache_test.go
@@ -1209,6 +1209,81 @@ func TestResultsCacheUsesLowerStepCache(t *testing.T) {
 	require.Equal(t, mkAPIResponse(0, 120*1000, 30*1000), resp)
 }
 
+func TestResultsCacheLowerStepHitPreservesRequestStep(t *testing.T) {
+	const (
+		lowerStep   = 15 * 1000
+		requestStep = 30 * 1000
+		requestEnd  = 120 * 1000
+	)
+
+	for _, tc := range []struct {
+		name    string
+		extents []Extent
+	}{
+		{
+			name: "multiple extents collectively cover request",
+			extents: []Extent{
+				mkExtentWithStep(0, 75*1000, lowerStep),
+				mkExtentWithStep(75*1000, requestEnd, lowerStep),
+			},
+		},
+		{
+			name: "partial extent has unaligned end",
+			extents: []Extent{
+				mkExtentWithStep(0, 75*1000, lowerStep),
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cacheBackend := cache.NewMockCache()
+			splitter := alternativeStepSplitter{
+				interval: day,
+				steps:    []int64{lowerStep},
+			}
+			cfg := ResultsCacheConfig{
+				CacheConfig: cache.Config{Cache: cacheBackend},
+			}
+			rcm, _, err := NewResultsCacheMiddleware(
+				log.NewNopLogger(),
+				cfg,
+				splitter,
+				mockLimits{},
+				PrometheusCodec,
+				PrometheusResponseExtractor{},
+				nil,
+				nil,
+				nil,
+			)
+			require.NoError(t, err)
+
+			rc := rcm.Wrap(HandlerFunc(func(_ context.Context, req Request) (Response, error) {
+				return mkAPIResponse(req.GetStart(), req.GetEnd(), req.GetStep()), nil
+			})).(*resultsCache)
+			ctx := user.InjectOrgID(context.Background(), "1")
+
+			lowerStepReq := &PrometheusRequest{
+				Path:  "/api/v1/query_range",
+				Start: 0,
+				End:   requestEnd,
+				Step:  lowerStep,
+				Query: "up",
+			}
+			rc.put(ctx, splitter.GenerateCacheKey("1", lowerStepReq), tc.extents)
+
+			request := &PrometheusRequest{
+				Path:  "/api/v1/query_range",
+				Start: 0,
+				End:   requestEnd,
+				Step:  requestStep,
+				Query: "up",
+			}
+			resp, err := rc.Do(ctx, request)
+			require.NoError(t, err)
+			require.Equal(t, mkAPIResponse(0, requestEnd, requestStep), resp)
+		})
+	}
+}
+
 func TestResultsCacheFetchesAlternativeKeysInBulk(t *testing.T) {
 	cacheRecorder := &recordingCache{Cache: cache.NewMockCache()}
 	splitter := alternativeStepSplitter{


### PR DESCRIPTION
A query starts at 0 with step 30. It should return:

`0, 30, 60, 90, 120`

A lower-step cache has two parts: `[0, 75]` and `[75, 120]`. The cached result can become:

`0, 30, 60, 75, 105`

This change only reuses a lower-step cache entry when one extent covers the full request.