### PR TITLE
receive: treat an unset tenant_matcher_type as exact in shard size overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 
 ### Fixed
 
+- [#9003](https://github.com/thanos-io/thanos/pull/9003) Receive: Treat an unset `tenant_matcher_type` in a shuffle sharding override as an exact match, instead of skipping the override and falling back to the default shard size.
+
 - [#8990](https://github.com/thanos-io/thanos/pull/8990): Receive: Avoid a panic when pruning starts before a tenant TSDB is ready.
 - [#8968](https://github.com/thanos-io/thanos/pull/8968): *: Bump `google.golang.org/grpc` to v1.82.1 to fix GHSA-hrxh-6v49-42gf (CVSS 8.6): HTTP/2 Rapid Reset DoS bypass, xDS RBAC authorization bypass, and NOT-rule panic.
 - [#8900](https://github.com/thanos-io/thanos/pull/8900): UI: Fix web UI static assets (JS/CSS) returning 404 on Windows by using slash-separated paths for the embedded file system.

--- a/pkg/receive/hashring.go
+++ b/pkg/receive/hashring.go
@@ -525,12 +525,14 @@ func (s *shuffleShardHashring) dedupedNodes() []Endpoint {
 // getShardSize returns the shard size for a specific tenant, taking into account any overrides.
 func (s *shuffleShardHashring) getShardSize(tenant string) int {
 	for _, override := range s.shuffleShardingConfig.Overrides {
-		switch override.TenantMatcherType {
-		case TenantMatcherTypeExact:
+		switch {
+		// An unset matcher type means exact, as documented on
+		// TenantMatcherTypeExact and handled by tenantSet.match.
+		case isExactMatcher(override.TenantMatcherType):
 			if slices.Contains(override.Tenants, tenant) {
 				return override.ShardSize
 			}
-		case TenantMatcherGlob:
+		case override.TenantMatcherType == TenantMatcherGlob:
 			for _, t := range override.Tenants {
 				matches, err := filepath.Match(t, tenant)
 				if err == nil && matches {

--- a/pkg/receive/hashring_test.go
+++ b/pkg/receive/hashring_test.go
@@ -684,6 +684,57 @@ func TestInvalidAZHashringCfg(t *testing.T) {
 	}
 }
 
+func TestShuffleShardHashringGetShardSize(t *testing.T) {
+	t.Parallel()
+
+	endpoints := []Endpoint{
+		{Address: "node-1", AZ: "az-1"},
+		{Address: "node-2", AZ: "az-1"},
+		{Address: "node-3", AZ: "az-2"},
+		{Address: "node-4", AZ: "az-2"},
+	}
+
+	cfg := ShuffleShardingConfig{
+		ShardSize: 2,
+		Overrides: []ShuffleShardingOverrideConfig{
+			{
+				// No matcher type, which means exact.
+				Tenants:   []string{"tenant-a"},
+				ShardSize: 3,
+			},
+			{
+				Tenants:           []string{"tenant-b"},
+				ShardSize:         4,
+				TenantMatcherType: TenantMatcherTypeExact,
+			},
+			{
+				Tenants:           []string{"glob-*"},
+				ShardSize:         4,
+				TenantMatcherType: TenantMatcherGlob,
+			},
+		},
+	}
+
+	baseRing, err := newKetamaHashring(endpoints, SectionsPerNode, 2)
+	require.NoError(t, err)
+	ring, err := newShuffleShardHashring(baseRing, cfg, 2, prometheus.NewRegistry(), "test")
+	require.NoError(t, err)
+
+	for _, tc := range []struct {
+		tenant   string
+		expected int
+	}{
+		{tenant: "tenant-a", expected: 3},
+		{tenant: "tenant-b", expected: 4},
+		{tenant: "glob-1", expected: 4},
+		{tenant: "other", expected: 2},
+	} {
+		t.Run(tc.tenant, func(t *testing.T) {
+			require.Equal(t, tc.expected, ring.getShardSize(tc.tenant))
+		})
+	}
+}
+
 func TestShuffleShardHashring(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Changes

Fixes #8983.

`getShardSize` switched on the matcher type and only handled the explicit `exact` value:

```go
switch override.TenantMatcherType {
case TenantMatcherTypeExact:
    ...
case TenantMatcherGlob:
```

An override that leaves `tenant_matcher_type` unset therefore matches no case and is skipped, so the tenant silently falls back to the default shard size — losing the routing determinism the override exists to provide.

Empty already means exact everywhere else in the package: it is documented on `TenantMatcherTypeExact` ("This is also the default one"), and `isExactMatcher` treats `""` and `"exact"` alike for `tenantSet.match`. This uses that same helper so the two paths agree.

## Verification

Added `TestShuffleShardHashringGetShardSize`, covering an override with no matcher type, one with an explicit `exact`, a glob, and a tenant with no override. The unset case returns 2 instead of 3 on main and passes here.

Note three tests fail on `main` in my environment (darwin/arm64), unrelated to this change and present before it: `TestRelabelWithUnsetValidationScheme`, `TestKetamaHashringEvenNodeSpread` and `writecapnp.TestMarshalWriteRequest`.

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.