### PR TITLE
docs: ignore cloud-native.slack.com in mdox link validation

### DIFF
--- a/.mdox.validate.yaml
+++ b/.mdox.validate.yaml
@@ -20,6 +20,9 @@ validators:
   # Causes http stream errors with statuscode 0 sometimes. But is safe to skip.
   - regex: 'slack\.cncf\.io'
     type: 'ignore'
+  # Slack workspace archive links require a logged-in session, so mdox gets a 403.
+  - regex: 'cloud-native\.slack\.com'
+    type: 'ignore'
   # 301 errors even when curl-ed.
   - regex: 'envoyproxy\.io'
     type: 'ignore'


### PR DESCRIPTION
## Changes

`make check-docs` has been red on every PR for roughly the last two weeks. The cause is mdox link validation getting a 403 from `cloud-native.slack.com`:

    docs/contributing/mentorship.md:91: "https://cloud-native.slack.com/archives/CL25937SP" not accessible; status code 403: Forbidden
    docs/blog/2023-20-11-thanoscon.md:41: "https://cloud-native.slack.com/archives/CL25937SP" not accessible; status code 403: Forbidden
    docs/proposals-done/202004-embedd-cortex-frontend.md:13: "https://cloud-native.slack.com/archives/CK5RSSC10/p1586939369171300" not accessible; status code 403: Forbidden
    docs/proposals-done/202004-embedd-cortex-frontend.md:43: "https://cloud-native.slack.com/archives/CK5RSSC10/p1586504362400300?thread_ts=1586492170.387900&cid=CK5RSSC10" not accessible; status code 403: Forbidden

The slack archive links require a logged-in session, so an unauthenticated request from a CI runner cannot succeed regardless of retries. The links are valid for anyone in the workspace, so ignoring them rather than replacing them seems right.

`.mdox.validate.yaml` already ignores `slack.cncf.io`, but that is the invite redirect, not the workspace host, which is why these were still being checked. The new entry sits directly beneath it and matches the existing rules for
`nginx.com`, `servicenow.com` and `docs.github.com`, all ignored with the same
403-from-GH-actions reasoning.

I deliberately left one other failure alone. The same runs also show `https://thanos.io/tip/components/store.md/#time-based-partitioning` failing with an http2 timeout. That is the project's own docs site and looks transient rather than a permanent block, so silencing it would switch off real validation for internal links.

## Verification

The added regex matches the failing Slack URLs and not the thanos.io one:

    MATCH   https://cloud-native.slack.com/archives/CL25937SP
    MATCH   https://cloud-native.slack.com/archives/CK5RSSC10/p1586939369171300
    MATCH   https://cloud-native.slack.com/archives/CK5RSSC10/p1586504362400300?thread_ts=1586492170.387900&cid=CK5RSSC10
    no      https://thanos.io/tip/components/store.md/#time-based-partitioning

Affected PRs where the docs check is currently red for this reason: #8999, #8998, #8987. #8976 from 12 Aug still passed, so the 403 started somewhere in between.

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.
