### PR TITLE
extprom: make TxGaugeVec.ResetTx and Submit goroutine-safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 
 ### Fixed
 
+- [#9000](https://github.com/thanos-io/thanos/pull/9000): extprom: Fix a data race in `TxGaugeVec` by locking `ResetTx` and `Submit` consistently with the other methods; concurrent `block.MetaFetcher.Fetch` calls sharing one `FetcherMetrics` no longer trip the race detector.
 - [#8990](https://github.com/thanos-io/thanos/pull/8990): Receive: Avoid a panic when pruning starts before a tenant TSDB is ready.
 - [#8968](https://github.com/thanos-io/thanos/pull/8968): *: Bump `google.golang.org/grpc` to v1.82.1 to fix GHSA-hrxh-6v49-42gf (CVSS 8.6): HTTP/2 Rapid Reset DoS bypass, xDS RBAC authorization bypass, and NOT-rule panic.
 - [#8900](https://github.com/thanos-io/thanos/pull/8900): UI: Fix web UI static assets (JS/CSS) returning 404 on Windows by using slash-separated paths for the embedded file system.

--- a/pkg/extprom/tx_gauge.go
+++ b/pkg/extprom/tx_gauge.go
@@ -44,20 +44,28 @@ func NewTxGaugeVec(reg prometheus.Registerer, opts prometheus.GaugeOpts, labelNa
 	return tx
 }
 
-// ResetTx starts new transaction. Not goroutine-safe.
+// ResetTx starts new transaction.
 func (tx *TxGaugeVec) ResetTx() {
+	tx.mtx.Lock()
+	defer tx.mtx.Unlock()
+
+	tx.resetTx()
+}
+
+// resetTx starts a new transaction. The caller must hold tx.mtx.
+func (tx *TxGaugeVec) resetTx() {
 	tx.tx = tx.newMetricVal()
 }
 
-// Submit atomically and fully applies new values from existing transaction GaugeVec. Not goroutine-safe.
+// Submit atomically and fully applies new values from existing transaction GaugeVec.
 func (tx *TxGaugeVec) Submit() {
+	tx.mtx.Lock()
+	defer tx.mtx.Unlock()
+
 	if tx.tx == nil {
 		return
 	}
-
-	tx.mtx.Lock()
 	tx.current = tx.tx
-	tx.mtx.Unlock()
 }
 
 // Describe is used in Register.
@@ -85,7 +93,7 @@ func (tx *TxGaugeVec) With(labels prometheus.Labels) prometheus.Gauge {
 	defer tx.mtx.Unlock()
 
 	if tx.tx == nil {
-		tx.ResetTx()
+		tx.resetTx()
 	}
 	return tx.tx.With(labels)
 }
@@ -100,7 +108,7 @@ func (tx *TxGaugeVec) WithLabelValues(lvs ...string) prometheus.Gauge {
 	defer tx.mtx.Unlock()
 
 	if tx.tx == nil {
-		tx.ResetTx()
+		tx.resetTx()
 	}
 	return tx.tx.WithLabelValues(lvs...)
 }

--- a/pkg/extprom/tx_gauge_test.go
+++ b/pkg/extprom/tx_gauge_test.go
@@ -5,6 +5,7 @@ package extprom
 
 import (
 	"sort"
+	"sync"
 	"testing"
 
 	"github.com/efficientgo/core/testutil"
@@ -519,4 +520,48 @@ func toProtoMessage(t *testing.T, c prometheus.Collector) []proto.Message {
 	}
 
 	return messages
+}
+
+// TestTxGaugeVecConcurrentTransactions runs the transaction cycle
+// (ResetTx -> WithLabelValues -> Submit) concurrently with Collect on a single
+// TxGaugeVec. Every method other than ResetTx already takes tx.mtx, so an
+// unguarded ResetTx (and an unguarded nil check in Submit) races the reads of
+// tx.tx. This mirrors concurrent block.MetaFetcher.Fetch calls sharing one
+// FetcherMetrics, which BaseFetcher's thread-safe run group allows. Run with
+// -race; it must not report a data race.
+func TestTxGaugeVecConcurrentTransactions(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	g := NewTxGaugeVec(reg, prometheus.GaugeOpts{Name: "metric"}, []string{"a"})
+
+	const (
+		writers = 8
+		iters   = 2000
+	)
+
+	var wg sync.WaitGroup
+	for i := 0; i < writers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iters; j++ {
+				g.ResetTx()
+				g.WithLabelValues("x").Inc()
+				g.Submit()
+			}
+		}()
+	}
+
+	// Registry scrapes call Collect concurrently with the transactions above.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for j := 0; j < iters; j++ {
+			if _, err := reg.Gather(); err != nil {
+				t.Errorf("gather: %v", err)
+				return
+			}
+		}
+	}()
+
+	wg.Wait()
 }


### PR DESCRIPTION
## Changes

`extprom.TxGaugeVec` guards `With`, `WithLabelValues`, `Submit`, `Collect` and
`Describe` with `tx.mtx`, but `ResetTx` writes the shared `tx.tx` field with no
lock, and `Submit` reads `tx.tx` in its nil-check before taking the lock. When
one transaction cycle runs concurrently with another (or with a registry scrape
calling `Collect`), the unguarded `ResetTx` write races the locked reads of
`tx.tx`. This is the remaining half of the race #6855 started fixing for the
`With*` methods.

It surfaces downstream as a `-race` CI failure in cortexproject/cortex#7707:
two `block.MetaFetcher.Fetch` calls share one `FetcherMetrics`, so one does
`ResetTx()` while the other is in `WithLabelValues()`. `BaseFetcher.fetch` runs
under a "thread safe run group", so concurrent `Fetch` is expected.

Fix, mirroring #6855 (add the missing lock, no behaviour change):
- `ResetTx` now takes `tx.mtx`. Because `With`/`WithLabelValues` call it while
  already holding the lock, the body moves to an unlocked `resetTx()` helper and
  those callers use it directly, avoiding self-deadlock.
- `Submit` takes the lock before the `tx.tx == nil` check.

Scope note (honest limit): this removes the data race. It does not make two
concurrent transactions *isolated* — a caller sharing one `TxGaugeVec` across
concurrent writers can still see a later `Submit` win. Single-owner use, the
documented pattern, is unaffected.

## Verification

Added `TestTxGaugeVecConcurrentTransactions`: 8 goroutines run
`ResetTx -> WithLabelValues -> Submit` while a 9th repeatedly `Gather`s the
registry. With `go test -race` it flags `DATA RACE` at `tx_gauge.go:49`
(`ResetTx`) on `main`, and passes after the fix. Full `pkg/extprom` suite green
under `-race`; `go vet` and `gofmt` clean.
