### PR TITLE
filter: prune StoreAPI fan-out for enumerable regex __name__ matchers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 
 ### Changed
 
+- [#9006](https://github.com/thanos-io/thanos/pull/9006): Store/Receive: the metric-name store filter (`--enable-feature=metric-names-filter`) now also prunes fan-out for regex `__name__=~"a|b"` matchers whose value set is fully enumerable, not only exact `__name__=` matchers.
 - [#6099](https://github.com/thanos-io/thanos/issues/6099): Tracing: drop the noisiest INTERNAL spans (`proxy.series`, `proxy.label_names`, `proxy.label_values`, `bucket_store_block_series`, `send_rules_response`, `send_rule_group_response`) so distributed traces stay usable; gRPC CLIENT/SERVER spans remain.
 - [#8907](https://github.com/thanos-io/thanos/pull/8907): UI: Migrate the React app (`pkg/ui/react-app`) from npm to pnpm; contributors now need pnpm 11+ instead of npm to build the Web UI.
 - [#8943](https://github.com/thanos-io/thanos/pull/8943): receive: always intern. *breaking :warning:* `--writer.intern` was removed on Thanos Receive and Receive will fail to start if that command line parameter is provided

--- a/pkg/filter/cuckoo.go
+++ b/pkg/filter/cuckoo.go
@@ -26,13 +26,46 @@ func (f *CuckooMetricNameStoreFilter) Matches(matchers []*labels.Matcher) bool {
 	f.mtx.RLock()
 	defer f.mtx.RUnlock()
 
+	var constraints [][]string
 	for _, m := range matchers {
-		if m.Type == labels.MatchEqual && m.Name == labels.MetricName {
-			return f.filter.Lookup(unsafe.Slice(unsafe.StringData(m.Value), len(m.Value)))
+		if m.Name != labels.MetricName {
+			continue
+		}
+
+		switch m.Type {
+		case labels.MatchEqual:
+			constraints = append(constraints, []string{m.Value})
+		case labels.MatchRegexp:
+			vs := m.SetMatches()
+			if len(vs) == 0 {
+				continue
+			}
+			constraints = append(constraints, vs)
+		}
+	}
+
+	if len(constraints) == 0 {
+		return true
+	}
+
+	for _, values := range constraints {
+		matches := false
+		for _, value := range values {
+			if f.lookup(value) {
+				matches = true
+				break
+			}
+		}
+		if !matches {
+			return false
 		}
 	}
 
 	return true
+}
+
+func (f *CuckooMetricNameStoreFilter) lookup(v string) bool {
+	return f.filter.Lookup(unsafe.Slice(unsafe.StringData(v), len(v)))
 }
 
 func (f *CuckooMetricNameStoreFilter) ResetAndSet(values ...string) {

--- a/pkg/filter/cuckoo_test.go
+++ b/pkg/filter/cuckoo_test.go
@@ -1,0 +1,111 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package filter
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/prometheus/prometheus/model/labels"
+)
+
+func TestCuckooMetricNameStoreFilter_Matches(t *testing.T) {
+	filter := NewCuckooMetricNameStoreFilter(100)
+	filter.ResetAndSet("http_requests_total", "up", "go_goroutines")
+
+	tests := []struct {
+		name     string
+		matchers []*labels.Matcher
+		want     bool
+	}{
+		{
+			name:     "exact present",
+			matchers: []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, labels.MetricName, "up")},
+			want:     true,
+		},
+		{
+			name:     "exact absent",
+			matchers: []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, labels.MetricName, "missing")},
+			want:     false,
+		},
+		{
+			name:     "regex set with one present",
+			matchers: []*labels.Matcher{labels.MustNewMatcher(labels.MatchRegexp, labels.MetricName, "up|down")},
+			want:     true,
+		},
+		{
+			name:     "regex set with none present",
+			matchers: []*labels.Matcher{labels.MustNewMatcher(labels.MatchRegexp, labels.MetricName, "a|b")},
+			want:     false,
+		},
+		{
+			name:     "non-enumerable regex",
+			matchers: []*labels.Matcher{labels.MustNewMatcher(labels.MatchRegexp, labels.MetricName, "up.*")},
+			want:     true,
+		},
+		{
+			name:     "no metric name matcher",
+			matchers: []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "job", "x")},
+			want:     true,
+		},
+		{
+			name:     "empty matcher slice",
+			matchers: nil,
+			want:     true,
+		},
+		{
+			name: "two metric name constraints",
+			matchers: []*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchEqual, labels.MetricName, "up"),
+				labels.MustNewMatcher(labels.MatchRegexp, labels.MetricName, "a|b"),
+			},
+			want: false,
+		},
+		{
+			name: "non-metric regex ignored",
+			matchers: []*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchEqual, labels.MetricName, "up"),
+				labels.MustNewMatcher(labels.MatchRegexp, "foo", "x|y"),
+			},
+			want: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := filter.Matches(test.matchers); got != test.want {
+				t.Fatalf("Matches() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+func BenchmarkCuckooMetricNameStoreFilter_Matches(b *testing.B) {
+	filter := NewCuckooMetricNameStoreFilter(20000)
+	values := make([]string, 10000)
+	for i := range values {
+		values[i] = fmt.Sprintf("name_%d", i)
+	}
+	filter.ResetAndSet(values...)
+
+	b.Run("equal", func(b *testing.B) {
+		matchers := []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, labels.MetricName, "name_9999")}
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			if !filter.Matches(matchers) {
+				b.Fatal("expected matcher to match")
+			}
+		}
+	})
+
+	b.Run("regexp_set", func(b *testing.B) {
+		matchers := []*labels.Matcher{labels.MustNewMatcher(labels.MatchRegexp, labels.MetricName, "name_1|name_999999")}
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			if !filter.Matches(matchers) {
+				b.Fatal("expected matcher to match")
+			}
+		}
+	})
+}


### PR DESCRIPTION
* [x] I added CHANGELOG entry for this change.

## Changes

Extends the Cuckoo metric-name store filter (`--enable-feature=metric-names-filter`, added in #7787) so it can prune fan-out for more queries.

Before, `CuckooMetricNameStoreFilter.Matches` only skipped a store when the request carried an exact `__name__="x"` matcher. A regex matcher such as `__name__=~"a|b|c"` — extremely common in Grafana dashboards, recording-rule groups and `or` queries — was ignored, so the querier always fanned out even when none of `a`, `b`, `c` exist on that store.

`Matches` now:

- collects **every** `__name__` matcher instead of returning on the first one;
- treats a `MatchRegexp` matcher whose value set is fully enumerable (`labels.Matcher.SetMatches()`) as a constraint, using its literal alternatives;
- keeps ignoring negative matchers and non-reducible regexes (e.g. `__name__=~"a.*"`), so those stay non-constraining and correctness is unchanged;
- returns `false` only when, for at least one constraint, **none** of its candidate metric names are present in the filter (AND semantics across constraints, OR within a set).

This only tightens an already-probabilistic, false-positive-only check, so it cannot cause missed data: an enumerable regex that would previously fan out unconditionally now fans out iff at least one of its names might be present.

Touched files: `pkg/filter/cuckoo.go`, `pkg/filter/cuckoo_test.go` (new), `CHANGELOG.md`. No proto or API changes.

Part of #1611.

## Verification

- New table-driven `TestCuckooMetricNameStoreFilter_Matches` covering exact hit/miss, enumerable regex (all-miss vs partial-hit), non-enumerable regex, no `__name__` matcher, empty matchers, multi-constraint AND, and non-`__name__` regex being ignored.
- New `BenchmarkCuckooMetricNameStoreFilter_Matches` (`equal` ~56 ns/op, `regexp_set` ~106 ns/op on a 10k-entry filter).
- `gofmt -l`, `go build ./pkg/filter/...`, `go vet ./pkg/filter/...`, `go test ./pkg/filter/...` all pass.