### PR TITLE
Wait for ConcurrentLister workers when the bucket listing fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 
 ### Fixed
 
+- [#8997](https://github.com/thanos-io/thanos/pull/8997): Block: Avoid a `send on closed channel` panic when the bucket listing fails part way through a concurrent metadata sync.
 - [#8990](https://github.com/thanos-io/thanos/pull/8990): Receive: Avoid a panic when pruning starts before a tenant TSDB is ready.
 - [#8968](https://github.com/thanos-io/thanos/pull/8968): *: Bump `google.golang.org/grpc` to v1.82.1 to fix GHSA-hrxh-6v49-42gf (CVSS 8.6): HTTP/2 Rapid Reset DoS bypass, xDS RBAC authorization bypass, and NOT-rule panic.
 - [#8900](https://github.com/thanos-io/thanos/pull/8900): UI: Fix web UI static assets (JS/CSS) returning 404 on Windows by using slash-separated paths for the embedded file system.

--- a/pkg/block/fetcher.go
+++ b/pkg/block/fetcher.go
@@ -319,7 +319,7 @@ func (f *ConcurrentLister) GetActiveAndPartialBlockIDs(ctx context.Context, acti
 	// Close and wait on every path, including the error one. The caller closes
 	// the activeBlocks channel as soon as this returns, so a worker still
 	// selecting on it would send on a closed channel; and a worker parked on the
-	// metaChan range would never be released, since cancelling gCtx does not
+	// metaChan range would never be released, since canceling gCtx does not
 	// break out of a receive.
 	close(metaChan)
 	waitErr := eg.Wait()

--- a/pkg/block/fetcher.go
+++ b/pkg/block/fetcher.go
@@ -304,7 +304,7 @@ func (f *ConcurrentLister) GetActiveAndPartialBlockIDs(ctx context.Context, acti
 		})
 	}
 
-	if err = f.bkt.Iter(ctx, "", func(name string) error {
+	iterErr := f.bkt.Iter(ctx, "", func(name string) error {
 		id, ok := IsBlockDir(name)
 		if !ok {
 			return nil
@@ -315,13 +315,20 @@ func (f *ConcurrentLister) GetActiveAndPartialBlockIDs(ctx context.Context, acti
 		case metaChan <- id:
 		}
 		return nil
-	}); err != nil {
-		return nil, err
-	}
+	})
+	// Close and wait on every path, including the error one. The caller closes
+	// the activeBlocks channel as soon as this returns, so a worker still
+	// selecting on it would send on a closed channel; and a worker parked on the
+	// metaChan range would never be released, since cancelling gCtx does not
+	// break out of a receive.
 	close(metaChan)
+	waitErr := eg.Wait()
 
-	if err := eg.Wait(); err != nil {
-		return nil, err
+	if iterErr != nil {
+		return nil, iterErr
+	}
+	if waitErr != nil {
+		return nil, waitErr
 	}
 	return partialBlocks, nil
 }

--- a/pkg/block/fetcher_concurrent_lister_test.go
+++ b/pkg/block/fetcher_concurrent_lister_test.go
@@ -78,7 +78,7 @@ func (b *gatedExistsBucket) WithExpectedErrs(objstore.IsOpFailureExpectedFunc) o
 // returns, including on the path where the bucket listing itself fails.
 //
 // Asserting on the panic directly would be racy: once the group context is
-// cancelled a parked worker usually takes its ctx.Done branch, and only
+// canceled a parked worker usually takes its ctx.Done branch, and only
 // sometimes loses the select to the closed channel. Holding one worker inside
 // Exists makes the same invariant deterministic.
 func TestConcurrentLister_WaitsForWorkersOnIterError(t *testing.T) {

--- a/pkg/block/fetcher_concurrent_lister_test.go
+++ b/pkg/block/fetcher_concurrent_lister_test.go
@@ -1,0 +1,148 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package block
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/efficientgo/core/testutil"
+	"github.com/go-kit/log"
+	"github.com/oklog/ulid/v2"
+	"github.com/pkg/errors"
+	"github.com/thanos-io/objstore"
+)
+
+// gatedExistsBucket lists a fixed set of block prefixes and drives two things
+// out of Exists: one block fails, which is how an object store hiccup cancels
+// the lister's errgroup, and one block blocks until released, which keeps a
+// worker demonstrably in flight while the failure propagates.
+type gatedExistsBucket struct {
+	objstore.Bucket
+
+	ids     []ulid.ULID
+	failFor ulid.ULID
+	holdFor ulid.ULID
+
+	existsErr error
+
+	hold     chan struct{} // closed by the test to release the held worker
+	held     chan struct{} // closed once a worker is inside the held Exists
+	failed   chan struct{} // closed once the failure has been returned
+	heldOnce sync.Once
+	failOnce sync.Once
+}
+
+func (b *gatedExistsBucket) Exists(_ context.Context, name string) (bool, error) {
+	switch {
+	case strings.HasPrefix(name, b.failFor.String()+"/"):
+		b.failOnce.Do(func() { close(b.failed) })
+		return false, b.existsErr
+	case strings.HasPrefix(name, b.holdFor.String()+"/"):
+		b.heldOnce.Do(func() { close(b.held) })
+		<-b.hold
+		return true, nil
+	}
+	return true, nil
+}
+
+func (b *gatedExistsBucket) Iter(ctx context.Context, _ string, f func(string) error, _ ...objstore.IterOption) error {
+	for _, id := range b.ids {
+		if err := f(id.String() + "/"); err != nil {
+			return err
+		}
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+	}
+	return nil
+}
+
+func (b *gatedExistsBucket) ReaderWithExpectedErrs(objstore.IsOpFailureExpectedFunc) objstore.BucketReader {
+	return b
+}
+
+func (b *gatedExistsBucket) WithExpectedErrs(objstore.IsOpFailureExpectedFunc) objstore.Bucket {
+	return b
+}
+
+// TestConcurrentLister_WaitsForWorkersOnIterError pins the invariant behind
+// #8996. BaseFetcher.fetchMetadata closes the activeBlocks channel as soon as
+// GetActiveAndPartialBlockIDs returns, so a worker that outlives the call can
+// send on a closed channel and take the process down with "send on closed
+// channel". The lister therefore has to have waited for every worker before it
+// returns, including on the path where the bucket listing itself fails.
+//
+// Asserting on the panic directly would be racy: once the group context is
+// cancelled a parked worker usually takes its ctx.Done branch, and only
+// sometimes loses the select to the closed channel. Holding one worker inside
+// Exists makes the same invariant deterministic.
+func TestConcurrentLister_WaitsForWorkersOnIterError(t *testing.T) {
+	// More prefixes than the lister's 64 workers, so the listing is still in
+	// flight when the failure cancels the group.
+	const numBlocks = 512
+
+	ids := make([]ulid.ULID, 0, numBlocks)
+	for i := range numBlocks {
+		ids = append(ids, ulid.MustNew(uint64(i+1), nil))
+	}
+
+	bkt := &gatedExistsBucket{
+		ids:       ids,
+		holdFor:   ids[0],
+		failFor:   ids[3],
+		existsErr: errors.New("simulated object store failure"),
+		hold:      make(chan struct{}),
+		held:      make(chan struct{}),
+		failed:    make(chan struct{}),
+	}
+
+	lister := NewConcurrentLister(log.NewNopLogger(), bkt)
+
+	activeBlocks := make(chan ActiveBlockFetchData)
+	var drained sync.WaitGroup
+	drained.Add(1)
+	go func() {
+		defer drained.Done()
+		for range activeBlocks {
+		}
+	}()
+
+	var (
+		err      error
+		returned = make(chan struct{})
+	)
+	go func() {
+		defer close(returned)
+		_, err = lister.GetActiveAndPartialBlockIDs(context.Background(), activeBlocks)
+	}()
+
+	// One worker is parked inside Exists, and the failure that cancels the
+	// group context has been returned, so the listing is on its way out.
+	<-bkt.held
+	<-bkt.failed
+
+	select {
+	case <-returned:
+		t.Fatal("GetActiveAndPartialBlockIDs returned while a worker was still running; " +
+			"the caller closes the activeBlocks channel at this point (#8996)")
+	case <-time.After(500 * time.Millisecond):
+	}
+
+	close(bkt.hold)
+
+	select {
+	case <-returned:
+	case <-time.After(30 * time.Second):
+		t.Fatal("GetActiveAndPartialBlockIDs did not return after the worker was released")
+	}
+
+	testutil.NotOk(t, err)
+
+	close(activeBlocks)
+	drained.Wait()
+}


### PR DESCRIPTION
Fixes #8996.

The reporter's reading of the error path is right, and it still holds on `main`:

```go
if err = f.bkt.Iter(ctx, "", func(name string) error {
        ...
}); err != nil {
        return nil, err          // <- metaChan not closed, eg.Wait() not called
}
close(metaChan)
if err := eg.Wait(); err != nil {
```

`BaseFetcher.fetchMetadata` closes the channel it passed in as soon as this returns:

```go
defer close(activeBlocksCh)
partialBlocks, err = f.blockIDsLister.GetActiveAndPartialBlockIDs(ctx, activeBlocksCh)
```

so a worker still sitting in its `select` can send on a closed channel, which is the reported stack at `fetcher.go:294`.

This closes `metaChan` and waits on every path, with the `Iter` error taking precedence when both fail. The close is worth having for its own sake too: cancelling the group context does not break a worker out of a `metaChan` receive, so a worker parked there would never be released.

## On the test

I first tried to assert on the panic itself and could not make it fire reliably, which is worth explaining rather than hiding. Once the group context is cancelled, a parked worker has both `<-gCtx.Done()` and the send ready, and it usually takes the `Done` branch; losing that select to the closed channel is exactly the intermittency behind "329 restarts in four days" while another pod ran six days clean. A test built on it would be flaky in whichever direction the scheduler happened to go.

So `TestConcurrentLister_WaitsForWorkersOnIterError` pins the invariant underneath instead: the lister must not return while a worker is still running. It holds one worker inside `Exists` on a gate, fails another block to cancel the group, and asserts the call has not returned while the held worker is in flight. That is deterministic, and it fails on `main` for the right reason:

```
--- FAIL: TestConcurrentLister_WaitsForWorkersOnIterError
    GetActiveAndPartialBlockIDs returned while a worker was still running;
    the caller closes the activeBlocks channel at this point (#8996)
```

I also tried a goroutine-leak assertion, which does not catch this: in that configuration the workers are parked in the `select` rather than on the `metaChan` receive, so they all exit via `Done` and nothing leaks. Mentioning it in case it looks like an obvious thing to have used.

## Checks

`go build`, `go vet ./pkg/block/` and `gofmt` are clean, and the new test passes with `-race`.

For the package suite I compared like for like, since this checkout has no object-storage credentials: 20 failures before the change and the same 20 after, with the failure sets identical once the timings are stripped. They are all environment (`insufficient s3 test configuration information`, `googleapi: Error 400: Unknown project id`), not this change.

I have not reproduced the original panic against a real GCS bucket, so the confirmation that Bucket Web stops restarting is still worth having from the reporter.
