### PR TITLE
compact: respect block-files-concurrency when uploading downsampled blocks

### DIFF
--- a/cmd/thanos/downsample.go
+++ b/cmd/thanos/downsample.go
@@ -418,7 +418,7 @@ func processDownsampling(
 
 	begin = time.Now()
 
-	err = block.Upload(ctx, logger, bkt, resdir, hashFunc)
+	err = block.Upload(ctx, logger, bkt, resdir, hashFunc, objstore.WithUploadConcurrency(blockFilesConcurrency))
 	if err != nil {
 		return compact.NewRetryError(errors.Wrapf(err, "upload downsampled block %s", id))
 	}


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

`cmd/thanos/downsample.go`'s `processDownsampling` downloaded the source block with `objstore.WithFetchConcurrency(blockFilesConcurrency)` but uploaded the resulting downsampled block with no upload options at all, so the upload always ran at the objstore default of concurrency 1 regardless of `--block-files-concurrency`. This patches the upload call to also pass `objstore.WithUploadConcurrency(blockFilesConcurrency)`, mirroring both the download call directly above it and the compactor's own (already-fixed) upload path in `pkg/compact/compact.go`.

## Verification

- `go build ./cmd/...` passes.
- `go vet ./cmd/thanos/... ./pkg/block/...` is clean.
- `golangci-lint run ./cmd/thanos/...` reports 0 issues.
- `go test ./cmd/thanos/... ./pkg/block/...` passes, including with `THANOS_TEST_OBJSTORE_SKIP=GCS,S3,AZURE,SWIFT,COS,ALIYUNOSS,BOS,OCI,OBS` set as `make test-local` does per CONTRIBUTING.md (the unskipped subset requires live cloud credentials not available in this environment and fails identically on `main` without this change).
- No new automated test was added to directly observe the concurrency increase: `block.Upload`'s concurrency option only affects the upload of the `chunks/` subdirectory (via `objstore.UploadDir`), and TSDB only splits chunks into multiple segment files past `DefaultChunkSegmentSize` (512MB), so a realistic unit-test block's `chunks/` directory contains exactly one file — there is nothing for concurrency to parallelize in a test small enough to run quickly. Confidence instead comes from this being a one-line, exact structural mirror of the already-tested `block.Download` call 40 lines above and of `pkg/compact/compact.go`'s identical, already-shipped fix for the compactor's own upload path (both wire the flag through to the same `objstore` concurrency-option mechanism).

Fixes #9001