### PR TITLE
receive: rename incoming labels colliding with external labels to exported_

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 
 ### Fixed
 
+- [#8130](https://github.com/thanos-io/thanos/issues/8130): Receive: Rename incoming labels that collide with the receiver's configured external/replica labels (`--label`) to `exported_<name>` instead of silently overwriting them, mirroring Prometheus' `honor_labels=false` behavior so incoming label values are no longer lost.
 - [#8990](https://github.com/thanos-io/thanos/pull/8990): Receive: Avoid a panic when pruning starts before a tenant TSDB is ready.
 - [#8968](https://github.com/thanos-io/thanos/pull/8968): *: Bump `google.golang.org/grpc` to v1.82.1 to fix GHSA-hrxh-6v49-42gf (CVSS 8.6): HTTP/2 Rapid Reset DoS bypass, xDS RBAC authorization bypass, and NOT-rule panic.
 - [#8900](https://github.com/thanos-io/thanos/pull/8900): UI: Fix web UI static assets (JS/CSS) returning 404 on Windows by using slash-separated paths for the embedded file system.

--- a/pkg/receive/capnproto_writer.go
+++ b/pkg/receive/capnproto_writer.go
@@ -66,6 +66,8 @@ func (r *CapNProtoWriter) Write(ctx context.Context, wreq *writecapnp.Request) e
 		Appender:       app,
 	}
 
+	extLset := r.multiTSDB.TenantExtLabels(wreq.Tenant)
+
 	var (
 		series  writecapnp.Series
 		builder labels.ScratchBuilder
@@ -83,17 +85,22 @@ func (r *CapNProtoWriter) Write(ctx context.Context, wreq *writecapnp.Request) e
 			continue
 		}
 
+		// Rename incoming labels that collide with the tenant's external labels
+		// to exported_<name>, so their values are not overwritten at query time.
+		incoming, _ := resolveLabelConflicts(series.Labels, extLset)
+
 		var lset labels.Labels
 		// Check if the TSDB has cached reference for those labels.
-		ref, lset = getRef.GetRef(series.Labels, series.Labels.Hash())
+		ref, lset = getRef.GetRef(incoming, incoming.Hash())
 		if ref == 0 {
 			// NOTE(GiedriusS): do a deep copy because the labels are reused in the capnp message.
 			// Creation of new series is much rarer compared to adding extra samples
 			// to an existing series.
 			builder.Reset()
-			series.Labels.Range(func(l labels.Label) {
+			incoming.Range(func(l labels.Label) {
 				builder.Add(strings.Clone(l.Name), strings.Clone(l.Value))
 			})
+			builder.Sort()
 			lset = builder.Labels()
 		}
 

--- a/pkg/receive/handler_test.go
+++ b/pkg/receive/handler_test.go
@@ -72,6 +72,10 @@ func (t *fakeTenantAppendable) TenantAppendable(_ string) (Appendable, error) {
 	return t.f, nil
 }
 
+func (t *fakeTenantAppendable) TenantExtLabels(_ string) labels.Labels {
+	return labels.EmptyLabels()
+}
+
 type fakeAppendable struct {
 	appender    storage.Appender
 	appenderErr func() error

--- a/pkg/receive/multitsdb.go
+++ b/pkg/receive/multitsdb.go
@@ -1279,6 +1279,17 @@ func (u *UnRegisterer) MustRegister(cs ...prometheus.Collector) {
 	}
 }
 
+// TenantExtLabels returns the full external label set that the receiver exposes
+// for the given tenant: the globally configured --label set, the tenant label,
+// and any hashring external_labels. This mirrors the label set applied to the
+// tenant's TSDB store at query time (see startTSDB / SetHashringConfig) and is
+// used by the write path to detect incoming labels that would otherwise be
+// silently overwritten.
+func (t *MultiTSDB) TenantExtLabels(tenantID string) labels.Labels {
+	initialLset := labelpb.ExtendSortedLabels(t.labels, labels.FromStrings(t.tenantLabelName, tenantID))
+	return t.extractTenantsLabels(tenantID, initialLset)
+}
+
 // extractTenantsLabels extracts tenant's external labels from hashring configs.
 // If one tenant appears in multiple hashring configs,
 // only the external label set from the first hashring config is applied.

--- a/pkg/receive/writer.go
+++ b/pkg/receive/writer.go
@@ -5,6 +5,7 @@ package receive
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	"github.com/go-kit/log"
@@ -28,6 +29,68 @@ type Appendable interface {
 
 type TenantStorage interface {
 	TenantAppendable(string) (Appendable, error)
+	// TenantExtLabels returns the external labels (configured via --label and
+	// hashring external_labels, plus the tenant label) that the receiver
+	// applies to the tenant's series at query time.
+	TenantExtLabels(string) labels.Labels
+}
+
+// resolveLabelConflicts renames incoming labels whose names collide with the
+// tenant's external labels by prefixing them with "exported_", mirroring
+// Prometheus' honor_labels=false behavior. Without this, the external labels
+// applied at query time silently overwrite the colliding incoming label values,
+// losing data (see thanos-io/thanos#8130).
+//
+// If the "exported_<name>" name is itself taken (by another incoming label or an
+// external label), the prefix is applied repeatedly until a free name is found,
+// matching Prometheus' resolveConflictingExposedLabels. It returns the resulting
+// labels and whether any rename happened; when there is no collision the input is
+// returned unchanged.
+func resolveLabelConflicts(lset, extLset labels.Labels) (labels.Labels, bool) {
+	if extLset.IsEmpty() {
+		return lset, false
+	}
+
+	var b *labels.Builder
+	extLset.Range(func(l labels.Label) {
+		v := lset.Get(l.Name)
+		if v == "" {
+			// No incoming label collides with this external label name.
+			return
+		}
+		if b == nil {
+			b = labels.NewBuilder(lset)
+		}
+		newName := l.Name
+		for {
+			newName = model.ExportedLabelPrefix + newName
+			// The renamed label must not collide with another incoming label
+			// nor with an external label (which would overwrite it again at
+			// query time).
+			if b.Get(newName) == "" && extLset.Get(newName) == "" {
+				break
+			}
+		}
+		b.Del(l.Name)
+		b.Set(newName, v)
+	})
+
+	if b == nil {
+		return lset, false
+	}
+	return b.Labels(), true
+}
+
+// detachLabels returns a deep copy of lset with freshly allocated strings so that
+// the TSDB, which holds labels long term, does not retain references to the
+// underlying request buffer.
+func detachLabels(lset labels.Labels) labels.Labels {
+	builder := labels.NewScratchBuilder(lset.Len())
+	lset.Range(func(l labels.Label) {
+		builder.Add(strings.Clone(l.Name), strings.Clone(l.Value))
+	})
+	builder.Sort()
+	return builder.Labels()
 }
 
 // Wraps storage.Appender to add validation and logging.
@@ -97,6 +160,8 @@ func (r *Writer) Write(ctx context.Context, tenantID string, wreq []prompb.TimeS
 		Appender:       app,
 	}
 
+	extLset := r.multiTSDB.TenantExtLabels(tenantID)
+
 	for _, t := range wreq {
 		// Check if time series labels are valid. If not, skip the time series
 		// and report the error.
@@ -108,10 +173,23 @@ func (r *Writer) Write(ctx context.Context, tenantID string, wreq []prompb.TimeS
 
 		lset := labelpb.ZLabelsToPromLabels(t.Labels)
 
+		// Rename incoming labels that collide with the tenant's external labels
+		// to exported_<name>, so their values are not overwritten at query time.
+		lset, renamed := resolveLabelConflicts(lset, extLset)
+
 		// Check if the TSDB has cached reference for those labels.
-		ref, lset = getRef.GetRef(lset, lset.Hash())
-		if ref == 0 {
-			// If not, copy labels, as TSDB will hold those strings long term. Given no
+		var cachedLset labels.Labels
+		ref, cachedLset = getRef.GetRef(lset, lset.Hash())
+		switch {
+		case ref != 0:
+			// Reuse the labels held by the TSDB for this existing series.
+			lset = cachedLset
+		case renamed:
+			// New series with rebuilt labels. They may still reference the request
+			// buffer, so detach their strings, as TSDB will hold them long term.
+			lset = detachLabels(lset)
+		default:
+			// New series. Copy labels, as TSDB will hold those strings long term. Given no
 			// copy unmarshal we don't want to keep memory for whole protobuf, only for labels.
 			// Do the reallocation here instead of one level higher because this ensures that we
 			// do _not_ intern all strings even if they are already exist. This is a high likelihood

--- a/pkg/receive/writer_test.go
+++ b/pkg/receive/writer_test.go
@@ -361,6 +361,71 @@ func TestWriter(t *testing.T) {
 				},
 			},
 		},
+		// The multiTSDB is set up with external labels {replica="01", tenant_id=<tenant>},
+		// so incoming labels named "replica" or "tenant_id" collide with them.
+		"should rename incoming label colliding with an external label to exported_": {
+			reqs: []*prompb.WriteRequest{
+				{
+					Timeseries: []prompb.TimeSeries{
+						{
+							Labels:  append(lbls, labelpb.ZLabel{Name: "replica", Value: "foo"}),
+							Samples: []prompb.Sample{{Value: 1, Timestamp: 10}},
+						},
+					},
+				},
+			},
+			expectedErr: nil,
+			expectedIngested: []prompb.TimeSeries{
+				{
+					Labels:  append(lbls, labelpb.ZLabel{Name: "exported_replica", Value: "foo"}),
+					Samples: []prompb.Sample{{Value: 1, Timestamp: 10}},
+				},
+			},
+		},
+		"should not modify incoming labels when there is no collision": {
+			reqs: []*prompb.WriteRequest{
+				{
+					Timeseries: []prompb.TimeSeries{
+						{
+							Labels:  append(lbls, labelpb.ZLabel{Name: "foo", Value: "bar"}),
+							Samples: []prompb.Sample{{Value: 1, Timestamp: 10}},
+						},
+					},
+				},
+			},
+			expectedErr: nil,
+			expectedIngested: []prompb.TimeSeries{
+				{
+					Labels:  append(lbls, labelpb.ZLabel{Name: "foo", Value: "bar"}),
+					Samples: []prompb.Sample{{Value: 1, Timestamp: 10}},
+				},
+			},
+		},
+		"should double-prefix when exported_ label already exists": {
+			reqs: []*prompb.WriteRequest{
+				{
+					Timeseries: []prompb.TimeSeries{
+						{
+							Labels: append(lbls,
+								labelpb.ZLabel{Name: "exported_replica", Value: "bar"},
+								labelpb.ZLabel{Name: "replica", Value: "foo"},
+							),
+							Samples: []prompb.Sample{{Value: 1, Timestamp: 10}},
+						},
+					},
+				},
+			},
+			expectedErr: nil,
+			expectedIngested: []prompb.TimeSeries{
+				{
+					Labels: append(lbls,
+						labelpb.ZLabel{Name: "exported_exported_replica", Value: "foo"},
+						labelpb.ZLabel{Name: "exported_replica", Value: "bar"},
+					),
+					Samples: []prompb.Sample{{Value: 1, Timestamp: 10}},
+				},
+			},
+		},
 	}
 
 	for testName, testData := range tests {
@@ -421,6 +486,56 @@ func TestWriter(t *testing.T) {
 
 				assertWrittenData(t, app, testData.expectedIngested)
 			})
+		})
+	}
+}
+
+func TestResolveLabelConflicts(t *testing.T) {
+	t.Parallel()
+
+	extLset := labels.FromStrings("replica", "01", "tenant_id", "acme")
+
+	for name, tc := range map[string]struct {
+		lset        labels.Labels
+		extLset     labels.Labels
+		expected    labels.Labels
+		expectedMod bool
+	}{
+		"no collision returns input unchanged": {
+			lset:        labels.FromStrings("__name__", "metric", "foo", "bar"),
+			extLset:     extLset,
+			expected:    labels.FromStrings("__name__", "metric", "foo", "bar"),
+			expectedMod: false,
+		},
+		"empty external labels returns input unchanged": {
+			lset:        labels.FromStrings("__name__", "metric", "replica", "k8s"),
+			extLset:     labels.EmptyLabels(),
+			expected:    labels.FromStrings("__name__", "metric", "replica", "k8s"),
+			expectedMod: false,
+		},
+		"single collision is renamed to exported_": {
+			lset:        labels.FromStrings("__name__", "metric", "replica", "k8s"),
+			extLset:     extLset,
+			expected:    labels.FromStrings("__name__", "metric", "exported_replica", "k8s"),
+			expectedMod: true,
+		},
+		"multiple collisions are all renamed": {
+			lset:        labels.FromStrings("__name__", "metric", "replica", "k8s", "tenant_id", "team"),
+			extLset:     extLset,
+			expected:    labels.FromStrings("__name__", "metric", "exported_replica", "k8s", "exported_tenant_id", "team"),
+			expectedMod: true,
+		},
+		"already-has-exported_ is prefixed again": {
+			lset:        labels.FromStrings("__name__", "metric", "exported_replica", "existing", "replica", "k8s"),
+			extLset:     extLset,
+			expected:    labels.FromStrings("__name__", "metric", "exported_exported_replica", "k8s", "exported_replica", "existing"),
+			expectedMod: true,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			got, mod := resolveLabelConflicts(tc.lset, tc.extLset)
+			testutil.Equals(t, tc.expectedMod, mod)
+			testutil.Equals(t, tc.expected, got)
 		})
 	}
 }


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Fixes #8130.

When a Thanos Receive instance announces external/replica labels via `--label` (or hashring `external_labels`), and a client remote-writes a series carrying a label whose **name** collides with one of those configured labels, the external label applied at query time silently overwrote the incoming value. The incoming data was lost with no indication (e.g. `prometheus="k8s"` from the client became `prometheus="shared"` after ingestion).

This PR mirrors Prometheus' `honor_labels=false` scrape behavior: at ingestion, an incoming label that collides with a configured external label is renamed to `exported_<name>` instead of being dropped, so both values are preserved. Using the example from the issue, the series becomes:

```
{prometheus="shared", exported_prometheus="k8s"}
```

Details:

- Added `resolveLabelConflicts` in `pkg/receive/writer.go`, which renames incoming labels colliding with the tenant's external labels to `exported_<name>` (via `model.ExportedLabelPrefix`). If `exported_<name>` is itself taken (by another incoming label or an external label), the prefix is applied repeatedly until a free name is found, matching Prometheus' `resolveConflictingExposedLabels`.
- Wired it into both write paths: the protobuf `Writer` and the Cap'n Proto `CapNProtoWriter`.
- Added `MultiTSDB.TenantExtLabels(tenant)` (and the corresponding `TenantStorage` interface method) to expose the exact external label set applied to a tenant's TSDB store at query time.
- When there is no collision, the incoming labels and the existing fast paths are left completely unchanged.

## Verification

Added table tests in `pkg/receive`:

- `TestResolveLabelConflicts` (unit) — no collision returns input unchanged; empty external labels unchanged; single collision renamed to `exported_`; multiple collisions all renamed; already-`exported_` label prefixed again (`exported_exported_<name>`).
- New cases in `TestWriter` (end-to-end through both the proto and Cap'n Proto writers, with external labels `replica`/`tenant_id` configured): collision renamed to `exported_replica`; no-collision unchanged; `exported_`-already-exists double-prefixed.

`go build ./...`, `go vet ./pkg/receive/...`, and `gofmt` are clean. Package tests pass. (CI will run the pinned linter and the full suite.)
