### PR TITLE
receive: prune tenants whose head never received a successful append

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 
 ### Fixed
 
+- [#8999](https://github.com/thanos-io/thanos/pull/8999): Receive: Prune tenants whose head never received a successful append and would otherwise never be marked inactive.
 - [#8990](https://github.com/thanos-io/thanos/pull/8990): Receive: Avoid a panic when pruning starts before a tenant TSDB is ready.
 - [#8968](https://github.com/thanos-io/thanos/pull/8968): *: Bump `google.golang.org/grpc` to v1.82.1 to fix GHSA-hrxh-6v49-42gf (CVSS 8.6): HTTP/2 Rapid Reset DoS bypass, xDS RBAC authorization bypass, and NOT-rule panic.
 - [#8900](https://github.com/thanos-io/thanos/pull/8900): UI: Fix web UI static assets (JS/CSS) returning 404 on Windows by using slash-separated paths for the embedded file system.

--- a/pkg/receive/multitsdb.go
+++ b/pkg/receive/multitsdb.go
@@ -335,6 +335,11 @@ type tenant struct {
 
 	maxBlockDuration int64
 
+	// createdAt is when this tenant object was constructed. It is the only time
+	// reference available for a tenant whose head never took a successful append,
+	// because Head.MaxTime() is math.MinInt64 until the first append lands.
+	createdAt time.Time
+
 	lastSuccessfulHeadCompaction atomic.Int64
 }
 
@@ -349,7 +354,15 @@ func (t *tenant) shouldBeMarkedInactive() bool {
 	}
 	head := db.Head()
 	if head.MaxTime() < 0 {
-		return false
+		// A head that never took a successful append has no time reference to
+		// measure staleness from, so fall back to when the tenant was created.
+		// Only mark such a tenant inactive when it holds nothing at all: no
+		// samples in the head and no blocks on disk. There is nothing to ship in
+		// that case either, so the shipper checks below would be vacuous.
+		if len(db.Blocks()) > 0 {
+			return false
+		}
+		return time.Since(t.createdAt).Milliseconds() > t.retentionDuration
 	}
 
 	sinceLastAppendMillis := time.Since(time.UnixMilli(head.MaxTime())).Milliseconds()
@@ -566,6 +579,7 @@ func newTenant(l log.Logger, retentionDuration, maxBlockDuration int64, name str
 		doneC:             make(chan struct{}),
 		tenantName:        name,
 		maxBlockDuration:  maxBlockDuration,
+		createdAt:         time.Now(),
 	}
 }
 

--- a/pkg/receive/multitsdb_test.go
+++ b/pkg/receive/multitsdb_test.go
@@ -1195,8 +1195,6 @@ func TestMultiTSDBDoesNotReturnPrunedTenants(t *testing.T) {
 }
 
 func TestMultiTSDBPruneNeverAppendedTenant(t *testing.T) {
-	t.Parallel()
-
 	for _, tc := range []struct {
 		name              string
 		retentionDuration time.Duration
@@ -1205,56 +1203,64 @@ func TestMultiTSDBPruneNeverAppendedTenant(t *testing.T) {
 	}{
 		{
 			name:              "never appended and older than retention is pruned",
-			retentionDuration: 500 * time.Millisecond,
-			waitBeforePrune:   time.Second,
+			retentionDuration: 100 * time.Millisecond,
+			waitBeforePrune:   300 * time.Millisecond,
 			expectPruned:      true,
 		},
 		{
 			name:              "never appended but within retention is kept",
-			retentionDuration: time.Hour,
-			waitBeforePrune:   0,
+			retentionDuration: 10 * time.Hour,
+			waitBeforePrune:   300 * time.Millisecond,
 			expectPruned:      false,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
+			dir := t.TempDir()
 
-			m := NewMultiTSDB(
-				openTestRoot(t, t.TempDir()),
-				log.NewNopLogger(),
-				prometheus.NewRegistry(),
-				&tsdb.Options{
-					MinBlockDuration:  (2 * time.Hour).Milliseconds(),
-					MaxBlockDuration:  (2 * time.Hour).Milliseconds(),
-					RetentionDuration: tc.retentionDuration.Milliseconds(),
-				},
-				labels.FromStrings("replica", "test"),
-				"tenant_id",
-				nil,
-				false,
-				false,
-				metadata.NoneFunc,
-				WithGCImmediately(),
-			)
-			t.Cleanup(m.Close)
+			synctest.Test(t, func(t *testing.T) {
+				m := NewMultiTSDB(
+					openTestRoot(t, dir),
+					log.NewNopLogger(),
+					prometheus.NewRegistry(),
+					&tsdb.Options{
+						MinBlockDuration:  (2 * time.Hour).Milliseconds(),
+						MaxBlockDuration:  (2 * time.Hour).Milliseconds(),
+						RetentionDuration: tc.retentionDuration.Milliseconds(),
+					},
+					labels.FromStrings("replica", "test"),
+					"tenant_id",
+					nil,
+					false,
+					false,
+					metadata.NoneFunc,
+					WithGCImmediately(),
+				)
+				t.Cleanup(m.Close)
 
-			const tenantID = "never-appended-tenant"
+				const tenantID = "never-appended-tenant"
 
-			// Create the tenant the way a write does, but never append to it.
-			// Its head stays empty, so Head.MaxTime() is math.MinInt64.
-			_, err := m.TenantAppendable(tenantID)
-			testutil.Ok(t, err)
-			testutil.Assert(t, m.testGetTenant(tenantID) != nil, "tenant should exist before pruning")
+				// Create the tenant the way a write does, but never append to it.
+				// Its head stays empty, so Head.MaxTime() is math.MinInt64.
+				_, err := m.TenantAppendable(tenantID)
+				testutil.Ok(t, err)
+				testutil.Assert(t, m.testGetTenant(tenantID) != nil, "tenant should exist before pruning")
 
-			time.Sleep(tc.waitBeforePrune)
-			testutil.Ok(t, m.Prune(context.Background()))
+				// synctest virtualizes this sleep, so it costs no real time. Keep it
+				// under the TSDB block-reload interval (which floors at 1s) so the
+				// DB's background reload loop stays parked instead of doing real work
+				// on every simulated tick.
+				time.Sleep(tc.waitBeforePrune)
+				synctest.Wait()
 
-			if tc.expectPruned {
-				testutil.Assert(t, m.testGetTenant(tenantID) == nil, "zombie tenant should have been pruned")
-				testutil.Equals(t, 0, len(m.TSDBLocalClients()))
-			} else {
-				testutil.Assert(t, m.testGetTenant(tenantID) != nil, "tenant within retention should be kept")
-			}
+				testutil.Ok(t, m.Prune(context.Background()))
+
+				if tc.expectPruned {
+					testutil.Assert(t, m.testGetTenant(tenantID) == nil, "zombie tenant should have been pruned")
+					testutil.Equals(t, 0, len(m.TSDBLocalClients()))
+				} else {
+					testutil.Assert(t, m.testGetTenant(tenantID) != nil, "tenant within retention should be kept")
+				}
+			})
 		})
 	}
 }

--- a/pkg/receive/multitsdb_test.go
+++ b/pkg/receive/multitsdb_test.go
@@ -1193,3 +1193,68 @@ func TestMultiTSDBDoesNotReturnPrunedTenants(t *testing.T) {
 
 	wg.Wait()
 }
+
+func TestMultiTSDBPruneNeverAppendedTenant(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name              string
+		retentionDuration time.Duration
+		waitBeforePrune   time.Duration
+		expectPruned      bool
+	}{
+		{
+			name:              "never appended and older than retention is pruned",
+			retentionDuration: 500 * time.Millisecond,
+			waitBeforePrune:   time.Second,
+			expectPruned:      true,
+		},
+		{
+			name:              "never appended but within retention is kept",
+			retentionDuration: time.Hour,
+			waitBeforePrune:   0,
+			expectPruned:      false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			m := NewMultiTSDB(
+				openTestRoot(t, t.TempDir()),
+				log.NewNopLogger(),
+				prometheus.NewRegistry(),
+				&tsdb.Options{
+					MinBlockDuration:  (2 * time.Hour).Milliseconds(),
+					MaxBlockDuration:  (2 * time.Hour).Milliseconds(),
+					RetentionDuration: tc.retentionDuration.Milliseconds(),
+				},
+				labels.FromStrings("replica", "test"),
+				"tenant_id",
+				nil,
+				false,
+				false,
+				metadata.NoneFunc,
+				WithGCImmediately(),
+			)
+			t.Cleanup(m.Close)
+
+			const tenantID = "never-appended-tenant"
+
+			// Create the tenant the way a write does, but never append to it.
+			// Its head stays empty, so Head.MaxTime() is math.MinInt64.
+			_, err := m.TenantAppendable(tenantID)
+			testutil.Ok(t, err)
+			testutil.Assert(t, m.testGetTenant(tenantID) != nil, "tenant should exist before pruning")
+
+			time.Sleep(tc.waitBeforePrune)
+			testutil.Ok(t, m.Prune(context.Background()))
+
+			if tc.expectPruned {
+				testutil.Assert(t, m.testGetTenant(tenantID) == nil, "zombie tenant should have been pruned")
+				testutil.Equals(t, 0, len(m.TSDBLocalClients()))
+			} else {
+				testutil.Assert(t, m.testGetTenant(tenantID) != nil, "tenant within retention should be kept")
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #8485.

## Changes

`tenant.shouldBeMarkedInactive` bails out on `head.MaxTime() < 0`, and the staleness check below it is derived from `head.MaxTime()` as well. A head that never took a successful append reports `math.MinInt64`, so such a tenant has no
time reference to measure against and can never be marked inactive or pruned.

The tenant then stays for the lifetime of the process, holding its TSDB, the periodic head compaction and uploader goroutines, a permanently registered per-tenant metric set, and a `store.Client` that every StoreAPI query fans out
to.

This actually adds a `createdAt` timestamp to `tenant` and uses it as the fallback reference when the head is empty. Such a tenant is only marked inactive when it holds nothing at all, meaning an empty head and no blocks on disk, so the change
can only ever delete an empty shell. With no blocks there is nothing left for the shipper to upload, which is why the empty case returns without falling through to the upload checks; that early return is also necessary because `lastSuccessfulHeadCompaction` is zero for a tenant that never appended and would keep it alive regardless.

Worth flagging: a tenant rebuilt from disk during `MultiTSDB.Open` gets a fresh `createdAt`, so a receive restart resets the fallback window. Using the tenant directory mtime instead would survive restarts. I kept `createdAt` here because
it is self-contained, but i'm happy to switch if you would rather it be durable.

On the reproduction question from #8485: a write that fails and is never retried produces this, but so does a plain restart. `MultiTSDB.Open` starts a  TSDB for every directory under the data dir, so a tenant whose head replays to nothing, for instance one whose blocks were all shipped and aged out, comes back
as a zombie. That makes it a persistent state rather than a transient one.

## Verification

New test `TestMultiTSDBPruneNeverAppendedTenant` covers both directions: a never-appended tenant older than the retention window is pruned, and one still inside the window is kept. Both create the tenant the way a write does, via
`TenantAppendable`, and never append.

`go test -count=1 -tags slicelabels -race -timeout 20m ./pkg/receive/` passes,  including `TestMultiTSDBPruneSkipsUnreadyTenant` from #8990.

CHANGELOG entry follows in a second push, once this PR has a number to reference.

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.
